### PR TITLE
removes Crds::lookup and lookup_versioned

### DIFF
--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -222,14 +222,6 @@ impl Crds {
         }
     }
 
-    pub fn lookup(&self, label: &CrdsValueLabel) -> Option<&CrdsValue> {
-        self.table.get(label).map(|x| &x.value)
-    }
-
-    pub fn lookup_versioned(&self, label: &CrdsValueLabel) -> Option<&VersionedCrdsValue> {
-        self.table.get(label)
-    }
-
     pub fn get(&self, label: &CrdsValueLabel) -> Option<&VersionedCrdsValue> {
         self.table.get(label)
     }

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -459,7 +459,7 @@ mod test {
             push.process_push_message(&mut crds, &Pubkey::default(), value.clone(), 0),
             Ok(())
         );
-        assert_eq!(crds.lookup(&label), Some(&value));
+        assert_eq!(crds.get(&label).unwrap().value, value);
 
         // push it again
         assert_matches!(
@@ -843,7 +843,7 @@ mod test {
             push.process_push_message(&mut crds, &Pubkey::default(), value.clone(), 0),
             Ok(())
         );
-        assert_eq!(crds.lookup(&label), Some(&value));
+        assert_eq!(crds.get(&label).unwrap().value, value);
 
         // push it again
         assert_matches!(

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -180,13 +180,9 @@ fn ring_network_create(num: usize) -> Network {
         let start_info = {
             let start = &network[&keys[k]];
             let start_id = start.lock().unwrap().id;
-            start
-                .lock()
-                .unwrap()
-                .crds
-                .lookup(&CrdsValueLabel::ContactInfo(start_id))
-                .unwrap()
-                .clone()
+            let label = CrdsValueLabel::ContactInfo(start_id);
+            let gossip = start.gossip.lock().unwrap();
+            gossip.crds.get(&label).unwrap().value.clone()
         };
         let end = network.get_mut(&keys[(k + 1) % keys.len()]).unwrap();
         end.lock()
@@ -226,7 +222,7 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
             let start = &network[k].lock().unwrap();
             let start_id = start.id;
             let start_label = CrdsValueLabel::ContactInfo(start_id);
-            start.crds.lookup(&start_label).unwrap().clone()
+            start.crds.get(&start_label).unwrap().value.clone()
         })
         .collect();
     for end in network.values_mut() {
@@ -275,11 +271,9 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
         // push a message to the network
         network_values.par_iter().for_each(|locked_node| {
             let node = &mut locked_node.lock().unwrap();
-            let mut m = node
-                .crds
-                .lookup(&CrdsValueLabel::ContactInfo(node.id))
-                .and_then(|v| v.contact_info().cloned())
-                .unwrap();
+            let label = CrdsValueLabel::ContactInfo(node.id);
+            let entry = node.crds.get(&label).unwrap();
+            let mut m = entry.value.contact_info().cloned().unwrap();
             m.wallclock = now;
             node.process_push_message(
                 &Pubkey::default(),


### PR DESCRIPTION
#### Problem
redundant api causing unnecessary code bloat

#### Summary of Changes
removed `Crds::lookup` and `lookup_versioned`.
