### PR TITLE
Do not keep oldest snapshot

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -737,9 +737,7 @@ pub fn purge_old_snapshot_archives<P: AsRef<Path>>(
         maximum_snapshots_to_retain
     );
     let mut archives = get_snapshot_archives(snapshot_output_dir);
-    // Keep the oldest snapshot so we can always play the ledger from it.
-    archives.pop();
-    let max_snaps = max(1, maximum_snapshots_to_retain);
+    let max_snaps = max(1, maximum_snapshots_to_retain); // Always keep at least one snapshot
     for old_archive in archives.into_iter().skip(max_snaps) {
         fs::remove_file(old_archive.0)
             .unwrap_or_else(|err| info!("Failed to remove old snapshot: {:}", err));


### PR DESCRIPTION
`snapshot_utils::purge_old_snapshot_archives()` kept around the oldest snapshot. After talking with @mvines, turns out that is no longer necessary, so I'm removing it.
