### PR TITLE
programs/stake: cancel deactivate

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -576,6 +576,8 @@ pub fn process_instruction(
             }
         }
         StakeInstruction::DelegateStake => {
+            let can_reverse_deactivation =
+                invoke_context.is_feature_active(&feature_set::stake_program_v4::id());
             let vote = keyed_account_at_index(keyed_accounts, 1)?;
 
             me.delegate(
@@ -584,6 +586,7 @@ pub fn process_instruction(
                 &from_keyed_account::<StakeHistory>(keyed_account_at_index(keyed_accounts, 3)?)?,
                 &config::from_keyed_account(keyed_account_at_index(keyed_accounts, 4)?)?,
                 &signers,
+                can_reverse_deactivation,
             )
         }
         StakeInstruction::Split(lamports) => {


### PR DESCRIPTION
#### Problem
We want to be able to "un-deactivate" stake if `current_epoch == deactivation_epoch`.

The mechanism to do so is that `delegate` -> `redelegate` gets modified to reset `Delegation.deactivation_epoch` to ` std::u64::MAX` if `Delegate.voter_pubkey == new_voter_pubkey`.

More info here: https://github.com/solana-labs/solana/issues/17341
#### Summary of Changes
We do a possibly hacky workaround. May be better to define a new instruction - `cancel_deactivate`.

Fixes #https://github.com/solana-labs/solana/issues/17341

CC: @joncinque 