### PR TITLE
Test account index and store alignment

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1314,7 +1314,7 @@ impl AccountsDb {
         max_clean_root: Option<Slot>,
     ) -> ReclaimResult {
         if purges.is_empty() {
-            return (HashMap::new(), HashMap::new());
+            return ReclaimResult::default();
         }
         // This number isn't carefully chosen; just guessed randomly such that
         // the hot loop will be the order of ~Xms.
@@ -1345,7 +1345,7 @@ impl AccountsDb {
         // and those stores may be used for background hashing.
         let reset_accounts = false;
 
-        let mut reclaim_result = (HashMap::new(), HashMap::new());
+        let mut reclaim_result = ReclaimResult::default();
         self.handle_reclaims(
             &reclaims,
             None,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6695,7 +6695,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_clean_multiple_zero_lamport_store_matches_index() {
+    fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
         solana_logger::setup();
 
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6704,17 +6704,18 @@ pub mod tests {
         let zero_lamport_account =
             AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
-        // Store account 1 & 2 in slot 0, then update account 1 in several more slots
+        // Store 2 accounts in slot 0, then update account 1 in two more slots
         accounts.store_uncached(0, &[(&pubkey1, &zero_lamport_account)]);
         accounts.store_uncached(0, &[(&pubkey2, &zero_lamport_account)]);
         accounts.store_uncached(1, &[(&pubkey1, &zero_lamport_account)]);
         accounts.store_uncached(2, &[(&pubkey1, &zero_lamport_account)]);
-
+        // Root all slots
         accounts.add_root(0);
         accounts.add_root(1);
         accounts.add_root(2);
 
-        // Account 1 ref'd from all 3 slots, account 2 from only 1 slot
+        // Account ref counts should match how many slots they were stored in
+        // Account 1 = 3 slots; account 2 = 1 slot
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 3);
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 1);
 
@@ -6723,13 +6724,19 @@ pub mod tests {
         // accounts are zero lamports
         assert!(accounts.storage.get_slot_stores(0).is_none());
         assert!(accounts.storage.get_slot_stores(1).is_none());
-        // Slot 2 is still around because ...
+        // Slot 2 only has a zero lamport account as well. But, calc_delete_dependencies()
+        // should exclude slot 2 from the clean due to changes in other slots
         assert!(accounts.storage.get_slot_stores(2).is_some());
-        // Check that the index has also been updated to unreference accounts
-        // and is in-sync with the store. Account 1 should be ref'd from slot 2,
-        // account 1 should have no remaining refs in the index
+        // Index ref counts should be consistent with the slot stores. Account 1 ref count
+        // should be 1 since slot 2 is the only alive slot; account 2 should have a ref
+        // count of 0 due to slot 0 being dead
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 0);
+
+        accounts.clean_accounts(None);
+        // Slot 2 will now be cleaned, which will leave account 1 with a ref count of 0
+        assert!(accounts.storage.get_slot_stores(2).is_none());
+        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 0);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Jeff tracked down a regression in https://github.com/solana-labs/solana/pull/16838 that was a result of the store and index falling out of sync. This test adds protection for the desired behavior of (keeping store and index in sync) in our unit tests.

#### Summary of Changes
Adds a unit test (and other very minor cleanup)

Fixes #
