### PR TITLE
Add --no-wait option to CLI's stake-authorize command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -276,6 +276,7 @@ pub enum CliCommand {
         memo: Option<String>,
         fee_payer: SignerIndex,
         custodian: Option<SignerIndex>,
+        no_wait: bool,
     },
     StakeSetLockup {
         stake_account_pubkey: Pubkey,
@@ -1679,6 +1680,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             memo,
             fee_payer,
             custodian,
+            no_wait,
         } => process_stake_authorize(
             &rpc_client,
             config,
@@ -1692,6 +1694,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             memo.as_ref(),
             *fee_payer,
+            *no_wait,
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -608,6 +608,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -638,6 +639,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -663,6 +665,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -688,6 +691,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sign_reply = process_command(&config_offline).unwrap();
@@ -706,6 +710,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -756,6 +761,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     let sign_reply = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_reply);
@@ -778,6 +784,7 @@ fn test_stake_authorize() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -881,6 +888,7 @@ fn test_stake_authorize_with_fee_payer() {
         memo: None,
         fee_payer: 1,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     // `config` balance has not changed, despite submitting the TX
@@ -902,6 +910,7 @@ fn test_stake_authorize_with_fee_payer() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     config_offline.output_format = OutputFormat::JsonCompact;
     let sign_reply = process_command(&config_offline).unwrap();
@@ -920,6 +929,7 @@ fn test_stake_authorize_with_fee_payer() {
         memo: None,
         fee_payer: 0,
         custodian: None,
+        no_wait: false,
     };
     process_command(&config).unwrap();
     // `config`'s balance again has not changed


### PR DESCRIPTION
#### Problem

CLI makes the user wait for `stake-authorize` transactions to confirm before the user can submit the next one. That waiting gets painful when attempting to rekey lots of accounts.

#### Summary of Changes

Add the same `--no-wait` option that is available to the `transfer` command and implement it the same way.  The CLI submits the transaction to the RPC node and then immediately exits.  The RPC node will automatically retry sending the transaction to the leader until its blockhash expires. Odds the transaction will land are high but not guaranteed.
