### PR TITLE
Accounts start opt

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1130,6 +1130,16 @@ fn new_banks_from_ledger(
         abort()
     });
 
+    let bank_forks = BankForks::new_from_banks(&initial_forks, root);
+    /*blockstore_processor::process_blockstore_from_root(
+        blockstore,
+        deserialized_bank,
+        &process_options,
+        &VerifyRecyclers::default(),
+        transaction_status_sender,
+        cache_block_time_sender,
+    )*/
+
     if let Some(warp_slot) = config.warp_slot {
         let snapshot_config = config.snapshot_config.as_ref().unwrap_or_else(|| {
             error!("warp slot requires a snapshot config");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1125,6 +1125,7 @@ fn new_banks_from_ledger(
     });
 
     let mut bank_forks = BankForks::new_from_banks(&[bank0.clone()], bank0.slot());
+
     let mut leader_schedule_cache = blockstore_processor::do_process_blockstore_from_root(
         &blockstore,
         bank0,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -91,14 +91,7 @@ pub fn load(
                 }
 
                 return to_loadresult(
-                    blockstore_processor::process_blockstore_from_root(
-                        blockstore,
-                        deserialized_bank,
-                        &process_options,
-                        &VerifyRecyclers::default(),
-                        transaction_status_sender,
-                        cache_block_time_sender,
-                    ),
+,
                     Some(deserialized_snapshot_hash),
                 );
             }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -407,14 +407,6 @@ pub fn process_blockstore(
         &recyclers,
         cache_block_time_sender,
     );
-    do_process_blockstore_from_root(
-        blockstore,
-        bank0,
-        &opts,
-        &recyclers,
-        None,
-        cache_block_time_sender,
-    )
 }
 
 // Process blockstore from a known root bank

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4514,10 +4514,6 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
-        if self.slot() > 0 {
-            self.clean_accounts(true);
-            self.shrink_all_slots();
-        }
         // Order and short-circuiting is significant; verify_hash requires a valid bank hash
         self.verify_bank_hash() && self.verify_hash()
     }


### PR DESCRIPTION
#### Problem

Startup clean and shrink accounts takes a long time and are blocking

#### Summary of Changes

Let replay stage process the local ledger post-snapshot in the general case instead of blockstore processor. This should remove the need of doing a clean/shrink up front and let the accounts_background_service handle it in the background.

Fixes #
