### PR TITLE
adds metric for turbine retransmit tree mismatch

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1383,7 +1383,7 @@ impl ClusterInfo {
     /// We need to avoid having obj locked while doing a io, such as the `send_to`
     pub fn retransmit_to(
         peers: &[&ContactInfo],
-        packet: &mut Packet,
+        packet: &Packet,
         s: &UdpSocket,
         forwarded: bool,
     ) -> Result<()> {

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -204,7 +204,7 @@ pub fn cluster_info_retransmit() {
     p.meta.size = 10;
     let peers = c1.tvu_peers();
     let retransmit_peers: Vec<_> = peers.iter().collect();
-    ClusterInfo::retransmit_to(&retransmit_peers, &mut p, &tn1, false).unwrap();
+    ClusterInfo::retransmit_to(&retransmit_peers, &p, &tn1, false).unwrap();
     let res: Vec<_> = [tn1, tn2, tn3]
         .into_par_iter()
         .map(|s| {


### PR DESCRIPTION
#### Problem
In order to remove port-based forwarding logic in turbine, we need to first track how often the turbine retransmit/broadcast trees mismatch across nodes. One consistency condition is that if the node is on the critical path (i.e. the first node in each neighborhood), then we expect that the packet arrives at tvu socket as opposed to tvu-forwards.

#### Summary of Changes
* 1st commit adds a metric to track how often above consistency condition is not met.
* 2nd commit just removes the nested for loop. No code logic change.