### PR TITLE
Fix lifetimes for entrypoint::ProcessInstruction

### DIFF
--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -22,7 +22,7 @@ pub type ProgramResult = ResultGeneric<(), ProgramError>;
 /// program_id: Program ID of the currently executing program accounts: Accounts
 /// passed as part of the instruction instruction_data: Instruction data
 pub type ProcessInstruction =
-    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+    for<'a> fn(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], instruction_data: &'a [u8]) -> ProgramResult;
 
 /// Programs indicate success with a return value of 0
 pub const SUCCESS: u64 = 0;


### PR DESCRIPTION
#### Problem

Without explicit lifetime annotations, `entrypoint::ProcessInstruction` desugars to

```rust
for<'r, 's, 't0, 't1> fn(&'r Pubkey, &'s [AccountInfo<'t0>], &'t1 [u8]) -> Result<_, _>
```

Note that `'s` and `'t0` are not related here. This is not what you want in practice, because you put `AccountInfo`s that hold `'t0` pointers inside a slice of lifetime `'s`, you want `'t0` to outlive `'s`; this is the only way that you can call such a function in practice.

But because `ProcessInstruction` is used in argument position, that has worked out until now. If you pass in a function that can deal with more general lifetimes, you can always call it with more constrained ones. But if you need the more constrained lifetimes because it's the only way to implement your `process_instruction`, then you can no longer pass that `process_instruction` to the `processor!` macro, because it expects a more general function. That then leads to an error like this one when writing tests:

    error[E0308]: mismatched types
      --> (...)
       |
    13 |     ...(processor!(processor::Processor::process));
       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
       |
       = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r Pubkey, &'s [AccountInfo<'t0>], &'t1 [u8]) -> Result<_, _>`
                  found fn pointer `for<'a> fn(&'a Pubkey, &'a [AccountInfo<'a>], &'a [u8]) -> Result<_, _>`


#### Summary of Changes

The simplest solution is to use a single lifetime for all arguments, notably the slice and the `AccountInfo`.

This is a breaking change; users will have to change their entry point definition from

```rust
fn process_instruction(
    program_id: &Pubkey,
    accounts: &[AccountInfo],
    instruction_data: &[u8],
) -> ProgramResult;
```
to
```rust
fn process_instruction<'a>(
    program_id: &'a Pubkey,
    accounts: &'a [AccountInfo<'a>],
    instruction_data: &'a [u8],
) -> ProgramResult;
```
if they use the `processor!` macro.