### PR TITLE
adds mapping from nodes pubkeys to their shred-version

### DIFF
--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -18,6 +18,7 @@ indexmap = { version = "1.6", features = ["rayon"] }
 itertools = "0.9.0"
 log = "0.4.11"
 lru = "0.6.1"
+matches = "0.1.8"
 num-traits = "0.2"
 rand = "0.7.0"
 rand_chacha = "0.2.2"


### PR DESCRIPTION

#### Problem
Crds values of nodes with different shred versions are creeping into
gossip table resulting in runtime issues as the one addressed in:
https://github.com/solana-labs/solana/pull/17899

#### Summary of Changes
This commit works towards enforcing more checks and filtering based on
shred version by adding necessary mapping and api to gossip table.
Once populated, pubkey->shred-version mapping persists as long as there
are any values associated with the pubkey.
