### PR TITLE
prunes received-cache only once per unique owner's key

### DIFF
--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -357,15 +357,11 @@ fn network_run_push(
                         })
                         .unwrap();
 
-                    let updated_labels: Vec<_> =
-                        updated.into_iter().map(|u| u.value.label()).collect();
+                    let origins: HashSet<_> =
+                        updated.into_iter().map(|u| u.value.pubkey()).collect();
                     let prunes_map = network
                         .get(&to)
-                        .map(|node| {
-                            node.lock()
-                                .unwrap()
-                                .prune_received_cache(updated_labels, &stakes)
-                        })
+                        .map(|node| node.lock().unwrap().prune_received_cache(origins, &stakes))
                         .unwrap();
 
                     for (from, prune_set) in prunes_map {


### PR DESCRIPTION
#### Problem
`prune_received_cache` is redundantly called with possibly duplicate origin keys:
https://github.com/solana-labs/solana/blob/a6a1355b8/core/src/cluster_info.rs#L2426-L2442


#### Summary of Changes
prune received-cache only once per unique owner's key
