### PR TITLE
Add blockstore-root-scan for api nodes on boot

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -139,6 +139,7 @@ pub struct JsonRpcConfig {
     pub rpc_bigtable_timeout: Option<Duration>,
     pub minimal_api: bool,
     pub obsolete_v1_7_api: bool,
+    pub rpc_scan_and_fix_roots: bool,
 }
 
 #[derive(Clone)]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -75,7 +75,7 @@ use std::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
     sync::mpsc::Receiver,
     sync::{Arc, Mutex, RwLock},
-    thread::sleep,
+    thread::{sleep, Builder},
     time::Duration,
 };
 
@@ -1089,6 +1089,21 @@ fn new_banks_from_ledger(
         });
     }
 
+    let blockstore = Arc::new(blockstore);
+    let blockstore_root_scan =
+        if config.rpc_addrs.is_some() && config.rpc_config.enable_rpc_transaction_history {
+            let blockstore = blockstore.clone();
+            let exit = exit.clone();
+            Some(
+                Builder::new()
+                    .name("blockstore-root-scan".to_string())
+                    .spawn(move || blockstore.scan_and_fix_roots(&exit))
+                    .unwrap(),
+            )
+        } else {
+            None
+        };
+
     let process_options = blockstore_processor::ProcessOptions {
         bpf_jit: config.bpf_jit,
         poh_verify,
@@ -1101,7 +1116,6 @@ fn new_banks_from_ledger(
         ..blockstore_processor::ProcessOptions::default()
     };
 
-    let blockstore = Arc::new(blockstore);
     let transaction_history_services =
         if config.rpc_addrs.is_some() && config.rpc_config.enable_rpc_transaction_history {
             initialize_rpc_transaction_history_services(
@@ -1193,6 +1207,12 @@ fn new_banks_from_ledger(
 
     bank_forks.set_snapshot_config(config.snapshot_config.clone());
     bank_forks.set_accounts_hash_interval_slots(config.accounts_hash_interval_slots);
+
+    if let Some(blockstore_root_scan) = blockstore_root_scan {
+        if let Err(err) = blockstore_root_scan.join() {
+            warn!("blockstore_root_scan failed to join {:?}", err);
+        }
+    }
 
     (
         genesis_config,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1090,19 +1090,21 @@ fn new_banks_from_ledger(
     }
 
     let blockstore = Arc::new(blockstore);
-    let blockstore_root_scan =
-        if config.rpc_addrs.is_some() && config.rpc_config.enable_rpc_transaction_history {
-            let blockstore = blockstore.clone();
-            let exit = exit.clone();
-            Some(
-                Builder::new()
-                    .name("blockstore-root-scan".to_string())
-                    .spawn(move || blockstore.scan_and_fix_roots(&exit))
-                    .unwrap(),
-            )
-        } else {
-            None
-        };
+    let blockstore_root_scan = if config.rpc_addrs.is_some()
+        && config.rpc_config.enable_rpc_transaction_history
+        && config.rpc_config.rpc_scan_and_fix_roots
+    {
+        let blockstore = blockstore.clone();
+        let exit = exit.clone();
+        Some(
+            Builder::new()
+                .name("blockstore-root-scan".to_string())
+                .spawn(move || blockstore.scan_and_fix_roots(&exit))
+                .unwrap(),
+        )
+    } else {
+        None
+    };
 
     let process_options = blockstore_processor::ProcessOptions {
         bpf_jit: config.bpf_jit,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -52,6 +52,7 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     sync::{
+        atomic::{AtomicBool, Ordering},
         mpsc::{sync_channel, Receiver, SyncSender, TrySendError},
         Arc, Mutex, RwLock,
     },
@@ -2923,12 +2924,60 @@ impl Blockstore {
         self.last_root()
     }
 
+    pub fn lowest_cleanup_slot(&self) -> Slot {
+        *self.lowest_cleanup_slot.read().unwrap()
+    }
+
     pub fn storage_size(&self) -> Result<u64> {
         self.db.storage_size()
     }
 
     pub fn is_primary_access(&self) -> bool {
         self.db.is_primary_access()
+    }
+
+    pub fn scan_and_fix_roots(&self, exit: &Arc<AtomicBool>) -> Result<()> {
+        let ancestor_iterator = AncestorIterator::new(self.last_root(), &self)
+            .take_while(|&slot| slot >= self.lowest_cleanup_slot());
+
+        let mut find_missing_roots = Measure::start("find_missing_roots");
+        let mut roots_to_fix = vec![];
+        for slot in ancestor_iterator.filter(|slot| !self.is_root(*slot)) {
+            if exit.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+            roots_to_fix.push(slot);
+        }
+        find_missing_roots.stop();
+        let mut fix_roots = Measure::start("fix_roots");
+        if !roots_to_fix.is_empty() {
+            info!("{} slots to be rooted", roots_to_fix.len());
+            for chunk in roots_to_fix.chunks(100) {
+                if exit.load(Ordering::Relaxed) {
+                    return Ok(());
+                }
+                trace!("{:?}", chunk);
+                self.set_roots(&roots_to_fix)?;
+            }
+        } else {
+            debug!(
+                "No missing roots found in range {} to {}",
+                self.lowest_cleanup_slot(),
+                self.last_root()
+            );
+        }
+        fix_roots.stop();
+        datapoint_info!(
+            "blockstore-scan_and_fix_roots",
+            (
+                "find_missing_roots_us",
+                find_missing_roots.as_us() as i64,
+                i64
+            ),
+            ("num_roots_to_fix", roots_to_fix.len() as i64, i64),
+            ("fix_roots_us", fix_roots.as_us() as i64, i64),
+        );
+        Ok(())
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1631,6 +1631,13 @@ pub fn main() {
                 .help("The number of upcoming leaders to which to forward transactions sent via rpc service."),
         )
         .arg(
+            Arg::with_name("rpc_scan_and_fix_roots")
+                .long("rpc-scan-and-fix-roots")
+                .takes_value(false)
+                .requires("enable_rpc_transaction_history")
+                .help("Verifies blockstore roots on boot and fixes any gaps"),
+        )
+        .arg(
             Arg::with_name("halt_on_trusted_validators_accounts_hash_mismatch")
                 .long("halt-on-trusted-validators-accounts-hash-mismatch")
                 .requires("trusted_validators")
@@ -2117,6 +2124,7 @@ pub fn main() {
                 .ok()
                 .map(Duration::from_secs),
             account_indexes: account_indexes.clone(),
+            rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
         },
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {
             (


### PR DESCRIPTION
#### Problem
Sometimes a chunk of blocks appear to be "missing" from the ledger because they are no longer recorded as roots in the blockstore Root CF. The tool introduced by #17045 requires a user to identify the missing gap, and stop the node to run the fix.

Actual problem:
When a node boots, it examines existing slots in its existing ledger to see if any are supermajority roots and greater than the last local root. If they are, the node squashes the banks (plus ancestors), but doesn't mark these slots as roots in blockstore. Some of these roots are set in replay stage, but anything older than `root_bank.parents()` isn't ever set.
This is likely to occur, for instance, when rebooting a node that hasn't yet caught up to the cluster.

#### Summary of Changes

**Ledger Fixup:**
On boot of an api node, scan all the existing roots -- starting from `Blockstore::last_root()` and working backward through its ancestors -- and fix as needed.
We believe the Root CF issue occurs when the validator is exited, so performing this scan-and-fix on boot should prevent the data-availability issue.

On a mainnet-beta ledger:
- scanning 300k slots: ~2s
- fixing 300k roots: ~90s / (more realistic) fixing 2300 roots: ~3ms

**Preventative Fix:**
When a supermajority root > local root is found, mark it and any ancestors > local root as Roots in blockstore.

Fixes #17000 
