### PR TITLE
Add ledger-tool for restoring roots to the Roots CF

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2821,13 +2821,13 @@ fn main() {
                 AccessType::TryPrimaryThenSecondary,
                 wal_recovery_mode,
             );
-            let start_root = if let Some(height) = arg_matches.value_of("start_root") {
-                Slot::from_str(height).expect("Before root must be a number")
+            let start_root = if let Some(root) = arg_matches.value_of("start_root") {
+                Slot::from_str(root).expect("Before root must be a number")
             } else {
                 blockstore.max_root()
             };
-            let end_root = if let Some(height) = arg_matches.value_of("end_root") {
-                Slot::from_str(height).expect("Until root must be a number")
+            let end_root = if let Some(root) = arg_matches.value_of("end_root") {
+                Slot::from_str(root).expect("Until root must be a number")
             } else {
                 blockstore.lowest_slot()
             };
@@ -2839,10 +2839,14 @@ fn main() {
                 .filter(|slot| !blockstore.is_root(*slot))
                 .collect();
             if !roots_to_fix.is_empty() {
-                blockstore.set_roots(&roots_to_fix).unwrap_or_else(|err| {
-                    eprintln!("Unable to set roots {:?}: {}", roots_to_fix, err);
-                    exit(1);
-                });
+                eprintln!("{} slots to be rooted", roots_to_fix.len());
+                for chunk in roots_to_fix.chunks(100) {
+                    eprintln!("{:?}", chunk);
+                    blockstore.set_roots(&roots_to_fix).unwrap_or_else(|err| {
+                        eprintln!("Unable to set roots {:?}: {}", roots_to_fix, err);
+                        exit(1);
+                    });
+                }
             } else {
                 println!(
                     "No missing roots found in range {} to {}",


### PR DESCRIPTION
#### Problem
Sometimes a chunk of blocks appear to be "missing" from the ledger because they are no longer recorded as roots in the blockstore Root CF. The cause of this Roots-CF data issue is not clear.

However, we can restore the data by walking backward from a known root through its ancestors.

#### Summary of Changes
- Add `solana-ledger-tool repair-roots` that use an AncestorIterator from a provided (and verified) root and rewriting missing entries to the cf::Root

Stopgap for #17000
