### PR TITLE
take mutex once in process_dead_slots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1895,8 +1895,11 @@ impl AccountsDb {
 
         // If the slot is dead, remove the need to shrink the storages as
         // the storage entries will be purged.
-        for slot in dead_slots {
-            self.shrink_candidate_slots.lock().unwrap().remove(slot);
+        {
+            let mut list = self.shrink_candidate_slots.lock().unwrap();
+            for slot in dead_slots {
+                list.remove(slot);
+            }
         }
 
         debug!(


### PR DESCRIPTION
#### Problem
In a loop, we get a mutex lock, remove from a hashmap, and release the lock.
#### Summary of Changes
grab and keep the mutex on the hashmap. Delete all items in a batch.
Fixes #
