### PR TITLE
Add ability to change the validator identity at runtime

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -32,7 +32,6 @@ use std::{
         Deref,
     },
     path::{Path, PathBuf},
-    sync::Arc,
 };
 use thiserror::Error;
 
@@ -1190,7 +1189,7 @@ impl Tower {
         path.with_extension("bin.new")
     }
 
-    pub fn save(&self, node_keypair: &Arc<Keypair>) -> Result<()> {
+    pub fn save(&self, node_keypair: &Keypair) -> Result<()> {
         let mut measure = Measure::start("tower_save-ms");
 
         if self.node_pubkey != node_keypair.pubkey() {
@@ -1293,7 +1292,7 @@ pub struct SavedTower {
 }
 
 impl SavedTower {
-    pub fn new<T: Signer>(tower: &Tower, keypair: &Arc<T>) -> Result<Self> {
+    pub fn new<T: Signer>(tower: &Tower, keypair: &T) -> Result<Self> {
         let data = bincode::serialize(tower)?;
         let signature = keypair.sign_message(&data);
         Ok(Self { signature, data })
@@ -1391,7 +1390,7 @@ pub mod test {
         collections::HashMap,
         fs::{remove_file, OpenOptions},
         io::{Read, Seek, SeekFrom, Write},
-        sync::RwLock,
+        sync::{Arc, RwLock},
     };
     use tempfile::TempDir;
     use trees::{tr, Tree, TreeWalk};

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -341,7 +341,8 @@ impl ReplayStage {
             .spawn(move || {
                 let verify_recyclers = VerifyRecyclers::default();
                 let _exit = Finalizer::new(exit.clone());
-                let my_pubkey = cluster_info.id();
+                let mut identity_keypair = cluster_info.keypair().clone();
+                let mut my_pubkey = identity_keypair.pubkey();
                 let (
                     mut progress,
                     mut heaviest_subtree_fork_choice,
@@ -517,6 +518,7 @@ impl ReplayStage {
                                                     heaviest_bank_on_same_voted_fork,
                                                     &poh_recorder, my_latest_landed_vote,
                                                     &vote_account,
+                                                    &identity_keypair,
                                                     &authorized_voter_keypairs.read().unwrap(),
                                                     &mut voted_signatures,
                                                     has_new_vote_been_rooted, &mut
@@ -584,6 +586,7 @@ impl ReplayStage {
                             &mut tower,
                             &mut progress,
                             &vote_account,
+                            &identity_keypair,
                             &authorized_voter_keypairs.read().unwrap(),
                             &cluster_info,
                             &blockstore,
@@ -629,6 +632,14 @@ impl ReplayStage {
                                     i64
                                 ),
                             );
+
+                            if my_pubkey != cluster_info.id() {
+                                identity_keypair = cluster_info.keypair().clone();
+                                let my_old_pubkey = my_pubkey;
+                                my_pubkey = identity_keypair.pubkey();
+                                warn!("Identity changed from {} to {}", my_old_pubkey, my_pubkey);
+                            }
+
                             Self::reset_poh_recorder(
                                 &my_pubkey,
                                 &blockstore,
@@ -1293,6 +1304,7 @@ impl ReplayStage {
         tower: &mut Tower,
         progress: &mut ProgressMap,
         vote_account_pubkey: &Pubkey,
+        identity_keypair: &Keypair,
         authorized_voter_keypairs: &[Arc<Keypair>],
         cluster_info: &Arc<ClusterInfo>,
         blockstore: &Arc<Blockstore>,
@@ -1317,7 +1329,7 @@ impl ReplayStage {
         trace!("handle votable bank {}", bank.slot());
         let new_root = tower.record_bank_vote(bank, vote_account_pubkey);
 
-        if let Err(err) = tower.save(&cluster_info.keypair) {
+        if let Err(err) = tower.save(identity_keypair) {
             error!("Unable to save tower: {:?}", err);
             std::process::exit(1);
         }
@@ -1389,6 +1401,7 @@ impl ReplayStage {
             bank,
             poh_recorder,
             vote_account_pubkey,
+            identity_keypair,
             authorized_voter_keypairs,
             tower,
             switch_fork_decision,
@@ -1399,7 +1412,7 @@ impl ReplayStage {
     }
 
     fn generate_vote_tx(
-        node_keypair: &Arc<Keypair>,
+        node_keypair: &Keypair,
         bank: &Bank,
         vote_account_pubkey: &Pubkey,
         authorized_voter_keypairs: &[Arc<Keypair>],
@@ -1468,7 +1481,7 @@ impl ReplayStage {
         let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 
         let blockhash = bank.last_blockhash();
-        vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
+        vote_tx.partial_sign(&[node_keypair], blockhash);
         vote_tx.partial_sign(&[authorized_voter_keypair.as_ref()], blockhash);
 
         if !has_new_vote_been_rooted {
@@ -1491,6 +1504,7 @@ impl ReplayStage {
         poh_recorder: &Mutex<PohRecorder>,
         my_latest_landed_vote: Slot,
         vote_account_pubkey: &Pubkey,
+        identity_keypair: &Keypair,
         authorized_voter_keypairs: &[Arc<Keypair>],
         vote_signatures: &mut Vec<Signature>,
         has_new_vote_been_rooted: bool,
@@ -1529,7 +1543,7 @@ impl ReplayStage {
         // TODO: check the timestamp in this vote is correct, i.e. it shouldn't
         // have changed from the original timestamp of the vote.
         let vote_tx = Self::generate_vote_tx(
-            &cluster_info.keypair,
+            identity_keypair,
             heaviest_bank_on_same_fork,
             vote_account_pubkey,
             authorized_voter_keypairs,
@@ -1566,6 +1580,7 @@ impl ReplayStage {
         bank: &Bank,
         poh_recorder: &Mutex<PohRecorder>,
         vote_account_pubkey: &Pubkey,
+        identity_keypair: &Keypair,
         authorized_voter_keypairs: &[Arc<Keypair>],
         tower: &mut Tower,
         switch_fork_decision: &SwitchForkDecision,
@@ -1575,7 +1590,7 @@ impl ReplayStage {
     ) {
         let mut generate_time = Measure::start("generate_vote");
         let vote_tx = Self::generate_vote_tx(
-            &cluster_info.keypair,
+            identity_keypair,
             bank,
             vote_account_pubkey,
             authorized_voter_keypairs,
@@ -4702,6 +4717,7 @@ mod tests {
         let has_new_vote_been_rooted = false;
         let mut voted_signatures = vec![];
 
+        let identity_keypair = cluster_info.keypair().clone();
         let my_vote_keypair = vec![Arc::new(
             validator_keypairs.remove(&my_pubkey).unwrap().vote_keypair,
         )];
@@ -4727,6 +4743,7 @@ mod tests {
             &bank0,
             &poh_recorder,
             &my_vote_pubkey,
+            &identity_keypair,
             &my_vote_keypair,
             &mut tower,
             &SwitchForkDecision::SameFork,
@@ -4757,6 +4774,7 @@ mod tests {
                 &poh_recorder,
                 Tower::last_voted_slot_in_bank(refresh_bank, &my_vote_pubkey).unwrap(),
                 &my_vote_pubkey,
+                &identity_keypair,
                 &my_vote_keypair,
                 &mut voted_signatures,
                 has_new_vote_been_rooted,
@@ -4779,6 +4797,7 @@ mod tests {
             &bank1,
             &poh_recorder,
             &my_vote_pubkey,
+            &identity_keypair,
             &my_vote_keypair,
             &mut tower,
             &SwitchForkDecision::SameFork,
@@ -4802,6 +4821,7 @@ mod tests {
             &poh_recorder,
             Tower::last_voted_slot_in_bank(&bank2, &my_vote_pubkey).unwrap(),
             &my_vote_pubkey,
+            &identity_keypair,
             &my_vote_keypair,
             &mut voted_signatures,
             has_new_vote_been_rooted,
@@ -4838,6 +4858,7 @@ mod tests {
             &poh_recorder,
             Tower::last_voted_slot_in_bank(&expired_bank, &my_vote_pubkey).unwrap(),
             &my_vote_pubkey,
+            &identity_keypair,
             &my_vote_keypair,
             &mut voted_signatures,
             has_new_vote_been_rooted,
@@ -4894,6 +4915,7 @@ mod tests {
             &poh_recorder,
             Tower::last_voted_slot_in_bank(&expired_bank_sibling, &my_vote_pubkey).unwrap(),
             &my_vote_pubkey,
+            &identity_keypair,
             &my_vote_keypair,
             &mut voted_signatures,
             has_new_vote_been_rooted,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -1,7 +1,11 @@
 use {
     crate::validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     solana_client::rpc_client::RpcClient,
-    solana_gossip::{cluster_info::Node, gossip_service::discover_cluster, socketaddr},
+    solana_gossip::{
+        cluster_info::{ClusterInfo, Node},
+        gossip_service::discover_cluster,
+        socketaddr,
+    },
     solana_ledger::{blockstore::create_new_ledger, create_new_tmp_ledger},
     solana_net_utils::PortRange,
     solana_rpc::rpc::JsonRpcConfig,
@@ -502,7 +506,7 @@ impl TestValidator {
 
         let validator = Some(Validator::new(
             node,
-            &Arc::new(validator_identity),
+            Arc::new(validator_identity),
             &ledger_path,
             &vote_account_address,
             config.authorized_voter_keypairs.clone(),
@@ -598,6 +602,10 @@ impl TestValidator {
         if let Some(validator) = self.validator.take() {
             validator.join();
         }
+    }
+
+    pub fn cluster_info(&self) -> Arc<ClusterInfo> {
+        self.validator.as_ref().unwrap().cluster_info.clone()
     }
 }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2490,11 +2490,12 @@ impl ClusterInfo {
                     .collect()
             })
         };
+
         // Check if there is a duplicate instance of
         // this node with more recent timestamp.
+        let instance = self.instance.read().unwrap();
         let check_duplicate_instance = |values: &[CrdsValue]| {
             if should_check_duplicate_instance {
-                let instance = self.instance.read().unwrap();
                 for value in values {
                     if instance.check_duplicate(value) {
                         return Err(GossipError::DuplicateNodeInstance);

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -955,6 +955,7 @@ impl ClusterInfo {
             None => 0,
         };
         let mut entries = Vec::default();
+        let keypair = self.keypair();
         while !update.is_empty() {
             let ix = (epoch_slot_index % crds_value::MAX_EPOCH_SLOTS) as u8;
             let now = timestamp();
@@ -967,7 +968,7 @@ impl ClusterInfo {
             update = &update[n..];
             if n > 0 {
                 let epoch_slots = CrdsData::EpochSlots(ix, slots);
-                let entry = CrdsValue::new_signed(epoch_slots, &self.keypair());
+                let entry = CrdsValue::new_signed(epoch_slots, &keypair);
                 entries.push(entry);
             }
             epoch_slot_index += 1;
@@ -2286,10 +2287,11 @@ impl ClusterInfo {
     where
         I: IntoIterator<Item = (SocketAddr, Ping)>,
     {
+        let keypair = self.keypair();
         let packets: Vec<_> = pings
             .into_iter()
             .filter_map(|(addr, ping)| {
-                let pong = Pong::new(&ping, &self.keypair()).ok()?;
+                let pong = Pong::new(&ping, &keypair).ok()?;
                 let pong = Protocol::PongMessage(pong);
                 match Packet::from_data(Some(&addr), pong) {
                     Ok(packet) => Some(packet),

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -690,7 +690,7 @@ impl ClusterInfo {
         self.gossip.write().unwrap().set_self(&id);
         {
             let mut instance = self.instance.write().unwrap();
-            *instance = instance.with_id(id);
+            *instance = NodeInstance::new(&mut thread_rng(), id, timestamp());
         }
         *self.keypair.write().unwrap() = new_keypair;
         self.my_contact_info.write().unwrap().id = id;

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2725,9 +2725,9 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    pub fn gossip_contact_info(id: &Pubkey, gossip: SocketAddr, shred_version: u16) -> ContactInfo {
+    pub fn gossip_contact_info(id: Pubkey, gossip: SocketAddr, shred_version: u16) -> ContactInfo {
         ContactInfo {
-            id: *id,
+            id,
             gossip,
             wallclock: timestamp(),
             shred_version,
@@ -2737,7 +2737,7 @@ impl ClusterInfo {
 
     /// An alternative to Spy Node that has a valid gossip address and fully participate in Gossip.
     pub fn gossip_node(
-        id: &Pubkey,
+        id: Pubkey,
         gossip_addr: &SocketAddr,
         shred_version: u16,
     ) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
@@ -2752,7 +2752,7 @@ impl ClusterInfo {
 
     /// A Node with dummy ports to spy on gossip via pull requests
     pub fn spy_node(
-        id: &Pubkey,
+        id: Pubkey,
         shred_version: u16,
     ) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
         let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
@@ -3141,10 +3141,10 @@ mod tests {
     #[test]
     fn test_gossip_node() {
         //check that a gossip nodes always show up as spies
-        let (node, _, _) = ClusterInfo::spy_node(&solana_sdk::pubkey::new_rand(), 0);
+        let (node, _, _) = ClusterInfo::spy_node(solana_sdk::pubkey::new_rand(), 0);
         assert!(ClusterInfo::is_spy_node(&node));
         let (node, _, _) = ClusterInfo::gossip_node(
-            &solana_sdk::pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
             &"1.1.1.1:1111".parse().unwrap(),
             0,
         );
@@ -3424,7 +3424,7 @@ mod tests {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         //check that gossip doesn't try to push to invalid addresses
         let node = Node::new_localhost();
-        let (spy, _, _) = ClusterInfo::spy_node(&solana_sdk::pubkey::new_rand(), 0);
+        let (spy, _, _) = ClusterInfo::spy_node(solana_sdk::pubkey::new_rand(), 0);
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));
         cluster_info.insert_info(spy);
         cluster_info

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -213,7 +213,7 @@ pub struct ClusterInfo {
     /// The network
     pub gossip: RwLock<CrdsGossip>,
     /// set the keypair that will be used to sign crds values generated. It is unset only in tests.
-    pub keypair: Arc<Keypair>,
+    keypair: RwLock<Arc<Keypair>>,
     /// Network entrypoints
     entrypoints: RwLock<Vec<ContactInfo>>,
     outbound_budget: DataBudget,
@@ -224,7 +224,7 @@ pub struct ClusterInfo {
     local_message_pending_push_queue: Mutex<Vec<CrdsValue>>,
     contact_debug_interval: u64, // milliseconds, 0 = disabled
     contact_save_interval: u64,  // milliseconds, 0 = disabled
-    instance: NodeInstance,
+    instance: RwLock<NodeInstance>,
     contact_info_path: PathBuf,
 }
 
@@ -469,7 +469,7 @@ impl ClusterInfo {
         let id = contact_info.id;
         let me = Self {
             gossip: RwLock::new(CrdsGossip::default()),
-            keypair,
+            keypair: RwLock::new(keypair),
             entrypoints: RwLock::new(vec![]),
             outbound_budget: DataBudget::default(),
             my_contact_info: RwLock::new(contact_info),
@@ -481,7 +481,7 @@ impl ClusterInfo {
             socket: UdpSocket::bind("0.0.0.0:0").unwrap(),
             local_message_pending_push_queue: Mutex::default(),
             contact_debug_interval: DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS,
-            instance: NodeInstance::new(&mut thread_rng(), id, timestamp()),
+            instance: RwLock::new(NodeInstance::new(&mut thread_rng(), id, timestamp())),
             contact_info_path: PathBuf::default(),
             contact_save_interval: 0, // disabled
         };
@@ -503,7 +503,7 @@ impl ClusterInfo {
         my_contact_info.id = *new_id;
         ClusterInfo {
             gossip: RwLock::new(gossip),
-            keypair: self.keypair.clone(),
+            keypair: RwLock::new(self.keypair.read().unwrap().clone()),
             entrypoints: RwLock::new(self.entrypoints.read().unwrap().clone()),
             outbound_budget: self.outbound_budget.clone_non_atomic(),
             my_contact_info: RwLock::new(my_contact_info),
@@ -517,7 +517,7 @@ impl ClusterInfo {
                     .clone(),
             ),
             contact_debug_interval: self.contact_debug_interval,
-            instance: NodeInstance::new(&mut thread_rng(), *new_id, timestamp()),
+            instance: RwLock::new(NodeInstance::new(&mut thread_rng(), *new_id, timestamp())),
             contact_info_path: PathBuf::default(),
             contact_save_interval: 0, // disabled
         }
@@ -536,10 +536,10 @@ impl ClusterInfo {
         self.my_contact_info.write().unwrap().wallclock = now;
         let entries: Vec<_> = vec![
             CrdsData::ContactInfo(self.my_contact_info()),
-            CrdsData::NodeInstance(self.instance.with_wallclock(now)),
+            CrdsData::NodeInstance(self.instance.read().unwrap().with_wallclock(now)),
         ]
         .into_iter()
-        .map(|v| CrdsValue::new_signed(v, &self.keypair))
+        .map(|v| CrdsValue::new_signed(v, &self.keypair()))
         .collect();
         self.local_message_pending_push_queue
             .lock()
@@ -553,7 +553,7 @@ impl ClusterInfo {
 
     // TODO kill insert_info, only used by tests
     pub fn insert_info(&self, contact_info: ContactInfo) {
-        let value = CrdsValue::new_signed(CrdsData::ContactInfo(contact_info), &self.keypair);
+        let value = CrdsValue::new_signed(CrdsData::ContactInfo(contact_info), &self.keypair());
         let _ = self.gossip.write().unwrap().crds.insert(value, timestamp());
     }
 
@@ -678,6 +678,25 @@ impl ClusterInfo {
 
     pub fn id(&self) -> Pubkey {
         self.my_contact_info.read().unwrap().id
+    }
+
+    pub fn keypair(&self) -> RwLockReadGuard<Arc<Keypair>> {
+        self.keypair.read().unwrap()
+    }
+
+    pub fn set_keypair(&self, new_keypair: Arc<Keypair>) {
+        let id = new_keypair.pubkey();
+
+        self.gossip.write().unwrap().set_self(&id);
+        {
+            let mut instance = self.instance.write().unwrap();
+            *instance = instance.with_id(id);
+        }
+        *self.keypair.write().unwrap() = new_keypair;
+        self.my_contact_info.write().unwrap().id = id;
+
+        self.insert_self();
+        self.push_self(&HashMap::new(), None);
     }
 
     pub fn lookup_contact_info<F, Y>(&self, id: &Pubkey, map: F) -> Option<Y>
@@ -887,7 +906,7 @@ impl ClusterInfo {
         if min > last {
             let entry = CrdsValue::new_signed(
                 CrdsData::LowestSlot(0, LowestSlot::new(id, min, now)),
-                &self.keypair,
+                &self.keypair(),
             );
             self.local_message_pending_push_queue
                 .lock()
@@ -948,7 +967,7 @@ impl ClusterInfo {
             update = &update[n..];
             if n > 0 {
                 let epoch_slots = CrdsData::EpochSlots(ix, slots);
-                let entry = CrdsValue::new_signed(epoch_slots, &self.keypair);
+                let entry = CrdsValue::new_signed(epoch_slots, &self.keypair());
                 entries.push(entry);
             }
             epoch_slot_index += 1;
@@ -991,7 +1010,7 @@ impl ClusterInfo {
         }
 
         let message = CrdsData::AccountsHashes(SnapshotHash::new(self.id(), accounts_hashes));
-        self.push_message(CrdsValue::new_signed(message, &self.keypair));
+        self.push_message(CrdsValue::new_signed(message, &self.keypair()));
     }
 
     pub fn push_snapshot_hashes(&self, snapshot_hashes: Vec<(Slot, Hash)>) {
@@ -1004,7 +1023,7 @@ impl ClusterInfo {
         }
 
         let message = CrdsData::SnapshotHashes(SnapshotHash::new(self.id(), snapshot_hashes));
-        self.push_message(CrdsValue::new_signed(message, &self.keypair));
+        self.push_message(CrdsValue::new_signed(message, &self.keypair()));
     }
 
     fn push_vote_at_index(&self, vote: Transaction, vote_index: u8) {
@@ -1013,7 +1032,7 @@ impl ClusterInfo {
         let now = timestamp();
         let vote = Vote::new(self_pubkey, vote, now);
         let vote = CrdsData::Vote(vote_index, vote);
-        let vote = CrdsValue::new_signed(vote, &self.keypair);
+        let vote = CrdsValue::new_signed(vote, &self.keypair());
         self.gossip
             .write()
             .unwrap()
@@ -1136,7 +1155,7 @@ impl ClusterInfo {
         other_payload: &[u8],
     ) -> Result<(), GossipError> {
         self.gossip.write().unwrap().push_duplicate_shred(
-            &self.keypair,
+            &self.keypair(),
             shred,
             other_payload,
             None::<fn(Slot) -> Option<Pubkey>>, // Leader schedule
@@ -1431,8 +1450,10 @@ impl ClusterInfo {
     }
 
     fn insert_self(&self) {
-        let value =
-            CrdsValue::new_signed(CrdsData::ContactInfo(self.my_contact_info()), &self.keypair);
+        let value = CrdsValue::new_signed(
+            CrdsData::ContactInfo(self.my_contact_info()),
+            &self.keypair(),
+        );
         let _ = self.gossip.write().unwrap().crds.insert(value, timestamp());
     }
 
@@ -1545,7 +1566,7 @@ impl ClusterInfo {
             let gossip = self.time_gossip_read_lock("new_pull_reqs", &self.stats.new_pull_requests);
             match gossip.new_pull_request(
                 thread_pool,
-                self.keypair.deref(),
+                self.keypair().deref(),
                 now,
                 gossip_validators,
                 stakes,
@@ -1568,7 +1589,7 @@ impl ClusterInfo {
             }
         }
         let self_info = CrdsData::ContactInfo(self.my_contact_info());
-        let self_info = CrdsValue::new_signed(self_info, &self.keypair);
+        let self_info = CrdsValue::new_signed(self_info, &self.keypair());
         let pulls = pulls
             .into_iter()
             .flat_map(|(peer, filters)| repeat(peer.gossip).zip(filters))
@@ -1804,10 +1825,12 @@ impl ClusterInfo {
                 let recycler = PacketsRecycler::default();
                 let crds_data = vec![
                     CrdsData::Version(Version::new(self.id())),
-                    CrdsData::NodeInstance(self.instance.with_wallclock(timestamp())),
+                    CrdsData::NodeInstance(
+                        self.instance.read().unwrap().with_wallclock(timestamp()),
+                    ),
                 ];
                 for value in crds_data {
-                    let value = CrdsValue::new_signed(value, &self.keypair);
+                    let value = CrdsValue::new_signed(value, &self.keypair());
                     self.push_message(value);
                 }
                 let mut generate_pull_requests = true;
@@ -1997,7 +2020,7 @@ impl ClusterInfo {
         R: Rng + CryptoRng,
     {
         let mut cache = HashMap::<(Pubkey, SocketAddr), bool>::new();
-        let mut pingf = move || Ping::new_rand(&mut rng, &self.keypair).ok();
+        let mut pingf = move || Ping::new_rand(&mut rng, &self.keypair()).ok();
         let mut ping_cache = self.ping_cache.lock().unwrap();
         let mut hard_check = move |node| {
             let (check, ping) = ping_cache.check(now, node, &mut pingf);
@@ -2266,7 +2289,7 @@ impl ClusterInfo {
         let packets: Vec<_> = pings
             .into_iter()
             .filter_map(|(addr, ping)| {
-                let pong = Pong::new(&ping, &self.keypair).ok()?;
+                let pong = Pong::new(&ping, &self.keypair()).ok()?;
                 let pong = Protocol::PongMessage(pong);
                 match Packet::from_data(Some(&addr), pong) {
                     Ok(packet) => Some(packet),
@@ -2368,7 +2391,7 @@ impl ClusterInfo {
                             destination: from,
                             wallclock,
                         };
-                        prune_data.sign(&self.keypair);
+                        prune_data.sign(&self.keypair());
                         let prune_message = Protocol::PruneMessage(self_pubkey, prune_data);
                         Some((peer.gossip, prune_message))
                     })
@@ -2469,8 +2492,9 @@ impl ClusterInfo {
         // this node with more recent timestamp.
         let check_duplicate_instance = |values: &[CrdsValue]| {
             if should_check_duplicate_instance {
+                let instance = self.instance.read().unwrap();
                 for value in values {
-                    if self.instance.check_duplicate(value) {
+                    if instance.check_duplicate(value) {
                         return Err(GossipError::DuplicateNodeInstance);
                     }
                 }
@@ -3567,7 +3591,7 @@ mod tests {
             .unwrap()
             .new_pull_request(
                 &thread_pool,
-                cluster_info.keypair.deref(),
+                cluster_info.keypair().deref(),
                 timestamp(),
                 None,
                 &HashMap::new(),

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -407,11 +407,6 @@ impl NodeInstance {
         }
     }
 
-    // Clones the value with an updated id.
-    pub(crate) fn with_id(&self, from: Pubkey) -> Self {
-        Self { from, ..*self }
-    }
-
     // Clones the value with an updated wallclock.
     pub(crate) fn with_wallclock(&self, wallclock: u64) -> Self {
         Self { wallclock, ..*self }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -395,24 +395,26 @@ pub struct NodeInstance {
 }
 
 impl NodeInstance {
-    pub fn new<R>(rng: &mut R, pubkey: Pubkey, now: u64) -> Self
+    pub fn new<R>(rng: &mut R, from: Pubkey, now: u64) -> Self
     where
         R: Rng + CryptoRng,
     {
         Self {
-            from: pubkey,
+            from,
             wallclock: now,
             timestamp: now,
             token: rng.gen(),
         }
     }
 
+    // Clones the value with an updated id.
+    pub(crate) fn with_id(&self, from: Pubkey) -> Self {
+        Self { from, ..*self }
+    }
+
     // Clones the value with an updated wallclock.
-    pub(crate) fn with_wallclock(&self, now: u64) -> Self {
-        Self {
-            wallclock: now,
-            ..*self
-        }
+    pub(crate) fn with_wallclock(&self, wallclock: u64) -> Self {
+        Self { wallclock, ..*self }
     }
 
     // Returns true if the crds-value is a duplicate instance

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -121,7 +121,7 @@ pub fn discover_cluster(
 }
 
 pub fn discover(
-    keypair: Option<Arc<Keypair>>,
+    keypair: Option<Keypair>,
     entrypoint: Option<&SocketAddr>,
     num_nodes: Option<usize>, // num_nodes only counts validators, excludes spy nodes
     timeout: Duration,
@@ -133,8 +133,10 @@ pub fn discover(
     Vec<ContactInfo>, // all gossip peers
     Vec<ContactInfo>, // tvu peers (validators)
 )> {
-    let keypair = keypair.unwrap_or_else(|| Arc::new(Keypair::new()));
-
+    let keypair = {
+        #[allow(clippy::redundant_closure)]
+        keypair.unwrap_or_else(|| Keypair::new())
+    };
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, ip_echo, spy_ref) = make_gossip_node(
         keypair,
@@ -295,7 +297,7 @@ fn spy(
 /// Makes a spy or gossip node based on whether or not a gossip_addr was passed in
 /// Pass in a gossip addr to fully participate in gossip instead of relying on just pulls
 fn make_gossip_node(
-    keypair: Arc<Keypair>,
+    keypair: Keypair,
     entrypoint: Option<&SocketAddr>,
     exit: &Arc<AtomicBool>,
     gossip_addr: Option<&SocketAddr>,
@@ -307,7 +309,7 @@ fn make_gossip_node(
     } else {
         ClusterInfo::spy_node(keypair.pubkey(), shred_version)
     };
-    let cluster_info = ClusterInfo::new(node, keypair);
+    let cluster_info = ClusterInfo::new(node, Arc::new(keypair));
     if let Some(entrypoint) = entrypoint {
         cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(entrypoint));
     }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -303,9 +303,9 @@ fn make_gossip_node(
     should_check_duplicate_instance: bool,
 ) -> (GossipService, Option<TcpListener>, Arc<ClusterInfo>) {
     let (node, gossip_socket, ip_echo) = if let Some(gossip_addr) = gossip_addr {
-        ClusterInfo::gossip_node(&keypair.pubkey(), gossip_addr, shred_version)
+        ClusterInfo::gossip_node(keypair.pubkey(), gossip_addr, shred_version)
     } else {
-        ClusterInfo::spy_node(&keypair.pubkey(), shred_version)
+        ClusterInfo::spy_node(keypair.pubkey(), shred_version)
     };
     let cluster_info = ClusterInfo::new(node, keypair);
     if let Some(entrypoint) = entrypoint {

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -15,7 +15,6 @@ use {
         error,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         process::exit,
-        sync::Arc,
         time::Duration,
     },
 };
@@ -225,7 +224,7 @@ fn process_spy(matches: &ArgMatches) -> std::io::Result<()> {
         .value_of("node_pubkey")
         .map(|pubkey_str| pubkey_str.parse::<Pubkey>().unwrap());
     let shred_version = value_t_or_exit!(matches, "shred_version", u16);
-    let identity_keypair = keypair_of(matches, "identity").map(Arc::new);
+    let identity_keypair = keypair_of(matches, "identity");
 
     let entrypoint_addr = parse_entrypoint(matches);
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -211,7 +211,7 @@ impl LocalCluster {
 
         let leader_server = Validator::new(
             leader_node,
-            &leader_keypair,
+            leader_keypair.clone(),
             &leader_ledger_path,
             &leader_vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
@@ -353,7 +353,7 @@ impl LocalCluster {
         let voting_keypair = voting_keypair.unwrap();
         let validator_server = Validator::new(
             validator_node,
-            &validator_keypair,
+            validator_keypair.clone(),
             &ledger_path,
             &voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![voting_keypair.clone()])),
@@ -667,7 +667,7 @@ impl Cluster for LocalCluster {
             vec![validator_info.ledger_path.join("accounts")];
         let restarted_node = Validator::new(
             node,
-            &validator_info.keypair,
+            validator_info.keypair.clone(),
             &validator_info.ledger_path,
             &validator_info.voting_keypair.pubkey(),
             Arc::new(RwLock::new(vec![validator_info.voting_keypair.clone()])),

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -32,7 +32,7 @@ use {
         net::{IpAddr, Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
         process::exit,
-        sync::mpsc::channel,
+        sync::{mpsc::channel, Arc, RwLock},
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
 };
@@ -501,6 +501,7 @@ fn main() {
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
 
+    let admin_service_cluster_info = Arc::new(RwLock::new(None));
     admin_rpc_service::run(
         &ledger_path,
         admin_rpc_service::AdminRpcRequestMetadata {
@@ -512,6 +513,7 @@ fn main() {
             start_time: std::time::SystemTime::now(),
             validator_exit: genesis.validator_exit.clone(),
             authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
+            cluster_info: admin_service_cluster_info.clone(),
         },
     );
     let dashboard = if output == Output::Dashboard {
@@ -584,6 +586,7 @@ fn main() {
 
     match genesis.start_with_mint_address(mint_address) {
         Ok(test_validator) => {
+            *admin_service_cluster_info.write().unwrap() = Some(test_validator.cluster_info());
             if let Some(dashboard) = dashboard {
                 dashboard.run(Duration::from_millis(250));
             }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -360,7 +360,7 @@ fn start_gossip_node(
 ) -> (Arc<ClusterInfo>, Arc<AtomicBool>, GossipService) {
     let mut cluster_info = ClusterInfo::new(
         ClusterInfo::gossip_contact_info(
-            &identity_keypair.pubkey(),
+            identity_keypair.pubkey(),
             *gossip_addr,
             expected_shred_version.unwrap_or(0),
         ),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -349,7 +349,7 @@ fn get_trusted_snapshot_hashes(
 }
 
 fn start_gossip_node(
-    identity_keypair: &Arc<Keypair>,
+    identity_keypair: Arc<Keypair>,
     cluster_entrypoints: &[ContactInfo],
     ledger_path: &Path,
     gossip_addr: &SocketAddr,
@@ -358,14 +358,12 @@ fn start_gossip_node(
     gossip_validators: Option<HashSet<Pubkey>>,
     should_check_duplicate_instance: bool,
 ) -> (Arc<ClusterInfo>, Arc<AtomicBool>, GossipService) {
-    let mut cluster_info = ClusterInfo::new(
-        ClusterInfo::gossip_contact_info(
-            identity_keypair.pubkey(),
-            *gossip_addr,
-            expected_shred_version.unwrap_or(0),
-        ),
-        identity_keypair.clone(),
+    let contact_info = ClusterInfo::gossip_contact_info(
+        identity_keypair.pubkey(),
+        *gossip_addr,
+        expected_shred_version.unwrap_or(0),
     );
+    let mut cluster_info = ClusterInfo::new(contact_info, identity_keypair);
     cluster_info.set_entrypoints(cluster_entrypoints.to_vec());
     cluster_info.restore_contact_info(ledger_path, 0);
     let cluster_info = Arc::new(cluster_info);
@@ -775,7 +773,7 @@ fn rpc_bootstrap(
             *start_progress.write().unwrap() = ValidatorStartProgress::SearchingForRpcService;
 
             gossip = Some(start_gossip_node(
-                identity_keypair,
+                identity_keypair.clone(),
                 cluster_entrypoints,
                 ledger_path,
                 &node.info.gossip,
@@ -1915,6 +1913,20 @@ pub fn main() {
             .about("Run the validator")
         )
         .subcommand(
+            SubCommand::with_name("set-identity")
+            .about("Set the validator identity")
+            .arg(
+                Arg::with_name("identity")
+                    .index(1)
+                    .value_name("KEYPAIR")
+                    .takes_value(true)
+                    .validator(is_keypair)
+                    .help("Validator identity keypair")
+            )
+            .after_help("Note: the new identity only applies to the \
+                         currently running validator instance")
+        )
+        .subcommand(
             SubCommand::with_name("set-log-filter")
             .about("Adjust the validator log filter")
             .arg(
@@ -2028,6 +2040,29 @@ pub fn main() {
             monitor_validator(&ledger_path);
             return;
         }
+        ("set-identity", Some(subcommand_matches)) => {
+            let identity_keypair = value_t_or_exit!(subcommand_matches, "identity", String);
+
+            let identity_keypair = fs::canonicalize(&identity_keypair).unwrap_or_else(|err| {
+                println!("Unable to access path: {}: {:?}", identity_keypair, err);
+                exit(1);
+            });
+            println!("Validator identity: {}", identity_keypair.display());
+
+            let admin_client = admin_rpc_service::connect(&ledger_path);
+            admin_rpc_service::runtime()
+                .block_on(async move {
+                    admin_client
+                        .await?
+                        .set_identity(identity_keypair.display().to_string())
+                        .await
+                })
+                .unwrap_or_else(|err| {
+                    println!("setIdentity request failed: {}", err);
+                    exit(1);
+                });
+            return;
+        }
         ("set-log-filter", Some(subcommand_matches)) => {
             let filter = value_t_or_exit!(subcommand_matches, "filter", String);
             let admin_client = admin_rpc_service::connect(&ledger_path);
@@ -2050,17 +2085,21 @@ pub fn main() {
         _ => unreachable!(),
     };
 
-    let identity_keypair = Arc::new(keypair_of(&matches, "identity").unwrap_or_else(|| {
+    let identity_keypair = keypair_of(&matches, "identity").unwrap_or_else(|| {
         clap::Error::with_description(
             "The --identity <KEYPAIR> argument is required",
             clap::ErrorKind::ArgumentNotFound,
         )
         .exit();
-    }));
+    });
 
     let authorized_voter_keypairs = keypairs_of(&matches, "authorized_voter_keypairs")
         .map(|keypairs| keypairs.into_iter().map(Arc::new).collect())
-        .unwrap_or_else(|| vec![identity_keypair.clone()]);
+        .unwrap_or_else(|| {
+            vec![Arc::new(
+                keypair_of(&matches, "identity").expect("identity"),
+            )]
+        });
     let authorized_voter_keypairs = Arc::new(RwLock::new(authorized_voter_keypairs));
 
     let init_complete_file = matches.value_of("init_complete_file");
@@ -2472,6 +2511,7 @@ pub fn main() {
     info!("Starting validator with: {:#?}", std::env::args_os());
 
     let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
+    let admin_service_cluster_info = Arc::new(RwLock::new(None));
     admin_rpc_service::run(
         &ledger_path,
         admin_rpc_service::AdminRpcRequestMetadata {
@@ -2480,6 +2520,7 @@ pub fn main() {
             validator_exit: validator_config.validator_exit.clone(),
             start_progress: start_progress.clone(),
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
+            cluster_info: admin_service_cluster_info.clone(),
         },
     );
 
@@ -2582,6 +2623,8 @@ pub fn main() {
     solana_ledger::entry::init_poh();
     solana_runtime::snapshot_utils::remove_tmp_snapshot_archives(&snapshot_output_dir);
 
+    let identity_keypair = Arc::new(identity_keypair);
+
     let should_check_duplicate_instance = !matches.is_present("no_duplicate_instance_check");
     if !cluster_entrypoints.is_empty() {
         rpc_bootstrap(
@@ -2612,7 +2655,7 @@ pub fn main() {
 
     let validator = Validator::new(
         node,
-        &identity_keypair,
+        identity_keypair,
         &ledger_path,
         &vote_account,
         authorized_voter_keypairs,
@@ -2621,6 +2664,7 @@ pub fn main() {
         should_check_duplicate_instance,
         start_progress,
     );
+    *admin_service_cluster_info.write().unwrap() = Some(validator.cluster_info.clone());
 
     if let Some(filename) = init_complete_file {
         File::create(filename).unwrap_or_else(|_| {


### PR DESCRIPTION
```
$ solana-validator set-identity --help
Set the validator identity

USAGE:
    solana-validator --ledger <DIR> set-identity [KEYPAIR]

FLAGS:
    -h, --help    Prints help information

ARGS:
    <KEYPAIR>    Validator identity keypair

Note: the new identity only applies to the currently running validator instance
```
