### PR TITLE
Rename ValidatorExit and move to sdk

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3,7 +3,6 @@
 use crate::{
     rpc_health::*,
     send_transaction_service::{SendTransactionService, TransactionInfo},
-    validator::ValidatorExit,
 };
 use bincode::{config::Options, serialize};
 use jsonrpc_core::{types::error, Error, Metadata, Result};
@@ -58,6 +57,7 @@ use solana_sdk::{
     commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
+    exit::Exit,
     hash::Hash,
     pubkey::Pubkey,
     sanitize::Sanitize,
@@ -148,7 +148,7 @@ pub struct JsonRpcRequestProcessor {
     blockstore: Arc<Blockstore>,
     config: JsonRpcConfig,
     snapshot_config: Option<SnapshotConfig>,
-    validator_exit: Arc<RwLock<ValidatorExit>>,
+    validator_exit: Arc<RwLock<Exit>>,
     health: Arc<RpcHealth>,
     cluster_info: Arc<ClusterInfo>,
     genesis_hash: Hash,
@@ -235,7 +235,7 @@ impl JsonRpcRequestProcessor {
         bank_forks: Arc<RwLock<BankForks>>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         blockstore: Arc<Blockstore>,
-        validator_exit: Arc<RwLock<ValidatorExit>>,
+        validator_exit: Arc<RwLock<Exit>>,
         health: Arc<RpcHealth>,
         cluster_info: Arc<ClusterInfo>,
         genesis_hash: Hash,
@@ -3772,8 +3772,8 @@ fn deserialize_transaction(
         .map(|transaction| (wire_transaction, transaction))
 }
 
-pub(crate) fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<ValidatorExit>> {
-    let mut validator_exit = ValidatorExit::default();
+pub(crate) fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<Exit>> {
+    let mut validator_exit = Exit::default();
     let exit_ = exit.clone();
     validator_exit.register_exit(Box::new(move || exit_.store(true, Ordering::Relaxed)));
     Arc::new(RwLock::new(validator_exit))

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -6,7 +6,6 @@ use crate::{
     rpc::{rpc_deprecated_v1_7::*, rpc_full::*, rpc_minimal::*, rpc_obsolete_v1_7::*, *},
     rpc_health::*,
     send_transaction_service::{LeaderInfo, SendTransactionService},
-    validator::ValidatorExit,
 };
 use jsonrpc_core::{futures::prelude::*, MetaIoHandler};
 use jsonrpc_http_server::{
@@ -27,8 +26,8 @@ use solana_runtime::{
     snapshot_utils,
 };
 use solana_sdk::{
-    genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash, native_token::lamports_to_sol,
-    pubkey::Pubkey,
+    exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
+    native_token::lamports_to_sol, pubkey::Pubkey,
 };
 use std::{
     collections::HashSet,
@@ -273,7 +272,7 @@ impl JsonRpcService {
         poh_recorder: Option<Arc<Mutex<PohRecorder>>>,
         genesis_hash: Hash,
         ledger_path: &Path,
-        validator_exit: Arc<RwLock<ValidatorExit>>,
+        validator_exit: Arc<RwLock<Exit>>,
         trusted_validators: Option<HashSet<Pubkey>>,
         override_health_check: Arc<AtomicBool>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         rpc::JsonRpcConfig,
-        validator::{Validator, ValidatorConfig, ValidatorExit, ValidatorStartProgress},
+        validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     },
     solana_client::rpc_client::RpcClient,
     solana_gossip::{cluster_info::Node, gossip_service::discover_cluster, socketaddr},
@@ -18,6 +18,7 @@ use {
         clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
         epoch_schedule::EpochSchedule,
+        exit::Exit,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
         native_token::sol_to_lamports,
@@ -79,7 +80,7 @@ pub struct TestValidatorGenesis {
     programs: Vec<ProgramInfo>,
     epoch_schedule: Option<EpochSchedule>,
     node_config: TestValidatorNodeConfig,
-    pub validator_exit: Arc<RwLock<ValidatorExit>>,
+    pub validator_exit: Arc<RwLock<Exit>>,
     pub start_progress: Arc<RwLock<ValidatorStartProgress>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub max_ledger_shreds: Option<u64>,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2703,7 +2703,7 @@ impl ClusterInfo {
                                     self.id()
                                 );
                                 exit.store(true, Ordering::Relaxed);
-                                // TODO: Pass through ValidatorExit here so
+                                // TODO: Pass through Exit here so
                                 // that this will exit cleanly.
                                 std::process::exit(1);
                             }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -7,7 +7,6 @@ use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana_client::thin_client::create_client;
 use solana_core::consensus::VOTE_THRESHOLD_DEPTH;
-use solana_core::validator::ValidatorExit;
 use solana_gossip::{
     cluster_info::VALIDATOR_PORT_RANGE, contact_info::ContactInfo, gossip_service::discover_cluster,
 };
@@ -20,6 +19,7 @@ use solana_sdk::{
     clock::{self, Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
     commitment_config::CommitmentConfig,
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
+    exit::Exit,
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -178,7 +178,7 @@ pub fn sleep_n_epochs(
 
 pub fn kill_entry_and_spend_and_verify_rest(
     entry_point_info: &ContactInfo,
-    entry_point_validator_exit: &Arc<RwLock<ValidatorExit>>,
+    entry_point_validator_exit: &Arc<RwLock<Exit>>,
     funding_keypair: &Keypair,
     nodes: usize,
     slot_millis: u64,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -1,4 +1,5 @@
-use solana_core::validator::{ValidatorConfig, ValidatorExit};
+use solana_core::validator::ValidatorConfig;
+use solana_sdk::exit::Exit;
 use std::sync::{Arc, RwLock};
 
 pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
@@ -52,7 +53,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
         accounts_db_use_index_hash_calculation: config.accounts_db_use_index_hash_calculation,
         tpu_coalesce_ms: config.tpu_coalesce_ms,
-        validator_exit: Arc::new(RwLock::new(ValidatorExit::default())),
+        validator_exit: Arc::new(RwLock::new(Exit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
     }

--- a/sdk/src/exit.rs
+++ b/sdk/src/exit.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+
+#[derive(Default)]
+pub struct Exit {
+    exited: bool,
+    exits: Vec<Box<dyn FnOnce() + Send + Sync>>,
+}
+
+impl Exit {
+    pub fn register_exit(&mut self, exit: Box<dyn FnOnce() + Send + Sync>) {
+        if self.exited {
+            exit();
+        } else {
+            self.exits.push(exit);
+        }
+    }
+
+    pub fn exit(&mut self) {
+        self.exited = true;
+        for exit in self.exits.drain(..) {
+            exit();
+        }
+    }
+}
+
+impl fmt::Debug for Exit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} exits", self.exits.len())
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -21,6 +21,7 @@ pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod entrypoint_native;
 pub mod epoch_info;
+pub mod exit;
 pub mod feature;
 pub mod feature_set;
 pub mod genesis_config;

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -5,8 +5,11 @@ use {
     jsonrpc_ipc_server::{RequestContext, ServerBuilder},
     jsonrpc_server_utils::tokio,
     log::*,
-    solana_core::validator::{ValidatorExit, ValidatorStartProgress},
-    solana_sdk::signature::{read_keypair_file, Keypair, Signer},
+    solana_core::validator::ValidatorStartProgress,
+    solana_sdk::{
+        exit::Exit,
+        signature::{read_keypair_file, Keypair, Signer},
+    },
     std::{
         net::SocketAddr,
         path::Path,
@@ -21,7 +24,7 @@ pub struct AdminRpcRequestMetadata {
     pub rpc_addr: Option<SocketAddr>,
     pub start_time: SystemTime,
     pub start_progress: Arc<RwLock<ValidatorStartProgress>>,
-    pub validator_exit: Arc<RwLock<ValidatorExit>>,
+    pub validator_exit: Arc<RwLock<Exit>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
 }
 impl Metadata for AdminRpcRequestMetadata {}
@@ -67,7 +70,7 @@ impl AdminRpc for AdminRpcImpl {
             warn!("validator exit requested");
             meta.validator_exit.write().unwrap().exit();
 
-            // TODO: Debug why ValidatorExit doesn't always cause the validator to fully exit
+            // TODO: Debug why Exit doesn't always cause the validator to fully exit
             // (rocksdb background processing or some other stuck thread perhaps?).
             //
             // If the process is still alive after five seconds, exit harder

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -6,7 +6,8 @@ use {
     },
     solana_core::validator::ValidatorStartProgress,
     solana_sdk::{
-        clock::Slot, commitment_config::CommitmentConfig, native_token::Sol, pubkey::Pubkey,
+        clock::Slot, commitment_config::CommitmentConfig, exit::Exit, native_token::Sol,
+        pubkey::Pubkey,
     },
     std::{
         io,
@@ -31,7 +32,7 @@ impl Dashboard {
     pub fn new(
         ledger_path: &Path,
         log_path: Option<&Path>,
-        validator_exit: Option<&mut solana_core::validator::ValidatorExit>,
+        validator_exit: Option<&mut Exit>,
     ) -> Result<Self, io::Error> {
         println_name_value("Ledger location:", &format!("{}", ledger_path.display()));
         if let Some(log_path) = log_path {


### PR DESCRIPTION
#### Problem
ValidatorExit isn't specific to a validator; it is a general coordinated exit facility that just happens to be used by the validator. No reason it needs to be tied to the core validator code.

#### Summary of Changes
Rename struct to `Exit` and move to solana-sdk crate

cc https://github.com/solana-labs/solana/pull/17698#issuecomment-854130645
