### PR TITLE
investigate system performance test degradation 

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -34,7 +34,7 @@ use solana_sdk::transaction::Transaction;
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use test::Bencher;
 
@@ -94,7 +94,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &BankingStageStats::default(),
                 &recorder,
                 &Arc::new(RwLock::new(CostModel::default())),
-                &Arc::new(Mutex::new(CostTracker::new(std::u64::MAX, std::u64::MAX))),
+                &Arc::new(RwLock::new(CostTracker::new(std::u64::MAX, std::u64::MAX))),
             );
         });
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1276,12 +1276,15 @@ impl BankingStage {
         let mut cost_tracking_time = Measure::start("cost_tracking_time");
         let mut tx_cost = TransactionCost::new_with_capacity(MAX_WRITABLE_ACCOUNTS);
         {
-            let cost_model_readonly = cost_model.read().unwrap();
-            let mut cost_tracker_mutable = cost_tracker.write().unwrap();
+            //let cost_model_readonly = cost_model.read().unwrap();
+            //let mut cost_tracker_mutable = cost_tracker.write().unwrap();
             transactions.iter().enumerate().for_each(|(index, tx)| {
                 if !unprocessed_tx_indexes.iter().any(|&i| i == index) {
-                    cost_model_readonly.calculate_cost_no_alloc(&tx.transaction(), &mut tx_cost);
-                    cost_tracker_mutable.add_transaction(
+                    cost_model
+                        .read()
+                        .unwrap()
+                        .calculate_cost_no_alloc(tx.transaction(), &mut tx_cost);
+                    cost_tracker.write().unwrap().add_transaction(
                         &tx_cost.writable_accounts,
                         &(tx_cost.account_access_cost + tx_cost.execution_cost),
                     );

--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -131,7 +131,7 @@ impl CostModel {
                 cost.account_access_cost += NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST;
             }
         });
-        cost.execution_cost = self.find_transaction_cost(&transaction);
+        cost.execution_cost = self.find_transaction_cost(transaction);
         debug!("transaction {:?} has cost {:?}", transaction, cost);
     }
 

--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -42,8 +42,7 @@ impl TransactionCost {
     pub fn new_with_capacity(capacity: usize) -> Self {
         Self {
             writable_accounts: Vec::with_capacity(capacity),
-            account_access_cost: 0,
-            execution_cost: 0,
+            ..Self::default()
         }
     }
 

--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -107,6 +107,10 @@ impl CostModel {
         cost
     }
 
+    // calculate `transaction` cost, the result is passed back to caller via mutable
+    // parameter `cost`. Existing content in `cost` will be erased before adding new content
+    // This is to allow this function to reuse pre-allocated memory, as this function
+    // is often on hot-path.
     pub fn calculate_cost_no_alloc(&self, transaction: &Transaction, cost: &mut TransactionCost) {
         cost.reset();
 

--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -23,6 +23,8 @@ const NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST: u64 = 7;
 pub const ACCOUNT_MAX_COST: u64 = 100_000_000;
 pub const BLOCK_MAX_COST: u64 = 2_500_000_000;
 
+const DEMOTE_SYSVAR_WRITE_LOCKS: bool = true;
+
 // cost of transaction is made of account_access_cost and instruction execution_cost
 // where
 // account_access_cost is the sum of read/write/sign all accounts included in the transaction
@@ -34,6 +36,22 @@ pub struct TransactionCost {
     pub writable_accounts: Vec<Pubkey>,
     pub account_access_cost: u64,
     pub execution_cost: u64,
+}
+
+impl TransactionCost {
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        Self {
+            writable_accounts: Vec::with_capacity(capacity),
+            account_access_cost: 0,
+            execution_cost: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.writable_accounts.clear();
+        self.account_access_cost = 0;
+        self.execution_cost = 0;
+    }
 }
 
 #[derive(Debug)]
@@ -88,6 +106,30 @@ impl CostModel {
         cost.writable_accounts.extend(&non_signed_writable_accounts);
         debug!("transaction {:?} has cost {:?}", transaction, cost);
         cost
+    }
+
+    pub fn calculate_cost_no_alloc(&self, transaction: &Transaction, cost: &mut TransactionCost) {
+        cost.reset();
+
+        let message = transaction.message();
+        message.account_keys.iter().enumerate().for_each(|(i, k)| {
+            let is_signer = message.is_signer(i);
+            let is_writable = message.is_writable(i, DEMOTE_SYSVAR_WRITE_LOCKS);
+
+            if is_signer && is_writable {
+                cost.writable_accounts.push(*k);
+                cost.account_access_cost += SIGNED_WRITABLE_ACCOUNT_ACCESS_COST;
+            } else if is_signer && !is_writable {
+                cost.account_access_cost += SIGNED_READONLY_ACCOUNT_ACCESS_COST;
+            } else if !is_signer && is_writable {
+                cost.writable_accounts.push(*k);
+                cost.account_access_cost += NON_SIGNED_WRITABLE_ACCOUNT_ACCESS_COST;
+            } else {
+                cost.account_access_cost += NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST;
+            }
+        });
+        cost.execution_cost = self.find_transaction_cost(&transaction);
+        debug!("transaction {:?} has cost {:?}", transaction, cost);
     }
 
     // To update or insert instruction cost to table.
@@ -395,6 +437,33 @@ mod tests {
             .upsert_instruction_cost(&system_program::id(), &expected_execution_cost)
             .unwrap();
         let tx_cost = cost_model.calculate_cost(&tx);
+        assert_eq!(expected_account_cost, tx_cost.account_access_cost);
+        assert_eq!(expected_execution_cost, tx_cost.execution_cost);
+        assert_eq!(2, tx_cost.writable_accounts.len());
+    }
+
+    #[test]
+    fn test_cost_model_calculate_cost_no_alloc() {
+        let (mint_keypair, start_hash) = test_setup();
+        let tx =
+            system_transaction::transfer(&mint_keypair, &Keypair::new().pubkey(), 2, start_hash);
+
+        let expected_account_cost = SIGNED_WRITABLE_ACCOUNT_ACCESS_COST
+            + NON_SIGNED_WRITABLE_ACCOUNT_ACCESS_COST
+            + NON_SIGNED_READONLY_ACCOUNT_ACCESS_COST;
+        let expected_execution_cost = 8;
+
+        let mut cost_model = CostModel::default();
+        cost_model
+            .upsert_instruction_cost(&system_program::id(), &expected_execution_cost)
+            .unwrap();
+
+        // allocate cost, set some random number
+        let mut tx_cost = TransactionCost::new_with_capacity(8);
+        tx_cost.execution_cost = 101;
+        tx_cost.writable_accounts.push(Pubkey::new_unique());
+
+        cost_model.calculate_cost_no_alloc(&tx, &mut tx_cost);
         assert_eq!(expected_account_cost, tx_cost.account_access_cost);
         assert_eq!(expected_execution_cost, tx_cost.execution_cost);
         assert_eq!(2, tx_cost.writable_accounts.len());

--- a/core/src/cost_tracker.rs
+++ b/core/src/cost_tracker.rs
@@ -42,7 +42,7 @@ impl CostTracker {
         Ok(self.block_cost)
     }
 
-    fn would_fit(&self, keys: &[Pubkey], cost: &u64) -> Result<(), &'static str> {
+    pub fn would_fit(&self, keys: &[Pubkey], cost: &u64) -> Result<(), &'static str> {
         // check against the total package cost
         if self.block_cost + cost > self.block_cost_limit {
             return Err("would exceed block cost limit");

--- a/core/src/cost_tracker.rs
+++ b/core/src/cost_tracker.rs
@@ -70,7 +70,7 @@ impl CostTracker {
         Ok(())
     }
 
-    fn add_transaction(&mut self, keys: &[Pubkey], cost: &u64) {
+    pub fn add_transaction(&mut self, keys: &[Pubkey], cost: &u64) {
         for account_key in keys.iter() {
             *self
                 .cost_by_writable_accounts

--- a/core/src/cost_tracker.rs
+++ b/core/src/cost_tracker.rs
@@ -5,6 +5,8 @@ use crate::cost_model::TransactionCost;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use std::collections::HashMap;
 
+const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 512;
+
 #[derive(Debug, Clone)]
 pub struct CostTracker {
     account_cost_limit: u64,
@@ -21,7 +23,7 @@ impl CostTracker {
             account_cost_limit: chain_max,
             block_cost_limit: package_max,
             current_bank_slot: 0,
-            cost_by_writable_accounts: HashMap::new(),
+            cost_by_writable_accounts: HashMap::with_capacity(WRITABLE_ACCOUNTS_PER_BLOCK),
             block_cost: 0,
         }
     }

--- a/core/src/execute_cost_table.rs
+++ b/core/src/execute_cost_table.rs
@@ -33,8 +33,8 @@ impl ExecuteCostTable {
     pub fn new(cap: usize) -> Self {
         Self {
             capacity: cap,
-            table: HashMap::new(),
-            occurrences: HashMap::new(),
+            table: HashMap::with_capacity(cap),
+            occurrences: HashMap::with_capacity(cap),
         }
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1910,31 +1910,31 @@ impl ReplayStage {
         new_stats
     }
 
-    fn update_cost_model(_cost_model: &RwLock<CostModel>, _execute_timings: &ExecuteTimings) {
+    fn update_cost_model(cost_model: &RwLock<CostModel>, execute_timings: &ExecuteTimings) {
         let mut update_cost_model_time = Measure::start("update_cost_model_time");
-        //        let mut cost_model_mutable = cost_model.write().unwrap();
-        //        for (program_id, stats) in &execute_timings.details.per_program_timings {
-        //            let cost = stats.0 / stats.1 as u64;
-        //            match cost_model_mutable.upsert_instruction_cost(&program_id, &cost) {
-        //                Ok(c) => {
-        //                    debug!(
-        //                        "after replayed into bank, instruction {:?} has averaged cost {}",
-        //                        program_id, c
-        //                    );
-        //                }
-        //                Err(err) => {
-        //                    debug!(
-        //                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
-        //                        program_id, err
-        //                    );
-        //                }
-        //            }
-        //        }
-        //        drop(cost_model_mutable);
-        //        debug!(
-        //           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
-        //           cost_model.read().unwrap().get_instruction_cost_table()
-        //        );
+        let mut cost_model_mutable = cost_model.write().unwrap();
+        for (program_id, stats) in &execute_timings.details.per_program_timings {
+            let cost = stats.0 / stats.1 as u64;
+            match cost_model_mutable.upsert_instruction_cost(&program_id, &cost) {
+                Ok(c) => {
+                    debug!(
+                        "after replayed into bank, instruction {:?} has averaged cost {}",
+                        program_id, c
+                    );
+                }
+                Err(err) => {
+                    debug!(
+                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
+                        program_id, err
+                    );
+                }
+            }
+        }
+        drop(cost_model_mutable);
+        debug!(
+           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
+           cost_model.read().unwrap().get_instruction_cost_table()
+        );
         update_cost_model_time.stop();
 
         inc_new_counter_info!("replay_stage-update_cost_model", 1);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1719,7 +1719,7 @@ impl ReplayStage {
                     replay_vote_sender,
                     verify_recyclers,
                 );
-                Self::update_cost_model(&cost_model, &bank_progress.replay_stats.execute_timings);
+                Self::update_cost_model(cost_model, &bank_progress.replay_stats.execute_timings);
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
                     Err(err) => {
@@ -1915,7 +1915,7 @@ impl ReplayStage {
         let mut cost_model_mutable = cost_model.write().unwrap();
         for (program_id, stats) in &execute_timings.details.per_program_timings {
             let cost = stats.0 / stats.1 as u64;
-            match cost_model_mutable.upsert_instruction_cost(&program_id, &cost) {
+            match cost_model_mutable.upsert_instruction_cost(program_id, &cost) {
                 Ok(c) => {
                     debug!(
                         "after replayed into bank, instruction {:?} has averaged cost {}",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1719,11 +1719,7 @@ impl ReplayStage {
                     replay_vote_sender,
                     verify_recyclers,
                 );
-                Self::update_cost_model(cost_model, &bank_progress.replay_stats.execute_timings);
-                debug!(
-                    "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
-                    cost_model.read().unwrap().get_instruction_cost_table()
-                );
+                Self::update_cost_model(&cost_model, &bank_progress.replay_stats.execute_timings);
                 match replay_result {
                     Ok(replay_tx_count) => tx_count += replay_tx_count,
                     Err(err) => {
@@ -1914,30 +1910,42 @@ impl ReplayStage {
         new_stats
     }
 
-    fn update_cost_model(cost_model: &RwLock<CostModel>, execute_timings: &ExecuteTimings) {
-        let mut cost_model_mutable = cost_model.write().unwrap();
-        for (program_id, stats) in &execute_timings.details.per_program_timings {
-            let cost = stats.0 / stats.1 as u64;
-            match cost_model_mutable.upsert_instruction_cost(program_id, &cost) {
-                Ok(c) => {
-                    debug!(
-                        "after replayed into bank, instruction {:?} has averaged cost {}",
-                        program_id, c
-                    );
-                }
-                Err(err) => {
-                    debug!(
-                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
-                        program_id, err
-                    );
-                }
-            }
-        }
-        drop(cost_model_mutable);
-        debug!(
-           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
-           cost_model.read().unwrap().get_instruction_cost_table()
-       );
+    fn update_cost_model(_cost_model: &RwLock<CostModel>, _execute_timings: &ExecuteTimings) {
+        let mut update_cost_model_time = Measure::start("update_cost_model_time");
+        //        let mut cost_model_mutable = cost_model.write().unwrap();
+        //        for (program_id, stats) in &execute_timings.details.per_program_timings {
+        //            let cost = stats.0 / stats.1 as u64;
+        //            match cost_model_mutable.upsert_instruction_cost(&program_id, &cost) {
+        //                Ok(c) => {
+        //                    debug!(
+        //                        "after replayed into bank, instruction {:?} has averaged cost {}",
+        //                        program_id, c
+        //                    );
+        //                }
+        //                Err(err) => {
+        //                    debug!(
+        //                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
+        //                        program_id, err
+        //                    );
+        //                }
+        //            }
+        //        }
+        //        drop(cost_model_mutable);
+        //        debug!(
+        //           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
+        //           cost_model.read().unwrap().get_instruction_cost_table()
+        //        );
+        update_cost_model_time.stop();
+
+        inc_new_counter_info!("replay_stage-update_cost_model", 1);
+        datapoint_info!(
+            "replay-loop-timing-stats",
+            (
+                "update_cost_model_elapsed",
+                update_cost_model_time.as_us() as i64,
+                i64
+            )
+        );
     }
 
     fn update_propagation_status(


### PR DESCRIPTION
#### Problem
System test has poorer TPS with cost model

#### Summary of Changes
- add new metrics around cost model operations
- change mutex<cost_tracker> to RwLock<cost_tracker>
- removed steps to clone cost_tacker for local use - clone is expensive
- acquire and hold locks for batch of transactions, instead of doing so for each transaction. 
- remove redundant `would_fit` check from cost_tracker update execution path
- add `calculate_cost_no_alloc` to avoid heap allocation of `transaction_cost` for each call. `calculate_cost` is in hot path, many heap allocation can quickly add up to be very expensive.

All above are refactors, no logic change. 
 
Fixes #
