### PR TITLE
ledger tool limit_load_slot_count_from_snapshot avoids assert failures

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -107,6 +107,7 @@ mod tests {
                 AccountSecondaryIndexes::default(),
                 false,
                 accounts_db::AccountShrinkThreshold::default(),
+                false,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -150,10 +150,6 @@ fn load_from_snapshot(
         deserialized_bank.set_shrink_paths(shrink_paths);
     }
 
-    if process_options.accounts_db_test_hash_calculation {
-        deserialized_bank.update_accounts_hash_with_index_option(false, true);
-    }
-
     let deserialized_bank_slot_and_hash = (
         deserialized_bank.slot(),
         deserialized_bank.get_accounts_hash(),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -404,6 +404,7 @@ pub fn process_blockstore(
         opts.account_indexes.clone(),
         opts.accounts_db_caching_enabled,
         opts.shrink_ratio,
+        false,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");
@@ -3100,6 +3101,7 @@ pub mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            false,
         );
         *bank.epoch_schedule()
     }

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -61,6 +61,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        false,
     );
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -81,6 +82,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        false,
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&prev_bank, &mut pubkeys, 250_000).unwrap();

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -271,12 +271,16 @@ where
     );
 
     let bank_rc = BankRc::new(Accounts::new_empty(accounts_db), bank_fields.slot);
+
+    // if limit_load_slot_count_from_snapshot is set, then we need to side-step some correctness checks beneath this call
+    let debug_do_not_add_builtins = limit_load_slot_count_from_snapshot.is_some();
     let bank = Bank::new_from_fields(
         bank_rc,
         genesis_config,
         bank_fields,
         debug_keys,
         additional_builtins,
+        debug_do_not_add_builtins,
     );
 
     Ok(bank)

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -652,7 +652,9 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     measure.stop();
 
     let mut verify = Measure::start("verify");
-    if !bank.verify_snapshot_bank(test_hash_calculation) {
+    if !bank.verify_snapshot_bank(test_hash_calculation)
+        && limit_load_slot_count_from_snapshot.is_none()
+    {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
     }
     verify.stop();


### PR DESCRIPTION
#### Problem
It is useful to load snapshots with large #s of accounts and set limits on how many slots are loaded to gather metrics. The ledger-tool option limit_load_slot_count_from_snapshot enables this. For example, load 200k slots from a snapshot with 360M accounts allows loading of just ~180M accounts. However, this produces various asserts early in the load process. These are annoying and require manually commenting stuff out to get metrics.
#### Summary of Changes
Pass a parameter that allows lobotomizing a few asserts to allow progress even with 'invalid' system state.
Fixes #
