### PR TITLE
Fix flaky optimistic violation detection cluster test

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2184,11 +2184,20 @@ fn test_optimistic_confirmation_violation_detection() {
             OptimisticConfirmationVerifier::format_optimistic_confirmed_slot_violation_log(
                 prev_voted_slot,
             );
+        // Violation detection thread can be behind so poll logs up to 10 seconds
         if let Some(mut buf) = buf {
+            let start = Instant::now();
+            let mut success = false;
             let mut output = String::new();
-            buf.read_to_string(&mut output).unwrap();
-            assert!(output.contains(&expected_log));
+            while start.elapsed().as_secs() < 10 {
+                buf.read_to_string(&mut output).unwrap();
+                if output.contains(&expected_log) {
+                    success = true;
+                    break;
+                }
+            }
             print!("{}", output);
+            assert!(success);
         } else {
             panic!("dumped log and disabled testing");
         }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2195,6 +2195,7 @@ fn test_optimistic_confirmation_violation_detection() {
                     success = true;
                     break;
                 }
+                sleep(Duration::from_millis(10));
             }
             print!("{}", output);
             assert!(success);


### PR DESCRIPTION
#### Problem
`test_optimistic_confirmation_violation_detection` local cluster test was flaky
#### Summary of Changes
We parsed the logs to see if we could detect the optimistic confirmation violation immediately after a slot greater than the offending slot was rooted. However the violation detection runs in a separate thread which in some cases could be behind. The solution is to poll the log for 10 seconds after rooting which should give enough time for the violation detection thread to catch up

Tested flakiness by running the test 100 times on a gce dev machine

Fixes #
