### PR TITLE
Remove "synthetic" from sysvar definition

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -255,7 +255,7 @@ Tokens forfeit to the [cluster](terminology.md#cluster) if malicious [validator]
 
 ## sysvar
 
-A synthetic [account](terminology.md#account) maintained by the runtime and provided to programs which provide cluster state such as current tick height, rewards [points](terminology.md#point) values, etc.  Sysvars can either be [passed to the program as an account or queried by the program via a syscall](developing/runtime-facilities/sysvars.md).
+An [account](terminology.md#account) maintained by the runtime and provided to programs which provide cluster state such as current tick height, rewards [points](terminology.md#point) values, etc.  Sysvars can either be [passed to the program as an account or queried by the program via a syscall](developing/runtime-facilities/sysvars.md).
 
 ## thin client
 


### PR DESCRIPTION
#### Problem

sysvar definition may be confusing to those familiar with synthetic tokens

#### Summary of Changes

Remove "synthetic" from the sysvar definition
