### PR TITLE
docs: fix copy-pasta breaking typo in `getRecentBlockhash` example

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1887,7 +1887,7 @@ An RpcResponse containing a JSON object consisting of a string blockhash and Fee
 
 Request:
 ```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d 'i
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
   {"jsonrpc":"2.0","id":1, "method":"getRecentBlockhash"}
 '
 ```


### PR DESCRIPTION
#### Problem

Pesky `vim` users

#### Summary of Changes

Fix typo
