### PR TITLE
Fix syscalls in the C SDK failing at runtime when compiled as C++

### DIFF
--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -431,7 +431,7 @@ typedef struct {
  * @param bytes_len Number of byte arrays
  * @param result 32 byte array to hold the result
  */
-static uint64_t sol_sha256(
+uint64_t sol_sha256(
     const SolBytes *bytes,
     int bytes_len,
     const uint8_t *result
@@ -482,7 +482,7 @@ typedef struct {
  * @param program_id Program id of the signer
  * @param program_address Program address created, filled on return
  */
-static uint64_t sol_create_program_address(
+uint64_t sol_create_program_address(
     const SolSignerSeed *seeds,
     int seeds_len,
     const SolPubkey *program_id,
@@ -498,7 +498,7 @@ static uint64_t sol_create_program_address(
  * @param program_address Program address created, filled on return
  * @param bump_seed Bump seed required to create a valid program address
  */
-static uint64_t sol_try_find_program_address(
+uint64_t sol_try_find_program_address(
     const SolSignerSeed *seeds,
     int seeds_len,
     const SolPubkey *program_id,
@@ -510,6 +510,17 @@ static uint64_t sol_try_find_program_address(
  * Cross-program invocation
  *  * @{
  */
+
+/**
+ * Internal cross-program invocation function
+ */
+uint64_t sol_invoke_signed_c(
+  const SolInstruction *instruction,
+  const SolAccountInfo *account_infos,
+  int account_infos_len,
+  const SolSignerSeeds *signers_seeds,
+  int signers_seeds_len
+);
 
 /**
  * Invoke another program and sign for some of the keys
@@ -527,14 +538,6 @@ static uint64_t sol_invoke_signed(
     const SolSignerSeeds *signers_seeds,
     int signers_seeds_len
 ) {
-  uint64_t sol_invoke_signed_c(
-    const SolInstruction *instruction,
-    const SolAccountInfo *account_infos,
-    int account_infos_len,
-    const SolSignerSeeds *signers_seeds,
-    int signers_seeds_len
-  );
-
   return sol_invoke_signed_c(
     instruction,
     account_infos,


### PR DESCRIPTION
#### Problem
Some syscalls are wrongly declared `static` in solana_sdk.h, which makes clang++ assume they are local to the compilation unit. It therefore ignores the `extern "C" {}` block and mangles their names. While that doesn't break C++ compilation, the syscall fails at runtime with something along the lines of `ELF error: Unresolved symbol (_ZL26sol_create_program_addressPK13SolSignerSeediPK9SolPubkeyS4_)`.

#### Summary of Changes
Cleanly separate syscalls from non-syscalls and ensure the former are no longer declared static.
