### PR TITLE
Extricate RpcCompletedSlotsService from RetransmitStage

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -47,6 +47,7 @@ use solana_rpc::{
         OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
     },
     rpc::JsonRpcConfig,
+    rpc_completed_slots_service::RpcCompletedSlotsService,
     rpc_pubsub_service::{PubSubConfig, PubSubService},
     rpc_service::JsonRpcService,
     rpc_subscriptions::RpcSubscriptions,
@@ -80,7 +81,7 @@ use std::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
     sync::mpsc::Receiver,
     sync::{Arc, Mutex, RwLock},
-    thread::{sleep, Builder},
+    thread::{sleep, Builder, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -243,6 +244,7 @@ pub struct Validator {
     validator_exit: Arc<RwLock<Exit>>,
     json_rpc_service: Option<JsonRpcService>,
     pubsub_service: Option<PubSubService>,
+    rpc_completed_slots_service: JoinHandle<()>,
     optimistically_confirmed_bank_tracker: Option<OptimisticallyConfirmedBankTracker>,
     transaction_status_service: Option<TransactionStatusService>,
     rewards_recorder_service: Option<RewardsRecorderService>,
@@ -445,7 +447,7 @@ impl Validator {
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
 
-        let subscriptions = Arc::new(RpcSubscriptions::new_with_vote_subscription(
+        let rpc_subscriptions = Arc::new(RpcSubscriptions::new_with_vote_subscription(
             &exit,
             bank_forks.clone(),
             block_commitment_cache.clone(),
@@ -459,7 +461,7 @@ impl Validator {
         let completed_data_sets_service = CompletedDataSetsService::new(
             completed_data_sets_receiver,
             blockstore.clone(),
-            subscriptions.clone(),
+            rpc_subscriptions.clone(),
             &exit,
             max_slots.clone(),
         );
@@ -539,7 +541,7 @@ impl Validator {
                 } else {
                     Some(PubSubService::new(
                         config.pubsub_config.clone(),
-                        &subscriptions,
+                        &rpc_subscriptions,
                         rpc_pubsub_addr,
                         &exit,
                     ))
@@ -549,7 +551,7 @@ impl Validator {
                     &exit,
                     bank_forks.clone(),
                     optimistically_confirmed_bank,
-                    subscriptions.clone(),
+                    rpc_subscriptions.clone(),
                 )),
                 Some(bank_notification_sender),
             )
@@ -663,6 +665,10 @@ impl Validator {
         let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (cluster_confirmed_slot_sender, cluster_confirmed_slot_receiver) = unbounded();
+
+        let rpc_completed_slots_service =
+            RpcCompletedSlotsService::spawn(completed_slots_receiver, rpc_subscriptions.clone());
+
         let tvu = Tvu::new(
             vote_account,
             authorized_voter_keypairs,
@@ -695,12 +701,11 @@ impl Validator {
             },
             blockstore.clone(),
             ledger_signal_receiver,
-            &subscriptions,
+            &rpc_subscriptions,
             &poh_recorder,
             tower,
             &leader_schedule_cache,
             &exit,
-            completed_slots_receiver,
             block_commitment_cache,
             config.enable_partition.clone(),
             transaction_status_sender.clone(),
@@ -743,7 +748,7 @@ impl Validator {
             node.sockets.tpu,
             node.sockets.tpu_forwards,
             node.sockets.broadcast,
-            &subscriptions,
+            &rpc_subscriptions,
             transaction_status_sender,
             &blockstore,
             &config.broadcast_stage_type,
@@ -768,6 +773,7 @@ impl Validator {
             serve_repair_service,
             json_rpc_service,
             pubsub_service,
+            rpc_completed_slots_service,
             optimistically_confirmed_bank_tracker,
             transaction_status_service,
             rewards_recorder_service,
@@ -830,6 +836,10 @@ impl Validator {
         if let Some(pubsub_service) = self.pubsub_service {
             pubsub_service.join().expect("pubsub_service");
         }
+
+        self.rpc_completed_slots_service
+            .join()
+            .expect("rpc_completed_slots_service");
 
         if let Some(optimistically_confirmed_bank_tracker) =
             self.optimistically_confirmed_bank_tracker

--- a/rpc/src/rpc_completed_slots_service.rs
+++ b/rpc/src/rpc_completed_slots_service.rs
@@ -13,23 +13,20 @@ pub struct RpcCompletedSlotsService;
 impl RpcCompletedSlotsService {
     pub fn spawn(
         completed_slots_receiver: CompletedSlotsReceiver,
-        rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
-    ) -> Option<JoinHandle<()>> {
-        let rpc_subscriptions = rpc_subscriptions?;
-        Some(
-            Builder::new()
-                .name("solana-rpc-completed-slots-service".to_string())
-                .spawn(move || {
-                    for slots in completed_slots_receiver.iter() {
-                        for slot in slots {
-                            rpc_subscriptions.notify_slot_update(SlotUpdate::Completed {
-                                slot,
-                                timestamp: timestamp(),
-                            });
-                        }
+        rpc_subscriptions: Arc<RpcSubscriptions>,
+    ) -> JoinHandle<()> {
+        Builder::new()
+            .name("solana-rpc-completed-slots-service".to_string())
+            .spawn(move || {
+                for slots in completed_slots_receiver.iter() {
+                    for slot in slots {
+                        rpc_subscriptions.notify_slot_update(SlotUpdate::Completed {
+                            slot,
+                            timestamp: timestamp(),
+                        });
                     }
-                })
-                .unwrap(),
-        )
+                }
+            })
+            .unwrap()
     }
 }


### PR DESCRIPTION
RpcCompletedSlotsService was nestled in RetransmitStage but it has no dependencies on RetransmitStage.  Hoist it up to Validator and remove the unnecessary Tvu plumbing 