### PR TITLE
test-validator: Display genesis hash in dashboard

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -206,6 +206,8 @@ pub struct RpcContactInfo {
     pub version: Option<String>,
     /// First 4 bytes of the FeatureSet identifier
     pub feature_set: Option<u32>,
+    /// Shred version
+    pub shred_version: Option<u16>,
 }
 
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2789,6 +2789,7 @@ pub mod rpc_full {
                             rpc: valid_address_or_none(&contact_info.rpc),
                             version,
                             feature_set,
+                            shred_version: Some(my_shred_version),
                         })
                     } else {
                         None // Exclude spy nodes
@@ -4074,7 +4075,7 @@ pub mod tests {
             .expect("actual response deserialization");
 
         let expected = format!(
-            r#"{{"jsonrpc":"2.0","result":[{{"pubkey": "{}", "gossip": "127.0.0.1:1235", "tpu": "127.0.0.1:1234", "rpc": "127.0.0.1:{}", "version": null, "featureSet": null}}],"id":1}}"#,
+            r#"{{"jsonrpc":"2.0","result":[{{"pubkey": "{}", "gossip": "127.0.0.1:1235", "shredVersion": 0, "tpu": "127.0.0.1:1234", "rpc": "127.0.0.1:{}", "version": null, "featureSet": null}}],"id":1}}"#,
             leader_pubkey,
             rpc_port::DEFAULT_RPC_PORT
         );

--- a/docs/src/developing/test-validator.md
+++ b/docs/src/developing/test-validator.md
@@ -37,7 +37,9 @@ See [Appendix I](#appendix-i-status-output) for details
 Ledger location: test-ledger
 Log: test-ledger/validator.log
 Identity: EPhgPANa5Rh2wa4V2jxt7YbtWa3Uyw4sTeZ13cQjDDB8
+Genesis Hash: 4754oPEMhAKy14CZc8GzQUP93CB4ouELyaTs4P8ittYn
 Version: 1.6.7
+Shred Version: 13286
 Gossip Address: 127.0.0.1:1024
 TPU Address: 127.0.0.1:1027
 JSON RPC URL: http://127.0.0.1:8899
@@ -59,8 +61,10 @@ solana config set --url http://127.0.0.1:8899
 
 #### Verify the CLI Tool Suite configuration
 ```
-solana cluster-version
+solana genesis-hash
 ```
+* **NOTE:** The result should match the `Genesis Hash:` field in the
+`solana-test-validator` status output
 
 #### Check the wallet balance
 ```

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -87,13 +87,20 @@ impl Dashboard {
                     continue;
                 }
             };
-
             println_name_value("Identity:", &identity.to_string());
+
+            if let Ok(genesis_hash) = rpc_client.get_genesis_hash() {
+                println_name_value("Genesis Hash:", &genesis_hash.to_string());
+            }
+
             if let Some(contact_info) = get_contact_info(&rpc_client, &identity) {
                 println_name_value(
                     "Version:",
                     &contact_info.version.unwrap_or_else(|| "?".to_string()),
                 );
+                if let Some(shred_version) = contact_info.shred_version {
+                    println_name_value("Shred Version:", &shred_version.to_string());
+                }
                 if let Some(gossip) = contact_info.gossip {
                     println_name_value("Gossip Address:", &gossip.to_string());
                 }


### PR DESCRIPTION
#### Problem

No canonical way to verify that CLI tools are definitively configured to target a running `solana-test-validator`

#### Summary of Changes

* Query and display the genesis hash in `solana-test-validator`'s dashboard
* Update docs to query and compare the genesis hash after configuring CLI tools