### PR TITLE
Support running `cargo build` from an Apple M1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,5 +79,10 @@ exclude = [
     "programs/bpf",
 ]
 
+# TODO: Remove once the "simd-accel" feature from the reed-solomon-erasure
+# dependency is supported on Apple M1. v2 of the feature resolver is needed to
+# specify arch-specific features.
+resolver = "2"
+
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,7 +30,6 @@ prost = "0.7.0"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.0"
-reed-solomon-erasure = { version = "4.0.2", features = ["simd-accel"] }
 serde = "1.0.126"
 serde_bytes = "0.11.5"
 sha2 = "0.9.5"
@@ -55,6 +54,14 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 trees = "0.2.1"
+
+# Disable reed-solomon-erasure/simd-accel feature on aarch64 only since it
+# requires clang to support -march=native.
+[target.'cfg(any(target_arch = "aarch64", target_arch = "aarch64_apple_darwin"))'.dependencies]
+reed-solomon-erasure = { version = "4.0.2" }
+
+[target.'cfg(not(any(target_arch = "aarch64", target_arch = "aarch64_apple_darwin")))'.dependencies]
+reed-solomon-erasure = { version = "4.0.2", features = ["simd-accel"] }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts


### PR DESCRIPTION
#### Problem
I tried to run `cargo build` on my Apple M1 macbook and ran into a couple of build problems. This PR fixes those build problems so that `cargo build` can be run natively on M1.

#### Summary of Changes
- Update feature resolver to v2 to allow architecture-specific features
- Don't compile the `reed-solomon-erasure` dependency with the `simd-accel` feature on aarch64 since this is not supported on M1 (due to clang not supporting `-march=native` on M1). Note this change is arch-specific. Non-aarch64 architectures still compile with `simd-accel` enabled.
- Skip calling `is_x86_feature_detected` in a benchmark if running on non-x86 arch since this macro is unsupported otherwise.

#### Notes
- This is my first time interacting with the rust ecosystem, so please assume zero knowledge. The proposed changes are currently quite verbose, what's the best way to make them a bit more concise?
- ~The arch checks are currently very specific to aarch64. Another option is to keep aarch64 checks in Cargo.toml (clang -march flag issue), but change the target arch check in the benchmark to be `if x86` rather than `if !aarch64`~ implemented.