### PR TITLE
feat: add decodeUnchecked to borsh-schema.ts

### DIFF
--- a/web3.js/src/util/borsh-schema.ts
+++ b/web3.js/src/util/borsh-schema.ts
@@ -1,5 +1,5 @@
 import {Buffer} from 'buffer';
-import {serialize, deserialize} from 'borsh';
+import {serialize, deserialize, deserializeUnchecked} from 'borsh';
 
 // Class wrapping a plain object
 export class Struct {
@@ -13,6 +13,10 @@ export class Struct {
 
   static decode(data: Buffer): any {
     return deserialize(SOLANA_SCHEMA, this, data);
+  }
+
+  static decodeUnchecked(data: Buffer): any {
+    return deserializeUnchecked(SOLANA_SCHEMA, this, data);
   }
 }
 

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -228,4 +228,11 @@ describe('PublicKey', function () {
     const decoded = PublicKey.decode(encoded);
     expect(decoded.equals(publicKey)).to.be.true;
   });
+
+  it('canBeDeserializedUncheckedWithBorsh', () => {
+    const publicKey = Keypair.generate().publicKey;
+    const encoded = Buffer.concat([publicKey.encode(), new Uint8Array(10)]);
+    const decoded = PublicKey.decodeUnchecked(encoded);
+    expect(decoded.equals(publicKey)).to.be.true;
+  });
 });


### PR DESCRIPTION
https://github.com/solana-labs/solana-program-library/pull/1656#discussion_r642598440

Add function `decodeUnchecked` in `borsh-schema.ts` which calls `deserializeUnchecked` under the hood, for use in decoding `ValidatorList` objects.

@joncinque 