### PR TITLE
runtime: Executor usage counts retain only single-epoch memory

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -268,8 +268,7 @@ pub struct Builtins {
 
 const MAX_CACHED_EXECUTORS: usize = 100; // 10 MB assuming programs are around 100k
 
-/// LFU Cache of executors with
-/// max last-used-epoch staleness eviction
+/// LFU Cache of executors with single-epoch memory of usage counts
 #[derive(Debug)]
 struct CachedExecutors {
     max: usize,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -268,7 +268,7 @@ pub struct Builtins {
 
 const MAX_CACHED_EXECUTORS: usize = 100; // 10 MB assuming programs are around 100k
 
-/// LFU Cache of executors with single-epoch memory of usage counts.
+/// LFU Cache of executors with single-epoch memory of usage counts
 #[derive(Debug)]
 struct CachedExecutors {
     max: usize,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -308,7 +308,9 @@ impl CachedExecutors {
         for (key, (count, last_epoch, executor)) in self.executors.iter() {
             let last_used = last_epoch.load(Relaxed) as Epoch;
 
-            if last_used + self.max_epoch >= epoch {
+            // If executor was used at least max_epoch Epochs ago
+            // we add it to the new cloned cache
+            if !(last_used + self.max_epoch < epoch) {
                 executors.insert(
                     *key,
                     (

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -217,14 +217,14 @@ impl Clone for CowCachedExecutors {
 }
 impl CowCachedExecutors {
     fn clone_with_epoch(&self, epoch: u64) -> Self {
-        let exec = self.read().unwrap();
-        if exec.current_epoch() == epoch {
-            return self.clone();
+        let executors_raw = self.read().unwrap();
+        if executors_raw.current_epoch() == epoch {
+            self.clone()
         } else {
-            return Self {
+            Self {
                 shared: false,
-                executors: Arc::new(RwLock::new(exec.clone_with_epoch(epoch))),
-            };
+                executors: Arc::new(RwLock::new(executors_raw.clone_with_epoch(epoch))),
+            }
         }
     }
     fn new(executors: Arc<RwLock<CachedExecutors>>) -> Self {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -314,7 +314,7 @@ impl CachedExecutors {
         let mut executors = HashMap::new();
         for (key, entry) in self.executors.iter() {
             // The total_count = prev_epoch_count + epoch_count will be used for LFU eviction.
-            // If the epoch has changed, we store the prev_epoch_count and reset the epoch_count to 0
+            // If the epoch has changed, we store the prev_epoch_count and reset the epoch_count to 0.
             if epoch > self.current_epoch {
                 executors.insert(
                     *key,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -310,7 +310,7 @@ impl CachedExecutors {
 
             // If executor was used at least max_epoch Epochs ago
             // we add it to the new cloned cache
-            if !(last_used + self.max_epoch < epoch) {
+            if last_used + self.max_epoch >= epoch {
                 executors.insert(
                     *key,
                     (

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -268,7 +268,7 @@ pub struct Builtins {
 
 const MAX_CACHED_EXECUTORS: usize = 100; // 10 MB assuming programs are around 100k
 
-/// LFU Cache of executors with single-epoch memory of usage counts
+/// LFU Cache of executors with single-epoch memory of usage counts.
 #[derive(Debug)]
 struct CachedExecutors {
     max: usize,


### PR DESCRIPTION
#### Problem
Replaces https://github.com/solana-labs/solana/pull/17044

#### Summary of Changes
~~We evict old executors whenever the cache is `cloned_with_epoch` to prevent old programs or program versions from clogging up the cache potentially for all time.~~

We only retain usage counts from the previous epoch, and discard any previous usage counts.


TODO:
- add tests to ensure old unused are indeed evicted for various `Bank::_new_from_parent`