### PR TITLE
move all sort to sort_unstable

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -143,8 +143,7 @@ impl ClusterSlotsService {
         while let Ok(mut more) = cluster_slots_update_receiver.try_recv() {
             slots.append(&mut more);
         }
-        #[allow(clippy::stable_sort_primitive)]
-        slots.sort();
+        slots.sort_unstable();
 
         if !slots.is_empty() {
             cluster_info.push_epoch_slots(&slots);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5723,8 +5723,7 @@ impl AccountsDb {
         type AccountsMap<'a> =
             HashMap<Pubkey, (StoredMetaWriteVersion, AppendVecId, StoredAccountMeta<'a>)>;
         let mut slots = self.storage.all_slots();
-        #[allow(clippy::stable_sort_primitive)]
-        slots.sort();
+        slots.sort_unstable();
         if let Some(limit) = limit_load_slot_count_from_snapshot {
             slots.truncate(limit); // get rid of the newer slots and keep just the older
         }
@@ -5917,8 +5916,7 @@ impl AccountsDb {
 
     fn print_index(&self, label: &str) {
         let mut roots: Vec<_> = self.accounts_index.all_roots();
-        #[allow(clippy::stable_sort_primitive)]
-        roots.sort();
+        roots.sort_unstable();
         info!("{}: accounts_index roots: {:?}", label, roots,);
         for (pubkey, account_entry) in self.accounts_index.account_maps.read().unwrap().iter() {
             info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
@@ -5931,15 +5929,13 @@ impl AccountsDb {
 
     fn print_count_and_status(&self, label: &str) {
         let mut slots: Vec<_> = self.storage.all_slots();
-        #[allow(clippy::stable_sort_primitive)]
-        slots.sort();
+        slots.sort_unstable();
         info!("{}: count_and status for {} slots:", label, slots.len());
         for slot in &slots {
             let slot_stores = self.storage.get_slot_stores(*slot).unwrap();
             let r_slot_stores = slot_stores.read().unwrap();
             let mut ids: Vec<_> = r_slot_stores.keys().cloned().collect();
-            #[allow(clippy::stable_sort_primitive)]
-            ids.sort();
+            ids.sort_unstable();
             for id in &ids {
                 let entry = r_slot_stores.get(id).unwrap();
                 info!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1484,8 +1484,7 @@ impl Bank {
         }
 
         let mut ancestors: Vec<_> = roots.into_iter().collect();
-        #[allow(clippy::stable_sort_primitive)]
-        ancestors.sort();
+        ancestors.sort_unstable();
         ancestors
     }
 

--- a/sdk/src/hard_forks.rs
+++ b/sdk/src/hard_forks.rs
@@ -22,8 +22,7 @@ impl HardForks {
         } else {
             self.hard_forks.push((new_slot, 1));
         }
-        #[allow(clippy::stable_sort_primitive)]
-        self.hard_forks.sort();
+        self.hard_forks.sort_unstable();
     }
 
     // Returns a sorted-by-slot iterator over the registered hark forks


### PR DESCRIPTION
#### Problem
clippy disable is required to use old 'sort' vs 'sort_unstable' in all cases where we call 'sort'. It is acceptable to call 'sort_unstable' in all these cases. 'sort_unstable' is recommended and faster.
#### Summary of Changes
Convert all remaining 'sort' calls to 'sort_unstable' and remove clippy work-around.
Fixes #
