### PR TITLE
Make the sys-tuner oneliner actually copy-pastable

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -60,7 +60,7 @@ the latest recommended settings are applied.
 To run it:
 
 ```bash
-sudo solana-sys-tuner --user $(whoami) > sys-tuner.log 2>&1 &
+sudo $(type -p solana-sys-tuner) --user $(whoami) > sys-tuner.log 2>&1 &
 ```
 
 #### Manual

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -60,7 +60,7 @@ the latest recommended settings are applied.
 To run it:
 
 ```bash
-sudo $(type -p solana-sys-tuner) --user $(whoami) > sys-tuner.log 2>&1 &
+sudo $(command -v solana-sys-tuner) --user $(whoami) > sys-tuner.log 2>&1 &
 ```
 
 #### Manual


### PR DESCRIPTION
#### Problem

```
$ sudo solana-sys-tuner --user $(whoami)
sudo: solana-sys-tuner: command not found
```

because

```
$ type -p solana-sys-tuner
/home/sol/.local/share/solana/install/active_release/bin/solana-sys-tuner
$ sudo bash -c 'echo "$PATH"'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
```

#### Summary of Changes

```
$ sudo $(type -p solana-sys-tuner) --user $(whoami) --version
solana-sys-tuner 1.6.7 (src:ebb5fc12; feat:3458834192)
```

I think the bashism is ok for solana. :)

part of #13443 