### PR TITLE
Add label to community contributions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,15 @@
 #
 # https://doc.mergify.io/
 pull_request_rules:
+  - name: label changes from community
+    conditions:
+      - author≠@core-contributors
+      - author≠mergify[bot]
+      - author≠dependabot[bot]
+    actions:
+      label:
+        add:
+          - community
   - name: automatic merge (squash) on CI success
     conditions:
       - status-success=buildkite/solana


### PR DESCRIPTION
#### Problem
Community contributors aren't very visible and can sometimes go unnoticed for review from the core team

#### Summary of Changes
Add mergify rule that adds a label to community pr's

Fixes #
