### PR TITLE
Add bpf_loader_upgradeable to ProgramTest default builtins

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -705,8 +705,10 @@ impl ProgramTest {
         add_builtin!(solana_bpf_loader_deprecated_program!());
         if self.use_bpf_jit {
             add_builtin!(solana_bpf_loader_program_with_jit!());
+            add_builtin!(solana_bpf_loader_upgradeable_program_with_jit!());
         } else {
             add_builtin!(solana_bpf_loader_program!());
+            add_builtin!(solana_bpf_loader_upgradeable_program!());
         }
 
         // Add commonly-used SPL programs as a convenience to the user

--- a/program-test/tests/builtins.rs
+++ b/program-test/tests/builtins.rs
@@ -1,0 +1,46 @@
+use solana_sdk::{
+    bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+    signature::Keypair,
+};
+
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{signature::Signer, transaction::Transaction},
+};
+
+#[tokio::test]
+async fn test_bpf_loader_upgradable_present() {
+    // Arrange
+    let (mut banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
+
+    let buffer_keypair = Keypair::new();
+    let upgrade_authority_keypair = Keypair::new();
+
+    let rent = banks_client.get_rent().await.unwrap();
+    let buffer_rent = rent.minimum_balance(UpgradeableLoaderState::programdata_len(1).unwrap());
+
+    let create_buffer_instructions = bpf_loader_upgradeable::create_buffer(
+        &payer.pubkey(),
+        &buffer_keypair.pubkey(),
+        &upgrade_authority_keypair.pubkey(),
+        buffer_rent,
+        1,
+    )
+    .unwrap();
+
+    let mut transaction =
+        Transaction::new_with_payer(&create_buffer_instructions[..], Some(&payer.pubkey()));
+    transaction.sign(&[&payer, &buffer_keypair], recent_blockhash);
+
+    // Act
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    // Assert
+    let buffer_account = banks_client
+        .get_account(buffer_keypair.pubkey())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
+}

--- a/program-test/tests/builtins.rs
+++ b/program-test/tests/builtins.rs
@@ -1,12 +1,10 @@
 use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    signature::Keypair,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
 };
 
-use {
-    solana_program_test::ProgramTest,
-    solana_sdk::{signature::Signer, transaction::Transaction},
-};
+use solana_program_test::ProgramTest;
 
 #[tokio::test]
 async fn test_bpf_loader_upgradable_present() {


### PR DESCRIPTION
#### Problem

bpf_loader_upgradeable program is not loaded by default by ProgramTest and has to be added manually when required.

#### Summary of Changes

Add bpf_loader_upgradeable program to default builtins for ProgramTest
