### PR TITLE
Pad shreds on retrieval from blockstore only when needed

### DIFF
--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -14,7 +14,7 @@ pub fn repair_response_packet(
     nonce: Nonce,
 ) -> Option<Packet> {
     let shred = blockstore
-        .get_data_shred(slot, shred_index)
+        .get_data_shred_padded(slot, shred_index)
         .expect("Blockstore could not get data shred");
     shred
         .map(|shred| repair_response_packet_from_shred(shred, dest, nonce))

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -14,7 +14,7 @@ pub fn repair_response_packet(
     nonce: Nonce,
 ) -> Option<Packet> {
     let shred = blockstore
-        .get_data_shred_padded(slot, shred_index)
+        .get_padded_data_shred(slot, shred_index)
         .expect("Blockstore could not get data shred");
     shred
         .map(|shred| repair_response_packet_from_shred(shred, dest, nonce))

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -664,10 +664,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
-                    use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
-                    let mut serialized_shred = vec![0; SHRED_PAYLOAD_SIZE];
-                    serialized_shred.copy_from_slice(&b.data[..SHRED_PAYLOAD_SIZE]);
-                    Shred::new_from_serialized_shred(serialized_shred).ok()
+                    Shred::copy_from_packet(&b).ok()
                 })
                 .collect();
             assert!(!rv.is_empty());
@@ -752,10 +749,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
-                    use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
-                    let mut serialized_shred = vec![0; SHRED_PAYLOAD_SIZE];
-                    serialized_shred.copy_from_slice(&b.data[..SHRED_PAYLOAD_SIZE]);
-                    Shred::new_from_serialized_shred(serialized_shred).ok()
+                    Shred::copy_from_packet(&b).ok()
                 })
                 .collect();
             assert_eq!(rv[0].index(), 1);
@@ -1118,10 +1112,7 @@ mod tests {
 
     fn verify_responses<'a>(request: &RepairType, packets: impl Iterator<Item = &'a Packet>) {
         for packet in packets {
-            use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
-            let mut shred_payload = vec![0; SHRED_PAYLOAD_SIZE];
-            shred_payload.copy_from_slice(&packet.data[..SHRED_PAYLOAD_SIZE]);
-            let shred = Shred::new_from_serialized_shred(shred_payload).unwrap();
+            let shred = Shred::copy_from_packet(&packet).unwrap();
             request.verify_response(&shred);
         }
     }

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -664,7 +664,10 @@ mod tests {
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
-                    Shred::new_from_serialized_shred(b.data.to_vec()).ok()
+                    use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
+                    let mut serialized_shred = vec![0; SHRED_PAYLOAD_SIZE];
+                    serialized_shred.copy_from_slice(&b.data[..SHRED_PAYLOAD_SIZE]);
+                    Shred::new_from_serialized_shred(serialized_shred).ok()
                 })
                 .collect();
             assert!(!rv.is_empty());
@@ -749,7 +752,10 @@ mod tests {
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
-                    Shred::new_from_serialized_shred(b.data.to_vec()).ok()
+                    use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
+                    let mut serialized_shred = vec![0; SHRED_PAYLOAD_SIZE];
+                    serialized_shred.copy_from_slice(&b.data[..SHRED_PAYLOAD_SIZE]);
+                    Shred::new_from_serialized_shred(serialized_shred).ok()
                 })
                 .collect();
             assert_eq!(rv[0].index(), 1);
@@ -1112,7 +1118,9 @@ mod tests {
 
     fn verify_responses<'a>(request: &RepairType, packets: impl Iterator<Item = &'a Packet>) {
         for packet in packets {
-            let shred_payload = packet.data.to_vec();
+            use solana_ledger::shred::SHRED_PAYLOAD_SIZE;
+            let mut shred_payload = vec![0; SHRED_PAYLOAD_SIZE];
+            shred_payload.copy_from_slice(&packet.data[..SHRED_PAYLOAD_SIZE]);
             let shred = Shred::new_from_serialized_shred(shred_payload).unwrap();
             request.verify_response(&shred);
         }

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -20,7 +20,7 @@ use rayon::ThreadPool;
 use solana_ledger::{
     blockstore::{self, Blockstore, BlockstoreInsertionMetrics, MAX_DATA_SHREDS_PER_SLOT},
     leader_schedule_cache::LeaderScheduleCache,
-    shred::{Nonce, Shred},
+    shred::{Nonce, Shred, SHRED_PAYLOAD_SIZE},
 };
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
 use solana_perf::packet::Packets;
@@ -251,7 +251,8 @@ where
                             // with sufficiently large buffers. Needed to ensure
                             // call to `new_from_serialized_shred` is safe.
                             assert_eq!(packet.data.len(), PACKET_DATA_SIZE);
-                            let serialized_shred = packet.data.to_vec();
+                            let mut serialized_shred = packet.data.to_vec();
+                            serialized_shred.truncate(SHRED_PAYLOAD_SIZE);
                             if let Ok(shred) = Shred::new_from_serialized_shred(serialized_shred) {
                                 let repair_info = {
                                     if packet.meta.repair {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -252,6 +252,8 @@ where
                             // call to `new_from_serialized_shred` is safe.
                             assert_eq!(packet.data.len(), PACKET_DATA_SIZE);
                             let mut serialized_shred = packet.data.to_vec();
+                            // Truncate shred down to SHRED_PAYLOAD_SIZE to remove the nonce so
+                            // that the buffer is proper size for new_from_serialized_shred()
                             serialized_shred.truncate(SHRED_PAYLOAD_SIZE);
                             if let Ok(shred) = Shred::new_from_serialized_shred(serialized_shred) {
                                 let repair_info = {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7657,7 +7657,10 @@ pub mod tests {
                         .unwrap(),
                 )
                 .unwrap();
-                assert!(shred_payloads_equal_ignore_padding(&shred, &recovered_shred));
+                assert!(shred_payloads_equal_ignore_padding(
+                    &shred,
+                    &recovered_shred
+                ));
             }
 
             verify_index_integrity(&blockstore, slot);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3704,7 +3704,7 @@ pub fn make_many_slot_entries(
 
 // Check shreds for equality, ignoring any zero padding that either may have
 // used for tests only
-pub fn shreds_equal_ignore_padding(shred1: &Shred, shred2: &Shred) -> bool {
+pub fn shred_payloads_equal_ignore_padding(shred1: &Shred, shred2: &Shred) -> bool {
     shred1.payload[..shred1.data_header.size as usize]
         == shred2.payload[..shred2.data_header.size as usize]
 }
@@ -3867,7 +3867,7 @@ pub mod tests {
             .unwrap();
         let deserialized_shred = Shred::new_from_serialized_shred(serialized_shred).unwrap();
 
-        assert!(shreds_equal_ignore_padding(
+        assert!(shred_payloads_equal_ignore_padding(
             &last_shred,
             &deserialized_shred
         ));
@@ -5774,7 +5774,7 @@ pub mod tests {
             .collect();
         assert_eq!(result.len(), slot_8_shreds.len());
         for (left, right) in result.iter().zip(slot_8_shreds.iter()) {
-            assert!(shreds_equal_ignore_padding(&left, &right));
+            assert!(shred_payloads_equal_ignore_padding(&left, &right));
         }
 
         drop(blockstore);
@@ -7657,7 +7657,7 @@ pub mod tests {
                         .unwrap(),
                 )
                 .unwrap();
-                assert!(shreds_equal_ignore_padding(&shred, &recovered_shred));
+                assert!(shred_payloads_equal_ignore_padding(&shred, &recovered_shred));
             }
 
             verify_index_integrity(&blockstore, slot);


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/16602/ introduced a change where shreds would have zero-padding stripped upon insertion to the blockstore, and re-added upon retrieval. However, discussion [here](https://github.com/solana-labs/solana/pull/17147#issuecomment-837413792) let us to find that the zero-padding wasn't consistently applied, depending on the method used to retrieve shred(s) (there are multiple methods to pull shreds out).

#### Summary of Changes
This PR introduces a change in philosophy @carllin and I discussed where shreds will intentionally NOT be zero-padded when pulled out of the blockstore unless explicitly needed. There are several instances where zero padding may be necessary:
- Erasure
- Duplicate shred detection (could potentially be optimized by only comparing the actual payload and not the zero padding of the shred bytestreams).

In other cases, the idea is to not add the zero-padding back as we don't explicitly need it. This change in philosophy saves us some bytestream resizing; however, it comes at the cost of complexity of needing to know when the bytestream has had the zero-padding stripped vs. when it has not.

Fixes #
