### PR TITLE
Remove bloat from secondary indexes

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1335,7 +1335,6 @@ impl AccountsDb {
                         &pubkey,
                         &mut reclaims,
                         max_clean_root,
-                        &self.account_indexes,
                     );
                 }
                 reclaims
@@ -1476,12 +1475,9 @@ impl AccountsDb {
         let mut dead_keys = Vec::new();
 
         for (pubkey, slots_set) in pubkey_to_slot_set {
-            let is_empty = self.accounts_index.purge_exact(
-                &pubkey,
-                slots_set,
-                &mut reclaims,
-                &self.account_indexes,
-            );
+            let is_empty = self
+                .accounts_index
+                .purge_exact(&pubkey, slots_set, &mut reclaims);
             if is_empty {
                 dead_keys.push(pubkey);
             }
@@ -3264,22 +3260,14 @@ impl AccountsDb {
         match scan_result {
             ScanStorageResult::Cached(cached_keys) => {
                 for pubkey in cached_keys.iter() {
-                    self.accounts_index.purge_exact(
-                        pubkey,
-                        &purge_slot,
-                        &mut reclaims,
-                        &self.account_indexes,
-                    );
+                    self.accounts_index
+                        .purge_exact(pubkey, &purge_slot, &mut reclaims);
                 }
             }
             ScanStorageResult::Stored(stored_keys) => {
                 for set_ref in stored_keys.iter() {
-                    self.accounts_index.purge_exact(
-                        set_ref.key(),
-                        &purge_slot,
-                        &mut reclaims,
-                        &self.account_indexes,
-                    );
+                    self.accounts_index
+                        .purge_exact(set_ref.key(), &purge_slot, &mut reclaims);
                 }
             }
         }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -878,10 +878,9 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                     if index_entry.get().slot_list.read().unwrap().is_empty() {
                         index_entry.remove();
 
-                        // Note passing `None` to remove all the entries for this key
-                        // is only safe because we have the lock for this key's entry
-                        // in the AccountsIndex, so no other thread is also updating
-                        // the index
+                        // Note it's only safe to remove all the entries for this key
+                        // because we have the lock for this key's entry in the AccountsIndex,
+                        // so no other thread is also updating the index
                         self.purge_secondary_indexes_by_inner_key(key, account_indexes);
                     }
                 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -492,7 +492,7 @@ pub trait ZeroLamport {
     fn is_zero_lamport(&self) -> bool;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AccountsIndex<T> {
     pub account_maps: RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
     program_id_index: SecondaryIndex<DashMapSecondaryIndexEntry>,
@@ -501,6 +501,26 @@ pub struct AccountsIndex<T> {
     roots_tracker: RwLock<RootsTracker>,
     ongoing_scan_roots: RwLock<BTreeMap<Slot, u64>>,
     zero_lamport_pubkeys: DashSet<Pubkey>,
+}
+
+impl<T> Default for AccountsIndex<T> {
+    fn default() -> Self {
+        Self {
+            account_maps: RwLock::<AccountMap<Pubkey, AccountMapEntry<T>>>::default(),
+            program_id_index: SecondaryIndex::<DashMapSecondaryIndexEntry>::new(
+                "program_id_index_stats",
+            ),
+            spl_token_mint_index: SecondaryIndex::<DashMapSecondaryIndexEntry>::new(
+                "spl_token_mint_index_stats",
+            ),
+            spl_token_owner_index: SecondaryIndex::<RwLockSecondaryIndexEntry>::new(
+                "spl_token_owner_index_stats",
+            ),
+            roots_tracker: RwLock::<RootsTracker>::default(),
+            ongoing_scan_roots: RwLock::<BTreeMap<Slot, u64>>::default(),
+            zero_lamport_pubkeys: DashSet::<Pubkey>::default(),
+        }
+    }
 }
 
 impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {

--- a/runtime/src/secondary_index.rs
+++ b/runtime/src/secondary_index.rs
@@ -24,9 +24,9 @@ pub struct DashMapSecondaryIndexEntry {
 
 impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
     fn insert_if_not_exists(&self, key: &Pubkey) {
-        self.account_keys
-            .get(key)
-            .unwrap_or_else(|| self.account_keys.entry(*key).or_default().downgrade());
+        if self.account_keys.get(key).is_none() {
+            self.account_keys.entry(*key).or_default();
+        }
     }
 
     fn remove_inner_key(&self, key: &Pubkey) -> bool {

--- a/runtime/src/secondary_index.rs
+++ b/runtime/src/secondary_index.rs
@@ -168,7 +168,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
             });
         }
 
-        let prev_key = {
+        /*let prev_key = {
             let slots_map = self.reverse_index.get(inner_key).unwrap_or_else(|| {
                 self.reverse_index
                     .entry(*inner_key)
@@ -204,7 +204,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
             if prev_key != *key {
                 self.remove_index_entries(&prev_key, inner_key, &[slot]);
             }
-        }
+        }*/
     }
 
     pub fn remove_index_entries(&self, key: &Pubkey, inner_key: &Pubkey, slots: &[Slot]) {
@@ -269,7 +269,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
 
         // Check if the entry for `inner_key` in the reverse index is empty
         // and can be removed
-        let needs_remove = {
+        /*let needs_remove = {
             if let Some(slots_to_remove) = slots_to_remove {
                 self.reverse_index
                     .get(inner_key)
@@ -316,7 +316,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
         // Remove this value from those keys
         for (key, slots) in key_to_removed_slots {
             self.remove_index_entries(&key, inner_key, &slots);
-        }
+        }*/
     }
 
     pub fn get(&self, key: &Pubkey) -> Vec<Pubkey> {

--- a/runtime/src/secondary_index.rs
+++ b/runtime/src/secondary_index.rs
@@ -19,68 +19,63 @@ pub trait SecondaryIndexEntry: Debug {
 
 #[derive(Debug, Default)]
 pub struct DashMapSecondaryIndexEntry {
-    pubkey_to_slot_set: DashMap<Pubkey, ()>,
+    account_keys: DashMap<Pubkey, ()>,
 }
 
 impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
     fn insert_if_not_exists(&self, key: &Pubkey) {
-        self.pubkey_to_slot_set
+        self.account_keys
             .get(key)
-            .unwrap_or_else(|| self.pubkey_to_slot_set.entry(*key).or_default().downgrade());
+            .unwrap_or_else(|| self.account_keys.entry(*key).or_default().downgrade());
     }
 
     fn remove_inner_key(&self, key: &Pubkey) -> bool {
-        self.pubkey_to_slot_set.remove(key).is_some()
+        self.account_keys.remove(key).is_some()
     }
 
     fn is_empty(&self) -> bool {
-        self.pubkey_to_slot_set.is_empty()
+        self.account_keys.is_empty()
     }
 
     fn keys(&self) -> Vec<Pubkey> {
-        self.pubkey_to_slot_set
+        self.account_keys
             .iter()
             .map(|entry_ref| *entry_ref.key())
             .collect()
     }
 
     fn len(&self) -> usize {
-        self.pubkey_to_slot_set.len()
+        self.account_keys.len()
     }
 }
 
 #[derive(Debug, Default)]
 pub struct RwLockSecondaryIndexEntry {
-    pubkey_to_slot_set: RwLock<HashSet<Pubkey>>,
+    account_keys: RwLock<HashSet<Pubkey>>,
 }
 
 impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
     fn insert_if_not_exists(&self, key: &Pubkey) {
-        let exists = self.pubkey_to_slot_set.read().unwrap().contains(key);
+        let exists = self.account_keys.read().unwrap().contains(key);
         if !exists {
-            self.pubkey_to_slot_set.write().unwrap().insert(*key);
+            self.account_keys.write().unwrap().insert(*key);
         };
     }
 
     fn remove_inner_key(&self, key: &Pubkey) -> bool {
-        self.pubkey_to_slot_set.write().unwrap().remove(key)
+        self.account_keys.write().unwrap().remove(key)
     }
 
     fn is_empty(&self) -> bool {
-        self.pubkey_to_slot_set.read().unwrap().is_empty()
+        self.account_keys.read().unwrap().is_empty()
     }
 
     fn keys(&self) -> Vec<Pubkey> {
-        self.pubkey_to_slot_set
-            .read()
-            .unwrap()
-            .iter()
-            .cloned()
-            .collect()
+        self.account_keys.read().unwrap().iter().cloned().collect()
     }
 
     fn len(&self) -> usize {
-        self.pubkey_to_slot_set.read().unwrap().len()
+        self.account_keys.read().unwrap().len()
     }
 }
 

--- a/runtime/src/secondary_index.rs
+++ b/runtime/src/secondary_index.rs
@@ -1,20 +1,13 @@
-use crate::contains::Contains;
 use dashmap::{mapref::entry::Entry::Occupied, DashMap};
-use log::*;
-use solana_sdk::{clock::Slot, pubkey::Pubkey};
-use std::{
-    borrow::Borrow,
-    collections::{hash_map, HashMap, HashSet},
-    fmt::Debug,
-    sync::{Arc, RwLock},
-};
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashSet, fmt::Debug, sync::RwLock};
 
-pub type SecondaryReverseIndexEntry = RwLock<HashMap<Slot, Pubkey>>;
+pub type SecondaryReverseIndexEntry = RwLock<HashSet<Pubkey>>;
 
 pub trait SecondaryIndexEntry: Debug {
-    fn get_or_create(&self, key: &Pubkey, f: &dyn Fn(&RwLock<HashSet<Slot>>));
-    fn get<T>(&self, key: &Pubkey, f: &dyn Fn(Option<&RwLock<HashSet<Slot>>>) -> T) -> T;
-    fn remove_key_if_empty(&self, key: &Pubkey);
+    fn insert_if_not_exists(&self, key: &Pubkey);
+    // Removes a value from the set. Returns whether the value was present in the set.
+    fn remove_inner_key(&self, key: &Pubkey) -> bool;
     fn is_empty(&self) -> bool;
     fn keys(&self) -> Vec<Pubkey>;
     fn len(&self) -> usize;
@@ -22,39 +15,18 @@ pub trait SecondaryIndexEntry: Debug {
 
 #[derive(Debug, Default)]
 pub struct DashMapSecondaryIndexEntry {
-    pubkey_to_slot_set: DashMap<Pubkey, RwLock<HashSet<Slot>>>,
+    pubkey_to_slot_set: DashMap<Pubkey, ()>,
 }
 
 impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
-    fn get_or_create(&self, key: &Pubkey, f: &dyn Fn(&RwLock<HashSet<Slot>>)) {
-        let slot_set = self.pubkey_to_slot_set.get(key).unwrap_or_else(|| {
-            self.pubkey_to_slot_set
-                .entry(*key)
-                .or_insert(RwLock::new(HashSet::new()))
-                .downgrade()
-        });
-
-        f(&slot_set)
+    fn insert_if_not_exists(&self, key: &Pubkey) {
+        self.pubkey_to_slot_set
+            .get(key)
+            .unwrap_or_else(|| self.pubkey_to_slot_set.entry(*key).or_default().downgrade());
     }
 
-    fn get<T>(&self, key: &Pubkey, f: &dyn Fn(Option<&RwLock<HashSet<Slot>>>) -> T) -> T {
-        let slot_set = self.pubkey_to_slot_set.get(key);
-
-        f(slot_set.as_ref().map(|entry_ref| entry_ref.value()))
-    }
-
-    fn remove_key_if_empty(&self, key: &Pubkey) {
-        if let Occupied(key_entry) = self.pubkey_to_slot_set.entry(*key) {
-            // Delete the `key` if the slot set is empty
-            let slot_set = key_entry.get();
-
-            // Write lock on `key_entry` above through the `entry`
-            // means nobody else has access to this lock at this time,
-            // so this check for empty -> remove() is atomic
-            if slot_set.read().unwrap().is_empty() {
-                key_entry.remove();
-            }
-        }
+    fn remove_inner_key(&self, key: &Pubkey) -> bool {
+        self.pubkey_to_slot_set.remove(key).is_some()
     }
 
     fn is_empty(&self) -> bool {
@@ -75,48 +47,19 @@ impl SecondaryIndexEntry for DashMapSecondaryIndexEntry {
 
 #[derive(Debug, Default)]
 pub struct RwLockSecondaryIndexEntry {
-    pubkey_to_slot_set: RwLock<HashMap<Pubkey, Arc<RwLock<HashSet<Slot>>>>>,
+    pubkey_to_slot_set: RwLock<HashSet<Pubkey>>,
 }
 
 impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
-    fn get_or_create(&self, key: &Pubkey, f: &dyn Fn(&RwLock<HashSet<Slot>>)) {
-        let slot_set = self.pubkey_to_slot_set.read().unwrap().get(key).cloned();
-
-        let slot_set = {
-            if let Some(slot_set) = slot_set {
-                slot_set
-            } else {
-                self.pubkey_to_slot_set
-                    .write()
-                    .unwrap()
-                    .entry(*key)
-                    .or_insert_with(|| Arc::new(RwLock::new(HashSet::new())))
-                    .clone()
-            }
+    fn insert_if_not_exists(&self, key: &Pubkey) {
+        let exists = self.pubkey_to_slot_set.read().unwrap().contains(key);
+        if !exists {
+            self.pubkey_to_slot_set.write().unwrap().insert(*key);
         };
-
-        f(&slot_set)
     }
 
-    fn get<T>(&self, key: &Pubkey, f: &dyn Fn(Option<&RwLock<HashSet<Slot>>>) -> T) -> T {
-        let slot_set = self.pubkey_to_slot_set.read().unwrap().get(key).cloned();
-        f(slot_set.as_deref())
-    }
-
-    fn remove_key_if_empty(&self, key: &Pubkey) {
-        if let hash_map::Entry::Occupied(key_entry) =
-            self.pubkey_to_slot_set.write().unwrap().entry(*key)
-        {
-            // Delete the `key` if the slot set is empty
-            let slot_set = key_entry.get();
-
-            // Write lock on `key_entry` above through the `entry`
-            // means nobody else has access to this lock at this time,
-            // so this check for empty -> remove() is atomic
-            if slot_set.read().unwrap().is_empty() {
-                key_entry.remove();
-            }
-        }
+    fn remove_inner_key(&self, key: &Pubkey) -> bool {
+        self.pubkey_to_slot_set.write().unwrap().remove(key)
     }
 
     fn is_empty(&self) -> bool {
@@ -127,7 +70,7 @@ impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
         self.pubkey_to_slot_set
             .read()
             .unwrap()
-            .keys()
+            .iter()
             .cloned()
             .collect()
     }
@@ -141,17 +84,13 @@ impl SecondaryIndexEntry for RwLockSecondaryIndexEntry {
 pub struct SecondaryIndex<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send> {
     // Map from index keys to index values
     pub index: DashMap<Pubkey, SecondaryIndexEntryType>,
-    // Map from index values back to index keys, used for cleanup.
-    // Alternative is to store Option<Pubkey> in each AccountInfo in the
-    // AccountsIndex if something is an SPL account with a mint, but then
-    // every AccountInfo would have to allocate `Option<Pubkey>`
     pub reverse_index: DashMap<Pubkey, SecondaryReverseIndexEntry>,
 }
 
 impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
     SecondaryIndex<SecondaryIndexEntryType>
 {
-    pub fn insert(&self, key: &Pubkey, inner_key: &Pubkey, slot: Slot) {
+    pub fn insert(&self, key: &Pubkey, inner_key: &Pubkey) {
         {
             let pubkeys_map = self.index.get(key).unwrap_or_else(|| {
                 self.index
@@ -160,92 +99,39 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
                     .downgrade()
             });
 
-            pubkeys_map.get_or_create(inner_key, &|slots_set: &RwLock<HashSet<Slot>>| {
-                let contains_key = slots_set.read().unwrap().contains(&slot);
-                if !contains_key {
-                    slots_set.write().unwrap().insert(slot);
-                }
-            });
+            pubkeys_map.insert_if_not_exists(inner_key);
         }
 
-        /*let prev_key = {
-            let slots_map = self.reverse_index.get(inner_key).unwrap_or_else(|| {
-                self.reverse_index
-                    .entry(*inner_key)
-                    .or_insert(RwLock::new(HashMap::new()))
-                    .downgrade()
-            });
-            let should_insert = {
-                // Most of the time, key should already exist and match
-                // the one in the update
-                if let Some(existing_key) = slots_map.read().unwrap().get(&slot) {
-                    existing_key != key
-                } else {
-                    // If there is no key yet, then insert
-                    true
-                }
-            };
-            if should_insert {
-                slots_map.write().unwrap().insert(slot, *key)
-            } else {
-                None
-            }
-        };
-
-        if let Some(prev_key) = prev_key {
-            // If the inner key was moved to a different primary key, remove
-            // the previous index entry.
-
-            // Check is necessary because another thread's writes could feasibly be
-            // interleaved between  `should_insert = { ... slots_map.get(...) ... }` and
-            // `prev_key = { ... slots_map.insert(...) ... }`
-            // Currently this isn't possible due to current AccountsIndex's (pubkey, slot)-per-thread
-            // exclusive-locking, but check is here for future-proofing a more relaxed implementation
-            if prev_key != *key {
-                self.remove_index_entries(&prev_key, inner_key, &[slot]);
-            }
-        }*/
+        let outer_keys = self.reverse_index.get(inner_key).unwrap_or_else(|| {
+            self.reverse_index
+                .entry(*inner_key)
+                .or_insert(RwLock::new(HashSet::new()))
+                .downgrade()
+        });
+        let should_insert = !outer_keys.read().unwrap().contains(&key);
+        if should_insert {
+            outer_keys.write().unwrap().insert(*key);
+        }
     }
 
-    pub fn remove_index_entries(&self, key: &Pubkey, inner_key: &Pubkey, slots: &[Slot]) {
-        let is_key_empty = if let Some(inner_key_map) = self.index.get(&key) {
-            // Delete the slot from the slot set
-            let is_inner_key_empty =
-                inner_key_map.get(&inner_key, &|slot_set: Option<&RwLock<HashSet<Slot>>>| {
-                    if let Some(slot_set) = slot_set {
-                        let mut w_slot_set = slot_set.write().unwrap();
-                        for slot in slots.iter() {
-                            let is_present = w_slot_set.remove(slot);
-                            if !is_present {
-                                warn!("Reverse index is missing previous entry for key {}, inner_key: {}, slot: {}",
-                                key, inner_key, slot);
-                            }
-                        }
-                        w_slot_set.is_empty()
-                    } else {
-                        false
-                    }
-                });
-
-            // Check if `key` is empty
-            if is_inner_key_empty {
-                // Write lock on `inner_key_entry` above through the `entry`
-                // means nobody else has access to this lock at this time,
-                // so this check for empty -> remove() is atomic
-                inner_key_map.remove_key_if_empty(inner_key);
-                inner_key_map.is_empty()
-            } else {
-                false
-            }
-        } else {
-            false
+    // Only safe to call from `remove_by_inner_key()` due to asserts
+    fn remove_index_entries(&self, outer_key: &Pubkey, removed_inner_key: &Pubkey) {
+        let is_outer_key_empty = {
+            let inner_key_map = self
+                .index
+                .get_mut(&outer_key)
+                .expect("If we're removing a key, then it must have an entry in the map");
+            // If we deleted a pubkey from the reverse_index, then the corresponding entry
+            // better exist in this index as well or the two indexes are out of sync!
+            assert!(inner_key_map.value().remove_inner_key(&removed_inner_key));
+            inner_key_map.is_empty()
         };
 
         // Delete the `key` if the set of inner keys is empty
-        if is_key_empty {
+        if is_outer_key_empty {
             // Other threads may have interleaved writes to this `key`,
             // so double-check again for its emptiness
-            if let Occupied(key_entry) = self.index.entry(*key) {
+            if let Occupied(key_entry) = self.index.entry(*outer_key) {
                 if key_entry.get().is_empty() {
                     key_entry.remove();
                 }
@@ -253,70 +139,23 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
         }
     }
 
-    // Specifying `slots_to_remove` == Some will only remove keys for those specific slots
-    // found for the `inner_key` in the reverse index. Otherwise, passing `None`
-    // will remove all keys that are found for the `inner_key` in the reverse index.
-
-    // Note passing `None` is dangerous unless you're sure there's no other competing threads
-    // writing updates to the index for this Pubkey at the same time!
-    pub fn remove_by_inner_key<'a, C>(&'a self, inner_key: &Pubkey, slots_to_remove: Option<&'a C>)
-    where
-        C: Contains<'a, Slot>,
-    {
+    pub fn remove_by_inner_key(&self, inner_key: &Pubkey) {
         // Save off which keys in `self.index` had slots removed so we can remove them
         // after we purge the reverse index
-        let mut key_to_removed_slots: HashMap<Pubkey, Vec<Slot>> = HashMap::new();
+        let mut removed_outer_keys: HashSet<Pubkey> = HashSet::new();
 
         // Check if the entry for `inner_key` in the reverse index is empty
         // and can be removed
-        /*let needs_remove = {
-            if let Some(slots_to_remove) = slots_to_remove {
-                self.reverse_index
-                    .get(inner_key)
-                    .map(|slots_map| {
-                        // Ideally we use a concurrent map here as well to prevent clean
-                        // from blocking writes, but memory usage of DashMap is high
-                        let mut w_slots_map = slots_map.value().write().unwrap();
-                        for slot in slots_to_remove.contains_iter() {
-                            if let Some(removed_key) = w_slots_map.remove(slot.borrow()) {
-                                key_to_removed_slots
-                                    .entry(removed_key)
-                                    .or_default()
-                                    .push(*slot.borrow());
-                            }
-                        }
-                        w_slots_map.is_empty()
-                    })
-                    .unwrap_or(false)
-            } else {
-                if let Some((_, removed_slot_map)) = self.reverse_index.remove(inner_key) {
-                    for (slot, removed_key) in removed_slot_map.into_inner().unwrap().into_iter() {
-                        key_to_removed_slots
-                            .entry(removed_key)
-                            .or_default()
-                            .push(slot);
-                    }
-                }
-                // We just removed the key, no need to remove it again
-                false
-            }
-        };
-
-        if needs_remove {
-            // Other threads may have interleaved writes to this `inner_key`, between
-            // releasing the `self.reverse_index.get(inner_key)` lock and now,
-            // so double-check again for emptiness
-            if let Occupied(slot_map) = self.reverse_index.entry(*inner_key) {
-                if slot_map.get().read().unwrap().is_empty() {
-                    slot_map.remove();
-                }
+        if let Some((_, outer_keys_set)) = self.reverse_index.remove(inner_key) {
+            for removed_outer_key in outer_keys_set.into_inner().unwrap().into_iter() {
+                removed_outer_keys.insert(removed_outer_key);
             }
         }
 
         // Remove this value from those keys
-        for (key, slots) in key_to_removed_slots {
-            self.remove_index_entries(&key, inner_key, &slots);
-        }*/
+        for outer_key in removed_outer_keys {
+            self.remove_index_entries(&outer_key, inner_key);
+        }
     }
 
     pub fn get(&self, key: &Pubkey) -> Vec<Pubkey> {


### PR DESCRIPTION
#### Problem
Secondary indexes are bloated by slot information

#### Summary of Changes
Remove a lot of the fine grained slot tracking, and instead only purge secondary indexes when an entire pubkey is marked dead in `handle_dead_keys()`

This seems to reduce memory usage of secondary indexes by about 2/3, from 60GB to 20GB for the program id index for instance.

cc @brooksprumo @steviez 

Fixes #
