### PR TITLE
Add build script to extract a list of registered syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "num-traits",
  "rand 0.7.3",
  "rand_core 0.6.2",
+ "regex",
  "rustversion",
  "sha3",
  "solana-measure",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2792,6 +2792,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rand_core 0.6.2",
+ "regex",
  "sha3",
  "solana-measure",
  "solana-runtime",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bpf-loader-program"
 edition = "2018"
 
+[build-dependencies]
+regex = "1.5.4"
+
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"

--- a/programs/bpf_loader/build.rs
+++ b/programs/bpf_loader/build.rs
@@ -1,0 +1,34 @@
+use regex::Regex;
+use std::{
+    fs::File,
+    io::{prelude::*, BufWriter, Read},
+    path::PathBuf,
+    process::exit,
+    str,
+};
+
+/**
+ * Extract a list of registered syscall names and save it in a file
+ * for distribution with the SDK.  This file is read by cargo-build-bpf
+ * to verify undefined symbols in a .so module that cargo-build-bpf has built.
+ */
+fn main() {
+    let path = PathBuf::from("src/syscalls.rs");
+    let mut file = match File::open(&path) {
+        Ok(x) => x,
+        _ => exit(1),
+    };
+    let mut text = vec![];
+    file.read_to_end(&mut text).unwrap();
+    let text = str::from_utf8(&text).unwrap();
+    let path = PathBuf::from("../../sdk/bpf/syscalls.txt");
+    let file = match File::create(&path) {
+        Ok(x) => x,
+        _ => exit(1),
+    };
+    let mut out = BufWriter::new(file);
+    let sysc_re = Regex::new(r#"register_syscall_by_name\([[:space:]]*b"([^"]+)","#).unwrap();
+    for caps in sysc_re.captures_iter(&text) {
+        writeln!(out, "{}", caps[1].to_string()).unwrap();
+    }
+}

--- a/sdk/bpf/.gitignore
+++ b/sdk/bpf/.gitignore
@@ -7,3 +7,4 @@
 /dependencies/bin*
 /dependencies/.crates.toml
 /dependencies/.crates2.json
+/syscalls.txt


### PR DESCRIPTION
The list is used in cargo-build-bpf to check generated .so modules for
undefined symbols that are not known run-time syscalls.

#### Problem

cargo-build-bpf needs a list of registered syscalls to check undefined functions in generated .so files.

#### Summary of Changes

Added a build script that generates the list of registered syscalls and saves it in a file, that can be distributed with the SDK and later used by cargo-build-bpf.
