### PR TITLE
account.rent_epoch private

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -39,7 +39,7 @@ pub struct AccountSharedData {
     /// this account's data contains a loaded program (and is now read-only)
     executable: bool,
     /// the epoch at which this account will next owe rent
-    pub rent_epoch: Epoch,
+    rent_epoch: Epoch,
 }
 
 /// Compares two ReadableAccounts


### PR DESCRIPTION
#### Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

#### Summary of Changes
Nobody uses rent_epoch directly anymore, so make private.

Fixes #
