### PR TITLE
chore: remove set_upgrade_authority_via_cpi_enabled feature

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     feature_set::{
         blake3_syscall_enabled, cpi_data_cost, demote_sysvar_write_locks,
         enforce_aligned_host_addrs, keccak256_syscall_enabled, memory_ops_syscalls,
-        set_upgrade_authority_via_cpi_enabled, sysvar_via_syscall, update_data_on_realloc,
+        sysvar_via_syscall, update_data_on_realloc,
     },
     hash::{Hasher, HASH_BYTES},
     ic_msg,
@@ -2128,16 +2128,13 @@ fn check_account_infos(
 fn check_authorized_program(
     program_id: &Pubkey,
     instruction_data: &[u8],
-    invoke_context: &Ref<&mut dyn InvokeContext>,
 ) -> Result<(), EbpfError<BpfError>> {
     if native_loader::check_id(program_id)
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
         || (bpf_loader_upgradeable::check_id(program_id)
             && !(bpf_loader_upgradeable::is_upgrade_instruction(instruction_data)
-                || (bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)
-                    && invoke_context
-                        .is_feature_active(&set_upgrade_authority_via_cpi_enabled::id()))))
+                || bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)))
     {
         return Err(SyscallError::ProgramNotSupported(*program_id).into());
     }
@@ -2252,7 +2249,7 @@ fn call<'a>(
                 }
             })
             .collect::<Vec<bool>>();
-        check_authorized_program(&callee_program_id, &instruction.data, &invoke_context)?;
+        check_authorized_program(&callee_program_id, &instruction.data)?;
         let (accounts, account_refs) = syscall.translate_accounts(
             &message.account_keys,
             callee_program_id_index,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -119,10 +119,6 @@ pub mod enforce_aligned_host_addrs {
     solana_sdk::declare_id!("6Qob9Z4RwGdf599FDVCqsjuKjR8ZFR3oVs2ByRLWBsua");
 }
 
-pub mod set_upgrade_authority_via_cpi_enabled {
-    solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
-}
-
 pub mod update_data_on_realloc {
     solana_sdk::declare_id!("BkPcYCrwHXBoTsv9vMhiRF9gteZmDj3Uwisz9CDjoMKp");
 }
@@ -185,7 +181,6 @@ lazy_static! {
         (sysvar_via_syscall::id(), "provide sysvars via syscalls"),
         (check_duplicates_by_hash::id(), "use transaction message hash for duplicate check"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
-        (set_upgrade_authority_via_cpi_enabled::id(), "set upgrade authority instruction via cpi calls for upgradable programs"),
         (update_data_on_realloc::id(), "Retain updated data values modified after realloc via CPI"),
         (keccak256_syscall_enabled::id(), "keccak256 syscall"),
         (stake_program_v4::id(), "solana_stake_program v4"),


### PR DESCRIPTION
#### Summary of Changes

Removes feature guard for setting `upgrade_authority` via CPI calls
