### PR TITLE
explorer: Display correct list of block programs

### DIFF
--- a/explorer/src/components/block/BlockAccountsCard.tsx
+++ b/explorer/src/components/block/BlockAccountsCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ConfirmedBlock, PublicKey } from "@solana/web3.js";
+import { BlockResponse, PublicKey } from "@solana/web3.js";
 import { Address } from "components/common/Address";
 
 type AccountStats = {
@@ -9,18 +9,19 @@ type AccountStats = {
 
 const PAGE_SIZE = 25;
 
-export function BlockAccountsCard({ block }: { block: ConfirmedBlock }) {
+export function BlockAccountsCard({ block }: { block: BlockResponse }) {
   const [numDisplayed, setNumDisplayed] = React.useState(10);
   const totalTransactions = block.transactions.length;
 
   const accountStats = React.useMemo(() => {
     const statsMap = new Map<string, AccountStats>();
     block.transactions.forEach((tx) => {
+      const message = tx.transaction.message;
       const txSet = new Map<string, boolean>();
-      tx.transaction.instructions.forEach((ix) => {
-        ix.keys.forEach((key) => {
-          const address = key.pubkey.toBase58();
-          txSet.set(address, key.isWritable);
+      message.instructions.forEach((ix) => {
+        ix.accounts.forEach((index) => {
+          const address = message.accountKeys[index].toBase58();
+          txSet.set(address, message.isAccountWritable(index));
         });
       });
 

--- a/explorer/src/components/block/BlockHistoryCard.tsx
+++ b/explorer/src/components/block/BlockHistoryCard.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { ConfirmedBlock } from "@solana/web3.js";
+import { BlockResponse } from "@solana/web3.js";
 import { ErrorCard } from "components/common/ErrorCard";
 import { Signature } from "components/common/Signature";
-import bs58 from "bs58";
 
 const PAGE_SIZE = 25;
 
-export function BlockHistoryCard({ block }: { block: ConfirmedBlock }) {
+export function BlockHistoryCard({ block }: { block: BlockResponse }) {
   const [numDisplayed, setNumDisplayed] = React.useState(PAGE_SIZE);
 
   if (block.transactions.length === 0) {
@@ -32,7 +31,7 @@ export function BlockHistoryCard({ block }: { block: ConfirmedBlock }) {
               let statusText;
               let statusClass;
               let signature: React.ReactNode;
-              if (tx.meta?.err || !tx.transaction.signature) {
+              if (tx.meta?.err || tx.transaction.signatures.length === 0) {
                 statusClass = "warning";
                 statusText = "Failed";
               } else {
@@ -40,12 +39,9 @@ export function BlockHistoryCard({ block }: { block: ConfirmedBlock }) {
                 statusText = "Success";
               }
 
-              if (tx.transaction.signature) {
+              if (tx.transaction.signatures.length > 0) {
                 signature = (
-                  <Signature
-                    signature={bs58.encode(tx.transaction.signature)}
-                    link
-                  />
+                  <Signature signature={tx.transaction.signatures[0]} link />
                 );
               }
 

--- a/explorer/src/components/block/BlockOverviewCard.tsx
+++ b/explorer/src/components/block/BlockOverviewCard.tsx
@@ -7,7 +7,7 @@ import { Slot } from "components/common/Slot";
 import { ClusterStatus, useCluster } from "providers/cluster";
 import { BlockHistoryCard } from "./BlockHistoryCard";
 import { BlockRewardsCard } from "./BlockRewardsCard";
-import { ConfirmedBlock } from "@solana/web3.js";
+import { BlockResponse } from "@solana/web3.js";
 import { NavLink } from "react-router-dom";
 import { clusterPath } from "utils/url";
 import { BlockProgramsCard } from "./BlockProgramsCard";
@@ -134,7 +134,7 @@ function MoreSection({
   tab,
 }: {
   slot: number;
-  block: ConfirmedBlock;
+  block: BlockResponse;
   tab?: string;
 }) {
   return (

--- a/explorer/src/components/block/BlockRewardsCard.tsx
+++ b/explorer/src/components/block/BlockRewardsCard.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { lamportsToSolString } from "utils";
-import { ConfirmedBlock, PublicKey } from "@solana/web3.js";
+import { BlockResponse, PublicKey } from "@solana/web3.js";
 import { Address } from "components/common/Address";
 
 const PAGE_SIZE = 10;
 
-export function BlockRewardsCard({ block }: { block: ConfirmedBlock }) {
+export function BlockRewardsCard({ block }: { block: BlockResponse }) {
   const [rewardsDisplayed, setRewardsDisplayed] = React.useState(PAGE_SIZE);
 
   if (!block.rewards || block.rewards.length < 1) {

--- a/explorer/src/components/instruction/InstructionCard.tsx
+++ b/explorer/src/components/instruction/InstructionCard.tsx
@@ -38,10 +38,12 @@ export function InstructionCard({
   const [showRaw, setShowRaw] = React.useState(defaultRaw || false);
   const signature = useContext(SignatureContext);
   const details = useTransactionDetails(signature);
+
   let raw: TransactionInstruction | undefined = undefined;
   if (details && childIndex === undefined) {
-    raw = details?.data?.raw?.transaction.instructions[index];
+    raw = details?.data?.raw?.instructions[index];
   }
+
   const fetchRaw = useFetchRawTransaction();
   const fetchRawTrigger = () => fetchRaw(signature);
 

--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -7,7 +7,6 @@ import {
   PartiallyDecodedInstruction,
   PublicKey,
   SignatureResult,
-  Transaction,
   TransactionSignature,
 } from "@solana/web3.js";
 import { BpfLoaderDetailsCard } from "components/instruction/bpf-loader/BpfLoaderDetailsCard";
@@ -59,8 +58,6 @@ export function InstructionsSection({ signature }: SignatureProps) {
 
   if (!status?.data?.info || !details?.data?.transaction) return null;
 
-  const raw = details.data.raw?.transaction;
-
   const { transaction } = details.data.transaction;
   const { meta } = details.data.transaction;
 
@@ -106,7 +103,6 @@ export function InstructionsSection({ signature }: SignatureProps) {
             signature,
             tx: transaction,
             childIndex,
-            raw,
           });
 
           innerCards.push(res);
@@ -120,7 +116,6 @@ export function InstructionsSection({ signature }: SignatureProps) {
         signature,
         tx: transaction,
         innerCards,
-        raw,
       });
     }
   );
@@ -147,7 +142,6 @@ function renderInstructionCard({
   signature,
   innerCards,
   childIndex,
-  raw,
 }: {
   ix: ParsedInstruction | PartiallyDecodedInstruction;
   tx: ParsedTransaction;
@@ -156,7 +150,6 @@ function renderInstructionCard({
   signature: TransactionSignature;
   innerCards?: JSX.Element[];
   childIndex?: number;
-  raw?: Transaction;
 }) {
   const key = `${index}-${childIndex}`;
 


### PR DESCRIPTION
#### Problem
The programs called from inner instructions are listed on the block details page but are not always correct. The program id index is used incorrectly.

#### Summary of Changes
Use new `getBlock` web3 api to ensure that message keys are accessed in the correct order

Fixes https://github.com/solana-labs/solana/issues/17451
