### PR TITLE
skips values which are within push-window when generating pull-responses

### DIFF
--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -260,8 +260,13 @@ impl CrdsGossip {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
     ) -> Vec<Vec<CrdsValue>> {
-        self.pull
-            .generate_pull_responses(&self.crds, filters, output_size_limit, now)
+        self.pull.generate_pull_responses(
+            &self.crds,
+            filters,
+            output_size_limit,
+            self.push.wallclock_window(now),
+            now,
+        )
     }
 
     pub fn filter_pull_responses(

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -160,7 +160,8 @@ impl CrdsGossipPush {
             .collect()
     }
 
-    fn wallclock_window(&self, now: u64) -> impl RangeBounds<u64> {
+    // Returns wallclock window of values which are pushed between nodes.
+    pub(crate) fn wallclock_window(&self, now: u64) -> impl RangeBounds<u64> {
         now.saturating_sub(self.msg_timeout)..=now.saturating_add(self.msg_timeout)
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2544,7 +2544,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     cluster.restart_node(&validator_c_pubkey, validator_c_info);
 
     let mut votes_on_c_fork = std::collections::BTreeSet::new(); // S4 and S5
-    for _ in 0..100 {
+    for _ in 0..900 {
         sleep(Duration::from_millis(100));
 
         if let Some((last_vote, _)) = last_vote_in_tower(&val_c_ledger_path, &validator_c_pubkey) {


### PR DESCRIPTION


#### Problem
Gossip pull-response traffic shows a lot of relatively new values
(mostly votes) which by the time they are processed at the receiving
end, they are already available in its crds table (from push messages).

#### Summary of Changes
There is currently some existing logic to skip new values in pull
responses:
https://github.com/solana-labs/solana/blob/a0d721c6b/gossip/src/crds_gossip_pull.rs#L506-L509

This commit expands above logic by skipping all values which are recent
enough that are still pushed between nodes, except for:
* contact-infos: since when starting a validator, it does not receive
  any push-messages until it adopts entrypoint shred version.
* node-instances: since it is best to broadcast duplicate instances
  through all possible channels as soon as possible.
