### PR TITLE
ci: isolate release builds

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -3,16 +3,24 @@
 # Pull requests to not run these steps.
 steps:
   - command: "ci/publish-tarball.sh"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 60
     name: "publish tarball"
   - command: "ci/publish-bpf-sdk.sh"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 5
     name: "publish bpf sdk"
   - wait
   - command: "sdk/docker-solana/build.sh"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 60
     name: "publish docker"
   - command: "ci/publish-crate.sh"
+    agents:
+      - "queue=release-build"
     timeout_in_minutes: 240
     name: "publish crate"
     branches: "!master"


### PR DESCRIPTION
Manual backport of https://github.com/solana-labs/solana/pull/18132 to v1.6
