### PR TITLE
validator: run poh speed test earlier in start up

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -385,6 +385,7 @@ impl Validator {
             &exit,
             config.enforce_ulimit_nofile,
             &start_progress,
+            config.no_poh_speed_test,
         );
 
         *start_progress.write().unwrap() = ValidatorStartProgress::StartingServices;
@@ -615,10 +616,6 @@ impl Validator {
             } else {
                 (None, None)
             };
-
-        if !config.no_poh_speed_test {
-            check_poh_speed(&genesis_config, None);
-        }
 
         let waited_for_supermajority = if let Ok(waited) = wait_for_supermajority(
             config,
@@ -1021,6 +1018,7 @@ fn new_banks_from_ledger(
     exit: &Arc<AtomicBool>,
     enforce_ulimit_nofile: bool,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
+    no_poh_speed_test: bool,
 ) -> (
     GenesisConfig,
     BankForks,
@@ -1052,6 +1050,10 @@ fn new_banks_from_ledger(
             error!("Delete the ledger directory to continue: {:?}", ledger_path);
             abort();
         }
+    }
+
+    if !no_poh_speed_test {
+        check_poh_speed(&genesis_config, None);
     }
 
     let BlockstoreSignals {


### PR DESCRIPTION
#### Problem

The validator PoH speed test is fast and terminal upon failure.  However we run it after snapshot fetch and ledger replay, which are slow and the former bandwidth heavy

#### Summary of Changes

Run PoH speed test at earliest possible point in validator start up
