### PR TITLE
type AccountSecondaryIndexes = HashSet

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,10 +6,10 @@ use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
     accounts::{create_test_accounts, update_accounts_bench, Accounts},
-    accounts_index::Ancestors,
+    accounts_index::{AccountSecondaryIndexes, Ancestors},
 };
 use solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey};
-use std::{collections::HashSet, env, fs, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     solana_logger::setup();
@@ -58,8 +58,12 @@ fn main() {
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {:?}", path);
     }
-    let accounts =
-        Accounts::new_with_config(vec![path], &ClusterType::Testnet, HashSet::new(), false);
+    let accounts = Accounts::new_with_config(
+        vec![path],
+        &ClusterType::Testnet,
+        AccountSecondaryIndexes::default(),
+        false,
+    );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");
     let pubkeys: Vec<_> = (0..num_slots)

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -46,7 +46,7 @@ use solana_ledger::{
 use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_runtime::{
-    accounts_index::AccountIndex,
+    accounts_index::AccountSecondaryIndexes,
     bank::Bank,
     bank_forks::{BankForks, SnapshotConfig},
     commitment::BlockCommitmentCache,
@@ -125,7 +125,7 @@ pub struct ValidatorConfig {
     pub no_poh_speed_test: bool,
     pub poh_pinned_cpu_core: usize,
     pub poh_hashes_per_batch: u64,
-    pub account_indexes: HashSet<AccountIndex>,
+    pub account_indexes: AccountSecondaryIndexes,
     pub accounts_db_caching_enabled: bool,
     pub warp_slot: Option<Slot>,
     pub accounts_db_test_hash_calculation: bool,
@@ -181,7 +181,7 @@ impl Default for ValidatorConfig {
             no_poh_speed_test: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
-            account_indexes: HashSet::new(),
+            account_indexes: AccountSecondaryIndexes::default(),
             accounts_db_caching_enabled: false,
             warp_slot: None,
             accounts_db_test_hash_calculation: false,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -47,6 +47,7 @@ mod tests {
     use solana_runtime::{
         accounts_background_service::{AbsRequestSender, SnapshotRequestHandler},
         accounts_db,
+        accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta},
         bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -106,7 +107,7 @@ mod tests {
                 &[],
                 None,
                 None,
-                HashSet::new(),
+                AccountSecondaryIndexes::default(),
                 false,
             );
             bank0.freeze();
@@ -163,7 +164,7 @@ mod tests {
             old_genesis_config,
             None,
             None,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             false,
         )
         .unwrap();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -16,7 +16,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
-    accounts_index::AccountIndex,
+    accounts_index::AccountSecondaryIndexes,
     bank::{
         Bank, ExecuteTimings, InnerInstructionsList, TransactionBalancesSet,
         TransactionExecutionResult, TransactionLogMessages, TransactionResults,
@@ -366,7 +366,7 @@ pub struct ProcessOptions {
     pub new_hard_forks: Option<Vec<Slot>>,
     pub frozen_accounts: Vec<Pubkey>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
-    pub account_indexes: HashSet<AccountIndex>,
+    pub account_indexes: AccountSecondaryIndexes,
     pub accounts_db_caching_enabled: bool,
     pub allow_dead_slots: bool,
 }
@@ -2990,7 +2990,7 @@ pub mod tests {
             &[],
             None,
             None,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             false,
         );
         *bank.epoch_schedule()

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use solana_runtime::{
     accounts::{create_test_accounts, AccountAddressFilter, Accounts},
-    accounts_index::Ancestors,
+    accounts_index::{AccountSecondaryIndexes, Ancestors},
     bank::*,
 };
 use solana_sdk::{
@@ -56,7 +56,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
         &[],
         None,
         None,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     );
     bencher.iter(|| {
@@ -75,7 +75,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         &[],
         None,
         None,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -100,7 +100,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new_with_config(
         vec![PathBuf::from("bench_accounts_hash_internal")],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -118,7 +118,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new_with_config(
         vec![PathBuf::from("update_accounts_hash")],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -135,7 +135,7 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new_with_config(
         vec![PathBuf::from("accounts_delta_hash")],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -151,7 +151,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     let accounts = Accounts::new_with_config(
         vec![PathBuf::from("accounts_delete_deps")],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     );
     let mut old_pubkey = Pubkey::default();
@@ -184,7 +184,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
                 .join(bench_name),
         ],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     ));
     let num_keys = 1000;
@@ -313,7 +313,7 @@ fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (AccountSharedD
                 .join("bench_dashmap_par_iter"),
         ],
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     ));
 
@@ -364,8 +364,12 @@ fn bench_dashmap_iter(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_load_largest_accounts(b: &mut Bencher) {
-    let accounts =
-        Accounts::new_with_config(Vec::new(), &ClusterType::Development, HashSet::new(), false);
+    let accounts = Accounts::new_with_config(
+        Vec::new(),
+        &ClusterType::Development,
+        AccountSecondaryIndexes::default(),
+        false,
+    );
     let mut rng = rand::thread_rng();
     for _ in 0..10_000 {
         let lamports = rng.gen();

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -3,9 +3,11 @@
 extern crate test;
 
 use rand::{thread_rng, Rng};
-use solana_runtime::{accounts_db::AccountInfo, accounts_index::AccountsIndex};
+use solana_runtime::{
+    accounts_db::AccountInfo,
+    accounts_index::{AccountSecondaryIndexes, AccountsIndex},
+};
 use solana_sdk::pubkey::{self, Pubkey};
-use std::collections::HashSet;
 use test::Bencher;
 
 #[bench]
@@ -24,7 +26,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
                 pubkey,
                 &Pubkey::default(),
                 &[],
-                &HashSet::new(),
+                &AccountSecondaryIndexes::default(),
                 AccountInfo::default(),
                 &mut reclaims,
             );
@@ -41,7 +43,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
                 &pubkeys[pubkey],
                 &Pubkey::default(),
                 &[],
-                &HashSet::new(),
+                &AccountSecondaryIndexes::default(),
                 AccountInfo::default(),
                 &mut reclaims,
             );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -22,8 +22,8 @@ use crate::{
     accounts_cache::{AccountsCache, CachedAccount, SlotCache},
     accounts_hash::{AccountsHash, CalculateHashIntermediate, HashStats, PreviousPass},
     accounts_index::{
-        AccountIndex, AccountIndexGetResult, AccountsIndex, AccountsIndexRootsStats, Ancestors,
-        IndexKey, IsCached, SlotList, SlotSlice, ZeroLamport,
+        AccountIndexGetResult, AccountSecondaryIndexes, AccountsIndex, AccountsIndexRootsStats,
+        Ancestors, IndexKey, IsCached, SlotList, SlotSlice, ZeroLamport,
     },
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta},
     contains::Contains,
@@ -813,7 +813,7 @@ pub struct AccountsDb {
 
     pub cluster_type: Option<ClusterType>,
 
-    pub account_indexes: HashSet<AccountIndex>,
+    pub account_indexes: AccountSecondaryIndexes,
 
     pub caching_enabled: bool,
 
@@ -1220,7 +1220,7 @@ impl Default for AccountsDb {
             shrink_stats: ShrinkStats::default(),
             stats: AccountsStats::default(),
             cluster_type: None,
-            account_indexes: HashSet::new(),
+            account_indexes: AccountSecondaryIndexes::default(),
             caching_enabled: false,
             #[cfg(test)]
             load_delay: u64::default(),
@@ -1232,13 +1232,18 @@ impl Default for AccountsDb {
 
 impl AccountsDb {
     pub fn new(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
-        AccountsDb::new_with_config(paths, cluster_type, HashSet::new(), false)
+        AccountsDb::new_with_config(
+            paths,
+            cluster_type,
+            AccountSecondaryIndexes::default(),
+            false,
+        )
     }
 
     pub fn new_with_config(
         paths: Vec<PathBuf>,
         cluster_type: &ClusterType,
-        account_indexes: HashSet<AccountIndex>,
+        account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
     ) -> Self {
         let mut new = if !paths.is_empty() {
@@ -8664,7 +8669,7 @@ pub mod tests {
             &key0,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info0,
             &mut reclaims,
         );
@@ -8673,7 +8678,7 @@ pub mod tests {
             &key0,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info1.clone(),
             &mut reclaims,
         );
@@ -8682,7 +8687,7 @@ pub mod tests {
             &key1,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info1,
             &mut reclaims,
         );
@@ -8691,7 +8696,7 @@ pub mod tests {
             &key1,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info2.clone(),
             &mut reclaims,
         );
@@ -8700,7 +8705,7 @@ pub mod tests {
             &key2,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info2,
             &mut reclaims,
         );
@@ -8709,7 +8714,7 @@ pub mod tests {
             &key2,
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             info3,
             &mut reclaims,
         );
@@ -9063,7 +9068,7 @@ pub mod tests {
         let db = Arc::new(AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         ));
 
@@ -9110,7 +9115,7 @@ pub mod tests {
         let db = Arc::new(AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         ));
 
@@ -9158,7 +9163,7 @@ pub mod tests {
         let db = Arc::new(AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         ));
 
@@ -9289,7 +9294,7 @@ pub mod tests {
         let db = Arc::new(AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         ));
         let account_key = Pubkey::new_unique();
@@ -9393,7 +9398,7 @@ pub mod tests {
         let accounts_db = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         );
         let slot: Slot = 0;
@@ -9447,7 +9452,7 @@ pub mod tests {
         let accounts_db = Arc::new(AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         ));
         let slots: Vec<_> = (0..num_slots as Slot).into_iter().collect();
@@ -9845,7 +9850,7 @@ pub mod tests {
         let db = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::default(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         );
         let account_key1 = Pubkey::new_unique();
@@ -10107,7 +10112,7 @@ pub mod tests {
         let mut db = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         );
         db.load_delay = RACY_SLEEP_MS;
@@ -10178,7 +10183,7 @@ pub mod tests {
         let mut db = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         );
         db.load_delay = RACY_SLEEP_MS;
@@ -10252,7 +10257,7 @@ pub mod tests {
         let mut db = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             caching_enabled,
         );
         db.load_delay = RACY_SLEEP_MS;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -74,6 +74,8 @@ pub enum AccountIndex {
     SplTokenOwner,
 }
 
+pub type AccountSecondaryIndexes = HashSet<AccountIndex>;
+
 #[derive(Debug)]
 pub struct AccountMapEntryInner<T> {
     ref_count: AtomicU64,
@@ -819,7 +821,11 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         (w_account_entry.unwrap(), is_newly_inserted)
     }
 
-    pub fn handle_dead_keys(&self, dead_keys: &[&Pubkey], account_indexes: &HashSet<AccountIndex>) {
+    pub fn handle_dead_keys(
+        &self,
+        dead_keys: &[&Pubkey],
+        account_indexes: &AccountSecondaryIndexes,
+    ) {
         if !dead_keys.is_empty() {
             for key in dead_keys.iter() {
                 let mut w_index = self.account_maps.write().unwrap();
@@ -923,7 +929,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         pubkey: &Pubkey,
         slots_to_purge: &'a C,
         reclaims: &mut SlotList<T>,
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
     ) -> bool
     where
         C: Contains<'a, Slot>,
@@ -1051,7 +1057,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         slot: Slot,
         account_owner: &Pubkey,
         account_data: &[u8],
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
     ) {
         if account_indexes.is_empty() {
             return;
@@ -1103,7 +1109,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         pubkey: &Pubkey,
         account_owner: &Pubkey,
         account_data: &[u8],
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
         account_info: T,
         reclaims: &mut SlotList<T>,
     ) {
@@ -1126,7 +1132,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         pubkey: &Pubkey,
         account_owner: &Pubkey,
         account_data: &[u8],
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
         account_info: T,
         reclaims: &mut SlotList<T>,
     ) -> bool {
@@ -1180,7 +1186,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         &'a self,
         inner_key: &Pubkey,
         slots_to_remove: Option<&'a C>,
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
     ) where
         C: Contains<'a, Slot>,
     {
@@ -1206,7 +1212,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         slot_list: &mut SlotList<T>,
         reclaims: &mut SlotList<T>,
         max_clean_root: Option<Slot>,
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
     ) {
         let roots_tracker = &self.roots_tracker.read().unwrap();
         let newest_root_in_slot_list =
@@ -1233,7 +1239,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         pubkey: &Pubkey,
         reclaims: &mut SlotList<T>,
         max_clean_root: Option<Slot>,
-        account_indexes: &HashSet<AccountIndex>,
+        account_indexes: &AccountSecondaryIndexes,
     ) {
         let mut is_slot_list_empty = false;
         if let Some(mut locked_entry) = self.get_account_write_entry(pubkey) {
@@ -1438,13 +1444,13 @@ pub mod tests {
         DashMap(&'a SecondaryIndex<DashMapSecondaryIndexEntry>),
     }
 
-    pub fn spl_token_mint_index_enabled() -> HashSet<AccountIndex> {
+    pub fn spl_token_mint_index_enabled() -> AccountSecondaryIndexes {
         let mut account_indexes = HashSet::new();
         account_indexes.insert(AccountIndex::SplTokenMint);
         account_indexes
     }
 
-    pub fn spl_token_owner_index_enabled() -> HashSet<AccountIndex> {
+    pub fn spl_token_owner_index_enabled() -> AccountSecondaryIndexes {
         let mut account_indexes = HashSet::new();
         account_indexes.insert(AccountIndex::SplTokenOwner);
         account_indexes
@@ -1476,7 +1482,7 @@ pub mod tests {
         }
     }
 
-    fn create_dashmap_secondary_index_state() -> (usize, usize, HashSet<AccountIndex>) {
+    fn create_dashmap_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
         {
             // Check that we're actually testing the correct variant
             let index = AccountsIndex::<bool>::default();
@@ -1486,7 +1492,7 @@ pub mod tests {
         (0, PUBKEY_BYTES, spl_token_mint_index_enabled())
     }
 
-    fn create_rwlock_secondary_index_state() -> (usize, usize, HashSet<AccountIndex>) {
+    fn create_rwlock_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
         {
             // Check that we're actually testing the correct variant
             let index = AccountsIndex::<bool>::default();
@@ -2074,7 +2080,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2099,7 +2105,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2123,7 +2129,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2156,7 +2162,7 @@ pub mod tests {
                 &new_pubkey,
                 &Pubkey::default(),
                 &[],
-                &HashSet::new(),
+                &AccountSecondaryIndexes::default(),
                 true,
                 &mut vec![],
             );
@@ -2172,7 +2178,7 @@ pub mod tests {
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &[],
-                &HashSet::new(),
+                &AccountSecondaryIndexes::default(),
                 true,
                 &mut vec![],
             );
@@ -2303,7 +2309,7 @@ pub mod tests {
             &solana_sdk::pubkey::new_rand(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2328,7 +2334,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2442,7 +2448,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2457,7 +2463,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
         );
@@ -2478,7 +2484,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2488,7 +2494,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
         );
@@ -2510,7 +2516,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2520,7 +2526,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
         );
@@ -2529,7 +2535,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2538,7 +2544,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2550,7 +2556,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
         );
@@ -2584,7 +2590,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             12,
             &mut gc
         ));
@@ -2594,7 +2600,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             10,
             &mut gc
         ));
@@ -2611,7 +2617,7 @@ pub mod tests {
             &key.pubkey(),
             &Pubkey::default(),
             &[],
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
             9,
             &mut gc
         ));
@@ -2667,7 +2673,7 @@ pub mod tests {
         secondary_index: &SecondaryIndex<SecondaryIndexEntryType>,
         key_start: usize,
         key_end: usize,
-        account_index: &HashSet<AccountIndex>,
+        account_index: &AccountSecondaryIndexes,
     ) {
         // No roots, should be no reclaims
         let slots = vec![1, 2, 5, 9];
@@ -2756,7 +2762,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             None,
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -2772,7 +2778,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             None,
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2786,7 +2792,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             None,
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2800,7 +2806,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             Some(6),
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2813,7 +2819,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             Some(5),
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2827,7 +2833,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             Some(2),
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -2841,7 +2847,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             Some(1),
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -2855,7 +2861,7 @@ pub mod tests {
             &mut slot_list,
             &mut reclaims,
             Some(7),
-            &HashSet::new(),
+            &AccountSecondaryIndexes::default(),
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2894,7 +2900,7 @@ pub mod tests {
         secondary_index: &SecondaryIndex<SecondaryIndexEntryType>,
         key_start: usize,
         key_end: usize,
-        account_index: &HashSet<AccountIndex>,
+        account_index: &AccountSecondaryIndexes,
     ) {
         let account_key = Pubkey::new_unique();
         let index_key = Pubkey::new_unique();
@@ -2984,7 +2990,7 @@ pub mod tests {
         secondary_index: &SecondaryIndex<SecondaryIndexEntryType>,
         index_key_start: usize,
         index_key_end: usize,
-        account_index: &HashSet<AccountIndex>,
+        account_index: &AccountSecondaryIndexes,
     ) {
         let account_key = Pubkey::new_unique();
         let secondary_key1 = Pubkey::new_unique();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -39,7 +39,7 @@ use crate::{
         TransactionLoadResult, TransactionLoaders,
     },
     accounts_db::{ErrorCounters, SnapshotStorages},
-    accounts_index::{AccountIndex, Ancestors, IndexKey},
+    accounts_index::{AccountSecondaryIndexes, Ancestors, IndexKey},
     blockhash_queue::BlockhashQueue,
     builtins::{self, ActivationType},
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
@@ -932,7 +932,7 @@ impl Bank {
             &[],
             None,
             None,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             false,
         )
     }
@@ -944,7 +944,7 @@ impl Bank {
             &[],
             None,
             None,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             false,
         );
 
@@ -955,7 +955,7 @@ impl Bank {
     #[cfg(test)]
     pub(crate) fn new_with_config(
         genesis_config: &GenesisConfig,
-        account_indexes: HashSet<AccountIndex>,
+        account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
     ) -> Self {
         Self::new_with_paths(
@@ -975,7 +975,7 @@ impl Bank {
         frozen_account_pubkeys: &[Pubkey],
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         additional_builtins: Option<&Builtins>,
-        account_indexes: HashSet<AccountIndex>,
+        account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
     ) -> Self {
         let mut bank = Self::default();
@@ -5154,7 +5154,9 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         accounts_db::SHRINK_RATIO,
-        accounts_index::{AccountMap, Ancestors, ITER_BATCH_SIZE},
+        accounts_index::{
+            AccountIndex, AccountMap, AccountSecondaryIndexes, Ancestors, ITER_BATCH_SIZE,
+        },
         genesis_utils::{
             activate_all_features, bootstrap_validator_stake_lamports,
             create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
@@ -9040,7 +9042,7 @@ pub(crate) mod tests {
     #[test]
     fn test_get_filtered_indexed_accounts() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
-        let mut account_indexes = HashSet::new();
+        let mut account_indexes = AccountSecondaryIndexes::default();
         account_indexes.insert(AccountIndex::ProgramId);
         let bank = Arc::new(Bank::new_with_config(
             &genesis_config,
@@ -10493,7 +10495,7 @@ pub(crate) mod tests {
         // of the storage for this slot
         let mut bank0 = Arc::new(Bank::new_with_config(
             &genesis_config,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             false,
         ));
         bank0.restore_old_behavior_for_fragile_tests();
@@ -10524,7 +10526,11 @@ pub(crate) mod tests {
         let pubkey2 = solana_sdk::pubkey::new_rand();
 
         // Set root for bank 0, with caching enabled
-        let mut bank0 = Arc::new(Bank::new_with_config(&genesis_config, HashSet::new(), true));
+        let mut bank0 = Arc::new(Bank::new_with_config(
+            &genesis_config,
+            AccountSecondaryIndexes::default(),
+            true,
+        ));
         bank0.restore_old_behavior_for_fragile_tests();
 
         let pubkey0_size = get_shrink_account_size();
@@ -11703,7 +11709,7 @@ pub(crate) mod tests {
         genesis_config.rent = Rent::free();
         let bank0 = Arc::new(Bank::new_with_config(
             &genesis_config,
-            HashSet::new(),
+            AccountSecondaryIndexes::default(),
             accounts_db_caching_enabled,
         ));
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         accounts::Accounts,
         accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo},
-        accounts_index::{AccountIndex, Ancestors},
+        accounts_index::{AccountSecondaryIndexes, Ancestors},
         append_vec::AppendVec,
         bank::{Bank, BankFieldsToDeserialize, BankRc, Builtins},
         blockhash_queue::BlockhashQueue,
@@ -127,7 +127,7 @@ pub(crate) fn bank_from_stream<R>(
     frozen_account_pubkeys: &[Pubkey],
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
-    account_indexes: HashSet<AccountIndex>,
+    account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
 ) -> std::result::Result<Bank, Error>
 where
@@ -235,7 +235,7 @@ fn reconstruct_bank_from_fields<E>(
     unpacked_append_vec_map: UnpackedAppendVecMap,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
-    account_indexes: HashSet<AccountIndex>,
+    account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
 ) -> Result<Bank, Error>
 where
@@ -268,7 +268,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     account_paths: &[PathBuf],
     unpacked_append_vec_map: UnpackedAppendVecMap,
     cluster_type: &ClusterType,
-    account_indexes: HashSet<AccountIndex>,
+    account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
 ) -> Result<AccountsDb, Error>
 where

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -71,7 +71,7 @@ where
         account_paths,
         unpacked_append_vec_map,
         &ClusterType::Development,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     )
 }
@@ -123,8 +123,12 @@ where
 fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     solana_logger::setup();
     let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
-    let accounts =
-        Accounts::new_with_config(paths, &ClusterType::Development, HashSet::new(), false);
+    let accounts = Accounts::new_with_config(
+        paths,
+        &ClusterType::Development,
+        AccountSecondaryIndexes::default(),
+        false,
+    );
 
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100, 0);
@@ -220,7 +224,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         &[],
         None,
         None,
-        HashSet::new(),
+        AccountSecondaryIndexes::default(),
         false,
     )
     .unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         accounts_db::AccountsDb,
-        accounts_index::AccountIndex,
+        accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta, Builtins},
         bank_forks::ArchiveFormat,
         hardened_unpack::{unpack_snapshot, UnpackError, UnpackedAppendVecMap},
@@ -593,7 +593,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     genesis_config: &GenesisConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
-    account_indexes: HashSet<AccountIndex>,
+    account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
 ) -> Result<Bank> {
     let unpack_dir = tempfile::Builder::new()
@@ -772,7 +772,7 @@ fn rebuild_bank_from_snapshots(
     genesis_config: &GenesisConfig,
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
-    account_indexes: HashSet<AccountIndex>,
+    account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
 ) -> Result<Bank> {
     info!("snapshot version: {}", snapshot_version);


### PR DESCRIPTION
#### Problem
Account secondary indexes are about to be more complicated. Much code assumes that the account secondary indexes are defined only by a hashset. See [here](https://github.com/solana-labs/solana/issues/17019#issuecomment-834481000).
Follow up PR: #17110
#### Summary of Changes
Make a type and use type::default() so we can replace the implementation.
Fixes #
