### PR TITLE
parallel get_snapshot_storages

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -444,7 +444,10 @@ impl BankRc {
     }
 
     pub fn get_snapshot_storages(&self, slot: Slot) -> SnapshotStorages {
-        self.accounts.accounts_db.get_snapshot_storages(slot, None)
+        self.accounts
+            .accounts_db
+            .get_snapshot_storages(slot, None)
+            .0
     }
 }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -28,7 +28,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
     accounts_db: &AccountsDb,
     output_dir: P,
 ) -> std::io::Result<UnpackedAppendVecMap> {
-    let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value(), None);
+    let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value(), None).0;
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
     for storage in storage_entries.iter().flatten() {
         let storage_path = storage.get_path();
@@ -142,7 +142,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &mut writer,
         &*accounts.accounts_db,
         0,
-        &accounts.accounts_db.get_snapshot_storages(0, None),
+        &accounts.accounts_db.get_snapshot_storages(0, None).0,
     )
     .unwrap();
 
@@ -243,7 +243,7 @@ pub(crate) fn reconstruct_accounts_db_via_serialization(
     slot: Slot,
 ) -> AccountsDb {
     let mut writer = Cursor::new(vec![]);
-    let snapshot_storages = accounts.get_snapshot_storages(slot, None);
+    let snapshot_storages = accounts.get_snapshot_storages(slot, None).0;
     accountsdb_to_stream(
         SerdeStyle::Newer,
         &mut writer,
@@ -301,7 +301,12 @@ mod test_bank_serialize {
     where
         S: serde::Serializer,
     {
-        let snapshot_storages = bank.rc.accounts.accounts_db.get_snapshot_storages(0, None);
+        let snapshot_storages = bank
+            .rc
+            .accounts
+            .accounts_db
+            .get_snapshot_storages(0, None)
+            .0;
         // ensure there is a single snapshot storage example for ABI digesting
         assert_eq!(snapshot_storages.len(), 1);
 


### PR DESCRIPTION
#### Problem
Getting snapshots is serially in line in accounts bg svc before clean, flush cache, shrink, hash calc, etc. Speeding it up would be useful. It will also be useful to have slots already pulled out because getting slot #s is relatively expensive. We are also replacing other calls that currently use index scans to use store scans. Getting storages will be called in more places. All the places that call to get storages immediately spin up threads to act on the storages in parallel.

#### Summary of Changes
get snapshots more quickly and get slot#s at the same time. The slot #s will be used in subsequent prs.
Fixes #
