### PR TITLE
Fix the error for cross compile architecture

### DIFF
--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -117,7 +117,6 @@ fn main() {
                 );
             }
         }
-        
 
         if perf_libs::api().is_some() {
             let mut time = Measure::start("time");

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -84,35 +84,40 @@ fn main() {
             time.as_us() / iterations as u64
         );
 
-        if is_x86_feature_detected!("avx2") && entry::api().is_some() {
-            let mut time = Measure::start("time");
-            for _ in 0..iterations {
-                assert!(ticks[..num_entries]
-                    .verify_cpu_x86_simd(&start_hash, 8)
-                    .finish_verify());
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+            if is_x86_feature_detected!("avx2") && entry::api().is_some() {
+                let mut time = Measure::start("time");
+                for _ in 0..iterations {
+                    assert!(ticks[..num_entries]
+                        .verify_cpu_x86_simd(&start_hash, 8)
+                        .finish_verify());
+                }
+                time.stop();
+                println!(
+                    "{},cpu_simd_avx2,{}",
+                    num_entries,
+                    time.as_us() / iterations as u64
+                );
             }
-            time.stop();
-            println!(
-                "{},cpu_simd_avx2,{}",
-                num_entries,
-                time.as_us() / iterations as u64
-            );
         }
 
-        if is_x86_feature_detected!("avx512f") && entry::api().is_some() {
-            let mut time = Measure::start("time");
-            for _ in 0..iterations {
-                assert!(ticks[..num_entries]
-                    .verify_cpu_x86_simd(&start_hash, 16)
-                    .finish_verify());
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+            if is_x86_feature_detected!("avx512f") && entry::api().is_some() {
+                let mut time = Measure::start("time");
+                for _ in 0..iterations {
+                    assert!(ticks[..num_entries]
+                        .verify_cpu_x86_simd(&start_hash, 16)
+                        .finish_verify());
+                }
+                time.stop();
+                println!(
+                    "{},cpu_simd_avx512,{}",
+                    num_entries,
+                    time.as_us() / iterations as u64
+                );
             }
-            time.stop();
-            println!(
-                "{},cpu_simd_avx512,{}",
-                num_entries,
-                time.as_us() / iterations as u64
-            );
         }
+        
 
         if perf_libs::api().is_some() {
             let mut time = Measure::start("time");


### PR DESCRIPTION
#### Problem

The problem is mentioned at https://github.com/solana-labs/solana/issues/17268

#### Summary of Changes

I have simply followed what the compiler was saying, and I was able to get it compiled

Fixes #

- Added `#[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {` before the use of `is_x86_feature_detected!("avx512f")`
