### PR TITLE
validator: Avoid ip_echo_server unwrap

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -278,7 +278,7 @@ pub struct Validator {
     poh_service: PohService,
     tpu: Tpu,
     tvu: Tvu,
-    ip_echo_server: solana_net_utils::IpEchoServer,
+    ip_echo_server: Option<solana_net_utils::IpEchoServer>,
 }
 
 // in the distant future, get rid of ::new()/exit() and use Result properly...
@@ -593,7 +593,7 @@ impl Validator {
             std::thread::park();
         }
 
-        let ip_echo_server = solana_net_utils::ip_echo_server(node.sockets.ip_echo.unwrap());
+        let ip_echo_server = node.sockets.ip_echo.map(solana_net_utils::ip_echo_server);
 
         let gossip_service = GossipService::new(
             &cluster_info,
@@ -890,7 +890,9 @@ impl Validator {
         self.completed_data_sets_service
             .join()
             .expect("completed_data_sets_service");
-        self.ip_echo_server.shutdown_background();
+        if let Some(ip_echo_server) = self.ip_echo_server {
+            ip_echo_server.shutdown_background();
+        }
     }
 }
 


### PR DESCRIPTION
`node.sockets.ip_echo` is set to None here:
https://github.com/solana-labs/solana/blob/a8dca3976b3030d21373f4851fa61f798837ea39/validator/src/main.rs#L2398-L2399
and then unwrapped later in `core/src/valdiator.rs`

Fixes #17434