### PR TITLE
extends crds values timeouts if stakes are unknown

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1720,21 +1720,11 @@ impl ClusterInfo {
     fn handle_purge(
         &self,
         thread_pool: &ThreadPool,
-        bank_forks: &Option<Arc<RwLock<BankForks>>>,
+        bank_forks: Option<&RwLock<BankForks>>,
         stakes: &HashMap<Pubkey, u64>,
     ) {
-        let timeout = {
-            if let Some(ref bank_forks) = bank_forks {
-                let bank = bank_forks.read().unwrap().working_bank();
-                let epoch = bank.epoch();
-                let epoch_schedule = bank.epoch_schedule();
-                epoch_schedule.get_slots_in_epoch(epoch) * DEFAULT_MS_PER_SLOT
-            } else {
-                inc_new_counter_info!("cluster_info-purge-no_working_bank", 1);
-                CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS
-            }
-        };
-        let timeouts = self.gossip.read().unwrap().make_timeouts(stakes, timeout);
+        let epoch_ms = get_epoch_millis(bank_forks);
+        let timeouts = self.gossip.read().unwrap().make_timeouts(stakes, epoch_ms);
         let num_purged = self
             .time_gossip_write_lock("purge", &self.stats.purge)
             .purge(thread_pool, timestamp(), &timeouts);
@@ -1848,10 +1838,8 @@ impl ClusterInfo {
                     if exit.load(Ordering::Relaxed) {
                         return;
                     }
-
-                    self.handle_purge(&thread_pool, &bank_forks, &stakes);
+                    self.handle_purge(&thread_pool, bank_forks.as_deref(), &stakes);
                     entrypoints_processed = entrypoints_processed || self.process_entrypoints();
-
                     //TODO: possibly tune this parameter
                     //we saw a deadlock passing an self.read().unwrap().timeout into sleep
                     if start - last_push > CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 2 {
@@ -2479,28 +2467,6 @@ impl ClusterInfo {
         let _ = response_sender.send(packets);
     }
 
-    fn get_stakes_and_epoch_time(
-        bank_forks: Option<&Arc<RwLock<BankForks>>>,
-    ) -> (
-        HashMap<Pubkey, u64>, // staked nodes
-        u64,                  // epoch time ms
-    ) {
-        match bank_forks {
-            Some(ref bank_forks) => {
-                let bank = bank_forks.read().unwrap().root_bank();
-                let epoch = bank.epoch();
-                (
-                    bank.staked_nodes(),
-                    bank.get_slots_in_epoch(epoch) * DEFAULT_MS_PER_SLOT,
-                )
-            }
-            None => {
-                inc_new_counter_info!("cluster_info-purge-no_working_bank", 1);
-                (HashMap::new(), CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS)
-            }
-        }
-    }
-
     fn require_stake_for_gossip(
         &self,
         feature_set: Option<&FeatureSet>,
@@ -2646,7 +2612,7 @@ impl ClusterInfo {
     fn run_listen(
         &self,
         recycler: &PacketsRecycler,
-        bank_forks: Option<&Arc<RwLock<BankForks>>>,
+        bank_forks: Option<&RwLock<BankForks>>,
         requests_receiver: &PacketReceiver,
         response_sender: &PacketSender,
         thread_pool: &ThreadPool,
@@ -2667,19 +2633,18 @@ impl ClusterInfo {
                     .add_relaxed(excess_count as u64);
             }
         }
-        let (stakes, epoch_time_ms) = Self::get_stakes_and_epoch_time(bank_forks);
+        let epoch_time_ms = get_epoch_millis(bank_forks);
         // Using root_bank instead of working_bank here so that an enbaled
         // feature does not roll back (if the feature happens to get enabled in
         // a minority fork).
-        let feature_set = bank_forks.map(|bank_forks| {
-            bank_forks
-                .read()
-                .unwrap()
-                .root_bank()
-                .deref()
-                .feature_set
-                .clone()
-        });
+        let (feature_set, stakes) = match bank_forks {
+            None => (None, HashMap::default()),
+            Some(bank_forks) => {
+                let bank = bank_forks.read().unwrap().root_bank();
+                let feature_set = bank.feature_set.clone();
+                (Some(feature_set), bank.staked_nodes())
+            }
+        };
         self.process_packets(
             packets,
             thread_pool,
@@ -2719,7 +2684,7 @@ impl ClusterInfo {
                 while !exit.load(Ordering::Relaxed) {
                     if let Err(err) = self.run_listen(
                         &recycler,
-                        bank_forks.as_ref(),
+                        bank_forks.as_deref(),
                         &requests_receiver,
                         &response_sender,
                         &thread_pool,
@@ -2789,6 +2754,23 @@ impl ClusterInfo {
 
         (contact_info, gossip_socket, None)
     }
+}
+
+// Returns root bank's epoch duration in millis. Falls back on
+//     DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT
+// if there are no working banks.
+fn get_epoch_millis(bank_forks: Option<&RwLock<BankForks>>) -> u64 {
+    let num_slots = match bank_forks {
+        None => {
+            inc_new_counter_info!("cluster_info-purge-no_working_bank", 1);
+            DEFAULT_SLOTS_PER_EPOCH
+        }
+        Some(bank_forks) => {
+            let bank = bank_forks.read().unwrap().root_bank();
+            bank.get_slots_in_epoch(bank.epoch())
+        }
+    };
+    num_slots * DEFAULT_MS_PER_SLOT
 }
 
 /// Turbine logic
@@ -4494,6 +4476,14 @@ mod tests {
                 .pull_request_time
                 .len(),
             CRDS_UNIQUE_PUBKEY_CAPACITY
+        );
+    }
+
+    #[test]
+    fn test_get_epoch_millis_no_bank() {
+        assert_eq!(
+            get_epoch_millis(/*bank_forks=*/ None), // 48 hours
+            DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT
         );
     }
 }

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -3836,7 +3836,13 @@ mod tests {
         let entrypoint_crdsvalue =
             CrdsValue::new_unsigned(CrdsData::ContactInfo(entrypoint.clone()));
         let cluster_info = Arc::new(cluster_info);
-        let timeouts = cluster_info.gossip.read().unwrap().make_timeouts_test();
+        let timeouts = {
+            let gossip = cluster_info.gossip.read().unwrap();
+            gossip.make_timeouts(
+                &HashMap::default(), // stakes,
+                gossip.pull.crds_timeout,
+            )
+        };
         ClusterInfo::handle_pull_response(
             &cluster_info,
             &entrypoint_pubkey,

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -27,6 +27,7 @@ use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
     sync::Mutex,
+    time::Duration,
 };
 
 pub struct CrdsGossip {
@@ -300,9 +301,9 @@ impl CrdsGossip {
     pub fn make_timeouts(
         &self,
         stakes: &HashMap<Pubkey, u64>,
-        epoch_ms: u64,
+        epoch_duration: Duration,
     ) -> HashMap<Pubkey, u64> {
-        self.pull.make_timeouts(self.id, stakes, epoch_ms)
+        self.pull.make_timeouts(self.id, stakes, epoch_duration)
     }
 
     pub fn purge(

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -297,16 +297,12 @@ impl CrdsGossip {
         );
     }
 
-    pub fn make_timeouts_test(&self) -> HashMap<Pubkey, u64> {
-        self.make_timeouts(&HashMap::new(), self.pull.crds_timeout)
-    }
-
     pub fn make_timeouts(
         &self,
         stakes: &HashMap<Pubkey, u64>,
         epoch_ms: u64,
     ) -> HashMap<Pubkey, u64> {
-        self.pull.make_timeouts(&self.id, stakes, epoch_ms)
+        self.pull.make_timeouts(self.id, stakes, epoch_ms)
     }
 
     pub fn purge(

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -318,9 +318,8 @@ impl CrdsGossip {
         }
         if now > self.pull.crds_timeout {
             //sanity check
-            let min = self.pull.crds_timeout;
             assert_eq!(timeouts[&self.id], std::u64::MAX);
-            assert_eq!(timeouts[&Pubkey::default()], min);
+            assert!(timeouts.contains_key(&Pubkey::default()));
             rv = self
                 .pull
                 .purge_active(thread_pool, &mut self.crds, now, &timeouts);

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -554,15 +554,16 @@ impl CrdsGossipPull {
         stakes: &HashMap<Pubkey, u64>,
         epoch_ms: u64,
     ) -> HashMap<Pubkey, u64> {
+        let extended_timeout = self.crds_timeout.max(epoch_ms);
         let default_timeout = if stakes.values().all(|stake| *stake == 0) {
-            self.crds_timeout.max(epoch_ms)
+            extended_timeout
         } else {
             self.crds_timeout
         };
         stakes
             .iter()
             .filter(|(_, stake)| **stake > 0)
-            .map(|(pubkey, _)| (*pubkey, epoch_ms))
+            .map(|(pubkey, _)| (*pubkey, extended_timeout))
             .chain(vec![
                 (Pubkey::default(), default_timeout),
                 (self_pubkey, u64::MAX),

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -333,7 +333,10 @@ fn network_run_push(
             .par_iter()
             .map(|node| {
                 let mut node_lock = node.lock().unwrap();
-                let timeouts = node_lock.make_timeouts_test();
+                let timeouts = node_lock.make_timeouts(
+                    &HashMap::default(), // stakes
+                    node_lock.pull.crds_timeout,
+                );
                 node_lock.purge(thread_pool, now, &timeouts);
                 (node_lock.id, node_lock.new_push_messages(vec![], now))
             })

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -335,7 +335,7 @@ fn network_run_push(
                 let mut node_lock = node.lock().unwrap();
                 let timeouts = node_lock.make_timeouts(
                     &HashMap::default(), // stakes
-                    node_lock.pull.crds_timeout,
+                    Duration::from_millis(node_lock.pull.crds_timeout),
                 );
                 node_lock.purge(thread_pool, now, &timeouts);
                 (node_lock.id, node_lock.new_push_messages(vec![], now))


### PR DESCRIPTION
#### Problem
If stakes are unknown, then timeouts will be short, resulting in values
being purged from the crds table, and consequently higher pull-response
load when they are obtained again from gossip. In particular, this slows
down validator start where almost all values obtained from entrypoint
are immediately discarded.

#### Summary of Changes
extend crds values timeouts if stakes are unknown