### PR TITLE
remove antiquated assert

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -677,14 +677,6 @@ impl AccountsHash {
                         i = k;
                         look_for_first_key = false;
                         continue 'outer;
-                    } else {
-                        let prev = &slice[k - 1];
-                        assert!(
-                            !(prev.slot == now.slot
-                                && prev.version == now.version
-                                && (prev.hash != now.hash || prev.lamports != now.lamports)),
-                            "Conflicting store data. Pubkey: {}, Slot: {}, Version: {}, Hashes: {}, {}, Lamports: {}, {}", now.pubkey, now.slot, now.version, prev.hash, now.hash, prev.lamports, now.lamports
-                        );
                     }
                 }
 


### PR DESCRIPTION
#### Problem
This assert was added when we were tracking hash calculation inconsistencies. Future refactoring of this code path will make this assert not make sense. This assert has never triggered.
#### Summary of Changes
Removing the assert now to be explicit about that decision.
Fixes #
