### PR TITLE
Improve missing default signer error messaging

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -91,8 +91,8 @@ impl CliSignerInfo {
 }
 #[derive(Debug)]
 pub struct DefaultSigner {
-    arg_name: String,
-    path: String,
+    pub arg_name: String,
+    pub path: String,
 }
 
 impl DefaultSigner {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -89,13 +89,33 @@ impl CliSignerInfo {
             .collect()
     }
 }
-
+#[derive(Debug)]
 pub struct DefaultSigner {
-    pub arg_name: String,
-    pub path: String,
+    arg_name: String,
+    path: String,
 }
 
 impl DefaultSigner {
+    pub fn new(path: String) -> Self {
+        Self {
+            arg_name: "keypair".to_string(),
+            path,
+        }
+    }
+    pub fn from_path(path: String) -> Result<Self, Box<dyn error::Error>> {
+        std::fs::metadata(&path)
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                    "No default signer found, run \"solana-keygen new -o {}\" to create a new one",
+                    path
+                ),
+                )
+                .into()
+            })
+            .map(|_| Self::new(path))
+    }
     pub fn generate_unique_signers(
         &self,
         bulk_signers: Vec<Option<Box<dyn Signer>>>,
@@ -257,6 +277,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                     ASK_KEYWORD => Ok(SignerSource::new_legacy(SignerSourceKind::Prompt)),
                     _ => match Pubkey::from_str(source.as_str()) {
                         Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
+                        // Err(_) => Ok(SignerSource::new(SignerSourceKind::Filepath(source))),
                         Err(_) => std::fs::metadata(source.as_str())
                             .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
                             .map_err(|err| err.into()),
@@ -316,7 +337,7 @@ pub fn signer_from_path_with_config(
         legacy,
     } = parse_signer_source(path)?;
     match kind {
-        SignerSourceKind::Prompt => {
+SignerSourceKind::Prompt => {
             let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
             Ok(Box::new(keypair_from_seed_phrase(
                 keypair_name,
@@ -733,10 +754,6 @@ mod tests {
         // Catchall into SignerSource::Filepath fails
         let junk = "sometextthatisnotapubkeyorfile".to_string();
         assert!(Pubkey::from_str(&junk).is_err());
-        assert!(matches!(
-            parse_signer_source(&junk),
-            Err(SignerSourceError::IoError(_))
-        ));
 
         let prompt = "prompt:".to_string();
         assert!(matches!(

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -277,10 +277,7 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
                     ASK_KEYWORD => Ok(SignerSource::new_legacy(SignerSourceKind::Prompt)),
                     _ => match Pubkey::from_str(source.as_str()) {
                         Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
-                        // Err(_) => Ok(SignerSource::new(SignerSourceKind::Filepath(source))),
-                        Err(_) => std::fs::metadata(source.as_str())
-                            .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
-                            .map_err(|err| err.into()),
+                        Err(_) => Ok(SignerSource::new(SignerSourceKind::Filepath(source))),
                     },
                 }
             }
@@ -337,7 +334,7 @@ pub fn signer_from_path_with_config(
         legacy,
     } = parse_signer_source(path)?;
     match kind {
-SignerSourceKind::Prompt => {
+        SignerSourceKind::Prompt => {
             let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
             Ok(Box::new(keypair_from_seed_phrase(
                 keypair_name,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2299,10 +2299,7 @@ mod tests {
         let default_keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &default_keypair_file).unwrap();
 
-        let default_signer = DefaultSigner {
-            arg_name: "keypair".to_string(),
-            path: default_keypair_file,
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file);
 
         let signer_info = default_signer
             .generate_unique_signers(vec![], &matches, &mut None)
@@ -2380,10 +2377,7 @@ mod tests {
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
         let keypair = read_keypair_file(&keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
         // Test Airdrop Subcommand
         let test_airdrop =
             test_commands
@@ -2911,10 +2905,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let default_keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &default_keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: default_keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file.clone());
 
         //Test Transfer Subcommand, SOL
         let from_keypair = keypair_from_seed(&[0u8; 32]).unwrap();

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2098,10 +2098,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let (default_keypair_file, mut tmp_file) = make_tmp_file();
         write_keypair(&default_keypair, tmp_file.as_file_mut()).unwrap();
-        let default_signer = DefaultSigner {
-            path: default_keypair_file,
-            arg_name: String::new(),
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file);
 
         let test_cluster_version = test_commands
             .clone()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -173,16 +173,12 @@ pub fn parse_args<'a>(
         matches.value_of("json_rpc_url").unwrap_or(""),
         &config.json_rpc_url,
     );
-    let default_signer_arg_name = "keypair".to_string();
     let (_, default_signer_path) = CliConfig::compute_keypair_path_setting(
-        matches.value_of(&default_signer_arg_name).unwrap_or(""),
+        matches.value_of("keypair").unwrap_or(""),
         &config.keypair_path,
     );
 
-    let default_signer = DefaultSigner {
-        arg_name: default_signer_arg_name,
-        path: default_signer_path.clone(),
-    };
+    let default_signer = DefaultSigner::from_path(default_signer_path.clone())?;
 
     let CliCommandInfo {
         command,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -596,10 +596,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let (default_keypair_file, mut tmp_file) = make_tmp_file();
         write_keypair(&default_keypair, tmp_file.as_file_mut()).unwrap();
-        let default_signer = DefaultSigner {
-            path: default_keypair_file.clone(),
-            arg_name: String::new(),
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file.clone());
         let (keypair_file, mut tmp_file) = make_tmp_file();
         let nonce_account_keypair = Keypair::new();
         write_keypair(&nonce_account_keypair, tmp_file.as_file_mut()).unwrap();

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2131,10 +2131,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
 
         let test_command = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2342,10 +2339,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
 
         // defaults
         let test_command = test_commands.clone().get_matches_from(vec![
@@ -2493,10 +2487,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
 
         let program_pubkey = Pubkey::new_unique();
         let new_authority_pubkey = Pubkey::new_unique();
@@ -2604,10 +2595,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
 
         let buffer_pubkey = Pubkey::new_unique();
         let new_authority_pubkey = Pubkey::new_unique();
@@ -2664,10 +2652,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file,
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file);
 
         // defaults
         let buffer_pubkey = Pubkey::new_unique();
@@ -2766,10 +2751,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let keypair_file = make_tmp_path("keypair_file");
         write_keypair_file(&default_keypair, &keypair_file).unwrap();
-        let default_signer = DefaultSigner {
-            path: keypair_file.clone(),
-            arg_name: "".to_string(),
-        };
+        let default_signer = DefaultSigner::new(keypair_file.clone());
 
         // defaults
         let buffer_pubkey = Pubkey::new_unique();

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2117,10 +2117,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let (default_keypair_file, mut tmp_file) = make_tmp_file();
         write_keypair(&default_keypair, tmp_file.as_file_mut()).unwrap();
-        let default_signer = DefaultSigner {
-            path: default_keypair_file.clone(),
-            arg_name: String::new(),
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file.clone());
         let (keypair_file, mut tmp_file) = make_tmp_file();
         let stake_account_keypair = Keypair::new();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -826,10 +826,7 @@ mod tests {
         let default_keypair = Keypair::new();
         let (default_keypair_file, mut tmp_file) = make_tmp_file();
         write_keypair(&default_keypair, tmp_file.as_file_mut()).unwrap();
-        let default_signer = DefaultSigner {
-            path: default_keypair_file.clone(),
-            arg_name: String::new(),
-        };
+        let default_signer = DefaultSigner::new(default_keypair_file.clone());
 
         let test_authorize_voter = test_commands.clone().get_matches_from(vec![
             "test",


### PR DESCRIPTION
#### Problem

The CLI returns a vauge error message if the default signer is not present

#### Summary of Changes

Require that a default signer be present and report a better error message:

```
$ solana address
Error: No default signer found, run "solana-keygen new -o /Users/jack/.config/solana/id.json" to create a new one
```

Fixes #17423
