### PR TITLE
ci: fix release build agent targeting

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -3,16 +3,19 @@
 # Pull requests to not run these steps.
 steps:
   - command: "ci/publish-tarball.sh"
-    agents: "release-build"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 60
     name: "publish tarball"
   - wait
   - command: "sdk/docker-solana/build.sh"
-    agents: "release-build"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 60
     name: "publish docker"
   - command: "ci/publish-crate.sh"
-    agents: "release-build"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 240
     name: "publish crate"
     branches: "!master"


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/commit/d43c6eafaf87a671bbd6da8f573e253dcf8c6660 incorrectly specifies agent targeting

#### Summary of Changes

Use correct buildkite v2 syntax
