### PR TITLE
feat: add Keypair class and deprecate Account

### DIFF
--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -48,7 +48,7 @@
     "flow:gen": "flowgen lib/index.d.ts -o module.flow.js",
     "type:gen": "./scripts/typegen.sh",
     "lint": "set -ex; npm run pretty; eslint . --ext .js,.ts",
-    "lint:fix": "npm run pretty:fix && eslint . --fix",
+    "lint:fix": "npm run pretty:fix && eslint . --fix --ext .js,.ts",
     "ok": "run-s lint test doc",
     "pretty": "prettier --check '{,{src,test}/**/}*.{j,t}s'",
     "pretty:fix": "prettier --write '{,{src,test}/**/}*.{j,t}s'",

--- a/web3.js/src/account.ts
+++ b/web3.js/src/account.ts
@@ -6,6 +6,8 @@ import {PublicKey} from './publickey';
 
 /**
  * An account key pair (public and secret keys).
+ *
+ * @deprecated since v1.10.0 use {@link Keypair} instead.
  */
 export class Account {
   /** @internal */

--- a/web3.js/src/account.ts
+++ b/web3.js/src/account.ts
@@ -7,7 +7,7 @@ import {PublicKey} from './publickey';
 /**
  * An account key pair (public and secret keys).
  *
- * @deprecated since v1.10.0 use {@link Keypair} instead.
+ * @deprecated since v1.10.0, please use {@link Keypair} instead.
  */
 export class Account {
   /** @internal */

--- a/web3.js/src/bpf-loader.ts
+++ b/web3.js/src/bpf-loader.ts
@@ -1,7 +1,7 @@
-import {Account} from './account';
 import {PublicKey} from './publickey';
 import {Loader} from './loader';
 import type {Connection} from './connection';
+import type {TransactionSigner} from './transaction';
 
 export const BPF_LOADER_PROGRAM_ID = new PublicKey(
   'BPFLoader2111111111111111111111111111111111',
@@ -33,8 +33,8 @@ export class BpfLoader {
    */
   static load(
     connection: Connection,
-    payer: Account,
-    program: Account,
+    payer: TransactionSigner,
+    program: TransactionSigner,
     elf: Buffer | Uint8Array | Array<number>,
     loaderProgramId: PublicKey,
   ): Promise<boolean> {

--- a/web3.js/src/bpf-loader.ts
+++ b/web3.js/src/bpf-loader.ts
@@ -1,7 +1,7 @@
 import {PublicKey} from './publickey';
 import {Loader} from './loader';
 import type {Connection} from './connection';
-import type {TransactionSigner} from './transaction';
+import type {Signer} from './keypair';
 
 export const BPF_LOADER_PROGRAM_ID = new PublicKey(
   'BPFLoader2111111111111111111111111111111111',
@@ -33,8 +33,8 @@ export class BpfLoader {
    */
   static load(
     connection: Connection,
-    payer: TransactionSigner,
-    program: TransactionSigner,
+    payer: Signer,
+    program: Signer,
     elf: Buffer | Uint8Array | Array<number>,
     loaderProgramId: PublicKey,
   ): Promise<boolean> {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -29,6 +29,7 @@ import {IWSRequestParams} from 'rpc-websockets/dist/lib/client';
 import {AgentManager} from './agent-manager';
 import {NonceAccount} from './nonce-account';
 import {PublicKey} from './publickey';
+import {Signer} from './keypair';
 import {MS_PER_SLOT} from './timing';
 import {Transaction} from './transaction';
 import {Message} from './message';
@@ -37,7 +38,7 @@ import {promiseTimeout} from './util/promise-timeout';
 import {toBuffer} from './util/to-buffer';
 import type {Blockhash} from './blockhash';
 import type {FeeCalculator} from './fee-calculator';
-import type {TransactionSignature, TransactionSigner} from './transaction';
+import type {TransactionSignature} from './transaction';
 import type {CompiledInstruction} from './message';
 
 const PublicKeyFromString = coerce(
@@ -3212,7 +3213,7 @@ export class Connection {
    */
   async simulateTransaction(
     transaction: Transaction,
-    signers?: Array<TransactionSigner>,
+    signers?: Array<Signer>,
   ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>> {
     if (transaction.nonceInfo && signers) {
       transaction.sign(...signers);
@@ -3273,7 +3274,7 @@ export class Connection {
    */
   async sendTransaction(
     transaction: Transaction,
-    signers: Array<TransactionSigner>,
+    signers: Array<Signer>,
     options?: SendOptions,
   ): Promise<TransactionSignature> {
     if (transaction.nonceInfo) {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -35,7 +35,6 @@ import {Message} from './message';
 import {sleep} from './util/sleep';
 import {promiseTimeout} from './util/promise-timeout';
 import {toBuffer} from './util/to-buffer';
-import type {Account} from './account';
 import type {Blockhash} from './blockhash';
 import type {FeeCalculator} from './fee-calculator';
 import type {TransactionSignature, TransactionSigner} from './transaction';

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -35,10 +35,10 @@ import {Message} from './message';
 import {sleep} from './util/sleep';
 import {promiseTimeout} from './util/promise-timeout';
 import {toBuffer} from './util/to-buffer';
+import type {Account} from './account';
 import type {Blockhash} from './blockhash';
 import type {FeeCalculator} from './fee-calculator';
-import type {Account} from './account';
-import type {TransactionSignature} from './transaction';
+import type {TransactionSignature, TransactionSigner} from './transaction';
 import type {CompiledInstruction} from './message';
 
 const PublicKeyFromString = coerce(
@@ -3213,7 +3213,7 @@ export class Connection {
    */
   async simulateTransaction(
     transaction: Transaction,
-    signers?: Array<Account>,
+    signers?: Array<TransactionSigner>,
   ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>> {
     if (transaction.nonceInfo && signers) {
       transaction.sign(...signers);
@@ -3274,7 +3274,7 @@ export class Connection {
    */
   async sendTransaction(
     transaction: Transaction,
-    signers: Array<Account>,
+    signers: Array<TransactionSigner>,
     options?: SendOptions,
   ): Promise<TransactionSignature> {
     if (transaction.nonceInfo) {

--- a/web3.js/src/index.ts
+++ b/web3.js/src/index.ts
@@ -4,6 +4,7 @@ export * from './bpf-loader-deprecated';
 export * from './bpf-loader';
 export * from './connection';
 export * from './fee-calculator';
+export * from './keypair';
 export * from './loader';
 export * from './message';
 export * from './nonce-account';

--- a/web3.js/src/keypair.ts
+++ b/web3.js/src/keypair.ts
@@ -4,6 +4,14 @@ import type {SignKeyPair} from 'tweetnacl';
 import {PublicKey} from './publickey';
 
 /**
+ * Keypair signer interface
+ */
+export interface Signer {
+  publicKey: PublicKey;
+  secretKey: Uint8Array;
+}
+
+/**
  * An account keypair used for signing transactions.
  */
 export class Keypair {

--- a/web3.js/src/keypair.ts
+++ b/web3.js/src/keypair.ts
@@ -1,0 +1,76 @@
+import * as nacl from 'tweetnacl';
+import type {SignKeyPair} from 'tweetnacl';
+
+import {PublicKey} from './publickey';
+
+/**
+ * An account keypair used for signing transactions.
+ */
+export class Keypair {
+  /**
+   * @internal
+   *
+   * Create a new keypair instance from a {@link SignKeyPair}.
+   *
+   * @param keypair ed25519 keypair
+   */
+  constructor(private keypair: SignKeyPair) {}
+
+  /**
+   * Generate a new random keypair
+   */
+  static generate(): Keypair {
+    return new Keypair(nacl.sign.keyPair());
+  }
+
+  /**
+   * Create a keypair from a raw secret key byte array.
+   *
+   * This method should only be used to recreate a keypair from a previously
+   * generated secret key. Generating keypairs from a random seed should be done
+   * with the {@link Keypair.fromSeed} method.
+   *
+   * @throws error if the provided secret key is invalid and validation is not skipped.
+   *
+   * @param secretKey secret key byte array
+   * @param options: skip secret key validation
+   */
+  static fromSecretKey(
+    secretKey: Uint8Array,
+    options?: {skipValidation?: boolean},
+  ): Keypair {
+    const keypair = nacl.sign.keyPair.fromSecretKey(secretKey);
+    if (!options || !options.skipValidation) {
+      const encoder = new TextEncoder();
+      const signData = encoder.encode('@solana/web3.js-validation-v1');
+      const signature = nacl.sign.detached(signData, keypair.secretKey);
+      if (!nacl.sign.detached.verify(signData, signature, keypair.publicKey)) {
+        throw new Error('provided secretKey is invalid');
+      }
+    }
+    return new Keypair(keypair);
+  }
+
+  /**
+   * Generate a keypair from a 32 byte seed.
+   *
+   * @param seed seed byte array
+   */
+  static fromSeed(seed: Uint8Array): Keypair {
+    return new Keypair(nacl.sign.keyPair.fromSeed(seed));
+  }
+
+  /**
+   * The public key for this keypair
+   */
+  get publicKey(): PublicKey {
+    return new PublicKey(this.keypair.publicKey);
+  }
+
+  /**
+   * The raw secret key for this keypair
+   */
+  get secretKey(): Uint8Array {
+    return this.keypair.secretKey;
+  }
+}

--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -1,13 +1,13 @@
 import {Buffer} from 'buffer';
 import * as BufferLayout from 'buffer-layout';
 
-import {Account} from './account';
 import {PublicKey} from './publickey';
 import {Transaction, PACKET_DATA_SIZE} from './transaction';
 import {SYSVAR_RENT_PUBKEY} from './sysvar';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 import {sleep} from './util/sleep';
 import type {Connection} from './connection';
+import type {TransactionSigner} from './transaction';
 import {SystemProgram} from './system-program';
 
 // Keep program chunks under PACKET_DATA_SIZE, leaving enough room for the
@@ -58,8 +58,8 @@ export class Loader {
    */
   static async load(
     connection: Connection,
-    payer: Account,
-    program: Account,
+    payer: TransactionSigner,
+    program: TransactionSigner,
     programId: PublicKey,
     data: Buffer | Uint8Array | Array<number>,
   ): Promise<boolean> {

--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -7,7 +7,7 @@ import {SYSVAR_RENT_PUBKEY} from './sysvar';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 import {sleep} from './util/sleep';
 import type {Connection} from './connection';
-import type {TransactionSigner} from './transaction';
+import type {Signer} from './keypair';
 import {SystemProgram} from './system-program';
 
 // Keep program chunks under PACKET_DATA_SIZE, leaving enough room for the
@@ -58,8 +58,8 @@ export class Loader {
    */
   static async load(
     connection: Connection,
-    payer: TransactionSigner,
-    program: TransactionSigner,
+    payer: Signer,
+    program: Signer,
     programId: PublicKey,
     data: Buffer | Uint8Array | Array<number>,
   ): Promise<boolean> {

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -3,25 +3,18 @@ import nacl from 'tweetnacl';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 
-import type {CompiledInstruction} from './message';
 import {Message} from './message';
 import {PublicKey} from './publickey';
 import * as shortvec from './util/shortvec-encoding';
-import type {Blockhash} from './blockhash';
 import {toBuffer} from './util/to-buffer';
+import type {Signer} from './keypair';
+import type {Blockhash} from './blockhash';
+import type {CompiledInstruction} from './message';
 
 /**
  * Transaction signature as base-58 encoded string
  */
 export type TransactionSignature = string;
-
-/**
- * Transaction signer
- */
-export interface TransactionSigner {
-  publicKey: PublicKey;
-  secretKey: Uint8Array;
-}
 
 /**
  * Default (empty) signature
@@ -452,7 +445,7 @@ export class Transaction {
    *
    * The Transaction must be assigned a valid `recentBlockhash` before invoking this method
    */
-  sign(...signers: Array<TransactionSigner>) {
+  sign(...signers: Array<Signer>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
@@ -487,7 +480,7 @@ export class Transaction {
    *
    * All the caveats from the `sign` method apply to `partialSign`
    */
-  partialSign(...signers: Array<TransactionSigner>) {
+  partialSign(...signers: Array<Signer>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
@@ -512,7 +505,7 @@ export class Transaction {
   /**
    * @internal
    */
-  _partialSign(message: Message, ...signers: Array<TransactionSigner>) {
+  _partialSign(message: Message, ...signers: Array<Signer>) {
     const signData = message.serialize();
     signers.forEach(signer => {
       const signature = nacl.sign.detached(signData, signer.secretKey);

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -3,7 +3,6 @@ import nacl from 'tweetnacl';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 
-import type {Account} from './account';
 import type {CompiledInstruction} from './message';
 import {Message} from './message';
 import {PublicKey} from './publickey';

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -3,10 +3,10 @@ import nacl from 'tweetnacl';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 
+import type {Account} from './account';
 import type {CompiledInstruction} from './message';
 import {Message} from './message';
 import {PublicKey} from './publickey';
-import {Account} from './account';
 import * as shortvec from './util/shortvec-encoding';
 import type {Blockhash} from './blockhash';
 import {toBuffer} from './util/to-buffer';
@@ -15,6 +15,14 @@ import {toBuffer} from './util/to-buffer';
  * Transaction signature as base-58 encoded string
  */
 export type TransactionSignature = string;
+
+/**
+ * Transaction signer
+ */
+export interface TransactionSigner {
+  publicKey: PublicKey;
+  secretKey: Uint8Array;
+}
 
 /**
  * Default (empty) signature
@@ -432,7 +440,7 @@ export class Transaction {
   }
 
   /**
-   * Sign the Transaction with the specified accounts. Multiple signatures may
+   * Sign the Transaction with the specified signers. Multiple signatures may
    * be applied to a Transaction. The first signature is considered "primary"
    * and is used identify and confirm transactions.
    *
@@ -445,7 +453,7 @@ export class Transaction {
    *
    * The Transaction must be assigned a valid `recentBlockhash` before invoking this method
    */
-  sign(...signers: Array<Account>) {
+  sign(...signers: Array<TransactionSigner>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
@@ -480,7 +488,7 @@ export class Transaction {
    *
    * All the caveats from the `sign` method apply to `partialSign`
    */
-  partialSign(...signers: Array<Account>) {
+  partialSign(...signers: Array<TransactionSigner>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
@@ -505,7 +513,7 @@ export class Transaction {
   /**
    * @internal
    */
-  _partialSign(message: Message, ...signers: Array<Account>) {
+  _partialSign(message: Message, ...signers: Array<TransactionSigner>) {
     const signData = message.serialize();
     signers.forEach(signer => {
       const signature = nacl.sign.detached(signData, signer.secretKey);

--- a/web3.js/src/util/send-and-confirm-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-transaction.ts
@@ -1,8 +1,7 @@
 import {Connection} from '../connection';
 import {Transaction} from '../transaction';
-import type {Account} from '../account';
 import type {ConfirmOptions} from '../connection';
-import type {TransactionSignature} from '../transaction';
+import type {TransactionSignature, TransactionSigner} from '../transaction';
 
 /**
  * Sign, send and confirm a transaction.
@@ -11,14 +10,14 @@ import type {TransactionSignature} from '../transaction';
  *
  * @param {Connection} connection
  * @param {Transaction} transaction
- * @param {Array<Account>} signers
+ * @param {Array<TransactionSigner>} signers
  * @param {ConfirmOptions} [options]
  * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmTransaction(
   connection: Connection,
   transaction: Transaction,
-  signers: Array<Account>,
+  signers: Array<TransactionSigner>,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   const sendOptions = options && {

--- a/web3.js/src/util/send-and-confirm-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-transaction.ts
@@ -1,7 +1,8 @@
 import {Connection} from '../connection';
 import {Transaction} from '../transaction';
 import type {ConfirmOptions} from '../connection';
-import type {TransactionSignature, TransactionSigner} from '../transaction';
+import type {Signer} from '../keypair';
+import type {TransactionSignature} from '../transaction';
 
 /**
  * Sign, send and confirm a transaction.
@@ -10,14 +11,14 @@ import type {TransactionSignature, TransactionSigner} from '../transaction';
  *
  * @param {Connection} connection
  * @param {Transaction} transaction
- * @param {Array<TransactionSigner>} signers
+ * @param {Array<Signer>} signers
  * @param {ConfirmOptions} [options]
  * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmTransaction(
   connection: Connection,
   transaction: Transaction,
-  signers: Array<TransactionSigner>,
+  signers: Array<Signer>,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   const sendOptions = options && {

--- a/web3.js/test/bpf-loader.test.ts
+++ b/web3.js/test/bpf-loader.test.ts
@@ -7,7 +7,7 @@ import {
   BpfLoader,
   Transaction,
   sendAndConfirmTransaction,
-  Account,
+  Keypair,
 } from '../src';
 import {url} from './url';
 import {BPF_LOADER_PROGRAM_ID} from '../src/bpf-loader';
@@ -20,8 +20,8 @@ if (process.env.TEST_LIVE) {
     describe('load BPF program', () => {
       const connection = new Connection(url, 'confirmed');
 
-      let program = new Account();
-      let payerAccount = new Account();
+      let program = Keypair.generate();
+      let payerAccount = Keypair.generate();
       let programData: Buffer;
 
       before(async function () {
@@ -55,7 +55,7 @@ if (process.env.TEST_LIVE) {
         });
 
         // First load will fail part way due to lack of funds
-        const insufficientPayerAccount = new Account();
+        const insufficientPayerAccount = Keypair.generate();
         await helpers.airdrop({
           connection,
           address: insufficientPayerAccount.publicKey,
@@ -208,7 +208,7 @@ if (process.env.TEST_LIVE) {
           keys: [
             {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
           ],
-          programId: new Account().publicKey,
+          programId: Keypair.generate().publicKey,
         });
 
         simulatedTransaction.setSigners(payerAccount.publicKey);

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -16,6 +16,7 @@ import {
   PublicKey,
   StakeProgram,
   sendAndConfirmTransaction,
+  Keypair,
 } from '../src';
 import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../src/timing';
 import {MOCK_PORT, url} from './url';
@@ -132,7 +133,7 @@ describe('Connection', () => {
   }
 
   it('get account info - not found', async () => {
-    const account = new Account();
+    const account = Keypair.generate();
 
     await mockRpcResponse({
       method: 'getAccountInfo',
@@ -155,9 +156,9 @@ describe('Connection', () => {
   });
 
   it('get program accounts', async () => {
-    const account0 = new Account();
-    const account1 = new Account();
-    const programId = new Account();
+    const account0 = Keypair.generate();
+    const account1 = Keypair.generate();
+    const programId = Keypair.generate();
 
     {
       await helpers.airdrop({
@@ -543,7 +544,7 @@ describe('Connection', () => {
   });
 
   it('get balance', async () => {
-    const account = new Account();
+    const account = Keypair.generate();
 
     await mockRpcResponse({
       method: 'getBalance',
@@ -821,7 +822,7 @@ describe('Connection', () => {
         total: 1000000,
         circulating: 100000,
         nonCirculating: 900000,
-        nonCirculatingAccounts: [new Account().publicKey.toBase58()],
+        nonCirculatingAccounts: [Keypair.generate().publicKey.toBase58()],
       },
       withContext: true,
     });
@@ -1429,7 +1430,7 @@ describe('Connection', () => {
     const resultSignature = bs58.encode(result.transaction.signature);
     expect(resultSignature).to.eq(confirmedTransaction);
 
-    const newAddress = new Account().publicKey;
+    const newAddress = Keypair.generate().publicKey;
     const recentSignature = await helpers.airdrop({
       connection,
       address: newAddress,
@@ -1826,7 +1827,7 @@ describe('Connection', () => {
         total: 1000,
         circulating: 100,
         nonCirculating: 900,
-        nonCirculatingAccounts: [new Account().publicKey.toBase58()],
+        nonCirculatingAccounts: [Keypair.generate().publicKey.toBase58()],
       },
       withContext: true,
     });
@@ -1880,7 +1881,7 @@ describe('Connection', () => {
   if (process.env.TEST_LIVE) {
     describe('token methods', () => {
       const connection = new Connection(url, 'confirmed');
-      const newAccount = new Account().publicKey;
+      const newAccount = Keypair.generate().publicKey;
 
       let testToken: Token;
       let testTokenPubkey: PublicKey;
@@ -1900,7 +1901,7 @@ describe('Connection', () => {
         const mintOwner = new Account();
         const accountOwner = new Account();
         const token = await Token.createMint(
-          connection,
+          connection as any,
           payerAccount,
           mintOwner.publicKey,
           null,
@@ -1912,7 +1913,7 @@ describe('Connection', () => {
         await token.mintTo(tokenAccount, mintOwner, [], 11111);
 
         const token2 = await Token.createMint(
-          connection,
+          connection as any,
           payerAccount,
           mintOwner.publicKey,
           null,
@@ -2095,8 +2096,8 @@ describe('Connection', () => {
 
     it('consistent preflightCommitment', async () => {
       const connection = new Connection(url, 'singleGossip');
-      const sender = new Account();
-      const recipient = new Account();
+      const sender = Keypair.generate();
+      const recipient = Keypair.generate();
       let signature = await connection.requestAirdrop(
         sender.publicKey,
         2 * LAMPORTS_PER_SOL,
@@ -2118,7 +2119,7 @@ describe('Connection', () => {
       method: 'getLargestAccounts',
       params: [],
       value: new Array(20).fill(0).map(() => ({
-        address: new Account().publicKey.toBase58(),
+        address: Keypair.generate().publicKey.toBase58(),
         lamports: 1000,
       })),
       withContext: true,
@@ -2129,7 +2130,7 @@ describe('Connection', () => {
   });
 
   it('stake activation should throw when called for not delegated account', async () => {
-    const publicKey = new Account().publicKey;
+    const publicKey = Keypair.generate().publicKey;
     await mockRpcResponse({
       method: 'getStakeActivation',
       params: [publicKey.toBase58(), {}],
@@ -2147,7 +2148,7 @@ describe('Connection', () => {
       )[0];
       const votePubkey = new PublicKey(voteAccount.votePubkey);
 
-      const authorized = new Account();
+      const authorized = Keypair.generate();
       let signature = await connection.requestAirdrop(
         authorized.publicKey,
         2 * LAMPORTS_PER_SOL,
@@ -2158,7 +2159,7 @@ describe('Connection', () => {
         StakeProgram.space,
       );
 
-      const newStakeAccount = new Account();
+      const newStakeAccount = Keypair.generate();
       let createAndInitialize = StakeProgram.createAccount({
         fromPubkey: authorized.publicKey,
         stakePubkey: newStakeAccount.publicKey,
@@ -2209,7 +2210,7 @@ describe('Connection', () => {
 
   if (mockServer) {
     it('stake activation should only accept state with valid string literals', async () => {
-      const publicKey = new Account().publicKey;
+      const publicKey = Keypair.generate().publicKey;
 
       const addStakeActivationMock = async (state: any) => {
         await mockRpcResponse({
@@ -2250,7 +2251,7 @@ describe('Connection', () => {
   });
 
   it('request airdrop', async () => {
-    const account = new Account();
+    const account = Keypair.generate();
 
     await helpers.airdrop({
       connection,
@@ -2328,7 +2329,7 @@ describe('Connection', () => {
   });
 
   it('transaction failure', async () => {
-    const payer = new Account();
+    const payer = Keypair.generate();
 
     await helpers.airdrop({
       connection,
@@ -2336,7 +2337,7 @@ describe('Connection', () => {
       amount: LAMPORTS_PER_SOL,
     });
 
-    const newAccount = new Account();
+    const newAccount = Keypair.generate();
     let transaction = new Transaction().add(
       SystemProgram.createAccount({
         fromPubkey: payer.publicKey,
@@ -2391,8 +2392,8 @@ describe('Connection', () => {
     it('transaction', async () => {
       connection._commitment = 'confirmed';
 
-      const accountFrom = new Account();
-      const accountTo = new Account();
+      const accountFrom = Keypair.generate();
+      const accountTo = Keypair.generate();
       const minimumAmount = await connection.getMinimumBalanceForRentExemption(
         0,
       );
@@ -2494,8 +2495,8 @@ describe('Connection', () => {
     it('multi-instruction transaction', async () => {
       connection._commitment = 'confirmed';
 
-      const accountFrom = new Account();
-      const accountTo = new Account();
+      const accountFrom = Keypair.generate();
+      const accountTo = Keypair.generate();
 
       let signature = await connection.requestAirdrop(
         accountFrom.publicKey,
@@ -2572,8 +2573,8 @@ describe('Connection', () => {
     //   }
 
     //   const connection = new Connection(url, 'confirmed');
-    //   const owner = new Account();
-    //   const programAccount = new Account();
+    //   const owner = Keypair.generate();
+    //   const programAccount = Keypair.generate();
 
     //   const mockCallback = jest.fn();
 
@@ -2633,8 +2634,8 @@ describe('Connection', () => {
     it('program account change notification', async () => {
       connection._commitment = 'confirmed';
 
-      const owner = new Account();
-      const programAccount = new Account();
+      const owner = Keypair.generate();
+      const programAccount = Keypair.generate();
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         0,
       );
@@ -2737,7 +2738,7 @@ describe('Connection', () => {
 
     it('logs notification', async () => {
       let listener: number | undefined;
-      const owner = new Account();
+      const owner = Keypair.generate();
       const [logsRes, ctx] = await new Promise(resolve => {
         let received = false;
         listener = connection.onLogs(

--- a/web3.js/test/keypair.test.ts
+++ b/web3.js/test/keypair.test.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import {Buffer} from 'buffer';
+
 import {Keypair} from '../src';
 
 describe('Keypair', () => {

--- a/web3.js/test/keypair.test.ts
+++ b/web3.js/test/keypair.test.ts
@@ -1,0 +1,49 @@
+import {expect} from 'chai';
+import {Buffer} from 'buffer';
+import {Keypair} from '../src';
+
+describe('Keypair', () => {
+  it('generate new keypair', () => {
+    const keypair = Keypair.generate();
+    expect(keypair.secretKey).to.have.length(64);
+  });
+
+  it('create keypair from secret key', () => {
+    const secretKey = Buffer.from(
+      'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIg==',
+      'base64',
+    );
+    const keypair = Keypair.fromSecretKey(secretKey);
+    expect(keypair.publicKey.toBase58()).to.eq(
+      '2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF',
+    );
+  });
+
+  it('creating keypair from invalid secret key throws error', () => {
+    const secretKey = Buffer.from(
+      'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIG==',
+      'base64',
+    );
+    expect(() => {
+      Keypair.fromSecretKey(secretKey);
+    }).to.throw('provided secretKey is invalid');
+  });
+
+  it('creating keypair from invalid secret key succeeds if validation is skipped', () => {
+    const secretKey = Buffer.from(
+      'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIG==',
+      'base64',
+    );
+    const keypair = Keypair.fromSecretKey(secretKey, {skipValidation: true});
+    expect(keypair.publicKey.toBase58()).to.eq(
+      '2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhD',
+    );
+  });
+
+  it('generate keypair from random seed', () => {
+    const keypair = Keypair.fromSeed(Uint8Array.from(Array(32).fill(8)));
+    expect(keypair.publicKey.toBase58()).to.eq(
+      '2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1',
+    );
+  });
+});

--- a/web3.js/test/mocks/rpc-http.ts
+++ b/web3.js/test/mocks/rpc-http.ts
@@ -4,7 +4,7 @@ import invariant from 'assert';
 import * as mockttp from 'mockttp';
 
 import {mockRpcMessage} from './rpc-websockets';
-import {Connection, PublicKey, Transaction, TransactionSigner} from '../../src';
+import {Connection, PublicKey, Transaction, Signer} from '../../src';
 import type {Commitment, HttpHeaders, RpcParams} from '../../src/connection';
 
 export const mockServer: mockttp.Mockttp | undefined =
@@ -141,7 +141,7 @@ const processTransaction = async ({
 }: {
   connection: Connection;
   transaction: Transaction;
-  signers: Array<TransactionSigner>;
+  signers: Array<Signer>;
   commitment: Commitment;
   err?: any;
 }) => {

--- a/web3.js/test/mocks/rpc-http.ts
+++ b/web3.js/test/mocks/rpc-http.ts
@@ -4,7 +4,7 @@ import invariant from 'assert';
 import * as mockttp from 'mockttp';
 
 import {mockRpcMessage} from './rpc-websockets';
-import {Account, Connection, PublicKey, Transaction} from '../../src';
+import {Connection, PublicKey, Transaction, TransactionSigner} from '../../src';
 import type {Commitment, HttpHeaders, RpcParams} from '../../src/connection';
 
 export const mockServer: mockttp.Mockttp | undefined =
@@ -141,7 +141,7 @@ const processTransaction = async ({
 }: {
   connection: Connection;
   transaction: Transaction;
-  signers: Array<Account>;
+  signers: Array<TransactionSigner>;
   commitment: Commitment;
   err?: any;
 }) => {

--- a/web3.js/test/nonce.test.ts
+++ b/web3.js/test/nonce.test.ts
@@ -3,11 +3,11 @@ import {Buffer} from 'buffer';
 import {expect} from 'chai';
 
 import {
-  Account,
   Connection,
   SystemProgram,
   Transaction,
   PublicKey,
+  Keypair,
 } from '../src';
 import {NONCE_ACCOUNT_LENGTH} from '../src/nonce-account';
 import {MOCK_PORT, url} from './url';
@@ -19,7 +19,7 @@ const expectedData = (authorizedPubkey: PublicKey): [string, string] => {
   expectedData.writeInt32LE(0, 0); // Version, 4 bytes
   expectedData.writeInt32LE(1, 4); // State, 4 bytes
   authorizedPubkey.toBuffer().copy(expectedData, 8); // authorizedPubkey, 32 bytes
-  const mockNonce = new Account();
+  const mockNonce = Keypair.generate();
   mockNonce.publicKey.toBuffer().copy(expectedData, 40); // Hash, 32 bytes
   expectedData.writeUInt16LE(5000, 72); // feeCalculator, 8 bytes
   return [expectedData.toString('base64'), 'base64'];
@@ -45,8 +45,8 @@ describe('Nonce', () => {
   }
 
   it('create and query nonce account', async () => {
-    const from = new Account();
-    const nonceAccount = new Account();
+    const from = Keypair.generate();
+    const nonceAccount = Keypair.generate();
 
     await mockRpcResponse({
       method: 'getMinimumBalanceForRentExemption',
@@ -109,7 +109,7 @@ describe('Nonce', () => {
   });
 
   it('create and query nonce account with seed', async () => {
-    const from = new Account();
+    const from = Keypair.generate();
     const seed = 'seed';
     const noncePubkey = await PublicKey.createWithSeed(
       from.publicKey,

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -3,7 +3,7 @@ import {Buffer} from 'buffer';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {Account} from '../src/account';
+import {Keypair} from '../src/keypair';
 import {PublicKey, MAX_SEED_LENGTH} from '../src/publickey';
 
 use(chaiAsPromised);
@@ -331,7 +331,7 @@ describe('PublicKey', function () {
   });
 
   it('isOnCurve', () => {
-    let onCurve = new Account().publicKey;
+    let onCurve = Keypair.generate().publicKey;
     expect(PublicKey.isOnCurve(onCurve.toBuffer())).to.be.true;
     // A program address, yanked from one of the above tests. This is a pretty
     // poor test vector since it was created by the same code it is testing.

--- a/web3.js/test/secp256k1-program.test.ts
+++ b/web3.js/test/secp256k1-program.test.ts
@@ -4,7 +4,7 @@ import {privateKeyVerify, ecdsaSign, publicKeyCreate} from 'secp256k1';
 
 import {
   Connection,
-  Account,
+  Keypair,
   sendAndConfirmTransaction,
   LAMPORTS_PER_SOL,
   Transaction,
@@ -15,7 +15,7 @@ import {url} from './url';
 const randomPrivateKey = () => {
   let privateKey;
   do {
-    privateKey = new Account().secretKey.slice(0, 32);
+    privateKey = Keypair.generate().secretKey.slice(0, 32);
   } while (!privateKeyVerify(privateKey));
   return privateKey;
 };
@@ -25,7 +25,7 @@ if (process.env.TEST_LIVE) {
     const privateKey = randomPrivateKey();
     const publicKey = publicKeyCreate(privateKey, false).slice(1);
     const ethAddress = Secp256k1Program.publicKeyToEthAddress(publicKey);
-    const from = new Account();
+    const from = Keypair.generate();
     const connection = new Connection(url, 'confirmed');
 
     before(async function () {

--- a/web3.js/test/stake-program.test.ts
+++ b/web3.js/test/stake-program.test.ts
@@ -2,7 +2,7 @@ import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import {
-  Account,
+  Keypair,
   Authorized,
   Connection,
   Lockup,
@@ -22,14 +22,14 @@ use(chaiAsPromised);
 
 describe('StakeProgram', () => {
   it('createAccountWithSeed', async () => {
-    const fromPubkey = new Account().publicKey;
+    const fromPubkey = Keypair.generate().publicKey;
     const seed = 'test string';
     const newAccountPubkey = await PublicKey.createWithSeed(
       fromPubkey,
       seed,
       StakeProgram.programId,
     );
-    const authorizedPubkey = new Account().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
     const authorized = new Authorized(authorizedPubkey, authorizedPubkey);
     const lockup = new Lockup(0, 0, fromPubkey);
     const lamports = 123;
@@ -63,9 +63,9 @@ describe('StakeProgram', () => {
   });
 
   it('createAccount', () => {
-    const fromPubkey = new Account().publicKey;
-    const newAccountPubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
+    const fromPubkey = Keypair.generate().publicKey;
+    const newAccountPubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
     const authorized = new Authorized(authorizedPubkey, authorizedPubkey);
     const lockup = new Lockup(0, 0, fromPubkey);
     const lamports = 123;
@@ -96,9 +96,9 @@ describe('StakeProgram', () => {
   });
 
   it('delegate', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const votePubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const votePubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorizedPubkey,
@@ -111,9 +111,9 @@ describe('StakeProgram', () => {
   });
 
   it('authorize', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const newAuthorizedPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const newAuthorizedPubkey = Keypair.generate().publicKey;
     const stakeAuthorizationType = StakeAuthorizationLayout.Staker;
     const params = {
       stakePubkey,
@@ -128,11 +128,11 @@ describe('StakeProgram', () => {
   });
 
   it('authorize with custodian', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const newAuthorizedPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const newAuthorizedPubkey = Keypair.generate().publicKey;
     const stakeAuthorizationType = StakeAuthorizationLayout.Withdrawer;
-    const custodianPubkey = new Account().publicKey;
+    const custodianPubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorizedPubkey,
@@ -147,11 +147,11 @@ describe('StakeProgram', () => {
   });
 
   it('authorizeWithSeed', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorityBase = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorityBase = Keypair.generate().publicKey;
     const authoritySeed = 'test string';
-    const authorityOwner = new Account().publicKey;
-    const newAuthorizedPubkey = new Account().publicKey;
+    const authorityOwner = Keypair.generate().publicKey;
+    const newAuthorizedPubkey = Keypair.generate().publicKey;
     const stakeAuthorizationType = StakeAuthorizationLayout.Staker;
     const params = {
       stakePubkey,
@@ -170,13 +170,13 @@ describe('StakeProgram', () => {
   });
 
   it('authorizeWithSeed with custodian', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorityBase = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorityBase = Keypair.generate().publicKey;
     const authoritySeed = 'test string';
-    const authorityOwner = new Account().publicKey;
-    const newAuthorizedPubkey = new Account().publicKey;
+    const authorityOwner = Keypair.generate().publicKey;
+    const newAuthorizedPubkey = Keypair.generate().publicKey;
     const stakeAuthorizationType = StakeAuthorizationLayout.Staker;
-    const custodianPubkey = new Account().publicKey;
+    const custodianPubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorityBase,
@@ -195,9 +195,9 @@ describe('StakeProgram', () => {
   });
 
   it('split', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const splitStakePubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const splitStakePubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorizedPubkey,
@@ -221,9 +221,9 @@ describe('StakeProgram', () => {
   });
 
   it('withdraw', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const toPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const toPubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorizedPubkey,
@@ -237,10 +237,10 @@ describe('StakeProgram', () => {
   });
 
   it('withdraw with custodian', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
-    const toPubkey = new Account().publicKey;
-    const custodianPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const toPubkey = Keypair.generate().publicKey;
+    const custodianPubkey = Keypair.generate().publicKey;
     const params = {
       stakePubkey,
       authorizedPubkey,
@@ -255,8 +255,8 @@ describe('StakeProgram', () => {
   });
 
   it('deactivate', () => {
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
     const params = {stakePubkey, authorizedPubkey};
     const transaction = StakeProgram.deactivate(params);
     expect(transaction.instructions).to.have.length(1);
@@ -265,14 +265,14 @@ describe('StakeProgram', () => {
   });
 
   it('StakeInstructions', async () => {
-    const from = new Account();
+    const from = Keypair.generate();
     const seed = 'test string';
     const newAccountPubkey = await PublicKey.createWithSeed(
       from.publicKey,
       seed,
       StakeProgram.programId,
     );
-    const authorized = new Account();
+    const authorized = Keypair.generate();
     const amount = 123;
     const recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'; // Arbitrary known recentBlockhash
     const createWithSeed = StakeProgram.createAccountWithSeed({
@@ -305,8 +305,8 @@ describe('StakeProgram', () => {
       );
     }).to.throw();
 
-    const stake = new Account();
-    const vote = new Account();
+    const stake = Keypair.generate();
+    const vote = Keypair.generate();
     const delegate = StakeProgram.delegate({
       stakePubkey: stake.publicKey,
       authorizedPubkey: authorized.publicKey,
@@ -332,14 +332,14 @@ describe('StakeProgram', () => {
       )[0];
       const votePubkey = new PublicKey(voteAccount.votePubkey);
 
-      const payer = new Account();
+      const payer = Keypair.generate();
       await helpers.airdrop({
         connection,
         address: payer.publicKey,
         amount: 2 * LAMPORTS_PER_SOL,
       });
 
-      const authorized = new Account();
+      const authorized = Keypair.generate();
       await helpers.airdrop({
         connection,
         address: authorized.publicKey,
@@ -359,7 +359,7 @@ describe('StakeProgram', () => {
 
       {
         // Create Stake account without seed
-        const newStakeAccount = new Account();
+        const newStakeAccount = Keypair.generate();
         let createAndInitialize = StakeProgram.createAccount({
           fromPubkey: payer.publicKey,
           stakePubkey: newStakeAccount.publicKey,
@@ -427,7 +427,7 @@ describe('StakeProgram', () => {
       });
 
       // Test that withdraw fails before deactivation
-      const recipient = new Account();
+      const recipient = Keypair.generate();
       let withdraw = StakeProgram.withdraw({
         stakePubkey: newAccountPubkey,
         authorizedPubkey: authorized.publicKey,
@@ -471,7 +471,7 @@ describe('StakeProgram', () => {
       expect(recipientBalance).to.eq(minimumAmount + 20);
 
       // Split stake
-      const newStake = new Account();
+      const newStake = Keypair.generate();
       let split = StakeProgram.split({
         stakePubkey: newAccountPubkey,
         authorizedPubkey: authorized.publicKey,
@@ -490,7 +490,7 @@ describe('StakeProgram', () => {
       expect(balance).to.eq(minimumAmount + 2);
 
       // Authorize to new account
-      const newAuthorized = new Account();
+      const newAuthorized = Keypair.generate();
       await connection.requestAirdrop(
         newAuthorized.publicKey,
         LAMPORTS_PER_SOL,

--- a/web3.js/test/system-program.test.ts
+++ b/web3.js/test/system-program.test.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'buffer';
 import {expect} from 'chai';
 
 import {
-  Account,
+  Keypair,
   Connection,
   PublicKey,
   StakeProgram,
@@ -21,8 +21,8 @@ import {url} from './url';
 describe('SystemProgram', () => {
   it('createAccount', () => {
     const params = {
-      fromPubkey: new Account().publicKey,
-      newAccountPubkey: new Account().publicKey,
+      fromPubkey: Keypair.generate().publicKey,
+      newAccountPubkey: Keypair.generate().publicKey,
       lamports: 123,
       space: 0,
       programId: SystemProgram.programId,
@@ -39,8 +39,8 @@ describe('SystemProgram', () => {
 
   it('transfer', () => {
     const params = {
-      fromPubkey: new Account().publicKey,
-      toPubkey: new Account().publicKey,
+      fromPubkey: Keypair.generate().publicKey,
+      toPubkey: Keypair.generate().publicKey,
       lamports: 123,
     };
     const transaction = new Transaction().add(SystemProgram.transfer(params));
@@ -51,12 +51,12 @@ describe('SystemProgram', () => {
 
   it('transferWithSeed', () => {
     const params = {
-      fromPubkey: new Account().publicKey,
-      basePubkey: new Account().publicKey,
-      toPubkey: new Account().publicKey,
+      fromPubkey: Keypair.generate().publicKey,
+      basePubkey: Keypair.generate().publicKey,
+      toPubkey: Keypair.generate().publicKey,
       lamports: 123,
       seed: '你好',
-      programId: new Account().publicKey,
+      programId: Keypair.generate().publicKey,
     };
     const transaction = new Transaction().add(SystemProgram.transfer(params));
     expect(transaction.instructions).to.have.length(1);
@@ -68,7 +68,7 @@ describe('SystemProgram', () => {
 
   it('allocate', () => {
     const params = {
-      accountPubkey: new Account().publicKey,
+      accountPubkey: Keypair.generate().publicKey,
       space: 42,
     };
     const transaction = new Transaction().add(SystemProgram.allocate(params));
@@ -79,11 +79,11 @@ describe('SystemProgram', () => {
 
   it('allocateWithSeed', () => {
     const params = {
-      accountPubkey: new Account().publicKey,
-      basePubkey: new Account().publicKey,
+      accountPubkey: Keypair.generate().publicKey,
+      basePubkey: Keypair.generate().publicKey,
       seed: '你好',
       space: 42,
-      programId: new Account().publicKey,
+      programId: Keypair.generate().publicKey,
     };
     const transaction = new Transaction().add(SystemProgram.allocate(params));
     expect(transaction.instructions).to.have.length(1);
@@ -95,8 +95,8 @@ describe('SystemProgram', () => {
 
   it('assign', () => {
     const params = {
-      accountPubkey: new Account().publicKey,
-      programId: new Account().publicKey,
+      accountPubkey: Keypair.generate().publicKey,
+      programId: Keypair.generate().publicKey,
     };
     const transaction = new Transaction().add(SystemProgram.assign(params));
     expect(transaction.instructions).to.have.length(1);
@@ -106,10 +106,10 @@ describe('SystemProgram', () => {
 
   it('assignWithSeed', () => {
     const params = {
-      accountPubkey: new Account().publicKey,
-      basePubkey: new Account().publicKey,
+      accountPubkey: Keypair.generate().publicKey,
+      basePubkey: Keypair.generate().publicKey,
       seed: '你好',
-      programId: new Account().publicKey,
+      programId: Keypair.generate().publicKey,
     };
     const transaction = new Transaction().add(SystemProgram.assign(params));
     expect(transaction.instructions).to.have.length(1);
@@ -120,10 +120,10 @@ describe('SystemProgram', () => {
   });
 
   it('createAccountWithSeed', () => {
-    const fromPubkey = new Account().publicKey;
+    const fromPubkey = Keypair.generate().publicKey;
     const params = {
       fromPubkey,
-      newAccountPubkey: new Account().publicKey,
+      newAccountPubkey: Keypair.generate().publicKey,
       basePubkey: fromPubkey,
       seed: 'hi there',
       lamports: 123,
@@ -141,10 +141,10 @@ describe('SystemProgram', () => {
   });
 
   it('createNonceAccount', () => {
-    const fromPubkey = new Account().publicKey;
+    const fromPubkey = Keypair.generate().publicKey;
     const params = {
       fromPubkey,
-      noncePubkey: new Account().publicKey,
+      noncePubkey: Keypair.generate().publicKey,
       authorizedPubkey: fromPubkey,
       lamports: 123,
     };
@@ -176,10 +176,10 @@ describe('SystemProgram', () => {
   });
 
   it('createNonceAccount with seed', () => {
-    const fromPubkey = new Account().publicKey;
+    const fromPubkey = Keypair.generate().publicKey;
     const params = {
       fromPubkey,
-      noncePubkey: new Account().publicKey,
+      noncePubkey: Keypair.generate().publicKey,
       authorizedPubkey: fromPubkey,
       basePubkey: fromPubkey,
       seed: 'hi there',
@@ -216,8 +216,8 @@ describe('SystemProgram', () => {
 
   it('nonceAdvance', () => {
     const params = {
-      noncePubkey: new Account().publicKey,
-      authorizedPubkey: new Account().publicKey,
+      noncePubkey: Keypair.generate().publicKey,
+      authorizedPubkey: Keypair.generate().publicKey,
     };
     const instruction = SystemProgram.nonceAdvance(params);
     expect(params).to.eql(SystemInstruction.decodeNonceAdvance(instruction));
@@ -225,9 +225,9 @@ describe('SystemProgram', () => {
 
   it('nonceWithdraw', () => {
     const params = {
-      noncePubkey: new Account().publicKey,
-      authorizedPubkey: new Account().publicKey,
-      toPubkey: new Account().publicKey,
+      noncePubkey: Keypair.generate().publicKey,
+      authorizedPubkey: Keypair.generate().publicKey,
+      toPubkey: Keypair.generate().publicKey,
       lamports: 123,
     };
     const transaction = new Transaction().add(
@@ -240,9 +240,9 @@ describe('SystemProgram', () => {
 
   it('nonceAuthorize', () => {
     const params = {
-      noncePubkey: new Account().publicKey,
-      authorizedPubkey: new Account().publicKey,
-      newAuthorizedPubkey: new Account().publicKey,
+      noncePubkey: Keypair.generate().publicKey,
+      authorizedPubkey: Keypair.generate().publicKey,
+      newAuthorizedPubkey: Keypair.generate().publicKey,
     };
 
     const transaction = new Transaction().add(
@@ -254,8 +254,8 @@ describe('SystemProgram', () => {
   });
 
   it('non-SystemInstruction error', () => {
-    const from = new Account();
-    const to = new Account();
+    const from = Keypair.generate();
+    const to = Keypair.generate();
 
     const badProgramId = {
       keys: [
@@ -271,8 +271,8 @@ describe('SystemProgram', () => {
       );
     }).to.throw();
 
-    const stakePubkey = new Account().publicKey;
-    const authorizedPubkey = new Account().publicKey;
+    const stakePubkey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
     const params = {stakePubkey, authorizedPubkey};
     const transaction = StakeProgram.deactivate(params);
 
@@ -289,16 +289,16 @@ describe('SystemProgram', () => {
   if (process.env.TEST_LIVE) {
     it('live Nonce actions', async () => {
       const connection = new Connection(url, 'confirmed');
-      const nonceAccount = new Account();
-      const from = new Account();
+      const nonceAccount = Keypair.generate();
+      const from = Keypair.generate();
       await helpers.airdrop({
         connection,
         address: from.publicKey,
         amount: 2 * LAMPORTS_PER_SOL,
       });
 
-      const to = new Account();
-      const newAuthority = new Account();
+      const to = Keypair.generate();
+      const newAuthority = Keypair.generate();
       await helpers.airdrop({
         connection,
         address: newAuthority.publicKey,
@@ -403,7 +403,7 @@ describe('SystemProgram', () => {
       // Wait for blockhash to advance
       await sleep(500);
 
-      const withdrawAccount = new Account();
+      const withdrawAccount = Keypair.generate();
       const withdrawNonce = new Transaction().add(
         SystemProgram.nonceWithdraw({
           noncePubkey: nonceAccount.publicKey,
@@ -429,7 +429,7 @@ describe('SystemProgram', () => {
 
     it('live withSeed actions', async () => {
       const connection = new Connection(url, 'confirmed');
-      const baseAccount = new Account();
+      const baseAccount = Keypair.generate();
       await helpers.airdrop({
         connection,
         address: baseAccount.publicKey,
@@ -437,7 +437,7 @@ describe('SystemProgram', () => {
       });
       const basePubkey = baseAccount.publicKey;
       const seed = 'hi there';
-      const programId = new Account().publicKey;
+      const programId = Keypair.generate().publicKey;
       const createAccountWithSeedAddress = await PublicKey.createWithSeed(
         basePubkey,
         seed,
@@ -474,8 +474,8 @@ describe('SystemProgram', () => {
       expect(createAccountWithSeedBalance).to.eq(minimumAmount);
 
       // Test CreateAccountWithSeed where fromPubkey != basePubkey
-      const uniqueFromAccount = new Account();
-      const newBaseAccount = new Account();
+      const uniqueFromAccount = Keypair.generate();
+      const newBaseAccount = Keypair.generate();
       const createAccountWithSeedAddress2 = await PublicKey.createWithSeed(
         newBaseAccount.publicKey,
         seed,
@@ -510,7 +510,7 @@ describe('SystemProgram', () => {
       expect(createAccountWithSeedBalance2).to.eq(minimumAmount);
 
       // Transfer to a derived address to prep for TransferWithSeed
-      const programId2 = new Account().publicKey;
+      const programId2 = Keypair.generate().publicKey;
       const transferWithSeedAddress = await PublicKey.createWithSeed(
         basePubkey,
         seed,
@@ -534,7 +534,7 @@ describe('SystemProgram', () => {
       expect(transferWithSeedAddressBalance).to.eq(3 * minimumAmount);
 
       // Test TransferWithSeed
-      const programId3 = new Account();
+      const programId3 = Keypair.generate();
       const toPubkey = await PublicKey.createWithSeed(
         basePubkey,
         seed,

--- a/web3.js/test/transaction-payer.test.ts
+++ b/web3.js/test/transaction-payer.test.ts
@@ -3,7 +3,7 @@ import invariant from 'assert';
 import {expect} from 'chai';
 
 import {
-  Account,
+  Keypair,
   Connection,
   Transaction,
   SystemProgram,
@@ -33,9 +33,9 @@ describe('Transaction Payer', () => {
   }
 
   it('transaction-payer', async () => {
-    const accountPayer = new Account();
-    const accountFrom = new Account();
-    const accountTo = new Account();
+    const accountPayer = Keypair.generate();
+    const accountFrom = Keypair.generate();
+    const accountTo = Keypair.generate();
 
     await helpers.airdrop({
       connection,


### PR DESCRIPTION
#### Problem
The name of the `Account` class is very confusing because it really just represents a keypair that can be used to sign transactions. It's also very easy to pass an invalid secret key to the `Account` constructor which will cause problems later when used to sign transactions.

#### Summary of Changes
- Deprecate `Account` class
- Add new `Keypair` class with `fromSecretKey` and `fromSeed` methods.
- Verify secret keys passed to `Keypair.fromSecretKey` by default (can be skipped by passing `skipValidation` option)
- Update all API methods from `Account` to the backwards compatible `TransactionSigner` interface

Fixes https://github.com/solana-labs/solana/issues/16628
Fixes https://github.com/solana-labs/solana/issues/15455

