### PR TITLE
removes manual trait impl for contact-info

### DIFF
--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -6,11 +6,10 @@ use solana_sdk::sanitize::{Sanitize, SanitizeError};
 #[cfg(test)]
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::timing::timestamp;
-use std::cmp::{Ord, Ordering, PartialEq, PartialOrd};
 use std::net::{IpAddr, SocketAddr};
 
 /// Structure representing a node on the network
-#[derive(Serialize, Deserialize, Clone, Debug, AbiExample)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, AbiExample, Deserialize, Serialize)]
 pub struct ContactInfo {
     pub id: Pubkey,
     /// gossip address
@@ -48,34 +47,13 @@ impl Sanitize for ContactInfo {
     }
 }
 
-impl Ord for ContactInfo {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
-impl PartialOrd for ContactInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for ContactInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for ContactInfo {}
-
 #[macro_export]
 macro_rules! socketaddr {
     ($ip:expr, $port:expr) => {
         std::net::SocketAddr::from((std::net::Ipv4Addr::from($ip), $port))
     };
     ($str:expr) => {{
-        let a: std::net::SocketAddr = $str.parse().unwrap();
-        a
+        $str.parse::<std::net::SocketAddr>().unwrap()
     }};
 }
 #[macro_export]

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -19,7 +19,7 @@
 //! CrdsValue enums.
 //!
 //! Merge strategy is implemented in:
-//!     impl PartialOrd for VersionedCrdsValue
+//!     fn overrides(value: &CrdsValue, other: &VersionedCrdsValue) -> bool
 //!
 //! A value is updated to a new version if the labels match, and the value
 //! wallclock is later, or the value hash is greater.
@@ -66,8 +66,6 @@ pub enum CrdsError {
 }
 
 /// This structure stores some local metadata associated with the CrdsValue
-/// The implementation of PartialOrd ensures that the "highest" version is always picked to be
-/// stored in the Crds
 #[derive(PartialEq, Debug, Clone)]
 pub struct VersionedCrdsValue {
     /// Ordinal index indicating insert order.


### PR DESCRIPTION
#### Problem
The current implementations only use the `id` and disregard other fields,
in particular `wallclock`. This can lead to bugs where an outdated
contact-info shadows or overrides a current one because they compare
equal.

#### Summary of Changes
Removed manual implementation in favor of derive macro.
