### PR TITLE
Add metrics for rpc send-transaction failures

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -66,7 +66,7 @@ use {
         stake_history::StakeHistory,
         system_instruction,
         sysvar::stake_history,
-        transaction::{self, Transaction},
+        transaction::{self, Transaction, TransactionError},
     },
     solana_transaction_status::{
         EncodedConfirmedTransaction, Reward, RewardType, TransactionConfirmationStatus,
@@ -2994,12 +2994,14 @@ pub mod rpc_full {
                 match meta.health.check() {
                     RpcHealthStatus::Ok => (),
                     RpcHealthStatus::Unknown => {
+                        inc_new_counter_info!("rpc-send-tx_health-unknown", 1);
                         return Err(RpcCustomError::NodeUnhealthy {
                             num_slots_behind: None,
                         }
                         .into());
                     }
                     RpcHealthStatus::Behind { num_slots } => {
+                        inc_new_counter_info!("rpc-send-tx_health-behind", 1);
                         return Err(RpcCustomError::NodeUnhealthy {
                             num_slots_behind: Some(num_slots),
                         }
@@ -3008,6 +3010,14 @@ pub mod rpc_full {
                 }
 
                 if let (Err(err), logs, _) = preflight_bank.simulate_transaction(&transaction) {
+                    match err {
+                        TransactionError::BlockhashNotFound => {
+                            inc_new_counter_info!("rpc-send-tx_err-blockhash-not-found", 1);
+                        }
+                        _ => {
+                            inc_new_counter_info!("rpc-send-tx_err-other", 1);
+                        }
+                    }
                     return Err(RpcCustomError::SendTransactionPreflightFailure {
                         message: format!("Transaction simulation failed: {}", err),
                         result: RpcSimulateTransactionResult {


### PR DESCRIPTION
#### Problem
We have little visibility into RPC send-transaction failures, which may be important to understanding the health and operation of RPC nodes.

#### Summary of Changes
Add metrics for health-check failures
Add metrics for transaction-simulation failures, noting blockhash-not-found explicitly
