### PR TITLE
update dependence version for gag to latest support windows

### DIFF
--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/solana-local-cluster"
 [dependencies]
 crossbeam-channel = "0.5"
 itertools = "0.9.0"
-gag = "0.1.10"
+gag = "1.0.0"
 fs_extra = "1.2.0"
 log = "0.4.11"
 rand = "0.7.0"


### PR DESCRIPTION
#### Problem
build failed on windows, 
   Compiling gag v0.1.10
error[E0433]: failed to resolve: could not find `unix` in `os`

#### Summary of Changes
update gag version to latest 1.0.0, which has solved the cross-platform compile on windows.

Fixes #
