### PR TITLE
Add repair and recovered metrics per slot

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -188,9 +188,14 @@ where
     }
 
     prune_shreds_invalid_repair(&mut shreds, &mut repair_infos, outstanding_requests);
+    let repairs: Vec<_> = repair_infos
+        .iter()
+        .map(|repair_info| repair_info.is_some())
+        .collect();
 
     let (completed_data_sets, inserted_indices) = blockstore.insert_shreds_handle_duplicate(
         shreds,
+        repairs,
         Some(leader_schedule_cache),
         false,
         &handle_duplicate,


### PR DESCRIPTION
#### Problem

No repair metrics per-slot makes it hard to see if a block was slow because of repair.

#### Summary of Changes

Add repaired and recovered metrics per-slot.

Fixes #
