### PR TITLE
rework hash calculation to not keep slot and write version

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4222,14 +4222,18 @@ impl AccountsDb {
         (0..chunks)
             .into_par_iter()
             .map(|chunk| {
+                let mut slot_last = 0;
                 let mut retval = B::default();
                 let start = snapshot_storages.range().start + chunk * MAX_ITEMS_PER_CHUNK;
                 let end = std::cmp::min(start + MAX_ITEMS_PER_CHUNK, snapshot_storages.range().end);
                 for slot in start..end {
                     let sub_storages = snapshot_storages.get(slot);
                     if let Some(sub_storages) = sub_storages {
+                        assert!(sub_storages.len() == 1);
                         for storage in sub_storages {
                             let slot = storage.slot();
+                            assert!(slot >= slot_last);
+                            slot_last = slot;
                             let accounts = storage.accounts.accounts(0);
                             accounts.into_iter().for_each(|stored_account| {
                                 scan_func(LoadedAccount::Stored(stored_account), &mut retval, slot)

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -676,26 +676,23 @@ impl AccountsHash {
             'outer: loop {
                 // at start of loop, item at 'i' is the first entry for a given pubkey - unless look_for_first
                 let now = &slice[i];
-                let last = now.pubkey;
+                let last = now;
                 if !look_for_first_key && now.lamports != ZERO_RAW_LAMPORTS_SENTINEL {
                     // first entry for this key that starts in our slice
                     result.push(now.hash);
                     sum += now.lamports as u128;
                 }
                 for (k, now) in slice.iter().enumerate().skip(i + 1) {
-                    if now.pubkey != last {
+                    if now.pubkey != last.pubkey {
                         i = k;
                         look_for_first_key = false;
                         continue 'outer;
                     } else {
-                        let prev = &slice[k - 1];
-                        assert!(
-                            !(prev.slot == now.slot
-                                && prev.version == now.version
-                                && (prev.hash != now.hash || prev.lamports != now.lamports)),
-                            "Conflicting store data. Pubkey: {}, Slot: {}, Version: {}, Hashes: {}, {}, Lamports: {}, {}", now.pubkey, now.slot, now.version, prev.hash, now.hash, prev.lamports, now.lamports
-                        );
+                        assert!(now.slot <= last.slot);
+                        if now.slot == last.slot {
+                            assert!(now.version < last.version);
                     }
+                }
                 }
 
                 break; // ran out of items in our slice, so our slice is done

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -681,14 +681,15 @@ impl AccountsHash {
                         sum += now.lamports as u128;
                     }
                     insert_item = false;
-                    if i + 1 == len {
+                    i += 1;
+                    if i == len {
                         break;
                     }
-                    i += 1;
                     now = &slice[i];
                 }
                 for (k, now) in slice.iter().enumerate().skip(i + 1) {
                     if now.pubkey != last.pubkey {
+                        assert!(now.pubkey > last.pubkey);
                         i = k - 1;
                         insert_item = true;
                         continue 'outer;

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -673,7 +673,7 @@ impl AccountsHash {
             'outer: loop {
                 // at start of loop, item at 'i' is the first entry for a given pubkey - unless look_for_first
                 let mut now = &slice[i];
-                let last = now;
+                let mut last = now;
                 if insert_item {
                     if now.lamports != ZERO_RAW_LAMPORTS_SENTINEL {
                         // first entry for this key that starts in our slice
@@ -686,6 +686,7 @@ impl AccountsHash {
                         break;
                     }
                     now = &slice[i];
+                    last = now;
                 }
                 for (k, now) in slice.iter().enumerate().skip(i + 1) {
                     if now.pubkey != last.pubkey {


### PR DESCRIPTION
#### Problem
It is constant time work to sort 400k storages by slot as opposed to n*lg(n)? [n=# accounts] work to sort account data by slot later.
Also, dragging around Slot and write_version per account can get expensive.
#### Summary of Changes
Take advantage of the fact that storages are sorted by slot to reduce the data we keep and eventually speed up hash and lamport calculation overall. Note that this isn't faster overall yet. So, this pr likely won't be submitted until the next phases and supporting pieces are ready. But, this is a logical unit of work.

Fixes #
