### PR TITLE
Purge expired BlockHeight data from blockstore

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -291,6 +291,10 @@ impl Blockstore {
             && self
                 .perf_samples_cf
                 .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
+                .block_height_cf
+                .compact_range(from_slot, to_slot)
                 .unwrap_or(false);
         compact_timer.stop();
         if !result {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -178,6 +178,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_range_cf::<cf::PerfSamples>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::BlockHeight>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
         let mut w_active_transaction_status_index =
             self.active_transaction_status_index.write().unwrap();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -340,6 +340,7 @@ impl Rocks {
             BlockHeight::NAME,
             get_cf_options::<BlockHeight>(&access_type, &oldest_slot),
         );
+        // Don't forget to add to run_purge_with_stats() in ledger/src/blockstore/blockstore_purge.rs!!
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -340,7 +340,8 @@ impl Rocks {
             BlockHeight::NAME,
             get_cf_options::<BlockHeight>(&access_type, &oldest_slot),
         );
-        // Don't forget to add to run_purge_with_stats() in ledger/src/blockstore/blockstore_purge.rs!!
+        // Don't forget to add to both run_purge_with_stats() and
+        // compact_storage() in ledger/src/blockstore/blockstore_purge.rs!!
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),


### PR DESCRIPTION
#### Problem

block_height cf's data is never removed.

Fortunately, storage impact should be very small.

#### Summary of Changes

Purge it correctly and add reminder comment to avoid future re-occurrence.

follow up to #17523 
