### PR TITLE
Properly handle block_height in Bigtable bincode deserialization

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -3,6 +3,7 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
+    deserialize_utils::default_on_eof,
     pubkey::Pubkey,
     signature::Signature,
     sysvar::is_sysvar_id,
@@ -89,6 +90,7 @@ struct StoredConfirmedBlock {
     transactions: Vec<StoredConfirmedBlockTransaction>,
     rewards: StoredConfirmedBlockRewards,
     block_time: Option<UnixTimestamp>,
+    #[serde(deserialize_with = "default_on_eof")]
     block_height: Option<u64>,
 }
 

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -82,6 +82,9 @@ fn key_to_slot(key: &str) -> Option<Slot> {
 // StoredConfirmedBlock holds the same contents as ConfirmedBlock, but is slightly compressed and avoids
 // some serde JSON directives that cause issues with bincode
 //
+// Note: in order to continue to support old bincode-serialized bigtable entries, if new fields are
+// added to ConfirmedBlock, they must either be excluded or set to `default_on_eof` here
+//
 #[derive(Serialize, Deserialize)]
 struct StoredConfirmedBlock {
     previous_blockhash: String,


### PR DESCRIPTION
#### Problem
Solana rpc/ledger-tool apis are not returning really old Bigtable blocks. This is because the new `block_height` field is not be properly handled by the bincode Bigtable deserializer.

#### Summary of Changes
- Set block_height to default on early eof deserialization
- Add comment to help avoid the oversight for additional fields in the future.
