### PR TITLE
adds fallback logic if retransmit multicast fails

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -465,9 +465,9 @@ fn retransmit(
 
         let mut retransmit_time = Measure::start("retransmit_to");
         if !packet.meta.forward {
-            ClusterInfo::retransmit_to(&neighbors, packet, sock, true)?;
+            ClusterInfo::retransmit_to(&neighbors, packet, sock, true);
         }
-        ClusterInfo::retransmit_to(&children, packet, sock, packet.meta.forward)?;
+        ClusterInfo::retransmit_to(&children, packet, sock, packet.meta.forward);
         retransmit_time.stop();
         retransmit_total += retransmit_time.as_us();
     }

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -209,7 +209,7 @@ pub fn cluster_info_retransmit() {
     p.meta.size = 10;
     let peers = c1.tvu_peers();
     let retransmit_peers: Vec<_> = peers.iter().collect();
-    ClusterInfo::retransmit_to(&retransmit_peers, &p, &tn1, false).unwrap();
+    ClusterInfo::retransmit_to(&retransmit_peers, &p, &tn1, false);
     let res: Vec<_> = [tn1, tn2, tn3]
         .into_par_iter()
         .map(|s| {


### PR DESCRIPTION
#### Problem
In retransmit-stage, based on the `packet.meta.seed` and resulting
children/neighbors, each packet is sent to a different set of peers:
https://github.com/solana-labs/solana/blob/708bbcb00/core/src/retransmit_stage.rs#L421-L457

However, current code errors out as soon as a multicast call fails,
which will skip all the remaining packets:
https://github.com/solana-labs/solana/blob/708bbcb00/core/src/retransmit_stage.rs#L467-L470

This can exacerbate packets loss in turbine.

#### Summary of Changes
This commit:
  * keeps iterating over retransmit packets for loop even if some
    intermediate sends fail.
  * adds a fallback to `UdpSocket::send_to` if `multicast` fails.

Recent discord chat:
https://discord.com/channels/428295358100013066/689412830075551748/849530845052403733

