### PR TITLE
Always bail if program modifies a ro account

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2997,6 +2997,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-ro-account_modify"
+version = "1.8.0"
+dependencies = [
+ "solana-program 1.8.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-ro-modify"
 version = "1.8.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "rust/param_passing_dep",
     "rust/rand",
     "rust/ro_modify",
+    "rust/ro_account_modify",
     "rust/sanity",
     "rust/sha",
     "rust/spoof1",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -83,6 +83,7 @@ fn main() {
             "param_passing",
             "rand",
             "ro_modify",
+            "ro_account_modify",
             "sanity",
             "sha",
             "spoof1",

--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -17,6 +17,7 @@ static const uint8_t TEST_INSTRUCTION_META_TOO_LARGE = 10;
 static const uint8_t TEST_RETURN_ERROR = 11;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER = 12;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE = 13;
+static const uint8_t TEST_WRITABLE_DEESCALATION_WRITABLE = 14;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -271,24 +272,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
         sol_assert(accounts[ARGUMENT_INDEX].data[i] == 0);
       }
     }
-    sol_log("Test writable deescalation");
-    {
-      uint8_t buffer[10];
-      for (int i = 0; i < 10; i++) {
-        buffer[i] = accounts[INVOKED_ARGUMENT_INDEX].data[i];
-      }
-      SolAccountMeta arguments[] = {
-          {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
-      uint8_t data[] = {WRITE_ACCOUNT, 10};
-      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
-                                          arguments, SOL_ARRAY_SIZE(arguments),
-                                          data, SOL_ARRAY_SIZE(data)};
-      sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
-
-      for (int i = 0; i < 10; i++) {
-        sol_assert(buffer[i] == accounts[INVOKED_ARGUMENT_INDEX].data[i]);
-      }
-    }
     break;
   }
   case TEST_PRIVILEGE_ESCALATION_SIGNER: {
@@ -521,6 +504,25 @@ extern uint64_t entrypoint(const uint8_t *input) {
                sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
     break;
   }
+  case TEST_WRITABLE_DEESCALATION_WRITABLE: {
+  sol_log("Test writable deescalation");
+      uint8_t buffer[10];
+      for (int i = 0; i < 10; i++) {
+        buffer[i] = accounts[INVOKED_ARGUMENT_INDEX].data[i];
+      }
+      SolAccountMeta arguments[] = {
+          {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
+      uint8_t data[] = {WRITE_ACCOUNT, 10};
+      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                          arguments, SOL_ARRAY_SIZE(arguments),
+                                          data, SOL_ARRAY_SIZE(data)};
+      sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
+
+      for (int i = 0; i < 10; i++) {
+        sol_assert(buffer[i] == accounts[INVOKED_ARGUMENT_INDEX].data[i]);
+      }
+      break;
+    }
   default:
     sol_panic();
   }

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -29,6 +29,7 @@ const TEST_INSTRUCTION_META_TOO_LARGE: u8 = 10;
 const TEST_RETURN_ERROR: u8 = 11;
 const TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: u8 = 12;
 const TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE: u8 = 13;
+const TEST_WRITABLE_DEESCALATION_WRITABLE: u8 = 14;
 
 // const MINT_INDEX: usize = 0;
 const ARGUMENT_INDEX: usize = 1;
@@ -354,27 +355,6 @@ fn process_instruction(
                 }
             }
 
-            msg!("Test writable deescalation");
-            {
-                const NUM_BYTES: usize = 10;
-                let mut buffer = [0; NUM_BYTES];
-                buffer.copy_from_slice(
-                    &accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES],
-                );
-
-                let instruction = create_instruction(
-                    *accounts[INVOKED_PROGRAM_INDEX].key,
-                    &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
-                    vec![WRITE_ACCOUNT, NUM_BYTES as u8],
-                );
-                let _ = invoke(&instruction, accounts);
-
-                assert_eq!(
-                    buffer,
-                    accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]
-                );
-            }
-
             msg!("Create account and init data");
             {
                 let from_lamports = accounts[FROM_INDEX].lamports();
@@ -602,6 +582,25 @@ fn process_instruction(
                 vec![VERIFY_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE],
             );
             invoke(&invoked_instruction, accounts)?;
+        }
+        TEST_WRITABLE_DEESCALATION_WRITABLE => {
+            msg!("Test writable deescalation writable");
+            const NUM_BYTES: usize = 10;
+            let mut buffer = [0; NUM_BYTES];
+            buffer
+                .copy_from_slice(&accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]);
+
+            let instruction = create_instruction(
+                *accounts[INVOKED_PROGRAM_INDEX].key,
+                &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
+                vec![WRITE_ACCOUNT, NUM_BYTES as u8],
+            );
+            let _ = invoke(&instruction, accounts);
+
+            assert_eq!(
+                buffer,
+                accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]
+            );
         }
         _ => panic!(),
     }

--- a/programs/bpf/rust/ro_account_modify/Cargo.toml
+++ b/programs/bpf/rust/ro_account_modify/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-bpf-rust-ro-account_modify"
+version = "1.8.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-ro-modify"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.8.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/ro_account_modify/src/lib.rs
+++ b/programs/bpf/rust/ro_account_modify/src/lib.rs
@@ -1,0 +1,70 @@
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    msg,
+    program::invoke,
+    pubkey::Pubkey,
+};
+
+const ARGUMENT_INDEX: usize = 0;
+
+const INSTRUCTION_MODIFY: u8 = 0;
+const INSTRUCTION_INVOKE_MODIFY: u8 = 1;
+const INSTRUCTION_MODIFY_INVOKE: u8 = 2;
+const INSTRUCTION_VERIFY_MODIFIED: u8 = 3;
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    assert!(!accounts[ARGUMENT_INDEX].is_writable);
+
+    match instruction_data[0] {
+        INSTRUCTION_MODIFY => {
+            msg!("modify ro account");
+            assert_eq!(0, accounts[ARGUMENT_INDEX].try_borrow_data()?[0]);
+            accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0] = 1;
+        }
+        INSTRUCTION_INVOKE_MODIFY => {
+            msg!("invoke and modify ro account");
+
+            assert_eq!(0, accounts[ARGUMENT_INDEX].try_borrow_data()?[0]);
+
+            let instruction = Instruction {
+                program_id: *program_id,
+                accounts: vec![AccountMeta::new_readonly(
+                    *accounts[ARGUMENT_INDEX].key,
+                    false,
+                )],
+                data: vec![INSTRUCTION_MODIFY],
+            };
+            invoke(&instruction, accounts)?;
+        }
+        INSTRUCTION_MODIFY_INVOKE => {
+            msg!("modify and invoke ro account");
+
+            assert_eq!(0, accounts[ARGUMENT_INDEX].try_borrow_data()?[0]);
+            accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0] = 1;
+
+            let instruction = Instruction {
+                program_id: *program_id,
+                accounts: vec![AccountMeta::new_readonly(
+                    *accounts[ARGUMENT_INDEX].key,
+                    false,
+                )],
+                data: vec![INSTRUCTION_VERIFY_MODIFIED],
+            };
+            invoke(&instruction, accounts)?;
+        }
+        INSTRUCTION_VERIFY_MODIFIED => {
+            msg!("verify modified");
+            assert_eq!(1, accounts[ARGUMENT_INDEX].try_borrow_data()?[0])
+        }
+        _ => panic!("Unknown instruction"),
+    }
+    Ok(())
+}

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -32,7 +32,7 @@ use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Clock,
     entrypoint::SUCCESS,
-    feature_set::{skip_ro_deserialization, upgradeable_close_instruction},
+    feature_set::upgradeable_close_instruction,
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
     keyed_account::{from_keyed_account, keyed_account_at_index},
@@ -827,12 +827,7 @@ impl Executor for BpfExecutor {
         }
         let mut deserialize_time = Measure::start("deserialize");
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
-        deserialize_parameters(
-            loader_id,
-            keyed_accounts,
-            parameter_bytes.as_slice(),
-            invoke_context.is_feature_active(&skip_ro_deserialization::id()),
-        )?;
+        deserialize_parameters(loader_id, keyed_accounts, parameter_bytes.as_slice())?;
         deserialize_time.stop();
         invoke_context.update_timing(
             serialize_time.as_us(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -91,14 +91,6 @@ pub mod check_program_owner {
     solana_sdk::declare_id!("5XnbR5Es9YXEARRuP6mdvoxiW3hx5atNNeBmwVd8P3QD");
 }
 
-pub mod cpi_share_ro_and_exec_accounts {
-    solana_sdk::declare_id!("6VgVBi3uRVqp56TtEwNou8idgdmhCD1aYqX8FaJ1fnJb");
-}
-
-pub mod skip_ro_deserialization {
-    solana_sdk::declare_id!("6Sw5JV84f7QkDe8gvRxpcPWFnPpfpgEnNziiy8sELaCp");
-}
-
 pub mod require_stake_for_gossip {
     solana_sdk::declare_id!("6oNzd5Z3M2L1xo4Q5hoox7CR2DuW7m1ETLWH5jHJthwa");
 }
@@ -166,8 +158,6 @@ lazy_static! {
         (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
         (check_init_vote_data::id(), "check initialized Vote data"),
         (check_program_owner::id(), "limit programs to operating on accounts owned by itself"),
-        (cpi_share_ro_and_exec_accounts::id(), "share RO and Executable accounts during cross-program invocations"),
-        (skip_ro_deserialization::id(), "skip deserialization of read-only accounts"),
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),


### PR DESCRIPTION
#### Problem

Performance optimizations resulted in the runtime ignoring changes by programs that attempted to write to read-only accounts.

#### Summary of Changes

- Always bail if a program writes a read-only account
- Add and update tests to validate this

Fixes #
