### PR TITLE
Fix net shaper script to properly query interfaces

### DIFF
--- a/scripts/net-shaper.sh
+++ b/scripts/net-shaper.sh
@@ -15,7 +15,7 @@ fi
 
 set -x
 
-iface="$(ifconfig | grep mtu | grep -iv loopback | grep -i running | awk 'BEGIN { FS = ":" } ; {print $1}')"
+iface="$(ip link show | grep mtu | grep -iv loopback | grep "state UP" | awk 'BEGIN { FS = ": " } ; {print $2}')"
 
 if [[ "$1" = cleanup ]]; then
   $sudo ~solana/.cargo/bin/solana-net-shaper cleanup -f "$2" -s "$3" -p "$4" -i "$iface"


### PR DESCRIPTION
Previously was using ifconfig which is not available on gce

#### Problem
Cannot run partition tests on buildkite due to the net shaper script failing on the gce nodes.

#### Summary of Changes
Use the ip link utility rather than ifconfig which is not available.

Fixes #
