### PR TITLE
Resize shreds on all get methods

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -314,7 +314,7 @@ impl Shred {
         }
     }
 
-    pub fn new_from_serialized_shred(mut payload: Vec<u8>) -> Result<Self> {
+    pub fn new_from_serialized_shred(payload: Vec<u8>) -> Result<Self> {
         let mut start = 0;
         let common_header: ShredCommonHeader =
             Self::deserialize_obj(&mut start, SIZE_OF_COMMON_SHRED_HEADER, &payload)?;
@@ -322,8 +322,7 @@ impl Shred {
         let slot = common_header.slot;
         // Shreds should be padded out to SHRED_PAYLOAD_SIZE
         // so that erasure generation/recovery works correctly
-        // But only the data_header.size is stored in blockstore.
-        payload.resize(SHRED_PAYLOAD_SIZE, 0);
+        assert!(payload.len() == SHRED_PAYLOAD_SIZE);
         let shred = if common_header.shred_type == ShredType(CODING_SHRED) {
             let coding_header: CodingShredHeader =
                 Self::deserialize_obj(&mut start, SIZE_OF_CODING_SHRED_HEADER, &payload)?;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -320,9 +320,10 @@ impl Shred {
             Self::deserialize_obj(&mut start, SIZE_OF_COMMON_SHRED_HEADER, &payload)?;
 
         let slot = common_header.slot;
-        // Shreds should be padded out to SHRED_PAYLOAD_SIZE
-        // so that erasure generation/recovery works correctly
-        assert!(payload.len() == SHRED_PAYLOAD_SIZE);
+        // Data hreds should be padded out to SHRED_PAYLOAD_SIZE so that erasure
+        // generation/recovery works correctly. Check uses >= because a full packet
+        // payload (including the nonce) could be passed in
+        assert!(payload.len() >= SHRED_PAYLOAD_SIZE);
         let shred = if common_header.shred_type == ShredType(CODING_SHRED) {
             let coding_header: CodingShredHeader =
                 Self::deserialize_obj(&mut start, SIZE_OF_CODING_SHRED_HEADER, &payload)?;


### PR DESCRIPTION
#### Problem
In another PR, we discovered that our logic to properly resize shreds pulled from the blockstore is a little inconsistent.

#### Summary of Changes
Funnel code paths through a common function.

Fixes #
