### PR TITLE
Removed pub from  some functions which are actually private to improve encapsulation

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -376,7 +376,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn consume_buffered_packets(
+    pub fn consume_buffered_packets(
         my_pubkey: &Pubkey,
         max_tx_ingestion_ns: u128,
         poh_recorder: &Arc<Mutex<PohRecorder>>,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -376,7 +376,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn consume_buffered_packets(
+    fn consume_buffered_packets(
         my_pubkey: &Pubkey,
         max_tx_ingestion_ns: u128,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
@@ -635,7 +635,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn process_loop(
+    fn process_loop(
         my_pubkey: Pubkey,
         verified_receiver: &CrossbeamReceiver<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
@@ -1279,7 +1279,7 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     /// Process the incoming packets
-    pub fn process_packets(
+    fn process_packets(
         my_pubkey: &Pubkey,
         verified_receiver: &CrossbeamReceiver<Vec<Packets>>,
         poh: &Arc<Mutex<PohRecorder>>,


### PR DESCRIPTION
#### Problem
A few functions in bank.rs are marked as pub but -- not used anywhere else outside of the module. Remove the pub marker to improve encapsulation.

#### Summary of Changes
Remove the pub marker to improve encapsulation. Readability improvement only, no functional impact.
Fixes #
