### PR TITLE
Websocket are you reopening or not? When no subscription at first

### DIFF
--- a/web3.js/test/websocket.test.ts
+++ b/web3.js/test/websocket.test.ts
@@ -79,5 +79,22 @@ if (process.env.TEST_LIVE) {
 
       await connection.removeSignatureListener(id);
     });
+
+    it('reconnects once subscription are created', async () => {
+      // wait for websocket to disconnect
+      await sleep(1100);
+      expect(connection._rpcWebSocketConnected).to.be.false;
+      expect(connection._rpcWebSocketIdleTimeout).to.eq(null);
+
+      const testSignature = bs58.encode(Buffer.alloc(64));
+      const id = connection.onSignature(testSignature, () => {});
+      
+      // wait for websocket to connect
+      await sleep(100);
+      expect(connection._rpcWebSocketConnected).to.be.true;
+      expect(connection._rpcWebSocketIdleTimeout).to.eq(null);
+
+      await connection.removeSignatureListener(id);
+    });
   });
 }

--- a/web3.js/test/websocket.test.ts
+++ b/web3.js/test/websocket.test.ts
@@ -81,20 +81,22 @@ if (process.env.TEST_LIVE) {
     });
 
     it('reconnects once subscription are created', async () => {
+      const newConnection = new Connection(url);
+
       // wait for websocket to disconnect
       await sleep(1100);
-      expect(connection._rpcWebSocketConnected).to.be.false;
-      expect(connection._rpcWebSocketIdleTimeout).to.eq(null);
+      expect(newConnection._rpcWebSocketConnected).to.be.false;
+      expect(newConnection._rpcWebSocketIdleTimeout).to.eq(null);
 
       const testSignature = bs58.encode(Buffer.alloc(64));
-      const id = connection.onSignature(testSignature, () => {});
-      
+      const id = newConnection.onSignature(testSignature, () => {});
+
       // wait for websocket to connect
       await sleep(100);
-      expect(connection._rpcWebSocketConnected).to.be.true;
-      expect(connection._rpcWebSocketIdleTimeout).to.eq(null);
+      expect(newConnection._rpcWebSocketConnected).to.be.true;
+      expect(newConnection._rpcWebSocketIdleTimeout).to.eq(null);
 
-      await connection.removeSignatureListener(id);
+      await newConnection.removeSignatureListener(id);
     });
   });
 }


### PR DESCRIPTION
#### Problem

Witchcraft exists in dapp-scaffold with no clear relevance
https://github.com/solana-labs/dapp-scaffold/blob/9352c93fe34fb061eed33030dc406074295a69b0/src/contexts/connection.tsx#L129-L161

"The websocket library solana/web3.js closes its websocket connection when the subscription list is empty after opening its first time, preventing subsequent subscriptions from receiving responses."

#### Summary of Changes
Let's add a test to guarantee the behavior is actually well taken care of in web3.js. We can ditch the "hack" in consumer code

Fixes #
