### PR TITLE
Clear release cache for stable-perf CI jobs

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -36,4 +36,7 @@ export CARGO_TARGET_CACHE=$HOME/cargo-target-cache/"$CHANNEL"-"$BUILDKITE_LABEL"
   # `std:
   #    "found possibly newer version of crate `std` which `xyz` depends on
   rm -rf target/bpfel-unknown-unknown
+  if [[ $BUILDKITE_LABEL = "stable-perf" ]]; then
+    rm -rf target/release
+  fi
 )


### PR DESCRIPTION
#### Problem
CI stable-perf cache can somehow get out of sync with bpf-tools, causing CI failures. Here is an example on `froome`: https://buildkite.com/solana-labs/solana/builds/46336#dfa2ae94-b6f2-4aa0-b740-d933ddbb26c5

#### Summary of Changes
Clearing the `target/release` cache for this job prevents the failures.
Successful CI run of this code on `froome`: https://buildkite.com/solana-labs/solana/builds/46336#dfa2ae94-b6f2-4aa0-b740-d933ddbb26c5
Effect on `stable-perf` job time seems negligible.

This is a bit of a hammer, but it isn't clear to me how these artifacts are getting out of sync.

Here was the most recent successful stable-perf job on `froome`, which generated the `cargo-target-cache/edge-stable-perf` cache that subsequently failed: https://buildkite.com/solana-labs/solana/builds/46325#051493d7-1dab-41dd-baf1-709266fd8d94
Nothing stands out to me as concerning.