### PR TITLE
Fix InvokeContext::push() account_deps

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -310,8 +310,6 @@ fn process_loader_upgradeable_instruction(
             let buffer = keyed_account_at_index(keyed_accounts, 3)?;
             let rent = from_keyed_account::<Rent>(keyed_account_at_index(keyed_accounts, 4)?)?;
             let clock = from_keyed_account::<Clock>(keyed_account_at_index(keyed_accounts, 5)?)?;
-            // TODO [KeyedAccounts to InvokeContext refactoring]
-            // let _system = keyed_account_at_index(keyed_accounts, 6)?;
             let authority = keyed_account_at_index(keyed_accounts, 7)?;
             let upgrade_authority_address = Some(*authority.unsigned_key());
             let upgrade_authority_signer = authority.signer_key().is_none();

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -358,7 +358,8 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
                                 *is_signer,
                                 *is_writable,
                                 &self.account_deps[index].0,
-                                &self.account_deps[index].1 as &RefCell<AccountSharedData>,
+                                // &self.account_deps[index].1 as &RefCell<AccountSharedData>,
+                                transmute_lifetime(*account),
                             )
                         } else {
                             index = index.saturating_sub(self.account_deps.len());

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -357,24 +357,15 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
                         // Currently we are constructing new accounts on the stack
                         // before calling MessageProcessor::process_cross_program_instruction
                         // Ideally we would recycle the existing accounts here.
-                        if index < self.account_deps.len() {
-                            (
-                                *is_signer,
-                                *is_writable,
-                                &self.account_deps[index].0,
-                                // &self.account_deps[index].1 as &RefCell<AccountSharedData>,
-                                transmute_lifetime(*account),
-                            )
+                        let key = if index < self.account_deps.len() {
+                            &self.account_deps[index].0
+                            // &self.account_deps[index].1 as &RefCell<AccountSharedData>,
                         } else {
                             index = index.saturating_sub(self.account_deps.len());
-                            (
-                                *is_signer,
-                                *is_writable,
-                                &self.message.account_keys[index],
-                                // &self.accounts[index] as &RefCell<AccountSharedData>,
-                                transmute_lifetime(*account),
-                            )
-                        }
+                            &self.message.account_keys[index]
+                            // &self.accounts[index] as &RefCell<AccountSharedData>,
+                        };
+                        (*is_signer, *is_writable, key, transmute_lifetime(*account))
                     })
             })
             .collect::<Option<Vec<_>>>()

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -353,6 +353,10 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
                     .chain(self.message.account_keys.iter())
                     .position(|key| key == *search_key)
                     .map(|mut index| {
+                        // TODO
+                        // Currently we are constructing new accounts on the stack
+                        // before calling MessageProcessor::process_cross_program_instruction
+                        // Ideally we would recycle the existing accounts here.
                         if index < self.account_deps.len() {
                             (
                                 *is_signer,
@@ -367,10 +371,6 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
                                 *is_signer,
                                 *is_writable,
                                 &self.message.account_keys[index],
-                                // TODO
-                                // Currently we are constructing new accounts on the stack
-                                // before calling MessageProcessor::process_cross_program_instruction
-                                // Ideally we would recycle the existing accounts here like this:
                                 // &self.accounts[index] as &RefCell<AccountSharedData>,
                                 transmute_lifetime(*account),
                             )


### PR DESCRIPTION
#### Problem
See #17284

#### Summary of Changes
Reverts aliasing of `account_deps` with the previous invocation stack frame in `InvokeContext::push()`.

Fixes #17284
Fixes #17135
Fixes #17083
