### PR TITLE
don't try to build secondary indexes if we don't need them

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5054,14 +5054,16 @@ impl AccountsDb {
                             }
                         }
                         drop(lock);
-                        for (pubkey, account_infos) in accounts_map.into_iter() {
-                            for (_, (_store_id, stored_account)) in account_infos.iter() {
-                                self.accounts_index.update_secondary_indexes(
-                                    &pubkey,
-                                    &stored_account.account_meta.owner,
-                                    &stored_account.data,
-                                    &self.account_indexes,
-                                );
+                        if !self.account_indexes.is_empty() {
+                            for (pubkey, account_infos) in accounts_map.into_iter() {
+                                for (_, (_store_id, stored_account)) in account_infos.iter() {
+                                    self.accounts_index.update_secondary_indexes(
+                                        &pubkey,
+                                        &stored_account.account_meta.owner,
+                                        &stored_account.data,
+                                        &self.account_indexes,
+                                    );
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
#### Problem
Validator startup time is commonly experienced. Generating the index is a large part of that time.

#### Summary of Changes
Don't try to build secondary indexes if we don't need to.

Fixes #
