### PR TITLE
feat: add convenience methods to EpochSchedule

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -19,7 +19,6 @@ import {
   create,
   tuple,
   unknown,
-  Infer,
   any,
 } from 'superstruct';
 import type {Struct} from 'superstruct';
@@ -375,7 +374,6 @@ const GetEpochInfoResult = pick({
   transactionCount: optional(number()),
 });
 
-type GetEpochScheduleResult = Infer<typeof GetEpochScheduleResult>;
 const GetEpochScheduleResult = pick({
   slotsPerEpoch: number(),
   leaderScheduleSlotOffset: number(),
@@ -2780,7 +2778,7 @@ export class Connection {
       epochSchedule.leaderScheduleSlotOffset,
       epochSchedule.warmup,
       epochSchedule.firstNormalEpoch,
-      epochSchedule.firstNormalSlot
+      epochSchedule.firstNormalSlot,
     );
   }
 

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -19,6 +19,7 @@ import {
   create,
   tuple,
   unknown,
+  Infer,
   any,
 } from 'superstruct';
 import type {Struct} from 'superstruct';
@@ -27,6 +28,7 @@ import RpcClient from 'jayson/lib/client/browser';
 import {IWSRequestParams} from 'rpc-websockets/dist/lib/client';
 
 import {AgentManager} from './agent-manager';
+import {EpochSchedule} from './epoch-schedule';
 import {NonceAccount} from './nonce-account';
 import {PublicKey} from './publickey';
 import {Signer} from './keypair';
@@ -373,23 +375,7 @@ const GetEpochInfoResult = pick({
   transactionCount: optional(number()),
 });
 
-/**
- * Epoch schedule
- * (see https://docs.solana.com/terminology#epoch)
- */
-export type EpochSchedule = {
-  /** The maximum number of slots in each epoch */
-  slotsPerEpoch: number;
-  /** The number of slots before beginning of an epoch to calculate a leader schedule for that epoch */
-  leaderScheduleSlotOffset: number;
-  /** Indicates whether epochs start short and grow */
-  warmup: boolean;
-  /** The first epoch with `slotsPerEpoch` slots */
-  firstNormalEpoch: number;
-  /** The first slot of `firstNormalEpoch` */
-  firstNormalSlot: number;
-};
-
+type GetEpochScheduleResult = Infer<typeof GetEpochScheduleResult>;
 const GetEpochScheduleResult = pick({
   slotsPerEpoch: number(),
   leaderScheduleSlotOffset: number(),
@@ -2788,7 +2774,14 @@ export class Connection {
     if ('error' in res) {
       throw new Error('failed to get epoch schedule: ' + res.error.message);
     }
-    return res.result;
+    const epochSchedule = res.result;
+    return new EpochSchedule(
+      epochSchedule.slotsPerEpoch,
+      epochSchedule.leaderScheduleSlotOffset,
+      epochSchedule.warmup,
+      epochSchedule.firstNormalEpoch,
+      epochSchedule.firstNormalSlot
+    );
   }
 
   /**

--- a/web3.js/src/epoch-schedule.ts
+++ b/web3.js/src/epoch-schedule.ts
@@ -3,7 +3,7 @@ const MINIMUM_SLOT_PER_EPOCH = 32;
 // Returns the number of trailing zeros in the binary representation of self.
 function trailingZeros(n: number) {
   let trailingZeros = 0;
-  while((n & 1) == 0) {
+  while ((n & 1) == 0) {
     n /= 2;
     trailingZeros++;
   }
@@ -26,7 +26,13 @@ export class EpochSchedule {
   /** The first slot of `firstNormalEpoch` */
   public firstNormalSlot: number;
 
-  constructor(slotsPerEpoch: number, leaderScheduleSlotOffset: number, warmup: boolean, firstNormalEpoch: number, firstNormalSlot: number) {
+  constructor(
+    slotsPerEpoch: number,
+    leaderScheduleSlotOffset: number,
+    warmup: boolean,
+    firstNormalEpoch: number,
+    firstNormalSlot: number,
+  ) {
     this.slotsPerEpoch = slotsPerEpoch;
     this.leaderScheduleSlotOffset = leaderScheduleSlotOffset;
     this.warmup = warmup;
@@ -35,11 +41,13 @@ export class EpochSchedule {
   }
 
   getFirstSlotInEpoch(epoch: number): number {
-    if(epoch <= this.firstNormalEpoch) {
+    if (epoch <= this.firstNormalEpoch) {
       return (Math.pow(2, epoch) - 1) * MINIMUM_SLOT_PER_EPOCH;
-    }
-    else {
-      return (epoch - this.firstNormalEpoch) * this.slotsPerEpoch + this.firstNormalSlot;
+    } else {
+      return (
+        (epoch - this.firstNormalEpoch) * this.slotsPerEpoch +
+        this.firstNormalSlot
+      );
     }
   }
 
@@ -48,11 +56,10 @@ export class EpochSchedule {
   }
 
   getSlotsInEpoch(epoch: number) {
-    if(epoch < this.firstNormalEpoch) {
+    if (epoch < this.firstNormalEpoch) {
       return Math.pow(2, epoch + trailingZeros(MINIMUM_SLOT_PER_EPOCH));
-    }
-    else {
+    } else {
       return this.slotsPerEpoch;
     }
   }
-};
+}

--- a/web3.js/src/epoch-schedule.ts
+++ b/web3.js/src/epoch-schedule.ts
@@ -1,5 +1,15 @@
 const MINIMUM_SLOT_PER_EPOCH = 32;
 
+// Returns the number of trailing zeros in the binary representation of self.
+function trailingZeros(n: number) {
+  let trailingZeros = 0;
+  while((n & 1) == 0) {
+    n /= 2;
+    trailingZeros++;
+  }
+  return trailingZeros;
+}
+
 /**
  * Epoch schedule
  * (see https://docs.solana.com/terminology#epoch)
@@ -39,7 +49,7 @@ export class EpochSchedule {
 
   getSlotsInEpoch(epoch: number) {
     if(epoch < this.firstNormalEpoch) {
-      return Math.pow(2, epoch) + MINIMUM_SLOT_PER_EPOCH;
+      return Math.pow(2, epoch + trailingZeros(MINIMUM_SLOT_PER_EPOCH));
     }
     else {
       return this.slotsPerEpoch;

--- a/web3.js/src/epoch-schedule.ts
+++ b/web3.js/src/epoch-schedule.ts
@@ -19,13 +19,14 @@ function nextPowerOfTwo(n: number) {
   n |= n >> 4;
   n |= n >> 8;
   n |= n >> 16;
+  n |= n >> 32;
   return n + 1;
 }
 
 /**
  * Epoch schedule
  * (see https://docs.solana.com/terminology#epoch)
- * Can be retreived with {@link connection.getEpochSchedule} method
+ * Can be retrieved with the {@link connection.getEpochSchedule} method
  */
 export class EpochSchedule {
   /** The maximum number of slots in each epoch */
@@ -69,9 +70,9 @@ export class EpochSchedule {
       return [epoch, slotIndex];
     } else {
       const normalSlotIndex = slot - this.firstNormalSlot;
-      const normalEpochIndex = (normalSlotIndex / this.slotsPerEpoch) | 0;
+      const normalEpochIndex = Math.floor(normalSlotIndex / this.slotsPerEpoch);
       const epoch = this.firstNormalEpoch + normalEpochIndex;
-      const slotIndex = normalSlotIndex % this.slotsPerEpoch | 0;
+      const slotIndex = normalSlotIndex % this.slotsPerEpoch;
       return [epoch, slotIndex];
     }
   }

--- a/web3.js/src/epoch-schedule.ts
+++ b/web3.js/src/epoch-schedule.ts
@@ -1,0 +1,48 @@
+const MINIMUM_SLOT_PER_EPOCH = 32;
+
+/**
+ * Epoch schedule
+ * (see https://docs.solana.com/terminology#epoch)
+ */
+export class EpochSchedule {
+  /** The maximum number of slots in each epoch */
+  public slotsPerEpoch: number;
+  /** The number of slots before beginning of an epoch to calculate a leader schedule for that epoch */
+  public leaderScheduleSlotOffset: number;
+  /** Indicates whether epochs start short and grow */
+  public warmup: boolean;
+  /** The first epoch with `slotsPerEpoch` slots */
+  public firstNormalEpoch: number;
+  /** The first slot of `firstNormalEpoch` */
+  public firstNormalSlot: number;
+
+  constructor(slotsPerEpoch: number, leaderScheduleSlotOffset: number, warmup: boolean, firstNormalEpoch: number, firstNormalSlot: number) {
+    this.slotsPerEpoch = slotsPerEpoch;
+    this.leaderScheduleSlotOffset = leaderScheduleSlotOffset;
+    this.warmup = warmup;
+    this.firstNormalEpoch = firstNormalEpoch;
+    this.firstNormalSlot = firstNormalSlot;
+  }
+
+  getFirstSlotInEpoch(epoch: number): number {
+    if(epoch <= this.firstNormalEpoch) {
+      return (Math.pow(2, epoch) - 1) * MINIMUM_SLOT_PER_EPOCH;
+    }
+    else {
+      return (epoch - this.firstNormalEpoch) * this.slotsPerEpoch + this.firstNormalSlot;
+    }
+  }
+
+  getLastSlotInEpoch(epoch: number): number {
+    return this.getFirstSlotInEpoch(epoch) + this.getSlotsInEpoch(epoch) - 1;
+  }
+
+  getSlotsInEpoch(epoch: number) {
+    if(epoch < this.firstNormalEpoch) {
+      return Math.pow(2, epoch) + MINIMUM_SLOT_PER_EPOCH;
+    }
+    else {
+      return this.slotsPerEpoch;
+    }
+  }
+};

--- a/web3.js/src/index.ts
+++ b/web3.js/src/index.ts
@@ -3,6 +3,7 @@ export * from './blockhash';
 export * from './bpf-loader-deprecated';
 export * from './bpf-loader';
 export * from './connection';
+export * from './epoch-schedule';
 export * from './fee-calculator';
 export * from './keypair';
 export * from './loader';

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -9,6 +9,7 @@ import {
   Account,
   Authorized,
   Connection,
+  EpochSchedule,
   SystemProgram,
   Transaction,
   LAMPORTS_PER_SOL,
@@ -24,7 +25,6 @@ import {
   BLOCKHASH_CACHE_TIMEOUT_MS,
   Commitment,
   EpochInfo,
-  EpochSchedule,
   InflationGovernor,
   SlotInfo,
 } from '../src/connection';
@@ -675,6 +675,14 @@ describe('Connection', () => {
         expect(epochSchedule[key]).to.be.greaterThan(0);
       }
     }
+
+    expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(6);
+    expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(14);
+
+    expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
+    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(8160 + 3 * 8192 - 1);
+
+    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
   });
 
   it('get leader schedule', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -683,7 +683,9 @@ describe('Connection', () => {
     expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(223);
 
     expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
-    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(8160 + 3 * 8192 - 1);
+    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(
+      8160 + 3 * 8192 - 1,
+    );
   });
 
   it('get leader schedule', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -676,13 +676,14 @@ describe('Connection', () => {
       }
     }
 
-    expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(6);
-    expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(14);
+    expect(epochSchedule.getSlotsInEpoch(4)).to.be.equal(512);
+    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
+
+    expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(96);
+    expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(223);
 
     expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
     expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(8160 + 3 * 8192 - 1);
-
-    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
   });
 
   it('get leader schedule', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -675,17 +675,6 @@ describe('Connection', () => {
         expect(epochSchedule[key]).to.be.greaterThan(0);
       }
     }
-
-    expect(epochSchedule.getSlotsInEpoch(4)).to.be.equal(512);
-    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
-
-    expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(96);
-    expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(223);
-
-    expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
-    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(
-      8160 + 3 * 8192 - 1,
-    );
   });
 
   it('get leader schedule', async () => {

--- a/web3.js/test/epoch-schedule.test.ts
+++ b/web3.js/test/epoch-schedule.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { EpochSchedule } from "../src";
+
+describe('EpochSchedule', () => {
+  it('slot methods work', () => {
+    const firstNormalEpoch = 8;
+    const firstNormalSlot = 8160;
+    const leaderScheduleSlotOffset = 8192;
+    const slotsPerEpoch = 8192;
+    const warmup = false;
+
+    const epochSchedule = new EpochSchedule(
+      slotsPerEpoch,
+      leaderScheduleSlotOffset,
+      warmup,
+      firstNormalEpoch,
+      firstNormalSlot,
+    );
+
+    expect(epochSchedule.getSlotsInEpoch(4)).to.be.equal(512);
+    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
+
+    expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(96);
+    expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(223);
+
+    expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
+    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(
+      8160 + 3 * 8192 - 1,
+    );
+  });
+});

--- a/web3.js/test/epoch-schedule.test.ts
+++ b/web3.js/test/epoch-schedule.test.ts
@@ -1,5 +1,6 @@
-import { expect } from "chai";
-import { EpochSchedule } from "../src";
+import {expect} from 'chai';
+
+import {EpochSchedule} from '../src';
 
 describe('EpochSchedule', () => {
   it('slot methods work', () => {

--- a/web3.js/test/epoch-schedule.test.ts
+++ b/web3.js/test/epoch-schedule.test.ts
@@ -4,11 +4,11 @@ import {EpochSchedule} from '../src';
 
 describe('EpochSchedule', () => {
   it('slot methods work', () => {
-    const firstNormalEpoch = 8;
-    const firstNormalSlot = 8160;
-    const leaderScheduleSlotOffset = 8192;
-    const slotsPerEpoch = 8192;
-    const warmup = false;
+    const firstNormalEpoch = 14;
+    const firstNormalSlot = 524_256;
+    const leaderScheduleSlotOffset = 432_000;
+    const slotsPerEpoch = 432_000;
+    const warmup = true;
 
     const epochSchedule = new EpochSchedule(
       slotsPerEpoch,
@@ -18,15 +18,29 @@ describe('EpochSchedule', () => {
       firstNormalSlot,
     );
 
+    expect(epochSchedule.getEpoch(35)).to.be.equal(1);
+    expect(epochSchedule.getEpochAndSlotIndex(35)).to.be.eql([1, 3]);
+
+    expect(
+      epochSchedule.getEpoch(firstNormalSlot + 3 * slotsPerEpoch + 12345),
+    ).to.be.equal(17);
+    expect(
+      epochSchedule.getEpochAndSlotIndex(
+        firstNormalSlot + 3 * slotsPerEpoch + 12345,
+      ),
+    ).to.be.eql([17, 12345]);
+
     expect(epochSchedule.getSlotsInEpoch(4)).to.be.equal(512);
-    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(8192);
+    expect(epochSchedule.getSlotsInEpoch(100)).to.be.equal(slotsPerEpoch);
 
     expect(epochSchedule.getFirstSlotInEpoch(2)).to.be.equal(96);
     expect(epochSchedule.getLastSlotInEpoch(2)).to.be.equal(223);
 
-    expect(epochSchedule.getFirstSlotInEpoch(10)).to.be.equal(8160 + 2 * 8192);
-    expect(epochSchedule.getLastSlotInEpoch(10)).to.be.equal(
-      8160 + 3 * 8192 - 1,
+    expect(epochSchedule.getFirstSlotInEpoch(16)).to.be.equal(
+      firstNormalSlot + 2 * slotsPerEpoch,
+    );
+    expect(epochSchedule.getLastSlotInEpoch(16)).to.be.equal(
+      firstNormalSlot + 3 * slotsPerEpoch - 1,
     );
   });
 });


### PR DESCRIPTION
#### Problem
`EpochSchedule` in rust has methods that allow easy navigation from epoch to slot.
https://github.com/solana-labs/solana/blob/18ec6756e49507c3945ab3d13d34dacbe897843b/sdk/program/src/epoch_schedule.rs#L151-L162

web3js consumer currently will have to replicate this logic client side, possibly being wrong if they don't know the cluster specificity (like I did, thinking `slotsPerEpoch` was a constant throughout valid for any epoch).

#### Summary of Changes
Change `EpochSchedule` to be a class and instantiate it before returning from `getEpochSchedule`. It provides the relevant methods, it could potentially have more but I added the one relevant to my use case.

Fixes #
