### PR TITLE
don't limit thread pool when cleaning on startup

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
     for x in 0..iterations {
         if clean {
             let mut time = Measure::start("clean");
-            accounts.accounts_db.clean_accounts(None);
+            accounts.accounts_db.clean_accounts(None, false);
             time.stop();
             println!("{}", time);
             for slot in 0..num_slots {

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -167,7 +167,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         accounts.add_root(i);
     }
     bencher.iter(|| {
-        accounts.accounts_db.clean_accounts(None);
+        accounts.accounts_db.clean_accounts(None, false);
     });
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2060,7 +2060,7 @@ mod tests {
             }
         }
         info!("done..cleaning..");
-        accounts.accounts_db.clean_accounts(None);
+        accounts.accounts_db.clean_accounts(None, false);
     }
 
     fn load_accounts_no_store(accounts: &Accounts, tx: Transaction) -> Vec<TransactionLoadResult> {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -154,7 +154,7 @@ impl SnapshotRequestHandler {
                 // accounts that were included in the bank delta hash when the bank was frozen,
                 // and if we clean them here, the newly created snapshot's hash may not match
                 // the frozen hash.
-                snapshot_root_bank.clean_accounts(true);
+                snapshot_root_bank.clean_accounts(true, false);
                 clean_time.stop();
 
                 if accounts_db_caching_enabled {
@@ -372,7 +372,7 @@ impl AccountsBackgroundService {
                             // slots >= bank.slot()
                             bank.force_flush_accounts_cache();
                         }
-                        bank.clean_accounts(true);
+                        bank.clean_accounts(true, false);
                         last_cleaned_block_height = bank.block_height();
                     }
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2118,7 +2118,7 @@ impl Bank {
         // accounts that were included in the bank delta hash when the bank was frozen,
         // and if we clean them here, any newly created snapshot's hash for this bank
         // may not match the frozen hash.
-        self.clean_accounts(true);
+        self.clean_accounts(true, false);
         clean.stop();
 
         let mut shrink = Measure::start("shrink");
@@ -4521,7 +4521,7 @@ impl Bank {
     pub fn verify_snapshot_bank(&self) -> bool {
         let mut clean_time = Measure::start("clean");
         if self.slot() > 0 {
-            self.clean_accounts(true);
+            self.clean_accounts(true, true);
         }
         clean_time.stop();
 
@@ -4803,7 +4803,7 @@ impl Bank {
             .add_program(program_id, process_instruction_with_context);
     }
 
-    pub fn clean_accounts(&self, skip_last: bool) {
+    pub fn clean_accounts(&self, skip_last: bool, is_startup: bool) {
         let max_clean_slot = if skip_last {
             // Don't clean the slot we're snapshotting because it may have zero-lamport
             // accounts that were included in the bank delta hash when the bank was frozen,
@@ -4813,7 +4813,10 @@ impl Bank {
         } else {
             None
         };
-        self.rc.accounts.accounts_db.clean_accounts(max_clean_slot);
+        self.rc
+            .accounts
+            .accounts_db
+            .clean_accounts(max_clean_slot, is_startup);
     }
 
     pub fn shrink_all_slots(&self, is_startup: bool) {
@@ -7333,7 +7336,7 @@ pub(crate) mod tests {
         bank.squash();
         bank.force_flush_accounts_cache();
         let hash = bank.update_accounts_hash();
-        bank.clean_accounts(false);
+        bank.clean_accounts(false, false);
         assert_eq!(bank.update_accounts_hash(), hash);
 
         let bank0 = Arc::new(new_from_parent(&bank));
@@ -7353,14 +7356,14 @@ pub(crate) mod tests {
 
         info!("bank0 purge");
         let hash = bank0.update_accounts_hash();
-        bank0.clean_accounts(false);
+        bank0.clean_accounts(false, false);
         assert_eq!(bank0.update_accounts_hash(), hash);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports(), 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank1 purge");
-        bank1.clean_accounts(false);
+        bank1.clean_accounts(false, false);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports(), 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
@@ -7381,7 +7384,7 @@ pub(crate) mod tests {
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
         bank1.force_flush_accounts_cache();
-        bank1.clean_accounts(false);
+        bank1.clean_accounts(false, false);
 
         assert!(bank1.verify_bank_hash());
     }
@@ -10604,7 +10607,7 @@ pub(crate) mod tests {
 
         // Clean accounts, which should add earlier slots to the shrink
         // candidate set
-        bank2.clean_accounts(false);
+        bank2.clean_accounts(false, false);
 
         // Slots 0 and 1 should be candidates for shrinking, but slot 2
         // shouldn't because none of its accounts are outdated by a later
@@ -10660,7 +10663,7 @@ pub(crate) mod tests {
         goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank).unwrap());
 
         bank.squash();
-        bank.clean_accounts(false);
+        bank.clean_accounts(false, false);
         let force_to_return_alive_account = 0;
         assert_eq!(
             bank.process_stale_slot_with_budget(22, force_to_return_alive_account),
@@ -11917,7 +11920,7 @@ pub(crate) mod tests {
                         current_major_fork_bank.squash();
                         // Try to get cache flush/clean to overlap with the scan
                         current_major_fork_bank.force_flush_accounts_cache();
-                        current_major_fork_bank.clean_accounts(false);
+                        current_major_fork_bank.clean_accounts(false, false);
                     }
                 },
             )
@@ -11953,7 +11956,7 @@ pub(crate) mod tests {
                         current_bank.squash();
                         if current_bank.slot() % 2 == 0 {
                             current_bank.force_flush_accounts_cache();
-                            current_bank.clean_accounts(true);
+                            current_bank.clean_accounts(true, false);
                         }
                         prev_bank = current_bank.clone();
                         current_bank = Arc::new(Bank::new_from_parent(
@@ -12680,7 +12683,7 @@ pub(crate) mod tests {
         bank2.squash();
 
         drop(bank1);
-        bank2.clean_accounts(false);
+        bank2.clean_accounts(false, false);
 
         let expected_ref_count_for_cleaned_up_keys = 0;
         let expected_ref_count_for_keys_only_in_slot_2 = bank2

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -960,7 +960,7 @@ pub fn bank_to_snapshot_archive<P: AsRef<Path>, Q: AsRef<Path>>(
     assert!(bank.is_complete());
     bank.squash(); // Bank may not be a root
     bank.force_flush_accounts_cache();
-    bank.clean_accounts(true);
+    bank.clean_accounts(true, false);
     bank.update_accounts_hash();
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1297,7 +1297,7 @@ mod tests {
             bank.force_flush_accounts_cache();
             // do clean and assert that it actually did its job
             assert_eq!(3, bank.get_snapshot_storages().len());
-            bank.clean_accounts(false);
+            bank.clean_accounts(false, false);
             assert_eq!(2, bank.get_snapshot_storages().len());
         });
     }

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -59,7 +59,7 @@ fn test_shrink_and_clean() {
 
         // let's dance.
         for _ in 0..10 {
-            accounts.clean_accounts(None);
+            accounts.clean_accounts(None, false);
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
 


### PR DESCRIPTION
#### Problem
Startup is slow. Clean is slow. Clean normally limits the # of threads it can use to keep from wrecking a validator.
At startup, clean is the only thing running.
#### Summary of Changes
Give clean all the threads it wants during startup.
Fixes #
