### PR TITLE
Switch EpochSlots to be frozen slots, not completed slots

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -387,7 +387,7 @@ impl Validator {
             bank_forks,
             blockstore,
             ledger_signal_receiver,
-            completed_slots_receivers,
+            completed_slots_receiver,
             leader_schedule_cache,
             snapshot_hash,
             TransactionHistoryServices {
@@ -719,7 +719,7 @@ impl Validator {
             tower,
             &leader_schedule_cache,
             &exit,
-            completed_slots_receivers,
+            completed_slots_receiver,
             block_commitment_cache,
             config.enable_partition.clone(),
             transaction_status_sender.clone(),
@@ -1042,7 +1042,7 @@ fn new_banks_from_ledger(
     BankForks,
     Arc<Blockstore>,
     Receiver<bool>,
-    [CompletedSlotsReceiver; 2],
+    CompletedSlotsReceiver,
     LeaderScheduleCache,
     Option<(Slot, Hash)>,
     TransactionHistoryServices,
@@ -1073,7 +1073,7 @@ fn new_banks_from_ledger(
     let BlockstoreSignals {
         mut blockstore,
         ledger_signal_receiver,
-        completed_slots_receivers,
+        completed_slots_receiver,
         ..
     } = Blockstore::open_with_signal(
         ledger_path,
@@ -1225,7 +1225,7 @@ fn new_banks_from_ledger(
         bank_forks,
         blockstore,
         ledger_signal_receiver,
-        completed_slots_receivers,
+        completed_slots_receiver,
         leader_schedule_cache,
         snapshot_hash,
         transaction_history_services,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -85,7 +85,8 @@ pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_P
 // (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
 pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
 
-pub type CompletedSlotsReceiver = Receiver<Vec<u64>>;
+pub type CompletedSlotsSender = SyncSender<Vec<Slot>>;
+pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;
 type CompletedRanges = Vec<(u32, u32)>;
 
 #[derive(Clone, Copy)]
@@ -118,7 +119,7 @@ pub struct CompletedDataSetInfo {
 pub struct BlockstoreSignals {
     pub blockstore: Blockstore,
     pub ledger_signal_receiver: Receiver<bool>,
-    pub completed_slots_receivers: [CompletedSlotsReceiver; 2],
+    pub completed_slots_receiver: CompletedSlotsReceiver,
 }
 
 // ledger window
@@ -144,7 +145,7 @@ pub struct Blockstore {
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
-    pub completed_slots_senders: Vec<SyncSender<Vec<Slot>>>,
+    pub completed_slots_senders: Vec<CompletedSlotsSender>,
     pub lowest_cleanup_slot: Arc<RwLock<Slot>>,
     no_compaction: bool,
 }
@@ -385,18 +386,16 @@ impl Blockstore {
             enforce_ulimit_nofile,
         )?;
         let (ledger_signal_sender, ledger_signal_receiver) = sync_channel(1);
-        let (completed_slots_sender1, completed_slots_receiver1) =
-            sync_channel(MAX_COMPLETED_SLOTS_IN_CHANNEL);
-        let (completed_slots_sender2, completed_slots_receiver2) =
+        let (completed_slots_sender, completed_slots_receiver) =
             sync_channel(MAX_COMPLETED_SLOTS_IN_CHANNEL);
 
         blockstore.new_shreds_signals = vec![ledger_signal_sender];
-        blockstore.completed_slots_senders = vec![completed_slots_sender1, completed_slots_sender2];
+        blockstore.completed_slots_senders = vec![completed_slots_sender];
 
         Ok(BlockstoreSignals {
             blockstore,
             ledger_signal_receiver,
-            completed_slots_receivers: [completed_slots_receiver1, completed_slots_receiver2],
+            completed_slots_receiver,
         })
     }
 
@@ -4568,7 +4567,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path!();
         let BlockstoreSignals {
             blockstore: ledger,
-            completed_slots_receivers: [recvr, _],
+            completed_slots_receiver: recvr,
             ..
         } = Blockstore::open_with_signal(&ledger_path, None, true).unwrap();
         let ledger = Arc::new(ledger);
@@ -4594,7 +4593,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path!();
         let BlockstoreSignals {
             blockstore: ledger,
-            completed_slots_receivers: [recvr, _],
+            completed_slots_receiver: recvr,
             ..
         } = Blockstore::open_with_signal(&ledger_path, None, true).unwrap();
         let ledger = Arc::new(ledger);
@@ -4638,7 +4637,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path!();
         let BlockstoreSignals {
             blockstore: ledger,
-            completed_slots_receivers: [recvr, _],
+            completed_slots_receiver: recvr,
             ..
         } = Blockstore::open_with_signal(&ledger_path, None, true).unwrap();
         let ledger = Arc::new(ledger);


### PR DESCRIPTION
#### Problem
If the cluster doesn't directly voted on one version of a slot `S` (maybe only voted on the descendants), and we marked slot `S` as dead, then currently there's no mechanism by which to detect that the cluster has frozen another version of this slot.

#### Summary of Changes
Switch EpochSlots to be for frozen slots instead of just completed slots, so we can later invoke dump/repair logic if a slot is frozen > duplicate threshold of the cluster. Design follows the proposal here: https://github.com/solana-labs/solana/pull/16127/commits/f79c0e803ea92b9eebc137c1675d54efb72f469d#diff-0bd0e50030bdee14082c678da5f3098df8156825fa86c59ad55ddbd2a3669585R82, which describes the context in more detail

Fixes #
