### PR TITLE
Add bip32 support to solana-keygen recover

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -96,6 +96,26 @@ where
         .map_err(|err| format!("{}", err))
 }
 
+// Return an error if a `SignerSourceKind::Prompt` cannot be parsed
+pub fn is_prompt_signer_source<T>(string: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    if string.as_ref() == ASK_KEYWORD {
+        return Ok(());
+    }
+    match parse_signer_source(string.as_ref())
+        .map_err(|err| format!("{}", err))?
+        .kind
+    {
+        SignerSourceKind::Prompt => Ok(()),
+        _ => Err(format!(
+            "Unable to parse input as `prompt:` URI scheme or `ASK` keyword: {}",
+            string
+        )),
+    }
+}
+
 // Return an error if string cannot be parsed as pubkey string or keypair file location
 pub fn is_pubkey_or_keypair<T>(string: T) -> Result<(), String>
 where

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -61,7 +61,7 @@ pub trait Signer {
     }
     /// Fallibly gets the implementor's public key
     fn try_pubkey(&self) -> Result<Pubkey, SignerError>;
-    /// Invallibly produces an Ed25519 signature over the provided `message`
+    /// Infallibly produces an Ed25519 signature over the provided `message`
     /// bytes. Returns the all-zeros `Signature` if signing is not possible.
     fn sign_message(&self, message: &[u8]) -> Signature {
         self.try_sign_message(message).unwrap_or_default()


### PR DESCRIPTION
#### Problem
`solana-keygen recover` only supports returning the raw Keypair from a seed phrase and passphrase. However, it would be useful to be able to derive HD Keypairs and save them to files for hot-wallet use.

#### Summary of Changes
- Add bip32 support to solana-keygen recover.

No behavior change:
```
$ solana-keygen recover -o <FILEPATH>
```

Derives raw Keypair:
```
$ solana-keygen recover -o <FILEPATH> ASK
```

Derives HD keys:
```
// m/44'/501'
$ solana-keygen recover -o <FILEPATH> prompt:

// m/44'/501'/0'/1'
$ solana-keygen recover -o <FILEPATH> prompt:?key=0/1

// m/44'/2017'/0'
$ solana-keygen recover -o <FILEPATH> prompt:?full-path=m/44/2017/0
```

Fixes #17114 
