### PR TITLE
Add block height to ConfirmedBlock structs

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2126,6 +2126,9 @@ impl fmt::Display for CliBlock {
         if let Some(block_time) = self.encoded_confirmed_block.block_time {
             writeln!(f, "Block Time: {:?}", Local.timestamp(block_time, 0))?;
         }
+        if let Some(block_height) = self.encoded_confirmed_block.block_height {
+            writeln!(f, "Block Height: {:?}", block_height)?;
+        }
         if !self.encoded_confirmed_block.rewards.is_empty() {
             let mut rewards = self.encoded_confirmed_block.rewards.clone();
             rewards.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));

--- a/core/src/bigtable_upload_service.rs
+++ b/core/src/bigtable_upload_service.rs
@@ -8,10 +8,10 @@ use std::{
 use tokio::runtime::Runtime;
 
 // Delay uploading the largest confirmed root for this many slots.  This is done in an attempt to
-// ensure that the `CacheBlockTimeService` has had enough time to add the block time for the root
+// ensure that the `CacheBlockMetaService` has had enough time to add the block time for the root
 // before it's uploaded to BigTable.
 //
-// A more direct connection between CacheBlockTimeService and BigTableUploadService would be
+// A more direct connection between CacheBlockMetaService and BigTableUploadService would be
 // preferable...
 const LARGEST_CONFIRMED_ROOT_UPLOAD_DELAY: usize = 100;
 

--- a/core/src/cache_block_meta_service.rs
+++ b/core/src/cache_block_meta_service.rs
@@ -1,4 +1,4 @@
-pub use solana_ledger::blockstore_processor::CacheBlockTimeSender;
+pub use solana_ledger::blockstore_processor::CacheBlockMetaSender;
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_ledger::blockstore::Blockstore,
@@ -14,18 +14,18 @@ use {
     },
 };
 
-pub type CacheBlockTimeReceiver = Receiver<Arc<Bank>>;
+pub type CacheBlockMetaReceiver = Receiver<Arc<Bank>>;
 
-pub struct CacheBlockTimeService {
+pub struct CacheBlockMetaService {
     thread_hdl: JoinHandle<()>,
 }
 
 const CACHE_BLOCK_TIME_WARNING_MS: u64 = 150;
 
-impl CacheBlockTimeService {
+impl CacheBlockMetaService {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        cache_block_time_receiver: CacheBlockTimeReceiver,
+        cache_block_meta_receiver: CacheBlockMetaReceiver,
         blockstore: Arc<Blockstore>,
         exit: &Arc<AtomicBool>,
     ) -> Self {
@@ -36,19 +36,19 @@ impl CacheBlockTimeService {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
-                let recv_result = cache_block_time_receiver.recv_timeout(Duration::from_secs(1));
+                let recv_result = cache_block_meta_receiver.recv_timeout(Duration::from_secs(1));
                 match recv_result {
                     Err(RecvTimeoutError::Disconnected) => {
                         break;
                     }
                     Ok(bank) => {
-                        let mut cache_block_time_timer = Measure::start("cache_block_time_timer");
-                        Self::cache_block_time(bank, &blockstore);
-                        cache_block_time_timer.stop();
-                        if cache_block_time_timer.as_ms() > CACHE_BLOCK_TIME_WARNING_MS {
+                        let mut cache_block_meta_timer = Measure::start("cache_block_meta_timer");
+                        Self::cache_block_meta(bank, &blockstore);
+                        cache_block_meta_timer.stop();
+                        if cache_block_meta_timer.as_ms() > CACHE_BLOCK_TIME_WARNING_MS {
                             warn!(
-                                "cache_block_time operation took: {}ms",
-                                cache_block_time_timer.as_ms()
+                                "cache_block_meta operation took: {}ms",
+                                cache_block_meta_timer.as_ms()
                             );
                         }
                     }
@@ -59,7 +59,7 @@ impl CacheBlockTimeService {
         Self { thread_hdl }
     }
 
-    fn cache_block_time(bank: Arc<Bank>, blockstore: &Arc<Blockstore>) {
+    fn cache_block_meta(bank: Arc<Bank>, blockstore: &Arc<Blockstore>) {
         if let Err(e) = blockstore.cache_block_time(bank.slot(), bank.clock().unix_timestamp) {
             error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
         }

--- a/core/src/cache_block_meta_service.rs
+++ b/core/src/cache_block_meta_service.rs
@@ -63,6 +63,9 @@ impl CacheBlockMetaService {
         if let Err(e) = blockstore.cache_block_time(bank.slot(), bank.clock().unix_timestamp) {
             error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
         }
+        if let Err(e) = blockstore.cache_block_height(bank.slot(), bank.block_height()) {
+            error!("cache_block_height failed: slot {:?} {:?}", bank.slot(), e);
+        }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod accounts_hash_verifier;
 pub mod banking_stage;
 pub mod bigtable_upload_service;
 pub mod broadcast_stage;
-pub mod cache_block_time_service;
+pub mod cache_block_meta_service;
 pub mod cluster_info_vote_listener;
 pub mod cluster_slot_state_verifier;
 pub mod cluster_slots;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     broadcast_stage::RetransmitSlotsSender,
-    cache_block_time_service::CacheBlockTimeSender,
+    cache_block_meta_service::CacheBlockMetaSender,
     cluster_info_vote_listener::{
         GossipDuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver, VoteTracker,
     },
@@ -123,7 +123,7 @@ pub struct ReplayStageConfig {
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
-    pub cache_block_time_sender: Option<CacheBlockTimeSender>,
+    pub cache_block_meta_sender: Option<CacheBlockMetaSender>,
     pub bank_notification_sender: Option<BankNotificationSender>,
     pub wait_for_vote_to_start_leader: bool,
 }
@@ -305,7 +305,7 @@ impl ReplayStage {
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
-            cache_block_time_sender,
+            cache_block_meta_sender,
             bank_notification_sender,
             wait_for_vote_to_start_leader,
         } = config;
@@ -375,7 +375,7 @@ impl ReplayStage {
                         &vote_account,
                         &mut progress,
                         transaction_status_sender.as_ref(),
-                        cache_block_time_sender.as_ref(),
+                        cache_block_meta_sender.as_ref(),
                         &verify_recyclers,
                         &mut heaviest_subtree_fork_choice,
                         &replay_vote_sender,
@@ -1626,7 +1626,7 @@ impl ReplayStage {
         vote_account: &Pubkey,
         progress: &mut ProgressMap,
         transaction_status_sender: Option<&TransactionStatusSender>,
-        cache_block_time_sender: Option<&CacheBlockTimeSender>,
+        cache_block_meta_sender: Option<&CacheBlockMetaSender>,
         verify_recyclers: &VerifyRecyclers,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
         replay_vote_sender: &ReplayVoteSender,
@@ -1751,7 +1751,7 @@ impl ReplayStage {
                         .send(BankNotification::Frozen(bank.clone()))
                         .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
                 }
-                blockstore_processor::cache_block_time(&bank, cache_block_time_sender);
+                blockstore_processor::cache_block_meta(&bank, cache_block_meta_sender);
 
                 let bank_hash = bank.hash();
                 if let Some(new_frozen_voters) =

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -958,7 +958,8 @@ impl JsonRpcRequestProcessor {
                             || confirmed_block.block_height.is_none()
                         {
                             let r_bank_forks = self.bank_forks.read().unwrap();
-                            if let Some(bank) = r_bank_forks.get(slot) {
+                            let bank = r_bank_forks.get(slot).cloned();
+                            if let Some(bank) = bank {
                                 if confirmed_block.block_time.is_none() {
                                     confirmed_block.block_time = Some(bank.clock().unix_timestamp);
                                 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -953,7 +953,20 @@ impl JsonRpcRequestProcessor {
                             .load(Ordering::SeqCst)
                 {
                     let result = self.blockstore.get_complete_block(slot, true);
-                    return Ok(result.ok().map(|confirmed_block| {
+                    return Ok(result.ok().map(|mut confirmed_block| {
+                        if confirmed_block.block_time.is_none()
+                            || confirmed_block.block_height.is_none()
+                        {
+                            let r_bank_forks = self.bank_forks.read().unwrap();
+                            if let Some(bank) = r_bank_forks.get(slot) {
+                                if confirmed_block.block_time.is_none() {
+                                    confirmed_block.block_time = Some(bank.clock().unix_timestamp);
+                                }
+                                if confirmed_block.block_height.is_none() {
+                                    confirmed_block.block_height = Some(bank.block_height());
+                                }
+                            }
+                        }
                         confirmed_block.configure(encoding, transaction_details, show_rewards)
                     }));
                 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -4,7 +4,7 @@
 use crate::{
     accounts_hash_verifier::AccountsHashVerifier,
     broadcast_stage::RetransmitSlotsSender,
-    cache_block_time_service::CacheBlockTimeSender,
+    cache_block_meta_service::CacheBlockMetaSender,
     cluster_info_vote_listener::{
         GossipDuplicateConfirmedSlotsReceiver, GossipVerifiedVoteHashReceiver,
         VerifiedVoteReceiver, VoteTracker,
@@ -116,7 +116,7 @@ impl Tvu {
         cfg: Option<Arc<AtomicBool>>,
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
-        cache_block_time_sender: Option<CacheBlockTimeSender>,
+        cache_block_meta_sender: Option<CacheBlockMetaSender>,
         snapshot_config_and_pending_package: Option<(SnapshotConfig, PendingSnapshotPackage)>,
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: RetransmitSlotsSender,
@@ -267,7 +267,7 @@ impl Tvu {
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
-            cache_block_time_sender,
+            cache_block_meta_sender,
             bank_notification_sender,
             wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
         };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     broadcast_stage::BroadcastStageType,
-    cache_block_time_service::{CacheBlockTimeSender, CacheBlockTimeService},
+    cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
     cluster_info_vote_listener::VoteTracker,
     completed_data_sets_service::CompletedDataSetsService,
     consensus::{reconcile_blockstore_roots_with_tower, Tower},
@@ -259,8 +259,8 @@ struct TransactionHistoryServices {
     max_complete_transaction_status_slot: Arc<AtomicU64>,
     rewards_recorder_sender: Option<RewardsRecorderSender>,
     rewards_recorder_service: Option<RewardsRecorderService>,
-    cache_block_time_sender: Option<CacheBlockTimeSender>,
-    cache_block_time_service: Option<CacheBlockTimeService>,
+    cache_block_meta_sender: Option<CacheBlockMetaSender>,
+    cache_block_meta_service: Option<CacheBlockMetaService>,
 }
 
 pub struct Validator {
@@ -270,7 +270,7 @@ pub struct Validator {
     optimistically_confirmed_bank_tracker: Option<OptimisticallyConfirmedBankTracker>,
     transaction_status_service: Option<TransactionStatusService>,
     rewards_recorder_service: Option<RewardsRecorderService>,
-    cache_block_time_service: Option<CacheBlockTimeService>,
+    cache_block_meta_service: Option<CacheBlockMetaService>,
     sample_performance_service: Option<SamplePerformanceService>,
     gossip_service: GossipService,
     serve_repair_service: ServeRepairService,
@@ -396,8 +396,8 @@ impl Validator {
                 max_complete_transaction_status_slot,
                 rewards_recorder_sender,
                 rewards_recorder_service,
-                cache_block_time_sender,
-                cache_block_time_service,
+                cache_block_meta_sender,
+                cache_block_meta_service,
             },
             tower,
         ) = new_banks_from_ledger(
@@ -724,7 +724,7 @@ impl Validator {
             config.enable_partition.clone(),
             transaction_status_sender.clone(),
             rewards_recorder_sender,
-            cache_block_time_sender,
+            cache_block_meta_sender,
             snapshot_config_and_pending_package,
             vote_tracker.clone(),
             retransmit_slots_sender,
@@ -787,7 +787,7 @@ impl Validator {
             optimistically_confirmed_bank_tracker,
             transaction_status_service,
             rewards_recorder_service,
-            cache_block_time_service,
+            cache_block_meta_service,
             sample_performance_service,
             snapshot_packager_service,
             completed_data_sets_service,
@@ -867,10 +867,10 @@ impl Validator {
                 .expect("rewards_recorder_service");
         }
 
-        if let Some(cache_block_time_service) = self.cache_block_time_service {
-            cache_block_time_service
+        if let Some(cache_block_meta_service) = self.cache_block_meta_service {
+            cache_block_meta_service
                 .join()
-                .expect("cache_block_time_service");
+                .expect("cache_block_meta_service");
         }
 
         if let Some(sample_performance_service) = self.sample_performance_service {
@@ -1144,7 +1144,7 @@ fn new_banks_from_ledger(
             .transaction_status_sender
             .as_ref(),
         transaction_history_services
-            .cache_block_time_sender
+            .cache_block_meta_sender
             .as_ref(),
     )
     .unwrap_or_else(|err| {
@@ -1331,10 +1331,10 @@ fn initialize_rpc_transaction_history_services(
         exit,
     ));
 
-    let (cache_block_time_sender, cache_block_time_receiver) = unbounded();
-    let cache_block_time_sender = Some(cache_block_time_sender);
-    let cache_block_time_service = Some(CacheBlockTimeService::new(
-        cache_block_time_receiver,
+    let (cache_block_meta_sender, cache_block_meta_receiver) = unbounded();
+    let cache_block_meta_sender = Some(cache_block_meta_sender);
+    let cache_block_meta_service = Some(CacheBlockMetaService::new(
+        cache_block_meta_receiver,
         blockstore,
         exit,
     ));
@@ -1344,8 +1344,8 @@ fn initialize_rpc_transaction_history_services(
         max_complete_transaction_status_slot,
         rewards_recorder_sender,
         rewards_recorder_service,
-        cache_block_time_sender,
-        cache_block_time_service,
+        cache_block_meta_sender,
+        cache_block_meta_service,
     }
 }
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -394,6 +394,7 @@ The result field will be an object with the following fields:
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
     - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting", "staking"
   - `blockTime: <i64 | null>` - estimated production time, as Unix timestamp (seconds since the Unix epoch). null if not available
+  - `blockHeight: <u64 | null>` - the number of blocks beneath this block
 
 #### Example:
 
@@ -409,6 +410,7 @@ Result:
 {
   "jsonrpc": "2.0",
   "result": {
+    "blockHeight": 428,
     "blockTime": null,
     "blockhash": "3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA",
     "parentSlot": 429,
@@ -492,6 +494,7 @@ Result:
 {
   "jsonrpc": "2.0",
   "result": {
+    "blockHeight": 428,
     "blockTime": null,
     "blockhash": "3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA",
     "parentSlot": 429,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     blockstore::Blockstore,
     blockstore_processor::{
-        self, BlockstoreProcessorError, BlockstoreProcessorResult, CacheBlockTimeSender,
+        self, BlockstoreProcessorError, BlockstoreProcessorResult, CacheBlockMetaSender,
         ProcessOptions, TransactionStatusSender,
     },
     entry::VerifyRecyclers,
@@ -37,7 +37,7 @@ pub fn load(
     snapshot_config: Option<&SnapshotConfig>,
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
 ) -> LoadResult {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
@@ -102,7 +102,7 @@ pub fn load(
                         &process_options,
                         &VerifyRecyclers::default(),
                         transaction_status_sender,
-                        cache_block_time_sender,
+                        cache_block_meta_sender,
                     ),
                     Some(deserialized_snapshot_hash),
                 );
@@ -120,7 +120,7 @@ pub fn load(
             &blockstore,
             account_paths,
             process_options,
-            cache_block_time_sender,
+            cache_block_meta_sender,
         ),
         None,
     )

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1776,11 +1776,7 @@ impl Blockstore {
     }
 
     pub fn cache_block_time(&self, slot: Slot, timestamp: UnixTimestamp) -> Result<()> {
-        if self.get_block_time(slot).unwrap_or_default().is_none() {
-            self.blocktime_cf.put(slot, &timestamp)
-        } else {
-            Ok(())
-        }
+        self.blocktime_cf.put(slot, &timestamp)
     }
 
     pub fn get_block_height(&self, slot: Slot) -> Result<Option<u64>> {
@@ -1798,11 +1794,7 @@ impl Blockstore {
     }
 
     pub fn cache_block_height(&self, slot: Slot, block_height: u64) -> Result<()> {
-        if self.get_block_height(slot).unwrap_or_default().is_none() {
-            self.block_height_cf.put(slot, &block_height)
-        } else {
-            Ok(())
-        }
+        self.block_height_cf.put(slot, &block_height)
     }
 
     pub fn get_first_available_block(&self) -> Result<Slot> {
@@ -1882,6 +1874,10 @@ impl Blockstore {
                     .get_protobuf_or_bincode::<StoredExtendedRewards>(slot)?
                     .unwrap_or_default()
                     .into();
+
+                // The Blocktime and BlockHeight column families are updated asynchronously; they
+                // may not be written by the time the complete slot entries are available. In this
+                // case, these fields will be `None`.
                 let block_time = self.blocktime_cf.get(slot)?;
                 let block_height = self.block_height_cf.get(slot)?;
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -55,6 +55,8 @@ const REWARDS_CF: &str = "rewards";
 const BLOCKTIME_CF: &str = "blocktime";
 /// Column family for Performance Samples
 const PERF_SAMPLES_CF: &str = "perf_samples";
+/// Column family for BlockHeight
+const BLOCK_HEIGHT_CF: &str = "block_height";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -151,6 +153,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The performance samples column
     pub struct PerfSamples;
+
+    #[derive(Debug)]
+    /// The block height column
+    pub struct BlockHeight;
 }
 
 pub enum AccessType {
@@ -212,9 +218,9 @@ impl Rocks {
         recovery_mode: Option<BlockstoreRecoveryMode>,
     ) -> Result<Rocks> {
         use columns::{
-            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
-            TransactionStatusIndex,
+            AddressSignatures, BlockHeight, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta,
+            Index, Orphans, PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta,
+            TransactionStatus, TransactionStatusIndex,
         };
 
         fs::create_dir_all(&path)?;
@@ -259,6 +265,8 @@ impl Rocks {
             ColumnFamilyDescriptor::new(Blocktime::NAME, get_cf_options(&access_type));
         let perf_samples_cf_descriptor =
             ColumnFamilyDescriptor::new(PerfSamples::NAME, get_cf_options(&access_type));
+        let block_height_cf_descriptor =
+            ColumnFamilyDescriptor::new(BlockHeight::NAME, get_cf_options(&access_type));
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),
@@ -279,6 +287,7 @@ impl Rocks {
             (Rewards::NAME, rewards_cf_descriptor),
             (Blocktime::NAME, blocktime_cf_descriptor),
             (PerfSamples::NAME, perf_samples_cf_descriptor),
+            (BlockHeight::NAME, block_height_cf_descriptor),
         ];
 
         // Open the database
@@ -316,9 +325,9 @@ impl Rocks {
 
     fn columns(&self) -> Vec<&'static str> {
         use columns::{
-            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
-            TransactionStatusIndex,
+            AddressSignatures, BlockHeight, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta,
+            Index, Orphans, PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta,
+            TransactionStatus, TransactionStatusIndex,
         };
 
         vec![
@@ -337,6 +346,7 @@ impl Rocks {
             Rewards::NAME,
             Blocktime::NAME,
             PerfSamples::NAME,
+            BlockHeight::NAME,
         ]
     }
 
@@ -577,6 +587,14 @@ impl ColumnName for columns::PerfSamples {
 }
 impl TypedColumn for columns::PerfSamples {
     type Type = blockstore_meta::PerfSample;
+}
+
+impl SlotColumn for columns::BlockHeight {}
+impl ColumnName for columns::BlockHeight {
+    const NAME: &'static str = BLOCK_HEIGHT_CF;
+}
+impl TypedColumn for columns::BlockHeight {
+    type Type = u64;
 }
 
 impl Column for columns::ShredCode {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -378,7 +378,7 @@ pub fn process_blockstore(
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
     opts: ProcessOptions,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
 ) -> BlockstoreProcessorResult {
     if let Some(num_threads) = opts.override_num_threads {
         PAR_THREAD_POOL.with(|pool| {
@@ -407,7 +407,7 @@ pub fn process_blockstore(
         blockstore,
         &opts,
         &recyclers,
-        cache_block_time_sender,
+        cache_block_meta_sender,
     );
     do_process_blockstore_from_root(
         blockstore,
@@ -415,7 +415,7 @@ pub fn process_blockstore(
         &opts,
         &recyclers,
         None,
-        cache_block_time_sender,
+        cache_block_meta_sender,
     )
 }
 
@@ -426,7 +426,7 @@ pub(crate) fn process_blockstore_from_root(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<&TransactionStatusSender>,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
 ) -> BlockstoreProcessorResult {
     do_process_blockstore_from_root(
         blockstore,
@@ -434,7 +434,7 @@ pub(crate) fn process_blockstore_from_root(
         opts,
         recyclers,
         transaction_status_sender,
-        cache_block_time_sender,
+        cache_block_meta_sender,
     )
 }
 
@@ -444,7 +444,7 @@ fn do_process_blockstore_from_root(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<&TransactionStatusSender>,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
 ) -> BlockstoreProcessorResult {
     info!("processing ledger from slot {}...", bank.slot());
 
@@ -505,7 +505,7 @@ fn do_process_blockstore_from_root(
                 opts,
                 recyclers,
                 transaction_status_sender,
-                cache_block_time_sender,
+                cache_block_meta_sender,
                 &mut timing,
             )?;
             initial_forks.sort_by_key(|bank| bank.slot());
@@ -813,7 +813,7 @@ fn process_bank_0(
     blockstore: &Blockstore,
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
 ) {
     assert_eq!(bank0.slot(), 0);
     let mut progress = ConfirmationProgress::new(bank0.last_blockhash());
@@ -829,7 +829,7 @@ fn process_bank_0(
     )
     .expect("processing for bank 0 must succeed");
     bank0.freeze();
-    cache_block_time(bank0, cache_block_time_sender);
+    cache_block_meta(bank0, cache_block_meta_sender);
 }
 
 // Given a bank, add its children to the pending slots queue if those children slots are
@@ -897,7 +897,7 @@ fn load_frozen_forks(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<&TransactionStatusSender>,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     timing: &mut ExecuteTimings,
 ) -> result::Result<Vec<Arc<Bank>>, BlockstoreProcessorError> {
     let mut initial_forks = HashMap::new();
@@ -952,7 +952,7 @@ fn load_frozen_forks(
                 recyclers,
                 &mut progress,
                 transaction_status_sender,
-                cache_block_time_sender,
+                cache_block_meta_sender,
                 None,
                 timing,
             )
@@ -1126,7 +1126,7 @@ fn process_single_slot(
     recyclers: &VerifyRecyclers,
     progress: &mut ConfirmationProgress,
     transaction_status_sender: Option<&TransactionStatusSender>,
-    cache_block_time_sender: Option<&CacheBlockTimeSender>,
+    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
     timing: &mut ExecuteTimings,
 ) -> result::Result<(), BlockstoreProcessorError> {
@@ -1146,7 +1146,7 @@ fn process_single_slot(
     })?;
 
     bank.freeze(); // all banks handled by this routine are created from complete slots
-    cache_block_time(bank, cache_block_time_sender);
+    cache_block_meta(bank, cache_block_meta_sender);
 
     Ok(())
 }
@@ -1221,13 +1221,13 @@ impl TransactionStatusSender {
     }
 }
 
-pub type CacheBlockTimeSender = Sender<Arc<Bank>>;
+pub type CacheBlockMetaSender = Sender<Arc<Bank>>;
 
-pub fn cache_block_time(bank: &Arc<Bank>, cache_block_time_sender: Option<&CacheBlockTimeSender>) {
-    if let Some(cache_block_time_sender) = cache_block_time_sender {
-        cache_block_time_sender
+pub fn cache_block_meta(bank: &Arc<Bank>, cache_block_meta_sender: Option<&CacheBlockMetaSender>) {
+    if let Some(cache_block_meta_sender) = cache_block_meta_sender {
+        cache_block_meta_sender
             .send(bank.clone())
-            .unwrap_or_else(|err| warn!("cache_block_time_sender failed: {:?}", err));
+            .unwrap_or_else(|err| warn!("cache_block_meta_sender failed: {:?}", err));
     }
 }
 

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -693,6 +693,7 @@ mod tests {
             previous_blockhash: Hash::default().to_string(),
             rewards: vec![],
             block_time: Some(1_234_567_890),
+            block_height: Some(1),
         };
         let bincode_block = compress_best(
             &bincode::serialize::<StoredConfirmedBlock>(&block.clone().into()).unwrap(),

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -89,6 +89,7 @@ struct StoredConfirmedBlock {
     transactions: Vec<StoredConfirmedBlockTransaction>,
     rewards: StoredConfirmedBlockRewards,
     block_time: Option<UnixTimestamp>,
+    block_height: Option<u64>,
 }
 
 impl From<ConfirmedBlock> for StoredConfirmedBlock {
@@ -100,6 +101,7 @@ impl From<ConfirmedBlock> for StoredConfirmedBlock {
             transactions,
             rewards,
             block_time,
+            block_height,
         } = confirmed_block;
 
         Self {
@@ -109,6 +111,7 @@ impl From<ConfirmedBlock> for StoredConfirmedBlock {
             transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
             rewards: rewards.into_iter().map(|reward| reward.into()).collect(),
             block_time,
+            block_height,
         }
     }
 }
@@ -122,6 +125,7 @@ impl From<StoredConfirmedBlock> for ConfirmedBlock {
             transactions,
             rewards,
             block_time,
+            block_height,
         } = confirmed_block;
 
         Self {
@@ -131,6 +135,7 @@ impl From<StoredConfirmedBlock> for ConfirmedBlock {
             transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
             rewards: rewards.into_iter().map(|reward| reward.into()).collect(),
             block_time,
+            block_height,
         }
     }
 }

--- a/storage-proto/proto/solana.storage.confirmed_block.rs
+++ b/storage-proto/proto/solana.storage.confirmed_block.rs
@@ -12,6 +12,8 @@ pub struct ConfirmedBlock {
     pub rewards: ::prost::alloc::vec::Vec<Reward>,
     #[prost(message, optional, tag = "6")]
     pub block_time: ::core::option::Option<UnixTimestamp>,
+    #[prost(message, optional, tag = "7")]
+    pub block_height: ::core::option::Option<BlockHeight>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmedTransaction {
@@ -127,6 +129,11 @@ pub struct Rewards {
 pub struct UnixTimestamp {
     #[prost(int64, tag = "1")]
     pub timestamp: i64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockHeight {
+    #[prost(uint64, tag = "1")]
+    pub block_height: u64,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -66,7 +66,7 @@ pub enum TransactionErrorType {
     InvalidProgramForExecution = 13,
     SanitizeFailure = 14,
     ClusterMaintenance = 15,
-    AccountBorrowOutstanding = 16,
+    AccountBorrowOutstandingTx = 16,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/storage-proto/src/confirmed_block.proto
+++ b/storage-proto/src/confirmed_block.proto
@@ -9,6 +9,7 @@ message ConfirmedBlock {
     repeated ConfirmedTransaction transactions = 4;
     repeated Reward rewards = 5;
     UnixTimestamp block_time = 6;
+    BlockHeight block_height = 7;
 }
 
 message ConfirmedTransaction {
@@ -94,4 +95,8 @@ message Rewards {
 
 message UnixTimestamp {
     int64 timestamp = 1;
+}
+
+message BlockHeight {
+    uint64 block_height = 1;
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -118,6 +118,7 @@ impl From<ConfirmedBlock> for generated::ConfirmedBlock {
             transactions,
             rewards,
             block_time,
+            block_height,
         } = confirmed_block;
 
         Self {
@@ -127,6 +128,7 @@ impl From<ConfirmedBlock> for generated::ConfirmedBlock {
             transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
             rewards: rewards.into_iter().map(|r| r.into()).collect(),
             block_time: block_time.map(|timestamp| generated::UnixTimestamp { timestamp }),
+            block_height: block_height.map(|block_height| generated::BlockHeight { block_height }),
         }
     }
 }
@@ -143,6 +145,7 @@ impl TryFrom<generated::ConfirmedBlock> for ConfirmedBlock {
             transactions,
             rewards,
             block_time,
+            block_height,
         } = confirmed_block;
 
         Ok(Self {
@@ -155,6 +158,7 @@ impl TryFrom<generated::ConfirmedBlock> for ConfirmedBlock {
                 .collect::<std::result::Result<Vec<TransactionWithStatusMeta>, Self::Error>>()?,
             rewards: rewards.into_iter().map(|r| r.into()).collect(),
             block_time: block_time.map(|generated::UnixTimestamp { timestamp }| timestamp),
+            block_height: block_height.map(|generated::BlockHeight { block_height }| block_height),
         })
     }
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -586,7 +586,7 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                     tx_by_addr::TransactionErrorType::InstructionError
                 }
                 TransactionError::AccountBorrowOutstanding => {
-                    tx_by_addr::TransactionErrorType::AccountBorrowOutstanding
+                    tx_by_addr::TransactionErrorType::AccountBorrowOutstandingTx
                 }
             } as i32,
             instruction_error: match transaction_error {

--- a/storage-proto/src/transaction_by_addr.proto
+++ b/storage-proto/src/transaction_by_addr.proto
@@ -30,7 +30,7 @@ enum TransactionErrorType {
     PROGRAM_ACCOUNT_NOT_FOUND = 3;
     INSUFFICIENT_FUNDS_FOR_FEE = 4;
     INVALID_ACCOUNT_FOR_FEE = 5;
-    DUPLICATE_SIGNATURE = 6;
+    ALREADY_PROCESSED = 6;
     BLOCKHASH_NOT_FOUND = 7;
     INSTRUCTION_ERROR = 8;
     CALL_CHAIN_TOO_DEEP = 9;
@@ -40,6 +40,7 @@ enum TransactionErrorType {
     INVALID_PROGRAM_FOR_EXECUTION = 13;
     SANITIZE_FAILURE = 14;
     CLUSTER_MAINTENANCE = 15;
+    ACCOUNT_BORROW_OUTSTANDING_TX = 16;
 }
 
 message InstructionError {
@@ -97,6 +98,7 @@ enum InstructionErrorType {
     ACCOUNT_NOT_RENT_EXEMPT = 45;
     INVALID_ACCOUNT_OWNER = 46;
     ARITHMETIC_OVERFLOW = 47;
+    UNSUPPORTED_SYSVAR = 48;
 }
 
 message UnixTimestamp {

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -346,6 +346,7 @@ pub struct ConfirmedBlock {
     pub transactions: Vec<TransactionWithStatusMeta>,
     pub rewards: Rewards,
     pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
 }
 
 impl ConfirmedBlock {
@@ -361,6 +362,7 @@ impl ConfirmedBlock {
                 .collect(),
             rewards: self.rewards,
             block_time: self.block_time,
+            block_height: self.block_height,
         }
     }
 
@@ -403,6 +405,7 @@ impl ConfirmedBlock {
                 None
             },
             block_time: self.block_time,
+            block_height: self.block_height,
         }
     }
 }
@@ -416,6 +419,7 @@ pub struct EncodedConfirmedBlock {
     pub transactions: Vec<EncodedTransactionWithStatusMeta>,
     pub rewards: Rewards,
     pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -431,6 +435,7 @@ pub struct UiConfirmedBlock {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rewards: Option<Rewards>,
     pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
 }
 
 impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
@@ -443,6 +448,7 @@ impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
             signatures: None,
             rewards: Some(block.rewards),
             block_time: block.block_time,
+            block_height: block.block_height,
         }
     }
 }
@@ -456,6 +462,7 @@ impl From<UiConfirmedBlock> for EncodedConfirmedBlock {
             transactions: block.transactions.unwrap_or_default(),
             rewards: block.rewards.unwrap_or_default(),
             block_time: block.block_time,
+            block_height: block.block_height,
         }
     }
 }


### PR DESCRIPTION
#### Problem
As of https://github.com/solana-labs/solana/pull/17506, `last_valid_block_height` is available to assess recent-blockhash expiration. But it is only possible to get the block height of the current Bank (via `getBlockHeight` or `getEpochInfo` rpcs).

#### Summary of Changes
- Add block_height to ConfirmedBlock structs
- Create BlockHeight column in Blockstore
- Cache block height along with block time (and rename service to be more general, now that it's doing two things -- this is most of the churn)
- Return block_height with Blockstore block requests, which means it will also be stored in BigTable blocks
