### PR TITLE
add Ancestors to get_snapshot_storages to prepare for the future

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4245,7 +4245,7 @@ impl AccountsDb {
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         if !use_index {
             let mut time = Measure::start("collect");
-            let combined_maps = self.get_snapshot_storages(slot);
+            let combined_maps = self.get_snapshot_storages(slot, Some(ancestors));
             time.stop();
 
             let timings = HashStats {
@@ -5133,7 +5133,11 @@ impl AccountsDb {
         }
     }
 
-    pub fn get_snapshot_storages(&self, snapshot_slot: Slot) -> SnapshotStorages {
+    pub fn get_snapshot_storages(
+        &self,
+        snapshot_slot: Slot,
+        _ancestors: Option<&Ancestors>,
+    ) -> SnapshotStorages {
         self.storage
             .0
             .iter()
@@ -5732,7 +5736,7 @@ pub mod tests {
         accounts.store_uncached(slot, &to_store[..]);
         accounts.add_root(slot);
 
-        let storages = accounts.get_snapshot_storages(slot);
+        let storages = accounts.get_snapshot_storages(slot, None);
         (storages, raw_expected)
     }
 
@@ -8127,7 +8131,7 @@ pub mod tests {
     #[test]
     fn test_get_snapshot_storages_empty() {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
-        assert!(db.get_snapshot_storages(0).is_empty());
+        assert!(db.get_snapshot_storages(0, None).is_empty());
     }
 
     #[test]
@@ -8142,10 +8146,10 @@ pub mod tests {
 
         db.add_root(base_slot);
         db.store_uncached(base_slot, &[(&key, &account)]);
-        assert!(db.get_snapshot_storages(before_slot).is_empty());
+        assert!(db.get_snapshot_storages(before_slot, None).is_empty());
 
-        assert_eq!(1, db.get_snapshot_storages(base_slot).len());
-        assert_eq!(1, db.get_snapshot_storages(after_slot).len());
+        assert_eq!(1, db.get_snapshot_storages(base_slot, None).len());
+        assert_eq!(1, db.get_snapshot_storages(after_slot, None).len());
     }
 
     #[test]
@@ -8165,10 +8169,10 @@ pub mod tests {
             .unwrap()
             .clear();
         db.add_root(base_slot);
-        assert!(db.get_snapshot_storages(after_slot).is_empty());
+        assert!(db.get_snapshot_storages(after_slot, None).is_empty());
 
         db.store_uncached(base_slot, &[(&key, &account)]);
-        assert_eq!(1, db.get_snapshot_storages(after_slot).len());
+        assert_eq!(1, db.get_snapshot_storages(after_slot, None).len());
     }
 
     #[test]
@@ -8181,10 +8185,10 @@ pub mod tests {
         let after_slot = base_slot + 1;
 
         db.store_uncached(base_slot, &[(&key, &account)]);
-        assert!(db.get_snapshot_storages(after_slot).is_empty());
+        assert!(db.get_snapshot_storages(after_slot, None).is_empty());
 
         db.add_root(base_slot);
-        assert_eq!(1, db.get_snapshot_storages(after_slot).len());
+        assert_eq!(1, db.get_snapshot_storages(after_slot, None).len());
     }
 
     #[test]
@@ -8198,7 +8202,7 @@ pub mod tests {
 
         db.store_uncached(base_slot, &[(&key, &account)]);
         db.add_root(base_slot);
-        assert_eq!(1, db.get_snapshot_storages(after_slot).len());
+        assert_eq!(1, db.get_snapshot_storages(after_slot, None).len());
 
         db.storage
             .get_slot_stores(0)
@@ -8209,7 +8213,7 @@ pub mod tests {
             .next()
             .unwrap()
             .remove_account(0, true);
-        assert!(db.get_snapshot_storages(after_slot).is_empty());
+        assert!(db.get_snapshot_storages(after_slot, None).is_empty());
     }
 
     #[test]
@@ -8373,7 +8377,7 @@ pub mod tests {
         accounts.store_uncached(current_slot, &[(&pubkey2, &zero_lamport_account)]);
         accounts.store_uncached(current_slot, &[(&pubkey3, &zero_lamport_account)]);
 
-        let snapshot_stores = accounts.get_snapshot_storages(current_slot);
+        let snapshot_stores = accounts.get_snapshot_storages(current_slot, None);
         let total_accounts: usize = snapshot_stores
             .iter()
             .flatten()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -444,7 +444,7 @@ impl BankRc {
     }
 
     pub fn get_snapshot_storages(&self, slot: Slot) -> SnapshotStorages {
-        self.accounts.accounts_db.get_snapshot_storages(slot)
+        self.accounts.accounts_db.get_snapshot_storages(slot, None)
     }
 }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -28,7 +28,7 @@ fn copy_append_vecs<P: AsRef<Path>>(
     accounts_db: &AccountsDb,
     output_dir: P,
 ) -> std::io::Result<UnpackedAppendVecMap> {
-    let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
+    let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value(), None);
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
     for storage in storage_entries.iter().flatten() {
         let storage_path = storage.get_path();
@@ -142,7 +142,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &mut writer,
         &*accounts.accounts_db,
         0,
-        &accounts.accounts_db.get_snapshot_storages(0),
+        &accounts.accounts_db.get_snapshot_storages(0, None),
     )
     .unwrap();
 
@@ -243,7 +243,7 @@ pub(crate) fn reconstruct_accounts_db_via_serialization(
     slot: Slot,
 ) -> AccountsDb {
     let mut writer = Cursor::new(vec![]);
-    let snapshot_storages = accounts.get_snapshot_storages(slot);
+    let snapshot_storages = accounts.get_snapshot_storages(slot, None);
     accountsdb_to_stream(
         SerdeStyle::Newer,
         &mut writer,
@@ -301,7 +301,7 @@ mod test_bank_serialize {
     where
         S: serde::Serializer,
     {
-        let snapshot_storages = bank.rc.accounts.accounts_db.get_snapshot_storages(0);
+        let snapshot_storages = bank.rc.accounts.accounts_db.get_snapshot_storages(0, None);
         // ensure there is a single snapshot storage example for ABI digesting
         assert_eq!(snapshot_storages.len(), 1);
 


### PR DESCRIPTION
#### Problem
We will soon need ancestors to get snapshots. This change is noisy.
#### Summary of Changes
Add the parameter now.
Fixes #
