### PR TITLE
Validator progress bars are now rendered when stdout is not a terminal

### DIFF
--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -1,7 +1,6 @@
 use {
-    crate::{admin_rpc_service, new_spinner_progress_bar, println_name_value},
+    crate::{admin_rpc_service, new_spinner_progress_bar, println_name_value, ProgressBar},
     console::style,
-    indicatif::ProgressBar,
     solana_client::{
         client_error, rpc_client::RpcClient, rpc_request, rpc_response::RpcContactInfo,
     },


### PR DESCRIPTION
`indicatif::ProgressBar` hides itself when stdout is not a terminal, which makes it hard to run `solana-validator exit` from a script and monitor its progress.  

Add a ProgressBar wrapper that detects a non-terminal and redirect progress bar output to `println!()` if so