### PR TITLE
recalibrate cost limit

### DIFF
--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -32,8 +32,8 @@ const NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST: u32 = COST_UNIT;
 // is 575_687, and the largest chain cost (eg account cost) is 559_000
 // Configuring cost model to have larger block limit and smaller account limit
 // to encourage packing parallelizable transactions in block.
-pub const ACCOUNT_MAX_COST: u32 = COST_UNIT * 10_000;
-pub const BLOCK_MAX_COST: u32 = COST_UNIT * 10_000_000;
+pub const ACCOUNT_MAX_COST: u32 = COST_UNIT * 200_000;
+pub const BLOCK_MAX_COST: u32 = COST_UNIT * 500_000;
 
 // cost of transaction is made of account_access_cost and instruction execution_cost
 // where

--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -33,7 +33,7 @@ const NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST: u32 = COST_UNIT;
 // Configuring cost model to have larger block limit and smaller account limit
 // to encourage packing parallelizable transactions in block.
 pub const ACCOUNT_MAX_COST: u32 = COST_UNIT * 200_000;
-pub const BLOCK_MAX_COST: u32 = COST_UNIT * 500_000;
+pub const BLOCK_MAX_COST: u32 = COST_UNIT * 5_000_000;
 
 // cost of transaction is made of account_access_cost and instruction execution_cost
 // where


### PR DESCRIPTION
#### Problem
issue #17636 

#### Summary of Changes
Recalibrate cost limits by running latest build on recent snapshot, using ledger-tool to collect the stats.

Fixes #
