### PR TITLE
Rudimentary working implementation for incremental snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,6 +5400,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "walkdir",
  "zstd",
 ]
 

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -153,6 +153,11 @@ impl AccountsHashVerifier {
             }
         }
 
+        // bprumo TODO: here's where the snapshot interval is used, and when a true snapshot is made
+        // bprumo TODO: We could alternatively and optimistically set
+        // AccountsDb::last_full_snapshot_slot here as well, but there's a risk that the full
+        // snapshot does not actually successfully complete, which may be an issue for future
+        // cleans and/or future incremental snapshots.
         if accounts_package.block_height % snapshot_interval_slots == 0 {
             if let Some(pending_snapshot_package) = pending_snapshot_package.as_ref() {
                 *pending_snapshot_package.lock().unwrap() = Some(accounts_package);

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,5 +1,8 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
-use solana_runtime::{snapshot_package::AccountsPackage, snapshot_utils};
+use solana_runtime::{
+    snapshot_info, snapshot_info::SyncSnapshotInfo, snapshot_package::AccountsPackage,
+    snapshot_utils,
+};
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     sync::{
@@ -23,6 +26,7 @@ impl SnapshotPackagerService {
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
         maximum_snapshots_to_retain: usize,
+        snapshot_info: Option<SyncSnapshotInfo>,
     ) -> Self {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
@@ -48,6 +52,12 @@ impl SnapshotPackagerService {
                         ) {
                             warn!("Failed to create snapshot archive: {}", err);
                         } else {
+                            // At this point a full snapshot has successfully been taken, so update the SnapshotInfo.
+                            snapshot_info::set_last_full_snapshot_slot(
+                                snapshot_info.as_ref(),
+                                snapshot_package.slot,
+                            );
+
                             hashes.push((snapshot_package.slot, snapshot_package.hash));
                             while hashes.len() > MAX_SNAPSHOT_HASHES {
                                 hashes.remove(0);

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -157,9 +157,10 @@ mod tests {
         }
 
         // Create a packageable snapshot
-        let output_tar_path = snapshot_utils::get_snapshot_archive_path(
+        let output_tar_path = snapshot_utils::build_snapshot_archive_path(
             snapshot_package_output_path,
-            &(42, Hash::default()),
+            42,
+            &Hash::default(),
             ArchiveFormat::TarBzip2,
         );
         let snapshot_package = AccountsPackage::new(

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -492,6 +492,7 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+                incremental_snapshot_interval_slots: std::u64::MAX,
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -107,6 +107,7 @@ mod tests {
                 AccountSecondaryIndexes::default(),
                 false,
                 accounts_db::AccountShrinkThreshold::default(),
+                None,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);
@@ -169,6 +170,7 @@ mod tests {
             false,
             None,
             accounts_db::AccountShrinkThreshold::default(),
+            None,
         )
         .unwrap();
 
@@ -451,6 +453,7 @@ mod tests {
             &exit,
             &cluster_info,
             DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+            None,
         );
 
         let thread_pool = accounts_db::make_min_priority_thread_pool();

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -146,7 +146,7 @@ mod tests {
 
         let old_last_bank = old_bank_forks.get(old_last_slot).unwrap();
 
-        let deserialized_bank = snapshot_utils::bank_from_archive(
+        let deserialized_bank = snapshot_utils::bank_from_snapshot_archive(
             &account_paths,
             &[],
             &old_bank_forks

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -259,9 +259,10 @@ pub fn download_snapshot<'a, 'b>(
         ArchiveFormat::TarGzip,
         ArchiveFormat::TarBzip2,
     ] {
-        let desired_snapshot_package = snapshot_utils::get_snapshot_archive_path(
+        let desired_snapshot_package = snapshot_utils::build_snapshot_archive_path(
             snapshot_output_dir.to_path_buf(),
-            &desired_snapshot_hash,
+            desired_snapshot_hash.0,
+            &desired_snapshot_hash.1,
             *compression,
         );
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -691,6 +691,7 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+            incremental_snapshot_interval_slots: std::u64::MAX, // bprumo TODO: put in real value
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -722,6 +722,7 @@ fn load_bank_forks(
         process_options,
         None,
         None,
+        None,
     )
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -403,6 +403,7 @@ pub fn process_blockstore(
         opts.account_indexes.clone(),
         opts.accounts_db_caching_enabled,
         opts.shrink_ratio,
+        None,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");
@@ -3068,6 +3069,7 @@ pub mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         *bank.epoch_schedule()
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1671,12 +1671,13 @@ fn test_snapshot_download() {
         wait_for_next_snapshot(&cluster, &snapshot_package_output_path);
 
     trace!("found: {:?}", archive_filename);
-    let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
+    let validator_archive_path = snapshot_utils::build_snapshot_archive_path(
         validator_snapshot_test_config
             .snapshot_output_path
             .path()
             .to_path_buf(),
-        &archive_snapshot_hash,
+        archive_snapshot_hash.0,
+        &archive_snapshot_hash.1,
         ArchiveFormat::TarBzip2,
     );
 
@@ -1746,7 +1747,7 @@ fn test_snapshot_restart_tower() {
         wait_for_next_snapshot(&cluster, &snapshot_package_output_path);
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
+    let validator_archive_path = snapshot_utils::build_snapshot_archive_path(
         validator_snapshot_test_config
             .snapshot_output_path
             .path()
@@ -1808,7 +1809,7 @@ fn test_snapshots_blockstore_floor() {
 
     let (archive_filename, (archive_slot, archive_hash, _)) = loop {
         let archive =
-            snapshot_utils::get_highest_snapshot_archive_path(&snapshot_package_output_path);
+            snapshot_utils::get_highest_snapshot_archive_info(&snapshot_package_output_path);
         if archive.is_some() {
             trace!("snapshot exists");
             break archive.unwrap();
@@ -1817,7 +1818,7 @@ fn test_snapshots_blockstore_floor() {
     };
 
     // Copy archive to validator's snapshot output directory
-    let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
+    let validator_archive_path = snapshot_utils::build_snapshot_archive_path(
         validator_snapshot_test_config
             .snapshot_output_path
             .path()
@@ -3115,7 +3116,7 @@ fn wait_for_next_snapshot(
     );
     loop {
         if let Some((filename, (slot, hash, _))) =
-            snapshot_utils::get_highest_snapshot_archive_path(snapshot_package_output_path)
+            snapshot_utils::get_highest_snapshot_archive_info(snapshot_package_output_path)
         {
             trace!("snapshot for slot {} exists", slot);
             if slot >= last_slot {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -48,7 +48,7 @@ use {
         commitment::{BlockCommitmentArray, BlockCommitmentCache, CommitmentSlots},
         inline_spl_token_v2_0::{SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
         non_circulating_supply::calculate_non_circulating_supply,
-        snapshot_utils::get_highest_snapshot_archive_path,
+        snapshot_utils::get_highest_snapshot_archive_slot,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
@@ -2233,8 +2233,7 @@ pub mod rpc_minimal {
 
             meta.snapshot_config
                 .and_then(|snapshot_config| {
-                    get_highest_snapshot_archive_path(&snapshot_config.snapshot_package_output_path)
-                        .map(|(_, (slot, _, _))| slot)
+                    get_highest_snapshot_archive_slot(&snapshot_config.snapshot_package_output_path)
                 })
                 .ok_or_else(|| RpcCustomError::NoSnapshot.into())
         }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -199,13 +199,14 @@ impl RequestMiddleware for RpcRequestMiddleware {
         if let Some(ref snapshot_config) = self.snapshot_config {
             if request.uri().path() == "/snapshot.tar.bz2" {
                 // Convenience redirect to the latest snapshot
-                return if let Some((snapshot_archive, _)) =
-                    snapshot_utils::get_highest_snapshot_archive_path(
+                return if let Some(snapshot_archive_info) =
+                    snapshot_utils::get_highest_snapshot_archive_info(
                         &snapshot_config.snapshot_package_output_path,
                     ) {
                     RpcRequestMiddleware::redirect(&format!(
                         "/{}",
-                        snapshot_archive
+                        snapshot_archive_info
+                            .path
                             .file_name()
                             .unwrap_or_else(|| std::ffi::OsStr::new(""))
                             .to_str()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,6 +51,7 @@ symlink = "0.1.0"
 tar = "0.4.35"
 tempfile = "3.2.0"
 thiserror = "1.0"
+walkdir = "2"
 zstd = "0.5.1"
 
 [lib]

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     blockhash_queue::BlockhashQueue,
     rent_collector::RentCollector,
+    snapshot_info::SyncSnapshotInfo,
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
 };
 use dashmap::{
@@ -129,6 +130,7 @@ impl Accounts {
             AccountSecondaryIndexes::default(),
             false,
             shrink_ratio,
+            None,
         )
     }
 
@@ -138,6 +140,7 @@ impl Accounts {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
+        snapshot_info: Option<SyncSnapshotInfo>,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -146,6 +149,7 @@ impl Accounts {
                 account_indexes,
                 caching_enabled,
                 shrink_ratio,
+                snapshot_info,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
         }
@@ -1127,6 +1131,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         for ka in ka.iter() {
             accounts.store_slow_uncached(0, &ka.0, &ka.1);
@@ -1665,6 +1670,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         // Load accounts owned by various programs into AccountsDb
@@ -1694,6 +1700,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -1718,6 +1725,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.bank_hash_at(1);
     }
@@ -1740,6 +1748,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -1867,6 +1876,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -2018,6 +2028,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         {
             accounts
@@ -2071,6 +2082,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -2119,6 +2131,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         let instructions_key = solana_sdk::sysvar::instructions::id();
@@ -2405,6 +2418,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2525,6 +2539,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2560,6 +2575,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         let pubkey0 = Pubkey::new_unique();

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -165,8 +165,7 @@ impl SnapshotRequestHandler {
                 // accounts that were included in the bank delta hash when the bank was frozen,
                 // and if we clean them here, the newly created snapshot's hash may not match
                 // the frozen hash.
-                // bprumo TODO: snapshot_root_bank.clean_accounts_up_to_slot(highest_slot_to_clean, false);
-                // bprumo TODO: snapshot_root_bank.clean_accounts(true, false);
+                snapshot_root_bank.clean_accounts(true, false);
                 clean_time.stop();
 
                 if accounts_db_caching_enabled {
@@ -385,9 +384,7 @@ impl AccountsBackgroundService {
                             // slots >= bank.slot()
                             bank.force_flush_accounts_cache();
                         }
-                        // bprumo TODO: only clean up to last_full_snapshot_slot; may want to store
-                        // that as a loop variable
-                        // bprumo TODO: bank.clean_accounts(true, false);
+                        bank.clean_accounts(true, false);
                         last_cleaned_block_height = bank.block_height();
                     }
                 }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -152,19 +152,21 @@ impl SnapshotRequestHandler {
                 let highest_slot_to_clean = snapshot_utils::get_highest_snapshot_archive_slot(
                     &self.snapshot_config.snapshot_package_output_path,
                 )
-                .or_else(|| Some(snapshot_root_bank.slot()));
-                error!(
-                    "bprumo DEBUG: handle_snapshot_requests(): highest_slot_to_clean: {:?}",
-                    highest_slot_to_clean
+                .or_else(|| Some(snapshot_root_bank.slot())).map(|slot| slot.saturating_sub(1));
+                debug!(
+                    "bprumo DEBUG: handle_snapshot_requests(): bank slot: {}, highest_slot_to_clean: {:?}, accounts db caching enabled: {}",
+                    snapshot_root_bank.slot(),
+                    highest_slot_to_clean,
+                    accounts_db_caching_enabled
                 );
 
                 let mut clean_time = Measure::start("clean_time");
-                // bprumo TODO: fix comment
                 // Don't clean the slot we're snapshotting because it may have zero-lamport
                 // accounts that were included in the bank delta hash when the bank was frozen,
                 // and if we clean them here, the newly created snapshot's hash may not match
                 // the frozen hash.
-                snapshot_root_bank.clean_accounts_up_to_slot(highest_slot_to_clean, false);
+                // bprumo TODO: snapshot_root_bank.clean_accounts_up_to_slot(highest_slot_to_clean, false);
+                // bprumo TODO: snapshot_root_bank.clean_accounts(true, false);
                 clean_time.stop();
 
                 if accounts_db_caching_enabled {
@@ -352,7 +354,6 @@ impl AccountsBackgroundService {
                     // cache up to bank.slot(), so should be safe as long
                     // as any later snapshots that are taken are of
                     // slots >= bank.slot()
-                    // bprumo TODO: will need to look into this one, can not clean past last_full_snapshot_slot
                     bank.flush_accounts_cache_if_needed();
                 }
 
@@ -386,7 +387,7 @@ impl AccountsBackgroundService {
                         }
                         // bprumo TODO: only clean up to last_full_snapshot_slot; may want to store
                         // that as a loop variable
-                        // bprumo TODO remove? bank.clean_accounts(true, false);
+                        // bprumo TODO: bank.clean_accounts(true, false);
                         last_cleaned_block_height = bank.block_height();
                     }
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4933,7 +4933,7 @@ impl Bank {
     }
 
     pub fn clean_accounts(&self, skip_last: bool, is_startup: bool) {
-        let max_clean_slot = if skip_last {
+        let highest_slot_to_clean = if skip_last {
             // Don't clean the slot we're snapshotting because it may have zero-lamport
             // accounts that were included in the bank delta hash when the bank was frozen,
             // and if we clean them here, any newly created snapshot's hash for this bank
@@ -4942,10 +4942,14 @@ impl Bank {
         } else {
             None
         };
+        self.clean_accounts_up_to_slot(highest_slot_to_clean, is_startup);
+    }
+
+    pub fn clean_accounts_up_to_slot(&self, highest_slot_to_clean: Option<Slot>, is_startup: bool) {
         self.rc
             .accounts
             .accounts_db
-            .clean_accounts(max_clean_slot, is_startup);
+            .clean_accounts(highest_slot_to_clean, is_startup);
     }
 
     pub fn shrink_all_slots(&self, is_startup: bool) {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -27,22 +27,26 @@ pub enum ArchiveFormat {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SnapshotConfig {
-    // Generate a new snapshot every this many slots
-    pub snapshot_interval_slots: u64,
+    /// Generate a new snapshot every this many slots
+    pub snapshot_interval_slots: Slot,
 
-    // Where to store the latest packaged snapshot
+    /// Where to store the latest packaged snapshot
     pub snapshot_package_output_path: PathBuf,
 
-    // Where to place the snapshots for recent slots
+    /// Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
 
+    /// The archive format for the snapshot archive
     pub archive_format: ArchiveFormat,
 
-    // Snapshot version to generate
+    /// Snapshot version to generate
     pub snapshot_version: SnapshotVersion,
 
-    // Maximum number of snapshots to retain
+    /// Maximum number of snapshots to retain
     pub maximum_snapshots_to_retain: usize,
+
+    /// Generate a new incremental snapshot every this many slots
+    pub incremental_snapshot_interval_slots: Slot,
 }
 
 pub struct BankForks {

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -100,10 +100,12 @@ where
 
     let mut total_entries = 0;
     let mut last_log_update = Instant::now();
+    debug!("bprumo DEBUG: unpack_archive(), entries:");
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?;
         let path_str = path.display().to_string();
+        debug!("bprumo DEBUG: unpack_archive(),    entry path: {:?}", path);
 
         // Although the `tar` crate safely skips at the actual unpacking, fail
         // first by ourselves when there are odd paths like including `..` or /
@@ -200,6 +202,11 @@ pub fn unpack_snapshot<A: Read>(
 ) -> Result<UnpackedAppendVecMap> {
     assert!(!account_paths.is_empty());
     let mut unpacked_append_vec_map = UnpackedAppendVecMap::new();
+
+    debug!(
+        "bprumo DEBUG: unpack_snapshot():\n\tledger_dir: {:?}\n\taccount_paths: {:?}",
+        ledger_dir, account_paths
+    );
 
     unpack_archive(
         archive,

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -105,7 +105,6 @@ where
         let mut entry = entry?;
         let path = entry.path()?;
         let path_str = path.display().to_string();
-        debug!("bprumo DEBUG: unpack_archive(),    entry path: {:?}", path);
 
         // Although the `tar` crate safely skips at the actual unpacking, fail
         // first by ourselves when there are odd paths like including `..` or /
@@ -154,6 +153,10 @@ where
         )?;
         total_count = checked_total_count_increment(total_count, limit_count)?;
 
+        debug!(
+            "bprumo DEBUG: unpack_archive(),    entry path: {:?}, unpack_dir: {:?}",
+            path, unpack_dir
+        );
         // unpack_in does its own sanitization
         // ref: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack_in
         check_unpack_result(entry.unpack_in(unpack_dir)?, path_str)?;
@@ -221,6 +224,7 @@ pub fn unpack_snapshot<A: Read>(
                     account_paths.get(path_index).map(|path_buf| {
                         unpacked_append_vec_map
                             .insert(file.to_string(), path_buf.join("accounts").join(file));
+                        debug!("bprumo DEBUG: unpack_snapshot(), unpack_archive(), {{closure}}, inserting file: {:?}, path: {:?}", file.to_string(), path_buf.join("accounts").join(file));
                         path_buf.as_path()
                     })
                 } else {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -33,6 +33,7 @@ mod read_only_accounts_cache;
 pub mod rent_collector;
 pub mod secondary_index;
 pub mod serde_snapshot;
+pub mod snapshot_info;
 pub mod snapshot_package;
 pub mod snapshot_utils;
 pub mod sorted_storages;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -173,6 +173,57 @@ where
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn bank_from_stream_incremental<R>(
+    serde_style: SerdeStyle,
+    fss_stream: &mut BufReader<R>,
+    iss_stream: &mut BufReader<R>,
+    account_paths: &[PathBuf],
+    unpacked_append_vec_map: UnpackedAppendVecMap,
+    genesis_config: &GenesisConfig,
+    frozen_account_pubkeys: &[Pubkey],
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
+    additional_builtins: Option<&Builtins>,
+    account_indexes: AccountSecondaryIndexes,
+    caching_enabled: bool,
+    limit_load_slot_count_from_snapshot: Option<usize>,
+    shrink_ratio: AccountShrinkThreshold,
+) -> std::result::Result<Bank, Error>
+where
+    R: Read,
+{
+    macro_rules! INTO {
+        ($x:ident) => {{
+            let (_, fss_accounts_db_fields) = $x::deserialize_bank_fields(fss_stream)?;
+            let (bank_fields, iss_accounts_db_fields) = $x::deserialize_bank_fields(iss_stream)?;
+
+            let bank = reconstruct_bank_from_fields_incremental(
+                bank_fields,
+                fss_accounts_db_fields,
+                iss_accounts_db_fields,
+                genesis_config,
+                frozen_account_pubkeys,
+                account_paths,
+                unpacked_append_vec_map,
+                debug_keys,
+                additional_builtins,
+                account_indexes,
+                caching_enabled,
+                limit_load_slot_count_from_snapshot,
+                shrink_ratio,
+            )?;
+            Ok(bank)
+        }};
+    }
+    match serde_style {
+        SerdeStyle::Newer => INTO!(TypeContextFuture),
+    }
+    .map_err(|err| {
+        warn!("bankrc_from_stream error: {:?}", err);
+        err
+    })
+}
+
 pub(crate) fn bank_to_stream<W>(
     serde_style: SerdeStyle,
     stream: &mut BufWriter<W>,
@@ -194,6 +245,11 @@ where
             )
         };
     }
+
+    debug!(
+        "bprumo DEBUG: bank_to_stream(), snapshot_storages: {:?}",
+        snapshot_storages
+    );
     match serde_style {
         SerdeStyle::Newer => INTO!(TypeContextFuture),
     }
@@ -282,6 +338,53 @@ where
     Ok(bank)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn reconstruct_bank_from_fields_incremental<E>(
+    bank_fields: BankFieldsToDeserialize,
+    fss_accounts_db_fields: AccountsDbFields<E>,
+    iss_accounts_db_fields: AccountsDbFields<E>,
+    genesis_config: &GenesisConfig,
+    frozen_account_pubkeys: &[Pubkey],
+    account_paths: &[PathBuf],
+    unpacked_append_vec_map: UnpackedAppendVecMap,
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
+    additional_builtins: Option<&Builtins>,
+    account_indexes: AccountSecondaryIndexes,
+    caching_enabled: bool,
+    limit_load_slot_count_from_snapshot: Option<usize>,
+    shrink_ratio: AccountShrinkThreshold,
+) -> Result<Bank, Error>
+where
+    E: SerializableStorage,
+{
+    let mut accounts_db = reconstruct_accountsdb_from_fields_incremental(
+        fss_accounts_db_fields,
+        iss_accounts_db_fields,
+        account_paths,
+        unpacked_append_vec_map,
+        &genesis_config.cluster_type,
+        account_indexes,
+        caching_enabled,
+        limit_load_slot_count_from_snapshot,
+        shrink_ratio,
+    )?;
+    accounts_db.freeze_accounts(
+        &Ancestors::from(&bank_fields.ancestors),
+        frozen_account_pubkeys,
+    );
+
+    let bank_rc = BankRc::new(Accounts::new_empty(accounts_db), bank_fields.slot);
+    let bank = Bank::new_from_fields(
+        bank_rc,
+        genesis_config,
+        bank_fields,
+        debug_keys,
+        additional_builtins,
+    );
+
+    Ok(bank)
+}
+
 fn reconstruct_accountsdb_from_fields<E>(
     accounts_db_fields: AccountsDbFields<E>,
     account_paths: &[PathBuf],
@@ -303,6 +406,7 @@ where
         shrink_ratio,
     );
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
+    accounts_db.set_last_full_snapshot_slot(slot);
 
     // Ensure all account paths exist
     for path in &accounts_db.paths {
@@ -327,8 +431,10 @@ where
             let mut new_slot_storage = HashMap::new();
             for storage_entry in slot_storage.drain(..) {
                 let file_name = AppendVec::file_name(slot, storage_entry.id());
+                debug!("bprumo DEBUG: reconstruct_accountsdb_from_fields(): slot: {}, storage entry id: {}, appendvec filename: {:?}", slot, storage_entry.id(), file_name);
 
                 let append_vec_path = unpacked_append_vec_map.get(&file_name).ok_or_else(|| {
+                    debug!("bprumo DEBUG: reconstruct_accountsdb_from_fields(): failed to get append vec path! file_name: {:?}", file_name);
                     io::Error::new(
                         io::ErrorKind::NotFound,
                         format!("{} not found in unpacked append vecs", file_name),
@@ -343,6 +449,7 @@ where
                     accounts,
                     num_accounts,
                 );
+                debug!("bprumo DEBUG: reconstruct_accountsdb_from_fields(): append vec path: {:?}", append_vec_path);
 
                 new_slot_storage.insert(storage_entry.id(), Arc::new(u_storage_entry));
             }
@@ -384,6 +491,120 @@ where
     accounts_db
         .write_version
         .fetch_add(version, Ordering::Relaxed);
+    accounts_db.generate_index(limit_load_slot_count_from_snapshot);
+    Ok(accounts_db)
+}
+
+fn reconstruct_accountsdb_from_fields_incremental<E>(
+    fss_accounts_db_fields: AccountsDbFields<E>,
+    iss_accounts_db_fields: AccountsDbFields<E>,
+    account_paths: &[PathBuf],
+    unpacked_append_vec_map: UnpackedAppendVecMap,
+    cluster_type: &ClusterType,
+    account_indexes: AccountSecondaryIndexes,
+    caching_enabled: bool,
+    limit_load_slot_count_from_snapshot: Option<usize>,
+    shrink_ratio: AccountShrinkThreshold,
+) -> Result<AccountsDb, Error>
+where
+    E: SerializableStorage,
+{
+    let mut accounts_db = AccountsDb::new_with_config(
+        account_paths.to_vec(),
+        cluster_type,
+        account_indexes,
+        caching_enabled,
+        shrink_ratio,
+    );
+    let AccountsDbFields(fss_storage, _, fss_slot, _) = fss_accounts_db_fields;
+    let AccountsDbFields(iss_storage, iss_version, iss_slot, iss_bank_hash_info) =
+        iss_accounts_db_fields;
+    // bprumo TODO: what should be done if the versions are different between fss and iss? Just
+    // ignore, or error out?
+
+    accounts_db.set_last_full_snapshot_slot(fss_slot);
+
+    // Ensure all account paths exist
+    for path in &accounts_db.paths {
+        std::fs::create_dir_all(path)
+            .unwrap_or_else(|err| panic!("Failed to create directory {}: {}", path.display(), err));
+    }
+
+    let mut last_log_update = Instant::now();
+    let mut remaining_slots_to_process = fss_storage.len() + iss_storage.len();
+
+    // Remap the deserialized AppendVec paths to point to correct local paths
+    let mut storage = fss_storage.into_iter().chain(iss_storage.into_iter())
+        .map(|(slot, mut slot_storage)| {
+            let now = Instant::now();
+            if now.duration_since(last_log_update).as_secs() >= 10 {
+                info!("{} slots remaining...", remaining_slots_to_process);
+                last_log_update = now;
+            }
+            remaining_slots_to_process -= 1;
+
+            let mut new_slot_storage = HashMap::new();
+            for storage_entry in slot_storage.drain(..) {
+                let file_name = AppendVec::file_name(slot, storage_entry.id());
+
+                let append_vec_path = unpacked_append_vec_map.get(&file_name).ok_or_else(|| {
+                    debug!("bprumo DEBUG: reconstruct_accountsdb_from_fields_incremental(): failed to get append vec path! file_name: {:?}", file_name);
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("{} not found in unpacked append vecs", file_name),
+                    )
+                })?;
+
+                let (accounts, num_accounts) =
+                    AppendVec::new_from_file(append_vec_path, storage_entry.current_len())?;
+                let u_storage_entry = AccountStorageEntry::new_existing(
+                    slot,
+                    storage_entry.id(),
+                    accounts,
+                    num_accounts,
+                );
+                debug!("bprumo DEBUG: reconstruct_accountsdb_from_fields_incremental(): slot: {}, storage entry id: {}, append vec filename: {:?}, append vec path: {:?}", slot, storage_entry.id(), file_name, append_vec_path);
+
+                new_slot_storage.insert(storage_entry.id(), Arc::new(u_storage_entry));
+            }
+            Ok((slot, new_slot_storage))
+        })
+        .collect::<Result<HashMap<Slot, _>, Error>>()?;
+
+    // discard any slots with no storage entries
+    // this can happen if a non-root slot was serialized
+    // but non-root stores should not be included in the snapshot
+    storage.retain(|_slot, stores| !stores.is_empty());
+
+    accounts_db
+        .bank_hashes
+        .write()
+        .unwrap()
+        .insert(iss_slot, iss_bank_hash_info);
+
+    // Process deserialized data, set necessary fields in self
+    let max_id: usize = *storage
+        .values()
+        .flat_map(HashMap::keys)
+        .max()
+        .expect("At least one storage entry must exist from deserializing stream");
+
+    {
+        accounts_db.storage.0.extend(
+            storage.into_iter().map(|(slot, slot_storage_entry)| {
+                (slot, Arc::new(RwLock::new(slot_storage_entry)))
+            }),
+        );
+    }
+
+    if max_id > AppendVecId::MAX / 2 {
+        panic!("Storage id {} larger than allowed max", max_id);
+    }
+
+    accounts_db.next_id.store(max_id + 1, Ordering::Relaxed);
+    accounts_db
+        .write_version
+        .fetch_add(iss_version, Ordering::Relaxed);
     accounts_db.generate_index(limit_load_slot_count_from_snapshot);
     Ok(accounts_db)
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -75,6 +75,7 @@ where
         false,
         None,
         AccountShrinkThreshold::default(),
+        None,
     )
 }
 
@@ -131,6 +132,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
 
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -231,6 +233,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         false,
         None,
         AccountShrinkThreshold::default(),
+        None,
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_info.rs
+++ b/runtime/src/snapshot_info.rs
@@ -1,0 +1,166 @@
+//! Shared runtime information about snapshots
+//!
+//! Snapshot information is needed at runtime in multiple threads.  Currently, this is mainly to
+//! prevent cleaning of `AccountsDb` _past_ the last full snapshot slot.  However, snapshots are
+//! taken in a separate thread, and `AccountsDb` didn't have a way get that information.
+//!
+//! This module was created to solve that problem.  Now, all threads that need runtime snapshot
+//! information can have a `SyncSnapshotInfo` object to get/set the information they need.
+//!
+//! **NOTE** Client should use `SyncSnapshotInfo` and not `SnapshotInfo`, since the later does not
+//! include synchronization (and the whole point of this module is to share snapshot information
+//! between threads).
+//!
+//! **NOTE** There are helper functions to handle the common case of getting/setting snapshot
+//! information when you have a `Option<SyncSnapshotInfo>`.
+
+use solana_sdk::clock::Slot;
+use std::sync::{Arc, RwLock};
+
+/// Runtime information about snapshots
+///
+/// **NOTE** Clients should use `SyncSnapshotInfo` instead!
+///
+/// Information about the snapshots is needed in multiple threads at different times; for example,
+/// `AccountsDb` (and `Bank` via `AccountsDb`) need to ensure cleaning does not happen past the
+/// `last_full_snapshot_slot`.  Whereas `snapshot_utils`, `serde_snapshot`, `AccountsBackgroundService`, and
+/// `SnapshotPackagerService` need to be able to set these values when snapshots are taken.
+///
+/// Share this object between all interested parties to ensure a consistent view of the snapshot
+/// information.
+#[derive(Debug)]
+pub struct SnapshotInfo {
+    /// The slot when the last full snapshot was taken.  Can be `None` if there are no full
+    /// snapshots yet.
+    last_full_snapshot_slot: Option<Slot>,
+
+    /// The slot when the last incremental snapshot was taken.  Can be `None` if there are no
+    /// incremental snapshots yet.  It is required that this incremental snapshot's base slot is
+    /// the same as the `last_full_snapshot_slot`.
+    last_incremental_snapshot_slot: Option<Slot>,
+}
+
+/// Snapshot runtime information, wrapped to make it multi-thread safe
+pub type SyncSnapshotInfo = Arc<RwLock<SnapshotInfo>>;
+
+impl Default for SnapshotInfo {
+    fn default() -> Self {
+        Self {
+            last_full_snapshot_slot: None,
+            last_incremental_snapshot_slot: None,
+        }
+    }
+}
+
+impl SnapshotInfo {
+    /// Get the last full snapshot slot
+    pub fn last_full_snapshot_slot(&self) -> Option<Slot> {
+        self.last_full_snapshot_slot
+    }
+
+    /// Set the last full snapshot slot
+    pub fn set_last_full_snapshot_slot(&mut self, slot: Slot) {
+        self.last_full_snapshot_slot = Some(slot)
+    }
+
+    /// Get the last incremental snapshot slot
+    pub fn last_incremental_snapshot_slot(&self) -> Option<Slot> {
+        self.last_incremental_snapshot_slot
+    }
+
+    /// Set the last incremental snapshot slot
+    pub fn set_last_incremental_snapshot_slot(&mut self, slot: Slot) {
+        self.last_incremental_snapshot_slot = Some(slot)
+    }
+}
+
+/// Helper function to get the last full snapshot slot from an option-and-sync-wrapped SnapshotInfo
+pub fn get_last_full_snapshot_slot(snapshot_info: Option<&SyncSnapshotInfo>) -> Option<Slot> {
+    snapshot_info
+        .map(|sync_snapshot_info| sync_snapshot_info.read().unwrap().last_full_snapshot_slot())
+        .flatten()
+}
+
+/// Helper function to set the last full snapshot slot from an option-and-sync-wrapped SnapshotInfo
+pub fn set_last_full_snapshot_slot(snapshot_info: Option<&SyncSnapshotInfo>, slot: Slot) {
+    if let Some(sync_snapshot_info) = snapshot_info {
+        sync_snapshot_info
+            .write()
+            .unwrap()
+            .set_last_full_snapshot_slot(slot)
+    }
+}
+
+/// Helper function to get the last incremental snapshot slot from an option-and-sync-wrapped SnapshotInfo
+pub fn get_last_incremental_snapshot_slot(
+    snapshot_info: Option<&SyncSnapshotInfo>,
+) -> Option<Slot> {
+    snapshot_info
+        .map(|sync_snapshot_info| {
+            sync_snapshot_info
+                .read()
+                .unwrap()
+                .last_incremental_snapshot_slot()
+        })
+        .flatten()
+}
+
+/// Helper function to set the last incremental snapshot slot from an option-and-sync-wrapped SnapshotInfo
+pub fn set_last_incremental_snapshot_slot(snapshot_info: Option<&SyncSnapshotInfo>, slot: Slot) {
+    if let Some(sync_snapshot_info) = snapshot_info {
+        sync_snapshot_info
+            .write()
+            .unwrap()
+            .set_last_incremental_snapshot_slot(slot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_can_synchronize_two_threads() {
+        const STOP_COUNT: Slot = 10;
+        let snapshot_info = SyncSnapshotInfo::default();
+
+        // Loop on the last full snapshot slot, while updating the last incremental snapshot slot
+        let snapshot_info1 = snapshot_info.clone();
+        let handle1 = std::thread::spawn(move || {
+            let mut count = 0;
+            loop {
+                if let Some(last_full_snapshot_slot) =
+                    get_last_full_snapshot_slot(Some(&snapshot_info1))
+                {
+                    if last_full_snapshot_slot >= STOP_COUNT {
+                        break;
+                    }
+                }
+
+                set_last_incremental_snapshot_slot(Some(&snapshot_info1), count);
+                count += 1;
+            }
+        });
+
+        // Loop on the last incremental snapshot slot, while updating the last full snapshot slot
+        let snapshot_info2 = snapshot_info.clone();
+        let handle2 = std::thread::spawn(move || {
+            let mut count = 0;
+            loop {
+                if let Some(last_incremental_snapshot_slot) =
+                    get_last_incremental_snapshot_slot(Some(&snapshot_info2))
+                {
+                    if last_incremental_snapshot_slot >= STOP_COUNT {
+                        break;
+                    }
+                }
+
+                set_last_full_snapshot_slot(Some(&snapshot_info2), count);
+                count += 1;
+            }
+        });
+
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+    }
+}


### PR DESCRIPTION
This is a draft PR to get some eyes on my initial implementation for Incremental Snapshots (#17088).

So far this is only running through tests in `snapshot_utils.rs` (see the `roundtrip` tests at the bottom of the file). There are still many things to do for ISS:

- figure out cleaning (there will be some comments below)
- incorporate into the validator fully, so ISS are created while running, and ISS is used at startup
- add CLI args to validator to control ISS
- add ISS to RPC
- add ISS to gossip

In this PR you'll see a lot of `debug!()` prints. Those are just for me while developing and will eventually be removed once the impl is finalized.

The code also likely will not pass CI, since it is not meant to be a full/complete PR/implementation.

Additionally, many of the snapshot functions have been duplicated into sibling "incremental" versions. I'd like to remove this duplication and intend to do so by creating functions to handle the real impls with `Option<>` around the incremental snapshot parts. Unfortunately this doesn't work everywhere, in particular the deserialization, which I will call out below too.