### PR TITLE
Make timeout to discover_cluster optional field with default 30 seconds

### DIFF
--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -5,7 +5,7 @@ pub mod order_book;
 
 use crate::bench::{airdrop_lamports, create_client_accounts_file, do_bench_exchange, Config};
 use log::*;
-use solana_core::gossip_service::{discover_cluster, get_multi_client};
+use solana_core::gossip_service::{discover_cluster, get_multi_client, DEFAULT_DISCOVER_TIME_OUT};
 use solana_sdk::signature::Signer;
 
 fn main() {
@@ -55,7 +55,7 @@ fn main() {
         );
     } else {
         info!("Connecting to the cluster");
-        let nodes = discover_cluster(&entrypoint_addr, num_nodes).unwrap_or_else(|_| {
+        let nodes = discover_cluster(&entrypoint_addr, num_nodes, DEFAULT_DISCOVER_TIME_OUT).unwrap_or_else(|_| {
             panic!("Failed to discover nodes");
         });
 

--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -1,7 +1,7 @@
 use log::*;
 use solana_bench_exchange::bench::{airdrop_lamports, do_bench_exchange, Config};
 use solana_core::{
-    gossip_service::{discover_cluster, get_multi_client},
+    gossip_service::{discover_cluster, get_multi_client, DEFAULT_DISCOVER_TIME_OUT},
     validator::ValidatorConfig,
 };
 use solana_exchange_program::{
@@ -69,7 +69,7 @@ fn test_exchange_local_cluster() {
 
     info!("Connecting to the cluster");
     let nodes =
-        discover_cluster(&cluster.entry_point_info.gossip, NUM_NODES).unwrap_or_else(|err| {
+        discover_cluster(&cluster.entry_point_info.gossip, NUM_NODES, DEFAULT_DISCOVER_TIME_OUT).unwrap_or_else(|err| {
             error!("Failed to discover {} nodes: {:?}", NUM_NODES, err);
             exit(1);
         });

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -2,7 +2,7 @@
 use log::*;
 use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs, generate_keypairs};
 use solana_bench_tps::cli;
-use solana_core::gossip_service::{discover_cluster, get_client, get_multi_client};
+use solana_core::gossip_service::{discover_cluster, get_client, get_multi_client, DEFAULT_DISCOVER_TIME_OUT};
 use solana_genesis::Base64Account;
 use solana_sdk::fee_calculator::FeeRateGovernor;
 use solana_sdk::signature::{Keypair, Signer};
@@ -68,7 +68,7 @@ fn main() {
     }
 
     info!("Connecting to the cluster");
-    let nodes = discover_cluster(&entrypoint_addr, *num_nodes).unwrap_or_else(|err| {
+    let nodes = discover_cluster(&entrypoint_addr, *num_nodes, DEFAULT_DISCOVER_TIME_OUT).unwrap_or_else(|err| {
         eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
         exit(1);
     });

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -27,6 +27,8 @@ pub struct GossipService {
     thread_hdls: Vec<JoinHandle<()>>,
 }
 
+pub const DEFAULT_DISCOVER_TIME_OUT: Option<u64> = Some(30_u64);
+
 impl GossipService {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
@@ -81,15 +83,17 @@ impl GossipService {
 }
 
 /// Discover Validators in a cluster
+/// if time_out is set to None, the default value of 30 second will be used
 pub fn discover_cluster(
     entrypoint: &SocketAddr,
     num_nodes: usize,
+    time_out: Option<u64>,
 ) -> std::io::Result<Vec<ContactInfo>> {
     discover(
         None,
         Some(entrypoint),
         Some(num_nodes),
-        Some(30),
+        time_out,
         None,
         None,
         None,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         cluster_info::Node,
-        gossip_service::discover_cluster,
+        gossip_service::{discover_cluster, DEFAULT_DISCOVER_TIME_OUT},
         rpc::JsonRpcConfig,
         validator::{Validator, ValidatorConfig, ValidatorExit, ValidatorStartProgress},
     },
@@ -519,7 +519,7 @@ impl TestValidator {
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of
         // test validators concurrently...
-        discover_cluster(&gossip, 1)
+        discover_cluster(&gossip, 1, DEFAULT_DISCOVER_TIME_OUT)
             .map_err(|err| format!("TestValidator startup failed: {:?}", err))?;
 
         // This is a hack to delay until the fees are non-zero for test consistency

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -9,7 +9,7 @@ use solana_client::thin_client::create_client;
 use solana_core::validator::ValidatorExit;
 use solana_core::{
     cluster_info::VALIDATOR_PORT_RANGE, consensus::VOTE_THRESHOLD_DEPTH, contact_info::ContactInfo,
-    gossip_service::discover_cluster,
+    gossip_service::{discover_cluster, DEFAULT_DISCOVER_TIME_OUT},
 };
 use solana_ledger::{
     blockstore::Blockstore,
@@ -43,7 +43,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher + Sync + Send>(
     nodes: usize,
     ignore_nodes: HashSet<Pubkey, S>,
 ) {
-    let cluster_nodes = discover_cluster(&entry_point_info.gossip, nodes).unwrap();
+    let cluster_nodes = discover_cluster(&entry_point_info.gossip, nodes, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let ignore_nodes = Arc::new(ignore_nodes);
     cluster_nodes.par_iter().for_each(|ingress_node| {
@@ -184,7 +184,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     slot_millis: u64,
 ) {
     info!("kill_entry_and_spend_and_verify_rest...");
-    let cluster_nodes = discover_cluster(&entry_point_info.gossip, nodes).unwrap();
+    let cluster_nodes = discover_cluster(&entry_point_info.gossip, nodes, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     assert!(cluster_nodes.len() >= nodes);
     let client = create_client(entry_point_info.client_facing_addr(), VALIDATOR_PORT_RANGE);
     // sleep long enough to make sure we are in epoch 3

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -9,7 +9,7 @@ use solana_client::thin_client::{create_client, ThinClient};
 use solana_core::{
     cluster_info::{Node, VALIDATOR_PORT_RANGE},
     contact_info::ContactInfo,
-    gossip_service::discover_cluster,
+    gossip_service::{discover_cluster, DEFAULT_DISCOVER_TIME_OUT},
     validator::{Validator, ValidatorConfig, ValidatorStartProgress},
 };
 use solana_ledger::create_new_tmp_ledger;
@@ -273,10 +273,11 @@ impl LocalCluster {
         discover_cluster(
             &cluster.entry_point_info.gossip,
             config.node_stakes.len() + config.num_listeners as usize,
+            DEFAULT_DISCOVER_TIME_OUT,
         )
         .unwrap();
 
-        discover_cluster(&cluster.entry_point_info.gossip, config.node_stakes.len()).unwrap();
+        discover_cluster(&cluster.entry_point_info.gossip, config.node_stakes.len(), DEFAULT_DISCOVER_TIME_OUT).unwrap();
 
         cluster
     }
@@ -410,6 +411,7 @@ impl LocalCluster {
         let cluster_nodes = discover_cluster(
             &alive_node_contact_infos[0].gossip,
             alive_node_contact_infos.len(),
+            DEFAULT_DISCOVER_TIME_OUT,
         )
         .unwrap();
         info!("{} discovered {} nodes", test_name, cluster_nodes.len());
@@ -429,6 +431,7 @@ impl LocalCluster {
         let cluster_nodes = discover_cluster(
             &alive_node_contact_infos[0].gossip,
             alive_node_contact_infos.len(),
+            DEFAULT_DISCOVER_TIME_OUT,
         )
         .unwrap();
         info!("{} discovered {} nodes", test_name, cluster_nodes.len());

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,7 +16,7 @@ use solana_core::{
     cluster_info::{self, VALIDATOR_PORT_RANGE},
     consensus::{Tower, SWITCH_FORK_THRESHOLD, VOTE_THRESHOLD_DEPTH},
     crds_value::{self, CrdsData, CrdsValue},
-    gossip_service::discover_cluster,
+    gossip_service::{discover_cluster, DEFAULT_DISCOVER_TIME_OUT},
     optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
     validator::ValidatorConfig,
 };
@@ -376,7 +376,7 @@ fn run_cluster_partition<C>(
         HashSet::new(),
     );
 
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, num_nodes).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, num_nodes, DEFAULT_DISCOVER_TIME_OUT).unwrap();
 
     // Check epochs have correct number of slots
     info!("PARTITION_TEST sleeping until partition starting condition",);
@@ -1307,7 +1307,7 @@ fn test_forwarding() {
     };
     let cluster = LocalCluster::new(&mut config);
 
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 2).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 2, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     assert!(cluster_nodes.len() >= 2);
 
     let leader_pubkey = cluster.entry_point_info.id;
@@ -1371,7 +1371,7 @@ fn test_listener_startup() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config);
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 4).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 4, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     assert_eq!(cluster_nodes.len(), 4);
 }
 
@@ -1388,7 +1388,7 @@ fn test_mainnet_beta_cluster_type() {
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config);
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     assert_eq!(cluster_nodes.len(), 1);
 
     let client = create_client(
@@ -1566,7 +1566,7 @@ fn test_consistency_halt() {
     let mut cluster = LocalCluster::new(&mut config);
 
     sleep(Duration::from_millis(5000));
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     info!("num_nodes: {}", cluster_nodes.len());
 
     // Add a validator with the leader as trusted, it should halt when it detects
@@ -1593,7 +1593,7 @@ fn test_consistency_halt() {
     );
     let num_nodes = 2;
     assert_eq!(
-        discover_cluster(&cluster.entry_point_info.gossip, num_nodes)
+        discover_cluster(&cluster.entry_point_info.gossip, num_nodes, DEFAULT_DISCOVER_TIME_OUT)
             .unwrap()
             .len(),
         num_nodes
@@ -1602,7 +1602,7 @@ fn test_consistency_halt() {
     // Check for only 1 node on the network.
     let mut encountered_error = false;
     loop {
-        let discover = discover_cluster(&cluster.entry_point_info.gossip, 2);
+        let discover = discover_cluster(&cluster.entry_point_info.gossip, 2, DEFAULT_DISCOVER_TIME_OUT);
         match discover {
             Err(_) => {
                 encountered_error = true;
@@ -1828,7 +1828,7 @@ fn test_snapshots_blockstore_floor() {
     // Start up a new node from a snapshot
     let validator_stake = 5;
 
-    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1).unwrap();
+    let cluster_nodes = discover_cluster(&cluster.entry_point_info.gossip, 1, DEFAULT_DISCOVER_TIME_OUT).unwrap();
     let mut trusted_validators = HashSet::new();
     trusted_validators.insert(cluster_nodes[0].id);
     validator_snapshot_test_config


### PR DESCRIPTION
#### Problem
A number of PRs failed in the test coverage due to various time out issue related to cluster discover. 
kind: Other, error: \"Discover failed\". For examples:

https://buildkite.com/solana-labs/solana/builds/46814#a7decbc3-7328-4861-8e5a-f50d808f0eb7
https://buildkite.com/solana-labs/solana/builds/46802#fc2cc901-93ff-4eb0-be8b-35e7ea9f168f
https://buildkite.com/solana-labs/solana/builds/46794#fe3de2fb-7f93-431a-aab7-327eaaa565af
https://buildkite.com/solana-labs/solana/builds/46799#c1002b5a-a4b1-4d6f-9174-4eb657f16932

These flaky tests increases developer's cost in PR.

Root cause:
The hardcoded 30 seconds might not be sufficient to finish this in a busy system under heavy test loads.

#### Summary of Changes
Made discover_cluster to take the optional timeout field. Allowing the tests to specify higher values.
Fixes #
