### PR TITLE
Ancestors to HashSet: From(Vec)

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -89,9 +89,9 @@ fn main() {
         create_time
     );
     let mut ancestors = Vec::with_capacity(num_slots);
-    ancestors.push((0, 0));
+    ancestors.push(0);
     for i in 1..num_slots {
-        ancestors.push((i as u64, i - 1));
+        ancestors.push(i as u64);
         accounts.add_root(i as u64);
     }
     let ancestors = Ancestors::from(ancestors);

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -108,7 +108,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let num_accounts = 60_000;
     let slot = 0;
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
-    let ancestors = Ancestors::from(vec![(0, 0)]);
+    let ancestors = Ancestors::from(vec![0]);
     let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(0, &ancestors);
     bencher.iter(|| assert!(accounts.verify_bank_hash_and_lamports(0, &ancestors, total_lamports)));
 }
@@ -124,7 +124,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
-    let ancestors = Ancestors::from(vec![(0, 0)]);
+    let ancestors = Ancestors::from(vec![0]);
     bencher.iter(|| {
         accounts.accounts_db.update_accounts_hash(0, &ancestors);
     });
@@ -378,7 +378,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
         accounts.store_slow_uncached(0, &pubkey, &account);
     }
-    let ancestors = Ancestors::from(vec![(0, 0)]);
+    let ancestors = Ancestors::from(vec![0]);
     b.iter(|| {
         accounts.load_largest_accounts(
             &ancestors,

--- a/runtime/src/ancestors.rs
+++ b/runtime/src/ancestors.rs
@@ -16,29 +16,29 @@ pub struct Ancestors {
 // that we prefer to implement them in a sparse HashMap
 const ANCESTORS_HASH_MAP_SIZE: u64 = 10_000;
 
-impl From<Vec<(Slot, usize)>> for Ancestors {
-    fn from(source: Vec<(Slot, usize)>) -> Ancestors {
+impl From<Vec<Slot>> for Ancestors {
+    fn from(source: Vec<Slot>) -> Ancestors {
         let mut result = Ancestors::default();
         if !source.is_empty() {
             result.min = Slot::MAX;
             result.max = Slot::MIN;
-            source.iter().for_each(|(slot, _)| {
+            source.iter().for_each(|slot| {
                 result.min = std::cmp::min(result.min, *slot);
                 result.max = std::cmp::max(result.max, *slot + 1);
             });
             let range = result.range();
             if range > ANCESTORS_HASH_MAP_SIZE {
-                result.large_range_slots = source.into_iter().map(|(slot, _)| slot).collect();
+                result.large_range_slots = source.into_iter().collect();
                 result.min = 0;
                 result.max = 0;
             } else {
                 result.slots = vec![None; range as usize];
-                source.into_iter().for_each(|(slot, size)| {
+                source.into_iter().for_each(|slot| {
                     let slot = result.slot_index(&slot);
                     if result.slots[slot].is_none() {
                         result.count += 1;
                     }
-                    result.slots[slot] = Some(size);
+                    result.slots[slot] = Some(0);
                 });
             }
         }
@@ -181,6 +181,11 @@ pub mod tests {
         }
     }
 
+    impl From<Vec<(Slot, usize)>> for Ancestors {
+        fn from(source: Vec<(Slot, usize)>) -> Ancestors {
+            Ancestors::from(source.into_iter().map(|(slot, _)| slot).collect::<Vec<_>>())
+        }
+    }
     impl Ancestors {
         pub fn insert(&mut self, mut slot: Slot, size: usize) {
             if self.large_range_slots.is_empty() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1031,7 +1031,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
     ) -> Self {
         let mut bank = Self::default();
-        bank.ancestors = Ancestors::from(vec![(bank.slot(), 0)]);
+        bank.ancestors = Ancestors::from(vec![bank.slot()]);
         bank.transaction_debug_keys = debug_keys;
         bank.cluster_type = Some(genesis_config.cluster_type);
 
@@ -1184,9 +1184,9 @@ impl Bank {
         );
 
         let mut ancestors = Vec::with_capacity(1 + new.parents().len());
-        ancestors.push((new.slot(), 0));
+        ancestors.push(new.slot());
         new.parents().iter().for_each(|p| {
-            ancestors.push((p.slot(), 0));
+            ancestors.push(p.slot());
         });
         new.ancestors = Ancestors::from(ancestors);
 
@@ -4351,7 +4351,7 @@ impl Bank {
         &self,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        let just_self: Ancestors = Ancestors::from(vec![(self.slot(), 0)]);
+        let just_self: Ancestors = Ancestors::from(vec![self.slot()]);
         if let Some((account, slot)) = self.load_slow_with_fixed_root(&just_self, pubkey) {
             if slot == self.slot() {
                 return Some((account, slot));

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -76,7 +76,7 @@ fn test_bad_bank_hash() {
     let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
     let some_slot: Slot = 0;
-    let ancestors = Ancestors::from([(some_slot, 0usize)].iter().copied().collect::<Vec<_>>());
+    let ancestors = Ancestors::from(vec![some_slot]);
 
     let max_accounts = 200;
     let mut accounts_keys: Vec<_> = (0..max_accounts)


### PR DESCRIPTION
#### Problem
migrating ancestors to be a hashset instead of hashmap. API is already changed.
#### Summary of Changes
move production code to stop passing size value to Ancestors instance.
Fixes #
