### PR TITLE
rework dirty_pubkeys from insert_new_if_missing_into_primary_index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5872,13 +5872,10 @@ impl AccountsDb {
 
     fn generate_index_for_slot<'a>(&self, accounts_map: GenerateIndexAccountsMap<'a>, slot: &Slot) {
         if !accounts_map.is_empty() {
-            let len = accounts_map.len();
-
-            let mut items = Vec::with_capacity(len);
-            let mut dirty_pubkeys = accounts_map
+            let items = accounts_map
                 .iter()
                 .map(|(pubkey, (_, store_id, stored_account))| {
-                    items.push((
+                    (
                         pubkey,
                         AccountInfo {
                             store_id: *store_id,
@@ -5886,25 +5883,17 @@ impl AccountsDb {
                             stored_size: stored_account.stored_size,
                             lamports: stored_account.account_meta.lamports,
                         },
-                    ));
-                    *pubkey
+                    )
                 })
                 .collect::<Vec<_>>();
 
-            let items_len = items.len();
-            let dirty_pubkey_mask = self
+            let dirty_pubkeys = self
                 .accounts_index
                 .insert_new_if_missing_into_primary_index(*slot, items);
 
-            assert_eq!(dirty_pubkey_mask.len(), items_len);
-
-            let mut dirty_pubkey_mask_iter = dirty_pubkey_mask.iter();
-
-            // dirty_pubkey_mask will return true if an item has multiple rooted entries for
+            // dirty_pubkeys will contain a pubkey if an item has multiple rooted entries for
             // a given pubkey. If there is just a single item, there is no cleaning to
-            // be done on that pubkey. Prune the touched pubkey set here for only those
-            // pubkeys with multiple updates.
-            dirty_pubkeys.retain(|_k| *dirty_pubkey_mask_iter.next().unwrap());
+            // be done on that pubkey. Use only those pubkeys with multiple updates.
             if !dirty_pubkeys.is_empty() {
                 self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
             }


### PR DESCRIPTION
#### Problem
When we rework how we generate the initial accounts index, it becomes difficult to return a mask for finding dirty pubkeys.
#### Summary of Changes
Directly return a list of dirty pubkeys, which is what the calling function has to create anyway.
Fixes #
