### PR TITLE
DOCS: Update leader-rotation.md

### DIFF
--- a/docs/src/cluster/leader-rotation.md
+++ b/docs/src/cluster/leader-rotation.md
@@ -19,7 +19,7 @@ Without a partition lasting longer than an epoch, the cluster will work as follo
 
 For example:
 
-The epoch duration is 100 slots. The root fork is updated from fork computed at slot height 99 to a fork computed at slot height 102. Forks with slots at height 100, 101 were skipped because of failures. The new leader schedule is computed using fork at slot height 102. It is active from slot 200 until it is updated again.
+Let's assume an epoch duration of 100 slots, which in reality is magnitudes higher. The root fork is updated from fork computed at slot height 99 to a fork computed at slot height 102. Forks with slots at height 100, 101 were skipped because of failures. The new leader schedule is computed using fork at slot height 102. It is active from slot 200 until it is updated again.
 
 No inconsistency can exist because every validator that is voting with the cluster has skipped 100 and 101 when its root passes 102. All validators, regardless of voting pattern, would be committing to a root that is either 102, or a descendant of 102.
 


### PR DESCRIPTION
#### Problem
Confusing wording regarding epoch length, which is stated as 100.  ("For example" does not really mean "100 is fictional")

![grafik](https://user-images.githubusercontent.com/37071670/123271689-61f40e00-d501-11eb-8bf7-23643ca851ae.png)

#### Summary of Changes
Made clear it's a fictive number

