### PR TITLE
ancestors is set instead of map

### DIFF
--- a/runtime/src/ancestors.rs
+++ b/runtime/src/ancestors.rs
@@ -83,7 +83,7 @@ impl From<&Ancestors> for HashMap<Slot, usize> {
     fn from(source: &Ancestors) -> HashMap<Slot, usize> {
         let mut result = HashMap::with_capacity(source.len());
         source.keys().iter().for_each(|slot| {
-            result.insert(*slot, *source.get(slot).unwrap());
+            result.insert(*slot, 0);
         });
         result
     }
@@ -102,15 +102,15 @@ impl Ancestors {
         }
     }
 
-    pub fn get(&self, slot: &Slot) -> Option<&usize> {
+    pub fn get(&self, slot: &Slot) -> bool {
         if self.large_range_slots.is_empty() {
             if slot < &self.min || slot >= &self.max {
-                return None;
+                return false;
             }
             let slot = self.slot_index(slot);
-            self.slots[slot].as_ref()
+            self.slots[slot].is_some()
         } else {
-            self.large_range_slots.get(slot)
+            self.large_range_slots.get(slot).is_some()
         }
     }
 
@@ -272,10 +272,10 @@ pub mod tests {
             let key = item.0;
             min = std::cmp::min(min, *key);
             max = std::cmp::max(max, *key);
-            assert_eq!(ancestors.get(&key).unwrap(), item.1);
+            assert!(ancestors.get(&key));
         }
         for slot in min - 1..max + 2 {
-            assert_eq!(ancestors.get(&slot), hashset.get(&slot));
+            assert_eq!(ancestors.get(&slot), hashset.contains(&slot));
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1132,8 +1132,8 @@ impl Bank {
 
         let mut ancestors = Vec::with_capacity(1 + new.parents().len());
         ancestors.push((new.slot(), 0));
-        new.parents().iter().enumerate().for_each(|(i, p)| {
-            ancestors.push((p.slot(), i + 1));
+        new.parents().iter().for_each(|p| {
+            ancestors.push((p.slot(), 0));
         });
         new.ancestors = Ancestors::from(ancestors);
 

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -143,7 +143,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         if let Some(stored_forks) = keymap.get(key_slice) {
             let res = stored_forks
                 .iter()
-                .find(|(f, _)| ancestors.get(f).is_some() || self.roots.get(f).is_some())
+                .find(|(f, _)| ancestors.get(f) || self.roots.get(f).is_some())
                 .cloned();
             if res.is_some() {
                 return res;


### PR DESCRIPTION
#### Problem
It turns out Ancestors doesn't need to be HashMap and keep track of the a usize value per slot (except we need to persist to/from for bank serialization format).

#### Summary of Changes
Change Ancestors api to be like a HashSet instead of HashMap. Next, I will refactor Ancestors to internally be a bit vector instead of the more complicated implementation we have now.

Fixes #
