### PR TITLE
Remove const qualifier from syscall out-parameters

### DIFF
--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -436,7 +436,7 @@ typedef struct {
 uint64_t sol_sha256(
     const SolBytes *bytes,
     int bytes_len,
-    const uint8_t *result
+    uint8_t *result
 );
 
 /**
@@ -454,7 +454,7 @@ uint64_t sol_sha256(
 uint64_t sol_keccak256(
     const SolBytes *bytes,
     int bytes_len,
-    const uint8_t *result
+    uint8_t *result
 );
 
 /**
@@ -506,7 +506,7 @@ uint64_t sol_create_program_address(
     const SolSignerSeed *seeds,
     int seeds_len,
     const SolPubkey *program_id,
-    const SolPubkey *program_address
+    SolPubkey *program_address
 );
 
 /**
@@ -522,8 +522,8 @@ uint64_t sol_try_find_program_address(
     const SolSignerSeed *seeds,
     int seeds_len,
     const SolPubkey *program_id,
-    const SolPubkey *program_address,
-    const uint8_t *bump_seed
+    SolPubkey *program_address,
+    uint8_t *bump_seed
 );
 
 /**


### PR DESCRIPTION
#### Problem
In the C SDK header, syscalls' out-parameters are currently declared const, even though (being out-parameters) they are being written to by the function.

#### Summary of Changes
Removed const.