### PR TITLE
calculate_capitalization uses hash calculation

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -121,6 +121,7 @@ fn main() {
                 solana_sdk::clock::Slot::default(),
                 &ancestors,
                 None,
+                false,
             );
             time_store.stop();
             if results != results_store {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -783,7 +783,8 @@ fn open_genesis_config_by(ledger_path: &Path, matches: &ArgMatches<'_>) -> Genes
 }
 
 fn assert_capitalization(bank: &Bank) {
-    assert!(bank.calculate_and_verify_capitalization());
+    let debug_verify = true;
+    assert!(bank.calculate_and_verify_capitalization(debug_verify));
 }
 
 #[allow(clippy::cognitive_complexity)]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -558,10 +558,14 @@ fn do_process_blockstore_from_root(
     );
     assert!(bank_forks.active_banks().is_empty());
 
+    let debug_verify = true;
     // We might be promptly restarted after bad capitalization was detected while creating newer snapshot.
     // In that case, we're most likely restored from the last good snapshot and replayed up to this root.
     // So again check here for the bad capitalization to avoid to continue until the next snapshot creation.
-    if !bank_forks.root_bank().calculate_and_verify_capitalization() {
+    if !bank_forks
+        .root_bank()
+        .calculate_and_verify_capitalization(debug_verify)
+    {
         return Err(BlockstoreProcessorError::RootBankWithMismatchedCapitalization(root));
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -558,7 +558,7 @@ fn do_process_blockstore_from_root(
     );
     assert!(bank_forks.active_banks().is_empty());
 
-    let debug_verify = true;
+    let debug_verify = false;
     // We might be promptly restarted after bad capitalization was detected while creating newer snapshot.
     // In that case, we're most likely restored from the last good snapshot and replayed up to this root.
     // So again check here for the bad capitalization to avoid to continue until the next snapshot creation.

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -627,20 +627,24 @@ impl Accounts {
             .collect()
     }
 
-    pub fn calculate_capitalization(&self, ancestors: &Ancestors) -> u64 {
-        self.accounts_db.unchecked_scan_accounts(
-            "calculate_capitalization_scan_elapsed",
-            ancestors,
-            |total_capitalization: &mut u64, (_pubkey, loaded_account, _slot)| {
-                let lamports = loaded_account.lamports();
-                if Self::is_loadable(lamports) {
-                    *total_capitalization = AccountsDb::checked_iterative_sum_for_capitalization(
-                        *total_capitalization,
-                        lamports,
-                    );
-                }
-            },
-        )
+    pub fn calculate_capitalization(
+        &self,
+        ancestors: &Ancestors,
+        slot: Slot,
+        can_cached_slot_be_unflushed: bool,
+        debug_verify: bool,
+    ) -> u64 {
+        let use_index = false;
+        self.accounts_db
+            .update_accounts_hash_with_index_option(
+                use_index,
+                debug_verify,
+                slot,
+                ancestors,
+                None,
+                can_cached_slot_be_unflushed,
+            )
+            .1
     }
 
     #[must_use]

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -48,6 +48,10 @@ impl SlotCacheInner {
         );
     }
 
+    pub fn get_all_pubkeys(&self) -> Vec<Pubkey> {
+        self.cache.iter().map(|item| *item.key()).collect()
+    }
+
     pub fn insert(
         &self,
         pubkey: &Pubkey,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1550,6 +1550,10 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         })
     }
 
+    pub fn min_root(&self) -> Option<Slot> {
+        self.roots_tracker.read().unwrap().min_root()
+    }
+
     pub fn reset_uncleaned_roots(&self, max_clean_root: Option<Slot>) -> HashSet<Slot> {
         let mut cleaned_roots = HashSet::new();
         let mut w_roots_tracker = self.roots_tracker.write().unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1010,6 +1010,7 @@ pub fn process_accounts_package_pre(
             thread_pool,
             crate::accounts_hash::HashStats::default(),
             false,
+            None,
         )
         .unwrap();
 

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -64,14 +64,16 @@ impl<'a> SortedStorages<'a> {
     ) -> Self {
         let mut min = Slot::MAX;
         let mut max = Slot::MIN;
+        let mut adjust_min_max = |slot| {
+            min = std::cmp::min(slot, min);
+            max = std::cmp::max(slot + 1, max);
+        };
         // none, either, or both of min/max could be specified
         if let Some(slot) = min_slot {
-            min = std::cmp::min(slot, min);
-            max = std::cmp::max(slot + 1, max);
+            adjust_min_max(slot);
         }
         if let Some(slot) = max_slot_inclusive {
-            min = std::cmp::min(slot, min);
-            max = std::cmp::max(slot + 1, max);
+            adjust_min_max(slot);
         }
 
         let mut slot_count = 0;
@@ -79,9 +81,7 @@ impl<'a> SortedStorages<'a> {
         let source_ = source.clone();
         source_.for_each(|(_, slot)| {
             slot_count += 1;
-            let slot = *slot;
-            min = std::cmp::min(slot, min);
-            max = std::cmp::max(slot + 1, max);
+            adjust_min_max(*slot);
         });
         time.stop();
         let mut time2 = Measure::start("sort");

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -54,11 +54,12 @@ impl<'a> SortedStorages<'a> {
     // 2. slots and source are the same len
     pub fn new_with_slots<'b>(
         source: impl Iterator<Item = (&'a SnapshotStorage, &'b Slot)> + Clone,
+        // A slot used as a lower bound, but potentially smaller than the smallest slot in the given 'source' iterator
         min_slot: Option<Slot>,
-        // highest valid slot. Only matters if slots array does not contain a slot >= max_slot_inclusive.
+        // highest valid slot. Only matters if source array does not contain a slot >= max_slot_inclusive.
         // An example is a slot that has accounts in the write cache at slots <= 'max_slot_inclusive' but no storages at those slots.
-        // None => self.range.end = slots.max() + 1
-        // Some(slot) => self.range.end = std::cmp::max(slot, slots.max())
+        // None => self.range.end = source.1.max() + 1
+        // Some(slot) => self.range.end = std::cmp::max(slot, source.1.max())
         max_slot_inclusive: Option<Slot>,
     ) -> Self {
         let mut min = Slot::MAX;


### PR DESCRIPTION
#### Problem
#17095

#### Summary of Changes
rework calculate_capitalization to use the store scan instead of index scan. Call update_accounts_hash_with_index_option with index=false.
Fixes #
