### PR TITLE
Remove duplicate std::net reference in docs

### DIFF
--- a/docs/src/developing/on-chain-programs/developing-rust.md
+++ b/docs/src/developing/on-chain-programs/developing-rust.md
@@ -233,7 +233,6 @@ single-threaded environment, and must be deterministic:
   - `std::net`
   - `std::os`
   - `std::future`
-  - `std::net`
   - `std::process`
   - `std::sync`
   - `std::task`


### PR DESCRIPTION
#### Problem
Document for `/developing/on-chain-programs/developing-rust` contains duplicate `std::net` in list.

#### Summary of Changes
Remove one reference of `std::net`

Fixes #
