### PR TITLE
fix: optional stake lockup field parameters

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -40,6 +40,12 @@ export class PublicKey {
   }
 
   /**
+   * Default public key value. (All zeros)
+   */
+  static default: PublicKey = new PublicKey(
+    '11111111111111111111111111111111',
+  );
+  /**
    * Checks if two publicKeys are equal
    */
   equals(publicKey: PublicKey): boolean {

--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -42,9 +42,8 @@ export class PublicKey {
   /**
    * Default public key value. (All zeros)
    */
-  static default: PublicKey = new PublicKey(
-    '11111111111111111111111111111111',
-  );
+  static default: PublicKey = new PublicKey('11111111111111111111111111111111');
+
   /**
    * Checks if two publicKeys are equal
    */

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -59,6 +59,11 @@ export class Lockup {
     this.epoch = epoch;
     this.custodian = custodian;
   }
+
+  /**
+   * Default, inactive Lockup value
+   */
+  static default: Lockup = new Lockup(0, 0, PublicKey.default);
 }
 
 /**
@@ -72,7 +77,7 @@ export type CreateStakeAccountParams = {
   /** Authorities of the new stake account */
   authorized: Authorized;
   /** Lockup of the new stake account */
-  lockup: Lockup;
+  lockup?: Lockup;
   /** Funding amount */
   lamports: number;
 };
@@ -86,7 +91,7 @@ export type CreateStakeAccountWithSeedParams = {
   basePubkey: PublicKey;
   seed: string;
   authorized: Authorized;
-  lockup: Lockup;
+  lockup?: Lockup;
   lamports: number;
 };
 
@@ -96,7 +101,7 @@ export type CreateStakeAccountWithSeedParams = {
 export type InitializeStakeParams = {
   stakePubkey: PublicKey;
   authorized: Authorized;
-  lockup: Lockup;
+  lockup?: Lockup;
 };
 
 /**
@@ -502,7 +507,8 @@ export class StakeProgram {
    * Generate an Initialize instruction to add to a Stake Create transaction
    */
   static initialize(params: InitializeStakeParams): TransactionInstruction {
-    const {stakePubkey, authorized, lockup} = params;
+    const {stakePubkey, authorized, lockup: maybe_lockup} = params;
+    const lockup: Lockup = (typeof maybe_lockup !== 'undefined') ? maybe_lockup : Lockup.default;
     const type = STAKE_INSTRUCTION_LAYOUTS.Initialize;
     const data = encodeData(type, {
       authorized: {

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -507,8 +507,8 @@ export class StakeProgram {
    * Generate an Initialize instruction to add to a Stake Create transaction
    */
   static initialize(params: InitializeStakeParams): TransactionInstruction {
-    const {stakePubkey, authorized, lockup: maybe_lockup} = params;
-    const lockup: Lockup = (typeof maybe_lockup !== 'undefined') ? maybe_lockup : Lockup.default;
+    const {stakePubkey, authorized, lockup: maybeLockup} = params;
+    const lockup: Lockup = maybeLockup || Lockup.default;
     const type = STAKE_INSTRUCTION_LAYOUTS.Initialize;
     const data = encodeData(type, {
       authorized: {

--- a/web3.js/test/stake-program.test.ts
+++ b/web3.js/test/stake-program.test.ts
@@ -367,7 +367,6 @@ describe('StakeProgram', () => {
             authorized.publicKey,
             authorized.publicKey,
           ),
-          lockup: new Lockup(0, 0, new PublicKey(0)),
           lamports: minimumAmount + 42,
         });
 


### PR DESCRIPTION
#### Problem

I used the "chore" semantic commit prefix on a commit I meant to release.  Now I need to "fix" something, so...

--

`Lockups` are a fringe feature of the stake program.  It's annoying to have to specify them when creating/initializing stake accounts

#### Summary of Changes

Make them optional

Fixes #15326
