### PR TITLE
Support out of band dumping of unrooted slots in AccountsDb

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -576,7 +576,7 @@ impl RepairService {
             root_bank.clear_slot_signatures(*slot);
 
             // Clear the accounts for this slot
-            root_bank.remove_unrooted_slot(*slot);
+            root_bank.remove_unrooted_slots(&[*slot]);
 
             // Clear the slot-related data in blockstore. This will:
             // 1) Clear old shreds allowing new ones to be inserted

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -755,7 +755,7 @@ impl RecycleStores {
 }
 
 #[derive(Debug, Default)]
-struct RemoveUnrootedSlots {
+struct RemoveUnrootedSlotsSynchronization {
     // slots being flushed from the cache or being purged
     slots_under_contention: Mutex<HashSet<Slot>>,
     signal: Condvar,
@@ -843,7 +843,7 @@ pub struct AccountsDb {
     // Set of slots currently being flushed by `flush_slot_cache()` or removed
     // by `remove_unrooted_slot()`. Used to ensure `remove_unrooted_slots(slots)`
     // can safely clear the set of unrooted slots `slots`.
-    remove_unrooted_slots: RemoveUnrootedSlots,
+    remove_unrooted_slots: RemoveUnrootedSlotsSynchronization,
 }
 
 #[derive(Debug, Default)]
@@ -1286,7 +1286,7 @@ impl Default for AccountsDb {
             #[cfg(test)]
             load_limit: AtomicU64::default(),
             is_bank_drop_callback_enabled: AtomicBool::default(),
-            remove_unrooted_slots: RemoveUnrootedSlots::default(),
+            remove_unrooted_slots: RemoveUnrootedSlotsSynchronization::default(),
         }
     }
 }
@@ -3435,7 +3435,7 @@ impl AccountsDb {
             );
         }
 
-        let RemoveUnrootedSlots {
+        let RemoveUnrootedSlotsSynchronization {
             slots_under_contention,
             signal,
         } = &self.remove_unrooted_slots;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2652,8 +2652,8 @@ impl Bank {
         }
     }
 
-    pub fn remove_unrooted_slot(&self, slot: Slot) {
-        self.rc.accounts.accounts_db.remove_unrooted_slot(slot)
+    pub fn remove_unrooted_slots(&self, slots: &[Slot]) {
+        self.rc.accounts.accounts_db.remove_unrooted_slots(slots)
     }
 
     pub fn set_shrink_paths(&self, paths: Vec<PathBuf>) {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -217,7 +217,7 @@ impl BankForks {
                 "Root entering
                 epoch: {},
                 next_epoch_start_slot: {},
-                epoch_stakes: {:#?}",
+                : {:#?}",
                 new_epoch,
                 root_bank
                     .epoch_schedule()

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -217,7 +217,7 @@ impl BankForks {
                 "Root entering
                 epoch: {},
                 next_epoch_start_slot: {},
-                : {:#?}",
+                epoch_stakes: {:#?}",
                 new_epoch,
                 root_bank
                     .epoch_schedule()


### PR DESCRIPTION
#### Problem
Follow-up to https://github.com/solana-labs/solana/pull/17319.

Bad versions of duplicate blocks can be replayed, and thus need to be cleared from Accounts state before replaying the good version.

#### Summary of Changes
Support safe block dumping by:

1) Making sure cache flushes for the same block are not happening concurrently via the `RemoveUnrootedSlots` synchronization mechanism which keeps a list of slots being flushed from cache OR being removed by this new dumping path. This dumping path blocks until a flush is completed, whereas the cache flushing path will ignore requests to flush slots that are currently/about to be dumped.
2) Removing the slot completely from both the AccountsIndex and removing the storage entries by calling `purge_slots_from_cache_and_store()`.

Follow-up PR:
Notifying relevant scans that their results may be outdated, and abort those results, noted here:https://github.com/solana-labs/solana/blob/3d0cacc1a617b4344ea44afdb0b51e5627bd2761/runtime/src/accounts_db.rs#L3411

Fixes #
