### PR TITLE
Don't require non-existent param for `solana-keygen new`

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -106,9 +106,6 @@ fn no_outfile_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NO_OUTFILE_ARG.name)
         .long(NO_OUTFILE_ARG.long)
         .conflicts_with_all(&["outfile", "silent"])
-        // Require a seed phrase to avoid generating a keypair
-        // but having no way to get the private key
-        .requires("use_mnemonic")
         .help(NO_OUTFILE_ARG.help)
 }
 
@@ -121,7 +118,6 @@ impl KeyGenerationCommonArgs for App<'_, '_> {
         self.arg(word_count_arg())
             .arg(language_arg())
             .arg(no_passphrase_arg())
-            .arg(no_outfile_arg())
     }
 }
 
@@ -395,6 +391,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 )
                 .key_generation_common_args()
+                .arg(no_outfile_arg())
         )
         .subcommand(
             SubCommand::with_name("grind")
@@ -450,6 +447,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("Generate using a mnemonic key phrase.  Expect a significant slowdown in this mode"),
                 )
                 .key_generation_common_args()
+                .arg(
+                    no_outfile_arg()
+                    // Require a seed phrase to avoid generating a keypair
+                    // but having no way to get the private key
+                    .requires("use_mnemonic")
+                )
         )
         .subcommand(
             SubCommand::with_name("pubkey")


### PR DESCRIPTION
#### Problem
As of https://github.com/solana-labs/solana/pull/17251, `--use-mnemonic` is required with `--no-outfile`; but `solana-keygen new` does not support the former. This results in a nasty-looking panic:
```
$ solana-keygen new --no-outfile

thread 'main' panicked at 'Fatal internal error. Please consider filing a bug report at https://github.com/clap-rs/clap/issues', /.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/app/usage.rs:475:22
```

#### Summary of Changes
Pull `no_outfile_arg()` out of `key_generation_common_args()` so the requirement can be configured separately for `new` and `grind`

Fixes #17860 
