### PR TITLE
Plumbing for `snapshot_info`

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -217,8 +217,7 @@ impl AccountsHashVerifier {
 mod tests {
     use super::*;
     use solana_gossip::{cluster_info::make_accounts_hashes_message, contact_info::ContactInfo};
-    use solana_runtime::bank_forks::ArchiveFormat;
-    use solana_runtime::snapshot_utils::SnapshotVersion;
+    use solana_runtime::snapshot_utils::{ArchiveFormat, SnapshotVersion};
     use solana_sdk::{
         hash::hash,
         signature::{Keypair, Signer},

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,8 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_package::AccountsPackage, snapshot_runtime_info,
-    snapshot_runtime_info::SyncSnapshotRuntimeInfo, snapshot_utils,
+    snapshot_package::AccountsPackage,
+    snapshot_runtime_info::{self, SyncSnapshotRuntimeInfo},
+    snapshot_utils,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
@@ -88,9 +89,8 @@ mod tests {
     use solana_runtime::{
         accounts_db::AccountStorageEntry,
         bank::BankSlotDelta,
-        bank_forks::ArchiveFormat,
         snapshot_package::AccountsPackage,
-        snapshot_utils::{self, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
+        snapshot_utils::{self, ArchiveFormat, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_sdk::hash::Hash;
     use std::{

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -6,10 +6,11 @@ use {
     solana_net_utils::PortRange,
     solana_rpc::rpc::JsonRpcConfig,
     solana_runtime::{
-        bank_forks::{ArchiveFormat, SnapshotConfig, SnapshotVersion},
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_utils::DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+        snapshot_config::SnapshotConfig,
+        snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+        snapshot_utils::{ArchiveFormat, SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -489,6 +490,7 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+                snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -38,8 +38,9 @@ use solana_runtime::{
         AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
     },
     accounts_db::AccountShrinkThreshold,
-    bank_forks::{BankForks, SnapshotConfig},
+    bank_forks::BankForks,
     commitment::BlockCommitmentCache,
+    snapshot_config::SnapshotConfig,
     vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -57,9 +57,10 @@ use solana_runtime::{
     accounts_db::AccountShrinkThreshold,
     accounts_index::AccountSecondaryIndexes,
     bank::Bank,
-    bank_forks::{BankForks, SnapshotConfig},
+    bank_forks::BankForks,
     commitment::BlockCommitmentCache,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    snapshot_config::SnapshotConfig,
     snapshot_runtime_info::SyncSnapshotRuntimeInfo,
 };
 use solana_sdk::{

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -60,6 +60,7 @@ use solana_runtime::{
     bank_forks::{BankForks, SnapshotConfig},
     commitment::BlockCommitmentCache,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
 };
 use solana_sdk::{
     clock::Slot,
@@ -359,6 +360,7 @@ impl Validator {
                 .register_exit(Box::new(move || exit.store(true, Ordering::Relaxed)));
         }
 
+        let snapshot_runtime_info = SyncSnapshotRuntimeInfo::default();
         let (replay_vote_sender, replay_vote_receiver) = unbounded();
         let (
             genesis_config,
@@ -388,6 +390,7 @@ impl Validator {
             config.enforce_ulimit_nofile,
             &start_progress,
             config.no_poh_speed_test,
+            Some(snapshot_runtime_info.clone()),
         );
 
         *start_progress.write().unwrap() = ValidatorStartProgress::StartingServices;
@@ -614,6 +617,7 @@ impl Validator {
                     &exit,
                     &cluster_info,
                     snapshot_config.maximum_snapshots_to_retain,
+                    Some(snapshot_runtime_info),
                 );
                 (
                     Some(snapshot_packager_service),
@@ -1022,7 +1026,7 @@ fn post_process_restored_tower(
         })
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn new_banks_from_ledger(
     validator_identity: &Pubkey,
     vote_account: &Pubkey,
@@ -1033,6 +1037,7 @@ fn new_banks_from_ledger(
     enforce_ulimit_nofile: bool,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
     no_poh_speed_test: bool,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> (
     GenesisConfig,
     BankForks,
@@ -1147,6 +1152,7 @@ fn new_banks_from_ledger(
         transaction_history_services
             .cache_block_meta_sender
             .as_ref(),
+        snapshot_runtime_info,
     )
     .unwrap_or_else(|err| {
         error!("Failed to load ledger: {:?}", err);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -108,6 +108,7 @@ mod tests {
                 false,
                 accounts_db::AccountShrinkThreshold::default(),
                 false,
+                None,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);
@@ -170,6 +171,7 @@ mod tests {
             None,
             accounts_db::AccountShrinkThreshold::default(),
             check_hash_calculation,
+            None,
         )
         .unwrap();
 
@@ -451,6 +453,7 @@ mod tests {
             &exit,
             &cluster_info,
             DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+            None,
         );
 
         let thread_pool = accounts_db::make_min_priority_thread_pool();

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -46,10 +46,11 @@ mod tests {
         accounts_db,
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta},
-        bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
+        bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        snapshot_utils,
-        snapshot_utils::{SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
+        snapshot_config::SnapshotConfig,
+        snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+        snapshot_utils::{self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
         status_cache::MAX_CACHE_ENTRIES,
     };
     use solana_sdk::{
@@ -121,6 +122,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
                 maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+                snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -2,7 +2,7 @@
 use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
-use solana_runtime::{bank_forks::ArchiveFormat, snapshot_utils};
+use solana_runtime::{snapshot_utils, snapshot_utils::ArchiveFormat};
 use solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE, hash::Hash};
 use std::fs::{self, File};
 use std::io;

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -722,6 +722,7 @@ fn load_bank_forks(
         process_options,
         None,
         None,
+        None,
     )
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,10 +27,11 @@ use solana_ledger::{
 };
 use solana_runtime::{
     bank::{Bank, RewardCalculationEvent},
-    bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
+    bank_forks::BankForks,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
-    snapshot_utils,
-    snapshot_utils::{SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
+    snapshot_config::SnapshotConfig,
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+    snapshot_utils::{self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
 };
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -692,6 +693,7 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+            snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -10,6 +10,7 @@ use crate::{
 use log::*;
 use solana_runtime::{
     bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
     snapshot_utils,
 };
 use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash};
@@ -42,6 +43,7 @@ pub fn load(
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> LoadResult {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
@@ -70,6 +72,7 @@ pub fn load(
                 archive_slot,
                 archive_hash,
                 archive_format,
+                snapshot_runtime_info,
             );
         } else {
             info!("No snapshot package available; will load from genesis");
@@ -121,6 +124,7 @@ fn load_from_snapshot(
     archive_slot: Slot,
     archive_hash: Hash,
     archive_format: ArchiveFormat,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> LoadResult {
     info!("Loading snapshot package: {:?}", archive_filename);
 
@@ -144,6 +148,7 @@ fn load_from_snapshot(
         process_options.limit_load_slot_count_from_snapshot,
         process_options.shrink_ratio,
         process_options.accounts_db_test_hash_calculation,
+        snapshot_runtime_info,
     )
     .expect("Load from snapshot failed");
     if let Some(shrink_paths) = shrink_paths {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -9,9 +9,10 @@ use crate::{
 };
 use log::*;
 use solana_runtime::{
-    bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
+    bank_forks::BankForks,
+    snapshot_config::SnapshotConfig,
     snapshot_runtime_info::SyncSnapshotRuntimeInfo,
-    snapshot_utils,
+    snapshot_utils::{self, ArchiveFormat},
 };
 use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash};
 use std::{fs, path::PathBuf, process, result};

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -407,6 +407,7 @@ pub fn process_blockstore(
         opts.accounts_db_caching_enabled,
         opts.shrink_ratio,
         false,
+        None,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");
@@ -3117,6 +3118,7 @@ pub mod tests {
             false,
             AccountShrinkThreshold::default(),
             false,
+            None,
         );
         *bank.epoch_schedule()
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -37,8 +37,9 @@ use solana_local_cluster::{
     validator_configs::*,
 };
 use solana_runtime::{
-    bank_forks::{ArchiveFormat, SnapshotConfig},
-    snapshot_utils,
+    snapshot_config::SnapshotConfig,
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+    snapshot_utils::{self, ArchiveFormat},
 };
 use solana_sdk::{
     account::AccountSharedData,
@@ -3173,6 +3174,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+        snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
     };
 
     // Create the account paths

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -44,10 +44,11 @@ use {
         accounts::AccountAddressFilter,
         accounts_index::{AccountIndex, AccountSecondaryIndexes, IndexKey},
         bank::Bank,
-        bank_forks::{BankForks, SnapshotConfig},
+        bank_forks::BankForks,
         commitment::{BlockCommitmentArray, BlockCommitmentCache, CommitmentSlots},
         inline_spl_token_v2_0::{SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
         non_circulating_supply::calculate_non_circulating_supply,
+        snapshot_config::SnapshotConfig,
         snapshot_utils::get_highest_snapshot_archive_path,
     },
     solana_sdk::{

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -23,8 +23,7 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::{
-        bank_forks::{BankForks, SnapshotConfig},
-        commitment::BlockCommitmentCache,
+        bank_forks::BankForks, commitment::BlockCommitmentCache, snapshot_config::SnapshotConfig,
         snapshot_utils,
     },
     solana_sdk::{
@@ -490,8 +489,9 @@ mod tests {
             get_tmp_ledger_path,
         },
         solana_runtime::{
-            bank::Bank, bank_forks::ArchiveFormat, snapshot_utils::SnapshotVersion,
-            snapshot_utils::DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+            bank::Bank,
+            snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+            snapshot_utils::{ArchiveFormat, SnapshotVersion, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
         },
         solana_sdk::{
             genesis_config::{ClusterType, DEFAULT_GENESIS_ARCHIVE},
@@ -598,6 +598,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+                snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -62,6 +62,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
         false,
         AccountShrinkThreshold::default(),
         false,
+        None,
     );
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -83,6 +84,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         false,
         AccountShrinkThreshold::default(),
         false,
+        None,
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&prev_bank, &mut pubkeys, 250_000).unwrap();
@@ -109,6 +111,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     let num_accounts = 60_000;
@@ -136,6 +139,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
@@ -154,6 +158,7 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
@@ -171,6 +176,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     let mut old_pubkey = Pubkey::default();
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -205,6 +211,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     ));
     let num_keys = 1000;
     let slot = 0;
@@ -341,6 +348,7 @@ fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (AccountSharedD
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     ));
 
     let dashmap = DashMap::new();
@@ -396,6 +404,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
     let mut rng = rand::thread_rng();
     for _ in 0..10_000 {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     blockhash_queue::BlockhashQueue,
     rent_collector::RentCollector,
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
 };
 use dashmap::{
@@ -129,6 +130,7 @@ impl Accounts {
             AccountSecondaryIndexes::default(),
             false,
             shrink_ratio,
+            None,
         )
     }
 
@@ -138,6 +140,7 @@ impl Accounts {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
+        snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -146,6 +149,7 @@ impl Accounts {
                 account_indexes,
                 caching_enabled,
                 shrink_ratio,
+                snapshot_runtime_info,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
         }
@@ -1147,6 +1151,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         for ka in ka.iter() {
             accounts.store_slow_uncached(0, &ka.0, &ka.1);
@@ -1685,6 +1690,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         // Load accounts owned by various programs into AccountsDb
@@ -1714,6 +1720,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -1738,6 +1745,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.bank_hash_at(1);
     }
@@ -1760,6 +1768,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -1887,6 +1896,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         accounts.store_slow_uncached(0, &keypair0.pubkey(), &account0);
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
@@ -2038,6 +2048,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         {
             accounts
@@ -2091,6 +2102,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -2139,6 +2151,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         let instructions_key = solana_sdk::sysvar::instructions::id();
@@ -2425,6 +2438,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2545,6 +2559,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
         let collected_accounts = accounts.collect_accounts_to_store(
             txs.iter(),
@@ -2580,6 +2595,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
+            None,
         );
 
         let pubkey0 = Pubkey::new_unique();

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -4,7 +4,8 @@
 
 use crate::{
     bank::{Bank, BankSlotDelta, DropCallback},
-    bank_forks::{BankForks, SnapshotConfig},
+    bank_forks::BankForks,
+    snapshot_config::SnapshotConfig,
     snapshot_package::AccountsPackageSender,
     snapshot_utils,
 };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -50,6 +50,7 @@ use crate::{
     log_collector::LogCollector,
     message_processor::{ExecuteDetailsTimings, Executors, MessageProcessor},
     rent_collector::RentCollector,
+    snapshot_runtime_info::SyncSnapshotRuntimeInfo,
     stake_weighted_timestamp::{
         calculate_stake_weighted_timestamp, MaxAllowableDrift, MAX_ALLOWABLE_DRIFT_PERCENTAGE,
         MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW,
@@ -1020,6 +1021,7 @@ impl Bank {
             false,
             AccountShrinkThreshold::default(),
             false,
+            None,
         )
     }
 
@@ -1034,6 +1036,7 @@ impl Bank {
             false,
             AccountShrinkThreshold::default(),
             false,
+            None,
         );
 
         bank.ns_per_slot = std::u128::MAX;
@@ -1057,9 +1060,11 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             false,
+            None,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_paths(
         genesis_config: &GenesisConfig,
         paths: Vec<PathBuf>,
@@ -1070,6 +1075,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
         debug_do_not_add_builtins: bool,
+        snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
     ) -> Self {
         let mut bank = Self::default();
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
@@ -1082,6 +1088,7 @@ impl Bank {
             account_indexes,
             accounts_db_caching_enabled,
             shrink_ratio,
+            snapshot_runtime_info,
         ));
         bank.process_genesis_config(genesis_config);
         bank.finish_init(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -3,6 +3,7 @@
 use crate::{
     accounts_background_service::{AbsRequestSender, SnapshotRequest},
     bank::Bank,
+    snapshot_config::SnapshotConfig,
 };
 use log::*;
 use solana_metrics::inc_new_counter_info;
@@ -10,40 +11,9 @@ use solana_sdk::{clock::Slot, hash::Hash, timing};
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
     ops::Index,
-    path::PathBuf,
     sync::Arc,
     time::Instant,
 };
-
-pub use crate::snapshot_utils::SnapshotVersion;
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ArchiveFormat {
-    TarBzip2,
-    TarGzip,
-    TarZstd,
-    Tar,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SnapshotConfig {
-    // Generate a new snapshot every this many slots
-    pub snapshot_interval_slots: u64,
-
-    // Where to store the latest packaged snapshot
-    pub snapshot_package_output_path: PathBuf,
-
-    // Where to place the snapshots for recent slots
-    pub snapshot_path: PathBuf,
-
-    pub archive_format: ArchiveFormat,
-
-    // Snapshot version to generate
-    pub snapshot_version: SnapshotVersion,
-
-    // Maximum number of snapshots to retain
-    pub maximum_snapshots_to_retain: usize,
-}
 
 pub struct BankForks {
     banks: HashMap<Slot, Arc<Bank>>,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -33,6 +33,7 @@ mod read_only_accounts_cache;
 pub mod rent_collector;
 pub mod secondary_index;
 pub mod serde_snapshot;
+pub mod snapshot_config;
 pub mod snapshot_package;
 pub mod snapshot_runtime_info;
 pub mod snapshot_utils;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -14,6 +14,7 @@ use {
         message_processor::MessageProcessor,
         rent_collector::RentCollector,
         serde_snapshot::future::SerializableStorage,
+        snapshot_runtime_info::SyncSnapshotRuntimeInfo,
         stakes::Stakes,
     },
     bincode,
@@ -140,6 +141,7 @@ pub(crate) fn bank_from_stream<R>(
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -161,6 +163,7 @@ where
                 caching_enabled,
                 limit_load_slot_count_from_snapshot,
                 shrink_ratio,
+                snapshot_runtime_info,
             )?;
             Ok(bank)
         }};
@@ -252,6 +255,7 @@ fn reconstruct_bank_from_fields<E>(
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -265,6 +269,7 @@ where
         caching_enabled,
         limit_load_slot_count_from_snapshot,
         shrink_ratio,
+        snapshot_runtime_info,
     )?;
     accounts_db.freeze_accounts(
         &Ancestors::from(&bank_fields.ancestors),
@@ -314,6 +319,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     caching_enabled: bool,
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
+    snapshot_runtime_info: Option<SyncSnapshotRuntimeInfo>,
 ) -> Result<AccountsDb, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -324,6 +330,7 @@ where
         account_indexes,
         caching_enabled,
         shrink_ratio,
+        snapshot_runtime_info,
     );
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -75,6 +75,7 @@ where
         false,
         None,
         AccountShrinkThreshold::default(),
+        None,
     )
 }
 
@@ -131,6 +132,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
         AccountSecondaryIndexes::default(),
         false,
         AccountShrinkThreshold::default(),
+        None,
     );
 
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -231,6 +233,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         false,
         None,
         AccountShrinkThreshold::default(),
+        None,
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,0 +1,30 @@
+use crate::snapshot_runtime_info::SyncSnapshotRuntimeInfo;
+use crate::snapshot_utils::ArchiveFormat;
+use crate::snapshot_utils::SnapshotVersion;
+use solana_sdk::clock::Slot;
+use std::path::PathBuf;
+
+/// Snapshot configuration and runtime information
+#[derive(Clone, Debug)]
+pub struct SnapshotConfig {
+    /// Generate a new snapshot every this many slots
+    pub snapshot_interval_slots: Slot,
+
+    /// Where to store the latest packaged snapshot
+    pub snapshot_package_output_path: PathBuf,
+
+    /// Where to place the snapshots for recent slots
+    pub snapshot_path: PathBuf,
+
+    /// The archive format to use for snapshots
+    pub archive_format: ArchiveFormat,
+
+    /// Snapshot version to generate
+    pub snapshot_version: SnapshotVersion,
+
+    /// Maximum number of snapshots to retain
+    pub maximum_snapshots_to_retain: usize,
+
+    /// Shared snapshot runtime information
+    pub snapshot_runtime_info: SyncSnapshotRuntimeInfo,
+}

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,5 +1,4 @@
-use crate::bank_forks::ArchiveFormat;
-use crate::snapshot_utils::SnapshotVersion;
+use crate::snapshot_utils::{ArchiveFormat, SnapshotVersion};
 use crate::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
 use solana_sdk::genesis_config::ClusterType;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3,7 +3,6 @@ use {
         accounts_db::{AccountShrinkThreshold, AccountsDb},
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta, Builtins},
-        bank_forks::ArchiveFormat,
         hardened_unpack::{unpack_snapshot, ParallelSelector, UnpackError, UnpackedAppendVecMap},
         serde_snapshot::{
             bank_from_stream, bank_to_stream, SerdeStyle, SnapshotStorage, SnapshotStorages,
@@ -11,8 +10,7 @@ use {
         snapshot_package::{
             AccountsPackage, AccountsPackagePre, AccountsPackageSendError, AccountsPackageSender,
         },
-        snapshot_runtime_info,
-        snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+        snapshot_runtime_info::{self, SyncSnapshotRuntimeInfo},
         sorted_storages::SortedStorages,
     },
     bincode::{config::Options, serialize_into},
@@ -103,6 +101,15 @@ impl SnapshotVersion {
     fn maybe_from_string(version_string: &str) -> Option<SnapshotVersion> {
         version_string.parse::<Self>().ok()
     }
+}
+
+/// The different archive formats used for snapshots
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ArchiveFormat {
+    TarBzip2,
+    TarGzip,
+    TarZstd,
+    Tar,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -46,9 +46,13 @@ use {
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
         },
-        bank_forks::{ArchiveFormat, SnapshotConfig, SnapshotVersion},
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_utils::{get_highest_snapshot_archive_path, DEFAULT_MAX_SNAPSHOTS_TO_RETAIN},
+        snapshot_config::SnapshotConfig,
+        snapshot_runtime_info::SyncSnapshotRuntimeInfo,
+        snapshot_utils::{
+            get_highest_snapshot_archive_path, ArchiveFormat, SnapshotVersion,
+            DEFAULT_MAX_SNAPSHOTS_TO_RETAIN,
+        },
     },
     solana_sdk::{
         clock::{Slot, DEFAULT_S_PER_SLOT},
@@ -2398,6 +2402,7 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_snapshots_to_retain,
+        snapshot_runtime_info: SyncSnapshotRuntimeInfo::default(),
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
Do the plumbing for `snapshot_info` (PR #18199).

Additionally, set the last full snapshot slot in `SnapshotPackagerService` and `snapshot_utils`. This will be expanded when Incremental Snapshot support is added. As of now, AccountsDb does not use this information.

Related to Incremental Snapshots, #17088, and broken out from PR #17875.