### PR TITLE
Further removal of validator identity dependencies

### DIFF
--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -83,11 +83,11 @@ fn bench_retransmitter(bencher: &mut Bencher) {
         })
         .collect();
 
-    let keypair = Arc::new(Keypair::new());
+    let keypair = Keypair::new();
     let slot = 0;
     let parent = 0;
-    let shredder = Shredder::new(slot, parent, keypair, 0, 0).unwrap();
-    let mut data_shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+    let shredder = Shredder::new(slot, parent, 0, 0).unwrap();
+    let mut data_shreds = shredder.entries_to_shreds(&keypair, &entries, true, 0).0;
 
     let num_packets = data_shreds.len();
 

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -222,17 +222,17 @@ impl ForkProgress {
 
     pub fn new_from_bank(
         bank: &Bank,
-        my_pubkey: &Pubkey,
-        voting_pubkey: &Pubkey,
+        validator_identity: &Pubkey,
+        validator_vote_pubkey: &Pubkey,
         prev_leader_slot: Option<Slot>,
         num_blocks_on_fork: u64,
         num_dropped_blocks_on_fork: u64,
     ) -> Self {
         let validator_stake_info = {
-            if bank.collector_id() == my_pubkey {
+            if bank.collector_id() == validator_identity {
                 Some(ValidatorStakeInfo::new(
-                    *voting_pubkey,
-                    bank.epoch_vote_account_stake(voting_pubkey),
+                    *validator_vote_pubkey,
+                    bank.epoch_vote_account_stake(validator_vote_pubkey),
                     bank.total_epoch_stake(),
                 ))
             } else {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -114,7 +114,6 @@ struct SkippedSlotsInfo {
 }
 
 pub struct ReplayStageConfig {
-    pub my_pubkey: Pubkey,
     pub vote_account: Pubkey,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub exit: Arc<AtomicBool>,
@@ -298,7 +297,6 @@ impl ReplayStage {
         cost_model: Arc<RwLock<CostModel>>,
     ) -> Self {
         let ReplayStageConfig {
-            my_pubkey,
             vote_account,
             authorized_voter_keypairs,
             exit,
@@ -328,6 +326,7 @@ impl ReplayStage {
             .spawn(move || {
                 let verify_recyclers = VerifyRecyclers::default();
                 let _exit = Finalizer::new(exit.clone());
+                let my_pubkey = cluster_info.id();
                 let (
                     mut progress,
                     mut heaviest_subtree_fork_choice,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -42,10 +42,7 @@ use solana_runtime::{
     commitment::BlockCommitmentCache,
     vote_sender_types::ReplayVoteSender,
 };
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-};
+use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 use std::{
     boxed::Box,
     collections::HashSet,
@@ -131,8 +128,6 @@ impl Tvu {
         max_slots: &Arc<MaxSlots>,
         cost_model: &Arc<RwLock<CostModel>>,
     ) -> Self {
-        let keypair: Arc<Keypair> = cluster_info.keypair.clone();
-
         let Sockets {
             repair: repair_socket,
             fetch: fetch_sockets,
@@ -259,7 +254,6 @@ impl Tvu {
         };
 
         let replay_stage_config = ReplayStageConfig {
-            my_pubkey: keypair.pubkey(),
             vote_account: *vote_account,
             authorized_voter_keypairs,
             exit: exit.clone(),
@@ -353,6 +347,7 @@ pub mod tests {
     use solana_poh::poh_recorder::create_test_recorder;
     use solana_rpc::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank;
     use solana_runtime::bank::Bank;
+    use solana_sdk::signature::Signer;
     use std::sync::atomic::Ordering;
 
     #[ignore]

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -627,10 +627,10 @@ mod test {
         entries: &[Entry],
         slot: Slot,
         parent: Slot,
-        keypair: &Arc<Keypair>,
+        keypair: &Keypair,
     ) -> Vec<Shred> {
-        let shredder = Shredder::new(slot, parent, keypair.clone(), 0, 0).unwrap();
-        shredder.entries_to_shreds(entries, true, 0).0
+        let shredder = Shredder::new(slot, parent, 0, 0).unwrap();
+        shredder.entries_to_shreds(keypair, entries, true, 0).0
     }
 
     #[test]
@@ -639,7 +639,7 @@ mod test {
         let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
         let num_entries = 10;
         let original_entries = create_ticks(num_entries, 0, Hash::default());
-        let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Arc::new(Keypair::new()));
+        let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Keypair::new());
         shreds.reverse();
         blockstore
             .insert_shreds(shreds, None, false)

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -3408,11 +3408,10 @@ mod tests {
         let leader = Arc::new(Keypair::new());
         let keypair = Keypair::new();
         let (slot, parent_slot, reference_tick, version) = (53084024, 53084023, 0, 0);
-        let shredder =
-            Shredder::new(slot, parent_slot, leader.clone(), reference_tick, version).unwrap();
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
         let next_shred_index = rng.gen();
-        let shred = new_rand_shred(&mut rng, next_shred_index, &shredder);
-        let other_payload = new_rand_shred(&mut rng, next_shred_index, &shredder).payload;
+        let shred = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader);
+        let other_payload = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader).payload;
         let leader_schedule = |s| {
             if s == slot {
                 Some(leader.pubkey())

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -317,6 +317,7 @@ pub(crate) mod tests {
         rng: &mut R,
         next_shred_index: u32,
         shredder: &Shredder,
+        keypair: &Keypair,
     ) -> Shred {
         let entries: Vec<_> = std::iter::repeat_with(|| {
             let tx = system_transaction::transfer(
@@ -334,6 +335,7 @@ pub(crate) mod tests {
         .take(5)
         .collect();
         let (mut data_shreds, _coding_shreds, _last_shred_index) = shredder.entries_to_shreds(
+            keypair,
             &entries,
             true, // is_last_in_slot
             next_shred_index,
@@ -346,11 +348,10 @@ pub(crate) mod tests {
         let mut rng = rand::thread_rng();
         let leader = Arc::new(Keypair::new());
         let (slot, parent_slot, reference_tick, version) = (53084024, 53084023, 0, 0);
-        let shredder =
-            Shredder::new(slot, parent_slot, leader.clone(), reference_tick, version).unwrap();
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
         let next_shred_index = rng.gen();
-        let shred1 = new_rand_shred(&mut rng, next_shred_index, &shredder);
-        let shred2 = new_rand_shred(&mut rng, next_shred_index, &shredder);
+        let shred1 = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader);
+        let shred2 = new_rand_shred(&mut rng, next_shred_index, &shredder, &leader);
         let leader_schedule = |s| {
             if s == slot {
                 Some(leader.pubkey())

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1591,8 +1591,7 @@ impl Blockstore {
         let mut remaining_ticks_in_slot = num_slots * ticks_per_slot - num_ticks_in_start_slot;
 
         let mut current_slot = start_slot;
-        let mut shredder =
-            Shredder::new(current_slot, parent_slot, keypair.clone(), 0, version).unwrap();
+        let mut shredder = Shredder::new(current_slot, parent_slot, 0, version).unwrap();
         let mut all_shreds = vec![];
         let mut slot_entries = vec![];
         // Find all the entries for start_slot
@@ -1611,13 +1610,12 @@ impl Blockstore {
                     }
                 };
                 let (mut data_shreds, mut coding_shreds, _) =
-                    shredder.entries_to_shreds(&current_entries, true, start_index);
+                    shredder.entries_to_shreds(keypair, &current_entries, true, start_index);
                 all_shreds.append(&mut data_shreds);
                 all_shreds.append(&mut coding_shreds);
                 shredder = Shredder::new(
                     current_slot,
                     parent_slot,
-                    keypair.clone(),
                     (ticks_per_slot - remaining_ticks_in_slot) as u8,
                     version,
                 )
@@ -1632,7 +1630,7 @@ impl Blockstore {
 
         if !slot_entries.is_empty() {
             let (mut data_shreds, mut coding_shreds, _) =
-                shredder.entries_to_shreds(&slot_entries, is_full_slot, 0);
+                shredder.entries_to_shreds(keypair, &slot_entries, is_full_slot, 0);
             all_shreds.append(&mut data_shreds);
             all_shreds.append(&mut coding_shreds);
         }
@@ -3530,8 +3528,10 @@ pub fn create_new_ledger(
     let last_hash = entries.last().unwrap().hash;
     let version = solana_sdk::shred_version::version_from_hash(&last_hash);
 
-    let shredder = Shredder::new(0, 0, Arc::new(Keypair::new()), 0, version).unwrap();
-    let shreds = shredder.entries_to_shreds(&entries, true, 0).0;
+    let shredder = Shredder::new(0, 0, 0, version).unwrap();
+    let shreds = shredder
+        .entries_to_shreds(&Keypair::new(), &entries, true, 0)
+        .0;
     assert!(shreds.last().unwrap().last_in_slot());
 
     blockstore.insert_shreds(shreds, None, false)?;
@@ -3712,9 +3712,9 @@ pub fn entries_to_test_shreds(
     is_full_slot: bool,
     version: u16,
 ) -> Vec<Shred> {
-    Shredder::new(slot, parent_slot, Arc::new(Keypair::new()), 0, version)
+    Shredder::new(slot, parent_slot, 0, version)
         .unwrap()
-        .entries_to_shreds(&entries, is_full_slot, 0)
+        .entries_to_shreds(&Keypair::new(), &entries, is_full_slot, 0)
         .0
 }
 
@@ -8007,8 +8007,9 @@ pub mod tests {
     ) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
         let entries = make_slot_entries_with_transactions(num_entries);
         let leader_keypair = Arc::new(Keypair::new());
-        let shredder = Shredder::new(slot, parent_slot, leader_keypair.clone(), 0, 0).unwrap();
-        let (data_shreds, coding_shreds, _) = shredder.entries_to_shreds(&entries, true, 0);
+        let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
+        let (data_shreds, coding_shreds, _) =
+            shredder.entries_to_shreds(&leader_keypair, &entries, true, 0);
 
         let genesis_config = create_genesis_config(2).genesis_config;
         let bank = Arc::new(Bank::new(&genesis_config));
@@ -8062,9 +8063,10 @@ pub mod tests {
         let entries1 = make_slot_entries_with_transactions(1);
         let entries2 = make_slot_entries_with_transactions(1);
         let leader_keypair = Arc::new(Keypair::new());
-        let shredder = Shredder::new(slot, 0, leader_keypair, 0, 0).unwrap();
-        let (shreds, _, _) = shredder.entries_to_shreds(&entries1, true, 0);
-        let (duplicate_shreds, _, _) = shredder.entries_to_shreds(&entries2, true, 0);
+        let shredder = Shredder::new(slot, 0, 0, 0).unwrap();
+        let (shreds, _, _) = shredder.entries_to_shreds(&leader_keypair, &entries1, true, 0);
+        let (duplicate_shreds, _, _) =
+            shredder.entries_to_shreds(&leader_keypair, &entries2, true, 0);
         let shred = shreds[0].clone();
         let duplicate_shred = duplicate_shreds[0].clone();
         let non_duplicate_shred = shred.clone();

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -22,7 +22,7 @@ type IndexShredsMap = BTreeMap<u32, Vec<Shred>>;
 fn test_multi_fec_block_coding() {
     let keypair = Arc::new(Keypair::new());
     let slot = 0x1234_5678_9abc_def0;
-    let shredder = Shredder::new(slot, slot - 5, keypair.clone(), 0, 0).unwrap();
+    let shredder = Shredder::new(slot, slot - 5, 0, 0).unwrap();
     let num_fec_sets = 100;
     let num_data_shreds = (MAX_DATA_SHREDS_PER_FEC_BLOCK * num_fec_sets) as usize;
     let keypair0 = Keypair::new();
@@ -46,7 +46,8 @@ fn test_multi_fec_block_coding() {
         .collect();
 
     let serialized_entries = bincode::serialize(&entries).unwrap();
-    let (data_shreds, coding_shreds, next_index) = shredder.entries_to_shreds(&entries, true, 0);
+    let (data_shreds, coding_shreds, next_index) =
+        shredder.entries_to_shreds(&keypair, &entries, true, 0);
     assert_eq!(next_index as usize, num_data_shreds);
     assert_eq!(data_shreds.len(), num_data_shreds);
     assert_eq!(coding_shreds.len(), num_data_shreds);
@@ -190,7 +191,7 @@ fn setup_different_sized_fec_blocks(
     parent_slot: Slot,
     keypair: Arc<Keypair>,
 ) -> (IndexShredsMap, IndexShredsMap, usize) {
-    let shredder = Shredder::new(slot, parent_slot, keypair, 0, 0).unwrap();
+    let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
     let keypair0 = Keypair::new();
     let keypair1 = Keypair::new();
     let tx0 = system_transaction::transfer(&keypair0, &keypair1.pubkey(), 1, Hash::default());
@@ -227,7 +228,7 @@ fn setup_different_sized_fec_blocks(
     for i in 0..2 {
         let is_last = i == 1;
         let (data_shreds, coding_shreds, new_next_index) =
-            shredder.entries_to_shreds(&entries, is_last, next_index);
+            shredder.entries_to_shreds(&keypair, &entries, is_last, next_index);
         for shred in &data_shreds {
             if (shred.index() as usize) == total_num_data_shreds - 1 {
                 assert!(shred.data_complete());


### PR DESCRIPTION
More refactoring to reduce the validator identity keypair surface area across the validator code base:
1. Delete `ClusterInfo::id` field, `my_contact_info()` already holds the id
2. Shredder no longer holds a keypair, the callers can pass it in just as easily
3. Remove redundant `ReplayStageConfig::my_pubkey` field