### PR TITLE
explorer: retain inspector signatures and show simulation error

### DIFF
--- a/explorer/src/pages/inspector/RawInputCard.tsx
+++ b/explorer/src/pages/inspector/RawInputCard.tsx
@@ -33,7 +33,7 @@ function deserializeTransaction(bytes: Uint8Array): {
   return { message, signatures };
 }
 
-const MIN_MESSAGE_LENGTH =
+export const MIN_MESSAGE_LENGTH =
   3 + // header
   1 + // accounts length
   32 + // accounts, must have at least one address for fees


### PR DESCRIPTION
#### Problem
- If a full transaction is pasted into the inspector, the signatures are not encoded in the url.
- When simulation fails, no error message is displayed


