### PR TITLE
Clean up parse_host_port() error messages

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -355,10 +355,10 @@ pub fn is_host(string: String) -> Result<(), String> {
 pub fn parse_host_port(host_port: &str) -> Result<SocketAddr, String> {
     let addrs: Vec<_> = host_port
         .to_socket_addrs()
-        .map_err(|err| format!("Unable to resolve host {}: {}", host_port, err))?
+        .map_err(|err| format!("{}: {}", err, host_port))?
         .collect();
     if addrs.is_empty() {
-        Err(format!("Unable to resolve host: {}", host_port))
+        Err(format!("unable to parse: {}", host_port))
     } else {
         Ok(addrs[0])
     }


### PR DESCRIPTION
Old:
```
$ solana-gossip spy --entrypoint bad:123
error: Invalid value for '--entrypoint <HOST:PORT>': Unable to resolve host bad:123: failed to lookup address information: nodename nor servname provided, or not known
```

New:
```
$ solana-gossip spy --entrypoint bad:123
error: Invalid value for '--entrypoint <HOST:PORT>': failed to lookup address information: nodename nor servname provided, or not known: bad:123
```

"New" no longer implies that "bad:123" is the host name.