### PR TITLE
fix: Improve findProgramAddress error when MAX_SEED_LENGTH is exceeded

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -113,7 +113,7 @@ export class PublicKey {
     let buffer = Buffer.alloc(0);
     seeds.forEach(function (seed) {
       if (seed.length > MAX_SEED_LENGTH) {
-        throw new Error(`Max seed length exceeded`);
+        throw new TypeError(`Max seed length exceeded`);
       }
       buffer = Buffer.concat([buffer, toBuffer(seed)]);
     });
@@ -148,6 +148,9 @@ export class PublicKey {
         const seedsWithNonce = seeds.concat(Buffer.from([nonce]));
         address = await this.createProgramAddress(seedsWithNonce, programId);
       } catch (err) {
+        if (err instanceof TypeError) {
+          throw err;
+        }
         nonce--;
         continue;
       }


### PR DESCRIPTION
#### Problem
findProgramAddress calls createProgramAddress, which can throw for two reasons: a seed given is larger than MAX_SEED_LENGTH or because the address doesn't fall off the curve. Currently, both exceptions report "Unable to find a viable program address nonce", which in the first case doesn't call out the issue.

#### Summary of Changes
When MAX_SEED_LENGTH is exceeded, it doesn't help to try other nonces, so this error case is now handled by re-throwing the inner Error immediately. The error reported this way ("Max seed length exceeded") also points to the problem more directly than the previously reported "Unable to find a viable program address nonce".