### PR TITLE
Flatten SnapshotStorages

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,7 +38,7 @@ use crate::{
         AccountAddressFilter, Accounts, TransactionAccountDeps, TransactionAccounts,
         TransactionLoadResult, TransactionLoaders,
     },
-    accounts_db::{ErrorCounters, SnapshotStorages},
+    accounts_db::{ErrorCounters, SnapshotStorage},
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},
     blockhash_queue::BlockhashQueue,
@@ -371,7 +371,7 @@ impl BankRc {
         }
     }
 
-    pub fn get_snapshot_storages(&self, slot: Slot) -> SnapshotStorages {
+    pub fn get_snapshot_storages(&self, slot: Slot) -> SnapshotStorage {
         self.accounts.accounts_db.get_snapshot_storages(slot)
     }
 }
@@ -4436,11 +4436,8 @@ impl Bank {
         )
     }
 
-    pub fn get_snapshot_storages(&self) -> SnapshotStorages {
-        self.rc
-            .get_snapshot_storages(self.slot())
-            .into_iter()
-            .collect()
+    pub fn get_snapshot_storages(&self) -> SnapshotStorage {
+        self.rc.get_snapshot_storages(self.slot())
     }
 
     #[must_use]

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
         accounts::Accounts,
-        accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo},
+        accounts_db::{
+            AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo, SnapshotStorageEntry,
+        },
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         append_vec::{AppendVec, StoredMetaWriteVersion},
@@ -54,8 +56,6 @@ use utils::{serialize_iter_as_map, serialize_iter_as_seq, serialize_iter_as_tupl
 // a number of test cases in accounts_db use this
 #[cfg(test)]
 pub(crate) use self::tests::reconstruct_accounts_db_via_serialization;
-
-pub(crate) use crate::accounts_db::{SnapshotStorage, SnapshotStorages};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum SerdeStyle {
@@ -171,7 +171,7 @@ pub(crate) fn bank_to_stream<W>(
     serde_style: SerdeStyle,
     stream: &mut BufWriter<W>,
     bank: &Bank,
-    snapshot_storages: &[SnapshotStorage],
+    snapshot_storages: &[SnapshotStorageEntry],
 ) -> Result<(), Error>
 where
     W: Write,
@@ -199,7 +199,7 @@ where
 
 struct SerializableBankAndStorage<'a, C> {
     bank: &'a Bank,
-    snapshot_storages: &'a [SnapshotStorage],
+    snapshot_storages: &'a [SnapshotStorageEntry],
     phantom: std::marker::PhantomData<C>,
 }
 
@@ -215,7 +215,7 @@ impl<'a, C: TypeContext<'a>> Serialize for SerializableBankAndStorage<'a, C> {
 struct SerializableAccountsDb<'a, C> {
     accounts_db: &'a AccountsDb,
     slot: Slot,
-    account_storage_entries: &'a [SnapshotStorage],
+    account_storage_entries: &'a [SnapshotStorageEntry],
     phantom: std::marker::PhantomData<C>,
 }
 

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -243,14 +243,13 @@ impl<'a> TypeContext<'a> for Context {
             .load(Ordering::Relaxed);
 
         // (1st of 3 elements) write the list of account storage entry lists out as a map
-        let entry_count = RefCell::<usize>::new(0);
+        let entry_count = RefCell::<usize>::new(serializable_db.account_storage_entries.len());
         let entries =
             serialize_iter_as_map(serializable_db.account_storage_entries.iter().map(|x| {
-                *entry_count.borrow_mut() += x.len();
                 (
-                    x.first().unwrap().slot(),
+                    x.slot(),
                     serialize_iter_as_seq(
-                        x.iter()
+                        std::iter::once(x)
                             .map(|x| Self::SerializableAccountStorageEntry::from(x.as_ref())),
                     ),
                 )

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -30,7 +30,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
 ) -> std::io::Result<UnpackedAppendVecMap> {
     let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
-    for storage in storage_entries.iter().flatten() {
+    for storage in storage_entries {
         let storage_path = storage.get_path();
         let file_name = AppendVec::file_name(storage.slot(), storage.append_vec_id());
         let output_path = output_dir.as_ref().join(&file_name);
@@ -101,7 +101,7 @@ fn accountsdb_to_stream<W>(
     stream: &mut W,
     accounts_db: &AccountsDb,
     slot: Slot,
-    account_storage_entries: &[SnapshotStorage],
+    account_storage_entries: &[SnapshotStorageEntry],
 ) -> Result<(), Error>
 where
     W: Write,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,6 +1,6 @@
 use crate::bank_forks::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
-use crate::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
+use crate::{accounts_db::SnapshotStorage, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
 use solana_sdk::genesis_config::ClusterType;
 use solana_sdk::hash::Hash;
@@ -20,7 +20,7 @@ pub struct AccountsPackagePre {
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
-    pub storages: SnapshotStorages,
+    pub storages: SnapshotStorage,
     pub hash: Hash, // temporarily here while we still have to calculate hash before serializing bank
     pub archive_format: ArchiveFormat,
     pub snapshot_version: SnapshotVersion,
@@ -37,7 +37,7 @@ impl AccountsPackagePre {
         block_height: u64,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
-        storages: SnapshotStorages,
+        storages: SnapshotStorage,
         hash: Hash,
         archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
@@ -68,7 +68,7 @@ pub struct AccountsPackage {
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
-    pub storages: SnapshotStorages,
+    pub storages: SnapshotStorage,
     pub tar_output_file: PathBuf,
     pub hash: Hash,
     pub archive_format: ArchiveFormat,
@@ -81,7 +81,7 @@ impl AccountsPackage {
         block_height: u64,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
-        storages: SnapshotStorages,
+        storages: SnapshotStorage,
         tar_output_file: PathBuf,
         hash: Hash,
         archive_format: ArchiveFormat,


### PR DESCRIPTION
`AccountDb::SnapshotStorages` is a `Vec<Vec<>>` around
`Arc<AccountStorageEntry>`.  It is created in
`AccountsDb::get_snapshot_storages()`, but pretty much every usage of
`SnapshotStorages` immediately flattened the `Vec<Vec<>>`, since the
multidimensionality was not useful nor necessary.

This commit changes `get_snapshot_storages()` to output the flattened
Vec directly (i.e. `Vec<Arc<AccountStorageEntry`).  This simplifies the
callers usage of this function, as they no longer have to flatten
themselves.

However, this change does come at a cost.  The snapshot format changes.
The ABI is changed because the datatype of the snapshot storages
changed.

So, I've put up this Draft PR to get some feedback. I do not want to go through the trouble of creating a new snapshot format if this change is not worthwhile. What do you think?

@ryoqun @carllin @sakridge 