### PR TITLE
bumps up min number of bloom items in gossip pull requests

### DIFF
--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -29,9 +29,6 @@ use std::{
     sync::Mutex,
 };
 
-///The min size for bloom filters
-pub const CRDS_GOSSIP_DEFAULT_BLOOM_ITEMS: usize = 500;
-
 pub struct CrdsGossip {
     pub crds: Crds,
     pub id: Pubkey,


### PR DESCRIPTION
#### Problem
When a validator starts, it has an (almost) empty crds table and it only sends one pull-request to the entrypoint. The bloom filter in the pull-request targets 10% false rate given the number of items. So, if the `num_items` is very wrong, it makes a very small bloom filter with a very high false rate:
https://github.com/solana-labs/solana/blob/2ae57c172/runtime/src/bloom.rs#L70-L80
https://github.com/solana-labs/solana/blob/2ae57c172/core/src/crds_gossip_pull.rs#L48

As a result, it is very unlikely that the validator obtains entrypoint's contact-info in response. This exacerbates how long the validator will loop on:
> Waiting to adopt entrypoint shred version

https://github.com/solana-labs/solana/blob/ed51cde37/validator/src/main.rs#L390-L412


#### Summary of Changes
This commit increases the min number of bloom items when making gossip pull requests. Effectively this will break the entrypoint crds table into 64 shards, one pull-request for each, a larger bloom filter for each shard, and increases the chances that the response will include entrypoint's contact-info, which is needed for adopting shred version and validator start.