### PR TITLE
Add create-stake command to solana-tokens CLI

### DIFF
--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -149,6 +149,14 @@ where
                         .help("Keypair to fund accounts"),
                 )
                 .arg(
+                    Arg::with_name("unlocked_sol")
+                        .default_value("1.0")
+                        .long("unlocked-sol")
+                        .takes_value(true)
+                        .value_name("SOL_AMOUNT")
+                        .help("Amount of SOL to put in system account to pay for fees"),
+                )
+                .arg(
                     Arg::with_name("lockup_authority")
                         .long("lockup-authority")
                         .takes_value(true)

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -1,5 +1,6 @@
 use crate::args::{
-    Args, BalancesArgs, Command, DistributeTokensArgs, SplTokenArgs, StakeArgs, TransactionLogArgs,
+    Args, BalancesArgs, Command, DistributeTokensArgs, SenderStakeArgs, SplTokenArgs, StakeArgs,
+    TransactionLogArgs,
 };
 use clap::{
     crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand,
@@ -103,8 +104,71 @@ where
                 ),
         )
         .subcommand(
+            SubCommand::with_name("create-stake")
+                .about("Create stake accounts")
+                .arg(
+                    Arg::with_name("db_path")
+                        .long("db-path")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help(
+                            "Location for storing distribution database. \
+                            The database is used for tracking transactions as they are finalized \
+                            and preventing double spends.",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("input_csv")
+                        .long("input-csv")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("FILE")
+                        .help("Allocations CSV file"),
+                )
+                .arg(
+                    Arg::with_name("dry_run")
+                        .long("dry-run")
+                        .help("Do not execute any transfers"),
+                )
+                .arg(
+                    Arg::with_name("output_path")
+                        .long("output-path")
+                        .short("o")
+                        .value_name("FILE")
+                        .takes_value(true)
+                        .help("Write the transaction log to this file"),
+                )
+                .arg(
+                    Arg::with_name("sender_keypair")
+                        .long("from")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("SENDING_KEYPAIR")
+                        .validator(is_valid_signer)
+                        .help("Keypair to fund accounts"),
+                )
+                .arg(
+                    Arg::with_name("lockup_authority")
+                        .long("lockup-authority")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_valid_pubkey)
+                        .help("Lockup Authority Address"),
+                )
+                .arg(
+                    Arg::with_name("fee_payer")
+                        .long("fee-payer")
+                        .required(true)
+                        .takes_value(true)
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .help("Fee payer"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("distribute-stake")
-                .about("Distribute stake accounts")
+                .about("Split to stake accounts")
                 .arg(
                     Arg::with_name("db_path")
                         .long("db-path")
@@ -363,6 +427,58 @@ fn parse_distribute_tokens_args(
     })
 }
 
+fn parse_create_stake_args(
+    matches: &ArgMatches<'_>,
+) -> Result<DistributeTokensArgs, Box<dyn Error>> {
+    let mut wallet_manager = maybe_wallet_manager()?;
+    let signer_matches = ArgMatches::default(); // No default signer
+
+    let sender_keypair_str = value_t_or_exit!(matches, "sender_keypair", String);
+    let sender_keypair = signer_from_path(
+        &signer_matches,
+        &sender_keypair_str,
+        "sender",
+        &mut wallet_manager,
+    )?;
+
+    let fee_payer_str = value_t_or_exit!(matches, "fee_payer", String);
+    let fee_payer = signer_from_path(
+        &signer_matches,
+        &fee_payer_str,
+        "fee-payer",
+        &mut wallet_manager,
+    )?;
+
+    let lockup_authority_str = value_t!(matches, "lockup_authority", String).ok();
+    let lockup_authority = lockup_authority_str
+        .map(|path| {
+            pubkey_from_path(
+                &signer_matches,
+                &path,
+                "lockup authority",
+                &mut wallet_manager,
+            )
+        })
+        .transpose()?;
+
+    let stake_args = StakeArgs {
+        unlocked_sol: sol_to_lamports(value_t_or_exit!(matches, "unlocked_sol", f64)),
+        lockup_authority,
+        sender_stake_args: None,
+    };
+    Ok(DistributeTokensArgs {
+        input_csv: value_t_or_exit!(matches, "input_csv", String),
+        transaction_db: value_t_or_exit!(matches, "db_path", String),
+        output_path: matches.value_of("output_path").map(|path| path.to_string()),
+        dry_run: matches.is_present("dry_run"),
+        sender_keypair,
+        fee_payer,
+        stake_args: Some(stake_args),
+        spl_token_args: None,
+        transfer_amount: None,
+    })
+}
+
 fn parse_distribute_stake_args(
     matches: &ArgMatches<'_>,
 ) -> Result<DistributeTokensArgs, Box<dyn Error>> {
@@ -421,12 +537,17 @@ fn parse_distribute_stake_args(
         })
         .transpose()?;
 
-    let stake_args = StakeArgs {
+    let lockup_authority_address = lockup_authority.as_ref().map(|keypair| keypair.pubkey());
+    let sender_stake_args = SenderStakeArgs {
         stake_account_address,
-        unlocked_sol: sol_to_lamports(value_t_or_exit!(matches, "unlocked_sol", f64)),
         stake_authority,
         withdraw_authority,
         lockup_authority,
+    };
+    let stake_args = StakeArgs {
+        unlocked_sol: sol_to_lamports(value_t_or_exit!(matches, "unlocked_sol", f64)),
+        lockup_authority: lockup_authority_address,
+        sender_stake_args: Some(sender_stake_args),
     };
     Ok(DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
@@ -519,6 +640,9 @@ where
     let command = match matches.subcommand() {
         ("distribute-tokens", Some(matches)) => {
             Command::DistributeTokens(parse_distribute_tokens_args(matches)?)
+        }
+        ("create-stake", Some(matches)) => {
+            Command::DistributeTokens(parse_create_stake_args(matches)?)
         }
         ("distribute-stake", Some(matches)) => {
             Command::DistributeTokens(parse_distribute_stake_args(matches)?)

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -1,5 +1,18 @@
 use solana_sdk::{pubkey::Pubkey, signature::Signer};
 
+pub struct SenderStakeArgs {
+    pub stake_account_address: Pubkey,
+    pub stake_authority: Box<dyn Signer>,
+    pub withdraw_authority: Box<dyn Signer>,
+    pub lockup_authority: Option<Box<dyn Signer>>,
+}
+
+pub struct StakeArgs {
+    pub unlocked_sol: u64,
+    pub lockup_authority: Option<Pubkey>,
+    pub sender_stake_args: Option<SenderStakeArgs>,
+}
+
 pub struct DistributeTokensArgs {
     pub input_csv: String,
     pub transaction_db: String,
@@ -10,14 +23,6 @@ pub struct DistributeTokensArgs {
     pub stake_args: Option<StakeArgs>,
     pub spl_token_args: Option<SplTokenArgs>,
     pub transfer_amount: Option<u64>,
-}
-
-pub struct StakeArgs {
-    pub unlocked_sol: u64,
-    pub stake_account_address: Pubkey,
-    pub stake_authority: Box<dyn Signer>,
-    pub withdraw_authority: Box<dyn Signer>,
-    pub lockup_authority: Option<Box<dyn Signer>>,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
#### Problem

When we created the `solana-tokens` CLI, we only had locked up tokens and so the `distribute-stake` command requires a source stake account to split up and a lockup authority signer to change the target accounts' lockup dates. Now that we have unlocked tokens, it is tedious to manually move tokens into stake accounts just so `solana-tokens` can split them. Instead, it can skip the split and just create the stake accounts directly.

#### Summary of Changes

Add `create-stake` command to `solana-tokens` CLI.  It uses the `--from` System account to both send the `recipient` SOL for fees and to fund the new stake accounts. Unlike the `distribute-stake` stake command, it does not require a source stake account or a lockup authority signer.