### PR TITLE
fix c program deploy help

### DIFF
--- a/sdk/bpf/c/bpf.mk
+++ b/sdk/bpf/c/bpf.mk
@@ -172,7 +172,7 @@ ifeq (,$(wildcard $(subst .so,-keypair.json,$1)))
 	$(_@)solana-keygen new --no-passphrase --silent -o $(subst .so,-keypair.json,$1)
 endif
 	@echo To deploy this program:
-	@echo $$$$ solana program deploy $(realpath $1)
+	@echo $$$$ solana program deploy $(abspath $1)
 endef
 
 define TEST_C_RULE


### PR DESCRIPTION
#### Problem

deploy path not being reported by the makefile

#### Summary of Changes

Use `abspath` instead of `realpath`

Fixes #
