### PR TITLE
Add logging when RpcHealthStatus::Unknown

### DIFF
--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -98,7 +98,15 @@ impl RpcHealth {
                         RpcHealthStatus::Behind { num_slots }
                     }
                 }
-                _ => RpcHealthStatus::Unknown,
+                (latest_account_hash_slot, latest_trusted_validator_account_hash_slot) => {
+                    if latest_account_hash_slot.is_none() {
+                        warn!("health check: latest_account_hash_slot not available");
+                    }
+                    if latest_trusted_validator_account_hash_slot.is_none() {
+                        warn!("health check: latest_trusted_validator_account_hash_slot not available");
+                    }
+                    RpcHealthStatus::Unknown
+                }
             }
         } else {
             // No trusted validator point of reference available, so this validator is healthy


### PR DESCRIPTION
#### Problem
Recently, an RPC node started reporting `RpcHealthStatus::Unknown`, but it wasn't clear whether it was the node's own accounts hash or the trusted-validator accounts hashes (or both) that were missing from the cluster_info

#### Summary of Changes
Add logging to specify which data `is_none()` when `RpcHealthStatus::Unknown`
