### PR TITLE
test-validator: Plumb --limit-ledger-size

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -82,6 +82,7 @@ pub struct TestValidatorGenesis {
     pub validator_exit: Arc<RwLock<ValidatorExit>>,
     pub start_progress: Arc<RwLock<ValidatorStartProgress>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+    pub max_ledger_shreds: Option<u64>,
 }
 
 impl TestValidatorGenesis {
@@ -497,9 +498,7 @@ impl TestValidator {
             bpf_jit: !config.no_bpf_jit,
             validator_exit: config.validator_exit.clone(),
             rocksdb_compaction_interval: Some(100), // Compact every 100 slots
-            max_ledger_shreds: Some(10_000), /* 10,000 was derived empirically by watching the size
-                                             of the rocksdb/ directory self-limit itself to the
-                                             40MB-150MB range when running `solana-test-validator` */
+            max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
             ..ValidatorConfig::default()
         };


### PR DESCRIPTION
#### Problem

`solana-test-validator` doesn't keep many shreds around by default and has no knob in case you'd like it to

#### Summary of Changes

Plumb `--limit-ledger-size`
