### PR TITLE
Add documentation for --ignore-case

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -642,7 +642,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                 && starts_and_ends_with_args.is_empty()
             {
                 eprintln!(
-                    "Error: No keypair search criteria provided (--starts-with or --ends-with or --starts-and-ends-with)"
+                    "Error: No keypair search criteria provided (--starts-with or --ends-with or --starts-and-ends-with, optionally --ignore-case)"
                 );
                 exit(1);
             }


### PR DESCRIPTION
#### Problem

The --ignore-case functionality is undocumented and doesn't appear in any help / error messages
e.g. https://twitter.com/dadadadaffy/status/1392854095803846659?s=20 
People end up writing a python scripts to duplicate the functionality

#### Summary of Changes

Add it to the error message that appears when running `solana-keygen grind` without any arguments.

Open to having it better documented somewhere else.


Fixes #
