### PR TITLE
feat: add getSlotLeaders method

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2470,6 +2470,25 @@ export class Connection {
   }
 
   /**
+   * Fetch `limit` number of slot leaders starting from `startSlot`
+   *
+   * @param startSlot fetch slot leaders starting from this slot
+   * @param limit number of slot leaders to return
+   */
+  async getSlotLeaders(
+    startSlot: number,
+    limit: number,
+  ): Promise<Array<PublicKey>> {
+    const args = [startSlot, limit];
+    const unsafeRes = await this._rpcRequest('getSlotLeaders', args);
+    const res = create(unsafeRes, jsonRpcResult(array(PublicKeyFromString)));
+    if ('error' in res) {
+      throw new Error('failed to get slot leaders: ' + res.error.message);
+    }
+    return res.result;
+  }
+
+  /**
    * Fetch the current status of a signature
    */
   async getSignatureStatus(

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -735,6 +735,18 @@ describe('Connection', () => {
     }
   });
 
+  it('get slot leaders', async () => {
+    await mockRpcResponse({
+      method: 'getSlotLeaders',
+      params: [0, 1],
+      value: ['11111111111111111111111111111111'],
+    });
+
+    const slotLeaders = await connection.getSlotLeaders(0, 1);
+    expect(slotLeaders).to.have.length(1);
+    expect(slotLeaders[0]).to.be.instanceOf(PublicKey);
+  });
+
   it('get cluster nodes', async () => {
     await mockRpcResponse({
       method: 'getClusterNodes',


### PR DESCRIPTION
#### Problem
No way to use the less resource intensive API `getSlotLeaders` to fetch the upcoming leader schedule

#### Summary of Changes

Fixes #
