### PR TITLE
[draft] accounts: parallel load across txs via core-pinned threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque 0.8.0",
@@ -5308,6 +5308,7 @@ dependencies = [
  "bv",
  "byteorder",
  "bzip2",
+ "core_affinity",
  "crossbeam-channel",
  "dashmap",
  "dir-diff",
@@ -5325,6 +5326,7 @@ dependencies = [
  "ouroboros",
  "rand 0.7.3",
  "rayon",
+ "rayon-core",
  "regex",
  "rustc_version",
  "serde",

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -339,7 +339,7 @@ fn test_rpc_subscriptions() {
     }
 
     // Wait for all signature subscriptions
-    let deadline = Instant::now() + Duration::from_secs(7);
+    let deadline = Instant::now() + Duration::from_secs(15);
     while !signature_set.is_empty() {
         let timeout = deadline.saturating_duration_since(Instant::now());
         match status_receiver.recv_timeout(timeout) {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -492,6 +492,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "core_affinity"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a03115cc34fb0d7c321dd154a3914b3ca082ccc5c11d91bf7117dbbe7171f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "num_cpus",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3461,7 @@ dependencies = [
  "bv",
  "byteorder 1.3.4",
  "bzip2",
+ "core_affinity",
  "crossbeam-channel",
  "dashmap",
  "dir-diff",
@@ -3466,6 +3479,7 @@ dependencies = [
  "ouroboros",
  "rand 0.7.3",
  "rayon",
+ "rayon-core",
  "regex",
  "rustc_version",
  "serde",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,6 +17,7 @@ bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.3.4"
 bzip2 = "0.3.3"
 dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
+core_affinity = "0.5.10"
 crossbeam-channel = "0.5"
 dir-diff = "0.3.2"
 flate2 = "1.0.14"
@@ -33,6 +34,7 @@ num_cpus = "1.13.0"
 ouroboros = "0.5.1"
 rand = "0.7.0"
 rayon = "1.5.0"
+rayon-core = "1.9.0"
 regex = "1.3.9"
 serde = { version = "1.0.126", features = ["rc"] }
 serde_derive = "1.0.103"

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -9,6 +9,7 @@ use crate::{
         TransactionExecutionResult,
     },
     blockhash_queue::BlockhashQueue,
+    hashed_transaction::HashedTransaction,
     rent_collector::RentCollector,
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
 };
@@ -18,6 +19,7 @@ use dashmap::{
 };
 use log::*;
 use rand::{thread_rng, Rng};
+use rayon::prelude::*;
 use solana_sdk::{
     account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
     account_utils::StateMut,
@@ -465,6 +467,87 @@ impl Accounts {
                 (_, (Err(e), _nonce_rollback)) => (Err(e), None),
             })
             .collect()
+    }
+
+    pub fn load_accounts_parallel<'a>(
+        &self,
+        ancestors: &Ancestors,
+        txs: &'a [HashedTransaction<'a>],
+        lock_results: Vec<TransactionCheckResult>,
+        hash_queue: &BlockhashQueue,
+        error_counters: &mut ErrorCounters,
+        rent_collector: &RentCollector,
+        feature_set: &FeatureSet,
+    ) -> Vec<TransactionLoadResult> {
+        let fee_config = FeeConfig {
+            secp256k1_program_enabled: feature_set
+                .is_active(&feature_set::secp256k1_program_enabled::id()),
+        };
+        let mut error_counters_list = vec![ErrorCounters::default(); lock_results.len()];
+
+        let res = self.accounts_db.pinned_thread_pool.install(|| {
+            txs.par_iter()
+                .map(|h| {
+                    let res: &'a Transaction = h.into();
+                    res
+                })
+                .zip(lock_results)
+                .zip(error_counters_list.par_iter_mut())
+                .map(|etx| match etx {
+                    ((tx, (Ok(()), nonce_rollback)), error_counters) => {
+                        let fee_calculator = nonce_rollback
+                            .as_ref()
+                            .map(|nonce_rollback| nonce_rollback.fee_calculator())
+                            .unwrap_or_else(|| {
+                                hash_queue
+                                    .get_fee_calculator(&tx.message().recent_blockhash)
+                                    .cloned()
+                            });
+                        let fee = if let Some(fee_calculator) = fee_calculator {
+                            fee_calculator.calculate_fee_with_config(tx.message(), &fee_config)
+                        } else {
+                            return (Err(TransactionError::BlockhashNotFound), None);
+                        };
+
+                        let loaded_transaction = match self.load_transaction(
+                            ancestors,
+                            tx,
+                            fee,
+                            error_counters,
+                            rent_collector,
+                            feature_set,
+                        ) {
+                            Ok(loaded_transaction) => loaded_transaction,
+                            Err(e) => return (Err(e), None),
+                        };
+
+                        // Update nonce_rollback with fee-subtracted accounts
+                        let nonce_rollback = if let Some(nonce_rollback) = nonce_rollback {
+                            match NonceRollbackFull::from_partial(
+                                nonce_rollback,
+                                tx.message(),
+                                &loaded_transaction.accounts,
+                            ) {
+                                Ok(nonce_rollback) => Some(nonce_rollback),
+                                Err(e) => return (Err(e), None),
+                            }
+                        } else {
+                            None
+                        };
+
+                        (Ok(loaded_transaction), nonce_rollback)
+                    }
+                    ((_, (Err(e), _nonce_rollback)), _) => (Err(e), None),
+                })
+                .collect()
+        });
+        *error_counters += error_counters_list
+            .iter()
+            .fold(ErrorCounters::default(), |mut x, y| {
+                x += *y;
+                x
+            });
+        res
     }
 
     fn filter_zero_lamport_account(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1301,7 +1301,7 @@ impl Default for AccountsDb {
                 .build()
                 .unwrap(),
             thread_pool_clean: make_min_priority_thread_pool(),
-            pinned_thread_pool: pinned_spawn_handler_frac(1, 4),
+            pinned_thread_pool: pinned_spawn_handler_frac(1, 1),
             min_num_stores: num_threads,
             bank_hashes: RwLock::new(bank_hashes),
             frozen_accounts: HashMap::new(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3074,9 +3074,9 @@ impl Bank {
         check_time.stop();
 
         let mut load_time = Measure::start("accounts_load");
-        let mut loaded_accounts = self.rc.accounts.load_accounts(
+        let mut loaded_accounts = self.rc.accounts.load_accounts_parallel(
             &self.ancestors,
-            hashed_txs.as_transactions_iter(),
+            hashed_txs,
             check_results,
             &self.blockhash_queue.read().unwrap(),
             &mut error_counters,

--- a/runtime/src/hashed_transaction.rs
+++ b/runtime/src/hashed_transaction.rs
@@ -39,12 +39,18 @@ impl<'a> From<&'a Transaction> for HashedTransaction<'a> {
     }
 }
 
+impl<'a> Into<&'a Transaction> for &'a HashedTransaction<'a> {
+    fn into(self) -> &'a Transaction {
+        self.transaction.as_ref()
+    }
+}
+
 pub trait HashedTransactionSlice<'a> {
     fn as_transactions_iter(&'a self) -> Box<dyn Iterator<Item = &'a Transaction> + '_>;
 }
 
 impl<'a> HashedTransactionSlice<'a> for [HashedTransaction<'a>] {
     fn as_transactions_iter(&'a self) -> Box<dyn Iterator<Item = &'a Transaction> + '_> {
-        Box::new(self.iter().map(|h| h.transaction.as_ref()))
+        Box::new(self.iter().map(|h| h.into()))
     }
 }

--- a/runtime/src/hashed_transaction.rs
+++ b/runtime/src/hashed_transaction.rs
@@ -39,9 +39,9 @@ impl<'a> From<&'a Transaction> for HashedTransaction<'a> {
     }
 }
 
-impl<'a> Into<&'a Transaction> for &'a HashedTransaction<'a> {
-    fn into(self) -> &'a Transaction {
-        self.transaction.as_ref()
+impl<'a> From<&'a HashedTransaction<'a>> for &'a Transaction {
+    fn from(h: &'a HashedTransaction<'a>) -> Self {
+        h.transaction.as_ref()
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod log_collector;
 pub mod message_processor;
 mod native_loader;
 pub mod non_circulating_supply;
+mod pinned_threads;
 mod pubkey_bins;
 mod read_only_accounts_cache;
 pub mod rent_collector;

--- a/runtime/src/pinned_threads.rs
+++ b/runtime/src/pinned_threads.rs
@@ -2,7 +2,7 @@ use rayon::ThreadPool;
 use rayon_core::{ThreadBuilder, ThreadPoolBuilder};
 use std::{io, thread};
 
-const NUM_THREADS_PER_CORE: usize = 8;
+const NUM_THREADS_PER_CORE: usize = 2;
 const MAX_NUM_OF_THREADS: usize = 128;
 
 #[derive(Debug, Default)]

--- a/runtime/src/pinned_threads.rs
+++ b/runtime/src/pinned_threads.rs
@@ -1,4 +1,3 @@
-use core_affinity;
 use rayon::ThreadPool;
 use rayon_core::{ThreadBuilder, ThreadPoolBuilder};
 use std::{io, thread};

--- a/runtime/src/pinned_threads.rs
+++ b/runtime/src/pinned_threads.rs
@@ -1,0 +1,71 @@
+use core_affinity;
+use rayon::ThreadPool;
+use rayon_core::{ThreadBuilder, ThreadPoolBuilder};
+use std::{io, thread};
+
+const NUM_THREADS_PER_CORE: usize = 8;
+
+#[derive(Debug, Default)]
+pub struct PinnedSpawn {
+    cores: Vec<core_affinity::CoreId>,
+    len: usize,
+    core_id_pointer: usize,
+}
+
+impl PinnedSpawn {
+    // pub fn new(num_cores: usize) -> Self {
+    //     let core_ids = core_affinity::get_core_ids().unwrap();
+    //     if num_cores > core_ids.len() {
+    //         panic!("More cores requested than available");
+    //     }
+    //     Self {
+    //         cores: core_ids.into_iter().rev().take(num_cores).collect(),
+    //         len: num_cores,
+    //         core_id_pointer: 0,
+    //     }
+    // }
+
+    // Pins as many threads as the ceil of the fraction times the total number of cores
+    // This ensures that at least 1 core would be pinned
+    pub fn new_frac_of_cores(num: usize, denom: usize) -> Self {
+        if num > denom {
+            panic!("fraction must be <= 1");
+        }
+        let core_ids = core_affinity::get_core_ids().unwrap();
+        let num_cores = (num * core_ids.len() - 1) / denom + 1;
+        Self {
+            cores: core_ids.into_iter().rev().take(num_cores).collect(),
+            len: num_cores,
+            core_id_pointer: 0,
+        }
+    }
+
+    // Spawn threads pinned to core in a round robin fashion
+    pub fn spawn(&mut self, thread: ThreadBuilder) -> io::Result<()> {
+        let mut b = thread::Builder::new();
+        if let Some(name) = thread.name() {
+            b = b.name(name.to_owned());
+        }
+        if let Some(stack_size) = thread.stack_size() {
+            b = b.stack_size(stack_size);
+        }
+        let id_for_spawn = self.cores[self.core_id_pointer];
+        b.spawn(move || {
+            core_affinity::set_for_current(id_for_spawn);
+            thread.run()
+        })?;
+        self.core_id_pointer += 1;
+        self.core_id_pointer %= self.len;
+        Ok(())
+    }
+}
+
+pub fn pinned_spawn_handler_frac(num: usize, denom: usize) -> ThreadPool {
+    let mut spawner = PinnedSpawn::new_frac_of_cores(num, denom);
+    ThreadPoolBuilder::new()
+        .thread_name(|i| format!("pinned-thread-for-parallel-load-{}", i))
+        .num_threads(spawner.len * NUM_THREADS_PER_CORE)
+        .spawn_handler(|thread| spawner.spawn(thread))
+        .build()
+        .unwrap()
+}

--- a/runtime/src/pinned_threads.rs
+++ b/runtime/src/pinned_threads.rs
@@ -3,6 +3,7 @@ use rayon_core::{ThreadBuilder, ThreadPoolBuilder};
 use std::{io, thread};
 
 const NUM_THREADS_PER_CORE: usize = 8;
+const MAX_NUM_OF_THREADS: usize = 128;
 
 #[derive(Debug, Default)]
 pub struct PinnedSpawn {
@@ -63,7 +64,10 @@ pub fn pinned_spawn_handler_frac(num: usize, denom: usize) -> ThreadPool {
     let mut spawner = PinnedSpawn::new_frac_of_cores(num, denom);
     ThreadPoolBuilder::new()
         .thread_name(|i| format!("pinned-thread-for-parallel-load-{}", i))
-        .num_threads(spawner.len * NUM_THREADS_PER_CORE)
+        .num_threads(std::cmp::min(
+            spawner.len * NUM_THREADS_PER_CORE,
+            MAX_NUM_OF_THREADS,
+        ))
         .spawn_handler(|thread| spawner.spawn(thread))
         .build()
         .unwrap()


### PR DESCRIPTION
#### Problem
Currently, `load_and_execute_transactions` loads sequentially within bank. This means the worst case latency for multiple sequential page faults can stall throughput.

#### Summary of Changes
Parallelise loads across TXs using an over-provisioned thread pool pinned to a fixed number of logical cores. The thread-pool is over-provisioned (by default by 8x) to deal with OS blocking threads when page faulting.

Fixes: https://github.com/solana-labs/solana/issues/17765 https://github.com/solana-labs/solana/issues/17761

CC (for early feedback): @sakridge @carllin 

TODO: 
1. Check no perf regression when running bench TPS
2. Check for perf improvement when triggering OS page evictions, thus forcing page faults.

Related:
1. TODO: Pipeline load->execution in banking and replay stage to hide latency.