### PR TITLE
Add a flag to simulateTransaction to use most recent blockhash

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -28,6 +28,8 @@ pub struct RpcSendTransactionConfig {
 pub struct RpcSimulateTransactionConfig {
     #[serde(default)]
     pub sig_verify: bool,
+    #[serde(default)]
+    pub use_most_recent_blockhash: bool,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
     pub encoding: Option<UiTransactionEncoding>,

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -29,7 +29,7 @@ pub struct RpcSimulateTransactionConfig {
     #[serde(default)]
     pub sig_verify: bool,
     #[serde(default)]
-    pub use_most_recent_blockhash: bool,
+    pub replace_recent_blockhash: bool,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
     pub encoding: Option<UiTransactionEncoding>,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2969,7 +2969,7 @@ pub mod rpc_full {
             debug!("simulate_transaction rpc request received");
             let config = config.unwrap_or_default();
             let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
-            let (_, transaction) = deserialize_transaction(data, encoding)?;
+            let (_, mut transaction) = deserialize_transaction(data, encoding)?;
 
             if config.sig_verify {
                 if let Err(e) = verify_transaction(&transaction) {
@@ -2978,6 +2978,9 @@ pub mod rpc_full {
             }
 
             let bank = &*meta.bank(config.commitment);
+            if config.use_most_recent_blockhash {
+                transaction.message.recent_blockhash = bank.last_blockhash();
+            }
             let (result, logs) = bank.simulate_transaction(transaction);
 
             Ok(new_response(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2978,7 +2978,7 @@ pub mod rpc_full {
             }
 
             let bank = &*meta.bank(config.commitment);
-            if config.use_most_recent_blockhash {
+            if config.replace_recent_blockhash {
                 transaction.message.recent_blockhash = bank.last_blockhash();
             }
             let (result, logs) = bank.simulate_transaction(transaction);

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3206,7 +3206,7 @@ Simulate sending a transaction
   - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false)
   - `commitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"finalized"`).
   - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
-  - `useMostRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be ignored and overridden with the most recent blockhash. (default: false)
+  - `replaceRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be replaced with the most recent blockhash. (default: false)
 
 #### Results:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3206,6 +3206,7 @@ Simulate sending a transaction
   - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false)
   - `commitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"finalized"`).
   - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
+  - `useMostRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be ignored and overridden with the most recent blockhash. (default: false)
 
 #### Results:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3203,10 +3203,11 @@ Simulate sending a transaction
 
 - `<string>` - Transaction, as an encoded string. The transaction must have a valid blockhash, but is not required to be signed.
 - `<object>` - (optional) Configuration object containing the following field:
-  - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false)
+  - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false, conflicts with `replaceRecentBlockhash`)
   - `commitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"finalized"`).
   - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
-  - `replaceRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be replaced with the most recent blockhash. (default: false)
+  - `replaceRecentBlockhash: <bool>` - (optional) if true the transaction recent blockhash will be replaced with the most recent blockhash.
+  (default: false, conflicts with `sigVerify`)
 
 #### Results:
 


### PR DESCRIPTION
#### Problem
RPC consistency issues makes it hard to fetch a recent blockhash for tx simulation and then use that blockhash for simulation. It also shouldn't be necessary to require clients to first fetch a recent blockhash for simulation.

#### Summary of Changes
- Add `replaceRecentBlockhash` flag to replace the recent blockhash used by a simulated transaction with the last blockhash

Fixes #
