### PR TITLE
include/exclude keys on account secondary index

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -702,13 +702,17 @@ impl Accounts {
         index_key: &IndexKey,
         filter: F,
     ) -> Vec<(Pubkey, AccountSharedData)> {
-        self.accounts_db.index_scan_accounts(
-            ancestors,
-            *index_key,
-            |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
-                Self::load_while_filtering(collector, some_account_tuple, |account| filter(account))
-            },
-        ).0
+        self.accounts_db
+            .index_scan_accounts(
+                ancestors,
+                *index_key,
+                |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
+                    Self::load_while_filtering(collector, some_account_tuple, |account| {
+                        filter(account)
+                    })
+                },
+            )
+            .0
     }
 
     pub fn load_all(&self, ancestors: &Ancestors) -> Vec<(Pubkey, AccountSharedData, Slot)> {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -708,7 +708,7 @@ impl Accounts {
             |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
                 Self::load_while_filtering(collector, some_account_tuple, |account| filter(account))
             },
-        )
+        ).0
     }
 
     pub fn load_all(&self, ancestors: &Ancestors) -> Vec<(Pubkey, AccountSharedData, Slot)> {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2275,6 +2275,16 @@ impl AccountsDb {
         F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
         A: Default,
     {
+        let key = match &index_key {
+            IndexKey::ProgramId(key) => key,
+            IndexKey::SplTokenMint(key) => key,
+            IndexKey::SplTokenOwner(key) => key,
+        };
+        if !self.account_indexes.include_key(key) {
+            // the requested key was not indexed in the secondary index, so do a normal scan
+            return self.scan_accounts(ancestors, scan_func);
+        }
+
         let mut collector = A::default();
         self.accounts_index.index_scan_accounts(
             ancestors,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2270,7 +2270,7 @@ impl AccountsDb {
         ancestors: &Ancestors,
         index_key: IndexKey,
         scan_func: F,
-    ) -> A
+    ) -> (A, bool)
     where
         F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
         A: Default,
@@ -2282,7 +2282,8 @@ impl AccountsDb {
         };
         if !self.account_indexes.include_key(key) {
             // the requested key was not indexed in the secondary index, so do a normal scan
-            return self.scan_accounts(ancestors, scan_func);
+            let used_index = false;
+            return (self.scan_accounts(ancestors, scan_func), used_index);
         }
 
         let mut collector = A::default();
@@ -2297,7 +2298,8 @@ impl AccountsDb {
                 scan_func(&mut collector, account_slot)
             },
         );
-        collector
+        let used_index = true;
+        (collector, used_index)
     }
 
     /// Scan a specific slot through all the account storage in parallel
@@ -5543,8 +5545,11 @@ impl AccountsDb {
 pub mod tests {
     use super::*;
     use crate::{
-        accounts_hash::MERKLE_FANOUT, accounts_index::tests::*, accounts_index::RefCount,
-        append_vec::AccountMeta, inline_spl_token_v2_0,
+        accounts_hash::MERKLE_FANOUT,
+        accounts_index::RefCount,
+        accounts_index::{tests::*, AccountSecondaryIndexesIncludeExclude},
+        append_vec::AccountMeta,
+        inline_spl_token_v2_0,
     };
     use assert_matches::assert_matches;
     use rand::{thread_rng, Rng};
@@ -6863,7 +6868,7 @@ pub mod tests {
     fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
         solana_logger::setup();
 
-        let accounts = AccountsDb::new_with_config(
+        let mut accounts = AccountsDb::new_with_config(
             Vec::new(),
             &ClusterType::Development,
             spl_token_mint_index_enabled(),
@@ -6907,16 +6912,51 @@ pub mod tests {
 
         // Secondary index should still find both pubkeys
         let mut found_accounts = HashSet::new();
-        accounts.accounts_index.index_scan_accounts(
-            &Ancestors::default(),
-            IndexKey::SplTokenMint(mint_key),
-            |key, _| {
+        let index_key = IndexKey::SplTokenMint(mint_key);
+        accounts
+            .accounts_index
+            .index_scan_accounts(&Ancestors::default(), index_key, |key, _| {
                 found_accounts.insert(*key);
-            },
-        );
+            });
         assert_eq!(found_accounts.len(), 2);
         assert!(found_accounts.contains(&pubkey1));
         assert!(found_accounts.contains(&pubkey2));
+
+        {
+            accounts.account_indexes.keys = Some(AccountSecondaryIndexesIncludeExclude {
+                exclude: true,
+                keys: [mint_key].iter().cloned().collect::<HashSet<Pubkey>>(),
+            });
+            // Secondary index can't be used - do normal scan: should still find both pubkeys
+            let found_accounts = accounts.index_scan_accounts(
+                &Ancestors::default(),
+                index_key,
+                |collection: &mut HashSet<Pubkey>, account| {
+                    collection.insert(*account.unwrap().0);
+                },
+            );
+            assert!(!found_accounts.1);
+            assert_eq!(found_accounts.0.len(), 2);
+            assert!(found_accounts.0.contains(&pubkey1));
+            assert!(found_accounts.0.contains(&pubkey2));
+
+            accounts.account_indexes.keys = None;
+
+            // Secondary index can now be used since it isn't marked as excluded
+            let found_accounts = accounts.index_scan_accounts(
+                &Ancestors::default(),
+                index_key,
+                |collection: &mut HashSet<Pubkey>, account| {
+                    collection.insert(*account.unwrap().0);
+                },
+            );
+            assert!(found_accounts.1);
+            assert_eq!(found_accounts.0.len(), 2);
+            assert!(found_accounts.0.contains(&pubkey1));
+            assert!(found_accounts.0.contains(&pubkey2));
+
+            accounts.account_indexes.keys = None;
+        }
 
         accounts.clean_accounts(None);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9046,7 +9046,7 @@ pub(crate) mod tests {
     fn test_get_filtered_indexed_accounts() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
         let mut account_indexes = AccountSecondaryIndexes::default();
-        account_indexes.insert(AccountIndex::ProgramId);
+        account_indexes.indexes.insert(AccountIndex::ProgramId);
         let bank = Arc::new(Bank::new_with_config(
             &genesis_config,
             account_indexes,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -39,7 +39,9 @@ use {
     solana_ledger::blockstore_db::BlockstoreRecoveryMode,
     solana_perf::recycler::enable_recycler_warming,
     solana_runtime::{
-        accounts_index::AccountIndex,
+        accounts_index::{
+            AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
+        },
         bank_forks::{ArchiveFormat, SnapshotConfig, SnapshotVersion},
         hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
         snapshot_utils::get_highest_snapshot_archive_path,
@@ -78,6 +80,9 @@ enum Operation {
     Initialize,
     Run,
 }
+
+const EXCLUDE_KEY: &str = "account-index-exclude-key";
+const INCLUDE_KEY: &str = "account-index-include-key";
 
 fn monitor_validator(ledger_path: &Path) {
     let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
@@ -1708,6 +1713,22 @@ pub fn main() {
                 .help("Enable an accounts index, indexed by the selected account field"),
         )
         .arg(
+            Arg::with_name("account_index_exclude_key")
+                .long(EXCLUDE_KEY)
+                .takes_value(true)
+                .multiple(true)
+                .value_name("KEY")
+                .help("When account indexes are enabled, exclude this key from the index."),
+        )
+        .arg(
+            Arg::with_name("account_index_include_key")
+                .long(INCLUDE_KEY)
+                .takes_value(true)
+                .multiple(true)
+                .value_name("KEY")
+                .help("When account indexes are enabled, only include specific keys in the index. This overrides --account-index-exclude-key."),
+        )
+        .arg(
             Arg::with_name("no_accounts_db_caching")
                 .long("no-accounts-db-caching")
                 .help("Disables accounts caching"),
@@ -2033,16 +2054,7 @@ pub fn main() {
 
     let contact_debug_interval = value_t_or_exit!(matches, "contact_debug_interval", u64);
 
-    let account_indexes: HashSet<AccountIndex> = matches
-        .values_of("account_indexes")
-        .unwrap_or_default()
-        .map(|value| match value {
-            "program-id" => AccountIndex::ProgramId,
-            "spl-token-mint" => AccountIndex::SplTokenMint,
-            "spl-token-owner" => AccountIndex::SplTokenOwner,
-            _ => unreachable!(),
-        })
-        .collect();
+    let account_indexes = process_account_indexes(&matches);
 
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let mut validator_config = ValidatorConfig {
@@ -2084,7 +2096,7 @@ pub fn main() {
             rpc_bigtable_timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
                 .ok()
                 .map(Duration::from_secs),
-            account_indexes: account_indexes.clone(),
+            account_indexes: account_indexes.indexes.clone(),
         },
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {
             (
@@ -2498,4 +2510,58 @@ pub fn main() {
     info!("Validator initialized");
     validator.join();
     info!("Validator exiting..");
+}
+
+fn process_account_indexes(matches: &ArgMatches) -> AccountSecondaryIndexes {
+    let account_indexes: HashSet<AccountIndex> = matches
+        .values_of("account_indexes")
+        .unwrap_or_default()
+        .map(|value| match value {
+            "program-id" => AccountIndex::ProgramId,
+            "spl-token-mint" => AccountIndex::SplTokenMint,
+            "spl-token-owner" => AccountIndex::SplTokenOwner,
+            _ => unreachable!(),
+        })
+        .collect();
+
+    let account_indexes_include_keys: HashSet<Pubkey> = matches
+        .values_of("account_index_include_key")
+        .unwrap_or_default()
+        .map(|value| Pubkey::from_str(value).expect("invalid pubkey"))
+        .collect();
+
+    let account_indexes_exclude_keys: HashSet<Pubkey> = matches
+        .values_of("account_index_exclude_key")
+        .unwrap_or_default()
+        .map(|value| Pubkey::from_str(value).expect("invalid pubkey"))
+        .collect();
+
+    let exclude_keys = !account_indexes_exclude_keys.is_empty();
+    let include_keys = !account_indexes_include_keys.is_empty();
+
+    if exclude_keys && include_keys {
+        panic!(
+            "Specify --{} or --{}, but not both.",
+            INCLUDE_KEY, EXCLUDE_KEY
+        );
+    }
+
+    let keys = if !account_indexes.is_empty() && (exclude_keys || include_keys) {
+        let account_indexes_keys = AccountSecondaryIndexesIncludeExclude {
+            exclude: exclude_keys,
+            keys: if exclude_keys {
+                account_indexes_exclude_keys
+            } else {
+                account_indexes_include_keys
+            },
+        };
+        Some(account_indexes_keys)
+    } else {
+        None
+    };
+
+    AccountSecondaryIndexes {
+        keys,
+        indexes: account_indexes,
+    }
 }


### PR DESCRIPTION
#### Problem
[Context](https://github.com/solana-labs/solana/issues/17019#issuecomment-834481000)
Validator startup time can be very slow and memory usage can be very high due to large secondary indexes.
 [Some pubkeys](https://github.com/solana-labs/solana/issues/17019#issuecomment-833319532) are so large that it is practically useless to include them.

#### Summary of Changes
Validator can be given pubkeys to include or exclude from the secondary index.
Add validator args, implement filter on include/exclude pubkeys before inserting into secondary indices.
Fixes #
