### PR TITLE
Revert "chore: bump trees from 0.2.1 to 0.4.2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
+name = "indexed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d480125acf340d6a6e59dab69ae19d6fca3a906e1eade277671272cc8f73794b"
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6723,9 +6729,12 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trees"
-version = "0.4.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
+checksum = "afa1821e85be4f56cc5bd08bdbc32c0e26d105c90bed9c637992f6c7f747c180"
+dependencies = [
+ "indexed",
+]
 
 [[package]]
 name = "try-lock"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,7 +69,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.8.0" }
 tempfile = "3.2.0"
 thiserror = "1.0"
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.8.0" }
-trees = "0.4.2"
+trees = "0.2.1"
 
 [dev-dependencies]
 jsonrpc-core = "17.1.0"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -52,7 +52,7 @@ tempfile = "3.2.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-trees = "0.4.2"
+trees = "0.2.1"
 
 # Disable reed-solomon-erasure/simd-accel feature on aarch64 only since it
 # requires clang to support -march=native.


### PR DESCRIPTION
Reverts solana-labs/solana#18041