### PR TITLE
Fix missing builtins in C programs linking with compiler_builtins

### DIFF
--- a/programs/bpf/c/src/float/float.c
+++ b/programs/bpf/c/src/float/float.c
@@ -1,0 +1,19 @@
+/**
+ * @brief Example C based BPF program that performs operations
+ * on floating point values.  The test fails if floating point
+ * emulation functions were not linked to the module.
+ */
+#include <solana_sdk.h>
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  SolAccountInfo ka[1];
+  SolParameters params = (SolParameters) { .ka = ka };
+
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
+    return ERROR_INVALID_ARGUMENT;
+  }
+  uint32_t *data = (uint32_t *)(params.ka[0].data);
+  *data += 1.5;
+
+  return SUCCESS;
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -431,6 +431,7 @@ fn test_program_bpf_sanity() {
         programs.extend_from_slice(&[
             ("alloc", true),
             ("bpf_to_bpf", true),
+            ("float", true),
             ("multiple_static", true),
             ("noop", true),
             ("noop++", true),

--- a/sdk/bpf/c/bpf.mk
+++ b/sdk/bpf/c/bpf.mk
@@ -15,7 +15,8 @@ OUT_DIR ?= ./out
 OS := $(shell uname)
 
 LLVM_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/llvm
-LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/11.0.1/include
+LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/12.0.1/include
+COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/rust/lib/rustlib/bpfel-unknown-unknown/lib
 
 ifdef LLVM_DIR
 CC := $(LLVM_DIR)/bin/clang
@@ -167,7 +168,7 @@ define SO_RULE
 $1: $2
 	@echo "[lld] $1 ($2)"
 	$(_@)mkdir -p $(dir $1)
-	$(_@)$(LLD) $(BPF_LLD_FLAGS) -o $1 $2
+	$(_@)$(LLD) $(BPF_LLD_FLAGS) -o $1 $2 $(COMPILER_RT_DIR)/libcompiler_builtins-*.rlib
 ifeq (,$(wildcard $(subst .so,-keypair.json,$1)))
 	$(_@)solana-keygen new --no-passphrase --silent -o $(subst .so,-keypair.json,$1)
 endif


### PR DESCRIPTION
#### Problem

BPF .so modules built from C are not linked with compiler-rt library that provides floating point emulation routines. Thus, if a C program contains operations that require floating point value conversion or arithmetic operations on floating point values, such a program fails at run time with undefined symbol errors.

#### Summary of Changes

This fix changes the linker command in makefile used to built BPF modules by C toolchain. The modules will be linked with the compiler_builtins library that we use for BPF modules built from Rust sources.

Fixes #17301
