### PR TITLE
Prevent withrawing Initialized stake account to rent-exempt reserve

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -610,6 +610,7 @@ pub fn process_instruction(
                 &from_keyed_account::<StakeHistory>(keyed_account_at_index(keyed_accounts, 3)?)?,
                 keyed_account_at_index(keyed_accounts, 4)?,
                 keyed_account_at_index(keyed_accounts, 5).ok(),
+                invoke_context.is_feature_active(&feature_set::stake_program_v4::id()),
             )
         }
         StakeInstruction::Deactivate => me.deactivate(


### PR DESCRIPTION
#### Problem
It is possible to end up with a Delegated stake account with 0 delegated stake by withdrawing an Initialized account to exactly the rent-exempt reserve and then delegating. This is confusing to users (is it activating? can it be redelegated?), and defies our intention that every stake account have more lamports than the rent-exempt reserve.

#### Summary of Changes
Bump `reserve` for Initialized stake accounts by 1 lamport
Also flesh out testing of withdrawals from Initialized accounts
