### PR TITLE
Fix a bug in input deserialization in the C SDK

### DIFF
--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -345,6 +345,8 @@ static bool sol_deserialize(
         input += MAX_PERMITTED_DATA_INCREASE;
         input = (uint8_t*)(((uint64_t)input + 8 - 1) & ~(8 - 1)); // padding
         input += sizeof(uint64_t);
+      } else {
+        input += 7; // padding
       }
       continue;
     }


### PR DESCRIPTION
#### Problem
When the input contains more accounts than the user has requested to be deserialized, and one of the excess ones is a dup, the input pointer is not adjusted correctly.

Compare the lines added by this commit to line 401: `input += 7; // padding`. Since the input data layout does not depend on the number of accounts the user wants to deserialize, this adjustment by 7 bytes must happen in both branches.

#### Summary of Changes
Adjust the `input` pointer by 7 bytes whether the user cares about the account or not.