### PR TITLE
Chore: remove dead code

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -68,13 +68,11 @@ pub enum ParsePubkeyError {
     WrongSize,
     #[error("Invalid Base58 string")]
     Invalid,
-    #[error("Infallible")]
-    Infallible,
 }
 
 impl From<Infallible> for ParsePubkeyError {
     fn from(_: Infallible) -> Self {
-        Self::Infallible
+        unreachable!("Infallible unihnabited");
     }
 }
 


### PR DESCRIPTION
#### Problem
Error type case variant is unnecessary. There is no way to construct argument of Infallible type.
