### PR TITLE
sort storages by slot before scan

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -29,6 +29,7 @@ pub struct HashStats {
     pub unreduced_entries: usize,
     pub num_snapshot_storage: usize,
     pub collect_snapshots_us: u64,
+    pub storage_sort_us: u64,
 }
 impl HashStats {
     fn log(&mut self) {
@@ -37,6 +38,7 @@ impl HashStats {
             + self.hash_time_total_us
             + self.sort_time_total_us
             + self.collect_snapshots_us
+            + self.storage_sort_us
             + self.flatten_time_total_us;
         datapoint_info!(
             "calculate_accounts_hash_without_index",
@@ -46,6 +48,7 @@ impl HashStats {
             ("sort", self.sort_time_total_us, i64),
             ("hash_total", self.hash_total, i64),
             ("flatten", self.flatten_time_total_us, i64),
+            ("storage_sort_us", self.storage_sort_us, i64),
             ("unreduced_entries", self.unreduced_entries as i64, i64),
             (
                 "collect_snapshots_us",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod secondary_index;
 pub mod serde_snapshot;
 pub mod snapshot_package;
 pub mod snapshot_utils;
+pub mod sorted_storages;
 pub mod stakes;
 pub mod status_cache;
 mod system_instruction_processor;

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -20,7 +20,7 @@ impl<'a> SortedStorages<'a> {
         }
     }
 
-    pub fn range_width(&self) -> u64 {
+    pub fn range_width(&self) -> Slot {
         self.range.end - self.range.start
     }
 

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -1,0 +1,117 @@
+use crate::accounts_db::SnapshotStorage;
+use log::*;
+use solana_measure::measure::Measure;
+use solana_sdk::clock::Slot;
+use std::ops::Range;
+
+pub struct SortedStorages<'a> {
+    range: Range<Slot>,
+    storages: Vec<Option<&'a SnapshotStorage>>,
+    count: usize,
+}
+
+impl<'a> SortedStorages<'a> {
+    pub fn get(&self, slot: Slot) -> Option<&SnapshotStorage> {
+        if !self.range.contains(&slot) {
+            None
+        } else {
+            let index = (slot - self.range.start) as usize;
+            self.storages[index]
+        }
+    }
+
+    pub fn range_width(&self) -> u64 {
+        self.range.end - self.range.start
+    }
+
+    pub fn range(&self) -> &Range<Slot> {
+        &self.range
+    }
+
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn new(source: &'a [SnapshotStorage]) -> Self {
+        let mut min = Slot::MAX;
+        let mut max = Slot::MIN;
+        let mut count = 0;
+        let mut time = Measure::start("get slot");
+        let slots = source
+            .iter()
+            .map(|storages| {
+                count += storages.len();
+                if !storages.is_empty() {
+                    storages.first().map(|storage| {
+                        let slot = storage.slot();
+                        min = std::cmp::min(slot, min);
+                        max = std::cmp::max(slot + 1, max);
+                        slot
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        time.stop();
+        let mut time2 = Measure::start("sort");
+        let range;
+        let mut storages;
+        if min > max {
+            range = Range::default();
+            storages = vec![];
+        } else {
+            range = Range {
+                start: min,
+                end: max,
+            };
+            let len = max - min;
+            storages = vec![None; len as usize];
+            source
+                .iter()
+                .zip(slots)
+                .for_each(|(original_storages, slot)| {
+                    if let Some(slot) = slot {
+                        let index = (slot - min) as usize;
+                        assert!(storages[index].is_none());
+                        storages[index] = Some(original_storages);
+                    }
+                });
+        }
+        time2.stop();
+        debug!("SortedStorages, times: {}, {}", time.as_us(), time2.as_us());
+        Self {
+            range,
+            storages,
+            count,
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    impl<'a> SortedStorages<'a> {
+        pub fn new_debug(source: &[(&'a SnapshotStorage, Slot)], min: Slot, len: usize) -> Self {
+            let mut storages = vec![None; len];
+            let range = Range {
+                start: min,
+                end: min + len as Slot,
+            };
+            let count = source.len();
+            for (storage, slot) in source {
+                storages[*slot as usize] = Some(*storage);
+            }
+
+            Self {
+                range,
+                storages,
+                count,
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
2 different use cases have emerged where it is useful to have storages sorted by slot.

1. merging write cache data with store data so we can use this scan in more places. Write cache data is organized by slot.
2. perf improvements for scanning accounts. If slots are in order, we don't have to keep track of a slot (or a write version) per slot, which is a large data savings.

#### Summary of Changes
Sort storages by slot.

Fixes #
