### PR TITLE
Explorer: display message when block rewards not found for interval

### DIFF
--- a/explorer/src/components/account/RewardsCard.tsx
+++ b/explorer/src/components/account/RewardsCard.tsx
@@ -61,8 +61,8 @@ export function RewardsCard({ pubkey }: { pubkey: PublicKey }) {
       </tr>
     );
   });
-
-  const { foundOldest } = rewards.data;
+  const rewardsFound = rewardsList.some((r) => r);
+  const { foundOldest, lowestFetchedEpoch, highestFetchedEpoch } = rewards.data;
   const fetching = rewards.status === FetchStatus.Fetching;
 
   return (
@@ -76,19 +76,26 @@ export function RewardsCard({ pubkey }: { pubkey: PublicKey }) {
           </div>
         </div>
 
-        <div className="table-responsive mb-0">
-          <table className="table table-sm table-nowrap card-table">
-            <thead>
-              <tr>
-                <th className="w-1 text-muted">Epoch</th>
-                <th className="text-muted">Effective Slot</th>
-                <th className="text-muted">Reward Amount</th>
-                <th className="text-muted">Post Balance</th>
-              </tr>
-            </thead>
-            <tbody className="list">{rewardsList}</tbody>
-          </table>
-        </div>
+        {rewardsFound ? (
+          <div className="table-responsive mb-0">
+            <table className="table table-sm table-nowrap card-table">
+              <thead>
+                <tr>
+                  <th className="w-1 text-muted">Epoch</th>
+                  <th className="text-muted">Effective Slot</th>
+                  <th className="text-muted">Reward Amount</th>
+                  <th className="text-muted">Post Balance</th>
+                </tr>
+              </thead>
+              <tbody className="list">{rewardsList}</tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="card-body">
+            No rewards issued between epochs {lowestFetchedEpoch} and{" "}
+            {highestFetchedEpoch}
+          </div>
+        )}
 
         <div className="card-footer">
           {foundOldest ? (

--- a/explorer/src/providers/accounts/rewards.tsx
+++ b/explorer/src/providers/accounts/rewards.tsx
@@ -6,6 +6,11 @@ import { ActionType } from "providers/block";
 import { FetchStatus } from "providers/cache";
 import { reportError } from "utils/sentry";
 
+const REWARDS_AVAILABLE_EPOCH = new Map<Cluster, number>([
+  [Cluster.MainnetBeta, 133],
+  [Cluster.Testnet, 43],
+]);
+
 const PAGE_SIZE = 15;
 
 export type Rewards = {
@@ -87,6 +92,7 @@ async function fetchRewards(
     url,
   });
 
+  const lowestAvailableEpoch = REWARDS_AVAILABLE_EPOCH.get(cluster) || 0;
   const connection = new Connection(url);
 
   if (!fromEpoch && highestEpoch) {
@@ -143,7 +149,7 @@ async function fetchRewards(
     status: FetchStatus.Fetched,
     data: {
       rewards: results || [],
-      foundOldest: lowestFetchedEpoch <= 0,
+      foundOldest: lowestFetchedEpoch <= lowestAvailableEpoch,
       highestFetchedEpoch: fromEpoch,
       lowestFetchedEpoch,
     },


### PR DESCRIPTION
#### Problem
There is currently no user feedback for situations where no block rewards are found for a given interval.

#### Summary of Changes
Rather than render an empty table, display a message saying rewards were not found for the fetched interval.

![Explorer-Solana (6)](https://user-images.githubusercontent.com/188792/121949813-c6e38300-cd0d-11eb-80ee-ec9813b0d7cf.png)

![Explorer-Solana (7)](https://user-images.githubusercontent.com/188792/121949806-c519bf80-cd0d-11eb-8e3f-d5dc4ea24e47.png)