### PR TITLE
Make account shrink configurable #17544

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
     accounts::{create_test_accounts, update_accounts_bench, Accounts},
+    accounts_db::{DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO},
     accounts_index::AccountSecondaryIndexes,
     ancestors::Ancestors,
 };
@@ -64,6 +65,8 @@ fn main() {
         &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),
         false,
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+        DEFAULT_ACCOUNTS_SHRINK_RATIO,
     );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
     accounts::{create_test_accounts, update_accounts_bench, Accounts},
-    accounts_db::{DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO},
+    accounts_db::DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     accounts_index::AccountSecondaryIndexes,
     ancestors::Ancestors,
 };
@@ -65,8 +65,7 @@ fn main() {
         &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),
         false,
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
     accounts::{create_test_accounts, update_accounts_bench, Accounts},
-    accounts_db::DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+    accounts_db::AccountShrinkThreshold,
     accounts_index::AccountSecondaryIndexes,
     ancestors::Ancestors,
 };
@@ -65,7 +65,7 @@ fn main() {
         &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),
         false,
-        DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+        AccountShrinkThreshold::default(),
     );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -88,6 +88,8 @@ pub struct TvuConfig {
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
     pub wait_for_vote_to_start_leader: bool,
+    pub accounts_shrink_optimize_total_space: bool,
+    pub accounts_shrink_ratio: f64,
 }
 
 impl Tvu {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -37,6 +37,7 @@ use solana_runtime::{
     accounts_background_service::{
         AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
     },
+    accounts_db::AccountShrinkThreshold,
     bank_forks::{BankForks, SnapshotConfig},
     commitment::BlockCommitmentCache,
     vote_sender_types::ReplayVoteSender,
@@ -88,8 +89,7 @@ pub struct TvuConfig {
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
     pub wait_for_vote_to_start_leader: bool,
-    pub accounts_shrink_optimize_total_space: bool,
-    pub accounts_shrink_ratio: f64,
+    pub accounts_shrink_ratio: AccountShrinkThreshold,
 }
 
 impl Tvu {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -52,7 +52,7 @@ use solana_rpc::{
     transaction_status_service::TransactionStatusService,
 };
 use solana_runtime::{
-    accounts_db::{DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO},
+    accounts_db::{AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION},
     accounts_index::AccountSecondaryIndexes,
     bank::Bank,
     bank_forks::{BankForks, SnapshotConfig},
@@ -139,8 +139,7 @@ pub struct ValidatorConfig {
     pub tpu_coalesce_ms: u64,
     pub validator_exit: Arc<RwLock<Exit>>,
     pub no_wait_for_vote_to_start_leader: bool,
-    pub accounts_shrink_optimize_total_space: bool,
-    pub accounts_shrink_ratio: f64,
+    pub accounts_shrink_ratio: AccountShrinkThreshold,
 }
 
 impl Default for ValidatorConfig {
@@ -197,8 +196,7 @@ impl Default for ValidatorConfig {
             tpu_coalesce_ms: DEFAULT_TPU_COALESCE_MS,
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             no_wait_for_vote_to_start_leader: true,
-            accounts_shrink_optimize_total_space: DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
         }
     }
 }
@@ -725,7 +723,6 @@ impl Validator {
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
                 wait_for_vote_to_start_leader,
-                accounts_shrink_optimize_total_space: config.accounts_shrink_optimize_total_space,
                 accounts_shrink_ratio: config.accounts_shrink_ratio,
             },
             &max_slots,
@@ -1098,7 +1095,6 @@ fn new_banks_from_ledger(
         debug_keys: config.debug_keys.clone(),
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,
-        optimize_total_space: config.accounts_shrink_optimize_total_space,
         shrink_ratio: config.accounts_shrink_ratio,
         ..blockstore_processor::ProcessOptions::default()
     };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -52,7 +52,7 @@ use solana_rpc::{
     transaction_status_service::TransactionStatusService,
 };
 use solana_runtime::{
-    accounts_db::{AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION},
+    accounts_db::AccountShrinkThreshold,
     accounts_index::AccountSecondaryIndexes,
     bank::Bank,
     bank_forks::{BankForks, SnapshotConfig},
@@ -196,7 +196,7 @@ impl Default for ValidatorConfig {
             tpu_coalesce_ms: DEFAULT_TPU_COALESCE_MS,
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             no_wait_for_vote_to_start_leader: true,
-            accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+            accounts_shrink_ratio: AccountShrinkThreshold::default(),
         }
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -52,6 +52,7 @@ use solana_rpc::{
     transaction_status_service::TransactionStatusService,
 };
 use solana_runtime::{
+    accounts_db::{DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO},
     accounts_index::AccountSecondaryIndexes,
     bank::Bank,
     bank_forks::{BankForks, SnapshotConfig},
@@ -138,6 +139,8 @@ pub struct ValidatorConfig {
     pub tpu_coalesce_ms: u64,
     pub validator_exit: Arc<RwLock<Exit>>,
     pub no_wait_for_vote_to_start_leader: bool,
+    pub accounts_shrink_optimize_total_space: bool,
+    pub accounts_shrink_ratio: f64,
 }
 
 impl Default for ValidatorConfig {
@@ -194,6 +197,8 @@ impl Default for ValidatorConfig {
             tpu_coalesce_ms: DEFAULT_TPU_COALESCE_MS,
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             no_wait_for_vote_to_start_leader: true,
+            accounts_shrink_optimize_total_space: DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            accounts_shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO,
         }
     }
 }
@@ -720,6 +725,8 @@ impl Validator {
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
                 wait_for_vote_to_start_leader,
+                accounts_shrink_optimize_total_space: config.accounts_shrink_optimize_total_space,
+                accounts_shrink_ratio: config.accounts_shrink_ratio,
             },
             &max_slots,
         );
@@ -1091,6 +1098,8 @@ fn new_banks_from_ledger(
         debug_keys: config.debug_keys.clone(),
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,
+        optimize_total_space: config.accounts_shrink_optimize_total_space,
+        shrink_ratio: config.accounts_shrink_ratio,
         ..blockstore_processor::ProcessOptions::default()
     };
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -224,11 +224,7 @@ mod tests {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
                 bank.update_accounts_hash();
-                snapshot_request_handler.handle_snapshot_requests(
-                    false,
-                    false,
-                    false,
-                );
+                snapshot_request_handler.handle_snapshot_requests(false, false, false);
             }
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -228,8 +228,6 @@ mod tests {
                     false,
                     false,
                     false,
-                    accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                    accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
                 );
             }
         }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -106,8 +106,7 @@ mod tests {
                 None,
                 AccountSecondaryIndexes::default(),
                 false,
-                accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
+                accounts_db::AccountShrinkThreshold::default(),
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);
@@ -167,8 +166,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             None,
-            accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            accounts_db::AccountShrinkThreshold::default(),
         )
         .unwrap();
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -106,6 +106,8 @@ mod tests {
                 None,
                 AccountSecondaryIndexes::default(),
                 false,
+                accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+                accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);
@@ -165,6 +167,8 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             None,
+            accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
         )
         .unwrap();
 
@@ -220,7 +224,13 @@ mod tests {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
                 bank.update_accounts_hash();
-                snapshot_request_handler.handle_snapshot_requests(false, false, false);
+                snapshot_request_handler.handle_snapshot_requests(
+                    false,
+                    false,
+                    false,
+                    accounts_db::DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+                    accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
+                );
             }
         }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -142,7 +142,6 @@ fn load_from_snapshot(
         process_options.account_indexes.clone(),
         process_options.accounts_db_caching_enabled,
         process_options.limit_load_slot_count_from_snapshot,
-        process_options.optimize_total_space,
         process_options.shrink_ratio,
     )
     .expect("Load from snapshot failed");

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -142,6 +142,8 @@ fn load_from_snapshot(
         process_options.account_indexes.clone(),
         process_options.accounts_db_caching_enabled,
         process_options.limit_load_slot_count_from_snapshot,
+        process_options.optimize_total_space,
+        process_options.shrink_ratio,
     )
     .expect("Load from snapshot failed");
     if let Some(shrink_paths) = shrink_paths {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -16,6 +16,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
+    accounts_db::AccountShrinkThreshold,
     accounts_index::AccountSecondaryIndexes,
     bank::{
         Bank, ExecuteTimings, InnerInstructionsList, RentDebits, TransactionBalancesSet,
@@ -373,8 +374,7 @@ pub struct ProcessOptions {
     pub limit_load_slot_count_from_snapshot: Option<usize>,
     pub allow_dead_slots: bool,
     pub accounts_db_test_hash_calculation: bool,
-    pub optimize_total_space: bool,
-    pub shrink_ratio: f64,
+    pub shrink_ratio: AccountShrinkThreshold,
 }
 
 pub fn process_blockstore(
@@ -402,7 +402,6 @@ pub fn process_blockstore(
         Some(&crate::builtins::get(opts.bpf_jit)),
         opts.account_indexes.clone(),
         opts.accounts_db_caching_enabled,
-        opts.optimize_total_space,
         opts.shrink_ratio,
     );
     let bank0 = Arc::new(bank0);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -373,6 +373,8 @@ pub struct ProcessOptions {
     pub limit_load_slot_count_from_snapshot: Option<usize>,
     pub allow_dead_slots: bool,
     pub accounts_db_test_hash_calculation: bool,
+    pub optimize_total_space: bool,
+    pub shrink_ratio: f64,
 }
 
 pub fn process_blockstore(
@@ -400,6 +402,8 @@ pub fn process_blockstore(
         Some(&crate::builtins::get(opts.bpf_jit)),
         opts.account_indexes.clone(),
         opts.accounts_db_caching_enabled,
+        opts.optimize_total_space,
+        opts.shrink_ratio,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");
@@ -1279,6 +1283,9 @@ pub mod tests {
     use crossbeam_channel::unbounded;
     use matches::assert_matches;
     use rand::{thread_rng, Rng};
+    use solana_runtime::accounts_db::{
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
+    };
     use solana_runtime::genesis_utils::{
         self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
     };
@@ -3064,6 +3071,8 @@ pub mod tests {
             None,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         *bank.epoch_schedule()
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1282,9 +1282,6 @@ pub mod tests {
     use crossbeam_channel::unbounded;
     use matches::assert_matches;
     use rand::{thread_rng, Rng};
-    use solana_runtime::accounts_db::{
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
-    };
     use solana_runtime::genesis_utils::{
         self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
     };
@@ -3070,8 +3067,7 @@ pub mod tests {
             None,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         *bank.epoch_schedule()
     }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -56,7 +56,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
-        accounts_shrink_optimize_total_space: config.accounts_shrink_optimize_total_space,
         accounts_shrink_ratio: config.accounts_shrink_ratio,
     }
 }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -56,6 +56,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
+        accounts_shrink_optimize_total_space: config.accounts_shrink_optimize_total_space,
+        accounts_shrink_ratio: config.accounts_shrink_ratio,
     }
 }
 

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -8,6 +8,7 @@ use rand::Rng;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use solana_runtime::{
     accounts::{create_test_accounts, AccountAddressFilter, Accounts},
+    accounts_db::AccountShrinkThreshold,
     accounts_index::AccountSecondaryIndexes,
     ancestors::Ancestors,
     bank::*,
@@ -59,6 +60,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
         None,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -78,6 +80,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         None,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&prev_bank, &mut pubkeys, 250_000).unwrap();
@@ -103,6 +106,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     let num_accounts = 60_000;
@@ -121,6 +125,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
@@ -138,6 +143,7 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
@@ -154,6 +160,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     let mut old_pubkey = Pubkey::default();
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -187,6 +194,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     ));
     let num_keys = 1000;
     let slot = 0;
@@ -316,6 +324,7 @@ fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (AccountSharedD
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     ));
 
     let dashmap = DashMap::new();
@@ -370,6 +379,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        AccountShrinkThreshold::default(),
     );
     let mut rng = rand::thread_rng();
     for _ in 0..10_000 {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -117,12 +117,19 @@ pub enum AccountAddressFilter {
 }
 
 impl Accounts {
-    pub fn new(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
+    pub fn new(
+        paths: Vec<PathBuf>,
+        cluster_type: &ClusterType,
+        optimize_total_space: bool,
+        shrink_ratio: f64,
+    ) -> Self {
         Self::new_with_config(
             paths,
             cluster_type,
             AccountSecondaryIndexes::default(),
             false,
+            optimize_total_space,
+            shrink_ratio,
         )
     }
 
@@ -131,6 +138,8 @@ impl Accounts {
         cluster_type: &ClusterType,
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
+        optimize_total_space: bool,
+        shrink_ratio: f64,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -138,6 +147,8 @@ impl Accounts {
                 cluster_type,
                 account_indexes,
                 caching_enabled,
+                optimize_total_space,
+                shrink_ratio,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
         }
@@ -1085,6 +1096,9 @@ pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::accounts_db::{
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
+    };
     use crate::rent_collector::RentCollector;
     use solana_sdk::{
         account::{AccountSharedData, WritableAccount},
@@ -1118,6 +1132,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         for ka in ka.iter() {
             accounts.store_slow_uncached(0, &ka.0, &ka.1);
@@ -1655,6 +1671,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
 
         // Load accounts owned by various programs into AccountsDb
@@ -1683,6 +1701,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -1706,6 +1726,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         accounts.bank_hash_at(1);
     }
@@ -1727,6 +1749,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -1853,6 +1877,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -2003,6 +2029,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         {
             accounts
@@ -2055,6 +2083,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -2102,6 +2132,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
 
         let instructions_key = solana_sdk::sysvar::instructions::id();
@@ -2387,6 +2419,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2506,6 +2540,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2540,6 +2576,8 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
 
         let pubkey0 = Pubkey::new_unique();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1093,9 +1093,6 @@ pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::accounts_db::{
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
-    };
     use crate::rent_collector::RentCollector;
     use solana_sdk::{
         account::{AccountSharedData, WritableAccount},
@@ -1129,8 +1126,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         for ka in ka.iter() {
             accounts.store_slow_uncached(0, &ka.0, &ka.1);
@@ -1668,8 +1664,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
 
         // Load accounts owned by various programs into AccountsDb
@@ -1698,8 +1693,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -1723,8 +1717,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         accounts.bank_hash_at(1);
     }
@@ -1746,8 +1739,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -1874,8 +1866,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -2026,8 +2017,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         {
             accounts
@@ -2080,8 +2070,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -2129,8 +2118,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
 
         let instructions_key = solana_sdk::sysvar::instructions::id();
@@ -2416,8 +2404,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2537,8 +2524,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2573,8 +2559,7 @@ mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
 
         let pubkey0 = Pubkey::new_unique();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,6 +1,7 @@
 use crate::{
     accounts_db::{
-        AccountsDb, BankHashInfo, ErrorCounters, LoadHint, LoadedAccount, ScanStorageResult, AccountShrinkThreshold,
+        AccountShrinkThreshold, AccountsDb, BankHashInfo, ErrorCounters, LoadHint, LoadedAccount,
+        ScanStorageResult,
     },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::Ancestors,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,6 +1,6 @@
 use crate::{
     accounts_db::{
-        AccountsDb, BankHashInfo, ErrorCounters, LoadHint, LoadedAccount, ScanStorageResult,
+        AccountsDb, BankHashInfo, ErrorCounters, LoadHint, LoadedAccount, ScanStorageResult, AccountShrinkThreshold,
     },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::Ancestors,
@@ -120,15 +120,13 @@ impl Accounts {
     pub fn new(
         paths: Vec<PathBuf>,
         cluster_type: &ClusterType,
-        optimize_total_space: bool,
-        shrink_ratio: f64,
+        shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
         Self::new_with_config(
             paths,
             cluster_type,
             AccountSecondaryIndexes::default(),
             false,
-            optimize_total_space,
             shrink_ratio,
         )
     }
@@ -138,8 +136,7 @@ impl Accounts {
         cluster_type: &ClusterType,
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
-        optimize_total_space: bool,
-        shrink_ratio: f64,
+        shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -147,7 +144,6 @@ impl Accounts {
                 cluster_type,
                 account_indexes,
                 caching_enabled,
-                optimize_total_space,
                 shrink_ratio,
             )),
             account_locks: Mutex::new(AccountLocks::default()),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -124,7 +124,7 @@ pub enum AccountShrinkThreshold {
     /// the specified threshold.
     IndividalStore { shrink_ratio: f64 },
 }
-pub const DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE: bool = false;
+pub const DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE: bool = true;
 pub const DEFAULT_ACCOUNTS_SHRINK_RATIO: f64 = 0.80;
 // The default extra account space in percentage from the ideal target
 const DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION: AccountShrinkThreshold =

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2311,8 +2311,8 @@ impl AccountsDb {
             for (slot, slot_shrink_candidates) in &shrink_slots {
                 candidates_count += slot_shrink_candidates.len();
                 for store in slot_shrink_candidates.values() {
-                    total_alive += self.page_align(store.alive_bytes() as u64);
-                    let alive_ratio = self.page_align(store.alive_bytes() as u64) as f64
+                    total_alive += Self::page_align(store.alive_bytes() as u64);
+                    let alive_ratio = Self::page_align(store.alive_bytes() as u64) as f64
                         / store.total_bytes() as f64;
                     store_usage.push((*slot, store.append_vec_id(), alive_ratio, store.clone(), 0));
                 }
@@ -2326,13 +2326,13 @@ impl AccountsDb {
                 usage.4 = usage.3.total_bytes() + all_total;
                 all_total = usage.4;
             }
-            // now working from the beginning of store_usage which are most sparse and see when we can stop
-            // shrinking while still achieving the goals.
+            // now working from the beginning of store_usage which are the most sparse and see when we can stop
+            // shrinking while still achieving the overall goals.
             let mut shrink_slots: ShrinkCandidates = HashMap::new();
             let mut shrunk_total: u64 = 0;
             for usage in &store_usage {
                 let store = &usage.3;
-                shrunk_total += self.page_align(store.alive_bytes() as u64);
+                shrunk_total += Self::page_align(store.alive_bytes() as u64);
                 let unshrunk_total = usage.4 - store.total_bytes(); // the unshrunk total after this
                 let total_bytes = shrunk_total + unshrunk_total;
                 shrink_slots
@@ -4901,8 +4901,8 @@ impl AccountsDb {
                 } else if self.caching_enabled
                     && Self::is_shrinking_productive(*slot, &[store.clone()])
                     && ((self.optimize_total_space
-                        && self.page_align(store.alive_bytes() as u64) < store.total_bytes())
-                        || (self.page_align(store.alive_bytes() as u64) as f64
+                        && Self::page_align(store.alive_bytes() as u64) < store.total_bytes())
+                        || (Self::page_align(store.alive_bytes() as u64) as f64
                             / store.total_bytes() as f64)
                             < self.shrink_ratio)
                 {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8866,10 +8866,7 @@ pub mod tests {
             let accounts = AccountsDb::new_single();
 
             for _ in 0..10 {
-                accounts.shrink_candidate_slots(
-                    DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                    DEFAULT_ACCOUNTS_SHRINK_RATIO,
-                );
+                accounts.shrink_candidate_slots();
             }
 
             accounts.shrink_all_slots(*startup);
@@ -9065,10 +9062,7 @@ pub mod tests {
 
         // Only, try to shrink stale slots, nothing happens because 90/100
         // is not small enough to do a shrink
-        accounts.shrink_candidate_slots(
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        );
+        accounts.shrink_candidate_slots();
         assert_eq!(
             pubkey_count,
             accounts.all_account_count_in_append_vec(shrink_slot)
@@ -10418,10 +10412,7 @@ pub mod tests {
                 .or_default()
                 .insert(slot0_store.append_vec_id(), slot0_store);
         }
-        db.shrink_candidate_slots(
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        );
+        db.shrink_candidate_slots();
 
         // Make slot 0 dead by updating the remaining key
         db.store_cached(2, &[(&account_key2, &account1)]);
@@ -10753,10 +10744,7 @@ pub mod tests {
                         .entry(slot)
                         .or_default()
                         .insert(store_id, store.clone());
-                    db.shrink_candidate_slots(
-                        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                        DEFAULT_ACCOUNTS_SHRINK_RATIO,
-                    );
+                    db.shrink_candidate_slots();
                 })
                 .unwrap()
         };
@@ -10794,6 +10782,8 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
         let db = Arc::new(db);
         let num_cached_slots = 100;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -57,7 +57,6 @@ use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
     borrow::{Borrow, Cow},
     boxed::Box,
-    cmp,
     collections::{hash_map::Entry, BTreeSet, HashMap, HashSet},
     convert::TryFrom,
     io::{Error as IoError, Result as IoResult},
@@ -129,7 +128,7 @@ pub enum AccountShrinkThreshold {
 pub const DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE: bool = false;
 pub const DEFAULT_ACCOUNTS_SHRINK_RATIO: f64 = 0.80;
 // The default extra account space in percentage from the ideal target
-pub const DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION: AccountShrinkThreshold =
+const DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION: AccountShrinkThreshold =
     AccountShrinkThreshold::IndividalAccount {
         ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO,
     };
@@ -2009,7 +2008,6 @@ impl AccountsDb {
             for slot in dead_slots {
                 list.remove(slot);
             }
-            info!("process_dead_slots, candidates: {:?}", list.len());
         }
 
         debug!(
@@ -2331,7 +2329,7 @@ impl AccountsDb {
         store_usage.sort_by(|a, b| {
             a.alive_ratio
                 .partial_cmp(&b.alive_ratio)
-                .unwrap_or(cmp::Ordering::Equal)
+                .unwrap_or(std::cmp::Ordering::Equal)
         });
         // working backward on store_usage, get the all total bytes if the entries including this and after it are not shrunk
         // the total bytes for all unshrinked stores
@@ -4982,7 +4980,6 @@ impl AccountsDb {
                         }
                     }
                 }
-                info!("candidates counts: {:?}", shrink_candidate_slots.len());
             }
         }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9156,13 +9156,8 @@ pub mod tests {
         let output_candidates =
             accounts.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
         assert_eq!(1, output_candidates.len());
-
         assert_eq!(1, output_candidates[&dummy_slot].len());
-
-        assert_eq!(
-            true,
-            output_candidates[&dummy_slot].contains(&entry2.append_vec_id())
-        );
+        assert!(output_candidates[&dummy_slot].contains(&entry2.append_vec_id()));
 
         // case 3: two candidates, both are selected
         candidates.clear();
@@ -9202,14 +9197,8 @@ pub mod tests {
         assert_eq!(1, output_candidates[&dummy_slot].len());
         assert_eq!(1, output_candidates[&dummy_slot2].len());
 
-        assert_eq!(
-            true,
-            output_candidates[&dummy_slot].contains(&entry1.append_vec_id())
-        );
-        assert_eq!(
-            true,
-            output_candidates[&dummy_slot2].contains(&entry2.append_vec_id())
-        );
+        assert!(output_candidates[&dummy_slot].contains(&entry1.append_vec_id()));
+        assert!(output_candidates[&dummy_slot2].contains(&entry2.append_vec_id()));
     }
 
     #[test]
@@ -11195,10 +11184,10 @@ pub mod tests {
         assert!(accounts.is_candidate_for_shrink(entry.clone()));
         entry.alive_bytes.store(5000, Ordering::Relaxed);
         assert!(!accounts.is_candidate_for_shrink(entry.clone()));
-        accounts.shrink_ratio = AccountShrinkThreshold::TotalSpace {shrink_ratio: 0.3};
+        accounts.shrink_ratio = AccountShrinkThreshold::TotalSpace { shrink_ratio: 0.3 };
         entry.alive_bytes.store(3000, Ordering::Relaxed);
         assert!(accounts.is_candidate_for_shrink(entry.clone()));
-        accounts.shrink_ratio = AccountShrinkThreshold::IndividalStore {shrink_ratio: 0.3};
+        accounts.shrink_ratio = AccountShrinkThreshold::IndividalStore { shrink_ratio: 0.3 };
         assert!(!accounts.is_candidate_for_shrink(entry.clone()));
     }
 }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1330,11 +1330,6 @@ impl AccountsDb {
         optimize_total_space: bool,
         shrink_ratio: f64,
     ) -> Self {
-        info!(
-            "Creating new accountdb: caching_enabled {:?}, optimize_total_space: {:?}",
-            caching_enabled, optimize_total_space
-        );
-
         let mut new = if !paths.is_empty() {
             Self {
                 paths,
@@ -2294,6 +2289,75 @@ impl AccountsDb {
         self.accounts_index.all_roots()
     }
 
+    fn select_candidates_by_total_usage(
+        &self,
+        shrink_slots: &ShrinkCandidates,
+    ) -> ShrinkCandidates {
+        struct StoreUsageInfo {
+            slot: Slot,
+            alive_ratio: f64,
+            store: Arc<AccountStorageEntry>,
+            all_total_bytes: u64,
+        }
+        let mut measure = Measure::start("select_top_sparse_storage_entries-ms");
+        let mut store_usage: Vec<StoreUsageInfo> = Vec::with_capacity(shrink_slots.len());
+        let mut total_alive_bytes: u64 = 0;
+        let mut candidates_count: usize = 0;
+        for (slot, slot_shrink_candidates) in shrink_slots {
+            candidates_count += slot_shrink_candidates.len();
+            for store in slot_shrink_candidates.values() {
+                total_alive_bytes += Self::page_align(store.alive_bytes() as u64);
+                let alive_ratio = Self::page_align(store.alive_bytes() as u64) as f64
+                    / store.total_bytes() as f64;
+                store_usage.push(StoreUsageInfo {
+                    slot: *slot,
+                    alive_ratio,
+                    store: store.clone(),
+                    all_total_bytes: 0,
+                });
+            }
+        }
+        store_usage.sort_by(|a, b| {
+            a.alive_ratio
+                .partial_cmp(&b.alive_ratio)
+                .unwrap_or(cmp::Ordering::Equal)
+        });
+        // working backward on store_usage, get the all total bytes if the entries including this and after it are not shrunk
+        // the total bytes for all unshrinked stores
+        let mut all_total: u64 = 0;
+        for i in (0..store_usage.len()).rev() {
+            let usage = &mut store_usage[i];
+            usage.all_total_bytes = usage.store.total_bytes() + all_total;
+            all_total = usage.all_total_bytes;
+        }
+        // now working from the beginning of store_usage which are the most sparse and see when we can stop
+        // shrinking while still achieving the overall goals.
+        let mut shrink_slots: ShrinkCandidates = HashMap::new();
+        let mut shrunk_total: u64 = 0;
+        for usage in &store_usage {
+            let store = &usage.store;
+            shrunk_total += Self::page_align(store.alive_bytes() as u64);
+            let unshrunk_total = usage.all_total_bytes - store.total_bytes(); // the unshrunk total after this
+            let total_bytes = shrunk_total + unshrunk_total;
+            shrink_slots
+                .entry(usage.slot)
+                .or_default()
+                .insert(store.append_vec_id(), store.clone());
+
+            if (total_alive_bytes as f64) / (total_bytes as f64) > self.shrink_ratio {
+                // we have reached our goal, stop
+                break;
+            }
+        }
+        measure.stop();
+        inc_new_counter_info!(
+            "select_top_sparse_storage_entries-ms",
+            measure.as_ms() as usize
+        );
+        inc_new_counter_info!("select_top_sparse_storage_entries-seeds", candidates_count);
+        shrink_slots
+    }
+
     pub fn shrink_candidate_slots(&self) -> usize {
         let shrink_slots = std::mem::take(&mut *self.shrink_candidate_slots.lock().unwrap());
 
@@ -2302,56 +2366,7 @@ impl AccountsDb {
             shrink_slots.len()
         );
         let shrink_slots = if self.optimize_total_space {
-            let mut measure = Measure::start("select_top_sparse_storage_entries-ms");
-
-            let mut store_usage: Vec<(Slot, AppendVecId, f64, Arc<AccountStorageEntry>, u64)> =
-                Vec::with_capacity(shrink_slots.len());
-            let mut total_alive: u64 = 0;
-            let mut candidates_count: usize = 0;
-            for (slot, slot_shrink_candidates) in &shrink_slots {
-                candidates_count += slot_shrink_candidates.len();
-                for store in slot_shrink_candidates.values() {
-                    total_alive += Self::page_align(store.alive_bytes() as u64);
-                    let alive_ratio = Self::page_align(store.alive_bytes() as u64) as f64
-                        / store.total_bytes() as f64;
-                    store_usage.push((*slot, store.append_vec_id(), alive_ratio, store.clone(), 0));
-                }
-            }
-            store_usage.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(cmp::Ordering::Equal));
-            // working backward on store_usage, get the all total bytes if the entries including it and after it are not shrunk
-            // the total bytes for all unshrinked stores
-            let mut all_total: u64 = 0;
-            for i in (0..store_usage.len()).rev() {
-                let usage = &mut store_usage[i];
-                usage.4 = usage.3.total_bytes() + all_total;
-                all_total = usage.4;
-            }
-            // now working from the beginning of store_usage which are the most sparse and see when we can stop
-            // shrinking while still achieving the overall goals.
-            let mut shrink_slots: ShrinkCandidates = HashMap::new();
-            let mut shrunk_total: u64 = 0;
-            for usage in &store_usage {
-                let store = &usage.3;
-                shrunk_total += Self::page_align(store.alive_bytes() as u64);
-                let unshrunk_total = usage.4 - store.total_bytes(); // the unshrunk total after this
-                let total_bytes = shrunk_total + unshrunk_total;
-                shrink_slots
-                    .entry(usage.0)
-                    .or_default()
-                    .insert(store.append_vec_id(), store.clone());
-
-                if (total_alive as f64) / (total_bytes as f64) < self.shrink_ratio {
-                    // we have reached our goal, stop
-                    break;
-                }
-            }
-            measure.stop();
-            inc_new_counter_info!(
-                "select_top_sparse_storage_entries-ms",
-                measure.as_ms() as usize
-            );
-            inc_new_counter_info!("select_top_sparse_storage_entries-seeds", candidates_count);
-            shrink_slots
+            self.select_candidates_by_total_usage(&shrink_slots)
         } else {
             shrink_slots
         };

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -128,7 +128,7 @@ pub const DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE: bool = false;
 pub const DEFAULT_ACCOUNTS_SHRINK_RATIO: f64 = 0.80;
 // The default extra account space in percentage from the ideal target
 const DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION: AccountShrinkThreshold =
-    AccountShrinkThreshold::IndividalStore {
+    AccountShrinkThreshold::TotalSpace {
         shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_RATIO,
     };
 
@@ -2348,7 +2348,7 @@ impl AccountsDb {
                     usage.slot, total_alive_bytes, total_bytes, alive_ratio, shrink_ratio
                 );
                 break;
-            }            
+            }
             let store = &usage.store;
             let current_store_size = store.total_bytes();
             let after_shrink_size = Self::page_align(store.alive_bytes() as u64);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4891,7 +4891,7 @@ impl AccountsDb {
         true
     }
 
-    fn is_candidate_for_shrink(&self, store: Arc<AccountStorageEntry>) -> bool {
+    fn is_candidate_for_shrink(&self, store: &Arc<AccountStorageEntry>) -> bool {
         match self.shrink_ratio {
             AccountShrinkThreshold::TotalSpace { shrink_ratio: _ } => {
                 Self::page_align(store.alive_bytes() as u64) < store.total_bytes()
@@ -4938,7 +4938,7 @@ impl AccountsDb {
                     dead_slots.insert(*slot);
                 } else if self.caching_enabled
                     && Self::is_shrinking_productive(*slot, &[store.clone()])
-                    && self.is_candidate_for_shrink(store.clone())
+                    && self.is_candidate_for_shrink(&store)
                 {
                     // Checking that this single storage entry is ready for shrinking,
                     // should be a sufficient indication that the slot is ready to be shrunk
@@ -11181,13 +11181,13 @@ pub mod tests {
         let dummy_size = 2 * PAGE_SIZE;
         let entry = Arc::new(AccountStorageEntry::new(&dummy_path, 0, 1, dummy_size));
         entry.alive_bytes.store(3000, Ordering::Relaxed);
-        assert!(accounts.is_candidate_for_shrink(entry.clone()));
+        assert!(accounts.is_candidate_for_shrink(&entry));
         entry.alive_bytes.store(5000, Ordering::Relaxed);
-        assert!(!accounts.is_candidate_for_shrink(entry.clone()));
+        assert!(!accounts.is_candidate_for_shrink(&entry));
         accounts.shrink_ratio = AccountShrinkThreshold::TotalSpace { shrink_ratio: 0.3 };
         entry.alive_bytes.store(3000, Ordering::Relaxed);
-        assert!(accounts.is_candidate_for_shrink(entry.clone()));
+        assert!(accounts.is_candidate_for_shrink(&entry));
         accounts.shrink_ratio = AccountShrinkThreshold::IndividalStore { shrink_ratio: 0.3 };
-        assert!(!accounts.is_candidate_for_shrink(entry));
+        assert!(!accounts.is_candidate_for_shrink(&entry));
     }
 }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7306,8 +7306,7 @@ pub mod tests {
             &ClusterType::Development,
             spl_token_mint_index_enabled(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -9118,11 +9117,11 @@ pub mod tests {
         solana_logger::setup();
 
         // case 1: no canidates
-        let mut accounts = AccountsDb::new_single();
-        accounts.optimize_total_space = true;
+        let accounts = AccountsDb::new_single();
 
         let mut candidates: ShrinkCandidates = HashMap::new();
-        let output_candidates = accounts.select_candidates_by_total_usage(&candidates);
+        let output_candidates =
+            accounts.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
 
         assert_eq!(0, output_candidates.len());
 
@@ -9158,7 +9157,8 @@ pub mod tests {
             .or_default()
             .insert(entry2.append_vec_id(), entry2.clone());
 
-        let output_candidates = accounts.select_candidates_by_total_usage(&candidates);
+        let output_candidates =
+            accounts.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
         assert_eq!(1, output_candidates.len());
 
         assert_eq!(1, output_candidates[&dummy_slot].len());
@@ -9200,7 +9200,8 @@ pub mod tests {
             .or_default()
             .insert(entry2.append_vec_id(), entry2.clone());
 
-        let output_candidates = accounts.select_candidates_by_total_usage(&candidates);
+        let output_candidates =
+            accounts.select_candidates_by_total_usage(&candidates, DEFAULT_ACCOUNTS_SHRINK_RATIO);
         assert_eq!(2, output_candidates.len());
         assert_eq!(1, output_candidates[&dummy_slot].len());
         assert_eq!(1, output_candidates[&dummy_slot2].len());
@@ -9713,8 +9714,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
 
         let account_key = Pubkey::new_unique();
@@ -9762,8 +9762,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
 
         let account_key = Pubkey::new_unique();
@@ -9812,8 +9811,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
 
         let zero_lamport_account_key = Pubkey::new_unique();
@@ -9945,8 +9943,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
         let account_key = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();
@@ -10051,8 +10048,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let slot: Slot = 0;
         let num_keys = 10;
@@ -10107,8 +10103,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
         let slots: Vec<_> = (0..num_slots as Slot).into_iter().collect();
         let stall_slot = num_slots as Slot;
@@ -10507,8 +10502,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let account_key1 = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();
@@ -10771,8 +10765,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         db.load_delay = RACY_SLEEP_MS;
         let db = Arc::new(db);
@@ -10844,8 +10837,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         db.load_delay = RACY_SLEEP_MS;
         let db = Arc::new(db);
@@ -10921,8 +10913,7 @@ pub mod tests {
             &ClusterType::Development,
             AccountSecondaryIndexes::default(),
             caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         );
         let db = Arc::new(db);
         let num_cached_slots = 100;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9109,7 +9109,7 @@ pub mod tests {
     fn test_select_candidates_by_total_usage() {
         solana_logger::setup();
 
-        // case 1: no canidates
+        // case 1: no candidates
         let accounts = AccountsDb::new_single();
 
         let mut candidates: ShrinkCandidates = HashMap::new();
@@ -11177,6 +11177,14 @@ pub mod tests {
         let dummy_path = Path::new("");
         let dummy_size = 2 * PAGE_SIZE;
         let entry = Arc::new(AccountStorageEntry::new(&dummy_path, 0, 1, dummy_size));
+        match accounts.shrink_ratio {
+            AccountShrinkThreshold::TotalSpace { shrink_ratio } => {
+                assert_eq!(DEFAULT_ACCOUNTS_SHRINK_RATIO, shrink_ratio)
+            }
+            AccountShrinkThreshold::IndividalStore { shrink_ratio: _ } => {
+                assert!(false, "Expect the default to be TotalSpace")
+            }
+        }
         entry.alive_bytes.store(3000, Ordering::Relaxed);
         assert!(accounts.is_candidate_for_shrink(&entry));
         entry.alive_bytes.store(5000, Ordering::Relaxed);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2298,7 +2298,7 @@ impl AccountsDb {
 
     /// Given the input `ShrinkCandidates`, this function sorts the stores by their alive ratio
     /// in increasing order with the most sparse entries in the front. It will then simulate the
-    /// shrinking by working on the most sparse entries first and if the overal alive ratio is
+    /// shrinking by working on the most sparse entries first and if the overall alive ratio is
     /// achieved, it will stop and return the filtered-down candidates.
     fn select_candidates_by_total_usage(
         &self,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -11179,10 +11179,13 @@ pub mod tests {
         let entry = Arc::new(AccountStorageEntry::new(&dummy_path, 0, 1, dummy_size));
         match accounts.shrink_ratio {
             AccountShrinkThreshold::TotalSpace { shrink_ratio } => {
-                assert_eq!(DEFAULT_ACCOUNTS_SHRINK_RATIO, shrink_ratio)
+                assert_eq!(
+                    (DEFAULT_ACCOUNTS_SHRINK_RATIO * 100.) as u64,
+                    (shrink_ratio * 100.) as u64
+                )
             }
             AccountShrinkThreshold::IndividalStore { shrink_ratio: _ } => {
-                assert!(false, "Expect the default to be TotalSpace")
+                panic!("Expect the default to be TotalSpace")
             }
         }
         entry.alive_bytes.store(3000, Ordering::Relaxed);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -116,13 +116,12 @@ lazy_static! {
 #[derive(Debug, Clone, Copy)]
 pub enum AccountShrinkThreshold {
     /// Measure the total space sparseness across all candididates
-    /// And select the candidiates by using the top sparse accounts to shrink
+    /// And select the candidiates by using the top sparse account storage entries to shrink.
     /// The value is the overall shrink threshold measured as ratio of the total live bytes
     /// over the total bytes.
     TotalSpace { ratio: f64 },
     /// Use the following option to shrink all accounts whose alive ratio is below
-    /// the specified threshold. All accounts with alive usage ratio below this thresholds
-    /// will be shrank.
+    /// the specified threshold.
     IndividalAccount { ratio: f64 },
 }
 pub const DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE: bool = false;
@@ -1318,7 +1317,7 @@ impl Default for AccountsDb {
             load_limit: AtomicU64::default(),
             is_bank_drop_callback_enabled: AtomicBool::default(),
             remove_unrooted_slots_synchronization: RemoveUnrootedSlotsSynchronization::default(),
-            shrink_ratio: DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+            shrink_ratio: AccountShrinkThreshold::default(),
         }
     }
 }
@@ -1330,7 +1329,7 @@ impl AccountsDb {
             cluster_type,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+            AccountShrinkThreshold::default(),
         )
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -11188,6 +11188,6 @@ pub mod tests {
         entry.alive_bytes.store(3000, Ordering::Relaxed);
         assert!(accounts.is_candidate_for_shrink(entry.clone()));
         accounts.shrink_ratio = AccountShrinkThreshold::IndividalStore { shrink_ratio: 0.3 };
-        assert!(!accounts.is_candidate_for_shrink(entry.clone()));
+        assert!(!accounts.is_candidate_for_shrink(entry));
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,9 +38,7 @@ use crate::{
         AccountAddressFilter, Accounts, TransactionAccountDeps, TransactionAccounts,
         TransactionLoadResult, TransactionLoaders,
     },
-    accounts_db::{
-        AccountShrinkThreshold, ErrorCounters, SnapshotStorages,
-    },
+    accounts_db::{AccountShrinkThreshold, ErrorCounters, SnapshotStorages},
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},
     blockhash_queue::BlockhashQueue,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,7 +38,10 @@ use crate::{
         AccountAddressFilter, Accounts, TransactionAccountDeps, TransactionAccounts,
         TransactionLoadResult, TransactionLoaders,
     },
-    accounts_db::{ErrorCounters, SnapshotStorages},
+    accounts_db::{
+        ErrorCounters, SnapshotStorages, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+    },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},
     blockhash_queue::BlockhashQueue,
@@ -1011,6 +1014,8 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         )
     }
 
@@ -1023,6 +1028,8 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         );
 
         bank.ns_per_slot = std::u128::MAX;
@@ -1034,6 +1041,8 @@ impl Bank {
         genesis_config: &GenesisConfig,
         account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
+        optimize_total_space: bool,
+        shrink_ratio: f64,
     ) -> Self {
         Self::new_with_paths(
             &genesis_config,
@@ -1043,6 +1052,8 @@ impl Bank {
             None,
             account_indexes,
             accounts_db_caching_enabled,
+            optimize_total_space,
+            shrink_ratio,
         )
     }
 
@@ -1054,6 +1065,8 @@ impl Bank {
         additional_builtins: Option<&Builtins>,
         account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
+        optimize_total_space: bool,
+        shrink_ratio: f64,
     ) -> Self {
         let mut bank = Self::default();
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
@@ -1065,6 +1078,8 @@ impl Bank {
             &genesis_config.cluster_type,
             account_indexes,
             accounts_db_caching_enabled,
+            optimize_total_space,
+            shrink_ratio,
         ));
         bank.process_genesis_config(genesis_config);
         bank.finish_init(genesis_config, additional_builtins);
@@ -5292,7 +5307,9 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         accounts_background_service::{AbsRequestHandler, SendDroppedBankCallback},
-        accounts_db::SHRINK_RATIO,
+        accounts_db::{
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        },
         accounts_index::{AccountIndex, AccountMap, AccountSecondaryIndexes, ITER_BATCH_SIZE},
         ancestors::Ancestors,
         genesis_utils::{
@@ -9195,6 +9212,8 @@ pub(crate) mod tests {
             &genesis_config,
             account_indexes,
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         ));
 
         let address = Pubkey::new_unique();
@@ -10644,6 +10663,8 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             false,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         ));
         bank0.restore_old_behavior_for_fragile_tests();
         goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
@@ -10655,11 +10676,13 @@ pub(crate) mod tests {
             .accounts
             .scan_slot(0, |stored_account| Some(stored_account.stored_size()));
 
-        // Create an account such that it takes SHRINK_RATIO of the total account space for
+        // Create an account such that it takes DEFAULT_ACCOUNTS_SHRINK_RATIO of the total account space for
         // the slot, so when it gets pruned, the storage entry will become a shrink candidate.
         let bank0_total_size: usize = sizes.into_iter().sum();
-        let pubkey0_size = (bank0_total_size as f64 / (1.0 - SHRINK_RATIO)).ceil();
-        assert!(pubkey0_size / (pubkey0_size + bank0_total_size as f64) > SHRINK_RATIO);
+        let pubkey0_size = (bank0_total_size as f64 / (1.0 - DEFAULT_ACCOUNTS_SHRINK_RATIO)).ceil();
+        assert!(
+            pubkey0_size / (pubkey0_size + bank0_total_size as f64) > DEFAULT_ACCOUNTS_SHRINK_RATIO
+        );
         pubkey0_size as usize
     }
 
@@ -10677,6 +10700,8 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             true,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         ));
         bank0.restore_old_behavior_for_fragile_tests();
 
@@ -10720,7 +10745,13 @@ pub(crate) mod tests {
         // Slots 0 and 1 should be candidates for shrinking, but slot 2
         // shouldn't because none of its accounts are outdated by a later
         // root
-        assert_eq!(bank2.shrink_candidate_slots(), 2);
+        assert_eq!(
+            bank2.shrink_candidate_slots(
+                DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+                DEFAULT_ACCOUNTS_SHRINK_RATIO
+            ),
+            2
+        );
         let alive_counts: Vec<usize> = (0..3)
             .map(|slot| {
                 bank2
@@ -10732,7 +10763,13 @@ pub(crate) mod tests {
             .collect();
 
         // No more slots should be shrunk
-        assert_eq!(bank2.shrink_candidate_slots(), 0);
+        assert_eq!(
+            bank2.shrink_candidate_slots(
+                DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+                DEFAULT_ACCOUNTS_SHRINK_RATIO
+            ),
+            0
+        );
         // alive_counts represents the count of alive accounts in the three slots 0,1,2
         assert_eq!(alive_counts, vec![9, 1, 7]);
     }
@@ -11896,6 +11933,8 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             accounts_db_caching_enabled,
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         ));
         bank0.set_callback(drop_callback);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -40,7 +40,6 @@ use crate::{
     },
     accounts_db::{
         AccountShrinkThreshold, ErrorCounters, SnapshotStorages,
-        DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},
@@ -1014,7 +1013,7 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+            AccountShrinkThreshold::default(),
         )
     }
 
@@ -1027,7 +1026,7 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+            AccountShrinkThreshold::default(),
         );
 
         bank.ns_per_slot = std::u128::MAX;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1039,7 +1039,6 @@ impl Bank {
         genesis_config: &GenesisConfig,
         account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
-        optimize_total_space: bool,
         shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
         Self::new_with_paths(
@@ -5302,9 +5301,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         accounts_background_service::{AbsRequestHandler, SendDroppedBankCallback},
-        accounts_db::{
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        },
+        accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
         accounts_index::{AccountIndex, AccountMap, AccountSecondaryIndexes, ITER_BATCH_SIZE},
         ancestors::Ancestors,
         genesis_utils::{
@@ -9207,8 +9204,7 @@ pub(crate) mod tests {
             &genesis_config,
             account_indexes,
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
 
         let address = Pubkey::new_unique();
@@ -10658,8 +10654,7 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
         bank0.restore_old_behavior_for_fragile_tests();
         goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
@@ -10695,8 +10690,7 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             true,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
         bank0.restore_old_behavior_for_fragile_tests();
 
@@ -11916,8 +11910,7 @@ pub(crate) mod tests {
             &genesis_config,
             AccountSecondaryIndexes::default(),
             accounts_db_caching_enabled,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold::default(),
         ));
         bank0.set_callback(drop_callback);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -39,8 +39,7 @@ use crate::{
         TransactionLoadResult, TransactionLoaders,
     },
     accounts_db::{
-        ErrorCounters, SnapshotStorages, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        ErrorCounters, SnapshotStorages, AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},
@@ -1014,8 +1013,7 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
         )
     }
 
@@ -1028,8 +1026,7 @@ impl Bank {
             None,
             AccountSecondaryIndexes::default(),
             false,
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
         );
 
         bank.ns_per_slot = std::u128::MAX;
@@ -1042,7 +1039,7 @@ impl Bank {
         account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
         optimize_total_space: bool,
-        shrink_ratio: f64,
+        shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
         Self::new_with_paths(
             &genesis_config,
@@ -1052,7 +1049,6 @@ impl Bank {
             None,
             account_indexes,
             accounts_db_caching_enabled,
-            optimize_total_space,
             shrink_ratio,
         )
     }
@@ -1065,8 +1061,7 @@ impl Bank {
         additional_builtins: Option<&Builtins>,
         account_indexes: AccountSecondaryIndexes,
         accounts_db_caching_enabled: bool,
-        optimize_total_space: bool,
-        shrink_ratio: f64,
+        shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
         let mut bank = Self::default();
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
@@ -1078,7 +1073,6 @@ impl Bank {
             &genesis_config.cluster_type,
             account_indexes,
             accounts_db_caching_enabled,
-            optimize_total_space,
             shrink_ratio,
         ));
         bank.process_genesis_config(genesis_config);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10746,10 +10746,7 @@ pub(crate) mod tests {
         // shouldn't because none of its accounts are outdated by a later
         // root
         assert_eq!(
-            bank2.shrink_candidate_slots(
-                DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                DEFAULT_ACCOUNTS_SHRINK_RATIO
-            ),
+            bank2.shrink_candidate_slots(),
             2
         );
         let alive_counts: Vec<usize> = (0..3)
@@ -10764,10 +10761,7 @@ pub(crate) mod tests {
 
         // No more slots should be shrunk
         assert_eq!(
-            bank2.shrink_candidate_slots(
-                DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-                DEFAULT_ACCOUNTS_SHRINK_RATIO
-            ),
+            bank2.shrink_candidate_slots(),
             0
         );
         // alive_counts represents the count of alive accounts in the three slots 0,1,2

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10745,10 +10745,7 @@ pub(crate) mod tests {
         // Slots 0 and 1 should be candidates for shrinking, but slot 2
         // shouldn't because none of its accounts are outdated by a later
         // root
-        assert_eq!(
-            bank2.shrink_candidate_slots(),
-            2
-        );
+        assert_eq!(bank2.shrink_candidate_slots(), 2);
         let alive_counts: Vec<usize> = (0..3)
             .map(|slot| {
                 bank2
@@ -10760,10 +10757,7 @@ pub(crate) mod tests {
             .collect();
 
         // No more slots should be shrunk
-        assert_eq!(
-            bank2.shrink_candidate_slots(),
-            0
-        );
+        assert_eq!(bank2.shrink_candidate_slots(), 0);
         // alive_counts represents the count of alive accounts in the three slots 0,1,2
         assert_eq!(alive_counts, vec![9, 1, 7]);
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -39,7 +39,8 @@ use crate::{
         TransactionLoadResult, TransactionLoaders,
     },
     accounts_db::{
-        ErrorCounters, SnapshotStorages, AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
+        AccountShrinkThreshold, ErrorCounters, SnapshotStorages,
+        DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION,
     },
     accounts_index::{AccountSecondaryIndexes, IndexKey},
     ancestors::{Ancestors, AncestorsForSerialization},

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         accounts::Accounts,
-        accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo},
+        accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo, AccountShrinkThreshold},
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         append_vec::{AppendVec, StoredMetaWriteVersion},
@@ -136,8 +136,7 @@ pub(crate) fn bank_from_stream<R>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
-    optimize_total_space: bool,
-    shrink_ratio: f64,
+    shrink_ratio: AccountShrinkThreshold,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -158,7 +157,6 @@ where
                 account_indexes,
                 caching_enabled,
                 limit_load_slot_count_from_snapshot,
-                optimize_total_space,
                 shrink_ratio,
             )?;
             Ok(bank)
@@ -250,8 +248,7 @@ fn reconstruct_bank_from_fields<E>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
-    optimize_total_space: bool,
-    shrink_ratio: f64,
+    shrink_ratio: AccountShrinkThreshold,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage,
@@ -264,7 +261,6 @@ where
         account_indexes,
         caching_enabled,
         limit_load_slot_count_from_snapshot,
-        optimize_total_space,
         shrink_ratio,
     )?;
     accounts_db.freeze_accounts(
@@ -292,8 +288,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
-    optimize_total_space: bool,
-    shrink_ratio: f64,
+    shrink_ratio: AccountShrinkThreshold,
 ) -> Result<AccountsDb, Error>
 where
     E: SerializableStorage,
@@ -303,7 +298,6 @@ where
         cluster_type,
         account_indexes,
         caching_enabled,
-        optimize_total_space,
         shrink_ratio,
     );
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
         accounts::Accounts,
-        accounts_db::{AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo, AccountShrinkThreshold},
+        accounts_db::{
+            AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo,
+        },
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         append_vec::{AppendVec, StoredMetaWriteVersion},

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -136,6 +136,8 @@ pub(crate) fn bank_from_stream<R>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
+    optimize_total_space: bool,
+    shrink_ratio: f64,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -156,6 +158,8 @@ where
                 account_indexes,
                 caching_enabled,
                 limit_load_slot_count_from_snapshot,
+                optimize_total_space,
+                shrink_ratio,
             )?;
             Ok(bank)
         }};
@@ -246,6 +250,8 @@ fn reconstruct_bank_from_fields<E>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
+    optimize_total_space: bool,
+    shrink_ratio: f64,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage,
@@ -258,6 +264,8 @@ where
         account_indexes,
         caching_enabled,
         limit_load_slot_count_from_snapshot,
+        optimize_total_space,
+        shrink_ratio,
     )?;
     accounts_db.freeze_accounts(
         &Ancestors::from(&bank_fields.ancestors),
@@ -284,6 +292,8 @@ fn reconstruct_accountsdb_from_fields<E>(
     account_indexes: AccountSecondaryIndexes,
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
+    optimize_total_space: bool,
+    shrink_ratio: f64,
 ) -> Result<AccountsDb, Error>
 where
     E: SerializableStorage,
@@ -293,6 +303,8 @@ where
         cluster_type,
         account_indexes,
         caching_enabled,
+        optimize_total_space,
+        shrink_ratio,
     );
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -3,10 +3,7 @@ use {
     super::*,
     crate::{
         accounts::{create_test_accounts, Accounts},
-        accounts_db::{
-            get_temp_accounts_paths, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-            DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        },
+        accounts_db::{get_temp_accounts_paths, AccountShrinkThreshold},
         bank::{Bank, StatusCacheRc},
         hardened_unpack::UnpackedAppendVecMap,
     },
@@ -77,8 +74,7 @@ where
         AccountSecondaryIndexes::default(),
         false,
         None,
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        AccountShrinkThreshold::default(),
     )
 }
 
@@ -134,8 +130,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        AccountShrinkThreshold::default(),
     );
 
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -235,8 +230,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         AccountSecondaryIndexes::default(),
         false,
         None,
-        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
-        DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        AccountShrinkThreshold::default(),
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -3,7 +3,10 @@ use {
     super::*,
     crate::{
         accounts::{create_test_accounts, Accounts},
-        accounts_db::get_temp_accounts_paths,
+        accounts_db::{
+            get_temp_accounts_paths, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        },
         bank::{Bank, StatusCacheRc},
         hardened_unpack::UnpackedAppendVecMap,
     },
@@ -74,6 +77,8 @@ where
         AccountSecondaryIndexes::default(),
         false,
         None,
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+        DEFAULT_ACCOUNTS_SHRINK_RATIO,
     )
 }
 
@@ -129,6 +134,8 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         &ClusterType::Development,
         AccountSecondaryIndexes::default(),
         false,
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+        DEFAULT_ACCOUNTS_SHRINK_RATIO,
     );
 
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -228,6 +235,8 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         AccountSecondaryIndexes::default(),
         false,
         None,
+        DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+        DEFAULT_ACCOUNTS_SHRINK_RATIO,
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -605,6 +605,8 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
+    optimize_total_space: bool,
+    shrink_ratio: f64,
 ) -> Result<Bank> {
     let unpack_dir = tempfile::Builder::new()
         .prefix(TMP_SNAPSHOT_PREFIX)
@@ -636,6 +638,8 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         account_indexes,
         accounts_db_caching_enabled,
         limit_load_slot_count_from_snapshot,
+        optimize_total_space,
+        shrink_ratio,
     )?;
 
     if !bank.verify_snapshot_bank() {
@@ -796,6 +800,8 @@ fn rebuild_bank_from_snapshots(
     account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
+    optimize_total_space: bool,
+    shrink_ratio: f64,
 ) -> Result<Bank> {
     info!("snapshot version: {}", snapshot_version);
 
@@ -832,6 +838,8 @@ fn rebuild_bank_from_snapshots(
                 account_indexes,
                 accounts_db_caching_enabled,
                 limit_load_slot_count_from_snapshot,
+                optimize_total_space,
+                shrink_ratio,
             ),
         }?)
     })?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_db::{AccountsDb, AccountShrinkThreshold},
+        accounts_db::{AccountShrinkThreshold, AccountsDb},
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta, Builtins},
         bank_forks::ArchiveFormat,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        accounts_db::AccountsDb,
+        accounts_db::{AccountsDb, AccountShrinkThreshold},
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta, Builtins},
         bank_forks::ArchiveFormat,
@@ -605,8 +605,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
-    optimize_total_space: bool,
-    shrink_ratio: f64,
+    shrink_ratio: AccountShrinkThreshold,
 ) -> Result<Bank> {
     let unpack_dir = tempfile::Builder::new()
         .prefix(TMP_SNAPSHOT_PREFIX)
@@ -638,7 +637,6 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         account_indexes,
         accounts_db_caching_enabled,
         limit_load_slot_count_from_snapshot,
-        optimize_total_space,
         shrink_ratio,
     )?;
 
@@ -800,8 +798,7 @@ fn rebuild_bank_from_snapshots(
     account_indexes: AccountSecondaryIndexes,
     accounts_db_caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
-    optimize_total_space: bool,
-    shrink_ratio: f64,
+    shrink_ratio: AccountShrinkThreshold,
 ) -> Result<Bank> {
     info!("snapshot version: {}", snapshot_version);
 
@@ -838,7 +835,6 @@ fn rebuild_bank_from_snapshots(
                 account_indexes,
                 accounts_db_caching_enabled,
                 limit_load_slot_count_from_snapshot,
-                optimize_total_space,
                 shrink_ratio,
             ),
         }?)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -40,7 +40,8 @@ use {
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
         accounts_db::{
-            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
+            AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            DEFAULT_ACCOUNTS_SHRINK_RATIO,
         },
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
@@ -2107,6 +2108,16 @@ pub fn main() {
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let accounts_shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
 
+    let accounts_shrink_ratio = if accounts_shrink_optimize_total_space {
+        AccountShrinkThreshold::TotalSpace {
+            ratio: accounts_shrink_ratio,
+        }
+    } else {
+        AccountShrinkThreshold::IndividalAccount {
+            ratio: accounts_shrink_ratio,
+        }
+    };
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_path: value_t!(matches, "tower", PathBuf).ok(),
@@ -2204,7 +2215,6 @@ pub fn main() {
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
-        accounts_shrink_optimize_total_space,
         accounts_shrink_ratio,
         ..ValidatorConfig::default()
     };

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -39,6 +39,9 @@ use {
     solana_poh::poh_service,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
+        accounts_db::{
+            DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE, DEFAULT_ACCOUNTS_SHRINK_RATIO,
+        },
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
         },
@@ -1009,6 +1012,9 @@ pub fn main() {
     let default_max_snapshot_to_retain = &DEFAULT_MAX_SNAPSHOTS_TO_RETAIN.to_string();
     let default_min_snapshot_download_speed = &DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED.to_string();
     let default_max_snapshot_download_abort = &MAX_SNAPSHOT_DOWNLOAD_ABORT.to_string();
+    let default_accounts_shrink_optimize_total_space =
+        &DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE.to_string();
+    let default_accounts_shrink_ratio = &DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1778,6 +1784,28 @@ pub fn main() {
                 .hidden(true)
         )
         .arg(
+            Arg::with_name("accounts_shrink_optimize_total_space")
+                .long("accounts-shrink-optimize-total-space")
+                .takes_value(true)
+                .value_name("BOOLEAN")
+                .default_value(default_accounts_shrink_optimize_total_space)
+                .help("When this is set to true, the system will shrink the most \
+                       sparse accounts and when the overall account usage is reached \
+                       within accounts_shrink_ratio, the shrink will stop and \
+                       it will skip all other less sparse accounts."),
+        )
+        .arg(
+            Arg::with_name("accounts_shrink_ratio")
+                .long("accounts-shrink-ratio")
+                .takes_value(true)
+                .value_name("NUM")
+                .default_value(default_accounts_shrink_ratio)
+                .help("Specifies the shrink ratio for the accounts to be shrank \
+                       The shrink ratio is defined as the ratio of the bytes alive over the  \
+                       total bytes used. If the account's shrink ratio the overall account usage is reached \
+                       within accounts-extra-space percentage, the shrink will stop."),
+        )
+        .arg(
             Arg::with_name("no_duplicate_instance_check")
                 .long("no-duplicate-instance-check")
                 .takes_value(false)
@@ -2075,6 +2103,10 @@ pub fn main() {
     let account_indexes = process_account_indexes(&matches);
 
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
+    let accounts_shrink_optimize_total_space =
+        value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
+    let accounts_shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_path: value_t!(matches, "tower", PathBuf).ok(),
@@ -2172,6 +2204,8 @@ pub fn main() {
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
+        accounts_shrink_optimize_total_space,
+        accounts_shrink_ratio,
         ..ValidatorConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1799,12 +1799,12 @@ pub fn main() {
             Arg::with_name("accounts_shrink_ratio")
                 .long("accounts-shrink-ratio")
                 .takes_value(true)
-                .value_name("NUM")
+                .value_name("RATIO")
                 .default_value(default_accounts_shrink_ratio)
                 .help("Specifies the shrink ratio for the accounts to be shrank. \
                        The shrink ratio is defined as the ratio of the bytes alive over the  \
                        total bytes used. If the account's shrink ratio is less than this ratio \
-                       it becomes a candidate for shrinking."),
+                       it becomes a candidate for shrinking. The value must between 0. - 1.0."),
         )
         .arg(
             Arg::with_name("no_duplicate_instance_check")
@@ -2107,15 +2107,18 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
+    if shrink_ratio < 0.0 || shrink_ratio > 1.0 {
+        eprintln!(
+            "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0: {}",
+            shrink_ratio
+        );
+        exit(1);
+    }
 
     let accounts_shrink_ratio = if accounts_shrink_optimize_total_space {
-        AccountShrinkThreshold::TotalSpace {
-            ratio: shrink_ratio,
-        }
+        AccountShrinkThreshold::TotalSpace { shrink_ratio }
     } else {
-        AccountShrinkThreshold::IndividalAccount {
-            ratio: shrink_ratio,
-        }
+        AccountShrinkThreshold::IndividalStore { shrink_ratio }
     };
 
     let mut validator_config = ValidatorConfig {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1801,10 +1801,11 @@ pub fn main() {
                 .takes_value(true)
                 .value_name("RATIO")
                 .default_value(default_accounts_shrink_ratio)
-                .help("Specifies the shrink ratio for the accounts to be shrank. \
+                .help("Specifies the shrink ratio for the accounts to be shrunk. \
                        The shrink ratio is defined as the ratio of the bytes alive over the  \
                        total bytes used. If the account's shrink ratio is less than this ratio \
-                       it becomes a candidate for shrinking. The value must between 0. - 1.0."),
+                       it becomes a candidate for shrinking. The value must between 0. and 1.0 \
+                       inclusive."),
         )
         .arg(
             Arg::with_name("no_duplicate_instance_check")
@@ -2109,7 +2110,7 @@ pub fn main() {
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {
         eprintln!(
-            "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0: {}",
+            "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0 inclusive: {}",
             shrink_ratio
         );
         exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1801,10 +1801,10 @@ pub fn main() {
                 .takes_value(true)
                 .value_name("NUM")
                 .default_value(default_accounts_shrink_ratio)
-                .help("Specifies the shrink ratio for the accounts to be shrank \
+                .help("Specifies the shrink ratio for the accounts to be shrank. \
                        The shrink ratio is defined as the ratio of the bytes alive over the  \
                        total bytes used. If the account's shrink ratio is less than this ratio \
-                       it can become a candidate for shrink."),
+                       it becomes a candidate for shrinking."),
         )
         .arg(
             Arg::with_name("no_duplicate_instance_check")
@@ -2106,15 +2106,15 @@ pub fn main() {
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
-    let accounts_shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
+    let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
 
     let accounts_shrink_ratio = if accounts_shrink_optimize_total_space {
         AccountShrinkThreshold::TotalSpace {
-            ratio: accounts_shrink_ratio,
+            ratio: shrink_ratio,
         }
     } else {
         AccountShrinkThreshold::IndividalAccount {
-            ratio: accounts_shrink_ratio,
+            ratio: shrink_ratio,
         }
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1790,8 +1790,8 @@ pub fn main() {
                 .value_name("BOOLEAN")
                 .default_value(default_accounts_shrink_optimize_total_space)
                 .help("When this is set to true, the system will shrink the most \
-                       sparse accounts and when the overall account usage is reached \
-                       within accounts_shrink_ratio, the shrink will stop and \
+                       sparse accounts and when the overall shrink ratio is above \
+                       the specified accounts-shrink-ratio, the shrink will stop and \
                        it will skip all other less sparse accounts."),
         )
         .arg(
@@ -1802,8 +1802,8 @@ pub fn main() {
                 .default_value(default_accounts_shrink_ratio)
                 .help("Specifies the shrink ratio for the accounts to be shrank \
                        The shrink ratio is defined as the ratio of the bytes alive over the  \
-                       total bytes used. If the account's shrink ratio the overall account usage is reached \
-                       within accounts-extra-space percentage, the shrink will stop."),
+                       total bytes used. If the account's shrink ratio is less than this ratio \
+                       it can become a candidate for shrink."),
         )
         .arg(
             Arg::with_name("no_duplicate_instance_check")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2107,7 +2107,7 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
-    if shrink_ratio < 0.0 || shrink_ratio > 1.0 {
+    if !(0.0..=1.0).contains(&shrink_ratio) {
         eprintln!(
             "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0: {}",
             shrink_ratio


### PR DESCRIPTION
#### Problem
Different hardware is used for storing the accounts data with different properties. For instance an all-RAM setup might tolerate high write-amplification but would like to have the smallest possible size. A disk setup which cares about write bandwidth might be willing to sacrifice some space to reduce write IO.
#### Summary of Changes
1. Added both options for measuring space usage using total accounts usage and for individual store shrink ratio using an enum. Validator CLI options: --accounts-shrink-optimize-total-space and --accounts-shrink-ratio
2. Added code for selecting candidates based on total usage in a separate function select_candidates_by_total_usage
3. Added unit tests for the new functions added
4. The default implementations is kept at 0.8 shrink ratio on individual storage entries
Fixes #17544

#### Tests
Do integration testing running validator against MNB using both options. And observing the metrics captured. Did not find any material CPU usage over when accounts-shrink-optimize-total-space is true. In term of actual shrinking, I have measured the performance over several hours with both approaches. 
With AccountShrinkThreshold::IndividualStore way, we spend about 20% of the elapse time doing shrinking
With AccountShrinkThreshold::TotalSpace optimization: we spend about 10% of the time doing shrinking
Cargo test.