### PR TITLE
Update web3.js import sample

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -69,7 +69,7 @@ console.log(solanaWeb3);
 
 ### ES6
 ```js
-import solanaWeb3 from '@solana/web3.js';
+import * as solanaWeb3 from '@solana/web3.js';
 console.log(solanaWeb3);
 ```
 


### PR DESCRIPTION
#### Problem

I was using this with Create React App and I noticed that the documentation on importing web3.js as an ES6 module is incorrect.

#### Summary of Changes
The documentation states `import solanaWeb3 from '@solana/web3.js'` which would bring in the default export, but there is no default export specified in the [index file](https://github.com/solana-labs/solana/blob/master/web3.js/src/index.ts). In this case it should be `import * as solanaWeb3 from '@solana/web3.js';`
