### PR TITLE
tests: lamports -> lamports()

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1320,7 +1320,7 @@ pub mod test {
         },
     };
     use solana_sdk::{
-        account::{Account, AccountSharedData, WritableAccount},
+        account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         clock::Slot,
         hash::Hash,
         pubkey::Pubkey,
@@ -2459,7 +2459,7 @@ pub mod test {
         });
         let set: HashSet<u64> = vec![0u64, 1u64].into_iter().collect();
         let ancestors: HashMap<u64, HashSet<u64>> = [(2u64, set)].iter().cloned().collect();
-        Tower::update_ancestor_voted_stakes(&mut voted_stakes, 2, account.lamports, &ancestors);
+        Tower::update_ancestor_voted_stakes(&mut voted_stakes, 2, account.lamports(), &ancestors);
         assert_eq!(voted_stakes[&0], 1);
         assert_eq!(voted_stakes[&1], 1);
         assert_eq!(voted_stakes[&2], 1);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1602,7 +1602,7 @@ mod tests {
         assert_eq!(bank.get_balance(&buffer_address), 0);
         assert_eq!(None, bank.get_account(&buffer_address));
         let post_program_account = bank.get_account(&program_keypair.pubkey()).unwrap();
-        assert_eq!(post_program_account.lamports, min_program_balance);
+        assert_eq!(post_program_account.lamports(), min_program_balance);
         assert_eq!(post_program_account.owner(), &bpf_loader_upgradeable::id());
         assert_eq!(
             post_program_account.data().len(),
@@ -1616,7 +1616,7 @@ mod tests {
             }
         );
         let post_programdata_account = bank.get_account(&programdata_address).unwrap();
-        assert_eq!(post_programdata_account.lamports, min_programdata_balance);
+        assert_eq!(post_programdata_account.lamports(), min_programdata_balance);
         assert_eq!(
             post_programdata_account.owner(),
             &bpf_loader_upgradeable::id()

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -3114,7 +3114,7 @@ mod tests {
             ),
             Ok(())
         );
-        assert_eq!(stake_account.borrow().lamports, 0);
+        assert_eq!(stake_account.borrow().lamports(), 0);
         assert_eq!(stake_keyed_account.state(), Ok(StakeState::Uninitialized));
 
         // reset balance
@@ -4393,11 +4393,11 @@ mod tests {
                     ))
                 );
                 assert_eq!(
-                    stake_keyed_account.account.borrow().lamports,
+                    stake_keyed_account.account.borrow().lamports(),
                     rent_exempt_reserve + 1
                 );
                 assert_eq!(
-                    split_stake_keyed_account.account.borrow().lamports,
+                    split_stake_keyed_account.account.borrow().lamports(),
                     10_000_000 + stake_lamports - rent_exempt_reserve - 1
                 );
             }
@@ -4450,8 +4450,8 @@ mod tests {
             );
             // no lamport leakage
             assert_eq!(
-                stake_keyed_account.account.borrow().lamports
-                    + split_stake_keyed_account.account.borrow().lamports,
+                stake_keyed_account.account.borrow().lamports()
+                    + split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports
             );
 
@@ -4591,8 +4591,8 @@ mod tests {
             );
             // no lamport leakage
             assert_eq!(
-                stake_keyed_account.account.borrow().lamports
-                    + split_stake_keyed_account.account.borrow().lamports,
+                stake_keyed_account.account.borrow().lamports()
+                    + split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports + initial_balance
             );
 
@@ -4614,7 +4614,7 @@ mod tests {
                     split_stake_keyed_account.state()
                 );
                 assert_eq!(
-                    split_stake_keyed_account.account.borrow().lamports,
+                    split_stake_keyed_account.account.borrow().lamports(),
                     expected_stake
                         + rent_exempt_reserve
                         + initial_balance.saturating_sub(rent_exempt_reserve)
@@ -4706,8 +4706,8 @@ mod tests {
             );
             // no lamport leakage
             assert_eq!(
-                stake_keyed_account.account.borrow().lamports
-                    + split_stake_keyed_account.account.borrow().lamports,
+                stake_keyed_account.account.borrow().lamports()
+                    + split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports + initial_balance
             );
 
@@ -4734,7 +4734,7 @@ mod tests {
                     split_stake_keyed_account.state()
                 );
                 assert_eq!(
-                    split_stake_keyed_account.account.borrow().lamports,
+                    split_stake_keyed_account.account.borrow().lamports(),
                     expected_stake
                         + expected_rent_exempt_reserve
                         + initial_balance.saturating_sub(expected_rent_exempt_reserve)
@@ -4875,8 +4875,8 @@ mod tests {
 
             // no lamport leakage
             assert_eq!(
-                stake_keyed_account.account.borrow().lamports
-                    + split_stake_keyed_account.account.borrow().lamports,
+                stake_keyed_account.account.borrow().lamports()
+                    + split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports
             );
 
@@ -4965,8 +4965,8 @@ mod tests {
 
             // no lamport leakage
             assert_eq!(
-                stake_keyed_account.account.borrow().lamports
-                    + split_stake_keyed_account.account.borrow().lamports,
+                stake_keyed_account.account.borrow().lamports()
+                    + split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports + initial_balance
             );
 
@@ -5064,7 +5064,7 @@ mod tests {
             );
 
             assert_eq!(
-                split_stake_keyed_account.account.borrow().lamports,
+                split_stake_keyed_account.account.borrow().lamports(),
                 stake_lamports
             );
 
@@ -5106,7 +5106,7 @@ mod tests {
                         split_stake_keyed_account.state()
                     );
                     assert_eq!(
-                        split_stake_keyed_account.account.borrow().lamports,
+                        split_stake_keyed_account.account.borrow().lamports(),
                         expected_stake
                             + expected_rent_exempt_reserve
                             + (rent_exempt_reserve - expected_rent_exempt_reserve)
@@ -5186,10 +5186,10 @@ mod tests {
 
                 // check lamports
                 assert_eq!(
-                    stake_keyed_account.account.borrow().lamports,
+                    stake_keyed_account.account.borrow().lamports(),
                     stake_lamports * 2
                 );
-                assert_eq!(source_stake_keyed_account.account.borrow().lamports, 0);
+                assert_eq!(source_stake_keyed_account.account.borrow().lamports(), 0);
 
                 // check state
                 match state {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1319,7 +1319,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         let (load_res, _nonce_rollback) = &loaded_accounts[0];
         let loaded_transaction = load_res.as_ref().unwrap();
-        assert_eq!(loaded_transaction.accounts[0].lamports, min_balance);
+        assert_eq!(loaded_transaction.accounts[0].lamports(), min_balance);
 
         // Fee leaves zero balance fails
         accounts[0].1.set_lamports(min_balance);
@@ -2345,7 +2345,10 @@ mod tests {
             .map(|(_pubkey, account)| *account)
             .cloned()
             .unwrap();
-        assert_eq!(collected_nonce_account.lamports, nonce_account_pre.lamports,);
+        assert_eq!(
+            collected_nonce_account.lamports(),
+            nonce_account_pre.lamports(),
+        );
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
             &next_blockhash
@@ -2447,7 +2450,10 @@ mod tests {
             .map(|(_pubkey, account)| *account)
             .cloned()
             .unwrap();
-        assert_eq!(collected_nonce_account.lamports, nonce_account_pre.lamports);
+        assert_eq!(
+            collected_nonce_account.lamports(),
+            nonce_account_pre.lamports()
+        );
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
             &next_blockhash

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6263,14 +6263,14 @@ pub mod tests {
             {
                 account.checked_add_lamports(1).unwrap();
                 accounts.store_uncached(slot, &[(&pubkeys[idx], &account)]);
-                if account.lamports == 0 {
+                if account.lamports() == 0 {
                     let ancestors = vec![(slot, 0)].into_iter().collect();
                     assert!(accounts
                         .load_without_fixed_root(&ancestors, &pubkeys[idx])
                         .is_none());
                 } else {
                     let default_account = AccountSharedData::from(Account {
-                        lamports: account.lamports,
+                        lamports: account.lamports(),
                         ..Account::default()
                     });
                     assert_eq!(default_account, account);
@@ -6405,7 +6405,7 @@ pub mod tests {
                     .load_without_fixed_root(&ancestors, &key)
                     .unwrap()
                     .0
-                    .lamports,
+                    .lamports(),
                 (i as u64) + 1
             );
         }
@@ -7002,7 +7002,7 @@ pub mod tests {
         let (account, slot) = accounts
             .load_without_fixed_root(&ancestors, &pubkey)
             .unwrap();
-        assert_eq!((account.lamports, slot), (expected_lamports, slot));
+        assert_eq!((account.lamports(), slot), (expected_lamports, slot));
     }
 
     fn assert_not_load_account(accounts: &AccountsDb, slot: Slot, pubkey: Pubkey) {
@@ -7335,7 +7335,7 @@ pub mod tests {
                                     panic!("Could not fetch stored account {}, iter {}", pubkey, i)
                                 });
                             assert_eq!(slot, slot);
-                            assert_eq!(account.lamports, account_bal);
+                            assert_eq!(account.lamports(), account_bal);
                             i += 1;
                         }
                     })
@@ -7413,7 +7413,7 @@ pub mod tests {
             db.load_without_fixed_root(&ancestors, &key1)
                 .unwrap()
                 .0
-                .lamports,
+                .lamports(),
             3
         );
     }
@@ -8643,14 +8643,14 @@ pub mod tests {
         let normal_sysvar = solana_sdk::account::create_account_for_test(
             &solana_sdk::slot_history::SlotHistory::default(),
         );
-        assert_eq!(normal_sysvar.lamports, 1);
+        assert_eq!(normal_sysvar.lamports(), 1);
     }
 
     #[test]
     fn test_account_balance_for_capitalization_native_program() {
         let normal_native_program =
             solana_sdk::native_loader::create_loadable_account_for_test("foo");
-        assert_eq!(normal_native_program.lamports, 1);
+        assert_eq!(normal_native_program.lamports(), 1);
     }
 
     #[test]
@@ -8973,13 +8973,13 @@ pub mod tests {
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
-        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
-        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
         db.store_cached(2, &[(&account_key, &zero_lamport_account)]);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
@@ -8987,7 +8987,7 @@ pub mod tests {
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
-        assert_eq!(account.lamports, 0);
+        assert_eq!(account.lamports(), 0);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
     }
 
@@ -9021,7 +9021,7 @@ pub mod tests {
                 LoadHint::Unspecified,
             )
             .unwrap();
-        assert_eq!(account.0.lamports, 0);
+        assert_eq!(account.0.lamports(), 0);
         // since this item is in the cache, it should not be in the read only cache
         assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
 
@@ -9112,7 +9112,7 @@ pub mod tests {
             )
             .unwrap()
             .0
-            .lamports,
+            .lamports(),
             0
         );
     }
@@ -9233,7 +9233,7 @@ pub mod tests {
                 LoadHint::Unspecified,
             )
             .unwrap();
-        assert_eq!(account.0.lamports, zero_lamport_account.lamports);
+        assert_eq!(account.0.lamports(), zero_lamport_account.lamports());
 
         // Run clean, unrooted slot 1 should not be purged, and still readable from the cache,
         // because we're still doing a scan on it.
@@ -9246,7 +9246,7 @@ pub mod tests {
                 LoadHint::Unspecified,
             )
             .unwrap();
-        assert_eq!(account.0.lamports, slot1_account.lamports);
+        assert_eq!(account.0.lamports(), slot1_account.lamports());
 
         // When the scan is over, clean should not panic and should not purge something
         // still in the cache.
@@ -9260,7 +9260,7 @@ pub mod tests {
                 LoadHint::Unspecified,
             )
             .unwrap();
-        assert_eq!(account.0.lamports, slot1_account.lamports);
+        assert_eq!(account.0.lamports(), slot1_account.lamports());
 
         // Simulate dropping the bank, which finally removes the slot from the cache
         db.purge_slot(1);
@@ -9979,7 +9979,7 @@ pub mod tests {
                     let loaded_account = db.do_load(&ancestors, &pubkey, None, load_hint).unwrap();
                     // slot + 1 == account.lamports because of the account-cache-flush thread
                     assert_eq!(
-                        loaded_account.0.lamports,
+                        loaded_account.0.lamports(),
                         expected_lamports(&loaded_account)
                     );
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2157,7 +2157,7 @@ impl Bank {
                 panic!("{} repeated in genesis config", pubkey);
             }
             self.store_account(pubkey, &AccountSharedData::from(account.clone()));
-            self.capitalization.fetch_add(account.lamports, Relaxed);
+            self.capitalization.fetch_add(account.lamports(), Relaxed);
         }
         // updating sysvars (the fees sysvar in this case) now depends on feature activations in
         // genesis_config.accounts above
@@ -6195,7 +6195,7 @@ pub(crate) mod tests {
         // account data is blank now
         assert_eq!(account10.data().len(), 0);
         // 10 - 10(Rent) + 929(Transfer) - magic_rent_number(Rent)
-        assert_eq!(account10.lamports, 929 - magic_rent_number);
+        assert_eq!(account10.lamports(), 929 - magic_rent_number);
         rent_collected += magic_rent_number + 10;
 
         // 48993 - generic_rent_due_for_system_account(Rent)
@@ -6880,7 +6880,7 @@ pub(crate) mod tests {
 
         assert_eq!(bank.collected_rent.load(Relaxed), 0);
         assert_eq!(
-            bank.get_account(&rent_due_pubkey).unwrap().lamports,
+            bank.get_account(&rent_due_pubkey).unwrap().lamports(),
             little_lamports
         );
         assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch(), 0);
@@ -6902,12 +6902,12 @@ pub(crate) mod tests {
         // unrelated 1-lamport account exists
         assert_eq!(bank.collected_rent.load(Relaxed), rent_collected + 1);
         assert_eq!(
-            bank.get_account(&rent_due_pubkey).unwrap().lamports,
+            bank.get_account(&rent_due_pubkey).unwrap().lamports(),
             little_lamports - rent_collected
         );
         assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch(), 6);
         assert_eq!(
-            bank.get_account(&rent_exempt_pubkey).unwrap().lamports,
+            bank.get_account(&rent_exempt_pubkey).unwrap().lamports(),
             large_lamports
         );
         assert_eq!(
@@ -7086,8 +7086,8 @@ pub(crate) mod tests {
 
         // verify the stake and vote accounts are the right size
         assert!(
-            ((bank1.get_balance(&stake_id) - stake_account.lamports + bank1.get_balance(&vote_id)
-                - vote_account.lamports) as f64
+            ((bank1.get_balance(&stake_id) - stake_account.lamports() + bank1.get_balance(&vote_id)
+                - vote_account.lamports()) as f64
                 - rewards.validator_point_value * validator_points as f64)
                 .abs()
                 < 1.0
@@ -7254,7 +7254,7 @@ pub(crate) mod tests {
         let tx = system_transaction::transfer(&keypair, &pubkey, 10, blockhash);
         bank1.process_transaction(&tx).unwrap();
 
-        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
+        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports(), 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank0 purge");
@@ -7262,13 +7262,13 @@ pub(crate) mod tests {
         bank0.clean_accounts(false);
         assert_eq!(bank0.update_accounts_hash(), hash);
 
-        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
+        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports(), 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank1 purge");
         bank1.clean_accounts(false);
 
-        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
+        assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports(), 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         assert!(bank0.verify_bank_hash());
@@ -8377,7 +8377,7 @@ pub(crate) mod tests {
         let result = bank1.get_account_modified_since_parent_with_fixed_root(&pubkey);
         assert!(result.is_some());
         let (account, slot) = result.unwrap();
-        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
         assert_eq!(slot, 0);
 
         let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 1));
@@ -8388,12 +8388,12 @@ pub(crate) mod tests {
         let result = bank1.get_account_modified_since_parent_with_fixed_root(&pubkey);
         assert!(result.is_some());
         let (account, slot) = result.unwrap();
-        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
         assert_eq!(slot, 0);
         let result = bank2.get_account_modified_since_parent_with_fixed_root(&pubkey);
         assert!(result.is_some());
         let (account, slot) = result.unwrap();
-        assert_eq!(account.lamports, 101);
+        assert_eq!(account.lamports(), 101);
         assert_eq!(slot, 1);
 
         bank1.squash();
@@ -9177,7 +9177,7 @@ pub(crate) mod tests {
         let ((vote_id, vote_account), (stake_id, stake_account)) =
             crate::stakes::tests::create_staked_node_accounts(1_0000);
         bank.capitalization
-            .fetch_add(vote_account.lamports + stake_account.lamports, Relaxed);
+            .fetch_add(vote_account.lamports() + stake_account.lamports(), Relaxed);
         bank.store_account(&vote_id, &vote_account);
         bank.store_account(&stake_id, &stake_account);
         assert!(!bank.stakes.read().unwrap().vote_accounts().is_empty());
@@ -11697,7 +11697,7 @@ pub(crate) mod tests {
                     let mut expected_lamports = None;
                     let mut target_accounts_found = HashSet::new();
                     for (pubkey, account) in accounts {
-                        let account_balance = account.lamports;
+                        let account_balance = account.lamports();
                         if pubkeys_to_modify_.contains(&pubkey) {
                             target_accounts_found.insert(pubkey);
                             if let Some(expected_lamports) = expected_lamports {
@@ -12154,7 +12154,7 @@ pub(crate) mod tests {
         let mut vote_account = bank
             .get_account(&validator_vote_keypairs0.vote_keypair.pubkey())
             .unwrap_or_default();
-        let original_lamports = vote_account.lamports;
+        let original_lamports = vote_account.lamports();
         vote_account.set_lamports(0);
         // Simulate vote account removal via full withdrawal
         bank.store_account(
@@ -12467,7 +12467,7 @@ pub(crate) mod tests {
         let orig_lamports = bank
             .get_account(&sysvar::recent_blockhashes::id())
             .unwrap()
-            .lamports;
+            .lamports();
         info!("{:?}", bank.get_account(&sysvar::recent_blockhashes::id()));
         let tx = system_transaction::transfer(&mint_keypair, &blockhash_sysvar, 10, blockhash);
         assert_eq!(
@@ -12480,7 +12480,7 @@ pub(crate) mod tests {
         assert_eq!(
             bank.get_account(&sysvar::recent_blockhashes::id())
                 .unwrap()
-                .lamports,
+                .lamports(),
             orig_lamports
         );
         info!("{:?}", bank.get_account(&sysvar::recent_blockhashes::id()));

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1898,8 +1898,8 @@ mod tests {
             &ancestors,
         );
         assert_eq!(result, Ok(()));
-        assert_eq!(accounts[0].borrow().lamports, 100);
-        assert_eq!(accounts[1].borrow().lamports, 0);
+        assert_eq!(accounts[0].borrow().lamports(), 100);
+        assert_eq!(accounts[1].borrow().lamports(), 0);
 
         let message = Message::new(
             &[Instruction::new_with_bincode(
@@ -1994,11 +1994,11 @@ mod tests {
                     MockSystemInstruction::MultiBorrowMut => {
                         let from_lamports = {
                             let from_account = keyed_accounts[0].try_account_ref_mut()?;
-                            from_account.lamports
+                            from_account.lamports()
                         };
                         let dup_lamports = {
                             let dup_account = keyed_accounts[2].try_account_ref_mut()?;
-                            dup_account.lamports
+                            dup_account.lamports()
                         };
                         if from_lamports != dup_lamports {
                             return Err(InstructionError::InvalidArgument);
@@ -2141,8 +2141,8 @@ mod tests {
             &ancestors,
         );
         assert_eq!(result, Ok(()));
-        assert_eq!(accounts[0].borrow().lamports, 80);
-        assert_eq!(accounts[1].borrow().lamports, 20);
+        assert_eq!(accounts[0].borrow().lamports(), 80);
+        assert_eq!(accounts[1].borrow().lamports(), 20);
         assert_eq!(accounts[0].borrow().data(), &vec![42]);
     }
 

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -148,19 +148,19 @@ mod tests {
         // collect rent on a newly-created account
         let collected = rent_collector
             .collect_from_created_account(&solana_sdk::pubkey::new_rand(), &mut created_account);
-        assert!(created_account.lamports < old_lamports);
-        assert_eq!(created_account.lamports + collected, old_lamports);
+        assert!(created_account.lamports() < old_lamports);
+        assert_eq!(created_account.lamports() + collected, old_lamports);
         assert_ne!(created_account.rent_epoch(), old_epoch);
 
         // collect rent on a already-existing account
         let collected = rent_collector
             .collect_from_existing_account(&solana_sdk::pubkey::new_rand(), &mut existing_account);
-        assert!(existing_account.lamports < old_lamports);
-        assert_eq!(existing_account.lamports + collected, old_lamports);
+        assert!(existing_account.lamports() < old_lamports);
+        assert_eq!(existing_account.lamports() + collected, old_lamports);
         assert_ne!(existing_account.rent_epoch(), old_epoch);
 
         // newly created account should be collected for less rent; thus more remaining balance
-        assert!(created_account.lamports() > existing_account.lamports);
+        assert!(created_account.lamports() > existing_account.lamports());
         assert_eq!(created_account.rent_epoch(), existing_account.rent_epoch());
     }
 
@@ -181,7 +181,7 @@ mod tests {
 
         // first mark account as being collected while being rent-exempt
         collected = rent_collector.collect_from_existing_account(&pubkey, &mut account);
-        assert_eq!(account.lamports, huge_lamports);
+        assert_eq!(account.lamports(), huge_lamports);
         assert_eq!(collected, 0);
 
         // decrease the balance not to be rent-exempt
@@ -189,7 +189,7 @@ mod tests {
 
         // ... and trigger another rent collection on the same epoch and check that rent is working
         collected = rent_collector.collect_from_existing_account(&pubkey, &mut account);
-        assert_eq!(account.lamports, tiny_lamports - collected);
+        assert_eq!(account.lamports(), tiny_lamports - collected);
         assert_ne!(collected, 0);
     }
 }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -535,8 +535,8 @@ mod tests {
             ),
             Ok(())
         );
-        assert_eq!(from_account.borrow().lamports, 50);
-        assert_eq!(to_account.borrow().lamports, 50);
+        assert_eq!(from_account.borrow().lamports(), 50);
+        assert_eq!(to_account.borrow().lamports(), 50);
         assert_eq!(to_account.borrow().owner(), &new_owner);
         assert_eq!(to_account.borrow().data(), &[0, 0]);
     }
@@ -569,8 +569,8 @@ mod tests {
             ),
             Ok(())
         );
-        assert_eq!(from_account.borrow().lamports, 50);
-        assert_eq!(to_account.borrow().lamports, 50);
+        assert_eq!(from_account.borrow().lamports(), 50);
+        assert_eq!(to_account.borrow().lamports(), 50);
         assert_eq!(to_account.borrow().owner(), &new_owner);
         assert_eq!(to_account.borrow().data(), &[0, 0]);
     }
@@ -606,8 +606,8 @@ mod tests {
             ),
             Ok(())
         );
-        assert_eq!(from_account.borrow().lamports, 50);
-        assert_eq!(to_account.borrow().lamports, 50);
+        assert_eq!(from_account.borrow().lamports(), 50);
+        assert_eq!(to_account.borrow().lamports(), 50);
         assert_eq!(to_account.borrow().owner(), &new_owner);
         assert_eq!(to_account.borrow().data(), &[0, 0]);
     }
@@ -658,7 +658,7 @@ mod tests {
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
-        assert_eq!(from_account.borrow().lamports, 100);
+        assert_eq!(from_account.borrow().lamports(), 100);
         assert_eq!(*to_account.borrow(), AccountSharedData::default());
     }
 
@@ -686,8 +686,8 @@ mod tests {
             Ok(())
         );
 
-        let from_lamports = from_account.borrow().lamports;
-        let to_lamports = to_account.borrow().lamports;
+        let from_lamports = from_account.borrow().lamports();
+        let to_lamports = to_account.borrow().lamports();
         let to_owner = *to_account.borrow().owner();
         assert_eq!(from_lamports, 100);
         assert_eq!(to_lamports, 0);
@@ -757,7 +757,7 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         );
         assert!(result.is_ok());
-        assert_eq!(to_account.borrow().lamports, 50);
+        assert_eq!(to_account.borrow().lamports(), 50);
         assert_eq!(
             to_account.borrow().data().len() as u64,
             MAX_PERMITTED_DATA_LENGTH
@@ -791,7 +791,7 @@ mod tests {
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
 
-        let from_lamports = from_account.borrow().lamports;
+        let from_lamports = from_account.borrow().lamports();
         assert_eq!(from_lamports, 100);
         assert_eq!(owned_account, unchanged_account);
 
@@ -809,7 +809,7 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
-        let from_lamports = from_account.borrow().lamports;
+        let from_lamports = from_account.borrow().lamports();
         assert_eq!(from_lamports, 100);
         assert_eq!(*owned_account.borrow(), unchanged_account);
 
@@ -1077,8 +1077,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         )
         .unwrap();
-        let from_lamports = from_keyed_account.account.borrow().lamports;
-        let to_lamports = to_keyed_account.account.borrow().lamports;
+        let from_lamports = from_keyed_account.account.borrow().lamports();
+        let to_lamports = to_keyed_account.account.borrow().lamports();
         assert_eq!(from_lamports, 50);
         assert_eq!(to_lamports, 51);
 
@@ -1091,8 +1091,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
-        assert_eq!(from_keyed_account.account.borrow().lamports, 50);
-        assert_eq!(to_keyed_account.account.borrow().lamports, 51);
+        assert_eq!(from_keyed_account.account.borrow().lamports(), 50);
+        assert_eq!(to_keyed_account.account.borrow().lamports(), 51);
 
         // test unsigned transfer of zero
         let from_keyed_account = KeyedAccount::new(&from, false, &from_account);
@@ -1104,8 +1104,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         )
         .is_ok(),);
-        assert_eq!(from_keyed_account.account.borrow().lamports, 50);
-        assert_eq!(to_keyed_account.account.borrow().lamports, 51);
+        assert_eq!(from_keyed_account.account.borrow().lamports(), 50);
+        assert_eq!(to_keyed_account.account.borrow().lamports(), 51);
     }
 
     #[test]
@@ -1131,8 +1131,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         )
         .unwrap();
-        let from_lamports = from_keyed_account.account.borrow().lamports;
-        let to_lamports = to_keyed_account.account.borrow().lamports;
+        let from_lamports = from_keyed_account.account.borrow().lamports();
+        let to_lamports = to_keyed_account.account.borrow().lamports();
         assert_eq!(from_lamports, 50);
         assert_eq!(to_lamports, 51);
 
@@ -1148,8 +1148,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
-        assert_eq!(from_keyed_account.account.borrow().lamports, 50);
-        assert_eq!(to_keyed_account.account.borrow().lamports, 51);
+        assert_eq!(from_keyed_account.account.borrow().lamports(), 50);
+        assert_eq!(to_keyed_account.account.borrow().lamports(), 51);
 
         // test unsigned transfer of zero
         let from_keyed_account = KeyedAccount::new(&from, false, &from_account);
@@ -1163,8 +1163,8 @@ mod tests {
             &MockInvokeContext::new(vec![]),
         )
         .is_ok(),);
-        assert_eq!(from_keyed_account.account.borrow().lamports, 50);
-        assert_eq!(to_keyed_account.account.borrow().lamports, 51);
+        assert_eq!(from_keyed_account.account.borrow().lamports(), 50);
+        assert_eq!(to_keyed_account.account.borrow().lamports(), 51);
     }
 
     #[test]

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -7,7 +7,7 @@ use solana_runtime::{
 };
 use solana_sdk::genesis_config::ClusterType;
 use solana_sdk::{
-    account::{AccountSharedData, WritableAccount},
+    account::{AccountSharedData, ReadableAccount, WritableAccount},
     clock::Slot,
     pubkey::Pubkey,
 };
@@ -48,7 +48,7 @@ fn test_shrink_and_clean() {
                 ));
             }
 
-            alive_accounts.retain(|(_pubkey, account)| account.lamports >= 1);
+            alive_accounts.retain(|(_pubkey, account)| account.lamports() >= 1);
 
             for (pubkey, account) in alive_accounts.iter_mut() {
                 account.checked_sub_lamports(1).unwrap();

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -280,7 +280,7 @@ mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
     use solana_sdk::{
-        account::AccountSharedData,
+        account::{AccountSharedData, ReadableAccount},
         client::SyncClient,
         genesis_config::create_genesis_config,
         signature::{Keypair, Signer},
@@ -374,7 +374,7 @@ mod tests {
             .unwrap();
 
         let account = get_account_at(&bank_client, &base_pubkey, 0);
-        assert_eq!(account.lamports, lamports);
+        assert_eq!(account.lamports(), lamports);
         let authorized = StakeState::authorized_from(&account).unwrap();
         assert_eq!(authorized.staker, stake_authority_pubkey);
         assert_eq!(authorized.withdrawer, withdraw_authority_pubkey);


### PR DESCRIPTION
#### Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

#### Summary of Changes
lamports -> lamports()

Fixes #