### PR TITLE
refactor so hash verify can be done by more callers

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4618,6 +4618,41 @@ impl AccountsDb {
         }
     }
 
+    fn calculate_accounts_hash_helper_with_verify(
+        &self,
+        use_index: bool,
+        debug_verify: bool,
+        slot: Slot,
+        ancestors: &Ancestors,
+        expected_capitalization: Option<u64>,
+        can_cached_slot_be_unflushed: bool,
+        check_hash: bool,
+    ) -> Result<(Hash, u64), BankHashVerificationError> {
+        let (hash, total_lamports) = self.calculate_accounts_hash_helper(
+            use_index,
+            slot,
+            ancestors,
+            check_hash,
+            can_cached_slot_be_unflushed,
+        )?;
+        if debug_verify {
+            // calculate the other way (store or non-store) and verify results match.
+            let (hash_other, total_lamports_other) = self.calculate_accounts_hash_helper(
+                !use_index,
+                slot,
+                ancestors,
+                check_hash,
+                can_cached_slot_be_unflushed,
+            )?;
+
+            let success = hash == hash_other
+                && total_lamports == total_lamports_other
+                && total_lamports == expected_capitalization.unwrap_or(total_lamports);
+            assert!(success, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}, slot: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index, slot);
+        }
+        Ok((hash, total_lamports))
+    }
+
     pub fn update_accounts_hash_with_index_option(
         &self,
         use_index: bool,
@@ -4629,31 +4664,16 @@ impl AccountsDb {
     ) -> (Hash, u64) {
         let check_hash = false;
         let (hash, total_lamports) = self
-            .calculate_accounts_hash_helper(
+            .calculate_accounts_hash_helper_with_verify(
                 use_index,
+                debug_verify,
                 slot,
                 ancestors,
-                check_hash,
+                expected_capitalization,
                 can_cached_slot_be_unflushed,
+                check_hash,
             )
             .unwrap(); // unwrap here will never fail since check_hash = false
-        if debug_verify {
-            // calculate the other way (store or non-store) and verify results match.
-            let (hash_other, total_lamports_other) = self
-                .calculate_accounts_hash_helper(
-                    !use_index,
-                    slot,
-                    ancestors,
-                    check_hash,
-                    can_cached_slot_be_unflushed,
-                )
-                .unwrap(); // unwrap here will never fail since check_hash = false
-
-            let success = hash == hash_other
-                && total_lamports == total_lamports_other
-                && total_lamports == expected_capitalization.unwrap_or(total_lamports);
-            assert!(success, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}, slot: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index, slot);
-        }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
         bank_hash_info.snapshot_hash = hash;


### PR DESCRIPTION
#### Problem
The ability to calculate the hash while verifying index and non-index versions is useful outside of the current code path that only supports this while updating the hash.
#### Summary of Changes
extract code to make a sub-function
Fixes #
