### PR TITLE
Disallow bad combination of arguments in keygen grind

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -17,6 +17,9 @@ use {
     std::{str::FromStr, sync::Arc},
 };
 
+// Sentinel value used to indicate to write to screen instead of file
+pub const STDOUT_OUTFILE_TOKEN: &str = "-";
+
 // Return parsed values from matches at `name`
 pub fn values_of<T>(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<T>>
 where

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        input_parsers::pubkeys_sigs_of,
+        input_parsers::{pubkeys_sigs_of, STDOUT_OUTFILE_TOKEN},
         offline::{SIGNER_ARG, SIGN_ONLY_ARG},
         ArgConstant,
     },
@@ -235,7 +235,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                 }
             } else {
                 match source {
-                    "-" => Ok(SignerSource::new(SignerSourceKind::Stdin)),
+                    STDOUT_OUTFILE_TOKEN => Ok(SignerSource::new(SignerSourceKind::Stdin)),
                     ASK_KEYWORD => Ok(SignerSource::new_legacy(SignerSourceKind::Prompt)),
                     _ => match Pubkey::from_str(source) {
                         Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn test_parse_signer_source() {
         assert!(matches!(
-            parse_signer_source("-").unwrap(),
+            parse_signer_source(STDOUT_OUTFILE_TOKEN).unwrap(),
             SignerSource {
                 kind: SignerSourceKind::Stdin,
                 derivation_path: None,

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -107,6 +107,7 @@ fn no_outfile_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NO_OUTFILE_ARG.name)
         .long(NO_OUTFILE_ARG.long)
         .conflicts_with_all(&["outfile", "silent"])
+        .requires("use_mnemonic")
         .help(NO_OUTFILE_ARG.help)
 }
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -107,6 +107,8 @@ fn no_outfile_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NO_OUTFILE_ARG.name)
         .long(NO_OUTFILE_ARG.long)
         .conflicts_with_all(&["outfile", "silent"])
+        // Require a seed phrase to avoid generating a keypair
+        // but having no way to get the private key
         .requires("use_mnemonic")
         .help(NO_OUTFILE_ARG.help)
 }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -5,6 +5,7 @@ use clap::{
     Arg, ArgMatches, SubCommand,
 };
 use solana_clap_utils::{
+    input_parsers::STDOUT_OUTFILE_TOKEN,
     input_validators::{is_parsable, is_prompt_signer_source},
     keypair::{
         keypair_from_path, keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
@@ -34,8 +35,6 @@ use std::{
 };
 
 const NO_PASSPHRASE: &str = "";
-// Sentinel value used to write to screen instead of file
-const STDOUT_OUTFILE_TOKEN: &str = "-";
 
 struct GrindMatch {
     starts: String,

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -34,6 +34,8 @@ use std::{
 };
 
 const NO_PASSPHRASE: &str = "";
+// Sentinel value used to write to screen instead of file
+const STDOUT_OUTFILE_TOKEN: &str = "-";
 
 struct GrindMatch {
     starts: String,
@@ -151,7 +153,7 @@ fn output_keypair(
     outfile: &str,
     source: &str,
 ) -> Result<(), Box<dyn error::Error>> {
-    if outfile == "-" {
+    if outfile == STDOUT_OUTFILE_TOKEN {
         let mut stdout = std::io::stdout();
         write_keypair(&keypair, &mut stdout)?;
     } else {
@@ -550,7 +552,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             };
 
             match outfile {
-                Some("-") => (),
+                Some(STDOUT_OUTFILE_TOKEN) => (),
                 Some(outfile) => check_for_overwrite(&outfile, &matches),
                 None => (),
             }
@@ -592,7 +594,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                 path.to_str().unwrap()
             };
 
-            if outfile != "-" {
+            if outfile != STDOUT_OUTFILE_TOKEN {
                 check_for_overwrite(&outfile, &matches);
             }
 


### PR DESCRIPTION
#### Problem
`solana-keygen grind` does not currently print the key when run with `--no-outfile`; if `--use-mnemonic` is not also specified, the result of this is useless as the private key is lost.

#### Summary of Changes
When `--no-outfile` is specified, require `--use-mnemonic`.
```
$ solana-keygen grind --starts-with s:1 --ignore-case --no-bip39-passphrase              
Searching with 12 threads for:
	1 pubkey that starts with 's' and ends with ''
Wrote grind keypair to sd3cFQrcrUi1hygi7QcTQPaXWUhbBHyFKPN9y79BUNV.json

// Usage that is now explicitly disallowed
$ solana-keygen grind --starts-with s:1 --ignore-case --no-bip39-passphrase --no-outfile               
error: The following required arguments were not provided:
    --use-mnemonic

USAGE:
    solana-keygen grind --config <FILEPATH> --ignore-case --language <LANGUAGE> --no-outfile --no-bip39-passphrase --num-threads <NUMBER> --starts-with <PREFIX:COUNT>... --use-mnemonic --word-count <NUMBER>

For more information try --help

$ solana-keygen grind --starts-with s:1 --ignore-case --no-bip39-passphrase --no-outfile --use-mnemonic
Searching with 12 threads for:
	1 pubkey that starts with 's' and ends with ''
================================================================================
Found matching key SPvXwbGcnjLif2JuXVUbLoTkUwYbntjLZDvW5sD5Qwi

Save this seed phrase to recover your new keypair:
unhappy loud crouch banana caught witness find polar century monster finger copy
================================================================================
```


Fixes #17119 
