### PR TITLE
initialize purge stats

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -881,6 +881,7 @@ impl PurgeStats {
                         Ordering::Relaxed,
                         Ordering::Relaxed,
                     ) == Ok(last)
+                    && last != 0
             })
             .unwrap_or(true);
 


### PR DESCRIPTION
#### Problem
PurgeStats logs incorrectly the first time it is called.

#### Summary of Changes
Wait until 1s has elapsed.

Fixes #
