### PR TITLE
increase bin count for hash scan

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4513,7 +4513,7 @@ impl AccountsDb {
         let mut scan_and_hash = move || {
             // When calculating hashes, it is helpful to break the pubkeys found into bins based on the pubkey value.
             // More bins means smaller vectors to sort, copy, etc.
-            const PUBKEY_BINS_FOR_CALCULATING_HASHES: usize = 64;
+            const PUBKEY_BINS_FOR_CALCULATING_HASHES: usize = 256;
 
             // # of passes should be a function of the total # of accounts that are active.
             // higher passes = slower total time, lower dynamic memory usage


### PR DESCRIPTION
#### Problem
When calculating hash of all accounts, accounts are divided into bins. Bin count is tunable. Setting it at its current max will help mnb and help 1B account sims.
#### Summary of Changes
Set at max.
Fixes #
