### PR TITLE
add metrics to handle_snapshot_requests

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -222,7 +222,7 @@ mod tests {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
                 bank.update_accounts_hash();
-                snapshot_request_handler.handle_snapshot_requests(false, false, false);
+                snapshot_request_handler.handle_snapshot_requests(false, false, false, 0);
             }
         }
 


### PR DESCRIPTION
#### Problem
As # accounts grows, handle_snapshot_requests code path execution time grows very large. Having metrics of the total processing time and idle time will help find and verify improvements. For example, if clean and hash calculation can be performed in parallel, then overall time could improve while individual times (hash & clean) could get worse.
#### Summary of Changes
add metrics
Fixes #
