### PR TITLE
add option --priority-trusted-validator

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -100,7 +100,8 @@ pub struct ValidatorConfig {
     pub fixed_leader_schedule: Option<FixedSchedule>,
     pub wait_for_supermajority: Option<Slot>,
     pub new_hard_forks: Option<Vec<Slot>>,
-    pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all
+    pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all, priority included
+    pub priority_trusted_validators: Option<HashSet<Pubkey>>, // None = all - common trusted
     pub repair_validators: Option<HashSet<Pubkey>>,  // None = repair from all
     pub gossip_validators: Option<HashSet<Pubkey>>,  // None = gossip with all
     pub halt_on_trusted_validators_accounts_hash_mismatch: bool,
@@ -156,6 +157,7 @@ impl Default for ValidatorConfig {
             wait_for_supermajority: None,
             new_hard_forks: None,
             trusted_validators: None,
+            priority_trusted_validators: None,
             repair_validators: None,
             gossip_validators: None,
             halt_on_trusted_validators_accounts_hash_mismatch: false,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -22,6 +22,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wait_for_supermajority: config.wait_for_supermajority,
         new_hard_forks: config.new_hard_forks.clone(),
         trusted_validators: config.trusted_validators.clone(),
+        priority_trusted_validators: config.priority_trusted_validators.clone(),
         repair_validators: config.repair_validators.clone(),
         gossip_validators: config.gossip_validators.clone(),
         halt_on_trusted_validators_accounts_hash_mismatch: config


### PR DESCRIPTION
#### Problem
Sometimes I get this (see picture). And I saw many messages about this problem many times in telegram chat.
![submitting 28 points](https://user-images.githubusercontent.com/71597545/116794265-61786180-aad4-11eb-85fb-f9a99634534b.png)

#### Summary of Changes

I have added new option `--primary-trusted-validator`. First 100 times (in loop) validator wait only primary trusted validators for download snapshot (if they presented). 
