### PR TITLE
fix: allow messages to be compiled without instructions

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -214,7 +214,7 @@ export class Transaction {
     }
 
     if (this.instructions.length < 1) {
-      throw new Error('No instructions provided');
+      console.warn('No instructions provided');
     }
 
     let feePayer: PublicKey;

--- a/web3.js/test/transaction.test.ts
+++ b/web3.js/test/transaction.test.ts
@@ -65,9 +65,7 @@ describe('Transaction', () => {
 
     it('validation', () => {
       const payer = Keypair.generate();
-      const other = Keypair.generate();
       const recentBlockhash = Keypair.generate().publicKey.toBase58();
-      const programId = Keypair.generate().publicKey;
 
       const transaction = new Transaction();
       expect(() => {
@@ -75,18 +73,6 @@ describe('Transaction', () => {
       }).to.throw('Transaction recentBlockhash required');
 
       transaction.recentBlockhash = recentBlockhash;
-
-      expect(() => {
-        transaction.compileMessage();
-      }).to.throw('No instructions provided');
-
-      transaction.add({
-        keys: [
-          {pubkey: other.publicKey, isSigner: true, isWritable: true},
-          {pubkey: payer.publicKey, isSigner: true, isWritable: true},
-        ],
-        programId,
-      });
 
       expect(() => {
         transaction.compileMessage();


### PR DESCRIPTION
#### Problem
Transactions are allowed to not have any instructions but the sdk throws an error when this situation is detected. This causes issues when handling past transactions without instructions.

#### Summary of Changes
- Log warning instead of throwing an error when handling a transaction without instructions.

Fixes https://github.com/solana-labs/solana-web3.js/issues/1038
