### PR TITLE
Add Contextual Search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -76,6 +76,7 @@ module.exports = {
       // This API key is "search-only" and safe to be published
       apiKey: "d58e0d68c875346d52645d68b13f3ac0",
       indexName: "solana",
+      contextualSearch: true,
     },
     footer: {
       style: "dark",


### PR DESCRIPTION
#### Problem

When searching, other language results appear in the Algolia dialogue.

#### Summary of Changes

Adds Docusaurus contextual search: this should prevent other language results appearing in the search area.
