### PR TITLE
Propagate dead slots up to replay

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2755,12 +2755,7 @@ impl Blockstore {
         let result: HashMap<u64, Vec<u64>> = slots
             .iter()
             .zip(slot_metas)
-            .filter_map(|(height, meta)| {
-                meta.map(|meta| {
-                    let valid_next_slots: Vec<u64> = meta.next_slots.to_vec();
-                    (*height, valid_next_slots)
-                })
-            })
+            .filter_map(|(height, meta)| meta.map(|meta| (*height, meta.next_slots.to_vec())))
             .collect();
 
         Ok(result)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2757,12 +2757,7 @@ impl Blockstore {
             .zip(slot_metas)
             .filter_map(|(height, meta)| {
                 meta.map(|meta| {
-                    let valid_next_slots: Vec<u64> = meta
-                        .next_slots
-                        .iter()
-                        .cloned()
-                        .filter(|s| !self.is_dead(*s))
-                        .collect();
+                    let valid_next_slots: Vec<u64> = meta.next_slots.to_vec();
                     (*height, valid_next_slots)
                 })
             })

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -549,6 +549,7 @@ fn do_process_blockstore_from_root(
             ""
         },
     );
+    assert!(bank_forks.active_banks().is_empty());
 
     // We might be promptly restarted after bad capitalization was detected while creating newer snapshot.
     // In that case, we're most likely restored from the last good snapshot and replayed up to this root.
@@ -697,6 +698,7 @@ pub fn confirm_slot(
     allow_dead_slots: bool,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let slot = bank.slot();
+
     let (entries, num_shreds, slot_full) = {
         let mut load_elapsed = Measure::start("load_elapsed");
         let load_result = blockstore
@@ -867,6 +869,11 @@ fn process_next_slots(
                     .unwrap(),
                 *next_slot,
             ));
+            trace!(
+                "New bank for slot {}, parent slot is {}",
+                next_slot,
+                bank.slot(),
+            );
             pending_slots.push((next_meta, next_bank, bank.last_blockhash()));
         }
     }
@@ -935,7 +942,8 @@ fn load_frozen_forks(
             }
 
             let mut progress = ConfirmationProgress::new(last_entry_hash);
-            let process_result = process_single_slot(
+
+            if process_single_slot(
                 blockstore,
                 &bank,
                 opts,
@@ -945,17 +953,9 @@ fn load_frozen_forks(
                 cache_block_time_sender,
                 None,
                 timing,
-            );
-            // Insert even dead banks into the BankForks so that cleanup
-            // of account state created on Bank creation via `Bank::new_from_parent()`
-            // will occur when the bank is dropped. Otherwise, this state is not
-            // cleaned
-            all_banks.insert(bank.slot(), bank.clone());
-
-            if let Err(e) = process_result {
-                warn!("processing single slot {} error {:?}", slot, e);
-                initial_forks.insert(bank.slot(), bank.clone());
-                all_banks.insert(bank.slot(), bank.clone());
+            )
+            .is_err()
+            {
                 continue;
             }
             txs += progress.num_txs;
@@ -963,6 +963,7 @@ fn load_frozen_forks(
             // Block must be frozen by this point, otherwise `process_single_slot` would
             // have errored above
             assert!(bank.is_frozen());
+            all_banks.insert(bank.slot(), bank.clone());
 
             // If we've reached the last known root in blockstore, start looking
             // for newer cluster confirmed roots
@@ -1797,18 +1798,8 @@ pub mod tests {
 
         // Should see the parent of the dead child
         assert_eq!(frozen_bank_slots(&bank_forks), vec![0, 1, 2, 3]);
+        assert_eq!(bank_forks.working_bank().slot(), 3);
 
-        // Dead slot should be included in the processing result
-        assert_eq!(bank_forks.working_bank().slot(), 4);
-
-        assert_eq!(
-            &bank_forks[4]
-                .parents()
-                .iter()
-                .map(|bank| bank.slot())
-                .collect::<Vec<_>>(),
-            &[2, 1, 0]
-        );
         assert_eq!(
             &bank_forks[3]
                 .parents()
@@ -1825,6 +1816,7 @@ pub mod tests {
                 .collect::<Vec<_>>(),
             &[1, 0]
         );
+        assert_eq!(bank_forks.working_bank().slot(), 3);
         verify_fork_infos(&bank_forks);
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2122,9 +2122,14 @@ fn test_optimistic_confirmation_violation_detection() {
             "Setting slot: {} on main fork as dead, should cause fork",
             prev_voted_slot
         );
-        // marking this voted slot as dead makes the saved tower garbage
-        // effectively. That's because its stray last vote becomes stale (= no
-        // ancestor in bank forks).
+        // Necessary otherwise tower will inform this validator that it's latest
+        // vote is on slot `prev_voted_slot`. This will then prevent this validator
+        // from resetting to the parent of `prev_voted_slot` to create an alternative fork because
+        // 1) Validator can't vote on earlier ancestor of last vote due to switch threshold (can't vote
+        // on ancestors of last vote)
+        // 2) Won't reset to this earlier ancestor becasue reset can only happen on same voted fork if
+        // it's for the last vote slot or later
+        remove_tower(&exited_validator_info.info.ledger_path, &entry_point_id);
         blockstore.set_dead_slot(prev_voted_slot).unwrap();
     }
 


### PR DESCRIPTION
#### Problem
1) The state machine `cluster_slot_state_verifier` in replay needs dead slots in the form of banks to make decisions about duplicate slot (detecting a confirmed version, dumping their descendants, repairing the correct version, etc.). However, currently `get_slots_since()` currently ignores dead slots if they were marked dead from a previous replay (and then the validator restarted for instance), so those slots never become banks.

2) Another issue is blockstore processor currently replays banks, but if they error/are marked dead, it continues here: https://github.com/solana-labs/solana/blob/6e9deaf1bd54b20d5ab07c90d6f484c2232c61cf/ledger/src/blockstore_processor.rs#L951, which means those banks are dropped and not added to `initial_forks ` via the following call https://github.com/solana-labs/solana/blob/6e9deaf1bd54b20d5ab07c90d6f484c2232c61cf/ledger/src/blockstore_processor.rs#L1027, and don't end up in the resulting  `BankForks`.  However, the call to `new_from_parent()` while constructing these dead banks *already* modified the account state by adding sysvars to the accounts state for that dead slot.

This inconsistency means if we then try to reconstruct the dead banks during replay via another call to `new_from_parent()`, we encounter errors/conflicts with that existing state. 

#### Summary of Changes
Blockstore processor now returns the tips of dead slots unless they have been outdated by a root, and then clean will sweep up all the dead state once a new root is set

Fixes #
