### PR TITLE
do not use index for verify_bank_hash_and_lamports

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4870,7 +4870,7 @@ impl AccountsDb {
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
-        let use_index = true;
+        let use_index = false;
         let check_hash = true;
         let can_cached_slot_be_unflushed = false;
         let (calculated_hash, calculated_lamports) = self


### PR DESCRIPTION
#### Problem
verify_bank_hash_and_lamports uses index scan currently. This is much slower than the non-index scan.
#### Summary of Changes
Switch to use index scan. This was not possible until recent changes in non-index scan.
Fixes #
