### PR TITLE
stop doing clean and shrink at validator startup

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -35,7 +35,8 @@ use solana_rpc::{
 };
 use solana_runtime::{
     accounts_background_service::{
-        AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
+        AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequest,
+        SnapshotRequestHandler,
     },
     accounts_db::AccountShrinkThreshold,
     bank_forks::{BankForks, SnapshotConfig},
@@ -247,6 +248,12 @@ impl Tvu {
         }
 
         let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender);
+
+        accounts_background_request_sender.send_snapshot_request(SnapshotRequest {
+            snapshot_root_bank: bank_forks.read().unwrap().working_bank(),
+            status_cache_slot_deltas: vec![],
+            just_clean_and_shrink: true,
+        });
 
         let accounts_background_request_handler = AbsRequestHandler {
             snapshot_request_handler,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4697,20 +4697,6 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self, test_hash_calculation: bool) -> bool {
-        info!("cleaning..");
-        let mut clean_time = Measure::start("clean");
-        if self.slot() > 0 {
-            self.clean_accounts(true, true);
-        }
-        clean_time.stop();
-
-        info!("shrinking..");
-        let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
-        if self.slot() > 0 {
-            self.shrink_all_slots(true);
-        }
-        shrink_all_slots_time.stop();
-
         info!("verify_bank_hash..");
         let mut verify_time = Measure::start("verify_bank_hash");
         let mut verify = self.verify_bank_hash(test_hash_calculation);
@@ -4724,8 +4710,6 @@ impl Bank {
 
         datapoint_info!(
             "verify_snapshot_bank",
-            ("clean_us", clean_time.as_us(), i64),
-            ("shrink_all_slots_us", shrink_all_slots_time.as_us(), i64),
             ("verify_bank_hash_us", verify_time.as_us(), i64),
             ("verify_hash_us", verify2_time.as_us(), i64),
         );

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -259,6 +259,7 @@ impl BankForks {
                             // if another `set_root()` is called before the snapshots package
                             // can be generated
                             status_cache_slot_deltas: bank.src.slot_deltas(&bank.src.roots()),
+                            just_clean_and_shrink: false,
                         })
                     {
                         warn!(


### PR DESCRIPTION
#### Problem
Validator startup does not need to clean and shrink prior to starting processing transactions. Clean and shrink operate as part of the accounts background service in a running validator.
#### Summary of Changes
Remove clean and shrink from verify_snapshot_bank.
Fixes #
