### PR TITLE
Update init-metrics.sh

### DIFF
--- a/net/init-metrics.sh
+++ b/net/init-metrics.sh
@@ -29,7 +29,7 @@ EOF
 useEnv=false
 delete=false
 createWithoutConfig=false
-host="https://metrics.solana.com:8086"
+host="https://metrics.solana.com:8087"
 while getopts "hdec:" opt; do
   case $opt in
   h|\?)


### PR DESCRIPTION
#### Problem
In the new InfluxDB architecture  port 8086 is the metrics server that acts as a load balancer, /write will go through influx relay  and then to both influxdb intances, so we have the same metrics on both, however a /query will go to just one of them. That script only uses /query so it'll just go to one instance. To avoid that, I've forwarded 8087 directly to our influx1 instance, you can call this one our old influxdb instance, so it'll work as before

#### Summary of Changes
Change port 8086 to 8087