### PR TITLE
Update RUSTFLAGS if it is set, instead of overriding in build-bpf

### DIFF
--- a/sdk/bpf/env.sh
+++ b/sdk/bpf/env.sh
@@ -15,4 +15,4 @@ export AR="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-ar"
 export OBJDUMP="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-objdump"
 export OBJCOPY="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-objcopy"
 
-export RUSTFLAGS="-C lto=no"
+export RUSTFLAGS="${RUSTFLAGS} -C lto=no"

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -448,7 +448,14 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     env::set_var("AR", llvm_bin.join("llvm-ar"));
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
-    env::set_var("RUSTFLAGS", "-C lto=no");
+    let rustflags = match env::var("RUSTFLAGS") {
+        Ok(rf) => rf + &" -C lto=no".to_string(),
+        _ => "-C lto=no".to_string(),
+    };
+    if config.verbose {
+        println!("RUSTFLAGS={}", rustflags);
+    }
+    env::set_var("RUSTFLAGS", rustflags);
     let cargo_build = PathBuf::from("cargo");
     let mut cargo_build_args = vec![
         "+bpf",


### PR DESCRIPTION
#### Problem

Users may pass additional command line parameters to rustc by setting RUSTFLAGS environment variable. This variable is reset in cargo-build-bpf, thus preventing users to pass their parameters.

#### Summary of Changes

Read the value of RUSTFLAGS variable and augment it, instead of resetting.

The problem is mentioned in issue #17849.
