### PR TITLE
account-decoder: don't use strings to convert between Pubkey types

### DIFF
--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -14,23 +14,23 @@ use std::str::FromStr;
 // A helper function to convert spl_token_v2_0::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
 pub fn spl_token_id_v2_0() -> Pubkey {
-    Pubkey::from_str(&spl_token_v2_0::id().to_string()).unwrap()
+    Pubkey::new_from_array(spl_token_v2_0::id().to_bytes())
 }
 
 // A helper function to convert spl_token_v2_0::native_mint::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
 pub fn spl_token_v2_0_native_mint() -> Pubkey {
-    Pubkey::from_str(&spl_token_v2_0::native_mint::id().to_string()).unwrap()
+    Pubkey::new_from_array(spl_token_v2_0::native_mint::id().to_bytes())
 }
 
 // A helper function to convert a solana_sdk::pubkey::Pubkey to spl_sdk::pubkey::Pubkey
 pub fn spl_token_v2_0_pubkey(pubkey: &Pubkey) -> SplTokenPubkey {
-    SplTokenPubkey::from_str(&pubkey.to_string()).unwrap()
+    SplTokenPubkey::new_from_array(pubkey.to_bytes())
 }
 
 // A helper function to convert a spl_sdk::pubkey::Pubkey to solana_sdk::pubkey::Pubkey
 pub fn pubkey_from_spl_token_v2_0(pubkey: &SplTokenPubkey) -> Pubkey {
-    Pubkey::from_str(&pubkey.to_string()).unwrap()
+    Pubkey::new_from_array(pubkey.to_bytes())
 }
 
 pub fn parse_token(

--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -3,12 +3,11 @@ use crate::parse_instruction::{
 };
 use serde_json::json;
 use solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey};
-use std::str::FromStr;
 
 // A helper function to convert spl_associated_token_account_v1_0::id() as spl_sdk::pubkey::Pubkey
 // to solana_sdk::pubkey::Pubkey
 pub fn spl_associated_token_id_v1_0() -> Pubkey {
-    Pubkey::from_str(&spl_associated_token_account_v1_0::id().to_string()).unwrap()
+    Pubkey::new_from_array(spl_associated_token_account_v1_0::id().to_bytes())
 }
 
 pub fn parse_associated_token(
@@ -58,7 +57,7 @@ mod test {
     };
 
     fn convert_pubkey(pubkey: Pubkey) -> SplAssociatedTokenPubkey {
-        SplAssociatedTokenPubkey::from_str(&pubkey.to_string()).unwrap()
+        SplAssociatedTokenPubkey::new_from_array(pubkey.to_bytes())
     }
 
     fn convert_compiled_instruction(

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -10,19 +10,15 @@ use inflector::Inflector;
 use serde_json::Value;
 use solana_account_decoder::parse_token::spl_token_id_v2_0;
 use solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey, system_program};
-use std::{
-    collections::HashMap,
-    str::{from_utf8, FromStr},
-};
+use std::{collections::HashMap, str::from_utf8};
 use thiserror::Error;
 
 lazy_static! {
     static ref ASSOCIATED_TOKEN_PROGRAM_ID: Pubkey = spl_associated_token_id_v1_0();
     static ref BPF_LOADER_PROGRAM_ID: Pubkey = solana_sdk::bpf_loader::id();
     static ref BPF_UPGRADEABLE_LOADER_PROGRAM_ID: Pubkey = solana_sdk::bpf_loader_upgradeable::id();
-    static ref MEMO_V1_PROGRAM_ID: Pubkey =
-        Pubkey::from_str(&spl_memo::v1::id().to_string()).unwrap();
-    static ref MEMO_V3_PROGRAM_ID: Pubkey = Pubkey::from_str(&spl_memo::id().to_string()).unwrap();
+    static ref MEMO_V1_PROGRAM_ID: Pubkey = Pubkey::new_from_array(spl_memo::v1::id().to_bytes());
+    static ref MEMO_V3_PROGRAM_ID: Pubkey = Pubkey::new_from_array(spl_memo::id().to_bytes());
     static ref STAKE_PROGRAM_ID: Pubkey = solana_stake_program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref TOKEN_PROGRAM_ID: Pubkey = spl_token_id_v2_0();


### PR DESCRIPTION
#### Problem

It doesn't make sense to allocate a string for this operation

#### Summary of Changes

Use arrays instead
