### PR TITLE
remove unused parameters from CalculateHashIntermediate

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6185,10 +6185,10 @@ pub mod tests {
         let pubkey255 = Pubkey::new(&[0xffu8; 32]);
 
         let mut raw_expected = vec![
-            CalculateHashIntermediate::new(0, Hash::default(), 1, slot, pubkey0),
-            CalculateHashIntermediate::new(1, Hash::default(), 128, slot, pubkey127),
-            CalculateHashIntermediate::new(2, Hash::default(), 129, slot, pubkey128),
-            CalculateHashIntermediate::new(3, Hash::default(), 256, slot, pubkey255),
+            CalculateHashIntermediate::new_without_slot(Hash::default(), 1, pubkey0),
+            CalculateHashIntermediate::new_without_slot(Hash::default(), 128, pubkey127),
+            CalculateHashIntermediate::new_without_slot(Hash::default(), 129, pubkey128),
+            CalculateHashIntermediate::new_without_slot(Hash::default(), 256, pubkey255),
         ];
 
         let expected_hashes = vec![


### PR DESCRIPTION
#### Problem
CalculateHashIntermediate has been refactored to not use slot or write version. The old constructor was left in place so tests didn't noisly change yet.
#### Summary of Changes
Get rid of unused parameters on the tests.
Fixes #
