### PR TITLE
Add NEW labels for RPC methods introduced in v1.7

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -348,6 +348,9 @@ Result:
 
 ### getBlock
 
+**NEW: This method is only available in solana-core v1.7 or newer. Please use
+[getBlock](jsonrpc-api.md#getblock) for solana-core v1.6**
+
 Returns identity and transaction information about a confirmed block in the ledger
 
 #### Parameters:
@@ -720,6 +723,9 @@ Result:
 
 ### getBlocks
 
+**NEW: This method is only available in solana-core v1.7 or newer. Please use
+[getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks) for solana-core v1.6**
+
 Returns a list of confirmed blocks between two slots
 
 #### Parameters:
@@ -750,6 +756,9 @@ Result:
 ```
 
 ### getBlocksWithLimit
+
+**NEW: This method is only available in solana-core v1.7 or newer. Please use
+[getConfirmedBlocksWithLimit](jsonrpc-api.md#getconfirmedblockswithlimit) for solana-core v1.6**
 
 Returns a list of confirmed blocks starting at the given slot
 
@@ -2007,6 +2016,10 @@ Result when the node has no snapshot:
 
 ### getSignaturesForAddress
 
+**NEW: This method is only available in solana-core v1.7 or newer. Please use
+[getConfirmedSignaturesForAddress2](jsonrpc-api.md#getconfirmedsignaturesforaddress2) for solana-core v1.6**
+
+
 Returns confirmed signatures for transactions involving an
 address backwards in time from the provided signature or most recent confirmed block
 
@@ -2724,6 +2737,9 @@ Result:
 ```
 
 ### getTransaction
+
+**NEW: This method is only available in solana-core v1.7 or newer. Please use
+[getConfirmedTransaction](jsonrpc-api.md#getconfirmedtransaction) for solana-core v1.6**
 
 Returns transaction details for a confirmed transaction
 


### PR DESCRIPTION
Once v1.7 hits beta, it will be unclear that the new methods like `getBlock` will be unavailable on mainnet for another month or so.  We got an early preview of this today when an incorrect manual deployment caused the master docs to be shipped to docs.solana.com.  To help reduce this temporary future confusion, annotate the new methods with information indicating the solana-core that they are available in
