### PR TITLE
Remove redundant copy from RocksDB get_cf() wrapper

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -353,7 +353,7 @@ impl Rocks {
     }
 
     fn get_cf(&self, cf: &ColumnFamily, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        let opt = self.0.get_cf(cf, key)?.map(|db_vec| db_vec.to_vec());
+        let opt = self.0.get_cf(cf, key)?;
         Ok(opt)
     }
 


### PR DESCRIPTION
#### Problem
Upon digging through our RocksDB wrapper code and chatting with @carllin, we discovered there is a redundant copy in the `get_bytes()` code path. This appears to be the result of an API change introduced into `rust-rocksdb` in v0.13.0. The discussion of that change is here: https://github.com/rust-rocksdb/rust-rocksdb/pull/345

Namely, the rocks function changed from [returning a C allocated byte array that could be accessed as a slice to returning a `Vector<u8>`](https://github.com/rust-rocksdb/rust-rocksdb/pull/345/files#diff-7d7d3a6ce5c2a3e8b39ce4f49b78a71365c8e06c0d9ddb78bc2dca68bfeb4a5bR963-R973). The updated rocks function already calls [`.to_vec()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.to_vec) which will copy the content to a new vector. We can return that vector as-is, no need to perform a copy on our side.

#### Summary of Changes
Remove the extra copy in our code