### PR TITLE
apply 'debug_do_not_add_builtins' to feature activations

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1237,7 +1237,7 @@ impl Bank {
         // Following code may touch AccountsDb, requiring proper ancestors
         let parent_epoch = parent.epoch();
         if parent_epoch < new.epoch() {
-            new.apply_feature_activations(false);
+            new.apply_feature_activations(false, false);
         }
 
         let cloned = new
@@ -1281,7 +1281,7 @@ impl Bank {
     pub fn warp_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
         let parent_timestamp = parent.clock().unix_timestamp;
         let mut new = Bank::new_from_parent(parent, collector_id, slot);
-        new.apply_feature_activations(true);
+        new.apply_feature_activations(true, false);
         new.update_epoch_stakes(new.epoch_schedule().get_epoch(slot));
         new.tick_height.store(new.max_tick_height(), Relaxed);
 
@@ -4287,7 +4287,7 @@ impl Bank {
         }
         self.feature_builtins = Arc::new(builtins.feature_builtins);
 
-        self.apply_feature_activations(true);
+        self.apply_feature_activations(true, debug_do_not_add_builtins);
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {
@@ -5078,7 +5078,11 @@ impl Bank {
 
     // This is called from snapshot restore AND for each epoch boundary
     // The entire code path herein must be idempotent
-    fn apply_feature_activations(&mut self, init_finish_or_warp: bool) {
+    fn apply_feature_activations(
+        &mut self,
+        init_finish_or_warp: bool,
+        debug_do_not_add_builtins: bool,
+    ) {
         let new_feature_activations = self.compute_active_feature_set(!init_finish_or_warp);
 
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
@@ -5108,8 +5112,10 @@ impl Bank {
             self.rewrite_stakes();
         }
 
-        self.ensure_feature_builtins(init_finish_or_warp, &new_feature_activations);
-        self.reconfigure_token2_native_mint();
+        if !debug_do_not_add_builtins {
+            self.ensure_feature_builtins(init_finish_or_warp, &new_feature_activations);
+            self.reconfigure_token2_native_mint();
+        }
         self.ensure_no_storage_rewards_pool();
     }
 


### PR DESCRIPTION
#### Problem
Large snapshots are useful to process for metrics and experiments. When passing --limit-load-slot-count-from-snapshot to ledger-tool verify, we end up with inconsistent state. This causes asserts. One class of asserts to avoid is adding accounts to frozen banks. feature activations can also cause us to attempt to add accounts.
#### Summary of Changes
apply 'debug_do_not_add_builtins' to feature activations
Fixes #
