### PR TITLE
Refactor SignerSource to expose DerivationPath to other kinds of signers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,6 +4107,7 @@ dependencies = [
  "rpassword",
  "solana-remote-wallet",
  "solana-sdk",
+ "tempfile",
  "thiserror",
  "tiny-bip39 0.8.0",
  "uriparse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "pbkdf2 0.6.0",
+ "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rand_core 0.6.2",
@@ -5121,6 +5122,7 @@ dependencies = [
  "solana-sdk-macro 1.7.0",
  "thiserror",
  "tiny-bip39 0.7.3",
+ "uriparse",
 ]
 
 [[package]]

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -20,6 +20,9 @@ uriparse = "0.6.3"
 url = "2.1.0"
 chrono = "0.4"
 
+[dev-dependencies]
+tempfile = "3.1.0"
+
 [lib]
 name = "solana_clap_utils"
 

--- a/clap-utils/src/fee_payer.rs
+++ b/clap-utils/src/fee_payer.rs
@@ -1,5 +1,7 @@
-use crate::{input_validators, ArgConstant};
-use clap::Arg;
+use {
+    crate::{input_validators, ArgConstant},
+    clap::Arg,
+};
 
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,19 +1,21 @@
-use crate::keypair::{
-    keypair_from_seed_phrase, pubkey_from_path, resolve_signer_from_path, signer_from_path,
-    ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+use {
+    crate::keypair::{
+        keypair_from_seed_phrase, pubkey_from_path, resolve_signer_from_path, signer_from_path,
+        ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+    },
+    chrono::DateTime,
+    clap::ArgMatches,
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_sdk::{
+        clock::UnixTimestamp,
+        commitment_config::CommitmentConfig,
+        genesis_config::ClusterType,
+        native_token::sol_to_lamports,
+        pubkey::Pubkey,
+        signature::{read_keypair_file, Keypair, Signature, Signer},
+    },
+    std::{str::FromStr, sync::Arc},
 };
-use chrono::DateTime;
-use clap::ArgMatches;
-use solana_remote_wallet::remote_wallet::RemoteWalletManager;
-use solana_sdk::{
-    clock::UnixTimestamp,
-    commitment_config::CommitmentConfig,
-    genesis_config::ClusterType,
-    native_token::sol_to_lamports,
-    pubkey::Pubkey,
-    signature::{read_keypair_file, Keypair, Signature, Signer},
-};
-use std::{str::FromStr, sync::Arc};
 
 // Return parsed values from matches at `name`
 pub fn values_of<T>(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<T>>

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -110,7 +110,7 @@ pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match parse_signer_source(string.as_ref()) {
+    match parse_signer_source(string.as_ref()).map_err(|err| format!("{}", err))? {
         SignerSource::Filepath(path) => is_keypair(path),
         _ => Ok(()),
     }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,5 +1,5 @@
 use {
-    crate::keypair::{parse_signer_source, SignerSource, ASK_KEYWORD},
+    crate::keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
     chrono::DateTime,
     solana_sdk::{
         clock::{Epoch, Slot},
@@ -110,8 +110,11 @@ pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match parse_signer_source(string.as_ref()).map_err(|err| format!("{}", err))? {
-        SignerSource::Filepath(path) => is_keypair(path),
+    match parse_signer_source(string.as_ref())
+        .map_err(|err| format!("{}", err))?
+        .kind
+    {
+        SignerSourceKind::Filepath(path) => is_keypair(path),
         _ => Ok(()),
     }
 }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,13 +1,15 @@
-use crate::keypair::{parse_signer_source, SignerSource, ASK_KEYWORD};
-use chrono::DateTime;
-use solana_sdk::{
-    clock::{Epoch, Slot},
-    hash::Hash,
-    pubkey::{Pubkey, MAX_SEED_LEN},
-    signature::{read_keypair_file, Signature},
+use {
+    crate::keypair::{parse_signer_source, SignerSource, ASK_KEYWORD},
+    chrono::DateTime,
+    solana_sdk::{
+        clock::{Epoch, Slot},
+        hash::Hash,
+        pubkey::{Pubkey, MAX_SEED_LEN},
+        signature::{read_keypair_file, Signature},
+    },
+    std::fmt::Display,
+    std::str::FromStr,
 };
-use std::fmt::Display;
-use std::str::FromStr;
 
 fn is_parsable_generic<U, T>(string: T) -> Result<(), String>
 where

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,31 +1,33 @@
-use crate::{
-    input_parsers::pubkeys_sigs_of,
-    offline::{SIGNER_ARG, SIGN_ONLY_ARG},
-    ArgConstant,
-};
-use bip39::{Language, Mnemonic, Seed};
-use clap::ArgMatches;
-use rpassword::prompt_password_stderr;
-use solana_remote_wallet::{
-    remote_keypair::generate_remote_keypair,
-    remote_wallet::{maybe_wallet_manager, RemoteWalletError, RemoteWalletManager},
-};
-use solana_sdk::{
-    hash::Hash,
-    message::Message,
-    pubkey::Pubkey,
-    signature::{
-        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
-        read_keypair_file, Keypair, NullSigner, Presigner, Signature, Signer,
+use {
+    crate::{
+        input_parsers::pubkeys_sigs_of,
+        offline::{SIGNER_ARG, SIGN_ONLY_ARG},
+        ArgConstant,
     },
-};
-use std::{
-    convert::TryFrom,
-    error,
-    io::{stdin, stdout, Write},
-    process::exit,
-    str::FromStr,
-    sync::Arc,
+    bip39::{Language, Mnemonic, Seed},
+    clap::ArgMatches,
+    rpassword::prompt_password_stderr,
+    solana_remote_wallet::{
+        remote_keypair::generate_remote_keypair,
+        remote_wallet::{maybe_wallet_manager, RemoteWalletError, RemoteWalletManager},
+    },
+    solana_sdk::{
+        hash::Hash,
+        message::Message,
+        pubkey::Pubkey,
+        signature::{
+            keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
+            read_keypair_file, Keypair, NullSigner, Presigner, Signature, Signer,
+        },
+    },
+    std::{
+        convert::TryFrom,
+        error,
+        io::{stdin, stdout, Write},
+        process::exit,
+        str::FromStr,
+        sync::Arc,
+    },
 };
 
 pub struct SignOnly {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -152,6 +152,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(source: S) -> SignerSource {
                 match scheme.as_str() {
                     "ask" => SignerSource::Ask,
                     "file" => SignerSource::Filepath(uri.path().to_string()),
+                    "stdin" => SignerSource::Stdin,
                     "usb" => SignerSource::Usb(source.to_string()),
                     _ => SignerSource::Filepath(source.to_string()),
                 }
@@ -461,6 +462,8 @@ mod tests {
     #[test]
     fn test_parse_signer_source() {
         assert!(matches!(parse_signer_source("-"), SignerSource::Stdin));
+        let ask = "stdin:".to_string();
+        assert!(matches!(parse_signer_source(&ask), SignerSource::Stdin));
         assert!(matches!(
             parse_signer_source(ASK_KEYWORD),
             SignerSource::Ask

--- a/clap-utils/src/memo.rs
+++ b/clap-utils/src/memo.rs
@@ -1,5 +1,4 @@
-use crate::ArgConstant;
-use clap::Arg;
+use {crate::ArgConstant, clap::Arg};
 
 pub const MEMO_ARG: ArgConstant<'static> = ArgConstant {
     name: "memo",

--- a/clap-utils/src/nonce.rs
+++ b/clap-utils/src/nonce.rs
@@ -1,5 +1,7 @@
-use crate::{input_validators::*, offline::BLOCKHASH_ARG, ArgConstant};
-use clap::{App, Arg};
+use {
+    crate::{input_validators::*, offline::BLOCKHASH_ARG, ArgConstant},
+    clap::{App, Arg},
+};
 
 pub const NONCE_ARG: ArgConstant<'static> = ArgConstant {
     name: "nonce",

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -1,5 +1,7 @@
-use crate::{input_validators::*, ArgConstant};
-use clap::{App, Arg};
+use {
+    crate::{input_validators::*, ArgConstant},
+    clap::{App, Arg},
+};
 
 pub const BLOCKHASH_ARG: ArgConstant<'static> = ArgConstant {
     name: "blockhash",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3461,6 +3461,7 @@ dependencies = [
  "num-derive 0.3.0",
  "num-traits",
  "pbkdf2 0.6.0",
+ "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rand_core 0.6.2",
@@ -3479,6 +3480,7 @@ dependencies = [
  "solana-program 1.7.0",
  "solana-sdk-macro 1.7.0",
  "thiserror",
+ "uriparse",
 ]
 
 [[package]]

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -1,8 +1,5 @@
 use {
-    solana_sdk::{
-        derivation_path::{DerivationPath, DerivationPathError},
-        pubkey::{ParsePubkeyError, Pubkey},
-    },
+    solana_sdk::pubkey::{ParsePubkeyError, Pubkey},
     std::{
         convert::{Infallible, TryFrom, TryInto},
         str::FromStr,
@@ -77,8 +74,6 @@ pub enum LocatorError {
     #[error(transparent)]
     PubkeyError(#[from] ParsePubkeyError),
     #[error(transparent)]
-    DerivationPathError(#[from] DerivationPathError),
-    #[error(transparent)]
     UriReferenceError(#[from] URIReferenceError),
     #[error("unimplemented scheme")]
     UnimplementedScheme,
@@ -96,15 +91,12 @@ impl From<Infallible> for LocatorError {
 pub struct Locator {
     pub manufacturer: Manufacturer,
     pub pubkey: Option<Pubkey>,
-    pub derivation_path: Option<DerivationPath>,
 }
 
 impl std::fmt::Display for Locator {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let maybe_path = self.pubkey.map(|p| p.to_string());
         let path = maybe_path.as_deref().unwrap_or("/");
-        let maybe_query = self.derivation_path.as_ref().map(|d| d.get_query());
-        let maybe_query2 = maybe_query.as_ref().map(|q| &q[1..]);
 
         let mut builder = URIReferenceBuilder::new();
         builder
@@ -113,8 +105,6 @@ impl std::fmt::Display for Locator {
             .try_authority(Some(self.manufacturer.as_ref()))
             .unwrap()
             .try_path(path)
-            .unwrap()
-            .try_query(maybe_query2)
             .unwrap();
 
         let uri = builder.build().unwrap();
@@ -141,28 +131,7 @@ impl Locator {
                         None
                     }
                 });
-                let key = if let Some(query) = uri.query() {
-                    let query_str = query.as_str();
-                    let query = qstring::QString::from(query_str);
-                    if query.len() > 1 {
-                        return Err(DerivationPathError::InvalidDerivationPath(
-                            "invalid query string, extra fields not supported".to_string(),
-                        )
-                        .into());
-                    }
-                    let key = query.get("key");
-                    if key.is_none() {
-                        return Err(DerivationPathError::InvalidDerivationPath(format!(
-                            "invalid query string `{}`, only `key` supported",
-                            query_str,
-                        ))
-                        .into());
-                    }
-                    key.map(|v| v.to_string())
-                } else {
-                    None
-                };
-                Self::new_from_parts(host.as_str(), path, key.as_deref())
+                Self::new_from_parts(host.as_str(), path)
             }
             (Some(_scheme), Some(_host)) => Err(LocatorError::UnimplementedScheme),
             (None, Some(_host)) => Err(LocatorError::UnimplementedScheme),
@@ -170,18 +139,15 @@ impl Locator {
         }
     }
 
-    pub fn new_from_parts<V, VE, P, PE, D, DE>(
+    pub fn new_from_parts<V, VE, P, PE>(
         manufacturer: V,
         pubkey: Option<P>,
-        derivation_path: Option<D>,
     ) -> Result<Self, LocatorError>
     where
         VE: Into<LocatorError>,
         V: TryInto<Manufacturer, Error = VE>,
         PE: Into<LocatorError>,
         P: TryInto<Pubkey, Error = PE>,
-        DE: Into<LocatorError>,
-        D: TryInto<DerivationPath, Error = DE>,
     {
         let manufacturer = manufacturer.try_into().map_err(|e| e.into())?;
         let pubkey = if let Some(pubkey) = pubkey {
@@ -189,15 +155,9 @@ impl Locator {
         } else {
             None
         };
-        let derivation_path = if let Some(derivation_path) = derivation_path {
-            Some(derivation_path.try_into().map_err(|e| e.into())?)
-        } else {
-            None
-        };
         Ok(Self {
             manufacturer,
             pubkey,
-            derivation_path,
         })
     }
 }
@@ -225,76 +185,50 @@ mod tests {
         let manufacturer_str = "ledger";
         let pubkey = Pubkey::new_unique();
         let pubkey_str = pubkey.to_string();
-        let derivation_path = DerivationPath::new_bip44(Some(0), Some(0));
-        let derivation_path_str = "0/0";
 
         let expect = Locator {
             manufacturer,
             pubkey: None,
-            derivation_path: None,
         };
         assert!(matches!(
-            Locator::new_from_parts(manufacturer, None::<Pubkey>, None::<DerivationPath>),
+            Locator::new_from_parts(manufacturer, None::<Pubkey>),
             Ok(e) if e == expect,
         ));
         assert!(matches!(
-            Locator::new_from_parts(manufacturer_str, None::<Pubkey>, None::<DerivationPath>),
+            Locator::new_from_parts(manufacturer_str, None::<Pubkey>),
             Ok(e) if e == expect,
         ));
 
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
-            derivation_path: None,
         };
         assert!(matches!(
-            Locator::new_from_parts(manufacturer, Some(pubkey), None::<DerivationPath>),
+            Locator::new_from_parts(manufacturer, Some(pubkey)),
             Ok(e) if e == expect,
         ));
         assert!(matches!(
-            Locator::new_from_parts(manufacturer_str, Some(pubkey_str.as_str()), None::<DerivationPath>),
-            Ok(e) if e == expect,
-        ));
-
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path.clone()),
-        };
-        assert!(matches!(
-            Locator::new_from_parts(manufacturer, None::<Pubkey>, Some(derivation_path)),
-            Ok(e) if e == expect,
-        ));
-        assert!(matches!(
-            Locator::new_from_parts(manufacturer, None::<Pubkey>, Some(derivation_path_str)),
+            Locator::new_from_parts(manufacturer_str, Some(pubkey_str.as_str())),
             Ok(e) if e == expect,
         ));
 
         assert!(matches!(
-            Locator::new_from_parts("bad-manufacturer", None::<Pubkey>, None::<DerivationPath>),
+            Locator::new_from_parts("bad-manufacturer", None::<Pubkey>),
             Err(LocatorError::ManufacturerError(e)) if e == ManufacturerError,
         ));
         assert!(matches!(
-            Locator::new_from_parts(manufacturer, Some("bad-pubkey"), None::<DerivationPath>),
+            Locator::new_from_parts(manufacturer, Some("bad-pubkey")),
             Err(LocatorError::PubkeyError(e)) if e == ParsePubkeyError::Invalid,
-        ));
-        let bad_path = "bad-derivation-path".to_string();
-        assert!(matches!(
-            Locator::new_from_parts(manufacturer, None::<Pubkey>, Some(bad_path.as_str())),
-            Err(LocatorError::DerivationPathError(
-                DerivationPathError::InvalidDerivationPath(_)
-            )),
         ));
     }
 
     #[test]
     fn test_locator_new_from_uri() {
-        let derivation_path = DerivationPath::new_bip44(Some(0), Some(0));
         let manufacturer = Manufacturer::Ledger;
         let pubkey = Pubkey::new_unique();
         let pubkey_str = pubkey.to_string();
 
-        // usb://ledger/{PUBKEY}?key=0'/0'
+        // usb://ledger/{PUBKEY}?key=0/0
         let mut builder = URIReferenceBuilder::new();
         builder
             .try_scheme(Some("usb"))
@@ -309,7 +243,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
-            derivation_path: Some(derivation_path.clone()),
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
 
@@ -326,7 +259,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
-            derivation_path: None,
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
 
@@ -343,7 +275,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: None,
-            derivation_path: None,
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
 
@@ -360,102 +291,8 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: None,
-            derivation_path: None,
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
-
-        // usb://ledger?key=0/0
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=0/0"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path.clone()),
-        };
-        assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
-
-        // usb://ledger?key=0'/0'
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=0'/0'"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path.clone()),
-        };
-        assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
-
-        // usb://ledger?key=0\'/0\'
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=0\'/0\'"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path.clone()),
-        };
-        assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
-
-        // usb://ledger/?key=0/0
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("/")
-            .unwrap()
-            .try_query(Some("key=0/0"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path),
-        };
-        assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
-
-        // usb://ledger?key=0/0/0
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=0/0/0"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
 
         // bad-scheme://ledger
         let mut builder = URIReferenceBuilder::new();
@@ -501,96 +338,10 @@ mod tests {
             Locator::new_from_uri(&uri),
             Err(LocatorError::PubkeyError(ParsePubkeyError::Invalid))
         );
-
-        // usb://ledger?key=0/0&bad-key=0/0
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=0/0&bad-key=0/0"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?bad-key=0/0
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("bad-key=0/0"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key=bad-value
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key=bad-value"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key=
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key="))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key
-        let mut builder = URIReferenceBuilder::new();
-        builder
-            .try_scheme(Some("usb"))
-            .unwrap()
-            .try_authority(Some(Manufacturer::Ledger.as_ref()))
-            .unwrap()
-            .try_path("")
-            .unwrap()
-            .try_query(Some("key"))
-            .unwrap();
-        let uri = builder.build().unwrap();
-        assert!(matches!(
-            Locator::new_from_uri(&uri),
-            Err(LocatorError::DerivationPathError(_))
-        ));
     }
 
     #[test]
     fn test_locator_new_from_path() {
-        let derivation_path = DerivationPath::new_bip44(Some(0), Some(0));
         let manufacturer = Manufacturer::Ledger;
         let pubkey = Pubkey::new_unique();
         let path = format!("usb://ledger/{}?key=0/0", pubkey);
@@ -601,7 +352,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
-            derivation_path: Some(derivation_path.clone()),
         };
         assert_eq!(Locator::new_from_path(path), Ok(expect));
 
@@ -610,7 +360,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
-            derivation_path: None,
         };
         assert_eq!(Locator::new_from_path(path), Ok(expect));
 
@@ -619,7 +368,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: None,
-            derivation_path: None,
         };
         assert_eq!(Locator::new_from_path(path), Ok(expect));
 
@@ -628,25 +376,6 @@ mod tests {
         let expect = Locator {
             manufacturer,
             pubkey: None,
-            derivation_path: None,
-        };
-        assert_eq!(Locator::new_from_path(path), Ok(expect));
-
-        // usb://ledger?key=0'/0'
-        let path = "usb://ledger?key=0'/0'";
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path.clone()),
-        };
-        assert_eq!(Locator::new_from_path(path), Ok(expect));
-
-        // usb://ledger/?key=0'/0'
-        let path = "usb://ledger?key=0'/0'";
-        let expect = Locator {
-            manufacturer,
-            pubkey: None,
-            derivation_path: Some(derivation_path),
         };
         assert_eq!(Locator::new_from_path(path), Ok(expect));
 
@@ -670,40 +399,5 @@ mod tests {
             Locator::new_from_path(path),
             Err(LocatorError::PubkeyError(ParsePubkeyError::Invalid))
         );
-
-        // usb://ledger?bad-key=0/0
-        let path = "usb://ledger?bad-key=0/0";
-        assert!(matches!(
-            Locator::new_from_path(path),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?bad-key=0'/0'
-        let path = "usb://ledger?bad-key=0'/0'";
-        assert!(matches!(
-            Locator::new_from_path(path),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key=bad-value
-        let path = format!("usb://ledger/{}?key=bad-value", pubkey);
-        assert!(matches!(
-            Locator::new_from_path(path),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key=
-        let path = format!("usb://ledger/{}?key=", pubkey);
-        assert!(matches!(
-            Locator::new_from_path(path),
-            Err(LocatorError::DerivationPathError(_))
-        ));
-
-        // usb://ledger?key
-        let path = format!("usb://ledger/{}?key", pubkey);
-        assert!(matches!(
-            Locator::new_from_path(path),
-            Err(LocatorError::DerivationPathError(_))
-        ));
     }
 }

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -402,6 +402,25 @@ mod tests {
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
 
+        // usb://ledger?key=0\'/0\'
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("usb"))
+            .unwrap()
+            .try_authority(Some(Manufacturer::Ledger.as_ref()))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0\'/0\'"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        let expect = Locator {
+            manufacturer,
+            pubkey: None,
+            derivation_path: Some(derivation_path.clone()),
+        };
+        assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
+
         // usb://ledger/?key=0/0
         let mut builder = URIReferenceBuilder::new();
         builder
@@ -420,6 +439,23 @@ mod tests {
             derivation_path: Some(derivation_path),
         };
         assert_eq!(Locator::new_from_uri(&uri), Ok(expect));
+
+        // usb://ledger?key=0/0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("usb"))
+            .unwrap()
+            .try_authority(Some(Manufacturer::Ledger.as_ref()))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0/0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            Locator::new_from_uri(&uri),
+            Err(LocatorError::DerivationPathError(_))
+        ));
 
         // bad-scheme://ledger
         let mut builder = URIReferenceBuilder::new();
@@ -465,6 +501,23 @@ mod tests {
             Locator::new_from_uri(&uri),
             Err(LocatorError::PubkeyError(ParsePubkeyError::Invalid))
         );
+
+        // usb://ledger?key=0/0&bad-key=0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("usb"))
+            .unwrap()
+            .try_authority(Some(Manufacturer::Ledger.as_ref()))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0/0&bad-key=0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            Locator::new_from_uri(&uri),
+            Err(LocatorError::DerivationPathError(_))
+        ));
 
         // usb://ledger?bad-key=0/0
         let mut builder = URIReferenceBuilder::new();

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -57,11 +57,12 @@ impl Signer for RemoteKeypair {
 
 pub fn generate_remote_keypair(
     locator: Locator,
+    derivation_path: DerivationPath,
     wallet_manager: &RemoteWalletManager,
     confirm_key: bool,
     keypair_name: &str,
 ) -> Result<RemoteKeypair, RemoteWalletError> {
-    let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_locator(locator);
+    let remote_wallet_info = RemoteWalletInfo::parse_locator(locator);
     if remote_wallet_info.manufacturer == Manufacturer::Ledger {
         let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
         let path = format!("{}{}", ledger.pretty_path, derivation_path.get_query());

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         ledger::get_ledger_from_info,
-        locator::Manufacturer,
+        locator::{Locator, Manufacturer},
         remote_wallet::{
             RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletManager,
             RemoteWalletType,
@@ -56,12 +56,12 @@ impl Signer for RemoteKeypair {
 }
 
 pub fn generate_remote_keypair(
-    path: String,
+    locator: Locator,
     wallet_manager: &RemoteWalletManager,
     confirm_key: bool,
     keypair_name: &str,
 ) -> Result<RemoteKeypair, RemoteWalletError> {
-    let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_path(path)?;
+    let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_locator(locator);
     if remote_wallet_info.manufacturer == Manufacturer::Ledger {
         let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
         let path = format!("{}{}", ledger.pretty_path, derivation_path.get_query());

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -253,15 +253,12 @@ pub struct RemoteWalletInfo {
 }
 
 impl RemoteWalletInfo {
-    pub fn parse_locator(locator: Locator) -> (Self, DerivationPath) {
-        (
-            RemoteWalletInfo {
-                manufacturer: locator.manufacturer,
-                pubkey: locator.pubkey.unwrap_or_default(),
-                ..RemoteWalletInfo::default()
-            },
-            locator.derivation_path.unwrap_or_default(),
-        )
+    pub fn parse_locator(locator: Locator) -> Self {
+        RemoteWalletInfo {
+            manufacturer: locator.manufacturer,
+            pubkey: locator.pubkey.unwrap_or_default(),
+            ..RemoteWalletInfo::default()
+        }
     }
 
     pub fn get_pretty_path(&self) -> String {
@@ -308,9 +305,8 @@ mod tests {
         let locator = Locator {
             manufacturer: Manufacturer::Ledger,
             pubkey: Some(pubkey),
-            derivation_path: Some(DerivationPath::from_key_str("1/2").unwrap()),
         };
-        let (wallet_info, derivation_path) = RemoteWalletInfo::parse_locator(locator);
+        let wallet_info = RemoteWalletInfo::parse_locator(locator);
         assert!(wallet_info.matches(&RemoteWalletInfo {
             model: "nano-s".to_string(),
             manufacturer: Manufacturer::Ledger,
@@ -319,15 +315,13 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
 
-        // Test that wallet id need not be complete for key derivation to work
+        // Test that pubkey need not be populated
         let locator = Locator {
             manufacturer: Manufacturer::Ledger,
             pubkey: None,
-            derivation_path: Some(DerivationPath::from_key_str("1").unwrap()),
         };
-        let (wallet_info, derivation_path) = RemoteWalletInfo::parse_locator(locator);
+        let wallet_info = RemoteWalletInfo::parse_locator(locator);
         assert!(wallet_info.matches(&RemoteWalletInfo {
             model: "nano-s".to_string(),
             manufacturer: Manufacturer::Ledger,
@@ -336,22 +330,6 @@ mod tests {
             pubkey: Pubkey::default(),
             error: None,
         }));
-        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), None));
-        let locator = Locator {
-            manufacturer: Manufacturer::Ledger,
-            pubkey: None,
-            derivation_path: Some(DerivationPath::from_key_str("1/2").unwrap()),
-        };
-        let (wallet_info, derivation_path) = RemoteWalletInfo::parse_locator(locator);
-        assert!(wallet_info.matches(&RemoteWalletInfo {
-            model: "".to_string(),
-            manufacturer: Manufacturer::Ledger,
-            serial: "".to_string(),
-            host_device_path: "/host/device/path".to_string(),
-            pubkey: Pubkey::default(),
-            error: None,
-        }));
-        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
     }
 
     #[test]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,11 +44,14 @@ byteorder = { version = "1.3.4", optional = true }
 chrono = { version = "0.4", optional = true }
 curve25519-dalek = { version = "2.1.0", optional = true }
 derivation-path = { version = "0.1.3", default-features = false }
+digest = { version = "0.9.0", optional = true }
+ed25519-dalek = { version = "=1.0.1", optional = true }
 generic-array = { version = "0.14.3", default-features = false, features = ["serde", "more_lengths"], optional = true }
 hex = "0.4.2"
 hmac = "0.10.1"
 itertools =  "0.9.0"
 lazy_static = "1.4.0"
+libsecp256k1 = { version = "0.3.5", optional = true }
 log = "0.4.11"
 memmap2 = { version = "0.1.0", optional = true }
 num-derive = "0.3"
@@ -57,23 +60,20 @@ pbkdf2 = { version = "0.6.0", default-features = false }
 rand = { version = "0.7.0", optional = true }
 rand_chacha = { version = "0.2.2", optional = true }
 rand_core = "0.6.2"
+rustversion = "1.0.4"
 serde = "1.0.122"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
 serde_json = { version = "1.0.56", optional = true }
 sha2 = "0.9.2"
-thiserror = "1.0"
-ed25519-dalek = { version = "=1.0.1", optional = true }
+sha3 = { version = "0.9.1", optional = true }
 solana-crate-features = { path = "../crate-features", version = "=1.7.0", optional = true }
 solana-logger = { path = "../logger", version = "=1.7.0", optional = true }
 solana-frozen-abi = { path = "../frozen-abi", version = "=1.7.0" }
 solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.7.0" }
 solana-program = { path = "program", version = "=1.7.0" }
 solana-sdk-macro = { path = "macro", version = "=1.7.0" }
-rustversion = "1.0.4"
-libsecp256k1 = { version = "0.3.5", optional = true }
-sha3 = { version = "0.9.1", optional = true }
-digest = { version = "0.9.0", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 curve25519-dalek = "2.1.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -57,6 +57,7 @@ memmap2 = { version = "0.1.0", optional = true }
 num-derive = "0.3"
 num-traits = "0.2"
 pbkdf2 = { version = "0.6.0", default-features = false }
+qstring = "0.7.2"
 rand = { version = "0.7.0", optional = true }
 rand_chacha = { version = "0.2.2", optional = true }
 rand_core = "0.6.2"
@@ -74,6 +75,7 @@ solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.7.0" }
 solana-program = { path = "program", version = "=1.7.0" }
 solana-sdk-macro = { path = "macro", version = "=1.7.0" }
 thiserror = "1.0"
+uriparse = "0.6.3"
 
 [dev-dependencies]
 curve25519-dalek = "2.1.0"

--- a/sdk/src/derivation_path.rs
+++ b/sdk/src/derivation_path.rs
@@ -7,6 +7,7 @@ use {
         str::FromStr,
     },
     thiserror::Error,
+    uriparse::URIReference,
 };
 
 const ACCOUNT_INDEX: usize = 2;
@@ -109,6 +110,7 @@ impl DerivationPath {
         self.0.path()
     }
 
+    // Assumes `key` query-string key
     pub fn get_query(&self) -> String {
         if let Some(account) = &self.account() {
             if let Some(change) = &self.change() {
@@ -118,6 +120,31 @@ impl DerivationPath {
             }
         } else {
             "".to_string()
+        }
+    }
+
+    // Only accepts single query string pair of type `key`
+    pub fn from_uri(uri: &URIReference<'_>) -> Result<Option<Self>, DerivationPathError> {
+        if let Some(query) = uri.query() {
+            let query_str = query.as_str();
+            let query = qstring::QString::from(query_str);
+            if query.len() > 1 {
+                return Err(DerivationPathError::InvalidDerivationPath(
+                    "invalid query string, extra fields not supported".to_string(),
+                ));
+            }
+            let key = query.get("key");
+            if key.is_none() {
+                return Err(DerivationPathError::InvalidDerivationPath(format!(
+                    "invalid query string `{}`, only `key` supported",
+                    query_str,
+                )));
+            }
+            // Use from_key_str instead of TryInto here to make it a little more explicit that this
+            // generates a Solana bip44 DerivationPath
+            Self::from_key_str(key.unwrap()).map(Some)
+        } else {
+            Ok(None)
         }
     }
 }
@@ -161,6 +188,7 @@ impl Bip44 for Solana {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uriparse::URIReferenceBuilder;
 
     struct TestCoin;
     impl Bip44 for TestCoin {
@@ -261,6 +289,164 @@ mod tests {
                 ChildIndex::Hardened(0),
             ])
         );
+    }
+
+    #[test]
+    fn test_new_from_uri() {
+        let derivation_path = DerivationPath::new_bip44(Some(0), Some(0));
+
+        // test://path?key=0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert_eq!(
+            DerivationPath::from_uri(&uri).unwrap(),
+            Some(derivation_path.clone())
+        );
+
+        // test://path?key=0'/0'
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0'/0'"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert_eq!(
+            DerivationPath::from_uri(&uri).unwrap(),
+            Some(derivation_path.clone())
+        );
+
+        // test://path?key=0\'/0\'
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0\'/0\'"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert_eq!(
+            DerivationPath::from_uri(&uri).unwrap(),
+            Some(derivation_path)
+        );
+
+        // test://path?key=0/0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0/0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
+
+        // test://path?key=0/0&bad-key=0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=0/0&bad-key=0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
+
+        // test://path?bad-key=0/0
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("bad-key=0/0"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
+
+        // test://path?key=bad-value
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key=bad-value"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
+
+        // test://path?key=
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key="))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
+
+        // test://path?key
+        let mut builder = URIReferenceBuilder::new();
+        builder
+            .try_scheme(Some("test"))
+            .unwrap()
+            .try_authority(Some("path"))
+            .unwrap()
+            .try_path("")
+            .unwrap()
+            .try_query(Some("key"))
+            .unwrap();
+        let uri = builder.build().unwrap();
+        assert!(matches!(
+            DerivationPath::from_uri(&uri),
+            Err(DerivationPathError::InvalidDerivationPath(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
DerivationPath parsing doesn't lend itself to code sharing (only available for `SignerSource::Usb`-type signers, within remote-wallet).

#### Summary of Changes
Refactor it:
- Add `DerivationPath::from_uri()` method that implements the DerivationPath parsing previously in `Locator::new_from_uri()`; move test cases to target derivation-path specifically
- Convert `SignerSource` to a struct that wraps the old `kind` and includes and optional `derivation_path`

Toward #5246
