### PR TITLE
update dependence version for gag to latest support windows

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -74,7 +74,7 @@ fn make_accounts_txs(
         .into_par_iter()
         .map(|_| {
             let mut new = dummy.clone();
-            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
             if !same_payer {
                 new.message.account_keys[0] = solana_sdk::pubkey::new_rand();
             }
@@ -185,7 +185,7 @@ fn main() {
             genesis_config.hash(),
         );
         // Ignore any pesky duplicate signature errors in the case we are using single-payer
-        let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+        let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
         fund.signatures = vec![Signature::new(&sig[0..64])];
         let x = bank.process_transaction(&fund);
         x.unwrap();
@@ -351,7 +351,7 @@ fn main() {
             if bank.slot() > 0 && bank.slot() % 16 == 0 {
                 for tx in transactions.iter_mut() {
                     tx.message.recent_blockhash = bank.last_blockhash();
-                    let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+                    let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
                     tx.signatures[0] = Signature::new(&sig[0..64]);
                 }
                 verified = to_packets_chunked(&transactions.clone(), packets_per_chunk);

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/solana-local-cluster"
 [dependencies]
 crossbeam-channel = "0.5"
 itertools = "0.9.0"
-gag = "0.1.10"
+gag = "1.0.0"
 fs_extra = "1.2.0"
 log = "0.4.11"
 rand = "0.7.0"

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -61,7 +61,7 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
             #[cfg(not(unix))]
             {
                 println!("logging to a file is not supported on this platform");
-                ()
+                None
             }
         }
     };


### PR DESCRIPTION
#### Problem
build failed on windows,
Compiling gag v0.1.10
error[E0433]: failed to resolve: could not find unix in os

#### Summary of Changes
update gag version to latest 1.0.0, which has solved the cross-platform compile on windows.

Fixes #
other fix,  map(|_| thread_rng().gen::<T>()).collect();