### PR TITLE
set hash bins to 65k

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4689,7 +4689,7 @@ impl AccountsDb {
         let mut scan_and_hash = move || {
             // When calculating hashes, it is helpful to break the pubkeys found into bins based on the pubkey value.
             // More bins means smaller vectors to sort, copy, etc.
-            const PUBKEY_BINS_FOR_CALCULATING_HASHES: usize = 256;
+            const PUBKEY_BINS_FOR_CALCULATING_HASHES: usize = 65536;
 
             // # of passes should be a function of the total # of accounts that are active.
             // higher passes = slower total time, lower dynamic memory usage


### PR DESCRIPTION
#### Problem
more bins breaks the accounts for scanning into smaller groups, allowing higher paralleism.
#### Summary of Changes
65k is our current structural limit and is probably a good stopping point for the moment.
Fixes #
