### PR TITLE
Add test for signed division in on-chain programs

### DIFF
--- a/programs/bpf/c/src/float/float.c
+++ b/programs/bpf/c/src/float/float.c
@@ -12,8 +12,16 @@ extern uint64_t entrypoint(const uint8_t *input) {
   if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
     return ERROR_INVALID_ARGUMENT;
   }
+  /* test float conversion to int compiles and works */
   uint32_t *data = (uint32_t *)(params.ka[0].data);
+  uint32_t new_data = *data + 1;
   *data += 1.5;
+  sol_assert(*data == new_data);
+
+  /* test signed division works for FP values */
+  double value = (double)new_data + 1.0;
+  value /= -2.0;
+  sol_assert(value < 0.0);
 
   return SUCCESS;
 }


### PR DESCRIPTION
Signed division should work correctly for BPF programs. This changes simply adds a test for checking the signed division operation on float values.

Fixes #3102
