### PR TITLE
docs: remove missing link

### DIFF
--- a/docs/src/running-validator/validator-reqs.md
+++ b/docs/src/running-validator/validator-reqs.md
@@ -73,8 +73,6 @@ releases at [solanalabs/solana](https://hub.docker.com/r/solanalabs/solana).
 
 Be sure to ensure that the machine used is not behind a residential NAT to avoid
 NAT traversal issues. A cloud-hosted machine works best. **Ensure that IP ports 8000 through 10000 are not blocked for Internet inbound and outbound traffic.**
-For more information on port forwarding with regards to residential networks,
-see [this document](http://www.mcs.sdsmt.edu/lpyeatt/courses/314/PortForwardingSetup.pdf).
 
 Prebuilt binaries are available for Linux x86_64 on CPUs supporting AVX2 \(Ubuntu 20.04 recommended\).
 MacOS or WSL users may build from source.


### PR DESCRIPTION
#### Problem

The link from the documentation no longer exists

```
curl -v http://www.mcs.sdsmt.edu/lpyeatt/courses/314/PortForwardingSetup.pdf
* Could not resolve host: www.mcs.sdsmt.edu
```

```
curl -v https://csc.mcs.sdsmt.edu/lpyeatt/courses/314/PortForwardingSetup.pdf

* 404 Not Found
* The requested URL /lpyeatt/courses/314/PortForwardingSetup.pdf was not found on this server.
```


#### Summary of Changes

Remove non-existent link
