### PR TITLE
Refactoring: Unify account_deps and accounts

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -290,7 +290,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         'outer: for key in &message.account_keys {
             for account_info in account_infos {
                 if account_info.unsigned_key() == key {
-                    accounts.push(Rc::new(RefCell::new(ai_to_a(account_info))));
+                    accounts.push((*key, Rc::new(RefCell::new(ai_to_a(account_info)))));
                     continue 'outer;
                 }
             }
@@ -343,7 +343,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
             for account_info in account_infos {
                 if account_info.unsigned_key() == account_pubkey {
-                    let account = &accounts[i];
+                    let (_key, account) = &accounts[i];
                     **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports();
 
                     let mut data = account_info.try_borrow_mut_data()?;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -344,6 +344,8 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             for account_info in account_infos {
                 if account_info.unsigned_key() == account_pubkey {
                     let (_key, account) = &accounts[i];
+                    // REFACTOR: account_deps unification
+                    assert_eq!(_key, account_pubkey);
                     **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports();
 
                     let mut data = account_info.try_borrow_mut_data()?;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -336,7 +336,6 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos
-        // REFACTOR: account_deps unification
         for (i, (pubkey, account)) in accounts.iter().enumerate().take(message.account_keys.len()) {
             if !message.is_writable(i, true) {
                 continue;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -336,16 +336,13 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos
-        for (i, account_pubkey) in message.account_keys.iter().enumerate() {
+        // REFACTOR: account_deps unification
+        for (i, (pubkey, account)) in accounts.iter().enumerate().take(message.account_keys.len()) {
             if !message.is_writable(i, true) {
                 continue;
             }
-
             for account_info in account_infos {
-                if account_info.unsigned_key() == account_pubkey {
-                    let (_key, account) = &accounts[i];
-                    // REFACTOR: account_deps unification
-                    assert_eq!(_key, account_pubkey);
+                if account_info.unsigned_key() == pubkey {
                     **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports();
 
                     let mut data = account_info.try_borrow_mut_data()?;

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1417,7 +1417,7 @@ type TranslatedAccount<'a> = (
     Option<AccountReferences<'a>>,
 );
 type TranslatedAccounts<'a> = (
-    Vec<Rc<RefCell<AccountSharedData>>>,
+    Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>,
     Vec<Option<AccountReferences<'a>>>,
 );
 
@@ -2062,7 +2062,7 @@ where
 
         if i == program_account_index || account.borrow().executable() {
             // Use the known account
-            accounts.push(account);
+            accounts.push((**account_key, account));
             refs.push(None);
         } else if let Some(account_info) =
             account_info_keys
@@ -2077,7 +2077,7 @@ where
                 })
         {
             let (account, account_ref) = do_translate(account_info, invoke_context)?;
-            accounts.push(account);
+            accounts.push((**account_key, account));
             refs.push(account_ref);
         } else {
             ic_msg!(
@@ -2266,6 +2266,7 @@ fn call<'a>(
                 ic_msg!(invoke_context, "Unknown program {}", callee_program_id,);
                 SyscallError::InstructionError(InstructionError::MissingAccount)
             })?
+            .1
             .clone();
         let programdata_executable =
             get_upgradeable_executable(&callee_program_id, &program_account, &invoke_context)?;
@@ -2307,7 +2308,7 @@ fn call<'a>(
     // Copy results back to caller
     {
         let invoke_context = syscall.get_context()?;
-        for (i, (account, account_ref)) in accounts.iter().zip(account_refs).enumerate() {
+        for (i, ((_key, account), account_ref)) in accounts.iter().zip(account_refs).enumerate() {
             let account = account.borrow();
             if let Some(mut account_ref) = account_ref {
                 if message.is_writable(i, demote_sysvar_write_locks) && !account.executable() {

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2309,6 +2309,8 @@ fn call<'a>(
     {
         let invoke_context = syscall.get_context()?;
         for (i, ((_key, account), account_ref)) in accounts.iter().zip(account_refs).enumerate() {
+            // REFACTOR: account_deps unification
+            assert_eq!(message.account_keys[i], *_key);
             let account = account.borrow();
             if let Some(mut account_ref) = account_ref {
                 if message.is_writable(i, demote_sysvar_write_locks) && !account.executable() {

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2310,7 +2310,6 @@ fn call<'a>(
         let invoke_context = syscall.get_context()?;
         for (i, ((_key, account), account_ref)) in accounts.iter().zip(account_refs).enumerate() {
             // REFACTOR: account_deps unification
-            assert_eq!(message.account_keys[i], *_key);
             let account = account.borrow();
             if let Some(mut account_ref) = account_ref {
                 if message.is_writable(i, demote_sysvar_write_locks) && !account.executable() {

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2309,7 +2309,6 @@ fn call<'a>(
     {
         let invoke_context = syscall.get_context()?;
         for (i, ((_key, account), account_ref)) in accounts.iter().zip(account_refs).enumerate() {
-            // REFACTOR: account_deps unification
             let account = account.borrow();
             if let Some(mut account_ref) = account_ref {
                 if message.is_writable(i, demote_sysvar_write_locks) && !account.executable() {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3090,16 +3090,22 @@ pub mod rpc_full {
                     accounts.push(if result.is_err() {
                         None
                     } else {
-                        transaction
-                            .message
-                            .account_keys
-                            .iter()
-                            .position(|pubkey| *pubkey == address)
-                            .map(|i| post_simulation_accounts.get(i))
-                            .flatten()
-                            .map(|(_pubkey, account)| {
-                                // REFACTOR: account_deps unification
-                                UiAccount::encode(&address, account, accounts_encoding, None, None)
+                        // REFACTOR: account_deps unification
+                        (0..transaction.message.account_keys.len())
+                            .position(|i| {
+                                post_simulation_accounts
+                                    .get(i)
+                                    .map(|(key, _account)| *key == address)
+                                    .unwrap_or(false)
+                            })
+                            .map(|i| {
+                                UiAccount::encode(
+                                    &address,
+                                    &post_simulation_accounts[i].1,
+                                    accounts_encoding,
+                                    None,
+                                    None,
+                                )
                             })
                     });
                 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3098,6 +3098,7 @@ pub mod rpc_full {
                             .map(|i| post_simulation_accounts.get(i))
                             .flatten()
                             .map(|(_pubkey, account)| {
+                                // REFACTOR: account_deps unification
                                 UiAccount::encode(&address, account, accounts_encoding, None, None)
                             })
                     });

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3097,7 +3097,7 @@ pub mod rpc_full {
                             .position(|pubkey| *pubkey == address)
                             .map(|i| post_simulation_accounts.get(i))
                             .flatten()
-                            .map(|account| {
+                            .map(|(_pubkey, account)| {
                                 UiAccount::encode(&address, account, accounts_encoding, None, None)
                             })
                     });

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3090,7 +3090,6 @@ pub mod rpc_full {
                     accounts.push(if result.is_err() {
                         None
                     } else {
-                        // REFACTOR: account_deps unification
                         (0..transaction.message.account_keys.len())
                             .position(|i| {
                                 post_simulation_accounts

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -278,7 +278,11 @@ impl Accounts {
                 accounts.push((*key, account));
             }
             debug_assert_eq!(accounts.len(), message.account_keys.len());
-            // REFACTOR: account_deps unification
+            // Appends the account_deps at the end of the accounts,
+            // this way they can be accessed in a uniform way.
+            // At places where only the accounts are needed,
+            // the account_deps are truncated using e.g:
+            // accounts.iter().take(message.account_keys.len())
             accounts.append(&mut account_deps);
 
             if let Some(payer_index) = payer_index {
@@ -996,7 +1000,6 @@ impl Accounts {
                 .zip(loaded_transaction.accounts.iter_mut())
                 .filter(|(i, (key, _account))| message.is_non_loader_key(key, *i))
             {
-                // REFACTOR: account_deps unification
                 let is_nonce_account = prepare_if_nonce_account(
                     account,
                     key,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -98,13 +98,11 @@ pub struct Accounts {
 
 // for the load instructions
 pub type TransactionAccounts = Vec<(Pubkey, AccountSharedData)>;
-pub type TransactionAccountDeps = Vec<(Pubkey, AccountSharedData)>;
 pub type TransactionRent = u64;
 pub type TransactionLoaders = Vec<Vec<(Pubkey, AccountSharedData)>>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct LoadedTransaction {
     pub accounts: TransactionAccounts,
-    pub account_deps: TransactionAccountDeps,
     pub loaders: TransactionLoaders,
     pub rent: TransactionRent,
     pub rent_debits: RentDebits,
@@ -281,7 +279,7 @@ impl Accounts {
             }
             debug_assert_eq!(accounts.len(), message.account_keys.len());
             // REFACTOR: account_deps unification
-            accounts.append(&mut account_deps.clone());
+            accounts.append(&mut account_deps);
 
             if let Some(payer_index) = payer_index {
                 if payer_index != 0 {
@@ -332,7 +330,6 @@ impl Accounts {
                             .collect::<Result<TransactionLoaders>>()?;
                         Ok(LoadedTransaction {
                             accounts,
-                            account_deps,
                             loaders,
                             rent: tx_rent,
                             rent_debits,
@@ -2014,7 +2011,6 @@ mod tests {
         let loaded0 = (
             Ok(LoadedTransaction {
                 accounts: transaction_accounts0,
-                account_deps: vec![],
                 loaders: transaction_loaders0,
                 rent: transaction_rent0,
                 rent_debits: RentDebits::default(),
@@ -2027,7 +2023,6 @@ mod tests {
         let loaded1 = (
             Ok(LoadedTransaction {
                 accounts: transaction_accounts1,
-                account_deps: vec![],
                 loaders: transaction_loaders1,
                 rent: transaction_rent1,
                 rent_debits: RentDebits::default(),
@@ -2411,7 +2406,6 @@ mod tests {
         let loaded = (
             Ok(LoadedTransaction {
                 accounts: transaction_accounts,
-                account_deps: vec![],
                 loaders: transaction_loaders,
                 rent: transaction_rent,
                 rent_debits: RentDebits::default(),
@@ -2529,7 +2523,6 @@ mod tests {
         let loaded = (
             Ok(LoadedTransaction {
                 accounts: transaction_accounts,
-                account_deps: vec![],
                 loaders: transaction_loaders,
                 rent: transaction_rent,
                 rent_debits: RentDebits::default(),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -993,15 +993,11 @@ impl Accounts {
             let message = &tx.message();
             let loaded_transaction = raccs.as_mut().unwrap();
             let mut fee_payer_index = None;
-            for ((i, key), (_key, account)) in message
-                .account_keys
-                .iter()
-                .enumerate()
+            for (i, (key, account)) in (0..message.account_keys.len())
                 .zip(loaded_transaction.accounts.iter_mut())
-                .filter(|((i, key), (_key, _account))| message.is_non_loader_key(key, *i))
+                .filter(|(i, (key, _account))| message.is_non_loader_key(key, *i))
             {
                 // REFACTOR: account_deps unification
-                assert_eq!(key, _key);
                 let is_nonce_account = prepare_if_nonce_account(
                     account,
                     key,
@@ -1038,7 +1034,7 @@ impl Accounts {
                             .rent_debits
                             .push(key, rent, account.lamports());
                     }
-                    accounts.push((key, &*account));
+                    accounts.push((&*key, &*account));
                 }
             }
         }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1000,6 +1000,8 @@ impl Accounts {
                 .zip(loaded_transaction.accounts.iter_mut())
                 .filter(|((i, key), (_key, _account))| message.is_non_loader_key(key, *i))
             {
+                // REFACTOR: account_deps unification
+                assert_eq!(key, _key);
                 let is_nonce_account = prepare_if_nonce_account(
                     account,
                     key,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -280,6 +280,8 @@ impl Accounts {
                 accounts.push((*key, account));
             }
             debug_assert_eq!(accounts.len(), message.account_keys.len());
+            // REFACTOR: account_deps unification
+            accounts.append(&mut account_deps.clone());
 
             if let Some(payer_index) = payer_index {
                 if payer_index != 0 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2949,15 +2949,14 @@ impl Bank {
         accounts: &mut TransactionAccounts,
         account_deps: &mut TransactionAccountDeps,
         loaders: &mut TransactionLoaders,
-        message: &Message,
     ) -> (
         TransactionAccountRefCells,
         TransactionAccountDepRefCells,
         TransactionLoaderRefCells,
     ) {
-        let account_refcells: Vec<_> = (0..message.account_keys.len())
-            .zip(accounts.drain(..))
-            .map(|(_i, (pubkey, account))| {
+        let account_refcells: Vec<_> = accounts
+            .drain(..)
+            .map(|(pubkey, account)| {
                 // REFACTOR: account_deps unification
                 (pubkey, Rc::new(RefCell::new(account)))
             })
@@ -3152,7 +3151,6 @@ impl Bank {
                             &mut loaded_transaction.accounts,
                             &mut loaded_transaction.account_deps,
                             &mut loaded_transaction.loaders,
-                            &tx.message,
                         );
 
                     let instruction_recorders = if enable_cpi_recording {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -630,7 +630,6 @@ impl NonceRollbackFull {
             nonce_address,
             nonce_account,
         } = partial;
-        // REFACTOR: account_deps unification
         let fee_payer = (0..message.account_keys.len()).find_map(|i| {
             if let Some((k, a)) = &accounts.get(i) {
                 if message.is_non_loader_key(k, i) {
@@ -2950,10 +2949,7 @@ impl Bank {
     ) -> (TransactionAccountRefCells, TransactionLoaderRefCells) {
         let account_refcells: Vec<_> = accounts
             .drain(..)
-            .map(|(pubkey, account)| {
-                // REFACTOR: account_deps unification
-                (pubkey, Rc::new(RefCell::new(account)))
-            })
+            .map(|(pubkey, account)| (pubkey, Rc::new(RefCell::new(account))))
             .collect();
         let loader_refcells: Vec<Vec<_>> = loaders
             .iter_mut()
@@ -4804,7 +4800,6 @@ impl Bank {
                 .zip(loaded_transaction.accounts.iter())
                 .filter(|(_i, (_pubkey, account))| (Stakes::is_stake(account)))
             {
-                // REFACTOR: account_deps unification
                 if Stakes::is_stake(account) {
                     if let Some(old_vote_account) = self.stakes.write().unwrap().store(
                         pubkey,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -262,7 +262,7 @@ pub struct ThisInvokeContext<'a> {
     rent: Rent,
     message: &'a Message,
     pre_accounts: Vec<PreAccount>,
-    accounts: &'a [Rc<RefCell<AccountSharedData>>],
+    accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
     account_deps: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
     programs: &'a [(Pubkey, ProcessInstructionWithContext)],
     logger: Rc<RefCell<dyn Logger>>,
@@ -285,7 +285,7 @@ impl<'a> ThisInvokeContext<'a> {
         message: &'a Message,
         instruction: &'a CompiledInstruction,
         executable_accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        accounts: &'a [Rc<RefCell<AccountSharedData>>],
+        accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
         account_deps: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
         programs: &'a [(Pubkey, ProcessInstructionWithContext)],
         log_collector: Option<Rc<LogCollector>>,
@@ -402,7 +402,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         &mut self,
         message: &Message,
         instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         caller_write_privileges: Option<&[bool]>,
     ) -> Result<(), InstructionError> {
         let stack_frame = self
@@ -477,7 +477,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
             .iter()
             .position(|key| key == pubkey)
         {
-            return Some(self.accounts[index].clone());
+            return Some(self.accounts[index].1.clone());
         }
         self.account_deps.iter().find_map(|(key, account)| {
             if key == pubkey {
@@ -629,7 +629,7 @@ impl MessageProcessor {
         message: &'a Message,
         instruction: &'a CompiledInstruction,
         executable_accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        accounts: &'a [Rc<RefCell<AccountSharedData>>],
+        accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
         demote_sysvar_write_locks: bool,
     ) -> Vec<(bool, bool, &'a Pubkey, &'a RefCell<AccountSharedData>)> {
         executable_accounts
@@ -641,7 +641,7 @@ impl MessageProcessor {
                     message.is_signer(index),
                     message.is_writable(index, demote_sysvar_write_locks),
                     &message.account_keys[index],
-                    &accounts[index] as &RefCell<AccountSharedData>,
+                    &accounts[index].1 as &RefCell<AccountSharedData>,
                 )
             }))
             .collect::<Vec<_>>()
@@ -801,7 +801,7 @@ impl MessageProcessor {
                 for keyed_account_index in keyed_account_indices {
                     let keyed_account = &keyed_accounts[*keyed_account_index];
                     if account_key == keyed_account.unsigned_key() {
-                        accounts.push(Rc::new(keyed_account.account.clone()));
+                        accounts.push((*account_key, Rc::new(keyed_account.account.clone())));
                         keyed_account_indices_reordered.push(*keyed_account_index);
                         continue 'root;
                     }
@@ -887,7 +887,7 @@ impl MessageProcessor {
         {
             let invoke_context = invoke_context.borrow();
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
-            for (src_keyed_account_index, (account, dst_keyed_account_index)) in accounts
+            for (src_keyed_account_index, ((_key, account), dst_keyed_account_index)) in accounts
                 .iter()
                 .zip(keyed_account_indices_reordered)
                 .enumerate()
@@ -929,7 +929,7 @@ impl MessageProcessor {
     pub fn process_cross_program_instruction(
         message: &Message,
         executable_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         caller_write_privileges: &[bool],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
@@ -985,13 +985,13 @@ impl MessageProcessor {
     pub fn create_pre_accounts(
         message: &Message,
         instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
     ) -> Vec<PreAccount> {
         let mut pre_accounts = Vec::with_capacity(instruction.accounts.len());
         {
             let mut work = |_unique_index: usize, account_index: usize| {
                 let key = &message.account_keys[account_index];
-                let account = accounts[account_index].borrow();
+                let account = accounts[account_index].1.borrow();
                 pre_accounts.push(PreAccount::new(key, &account));
                 Ok(())
             };
@@ -1018,7 +1018,7 @@ impl MessageProcessor {
         instruction: &CompiledInstruction,
         pre_accounts: &[PreAccount],
         executable_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         rent: &Rent,
         timings: &mut ExecuteDetailsTimings,
         demote_sysvar_write_locks: bool,
@@ -1035,10 +1035,11 @@ impl MessageProcessor {
                 {
                     // Verify account has no outstanding references
                     let _ = accounts[account_index]
+                        .1
                         .try_borrow_mut()
                         .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
                 }
-                let account = accounts[account_index].borrow();
+                let account = accounts[account_index].1.borrow();
                 pre_accounts[unique_index]
                     .verify(
                         program_id,
@@ -1077,7 +1078,7 @@ impl MessageProcessor {
         message: &Message,
         instruction: &CompiledInstruction,
         pre_accounts: &mut [PreAccount],
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         program_id: &Pubkey,
         rent: &Rent,
         caller_write_privileges: Option<&[bool]>,
@@ -1090,7 +1091,7 @@ impl MessageProcessor {
         let mut work = |_unique_index: usize, account_index: usize| {
             if account_index < message.account_keys.len() && account_index < accounts.len() {
                 let key = &message.account_keys[account_index];
-                let account = &accounts[account_index];
+                let (_key, account) = &accounts[account_index];
                 let is_writable = if let Some(caller_write_privileges) = caller_write_privileges {
                     caller_write_privileges[account_index]
                 } else {
@@ -1143,7 +1144,7 @@ impl MessageProcessor {
         message: &Message,
         instruction: &CompiledInstruction,
         executable_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         account_deps: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
@@ -1162,7 +1163,7 @@ impl MessageProcessor {
         if feature_set.is_active(&instructions_sysvar_enabled::id()) {
             for (i, key) in message.account_keys.iter().enumerate() {
                 if instructions::check_id(key) {
-                    let mut mut_account_ref = accounts[i].borrow_mut();
+                    let mut mut_account_ref = accounts[i].1.borrow_mut();
                     instructions::store_current_index(
                         mut_account_ref.data_as_mut_slice(),
                         instruction_index as u16,
@@ -1217,7 +1218,7 @@ impl MessageProcessor {
         &self,
         message: &Message,
         loaders: &[Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>],
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         account_deps: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
@@ -1282,25 +1283,29 @@ mod tests {
     fn test_invoke_context() {
         const MAX_DEPTH: usize = 10;
         let mut invoke_stack = vec![];
-        let mut keys = vec![];
         let mut accounts = vec![];
         let mut metas = vec![];
         for i in 0..MAX_DEPTH {
             invoke_stack.push(solana_sdk::pubkey::new_rand());
-            keys.push(solana_sdk::pubkey::new_rand());
-            accounts.push(Rc::new(RefCell::new(AccountSharedData::new(
-                i as u64,
-                1,
-                &invoke_stack[i],
-            ))));
-            metas.push(AccountMeta::new(keys[i], false));
+            accounts.push((
+                solana_sdk::pubkey::new_rand(),
+                Rc::new(RefCell::new(AccountSharedData::new(
+                    i as u64,
+                    1,
+                    &invoke_stack[i],
+                ))),
+            ));
+            metas.push(AccountMeta::new(accounts[i].0, false));
         }
         for program_id in invoke_stack.iter() {
-            accounts.push(Rc::new(RefCell::new(AccountSharedData::new(
-                1,
-                1,
-                &solana_sdk::pubkey::Pubkey::default(),
-            ))));
+            accounts.push((
+                *program_id,
+                Rc::new(RefCell::new(AccountSharedData::new(
+                    1,
+                    1,
+                    &solana_sdk::pubkey::Pubkey::default(),
+                ))),
+            ));
             metas.push(AccountMeta::new(*program_id, false));
         }
 
@@ -1342,8 +1347,8 @@ mod tests {
         for owned_index in (1..depth_reached).rev() {
             let not_owned_index = owned_index - 1;
             let metas = vec![
-                AccountMeta::new(keys[not_owned_index], false),
-                AccountMeta::new(keys[owned_index], false),
+                AccountMeta::new(accounts[not_owned_index].0, false),
+                AccountMeta::new(accounts[owned_index].0, false),
             ];
             let message = Message::new(
                 &[Instruction::new_with_bytes(
@@ -1355,14 +1360,17 @@ mod tests {
             );
 
             // modify account owned by the program
-            accounts[owned_index].borrow_mut().data_as_mut_slice()[0] =
+            accounts[owned_index].1.borrow_mut().data_as_mut_slice()[0] =
                 (MAX_DEPTH + owned_index) as u8;
             let mut these_accounts = accounts[not_owned_index..owned_index + 1].to_vec();
-            these_accounts.push(Rc::new(RefCell::new(AccountSharedData::new(
-                1,
-                1,
-                &solana_sdk::pubkey::Pubkey::default(),
-            ))));
+            these_accounts.push((
+                message.account_keys[2],
+                Rc::new(RefCell::new(AccountSharedData::new(
+                    1,
+                    1,
+                    &solana_sdk::pubkey::Pubkey::default(),
+                ))),
+            ));
             invoke_context
                 .verify_and_update(&message, &message.instructions[0], &these_accounts, None)
                 .unwrap();
@@ -1375,8 +1383,8 @@ mod tests {
             );
 
             // modify account not owned by the program
-            let data = accounts[not_owned_index].borrow_mut().data()[0];
-            accounts[not_owned_index].borrow_mut().data_as_mut_slice()[0] =
+            let data = accounts[not_owned_index].1.borrow_mut().data()[0];
+            accounts[not_owned_index].1.borrow_mut().data_as_mut_slice()[0] =
                 (MAX_DEPTH + not_owned_index) as u8;
             assert_eq!(
                 invoke_context.verify_and_update(
@@ -1394,7 +1402,7 @@ mod tests {
                     .data()[0],
                 data
             );
-            accounts[not_owned_index].borrow_mut().data_as_mut_slice()[0] = data;
+            accounts[not_owned_index].1.borrow_mut().data_as_mut_slice()[0] = data;
 
             invoke_context.pop();
         }
@@ -1870,26 +1878,28 @@ mod tests {
         let mut message_processor = MessageProcessor::default();
         message_processor.add_program(mock_system_program_id, mock_system_process_instruction);
 
-        let mut accounts: Vec<Rc<RefCell<AccountSharedData>>> = Vec::new();
-        let account = AccountSharedData::new_ref(100, 1, &mock_system_program_id);
-        accounts.push(account);
-        let account = AccountSharedData::new_ref(0, 1, &mock_system_program_id);
-        accounts.push(account);
+        let accounts = vec![
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::new_ref(100, 1, &mock_system_program_id),
+            ),
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::new_ref(0, 1, &mock_system_program_id),
+            ),
+        ];
 
-        let mut loaders: Vec<Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>> = Vec::new();
         let account = Rc::new(RefCell::new(create_loadable_account_for_test(
             "mock_system_program",
         )));
-        loaders.push(vec![(mock_system_program_id, account)]);
+        let loaders = vec![vec![(mock_system_program_id, account)]];
 
         let executors = Rc::new(RefCell::new(Executors::default()));
         let ancestors = Ancestors::default();
 
-        let from_pubkey = solana_sdk::pubkey::new_rand();
-        let to_pubkey = solana_sdk::pubkey::new_rand();
         let account_metas = vec![
-            AccountMeta::new(from_pubkey, true),
-            AccountMeta::new_readonly(to_pubkey, false),
+            AccountMeta::new(accounts[0].0, true),
+            AccountMeta::new_readonly(accounts[1].0, false),
         ];
         let message = Message::new(
             &[Instruction::new_with_bincode(
@@ -1897,7 +1907,7 @@ mod tests {
                 &MockSystemInstruction::Correct,
                 account_metas.clone(),
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
 
         let result = message_processor.process_message(
@@ -1916,8 +1926,8 @@ mod tests {
             &ancestors,
         );
         assert_eq!(result, Ok(()));
-        assert_eq!(accounts[0].borrow().lamports(), 100);
-        assert_eq!(accounts[1].borrow().lamports(), 0);
+        assert_eq!(accounts[0].1.borrow().lamports(), 100);
+        assert_eq!(accounts[1].1.borrow().lamports(), 0);
 
         let message = Message::new(
             &[Instruction::new_with_bincode(
@@ -1925,7 +1935,7 @@ mod tests {
                 &MockSystemInstruction::AttemptCredit { lamports: 50 },
                 account_metas.clone(),
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
 
         let result = message_processor.process_message(
@@ -1957,7 +1967,7 @@ mod tests {
                 &MockSystemInstruction::AttemptDataChange { data: 50 },
                 account_metas,
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
 
         let result = message_processor.process_message(
@@ -2050,28 +2060,29 @@ mod tests {
         let mut message_processor = MessageProcessor::default();
         message_processor.add_program(mock_program_id, mock_system_process_instruction);
 
-        let mut accounts: Vec<Rc<RefCell<AccountSharedData>>> = Vec::new();
-        let account = AccountSharedData::new_ref(100, 1, &mock_program_id);
-        accounts.push(account);
-        let account = AccountSharedData::new_ref(0, 1, &mock_program_id);
-        accounts.push(account);
+        let accounts = vec![
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::new_ref(100, 1, &mock_program_id),
+            ),
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::new_ref(0, 1, &mock_program_id),
+            ),
+        ];
 
-        let mut loaders: Vec<Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>> = Vec::new();
         let account = Rc::new(RefCell::new(create_loadable_account_for_test(
             "mock_system_program",
         )));
-        loaders.push(vec![(mock_program_id, account)]);
+        let loaders = vec![vec![(mock_program_id, account)]];
 
         let executors = Rc::new(RefCell::new(Executors::default()));
         let ancestors = Ancestors::default();
 
-        let from_pubkey = solana_sdk::pubkey::new_rand();
-        let to_pubkey = solana_sdk::pubkey::new_rand();
-        let dup_pubkey = from_pubkey;
         let account_metas = vec![
-            AccountMeta::new(from_pubkey, true),
-            AccountMeta::new(to_pubkey, false),
-            AccountMeta::new(dup_pubkey, false),
+            AccountMeta::new(accounts[0].0, true),
+            AccountMeta::new(accounts[1].0, false),
+            AccountMeta::new(accounts[0].0, false),
         ];
 
         // Try to borrow mut the same account
@@ -2081,7 +2092,7 @@ mod tests {
                 &MockSystemInstruction::BorrowFail,
                 account_metas.clone(),
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
         let result = message_processor.process_message(
             &message,
@@ -2113,7 +2124,7 @@ mod tests {
                 &MockSystemInstruction::MultiBorrowMut,
                 account_metas.clone(),
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
         let result = message_processor.process_message(
             &message,
@@ -2142,7 +2153,7 @@ mod tests {
                 },
                 account_metas,
             )],
-            Some(&from_pubkey),
+            Some(&accounts[0].0),
         );
         let ancestors = Ancestors::default();
         let result = message_processor.process_message(
@@ -2161,9 +2172,9 @@ mod tests {
             &ancestors,
         );
         assert_eq!(result, Ok(()));
-        assert_eq!(accounts[0].borrow().lamports(), 80);
-        assert_eq!(accounts[1].borrow().lamports(), 20);
-        assert_eq!(accounts[0].borrow().data(), &vec![42]);
+        assert_eq!(accounts[0].1.borrow().lamports(), 80);
+        assert_eq!(accounts[1].1.borrow().lamports(), 20);
+        assert_eq!(accounts[0].1.borrow().data(), &vec![42]);
     }
 
     #[test]
@@ -2215,25 +2226,28 @@ mod tests {
             Rc::new(RefCell::new(program_account.clone())),
         )];
 
-        let owned_key = solana_sdk::pubkey::new_rand();
         let owned_account = AccountSharedData::new(42, 1, &callee_program_id);
-
-        let not_owned_key = solana_sdk::pubkey::new_rand();
         let not_owned_account = AccountSharedData::new(84, 1, &solana_sdk::pubkey::new_rand());
 
         #[allow(unused_mut)]
-        let mut accounts = vec![
-            Rc::new(RefCell::new(owned_account)),
-            Rc::new(RefCell::new(not_owned_account)),
-            Rc::new(RefCell::new(program_account)),
+        let accounts = vec![
+            (
+                solana_sdk::pubkey::new_rand(),
+                Rc::new(RefCell::new(owned_account)),
+            ),
+            (
+                solana_sdk::pubkey::new_rand(),
+                Rc::new(RefCell::new(not_owned_account)),
+            ),
+            (callee_program_id, Rc::new(RefCell::new(program_account))),
         ];
 
         let compiled_instruction = CompiledInstruction::new(2, &(), vec![0, 1, 2]);
         let programs: Vec<(_, ProcessInstructionWithContext)> =
             vec![(callee_program_id, mock_process_instruction)];
         let metas = vec![
-            AccountMeta::new(owned_key, false),
-            AccountMeta::new(not_owned_key, false),
+            AccountMeta::new(accounts[0].0, false),
+            AccountMeta::new(accounts[1].0, false),
         ];
 
         let instruction = Instruction::new_with_bincode(
@@ -2271,7 +2285,7 @@ mod tests {
             .enumerate()
             .map(|(i, _)| message.is_writable(i, demote_sysvar_write_locks))
             .collect::<Vec<bool>>();
-        accounts[0].borrow_mut().data_as_mut_slice()[0] = 1;
+        accounts[0].1.borrow_mut().data_as_mut_slice()[0] = 1;
         assert_eq!(
             MessageProcessor::process_cross_program_instruction(
                 &message,
@@ -2282,7 +2296,7 @@ mod tests {
             ),
             Err(InstructionError::ExternalAccountDataModified)
         );
-        accounts[0].borrow_mut().data_as_mut_slice()[0] = 0;
+        accounts[0].1.borrow_mut().data_as_mut_slice()[0] = 0;
 
         let cases = vec![
             (MockInstruction::NoopSuccess, Ok(())),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -358,7 +358,6 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         let keyed_accounts = keyed_accounts
             .iter()
             .map(|(is_signer, is_writable, search_key, account)| {
-                // REFACTOR: account_deps unification
                 self.accounts
                     .iter()
                     .position(|(key, _account)| key == *search_key)
@@ -463,7 +462,6 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         self.feature_set.is_active(feature_id)
     }
     fn get_account(&self, pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>> {
-        // REFACTOR: account_deps unification
         self.accounts.iter().find_map(|(key, account)| {
             if key == pubkey {
                 Some(account.clone())
@@ -622,7 +620,6 @@ impl MessageProcessor {
             .map(|(key, account)| (false, false, key, account as &RefCell<AccountSharedData>))
             .chain(instruction.accounts.iter().map(|index| {
                 let index = *index as usize;
-                // REFACTOR: account_deps unification
                 (
                     message.is_signer(index),
                     message.is_writable(index, demote_sysvar_write_locks),
@@ -978,7 +975,6 @@ impl MessageProcessor {
             let mut work = |_unique_index: usize, account_index: usize| {
                 if account_index < message.account_keys.len() && account_index < accounts.len() {
                     let account = accounts[account_index].1.borrow();
-                    // REFACTOR: account_deps unification
                     pre_accounts.push(PreAccount::new(&accounts[account_index].0, &account));
                     return Ok(());
                 }
@@ -1080,7 +1076,6 @@ impl MessageProcessor {
         let mut work = |_unique_index: usize, account_index: usize| {
             if account_index < message.account_keys.len() && account_index < accounts.len() {
                 let (key, account) = &accounts[account_index];
-                // REFACTOR: account_deps unification
                 let is_writable = if let Some(caller_write_privileges) = caller_write_privileges {
                     caller_write_privileges[account_index]
                 } else {
@@ -1151,7 +1146,6 @@ impl MessageProcessor {
         if feature_set.is_active(&instructions_sysvar_enabled::id()) {
             for (pubkey, accont) in accounts.iter().take(message.account_keys.len()) {
                 if instructions::check_id(pubkey) {
-                    // REFACTOR: account_deps unification
                     let mut mut_account_ref = accont.borrow_mut();
                     instructions::store_current_index(
                         mut_account_ref.data_as_mut_slice(),

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -64,7 +64,7 @@ pub trait InvokeContext {
         &mut self,
         message: &Message,
         instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<AccountSharedData>>],
+        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         caller_pivileges: Option<&[bool]>,
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
@@ -395,7 +395,7 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
         &mut self,
         _message: &Message,
         _instruction: &CompiledInstruction,
-        _accounts: &[Rc<RefCell<AccountSharedData>>],
+        _accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         _caller_pivileges: Option<&[bool]>,
     ) -> Result<(), InstructionError> {
         Ok(())

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -90,7 +90,7 @@ pub trait InvokeContext {
     fn record_instruction(&self, instruction: &Instruction);
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
-    /// Get an account from a pre-account
+    /// Get an account by its key
     fn get_account(&self, pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>>;
     /// Update timing
     fn update_timing(


### PR DESCRIPTION
#### Problem
`account_deps` travel along slightly different code paths than the "normal" `accounts` do.
This makes mapping `accounts` into the VM memory harder and should thus be resolved first.

#### Summary of Changes
* Changes `ThisInvokeContext::get_account()` to use `accounts` instead of `pre_accounts`. So now, the `pre_accounts` are only used in `MessageProcessor::verify_and_update()` and `MessageProcessor::verify()`.
* Adds explicit keys to the `accounts` as tuples, the same way as it is with `account_deps`.
* Appends the `account_deps` at the end of the `accounts` slice and use the `message.account_keys.len()` as border between both subslices / ranges.

Fixes #
