### PR TITLE
chore: bump trees from 0.2.1 to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,12 +1999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
-name = "indexed"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d480125acf340d6a6e59dab69ae19d6fca3a906e1eade277671272cc8f73794b"
-
-[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6729,12 +6723,9 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trees"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa1821e85be4f56cc5bd08bdbc32c0e26d105c90bed9c637992f6c7f747c180"
-dependencies = [
- "indexed",
-]
+checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 
 [[package]]
 name = "try-lock"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,7 +69,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.8.0" }
 tempfile = "3.2.0"
 thiserror = "1.0"
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.8.0" }
-trees = "0.2.1"
+trees = "0.4.2"
 
 [dev-dependencies]
 jsonrpc-core = "17.1.0"

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1438,13 +1438,13 @@ pub mod test {
             forks: Tree<u64>,
             cluster_votes: &HashMap<Pubkey, Vec<u64>>,
         ) {
-            let root = forks.root().data;
+            let root = *forks.root().data();
             assert!(self.bank_forks.read().unwrap().get(root).is_some());
 
             let mut walk = TreeWalk::from(forks);
 
             while let Some(visit) = walk.get() {
-                let slot = visit.node().data;
+                let slot = *visit.node().data();
                 self.progress
                     .entry(slot)
                     .or_insert_with(|| ForkProgress::new(Hash::default(), None, None, 0, 0));
@@ -1452,7 +1452,7 @@ pub mod test {
                     walk.forward();
                     continue;
                 }
-                let parent = walk.get_parent().unwrap().data;
+                let parent = *walk.get_parent().unwrap().data();
                 let parent_bank = self.bank_forks.read().unwrap().get(parent).unwrap().clone();
                 let new_bank = Bank::new_from_parent(&parent_bank, &Pubkey::default(), slot);
                 for (pubkey, vote) in cluster_votes.iter() {

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -215,11 +215,11 @@ impl HeaviestSubtreeForkChoice {
 
     #[cfg(test)]
     pub(crate) fn new_from_tree<T: GetSlotHash>(forks: Tree<T>) -> Self {
-        let root = forks.root().data.slot_hash();
+        let root = forks.root().data().slot_hash();
         let mut walk = TreeWalk::from(forks);
         let mut heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new(root);
         while let Some(visit) = walk.get() {
-            let slot_hash = visit.node().data.slot_hash();
+            let slot_hash = visit.node().data().slot_hash();
             if heaviest_subtree_fork_choice
                 .fork_infos
                 .contains_key(&slot_hash)
@@ -227,7 +227,7 @@ impl HeaviestSubtreeForkChoice {
                 walk.forward();
                 continue;
             }
-            let parent_slot_hash = walk.get_parent().map(|n| n.data.slot_hash());
+            let parent_slot_hash = walk.get_parent().map(|n| n.data().slot_hash());
             heaviest_subtree_fork_choice.add_new_leaf_slot(slot_hash, parent_slot_hash);
             walk.forward();
         }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -52,7 +52,7 @@ tempfile = "3.2.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-trees = "0.2.1"
+trees = "0.4.2"
 
 # Disable reed-solomon-erasure/simd-accel feature on aarch64 only since it
 # requires clang to support -march=native.

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -410,13 +410,13 @@ impl Blockstore {
         let mut walk = TreeWalk::from(forks);
         let mut blockhashes = HashMap::new();
         while let Some(visit) = walk.get() {
-            let slot = visit.node().data;
+            let slot = *visit.node().data();
             if self.meta(slot).unwrap().is_some() && self.orphan(slot).unwrap().is_none() {
                 // If slot exists in blockstore and is not an orphan, then skip it
                 walk.forward();
                 continue;
             }
-            let parent = walk.get_parent().map(|n| n.data);
+            let parent = walk.get_parent().map(|n| *n.data());
             if parent.is_some() || !is_orphan {
                 let parent_hash = parent
                     // parent won't exist for first node in a tree where

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3315,7 +3315,7 @@ pub mod tests {
         */
         let starting_fork_slot = 5;
         let mut main_fork = tr(starting_fork_slot);
-        let mut main_fork_ref = main_fork.root_mut();
+        let mut main_fork_ref = main_fork.root_mut().get_mut();
 
         // Make enough slots to make a root slot > blockstore_root
         let expected_root_slot = starting_fork_slot + blockstore_root.unwrap_or(0);
@@ -3333,7 +3333,7 @@ pub mod tests {
                 main_fork_ref.push_front(minor_fork.clone());
             }
             main_fork_ref.push_front(tr(slot));
-            main_fork_ref = main_fork_ref.first_mut().unwrap();
+            main_fork_ref = main_fork_ref.front_mut().unwrap().get_mut();
         }
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / main_fork);
         let validator_keypairs = ValidatorVoteKeypairs::new_rand();


### PR DESCRIPTION
#18041, but with fixes for field/type changes, and real CI
