### PR TITLE
add check_hash to non-index hash calculation

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1002,7 +1002,9 @@ pub fn process_accounts_package_pre(
         let (hash, lamports) = AccountsDb::calculate_accounts_hash_without_index(
             &accounts_package.storages,
             thread_pool,
-        );
+            false,
+        )
+        .unwrap();
 
         assert_eq!(accounts_package.expected_capitalization, lamports);
 


### PR DESCRIPTION
#### Problem
Prepare to replace index scan at startup with store (ie. non-index) scan. Index scan has 'check_hash' option to verify the hash value of each account.
#### Summary of Changes
add 'check_hash' to non-index scan.
Fixes #