### PR TITLE
validator: expose max active pubsub subscriptions to CLI

### DIFF
--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl},
+        rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl, MAX_ACTIVE_SUBSCRIPTIONS},
         rpc_subscriptions::RpcSubscriptions,
     },
     jsonrpc_pubsub::{PubSubHandler, Session},
@@ -29,6 +29,7 @@ pub struct PubSubConfig {
     pub max_fragment_size: usize,
     pub max_in_buffer_capacity: usize,
     pub max_out_buffer_capacity: usize,
+    pub max_active_subscriptions: usize,
 }
 
 impl Default for PubSubConfig {
@@ -39,6 +40,7 @@ impl Default for PubSubConfig {
             max_fragment_size: 50 * 1024, // 50KB
             max_in_buffer_capacity: 50 * 1024, // 50KB
             max_out_buffer_capacity: 15 * 1024 * 1024, // max account size (10MB), then 5MB extra for base64 encoding overhead/etc
+            max_active_subscriptions: MAX_ACTIVE_SUBSCRIPTIONS,
         }
     }
 }
@@ -55,7 +57,10 @@ impl PubSubService {
         exit: &Arc<AtomicBool>,
     ) -> Self {
         info!("rpc_pubsub bound to {:?}", pubsub_addr);
-        let rpc = RpcSolPubSubImpl::new(subscriptions.clone());
+        let rpc = RpcSolPubSubImpl::new(
+            subscriptions.clone(),
+            pubsub_config.max_active_subscriptions,
+        );
         let exit_ = exit.clone();
 
         let thread_hdl = Builder::new()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1003,6 +1003,8 @@ pub fn main() {
         PubSubConfig::default().max_in_buffer_capacity.to_string();
     let default_rpc_pubsub_max_out_buffer_capacity =
         PubSubConfig::default().max_out_buffer_capacity.to_string();
+    let default_rpc_pubsub_max_active_subscriptions =
+        PubSubConfig::default().max_active_subscriptions.to_string();
     let default_rpc_send_transaction_retry_ms = ValidatorConfig::default()
         .send_transaction_retry_ms
         .to_string();
@@ -1611,6 +1613,16 @@ pub fn main() {
                 .help("The maximum size in bytes to which the outgoing websocket buffer can grow."),
         )
         .arg(
+            Arg::with_name("rpc_pubsub_max_active_subscriptions")
+                .long("rpc-pubsub-max-active-subscriptions")
+                .takes_value(true)
+                .value_name("NUMBER")
+                .validator(is_parsable::<usize>)
+                .default_value(&default_rpc_pubsub_max_active_subscriptions)
+                .help("The maximum number of active subscriptions that RPC PubSub will accept \
+                       across all connections."),
+        )
+        .arg(
             Arg::with_name("rpc_send_transaction_retry_ms")
                 .long("rpc-send-retry-ms")
                 .value_name("MILLISECS")
@@ -2185,6 +2197,11 @@ pub fn main() {
             max_out_buffer_capacity: value_t_or_exit!(
                 matches,
                 "rpc_pubsub_max_out_buffer_capacity",
+                usize
+            ),
+            max_active_subscriptions: value_t_or_exit!(
+                matches,
+                "rpc_pubsub_max_active_subscriptions",
                 usize
             ),
         },


### PR DESCRIPTION
#### Problem

RPC Pubsub max active connections is a compile time constant

#### Summary of Changes

Expose it via CLI flag
