### PR TITLE
Disable read-only optimization features

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -17,6 +17,7 @@ static const uint8_t TEST_INSTRUCTION_META_TOO_LARGE = 10;
 static const uint8_t TEST_RETURN_ERROR = 11;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER = 12;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE = 13;
+static const uint8_t TEST_WRITABLE_DEESCALATION_WRITABLE = 14;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -271,24 +272,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
         sol_assert(accounts[ARGUMENT_INDEX].data[i] == 0);
       }
     }
-    sol_log("Test writable deescalation");
-    {
-      uint8_t buffer[10];
-      for (int i = 0; i < 10; i++) {
-        buffer[i] = accounts[INVOKED_ARGUMENT_INDEX].data[i];
-      }
-      SolAccountMeta arguments[] = {
-          {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
-      uint8_t data[] = {WRITE_ACCOUNT, 10};
-      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
-                                          arguments, SOL_ARRAY_SIZE(arguments),
-                                          data, SOL_ARRAY_SIZE(data)};
-      sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
-
-      for (int i = 0; i < 10; i++) {
-        sol_assert(buffer[i] == accounts[INVOKED_ARGUMENT_INDEX].data[i]);
-      }
-    }
     break;
   }
   case TEST_PRIVILEGE_ESCALATION_SIGNER: {
@@ -521,6 +504,25 @@ extern uint64_t entrypoint(const uint8_t *input) {
                sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
     break;
   }
+  case TEST_WRITABLE_DEESCALATION_WRITABLE: {
+  sol_log("Test writable deescalation");
+      uint8_t buffer[10];
+      for (int i = 0; i < 10; i++) {
+        buffer[i] = accounts[INVOKED_ARGUMENT_INDEX].data[i];
+      }
+      SolAccountMeta arguments[] = {
+          {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
+      uint8_t data[] = {WRITE_ACCOUNT, 10};
+      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                          arguments, SOL_ARRAY_SIZE(arguments),
+                                          data, SOL_ARRAY_SIZE(data)};
+      sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
+
+      for (int i = 0; i < 10; i++) {
+        sol_assert(buffer[i] == accounts[INVOKED_ARGUMENT_INDEX].data[i]);
+      }
+      break;
+    }
   default:
     sol_panic();
   }

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -29,6 +29,7 @@ const TEST_INSTRUCTION_META_TOO_LARGE: u8 = 10;
 const TEST_RETURN_ERROR: u8 = 11;
 const TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: u8 = 12;
 const TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE: u8 = 13;
+const TEST_WRITABLE_DEESCALATION_WRITABLE: u8 = 14;
 
 // const MINT_INDEX: usize = 0;
 const ARGUMENT_INDEX: usize = 1;
@@ -354,27 +355,6 @@ fn process_instruction(
                 }
             }
 
-            msg!("Test writable deescalation");
-            {
-                const NUM_BYTES: usize = 10;
-                let mut buffer = [0; NUM_BYTES];
-                buffer.copy_from_slice(
-                    &accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES],
-                );
-
-                let instruction = create_instruction(
-                    *accounts[INVOKED_PROGRAM_INDEX].key,
-                    &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
-                    vec![WRITE_ACCOUNT, NUM_BYTES as u8],
-                );
-                let _ = invoke(&instruction, accounts);
-
-                assert_eq!(
-                    buffer,
-                    accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]
-                );
-            }
-
             msg!("Create account and init data");
             {
                 let from_lamports = accounts[FROM_INDEX].lamports();
@@ -602,6 +582,25 @@ fn process_instruction(
                 vec![VERIFY_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE],
             );
             invoke(&invoked_instruction, accounts)?;
+        }
+        TEST_WRITABLE_DEESCALATION_WRITABLE => {
+            msg!("Test writable deescalation writable");
+            const NUM_BYTES: usize = 10;
+            let mut buffer = [0; NUM_BYTES];
+            buffer
+                .copy_from_slice(&accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]);
+
+            let instruction = create_instruction(
+                *accounts[INVOKED_PROGRAM_INDEX].key,
+                &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
+                vec![WRITE_ACCOUNT, NUM_BYTES as u8],
+            );
+            let _ = invoke(&instruction, accounts);
+
+            assert_eq!(
+                buffer,
+                accounts[INVOKED_ARGUMENT_INDEX].data.borrow_mut()[..NUM_BYTES]
+            );
         }
         _ => panic!(),
     }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -753,6 +753,7 @@ fn test_program_bpf_invoke_sanity() {
     const TEST_RETURN_ERROR: u8 = 11;
     const TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: u8 = 12;
     const TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE: u8 = 13;
+    const TEST_WRITABLE_DEESCALATION_WRITABLE: u8 = 14;
 
     #[allow(dead_code)]
     #[derive(Debug)]
@@ -870,12 +871,10 @@ fn test_program_bpf_invoke_sanity() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
-                invoked_program_id.clone(),
             ],
             Languages::Rust => vec![
                 solana_sdk::system_program::id(),
                 solana_sdk::system_program::id(),
-                invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
@@ -993,6 +992,12 @@ fn test_program_bpf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
+            &[invoked_program_id.clone()],
+        );
+
+        do_invoke_failure_test_local(
+            TEST_WRITABLE_DEESCALATION_WRITABLE,
+            TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified),
             &[invoked_program_id.clone()],
         );
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -165,8 +165,6 @@ lazy_static! {
         (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
         (check_init_vote_data::id(), "check initialized Vote data"),
         (check_program_owner::id(), "limit programs to operating on accounts owned by itself"),
-        (cpi_share_ro_and_exec_accounts::id(), "share RO and Executable accounts during cross-program invocations"),
-        (skip_ro_deserialization::id(), "skip deserialization of read-only accounts"),
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),


### PR DESCRIPTION
#### Problem

To RO optimizations discard written read-only data instead of halting the program

#### Summary of Changes

Disable these features

Fixes #
