### PR TITLE
Add documentation for BankForks::prune_non_rooted()

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -294,6 +294,7 @@ impl BankForks {
     ///
     /// Given the following banks and slots...
     ///
+    /// ```text
     /// slot 6                   * (G)
     ///                         /
     /// slot 5        (F)  *   /
@@ -307,6 +308,7 @@ impl BankForks {
     /// slot 1          \  * (B)
     ///                  \ |
     /// slot 0             * (A)  <-- highest confirmed root [1]
+    /// ```
     ///
     /// ...where (D) is set as root, clean up (C) and (E), since they are not rooted.
     ///
@@ -321,6 +323,7 @@ impl BankForks {
     ///
     /// and in table form...
     ///
+    /// ```text
     ///       |          |  is root a  | is a descendant ||
     ///  slot | is root? | descendant? |    of root?     || keep?
     /// ------+----------+-------------+-----------------++-------
@@ -331,6 +334,7 @@ impl BankForks {
     ///   (E) |     N    |      N      |        N        ||   N
     ///   (F) |     N    |      N      |        Y        ||   Y
     ///   (G) |     N    |      N      |        Y        ||   Y
+    /// ```
     ///
     /// [1] RPC has the concept of commitment level, which is based on the highest confirmed root,
     /// i.e. the cluster-confirmed root.  This commitment is stronger than the local node's root.

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -306,16 +306,36 @@ impl BankForks {
     ///                \   |
     /// slot 1          \  * (B)
     ///                  \ |
-    /// slot 0             * (A)  <-- highest confirmed root
+    /// slot 0             * (A)  <-- highest confirmed root [1]
     ///
     /// ...where (D) is set as root, clean up (C) and (E), since they are not rooted.
-    /// (A) is kept because it is a lower slot than (D), and (D) is one of its decendants
+    ///
+    /// (A) is kept because it is greater-than-or-equal-to the highest confirmed root, and (D) is
+    ///     one of its descendants
     /// (B) is kept for the same reason as (A)
-    /// (C) is pruned since it is a lower slot than (D), but (D) is _not_ one of its decendants
+    /// (C) is pruned since it is a lower slot than (D), but (D) is _not_ one of its descendants
     /// (D) is kept since it is the root
-    /// (E) is pruned since it is not a decendant of (D)
-    /// (F) is kept since it is a decendant of (D)
+    /// (E) is pruned since it is not a descendant of (D)
+    /// (F) is kept since it is a descendant of (D)
     /// (G) is kept for the same reason as (F)
+    ///
+    /// and in table form...
+    ///
+    ///       |          |  is root a  | is a descendant ||
+    ///  slot | is root? | descendant? |    of root?     || keep?
+    /// ------+----------+-------------+-----------------++-------
+    ///   (A) |     N    |      Y      |        N        ||   Y
+    ///   (B) |     N    |      Y      |        N        ||   Y
+    ///   (C) |     N    |      N      |        N        ||   N
+    ///   (D) |     Y    |      N      |        N        ||   Y
+    ///   (E) |     N    |      N      |        N        ||   N
+    ///   (F) |     N    |      N      |        Y        ||   Y
+    ///   (G) |     N    |      N      |        Y        ||   Y
+    ///
+    /// [1] RPC has the concept of commitment level, which is based on the highest confirmed root,
+    /// i.e. the cluster-confirmed root.  This commitment is stronger than the local node's root.
+    /// So (A) and (B) are kept to facilitate RPC at different commitment levels.  Everything below
+    /// the highest confirmed root can be pruned.
     fn prune_non_rooted(&mut self, root: Slot, highest_confirmed_root: Option<Slot>) {
         let highest_confirmed_root = highest_confirmed_root.unwrap_or(root);
         let prune_slots: Vec<_> = self


### PR DESCRIPTION
No functional changes, just doc comments.

While in the process of learning about snapshots and reading through `BankForks::set_root()`, I wanted to understand `prune_non_rooted()`. I needed to draw out this diagram to visualize and understand it, so I figure it may be helpful for others too.