### PR TITLE
Port unconfirmed duplicate tracking logic from ProgressMap to ForkChoice

### DIFF
--- a/core/src/cluster_slot_state_verifier.rs
+++ b/core/src/cluster_slot_state_verifier.rs
@@ -646,7 +646,7 @@ mod test {
             vec![ResultingStateChange::MarkSlotDuplicate(slot_hash)],
         );
         assert!(!heaviest_subtree_fork_choice
-            .is_candidate_slot(&(slot, slot_hash))
+            .is_candidate(&(slot, slot_hash))
             .unwrap());
         for child_slot in descendants
             .get(&slot)
@@ -684,7 +684,7 @@ mod test {
                 .is_none());
         }
         assert!(heaviest_subtree_fork_choice
-            .is_candidate_slot(&(slot, slot_hash))
+            .is_candidate(&(slot, slot_hash))
             .unwrap());
     }
 

--- a/core/src/cluster_slot_state_verifier.rs
+++ b/core/src/cluster_slot_state_verifier.rs
@@ -266,7 +266,11 @@ pub(crate) fn check_slot_agrees_with_cluster(
     let frozen_hash = frozen_hash.unwrap();
     let gossip_duplicate_confirmed_hash = gossip_duplicate_confirmed_slots.get(&slot);
 
-    let is_local_replay_duplicate_confirmed = fork_choice.is_duplicate_confirmed(&(slot, frozen_hash)).expect("If the frozen hash exists, then the slot must exist in bank forks and thus in progress map");
+    // If the bank hasn't been frozen yet, then we haven't duplicate confirmed a local version
+    // this slot through replay yet.
+    let is_local_replay_duplicate_confirmed = fork_choice
+        .is_duplicate_confirmed(&(slot, frozen_hash))
+        .unwrap_or(false);
     let cluster_duplicate_confirmed_hash = get_cluster_duplicate_confirmed_hash(
         slot,
         gossip_duplicate_confirmed_hash,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1866,7 +1866,16 @@ pub mod test {
         let mut tower = Tower::new_with_key(&vote_simulator.node_pubkeys[0]);
 
         // Last vote is 47
-        tower.record_vote(47, Hash::default());
+        tower.record_vote(
+            47,
+            vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(47)
+                .unwrap()
+                .hash(),
+        );
 
         // Trying to switch to an ancestor of last vote should only not panic
         // if the current vote has a duplicate ancestor

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1,4 +1,5 @@
 use crate::{
+    heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
     latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
     progress_map::{LockoutIntervals, ProgressMap},
 };
@@ -573,6 +574,7 @@ impl Tower {
             .map(|candidate_slot_ancestors| candidate_slot_ancestors.contains(&last_voted_slot))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn make_check_switch_threshold_decision(
         &self,
         switch_slot: u64,
@@ -582,9 +584,10 @@ impl Tower {
         total_stake: u64,
         epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
+        heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
-        self.last_voted_slot()
-            .map(|last_voted_slot| {
+        self.last_voted_slot_hash()
+            .map(|(last_voted_slot, last_voted_hash)| {
                 let root = self.root();
                 let empty_ancestors = HashSet::default();
                 let empty_ancestors_due_to_minor_unsynced_ledger = || {
@@ -673,7 +676,7 @@ impl Tower {
                 if last_vote_ancestors.contains(&switch_slot) {
                     if self.is_stray_last_vote() {
                         return suspended_decision_due_to_major_unsynced_ledger();
-                    } else if let Some(latest_duplicate_ancestor) = progress.latest_unconfirmed_duplicate_ancestor(last_voted_slot) {
+                    } else if let Some(latest_duplicate_ancestor) = heaviest_subtree_fork_choice.latest_invalid_ancestor(&(last_voted_slot, last_voted_hash)) {
                         // We're rolling back because one of the ancestors of the last vote was a duplicate. In this
                         // case, it's acceptable if the switch candidate is one of ancestors of the previous vote,
                         // just fail the switch check because there's no point in voting on an ancestor. ReplayStage
@@ -821,6 +824,7 @@ impl Tower {
             .unwrap_or(SwitchForkDecision::SameFork)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn check_switch_threshold(
         &mut self,
         switch_slot: u64,
@@ -830,6 +834,7 @@ impl Tower {
         total_stake: u64,
         epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
+        heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
         let decision = self.make_check_switch_threshold_decision(
             switch_slot,
@@ -839,6 +844,7 @@ impl Tower {
             total_stake,
             epoch_vote_accounts,
             latest_validator_votes_for_frozen_banks,
+            heaviest_subtree_fork_choice,
         );
         let new_check = Some((switch_slot, decision.clone()));
         if new_check != self.last_switch_threshold_check {
@@ -1360,9 +1366,9 @@ pub mod test {
         cluster_info_vote_listener::VoteTracker,
         cluster_slot_state_verifier::{DuplicateSlotsTracker, GossipDuplicateConfirmedSlots},
         cluster_slots::ClusterSlots,
-        fork_choice::SelectVoteAndResetForkResult,
-        heaviest_subtree_fork_choice::{HeaviestSubtreeForkChoice, SlotHashKey},
-        progress_map::{DuplicateStats, ForkProgress},
+        fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
+        heaviest_subtree_fork_choice::SlotHashKey,
+        progress_map::ForkProgress,
         replay_stage::{HeaviestForkFailures, ReplayStage},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     };
@@ -1439,9 +1445,9 @@ pub mod test {
 
             while let Some(visit) = walk.get() {
                 let slot = visit.node().data;
-                self.progress.entry(slot).or_insert_with(|| {
-                    ForkProgress::new(Hash::default(), None, DuplicateStats::default(), None, 0, 0)
-                });
+                self.progress
+                    .entry(slot)
+                    .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0));
                 if self.bank_forks.read().unwrap().get(slot).is_some() {
                     walk.forward();
                     continue;
@@ -1530,6 +1536,7 @@ pub mod test {
                 &self.progress,
                 tower,
                 &self.latest_validator_votes_for_frozen_banks,
+                &self.heaviest_subtree_fork_choice,
             );
 
             // Make sure this slot isn't locked out or failing threshold
@@ -1593,9 +1600,7 @@ pub mod test {
         ) {
             self.progress
                 .entry(slot)
-                .or_insert_with(|| {
-                    ForkProgress::new(Hash::default(), None, DuplicateStats::default(), None, 0, 0)
-                })
+                .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0))
                 .fork_stats
                 .lockout_intervals
                 .entry(lockout_interval.1)
@@ -1702,14 +1707,7 @@ pub mod test {
         let mut progress = ProgressMap::default();
         progress.insert(
             0,
-            ForkProgress::new(
-                bank0.last_blockhash(),
-                None,
-                DuplicateStats::default(),
-                None,
-                0,
-                0,
-            ),
+            ForkProgress::new(bank0.last_blockhash(), None, None, 0, 0),
         );
         let bank_forks = BankForks::new(bank0);
         let heaviest_subtree_fork_choice =
@@ -1875,14 +1873,30 @@ pub mod test {
         let ancestor_of_voted_slot = 43;
         let duplicate_ancestor1 = 44;
         let duplicate_ancestor2 = 45;
-        vote_simulator.progress.set_unconfirmed_duplicate_slot(
-            duplicate_ancestor1,
-            &descendants.get(&duplicate_ancestor1).unwrap(),
-        );
-        vote_simulator.progress.set_unconfirmed_duplicate_slot(
-            duplicate_ancestor2,
-            &descendants.get(&duplicate_ancestor2).unwrap(),
-        );
+        vote_simulator
+            .heaviest_subtree_fork_choice
+            .mark_fork_invalid_candidate(&(
+                duplicate_ancestor1,
+                vote_simulator
+                    .bank_forks
+                    .read()
+                    .unwrap()
+                    .get(duplicate_ancestor1)
+                    .unwrap()
+                    .hash(),
+            ));
+        vote_simulator
+            .heaviest_subtree_fork_choice
+            .mark_fork_invalid_candidate(&(
+                duplicate_ancestor2,
+                vote_simulator
+                    .bank_forks
+                    .read()
+                    .unwrap()
+                    .get(duplicate_ancestor2)
+                    .unwrap()
+                    .hash(),
+            ));
         assert_eq!(
             tower.check_switch_threshold(
                 ancestor_of_voted_slot,
@@ -1891,7 +1905,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchDuplicateRollback(duplicate_ancestor2)
         );
@@ -1904,11 +1919,18 @@ pub mod test {
             confirm_ancestors.push(duplicate_ancestor2);
         }
         for (i, duplicate_ancestor) in confirm_ancestors.into_iter().enumerate() {
-            vote_simulator.progress.set_confirmed_duplicate_slot(
-                duplicate_ancestor,
-                ancestors.get(&duplicate_ancestor).unwrap(),
-                &descendants.get(&duplicate_ancestor).unwrap(),
-            );
+            vote_simulator
+                .heaviest_subtree_fork_choice
+                .mark_fork_valid_candidate(&(
+                    duplicate_ancestor,
+                    vote_simulator
+                        .bank_forks
+                        .read()
+                        .unwrap()
+                        .get(duplicate_ancestor)
+                        .unwrap()
+                        .hash(),
+                ));
             let res = tower.check_switch_threshold(
                 ancestor_of_voted_slot,
                 &ancestors,
@@ -1917,6 +1939,7 @@ pub mod test {
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
                 &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             );
             if i == 0 {
                 assert_eq!(
@@ -1952,7 +1975,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SameFork
         );
@@ -1966,7 +1990,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -1982,7 +2007,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -1998,7 +2024,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2014,7 +2041,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2032,7 +2060,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2048,7 +2077,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SwitchProof(Hash::default())
         );
@@ -2065,7 +2095,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SwitchProof(Hash::default())
         );
@@ -2091,7 +2122,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2123,7 +2155,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, num_validators * 10000)
         );
@@ -2138,7 +2171,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2170,7 +2204,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SwitchProof(Hash::default())
         );
@@ -2194,7 +2229,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2873,7 +2909,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SameFork
         );
@@ -2887,7 +2924,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2902,7 +2940,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SwitchProof(Hash::default())
         );
@@ -2972,7 +3011,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -2987,7 +3027,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::FailedSwitchThreshold(0, 20000)
         );
@@ -3002,7 +3043,8 @@ pub mod test {
                 &vote_simulator.progress,
                 total_stake,
                 bank0.epoch_vote_accounts(0).unwrap(),
-                &vote_simulator.latest_validator_votes_for_frozen_banks
+                &vote_simulator.latest_validator_votes_for_frozen_banks,
+                &vote_simulator.heaviest_subtree_fork_choice,
             ),
             SwitchForkDecision::SwitchProof(Hash::default())
         );

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -161,7 +161,6 @@ pub(crate) struct ForkProgress {
     pub(crate) propagated_stats: PropagatedStats,
     pub(crate) replay_stats: ReplaySlotStats,
     pub(crate) replay_progress: ConfirmationProgress,
-    pub(crate) duplicate_stats: DuplicateStats,
     // Note `num_blocks_on_fork` and `num_dropped_blocks_on_fork` only
     // count new blocks replayed since last restart, which won't include
     // blocks already existing in the ledger/before snapshot at start,
@@ -174,7 +173,6 @@ impl ForkProgress {
     pub fn new(
         last_entry: Hash,
         prev_leader_slot: Option<Slot>,
-        duplicate_stats: DuplicateStats,
         validator_stake_info: Option<ValidatorStakeInfo>,
         num_blocks_on_fork: u64,
         num_dropped_blocks_on_fork: u64,
@@ -208,7 +206,6 @@ impl ForkProgress {
             fork_stats: ForkStats::default(),
             replay_stats: ReplaySlotStats::default(),
             replay_progress: ConfirmationProgress::new(last_entry),
-            duplicate_stats,
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
             propagated_stats: PropagatedStats {
@@ -228,7 +225,6 @@ impl ForkProgress {
         my_pubkey: &Pubkey,
         voting_pubkey: &Pubkey,
         prev_leader_slot: Option<Slot>,
-        duplicate_stats: DuplicateStats,
         num_blocks_on_fork: u64,
         num_dropped_blocks_on_fork: u64,
     ) -> Self {
@@ -247,19 +243,10 @@ impl ForkProgress {
         Self::new(
             bank.last_blockhash(),
             prev_leader_slot,
-            duplicate_stats,
             validator_stake_info,
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
         )
-    }
-
-    pub fn is_duplicate_confirmed(&self) -> bool {
-        self.duplicate_stats.is_duplicate_confirmed
-    }
-
-    pub fn set_duplicate_confirmed(&mut self) {
-        self.duplicate_stats.set_duplicate_confirmed();
     }
 }
 
@@ -293,38 +280,6 @@ pub(crate) struct PropagatedStats {
     pub(crate) slot_vote_tracker: Option<Arc<RwLock<SlotVoteTracker>>>,
     pub(crate) cluster_slot_pubkeys: Option<Arc<RwLock<SlotPubkeys>>>,
     pub(crate) total_epoch_stake: u64,
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct DuplicateStats {
-    latest_unconfirmed_duplicate_ancestor: Option<Slot>,
-    is_duplicate_confirmed: bool,
-}
-
-impl DuplicateStats {
-    pub fn new_with_unconfirmed_duplicate_ancestor(
-        latest_unconfirmed_duplicate_ancestor: Option<Slot>,
-    ) -> Self {
-        Self {
-            latest_unconfirmed_duplicate_ancestor,
-            is_duplicate_confirmed: false,
-        }
-    }
-
-    fn set_duplicate_confirmed(&mut self) {
-        self.is_duplicate_confirmed = true;
-        self.latest_unconfirmed_duplicate_ancestor = None;
-    }
-
-    fn update_with_newly_confirmed_duplicate_ancestor(&mut self, newly_confirmed_ancestor: Slot) {
-        if let Some(latest_unconfirmed_duplicate_ancestor) =
-            self.latest_unconfirmed_duplicate_ancestor
-        {
-            if latest_unconfirmed_duplicate_ancestor <= newly_confirmed_ancestor {
-                self.latest_unconfirmed_duplicate_ancestor = None;
-            }
-        }
-    }
 }
 
 impl PropagatedStats {
@@ -458,102 +413,6 @@ impl ProgressMap {
         }
     }
 
-    #[cfg(test)]
-    pub fn is_unconfirmed_duplicate(&self, slot: Slot) -> Option<bool> {
-        self.get(&slot).map(|p| {
-            p.duplicate_stats
-                .latest_unconfirmed_duplicate_ancestor
-                .map(|ancestor| ancestor == slot)
-                .unwrap_or(false)
-        })
-    }
-
-    pub fn latest_unconfirmed_duplicate_ancestor(&self, slot: Slot) -> Option<Slot> {
-        self.get(&slot)
-            .map(|p| p.duplicate_stats.latest_unconfirmed_duplicate_ancestor)
-            .unwrap_or(None)
-    }
-
-    pub fn set_unconfirmed_duplicate_slot(&mut self, slot: Slot, descendants: &HashSet<u64>) {
-        if let Some(fork_progress) = self.get_mut(&slot) {
-            if fork_progress.is_duplicate_confirmed() {
-                assert!(fork_progress
-                    .duplicate_stats
-                    .latest_unconfirmed_duplicate_ancestor
-                    .is_none());
-                return;
-            }
-
-            if fork_progress
-                .duplicate_stats
-                .latest_unconfirmed_duplicate_ancestor
-                == Some(slot)
-            {
-                // Already been marked
-                return;
-            }
-            fork_progress
-                .duplicate_stats
-                .latest_unconfirmed_duplicate_ancestor = Some(slot);
-
-            for d in descendants {
-                if let Some(fork_progress) = self.get_mut(&d) {
-                    fork_progress
-                        .duplicate_stats
-                        .latest_unconfirmed_duplicate_ancestor = Some(std::cmp::max(
-                        fork_progress
-                            .duplicate_stats
-                            .latest_unconfirmed_duplicate_ancestor
-                            .unwrap_or(0),
-                        slot,
-                    ));
-                }
-            }
-        }
-    }
-
-    pub fn set_confirmed_duplicate_slot(
-        &mut self,
-        slot: Slot,
-        ancestors: &HashSet<u64>,
-        descendants: &HashSet<u64>,
-    ) {
-        for a in ancestors {
-            if let Some(fork_progress) = self.get_mut(&a) {
-                fork_progress.set_duplicate_confirmed();
-            }
-        }
-
-        if let Some(slot_fork_progress) = self.get_mut(&slot) {
-            // Setting the fields here is only correct and necessary if the loop above didn't
-            // already do this, so check with an assert.
-            assert!(!ancestors.contains(&slot));
-            let slot_had_unconfirmed_duplicate_ancestor = slot_fork_progress
-                .duplicate_stats
-                .latest_unconfirmed_duplicate_ancestor
-                .is_some();
-            slot_fork_progress.set_duplicate_confirmed();
-
-            if slot_had_unconfirmed_duplicate_ancestor {
-                for d in descendants {
-                    if let Some(descendant_fork_progress) = self.get_mut(&d) {
-                        descendant_fork_progress
-                            .duplicate_stats
-                            .update_with_newly_confirmed_duplicate_ancestor(slot);
-                    }
-                }
-            } else {
-                // Neither this slot `S`, nor earlier ancestors were marked as duplicate,
-                // so this means all descendants either:
-                // 1) Have no duplicate ancestors
-                // 2) Have a duplicate ancestor > `S`
-
-                // In both cases, there's no need to iterate through descendants because
-                // this confirmation on `S` is irrelevant to them.
-            }
-        }
-    }
-
     pub fn my_latest_landed_vote(&self, slot: Slot) -> Option<Slot> {
         self.progress_map
             .get(&slot)
@@ -569,12 +428,6 @@ impl ProgressMap {
         self.progress_map
             .get(&slot)
             .map(|s| s.fork_stats.is_supermajority_confirmed)
-    }
-
-    pub fn is_duplicate_confirmed(&self, slot: Slot) -> Option<bool> {
-        self.progress_map
-            .get(&slot)
-            .map(|s| s.is_duplicate_confirmed())
     }
 
     pub fn get_bank_prev_leader_slot(&self, bank: &Bank) -> Option<Slot> {
@@ -619,8 +472,6 @@ impl ProgressMap {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::consensus::test::VoteSimulator;
-    use trees::tr;
 
     #[test]
     fn test_add_vote_pubkey() {
@@ -711,21 +562,13 @@ mod test {
     fn test_is_propagated_status_on_construction() {
         // If the given ValidatorStakeInfo == None, then this is not
         // a leader slot and is_propagated == false
-        let progress = ForkProgress::new(
-            Hash::default(),
-            Some(9),
-            DuplicateStats::default(),
-            None,
-            0,
-            0,
-        );
+        let progress = ForkProgress::new(Hash::default(), Some(9), None, 0, 0);
         assert!(!progress.propagated_stats.is_propagated);
 
         // If the stake is zero, then threshold is always achieved
         let progress = ForkProgress::new(
             Hash::default(),
             Some(9),
-            DuplicateStats::default(),
             Some(ValidatorStakeInfo {
                 total_epoch_stake: 0,
                 ..ValidatorStakeInfo::default()
@@ -740,7 +583,6 @@ mod test {
         let progress = ForkProgress::new(
             Hash::default(),
             Some(9),
-            DuplicateStats::default(),
             Some(ValidatorStakeInfo {
                 total_epoch_stake: 2,
                 ..ValidatorStakeInfo::default()
@@ -754,7 +596,6 @@ mod test {
         let progress = ForkProgress::new(
             Hash::default(),
             Some(9),
-            DuplicateStats::default(),
             Some(ValidatorStakeInfo {
                 stake: 1,
                 total_epoch_stake: 2,
@@ -771,7 +612,6 @@ mod test {
         let progress = ForkProgress::new(
             Hash::default(),
             Some(9),
-            DuplicateStats::default(),
             Some(ValidatorStakeInfo::default()),
             0,
             0,
@@ -785,23 +625,12 @@ mod test {
 
         // Insert new ForkProgress for slot 10 (not a leader slot) and its
         // previous leader slot 9 (leader slot)
-        progress_map.insert(
-            10,
-            ForkProgress::new(
-                Hash::default(),
-                Some(9),
-                DuplicateStats::default(),
-                None,
-                0,
-                0,
-            ),
-        );
+        progress_map.insert(10, ForkProgress::new(Hash::default(), Some(9), None, 0, 0));
         progress_map.insert(
             9,
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -816,17 +645,7 @@ mod test {
         // The previous leader before 8, slot 7, does not exist in
         // progress map, so is_propagated(8) should return true as
         // this implies the parent is rooted
-        progress_map.insert(
-            8,
-            ForkProgress::new(
-                Hash::default(),
-                Some(7),
-                DuplicateStats::default(),
-                None,
-                0,
-                0,
-            ),
-        );
+        progress_map.insert(8, ForkProgress::new(Hash::default(), Some(7), None, 0, 0));
         assert!(progress_map.is_propagated(8));
 
         // If we set the is_propagated = true, is_propagated should return true
@@ -848,158 +667,5 @@ mod test {
             .unwrap()
             .is_leader_slot = true;
         assert!(!progress_map.is_propagated(10));
-    }
-
-    fn setup_set_unconfirmed_and_confirmed_duplicate_slot_tests(
-        smaller_duplicate_slot: Slot,
-        larger_duplicate_slot: Slot,
-    ) -> (ProgressMap, RwLock<BankForks>) {
-        // Create simple fork 0 -> 1 -> 2 -> 3 -> 4 -> 5
-        let forks = tr(0) / (tr(1) / (tr(2) / (tr(3) / (tr(4) / tr(5)))));
-        let mut vote_simulator = VoteSimulator::new(1);
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
-        let VoteSimulator {
-            mut progress,
-            bank_forks,
-            ..
-        } = vote_simulator;
-        let descendants = bank_forks.read().unwrap().descendants().clone();
-
-        // Mark the slots as unconfirmed duplicates
-        progress.set_unconfirmed_duplicate_slot(
-            smaller_duplicate_slot,
-            &descendants.get(&smaller_duplicate_slot).unwrap(),
-        );
-        progress.set_unconfirmed_duplicate_slot(
-            larger_duplicate_slot,
-            &descendants.get(&larger_duplicate_slot).unwrap(),
-        );
-
-        // Correctness checks
-        for slot in bank_forks.read().unwrap().banks().keys() {
-            if *slot < smaller_duplicate_slot {
-                assert!(progress
-                    .latest_unconfirmed_duplicate_ancestor(*slot)
-                    .is_none());
-            } else if *slot < larger_duplicate_slot {
-                assert_eq!(
-                    progress
-                        .latest_unconfirmed_duplicate_ancestor(*slot)
-                        .unwrap(),
-                    smaller_duplicate_slot
-                );
-            } else {
-                assert_eq!(
-                    progress
-                        .latest_unconfirmed_duplicate_ancestor(*slot)
-                        .unwrap(),
-                    larger_duplicate_slot
-                );
-            }
-        }
-
-        (progress, bank_forks)
-    }
-
-    #[test]
-    fn test_set_unconfirmed_duplicate_confirm_smaller_slot_first() {
-        let smaller_duplicate_slot = 1;
-        let larger_duplicate_slot = 4;
-        let (mut progress, bank_forks) = setup_set_unconfirmed_and_confirmed_duplicate_slot_tests(
-            smaller_duplicate_slot,
-            larger_duplicate_slot,
-        );
-        let descendants = bank_forks.read().unwrap().descendants().clone();
-        let ancestors = bank_forks.read().unwrap().ancestors();
-
-        // Mark the smaller duplicate slot as confirmed
-        progress.set_confirmed_duplicate_slot(
-            smaller_duplicate_slot,
-            &ancestors.get(&smaller_duplicate_slot).unwrap(),
-            &descendants.get(&smaller_duplicate_slot).unwrap(),
-        );
-        for slot in bank_forks.read().unwrap().banks().keys() {
-            if *slot < larger_duplicate_slot {
-                // Only slots <= smaller_duplicate_slot have been duplicate confirmed
-                if *slot <= smaller_duplicate_slot {
-                    assert!(progress.is_duplicate_confirmed(*slot).unwrap());
-                } else {
-                    assert!(!progress.is_duplicate_confirmed(*slot).unwrap());
-                }
-                // The unconfirmed duplicate flag has been cleared on the smaller
-                // descendants because their most recent duplicate ancestor has
-                // been confirmed
-                assert!(progress
-                    .latest_unconfirmed_duplicate_ancestor(*slot)
-                    .is_none());
-            } else {
-                assert!(!progress.is_duplicate_confirmed(*slot).unwrap(),);
-                // The unconfirmed duplicate flag has not been cleared on the smaller
-                // descendants because their most recent duplicate ancestor,
-                // `larger_duplicate_slot` has  not yet been confirmed
-                assert_eq!(
-                    progress
-                        .latest_unconfirmed_duplicate_ancestor(*slot)
-                        .unwrap(),
-                    larger_duplicate_slot
-                );
-            }
-        }
-
-        // Mark the larger duplicate slot as confirmed, all slots should no longer
-        // have any unconfirmed duplicate ancestors, and should be marked as duplciate confirmed
-        progress.set_confirmed_duplicate_slot(
-            larger_duplicate_slot,
-            &ancestors.get(&larger_duplicate_slot).unwrap(),
-            &descendants.get(&larger_duplicate_slot).unwrap(),
-        );
-        for slot in bank_forks.read().unwrap().banks().keys() {
-            // All slots <= the latest duplciate confirmed slot are ancestors of
-            // that slot, so they should all be marked duplicate confirmed
-            assert_eq!(
-                progress.is_duplicate_confirmed(*slot).unwrap(),
-                *slot <= larger_duplicate_slot
-            );
-            assert!(progress
-                .latest_unconfirmed_duplicate_ancestor(*slot)
-                .is_none());
-        }
-    }
-
-    #[test]
-    fn test_set_unconfirmed_duplicate_confirm_larger_slot_first() {
-        let smaller_duplicate_slot = 1;
-        let larger_duplicate_slot = 4;
-        let (mut progress, bank_forks) = setup_set_unconfirmed_and_confirmed_duplicate_slot_tests(
-            smaller_duplicate_slot,
-            larger_duplicate_slot,
-        );
-        let descendants = bank_forks.read().unwrap().descendants().clone();
-        let ancestors = bank_forks.read().unwrap().ancestors();
-
-        // Mark the larger duplicate slot as confirmed
-        progress.set_confirmed_duplicate_slot(
-            larger_duplicate_slot,
-            &ancestors.get(&larger_duplicate_slot).unwrap(),
-            &descendants.get(&larger_duplicate_slot).unwrap(),
-        );
-
-        // All slots should no longer have any unconfirmed duplicate ancestors
-        progress.set_confirmed_duplicate_slot(
-            smaller_duplicate_slot,
-            &ancestors.get(&smaller_duplicate_slot).unwrap(),
-            &descendants.get(&smaller_duplicate_slot).unwrap(),
-        );
-        for slot in bank_forks.read().unwrap().banks().keys() {
-            // All slots <= the latest duplciate confirmed slot are ancestors of
-            // that slot, so they should all be marked duplicate confirmed
-            assert_eq!(
-                progress.is_duplicate_confirmed(*slot).unwrap(),
-                *slot <= larger_duplicate_slot
-            );
-            assert!(progress
-                .latest_unconfirmed_duplicate_ancestor(*slot)
-                .is_none());
-        }
     }
 }

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -525,7 +525,7 @@ impl ProgressMap {
         }
 
         if let Some(slot_fork_progress) = self.get_mut(&slot) {
-            // Setting the fields here is nly correct and necessary if the loop above didn't
+            // Setting the fields here is only correct and necessary if the loop above didn't
             // already do this, so check with an assert.
             assert!(!ancestors.contains(&slot));
             let slot_had_unconfirmed_duplicate_ancestor = slot_fork_progress
@@ -986,9 +986,9 @@ mod test {
 
         // All slots should no longer have any unconfirmed duplicate ancestors
         progress.set_confirmed_duplicate_slot(
-            larger_duplicate_slot,
-            &ancestors.get(&larger_duplicate_slot).unwrap(),
-            &descendants.get(&larger_duplicate_slot).unwrap(),
+            smaller_duplicate_slot,
+            &ancestors.get(&smaller_duplicate_slot).unwrap(),
+            &descendants.get(&smaller_duplicate_slot).unwrap(),
         );
         for slot in bank_forks.read().unwrap().banks().keys() {
             // All slots <= the latest duplciate confirmed slot are ancestors of

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1782,6 +1782,9 @@ impl ReplayStage {
                 bank.freeze();
                 let bank_hash = bank.hash();
                 assert_ne!(bank_hash, Hash::default());
+                // Needs to be updated before `check_slot_agrees_with_cluster()` so that
+                // any updates in `check_slot_agrees_with_cluster()` on fork choice take
+                // effect
                 heaviest_subtree_fork_choice.add_new_leaf_slot(
                     (bank.slot(), bank.hash()),
                     Some((bank.parent_slot(), bank.parent_hash())),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -17,7 +17,7 @@ use crate::{
     fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
     heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
     latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
-    progress_map::{DuplicateStats, ForkProgress, ProgressMap, PropagatedStats},
+    progress_map::{ForkProgress, ProgressMap, PropagatedStats},
     repair_service::DuplicateSlotsResetReceiver,
     result::Result,
     rewards_recorder_service::RewardsRecorderSender,
@@ -389,8 +389,6 @@ impl ReplayStage {
                         &subscriptions,
                         &mut duplicate_slots_tracker,
                         &gossip_duplicate_confirmed_slots,
-                        &ancestors,
-                        &descendants,
                         &mut unfrozen_gossip_verified_vote_hashes,
                         &mut latest_validator_votes_for_frozen_banks,
                         &cluster_slots_update_sender,
@@ -421,8 +419,6 @@ impl ReplayStage {
                         &bank_forks,
                         &mut progress,
                         &mut heaviest_subtree_fork_choice,
-                        &ancestors,
-                        &descendants,
                     );
                     process_gossip_duplicate_confirmed_slots_time.stop();
 
@@ -449,8 +445,6 @@ impl ReplayStage {
                             &mut duplicate_slots_tracker,
                             &gossip_duplicate_confirmed_slots,
                             &bank_forks,
-                            &ancestors,
-                            &descendants,
                             &mut progress,
                             &mut heaviest_subtree_fork_choice,
                         );
@@ -494,10 +488,7 @@ impl ReplayStage {
                             &bank_forks,
                         );
 
-                        Self::mark_slots_confirmed(&confirmed_forks, &bank_forks, &mut progress,
-                                                   &mut duplicate_slots_tracker,
-                                                   &ancestors, &descendants, &mut
-                                                   heaviest_subtree_fork_choice);
+                        Self::mark_slots_confirmed(&confirmed_forks, &bank_forks, &mut progress, &mut duplicate_slots_tracker, &mut heaviest_subtree_fork_choice);
                     }
                     compute_slot_stats_time.stop();
 
@@ -533,6 +524,7 @@ impl ReplayStage {
                         &progress,
                         &mut tower,
                         &latest_validator_votes_for_frozen_banks,
+                        &heaviest_subtree_fork_choice,
                     );
                     select_vote_and_reset_forks_time.stop();
 
@@ -783,9 +775,6 @@ impl ReplayStage {
         // Initialize progress map with any root banks
         for bank in &frozen_banks {
             let prev_leader_slot = progress.get_bank_prev_leader_slot(bank);
-            let duplicate_stats = DuplicateStats::new_with_unconfirmed_duplicate_ancestor(
-                progress.latest_unconfirmed_duplicate_ancestor(bank.parent_slot()),
-            );
             progress.insert(
                 bank.slot(),
                 ForkProgress::new_from_bank(
@@ -793,7 +782,6 @@ impl ReplayStage {
                     &my_pubkey,
                     &vote_account,
                     prev_leader_slot,
-                    duplicate_stats,
                     0,
                     0,
                 ),
@@ -924,8 +912,6 @@ impl ReplayStage {
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         fork_choice: &mut HeaviestSubtreeForkChoice,
-        ancestors: &HashMap<Slot, HashSet<Slot>>,
-        descendants: &HashMap<Slot, HashSet<Slot>>,
     ) {
         let root = bank_forks.read().unwrap().root();
         for new_confirmed_slots in gossip_duplicate_confirmed_slots_receiver.try_iter() {
@@ -950,8 +936,6 @@ impl ReplayStage {
                         .map(|b| b.hash()),
                     duplicate_slots_tracker,
                     gossip_duplicate_confirmed_slots,
-                    ancestors,
-                    descendants,
                     progress,
                     fork_choice,
                     SlotStateUpdate::DuplicateConfirmed,
@@ -985,8 +969,6 @@ impl ReplayStage {
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
         gossip_duplicate_confirmed_slots: &GossipDuplicateConfirmedSlots,
         bank_forks: &RwLock<BankForks>,
-        ancestors: &HashMap<Slot, HashSet<Slot>>,
-        descendants: &HashMap<Slot, HashSet<Slot>>,
         progress: &mut ProgressMap,
         fork_choice: &mut HeaviestSubtreeForkChoice,
     ) {
@@ -1010,8 +992,6 @@ impl ReplayStage {
                 bank_hash,
                 duplicate_slots_tracker,
                 gossip_duplicate_confirmed_slots,
-                ancestors,
-                descendants,
                 progress,
                 fork_choice,
                 SlotStateUpdate::Duplicate,
@@ -1259,8 +1239,6 @@ impl ReplayStage {
         subscriptions: &Arc<RpcSubscriptions>,
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
         gossip_duplicate_confirmed_slots: &GossipDuplicateConfirmedSlots,
-        ancestors: &HashMap<Slot, HashSet<Slot>>,
-        descendants: &HashMap<Slot, HashSet<Slot>>,
         progress: &mut ProgressMap,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
     ) {
@@ -1303,8 +1281,6 @@ impl ReplayStage {
             Some(bank.hash()),
             duplicate_slots_tracker,
             gossip_duplicate_confirmed_slots,
-            ancestors,
-            descendants,
             progress,
             heaviest_subtree_fork_choice,
             SlotStateUpdate::Dead,
@@ -1676,8 +1652,6 @@ impl ReplayStage {
         subscriptions: &Arc<RpcSubscriptions>,
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
         gossip_duplicate_confirmed_slots: &GossipDuplicateConfirmedSlots,
-        ancestors: &HashMap<Slot, HashSet<Slot>>,
-        descendants: &HashMap<Slot, HashSet<Slot>>,
         unfrozen_gossip_verified_vote_hashes: &mut UnfrozenGossipVerifiedVoteHashes,
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
         cluster_slots_update_sender: &ClusterSlotsUpdateSender,
@@ -1709,11 +1683,6 @@ impl ReplayStage {
                 (num_blocks_on_fork, num_dropped_blocks_on_fork)
             };
 
-            // New children adopt the same latest duplicate ancestor as their parent.
-            let duplicate_stats = DuplicateStats::new_with_unconfirmed_duplicate_ancestor(
-                progress.latest_unconfirmed_duplicate_ancestor(bank.parent_slot()),
-            );
-
             // Insert a progress entry even for slots this node is the leader for, so that
             // 1) confirm_forks can report confirmation, 2) we can cache computations about
             // this bank in `select_forks()`
@@ -1723,7 +1692,6 @@ impl ReplayStage {
                     &my_pubkey,
                     vote_account,
                     prev_leader_slot,
-                    duplicate_stats,
                     num_blocks_on_fork,
                     num_dropped_blocks_on_fork,
                 )
@@ -1755,8 +1723,6 @@ impl ReplayStage {
                             subscriptions,
                             duplicate_slots_tracker,
                             gossip_duplicate_confirmed_slots,
-                            ancestors,
-                            descendants,
                             progress,
                             heaviest_subtree_fork_choice,
                         );
@@ -1795,8 +1761,6 @@ impl ReplayStage {
                     Some(bank.hash()),
                     duplicate_slots_tracker,
                     gossip_duplicate_confirmed_slots,
-                    ancestors,
-                    descendants,
                     progress,
                     heaviest_subtree_fork_choice,
                     SlotStateUpdate::Frozen,
@@ -2036,6 +2000,7 @@ impl ReplayStage {
         progress: &ProgressMap,
         tower: &mut Tower,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
+        fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SelectVoteAndResetForkResult {
         // Try to vote on the actual heaviest fork. If the heaviest bank is
         // locked out or fails the threshold check, the validator will:
@@ -2062,6 +2027,7 @@ impl ReplayStage {
                     .epoch_vote_accounts(heaviest_bank.epoch())
                     .expect("Bank epoch vote accounts must contain entry for the bank's own epoch"),
                 latest_validator_votes_for_frozen_banks,
+                fork_choice,
             );
 
             match switch_fork_decision {
@@ -2331,8 +2297,6 @@ impl ReplayStage {
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
-        ancestors: &HashMap<Slot, HashSet<Slot>>,
-        descendants: &HashMap<Slot, HashSet<Slot>>,
         fork_choice: &mut HeaviestSubtreeForkChoice,
     ) {
         let (root_slot, bank_hashes) = {
@@ -2347,8 +2311,8 @@ impl ReplayStage {
         for (slot, bank_hash) in confirmed_forks.iter().zip(bank_hashes.into_iter()) {
             // This case should be guaranteed as false by confirm_forks()
             if let Some(false) = progress.is_supermajority_confirmed(*slot) {
-                // Because supermajority confirmation will iterate through all ancestors/descendants
-                // in `check_slot_agrees_with_cluster`, only incur this cost if the slot wasn't already
+                // Because supermajority confirmation will iterate through and update the
+                // subtree in fork choice, only incur this cost if the slot wasn't already
                 // confirmed
                 progress.set_supermajority_confirmed_slot(*slot);
                 check_slot_agrees_with_cluster(
@@ -2359,8 +2323,6 @@ impl ReplayStage {
                     // Don't need to pass the gossip confirmed slots since `slot`
                     // is already marked as confirmed in progress
                     &BTreeMap::new(),
-                    ancestors,
-                    descendants,
                     progress,
                     fork_choice,
                     SlotStateUpdate::DuplicateConfirmed,
@@ -2674,7 +2636,6 @@ mod tests {
                 bank0.collector_id(),
                 &Pubkey::default(),
                 None,
-                DuplicateStats::default(),
                 0,
                 0,
             ),
@@ -2781,7 +2742,6 @@ mod tests {
                     .get(&bank1.collector_id())
                     .unwrap(),
                 Some(0),
-                DuplicateStats::default(),
                 0,
                 0,
             ),
@@ -2878,10 +2838,7 @@ mod tests {
 
         let mut progress = ProgressMap::default();
         for i in 0..=root {
-            progress.insert(
-                i,
-                ForkProgress::new(Hash::default(), None, DuplicateStats::default(), None, 0, 0),
-            );
+            progress.insert(i, ForkProgress::new(Hash::default(), None, None, 0, 0));
         }
 
         let mut duplicate_slots_tracker: DuplicateSlotsTracker =
@@ -2967,10 +2924,7 @@ mod tests {
         let mut heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new((root, root_hash));
         let mut progress = ProgressMap::default();
         for i in 0..=root {
-            progress.insert(
-                i,
-                ForkProgress::new(Hash::default(), None, DuplicateStats::default(), None, 0, 0),
-            );
+            progress.insert(i, ForkProgress::new(Hash::default(), None, None, 0, 0));
         }
         ReplayStage::handle_new_root(
             root,
@@ -3226,9 +3180,9 @@ mod tests {
             let bank0 = bank_forks.working_bank();
             let mut progress = ProgressMap::default();
             let last_blockhash = bank0.last_blockhash();
-            let mut bank0_progress = progress.entry(bank0.slot()).or_insert_with(|| {
-                ForkProgress::new(last_blockhash, None, DuplicateStats::default(), None, 0, 0)
-            });
+            let mut bank0_progress = progress
+                .entry(bank0.slot())
+                .or_insert_with(|| ForkProgress::new(last_blockhash, None, None, 0, 0));
             let shreds = shred_to_insert(&mint_keypair, bank0.clone());
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
@@ -3258,8 +3212,6 @@ mod tests {
                     &subscriptions,
                     &mut DuplicateSlotsTracker::default(),
                     &GossipDuplicateConfirmedSlots::default(),
-                    &HashMap::new(),
-                    &HashMap::new(),
                     &mut progress,
                     &mut HeaviestSubtreeForkChoice::new((0, Hash::default())),
                 );
@@ -3528,14 +3480,7 @@ mod tests {
         bank_forks.write().unwrap().insert(bank1);
         progress.insert(
             1,
-            ForkProgress::new(
-                bank0.last_blockhash(),
-                None,
-                DuplicateStats::default(),
-                None,
-                0,
-                0,
-            ),
+            ForkProgress::new(bank0.last_blockhash(), None, None, 0, 0),
         );
         let ancestors = bank_forks.read().unwrap().ancestors();
         let mut frozen_banks: Vec<_> = bank_forks
@@ -3962,7 +3907,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 Some(9),
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo {
                     total_epoch_stake,
                     ..ValidatorStakeInfo::default()
@@ -3976,7 +3920,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 Some(8),
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo {
                     total_epoch_stake,
                     ..ValidatorStakeInfo::default()
@@ -4059,7 +4002,6 @@ mod tests {
                 ForkProgress::new(
                     Hash::default(),
                     Some(prev_leader_slot),
-                    DuplicateStats::default(),
                     {
                         if i % 2 == 0 {
                             Some(ValidatorStakeInfo {
@@ -4139,7 +4081,6 @@ mod tests {
             let mut fork_progress = ForkProgress::new(
                 Hash::default(),
                 Some(prev_leader_slot),
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo {
                     total_epoch_stake,
                     ..ValidatorStakeInfo::default()
@@ -4199,7 +4140,7 @@ mod tests {
         // should succeed
         progress_map.insert(
             parent_slot,
-            ForkProgress::new(Hash::default(), None, DuplicateStats::default(), None, 0, 0),
+            ForkProgress::new(Hash::default(), None, None, 0, 0),
         );
         assert!(ReplayStage::check_propagation_for_start_leader(
             poh_slot,
@@ -4215,7 +4156,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -4242,21 +4182,13 @@ mod tests {
         let previous_leader_slot = parent_slot - 1;
         progress_map.insert(
             parent_slot,
-            ForkProgress::new(
-                Hash::default(),
-                Some(previous_leader_slot),
-                DuplicateStats::default(),
-                None,
-                0,
-                0,
-            ),
+            ForkProgress::new(Hash::default(), Some(previous_leader_slot), None, 0, 0),
         );
         progress_map.insert(
             previous_leader_slot,
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -4317,7 +4249,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -4353,7 +4284,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -4377,7 +4307,6 @@ mod tests {
             ForkProgress::new(
                 Hash::default(),
                 None,
-                DuplicateStats::default(),
                 Some(ValidatorStakeInfo::default()),
                 0,
                 0,
@@ -4627,8 +4556,6 @@ mod tests {
         // Mark 4 as duplicate, 3 should be the heaviest slot, but should not be votable
         // because of lockout
         blockstore.store_duplicate_slot(4, vec![], vec![]).unwrap();
-        let ancestors = bank_forks.read().unwrap().ancestors();
-        let descendants = bank_forks.read().unwrap().descendants().clone();
         let mut duplicate_slots_tracker = DuplicateSlotsTracker::default();
         let mut gossip_duplicate_confirmed_slots = GossipDuplicateConfirmedSlots::default();
         let bank4_hash = bank_forks.read().unwrap().get(4).unwrap().hash();
@@ -4639,9 +4566,7 @@ mod tests {
             Some(bank4_hash),
             &mut duplicate_slots_tracker,
             &gossip_duplicate_confirmed_slots,
-            &ancestors,
-            &descendants,
-            &mut progress,
+            &progress,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             SlotStateUpdate::Duplicate,
         );
@@ -4658,8 +4583,6 @@ mod tests {
 
         // Now mark 2, an ancestor of 4, as duplicate
         blockstore.store_duplicate_slot(2, vec![], vec![]).unwrap();
-        let ancestors = bank_forks.read().unwrap().ancestors();
-        let descendants = bank_forks.read().unwrap().descendants().clone();
         let bank2_hash = bank_forks.read().unwrap().get(2).unwrap().hash();
         assert_ne!(bank2_hash, Hash::default());
         check_slot_agrees_with_cluster(
@@ -4668,9 +4591,7 @@ mod tests {
             Some(bank2_hash),
             &mut duplicate_slots_tracker,
             &gossip_duplicate_confirmed_slots,
-            &ancestors,
-            &descendants,
-            &mut progress,
+            &progress,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             SlotStateUpdate::Duplicate,
         );
@@ -4697,9 +4618,7 @@ mod tests {
             Some(bank4_hash),
             &mut duplicate_slots_tracker,
             &gossip_duplicate_confirmed_slots,
-            &ancestors,
-            &descendants,
-            &mut progress,
+            &progress,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             SlotStateUpdate::DuplicateConfirmed,
         );
@@ -5113,6 +5032,7 @@ mod tests {
             progress,
             tower,
             latest_validator_votes_for_frozen_banks,
+            heaviest_subtree_fork_choice,
         );
         (
             vote_bank.map(|(b, _)| b.slot()),


### PR DESCRIPTION
#### Problem
Keeping the duplicate/duplicate confirmed tracking logic in ProgressMap is unwieldy for a number of reasons:

1) Requires a separate update in `cluster_slot_state_verifier` to update the ProgressMap, and then separately mark certain forks valid/invalid in ForkChoice: https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/cluster_slot_state_verifier.rs#L212-L217

2) Updating the ProgressMap for duplicate/duplicate confirmed tracking requires passing in ancestors/descendants: https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/progress_map.rs#L477 because it doesn't know about fork structure. This means ancestors/descendants have to be passed along to `cluster_slot_state_verifier::check_slot_agrees_with_cluster()`  https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/cluster_slot_state_verifier.rs#L242-L243 and a variety of ReplayStage functions that call down to that function

Furthermore, there are correctness issues that can arise because we track all the duplicate ancestor information in the ProgressMap and not ForkChoice. These stem from the fact that the fork choice only knows that a specific block was marked valid/invalid, but doesn't know if descendants of that block are valid/invalid. For example, consider the following order of events:

Given a fork `0 -> 1 -> 2 -> 3`
1) Fork 1 is marked duplicate. Currently, we set the `is_candidate` flag to false https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/heaviest_subtree_fork_choice.rs#L819 and then removes the entire subtree from fork choice.
2) Fork 2 is marked duplicate, and removes its entire subtree from fork choice, similar to 1) above.
3) Fork 1 is marked valid. At this point, without searching all of its ancestors, fork 3 has no idea whether it is part of fork choice because its own `is_candidate` flag is not set.

Now 3) is not an issue when considering the *overall* best slot returned by fork choice: https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/heaviest_subtree_fork_choice.rs#L175-L177, because that looks at the best slot field at the root node, and the root node contains aggregate information from the invalid fork `2`. However, functions like `heaviest_slot_on_same_voted_fork()`: https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/core/src/heaviest_subtree_fork_choice.rs#L688, look at the best slot field of a node that is potentially in the subtree of `2`, and didn't contain the aggregate information that `2` was marked invalid.


#### Summary of Changes
Port duplicate fork/duplicate confirmed status tracking and tests to fork choice

Fixes #
