### PR TITLE
increases timeout duration for gossip discover

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -657,14 +657,14 @@ fn main() {
     let rpc_addr = if !skip_gossip {
         info!("Finding cluster entry: {:?}", entrypoint_addr);
         let (gossip_nodes, _validators) = discover(
-            None,
+            None, // keypair
             Some(&entrypoint_addr),
-            None,
-            Some(60),
-            None,
-            Some(&entrypoint_addr),
-            None,
-            0,
+            None,                    // num_nodes
+            Duration::from_secs(60), // timeout
+            None,                    // find_node_by_pubkey
+            Some(&entrypoint_addr),  // find_node_by_gossip_addr
+            None,                    // my_gossip_addr
+            0,                       // my_shred_version
         )
         .unwrap_or_else(|err| {
             eprintln!("Failed to discover {} node: {:?}", entrypoint_addr, err);

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -85,17 +85,17 @@ pub fn discover_cluster(
     entrypoint: &SocketAddr,
     num_nodes: usize,
 ) -> std::io::Result<Vec<ContactInfo>> {
-    discover(
-        None,
+    let (_all_peers, validators) = discover(
+        None, // keypair
         Some(entrypoint),
         Some(num_nodes),
-        Some(30),
-        None,
-        None,
-        None,
-        0,
-    )
-    .map(|(_all_peers, validators)| validators)
+        Some(120), // timeout
+        None,      // find_node_by_pubkey
+        None,      // find_node_by_gossip_addr
+        None,      // my_gossip_addr
+        0,         // my_shred_version
+    )?;
+    Ok(validators)
 }
 
 pub fn discover(

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -10,7 +10,7 @@ use solana_sdk::pubkey::Pubkey;
 use std::net::{SocketAddr, UdpSocket};
 use std::process::exit;
 use std::str::FromStr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 fn run_dos(
     nodes: &[ContactInfo],
@@ -218,14 +218,14 @@ fn main() {
     if !skip_gossip {
         info!("Finding cluster entry: {:?}", entrypoint_addr);
         let (gossip_nodes, _validators) = discover(
-            None,
+            None, // keypair
             Some(&entrypoint_addr),
-            None,
-            Some(60),
-            None,
-            Some(&entrypoint_addr),
-            None,
-            0,
+            None,                    // num_nodes
+            Duration::from_secs(60), // timeout
+            None,                    // find_node_by_pubkey
+            Some(&entrypoint_addr),  // find_node_by_gossip_addr
+            None,                    // my_gossip_addr
+            0,                       // my_shred_version
         )
         .unwrap_or_else(|err| {
             eprintln!("Failed to discover {} node: {:?}", entrypoint_addr, err);

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -15,6 +15,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     process::exit,
     sync::Arc,
+    time::Duration,
 };
 
 fn parse_matches() -> ArgMatches<'static> {
@@ -238,15 +239,15 @@ fn process_spy(matches: &ArgMatches) -> std::io::Result<()> {
             .expect("unable to find an available gossip port")
         }),
     );
-
+    let discover_timeout = Duration::from_secs(timeout.unwrap_or(u64::MAX));
     let (_all_peers, validators) = discover(
         identity_keypair,
         entrypoint_addr.as_ref(),
         num_nodes,
-        timeout,
-        pubkey,
-        None,
-        Some(&gossip_addr),
+        discover_timeout,
+        pubkey,             // find_node_by_pubkey
+        None,               // find_node_by_gossip_addr
+        Some(&gossip_addr), // my_gossip_addr
         shred_version,
     )?;
 
@@ -271,13 +272,13 @@ fn process_rpc_url(matches: &ArgMatches) -> std::io::Result<()> {
     let timeout = value_t_or_exit!(matches, "timeout", u64);
     let shred_version = value_t_or_exit!(matches, "shred_version", u16);
     let (_all_peers, validators) = discover(
-        None,
+        None, // keypair
         entrypoint_addr.as_ref(),
-        Some(1),
-        Some(timeout),
-        None,
-        entrypoint_addr.as_ref(),
-        None,
+        Some(1), // num_nodes
+        Duration::from_secs(timeout),
+        None,                     // find_node_by_pubkey
+        entrypoint_addr.as_ref(), // find_node_by_gossip_addr
+        None,                     // my_gossip_addr
         shred_version,
     )?;
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/17236 increased default number of bloom items when making gossip
pull-requests. The change is effectively a no-op once a validator syncs
to a real cluster as the number of items will already become larger than
the default value there.

However, it adds overhead to tests with a very small cluster, and
results in `dicover_cluster` timeouts in tests.

#### Summary of Changes
* 1st commit increases timeout in `discover_cluster`.
* 2nd commit uses `Duration` type for timeout (type-safety and self-documenting unit).