### PR TITLE
Only add keys with multiple index entries to the clean set

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5087,7 +5087,7 @@ impl AccountsDb {
                         let len = accounts_map.len();
 
                         let mut items = Vec::with_capacity(len);
-                        let dirty_keys = accounts_map
+                        let mut dirty_pubkeys = accounts_map
                             .iter()
                             .map(|(pubkey, (_, store_id, stored_account))| {
                                 items.push((
@@ -5102,10 +5102,25 @@ impl AccountsDb {
                                 *pubkey
                             })
                             .collect::<Vec<_>>();
-                        self.uncleaned_pubkeys.insert(*slot, dirty_keys);
 
-                        self.accounts_index
+                        let items_len = items.len();
+                        let dirty_pubkey_mask = self
+                            .accounts_index
                             .insert_new_if_missing_into_primary_index(*slot, items);
+
+                        assert_eq!(dirty_pubkey_mask.len(), items_len);
+
+                        let mut dirty_pubkey_mask_iter = dirty_pubkey_mask.iter();
+
+                        // dirty_pubkey_mask will return true if an item has multiple rooted entries for
+                        // a given pubkey. If there is just a single item, there is no cleaning to
+                        // be done on that pubkey. Prune the touched pubkey set here for only those
+                        // pubkeys with multiple updates.
+                        dirty_pubkeys.retain(|_k| *dirty_pubkey_mask_iter.next().unwrap());
+                        if !dirty_pubkeys.is_empty() {
+                            self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
+                        }
+
                         if !self.account_indexes.is_empty() {
                             for (pubkey, (_, _store_id, stored_account)) in accounts_map.iter() {
                                 self.accounts_index.update_secondary_indexes(

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1205,7 +1205,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         &self,
         slot: Slot,
         items: Vec<(&Pubkey, T)>,
-    ) {
+    ) -> Vec<bool> {
         let potentially_new_items = items
             .iter()
             .map(|(_pubkey, account_info)| {
@@ -1220,7 +1220,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         items
             .into_iter()
             .zip(potentially_new_items.into_iter())
-            .for_each(|((pubkey, account_info), new_item)| {
+            .map(|((pubkey, account_info), new_item)| {
                 let account_entry = self.insert_new_entry_if_missing_with_lock(
                     pubkey,
                     &mut w_account_maps,
@@ -1231,8 +1231,12 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                 }
                 if let Some(mut w_account_entry) = account_entry {
                     w_account_entry.update(slot, account_info, &mut _reclaims);
+                    true
+                } else {
+                    false
                 }
-            });
+            })
+            .collect()
     }
 
     // Updates the given pubkey at the given slot with the new account information.

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4524,22 +4524,26 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
+        info!("cleaning..");
         let mut clean_time = Measure::start("clean");
         if self.slot() > 0 {
             self.clean_accounts(true, true);
         }
         clean_time.stop();
 
+        info!("shrinking..");
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
         if self.slot() > 0 {
             self.shrink_all_slots(true);
         }
         shrink_all_slots_time.stop();
 
+        info!("verify_bank_hash..");
         let mut verify_time = Measure::start("verify_bank_hash");
         let mut verify = self.verify_bank_hash();
         verify_time.stop();
 
+        info!("verify_hash..");
         let mut verify2_time = Measure::start("verify_hash");
         // Order and short-circuiting is significant; verify_hash requires a valid bank hash
         verify = verify && self.verify_hash();


### PR DESCRIPTION
#### Problem

Dirty pubkey set will consist of all pubkeys in the snapshot which means the clean operation following a snapshot ingest is very slow when there are a lot of pubkeys in the snapshot.

#### Summary of Changes

Only add keys which have multiple entries to the dirty set. Pubkeys with only 1 entry cannot be cleaned unless they are 0-lamport updates. Those are already handled through the accounts_index::zero_lamport_pubkeys set:
https://github.com/solana-labs/solana/blob/1108cb32b524fedf7ae85bf694160033be7e60af/runtime/src/accounts_index.rs#L1229-L1231

Fixes #
