### PR TITLE
Lijun issue #17174 snapshot download enhancement

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -5,6 +5,7 @@ use log::*;
 use solana_runtime::{bank_forks::ArchiveFormat, snapshot_utils};
 use solana_sdk::clock::Slot;
 use solana_sdk::hash::Hash;
+use std::fmt;
 use std::fs::{self, File};
 use std::io;
 use std::io::Read;
@@ -30,7 +31,7 @@ pub struct DownloadProgressRecord {
     pub elapsed_time: Duration,
     // Duration since the the last notification
     pub last_elapsed_time: Duration,
-    // the bytes/sec speed measured for the last time
+    // the bytes/sec speed measured for the last notification period
     pub last_throughput: f32,
     // the bytes/sec speed measured from the beginning
     pub total_throughput: f32,
@@ -42,6 +43,22 @@ pub struct DownloadProgressRecord {
     pub percentage_done: f32,
     // The times of the progress is being notified, it starts from 1 and increments by 1 each time
     pub notification_count: u64,
+}
+
+impl fmt::Debug for DownloadProgressRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DownloadProgress")
+            .field("elapsed_time", &self.elapsed_time)
+            .field("last_elapsed_time", &self.last_elapsed_time)
+            .field("last_throughput", &self.last_throughput)
+            .field("total_throughput", &self.total_throughput)
+            .field("last_elapsed_time", &self.last_elapsed_time)
+            .field("total_bytes", &self.total_bytes)
+            .field("current_bytes", &self.current_bytes)
+            .field("percentage_done", &self.percentage_done)
+            .field("notification_count", &self.notification_count)
+            .finish()
+    }
 }
 
 /// This callback allows the caller to get notified of the download progress modelled by DownloadProgressRecord

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -167,13 +167,13 @@ where
                     let mut progress_record = DownloadProgressRecord {
                         elapsed_time: self.start_time.elapsed(),
                         last_elapsed_time: self.last_print.elapsed(),
-                        last_throughput: last_throughput,
+                        last_throughput,
                         total_throughput: self.current_bytes as f32
                             / self.start_time.elapsed().as_secs_f32(),
                         total_bytes: self.download_size as usize,
                         current_bytes: self.current_bytes,
                         percentage_done: 100f32 * (total_bytes_f32 / self.download_size),
-                        estimated_remaining_time: estimated_remaining_time,
+                        estimated_remaining_time,
                         notification_count: self.notification_count,
                     };
                     let mut to_update_progress = false;
@@ -197,14 +197,12 @@ where
                     }
 
                     if let Some(callback) = &self.callback {
-                        if to_update_progress {
-                            if !callback(&progress_record) {
-                                info!("Download is aborted by the caller");
-                                return Err(io::Error::new(
-                                    io::ErrorKind::Other,
-                                    "Download is aborted by the caller",
-                                ));
-                            }
+                        if to_update_progress && !callback(&progress_record) {
+                            info!("Download is aborted by the caller");
+                            return Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                "Download is aborted by the caller",
+                            ));
                         }
                     }
                     Ok(n)

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -191,7 +191,7 @@ where
                             if !callback(&progress_record) {
                                 info!("Download is aborted by the caller");
                                 return Err(io::Error::new(
-                                    io::ErrorKind::Interrupted,
+                                    io::ErrorKind::Other,
                                     "Download is aborted by the caller",
                                 ));
                             }

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -160,8 +160,9 @@ where
                     let diff_bytes_f32 = (self.current_bytes - self.last_print_bytes) as f32;
                     let last_throughput = diff_bytes_f32 / self.last_print.elapsed().as_secs_f32();
                     let mut estimated_remaining_time: f32 = f32::MAX;
-                    if last_throughput > 0_f32  {
-                        estimated_remaining_time = (self.download_size - self.current_bytes as f32) / last_throughput;
+                    if last_throughput > 0_f32 {
+                        estimated_remaining_time =
+                            (self.download_size - self.current_bytes as f32) / last_throughput;
                     }
                     let mut progress_record = DownloadProgressRecord {
                         elapsed_time: self.start_time.elapsed(),

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -30,7 +30,7 @@ pub struct DownloadProgressRecord {
     pub elapsed_time: Duration,
     // Duration since the the last notification
     pub last_elapsed_time: Duration,
-    // the bytes/sec speed measured for the last time 
+    // the bytes/sec speed measured for the last time
     pub last_throughput: f32,
     // the bytes/sec speed measured from the beginning
     pub total_throughput: f32,
@@ -47,14 +47,16 @@ pub struct DownloadProgressRecord {
 /// This callback allows the caller to get notified of the download progress modelled by DownloadProgressRecord
 /// Return "true" to continue the download
 /// Return "false" to abort the download
-type ProgressNotifyCallack = fn(progress_report: &DownloadProgressRecord) -> bool;
 
-pub fn download_file(
+pub fn download_file<F>(
     url: &str,
     destination_file: &Path,
     use_progress_bar: bool,
-    progress_notify_callback: Option<ProgressNotifyCallack>,
-) -> Result<(), String> {
+    progress_notify_callback: &Option<F>,
+) -> Result<(), String>
+where
+    F: Fn(&DownloadProgressRecord) -> bool,
+{
     if destination_file.is_file() {
         return Err(format!("{:?} already exists", destination_file));
     }
@@ -110,7 +112,10 @@ pub fn download_file(
         info!("Downloading {} bytes from {}", download_size, url);
     }
 
-    struct DownloadProgress<R> {
+    struct DownloadProgress<R, F>
+    where
+        F: Fn(&DownloadProgressRecord) -> bool,
+    {
         progress_bar: ProgressBar,
         response: R,
         last_print: Instant,
@@ -119,11 +124,14 @@ pub fn download_file(
         download_size: f32,
         use_progress_bar: bool,
         start_time: Instant,
-        callback: Option<ProgressNotifyCallack>,
+        callback: Option<F>,
         notification_count: u64,
     }
 
-    impl<R: Read> Read for DownloadProgress<R> {
+    impl<R: Read, F> Read for DownloadProgress<R, F>
+    where
+        F: Fn(&DownloadProgressRecord) -> bool,
+    {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
             match self.response.read(buf) {
                 Ok(n) => {
@@ -134,11 +142,12 @@ pub fn download_file(
                         elapsed_time: self.start_time.elapsed(),
                         last_elapsed_time: self.last_print.elapsed(),
                         last_throughput: diff_bytes_f32 / self.last_print.elapsed().as_secs_f32(),
-                        total_throughput: self.current_bytes as f32 / self.start_time.elapsed().as_secs_f32(),
+                        total_throughput: self.current_bytes as f32
+                            / self.start_time.elapsed().as_secs_f32(),
                         total_bytes: self.download_size as usize,
                         current_bytes: self.current_bytes,
                         percentage_done: 100f32 * (total_bytes_f32 / self.download_size),
-                        notification_count: self.notification_count
+                        notification_count: self.notification_count,
                     };
                     let mut to_update_progress = false;
                     if progress_record.last_elapsed_time.as_secs() > 5 {
@@ -160,17 +169,20 @@ pub fn download_file(
                         );
                     }
 
-                    if let Some(callback) = self.callback {
+                    if let Some(callback) = &self.callback {
                         if to_update_progress {
                             if !callback(&progress_record) {
                                 info!("Download is aborted by the caller");
-                                return Err(io::Error::new(io::ErrorKind::Interrupted, "Download is aborted by the caller"));
+                                return Err(io::Error::new(
+                                    io::ErrorKind::Interrupted,
+                                    "Download is aborted by the caller",
+                                ));
                             }
                         }
                     }
                     Ok(n)
-                },
-                Err(e) => Err(e)
+                }
+                Err(e) => Err(e),
             }
         }
     }
@@ -184,7 +196,7 @@ pub fn download_file(
         download_size: (download_size as f32).max(1f32),
         use_progress_bar,
         start_time: Instant::now(),
-        callback: progress_notify_callback,
+        callback: progress_notify_callback.as_ref(),
         notification_count: 0,
     };
 
@@ -224,7 +236,7 @@ pub fn download_genesis_if_missing(
             &format!("http://{}/{}", rpc_addr, "genesis.tar.bz2"),
             &tmp_genesis_package,
             use_progress_bar,
-            None,
+            &None::<fn(&DownloadProgressRecord) -> bool>,
         )?;
 
         Ok(tmp_genesis_package)
@@ -233,14 +245,17 @@ pub fn download_genesis_if_missing(
     }
 }
 
-pub fn download_snapshot(
+pub fn download_snapshot<F>(
     rpc_addr: &SocketAddr,
     snapshot_output_dir: &Path,
     desired_snapshot_hash: (Slot, Hash),
     use_progress_bar: bool,
     maximum_snapshots_to_retain: usize,
-    progress_notify_callback: Option<ProgressNotifyCallack>,
-) -> Result<(), String> {
+    progress_notify_callback: &Option<F>,
+) -> Result<(), String>
+where
+    F: Fn(&DownloadProgressRecord) -> bool,
+{
     snapshot_utils::purge_old_snapshot_archives(snapshot_output_dir, maximum_snapshots_to_retain);
 
     for compression in &[
@@ -270,7 +285,7 @@ pub fn download_snapshot(
             ),
             &desired_snapshot_package,
             use_progress_bar,
-            progress_notify_callback,
+            &progress_notify_callback,
         )
         .is_ok()
         {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -20,7 +20,7 @@ use solana_core::{
     optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
     validator::ValidatorConfig,
 };
-use solana_download_utils::download_snapshot;
+use solana_download_utils::{download_snapshot, DownloadProgressRecord};
 use solana_ledger::{
     ancestor_iterator::AncestorIterator,
     blockstore::{Blockstore, PurgeType},
@@ -1685,6 +1685,7 @@ fn test_snapshot_download() {
         archive_snapshot_hash,
         false,
         snapshot_utils::DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+        &None::<fn(&DownloadProgressRecord) -> bool>,
     )
     .unwrap();
 

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -112,7 +112,7 @@ fn install_if_missing(
         url.push_str(version);
         url.push('/');
         url.push_str(file.to_str().unwrap());
-        download_file(&url.as_str(), &file, true)?;
+        download_file(&url.as_str(), &file, true, None)?;
         fs::create_dir_all(&target_path).map_err(|err| err.to_string())?;
         let zip = File::open(&file).map_err(|err| err.to_string())?;
         let tar = BzDecoder::new(BufReader::new(zip));

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -4,7 +4,7 @@ use {
         crate_description, crate_name, crate_version, value_t, value_t_or_exit, values_t, App, Arg,
     },
     regex::Regex,
-    solana_download_utils::download_file,
+    solana_download_utils::{download_file, DownloadProgressRecord},
     solana_sdk::signature::{write_keypair_file, Keypair},
     std::{
         collections::HashMap,
@@ -112,7 +112,12 @@ fn install_if_missing(
         url.push_str(version);
         url.push('/');
         url.push_str(file.to_str().unwrap());
-        download_file(&url.as_str(), &file, true, None)?;
+        download_file(
+            &url.as_str(),
+            &file,
+            true,
+            &None::<fn(&DownloadProgressRecord) -> bool>,
+        )?;
         fs::create_dir_all(&target_path).map_err(|err| err.to_string())?;
         let zip = File::open(&file).map_err(|err| err.to_string())?;
         let tar = BzDecoder::new(BufReader::new(zip));

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -85,8 +85,10 @@ enum Operation {
 
 const EXCLUDE_KEY: &str = "account-index-exclude-key";
 const INCLUDE_KEY: &str = "account-index-include-key";
-const DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED: f32 = 10485760_f32;
-const MAX_DOWNLOAD_ABORT: u32 = 5;
+// The default minimal snapshot download speed (bytes/second)
+const DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED: u64 = 10485760;
+// The maximum times of snapshot download abort and retry
+const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
 
 fn monitor_validator(ledger_path: &Path) {
     let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
@@ -815,6 +817,7 @@ fn rpc_bootstrap(
     should_check_duplicate_instance: bool,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
     minimal_snapshot_download_speed: f32,
+    maximum_snapshot_download_abort: u64,
 ) {
     if !no_port_check {
         let mut order: Vec<_> = (0..cluster_entrypoints.len()).collect();
@@ -971,14 +974,16 @@ fn rpc_bootstrap(
                                        && download_progress.notification_count <= 1
                                        && download_progress.percentage_done <= 2_f32
                                        && download_progress.estimated_remaining_time > 60_f32
-                                       && download_abort_count < MAX_DOWNLOAD_ABORT {
+                                       && download_abort_count < maximum_snapshot_download_abort {
                                         if let Some(ref trusted_validators) = validator_config.trusted_validators {
                                             if trusted_validators.contains(&rpc_contact_info.id) && trusted_validators.len() == 1 {
                                                 return true; // Do not abort download from the one-and-only trusted validator
                                             }
                                         }
-                                        warn!("The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, try a different node. Abort count: {}, Progress detail: {:?}",
-                                            download_progress.last_throughput, minimal_snapshot_download_speed, download_abort_count, download_progress);
+                                        warn!("The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, will abort \
+                                               and try a different node. Abort count: {}, Progress detail: {:?}",
+                                               download_progress.last_throughput, minimal_snapshot_download_speed,
+                                               download_abort_count, download_progress);
                                         false
                                     } else {
                                         true
@@ -1068,6 +1073,7 @@ pub fn main() {
     let default_rpc_threads = num_cpus::get().to_string();
     let default_max_snapshot_to_retain = &DEFAULT_MAX_SNAPSHOTS_TO_RETAIN.to_string();
     let default_min_snapshot_download_speed = &DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED.to_string();
+    let default_max_snapshot_download_abort = &MAX_SNAPSHOT_DOWNLOAD_ABORT.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1380,6 +1386,15 @@ pub fn main() {
                 .help("The minimal speed of snapshot downloads measured in bytes/second. \
                       If the initial download speed falls below this threshold, the system will \
                       retry the download against a different rpc node."),
+        )
+        .arg(
+            Arg::with_name("maximum_snapshot_download_abort")
+                .long("maximum-snapshot-download-abort")
+                .value_name("MAXIMUM_SNAPSHOT_DOWNLOAD_ABORT")
+                .takes_value(true)
+                .default_value(default_max_snapshot_download_abort)
+                .help("The maximum number of times to abort and retry when encountering a \
+                      slow snapshot download."),
         )
         .arg(
             Arg::with_name("contact_debug_interval")
@@ -2287,6 +2302,9 @@ pub fn main() {
         value_t_or_exit!(matches, "maximum_snapshots_to_retain", usize);
     let minimal_snapshot_download_speed =
         value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
+    let maximum_snapshot_download_abort =
+        value_t_or_exit!(matches, "maximum_snapshot_download_abort", u64);
+
     let snapshot_output_dir = if matches.is_present("snapshots") {
         PathBuf::from(matches.value_of("snapshots").unwrap())
     } else {
@@ -2547,6 +2565,7 @@ pub fn main() {
             should_check_duplicate_instance,
             &start_progress,
             minimal_snapshot_download_speed,
+            maximum_snapshot_download_abort,
         );
         *start_progress.write().unwrap() = ValidatorStartProgress::Initializing;
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -966,8 +966,11 @@ fn rpc_bootstrap(
                                 maximum_snapshots_to_retain,
                                 &Some(|download_progress: &DownloadProgressRecord| {
                                     debug!("Download progress: {:?}", download_progress);
+
                                     if download_progress.last_throughput <  minimal_snapshot_download_speed
                                        && download_progress.notification_count <= 1
+                                       && download_progress.percentage_done <= 2_f32
+                                       && download_progress.estimated_remaining_time > 60_f32
                                        && download_abort_count < MAX_DOWNLOAD_ABORT {
                                         if let Some(ref trusted_validators) = validator_config.trusted_validators {
                                             if trusted_validators.contains(&rpc_contact_info.id) && trusted_validators.len() == 1 {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1377,9 +1377,9 @@ pub fn main() {
                 .value_name("MINIMAL_SNAPSHOT_DOWNLOAD_SPEED")
                 .takes_value(true)
                 .default_value(default_min_snapshot_download_speed)
-                .help("The minimal speed of snapshots download speed measured in bytes/second. \
-                      If the intial download speed falls below the threshold, the system will try \
-                      a different rpc node for download."),
+                .help("The minimal speed of snapshot downloads measured in bytes/second. \
+                      If the initial download speed falls below this threshold, the system will \
+                      retry the download against a different rpc node."),
         )
         .arg(
             Arg::with_name("contact_debug_interval")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -34,7 +34,9 @@ use {
             is_snapshot_config_invalid, Validator, ValidatorConfig, ValidatorStartProgress,
         },
     },
-    solana_download_utils::{download_genesis_if_missing, download_snapshot},
+    solana_download_utils::{
+        download_genesis_if_missing, download_snapshot, DownloadProgressRecord,
+    },
     solana_ledger::blockstore_db::BlockstoreRecoveryMode,
     solana_perf::recycler::enable_recycler_warming,
     solana_rpc::rpc_pubsub_service::PubSubConfig,
@@ -958,8 +960,13 @@ fn rpc_bootstrap(
                                 snapshot_hash,
                                 use_progress_bar,
                                 maximum_snapshots_to_retain,
-                                Some(|download_progress| { 
+                                &Some(|download_progress: &DownloadProgressRecord| {
                                     if download_progress.last_throughput <  MIN_SNAPSHOT_DOWNLOAD_SPEED && download_progress.notification_count <= 1 {
+                                        if let Some(ref trusted_validators) = validator_config.trusted_validators {
+                                            if trusted_validators.contains(&rpc_contact_info.id) {
+                                                return true; // Never blacklist a trusted node
+                                            }
+                                        }
                                         info!("The snapshot download is too slow, throughput: {} < min speed {}, try a different node",
                                             download_progress.last_throughput, MIN_SNAPSHOT_DOWNLOAD_SPEED);
                                         false

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -965,17 +965,17 @@ fn rpc_bootstrap(
                                 use_progress_bar,
                                 maximum_snapshots_to_retain,
                                 &Some(|download_progress: &DownloadProgressRecord| {
-                                    info!("Download progress: {:?}", download_progress);
+                                    debug!("Download progress: {:?}", download_progress);
                                     if download_progress.last_throughput <  minimal_snapshot_download_speed
                                        && download_progress.notification_count <= 1
-                                       && download_abort_count <= MAX_DOWNLOAD_ABORT {
+                                       && download_abort_count < MAX_DOWNLOAD_ABORT {
                                         if let Some(ref trusted_validators) = validator_config.trusted_validators {
                                             if trusted_validators.contains(&rpc_contact_info.id) && trusted_validators.len() == 1 {
                                                 return true; // Do not abort download from the one-and-only trusted validator
                                             }
                                         }
-                                        info!("The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, try a different node. Progress detail: {:?}",
-                                            download_progress.last_throughput, minimal_snapshot_download_speed, download_progress);
+                                        warn!("The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, try a different node. Abort count: {}, Progress detail: {:?}",
+                                            download_progress.last_throughput, minimal_snapshot_download_speed, download_abort_count, download_progress);
                                         false
                                     } else {
                                         true

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -958,6 +958,7 @@ fn rpc_bootstrap(
                                 snapshot_hash,
                                 use_progress_bar,
                                 maximum_snapshots_to_retain,
+                                Some(|_| { true }),
                             );
                             gossip_service.join().unwrap();
                             ret

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1377,7 +1377,9 @@ pub fn main() {
                 .value_name("MINIMAL_SNAPSHOT_DOWNLOAD_SPEED")
                 .takes_value(true)
                 .default_value(default_min_snapshot_download_speed)
-                .help("The minimal speed of snapshots download speed measured in bytes/second. If the intial download speed falls belong the threshold, the system will try a different rpc node for download.")
+                .help("The minimal speed of snapshots download speed measured in bytes/second. \
+                      If the intial download speed falls below the threshold, the system will try \
+                      a different rpc node for download."),
         )
         .arg(
             Arg::with_name("contact_debug_interval")
@@ -2283,7 +2285,8 @@ pub fn main() {
     let maximum_local_snapshot_age = value_t_or_exit!(matches, "maximum_local_snapshot_age", u64);
     let maximum_snapshots_to_retain =
         value_t_or_exit!(matches, "maximum_snapshots_to_retain", usize);
-    let minimal_snapshot_download_speed = value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
+    let minimal_snapshot_download_speed =
+        value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
     let snapshot_output_dir = if matches.is_present("snapshots") {
         PathBuf::from(matches.value_of("snapshots").unwrap())
     } else {


### PR DESCRIPTION
#### Problem
Validators choose the newest snasphot by slot from the trusted validator set without any regard for how quickly it might download that snapshot. Sometimes this results in very slow download speeds when the validator tries to download a snapshot from across the world.
#### Summary of Changes
1. Allow the validator bootstrap code to specify the minimal snapshot download speed. If the snapshot download speed is detected below that, a different RPC can be retried. The default is 10MB/sec.
2. To prevent spinning on a number of sub-optimal choices and not making progress, the abort/retry logic is implemented with the following safe guards: 2.1 at maximum we do this retry for 5 times. 2.2 if the download in one notification round (5 second) is more than 2%, do not do retry -- it is not as bad anyway. 2.3 if the remaining estimate time is less than 1 minutes, do not abort retry as it will be done quickly anyway. 2.4 We do this abort/retry logic only at the first notification to avoid wasting download efforts -- the reasoning is being opportunistic and too greedy may not achieve overall shorter download time.
3. The download_snapshot and download_file is modified with the option allowing caller to notified of download progress via a callback. This allows the business logic of retrying to the place it belongs.

#### Tests
1. Cargo test
2. Manually start the validator against the mainnet with different minimal-snapshot-download-speed speed to observe the retry and non-retry situation and the maximum retry. Multiple validator restart also at different time can also observe the different snapshot sizes and see the download_size influencing the logic.
3. Still looking into enhancing unit test to improve coverage 
Fixes #17174 
