### PR TITLE
Add test to ensure data shreds with empty data would be inserted

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5303,17 +5303,46 @@ pub mod tests {
             let mut shred5 = shreds[5].clone();
             shred5.payload.push(10);
             shred5.data_header.size = shred5.payload.len() as u16;
-            assert_eq!(
-                blockstore.should_insert_data_shred(
-                    &shred5,
-                    &slot_meta,
-                    &HashMap::new(),
-                    &last_root,
-                    None,
-                    false
-                ),
+            assert!(!blockstore.should_insert_data_shred(
+                &shred5,
+                &slot_meta,
+                &HashMap::new(),
+                &last_root,
+                None,
                 false
+            ));
+
+            // Ensure that an empty shred (one with no data) would get inserted. Such shreds
+            // may be used as signals (broadcast does so to indicate a slot was interrupted)
+            // Reuse shred5's header values to avoid a false negative result
+            let mut empty_shred = Shred::new_from_data(
+                shred5.common_header.slot,
+                shred5.common_header.index,
+                shred5.data_header.parent_offset,
+                None, // data
+                true, // is_last_data
+                true, // is_last_in_slot
+                0,    // reference_tick
+                shred5.common_header.version,
+                shred5.common_header.fec_set_index,
             );
+            assert!(blockstore.should_insert_data_shred(
+                &empty_shred,
+                &slot_meta,
+                &HashMap::new(),
+                &last_root,
+                None,
+                false
+            ));
+            empty_shred.data_header.size = 0;
+            assert!(!blockstore.should_insert_data_shred(
+                &empty_shred,
+                &slot_meta,
+                &HashMap::new(),
+                &last_root,
+                None,
+                false
+            ));
 
             // Trying to insert another "is_last" shred with index < the received index should fail
             // skip over shred 7


### PR DESCRIPTION
#### Problem
Per discussion linked below, it isn't immediately obvious that empty shreds (headers but no payload) would be inserted into blockstore
https://github.com/solana-labs/solana/pull/16602#discussion_r623232699

#### Summary of Changes
Add test to ensure shreds created with no data are treated as valid in the eyes of the blockstore
