### PR TITLE
Revert "Clean up build warning"

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1448,17 +1448,22 @@ fn report_target_features() {
         not(target_os = "macos")
     ))]
     {
-        // Validator binaries built on a machine with AVX support will generate invalid opcodes
-        // when run on machines without AVX causing a non-obvious process abort.  Instead detect
-        // the mismatch and error cleanly.
-        if is_x86_feature_detected!("avx") {
-            info!("AVX detected");
-        } else {
-            error!(
-                "Your machine does not have AVX support, please rebuild from source on your machine"
-            );
-            abort();
-        }
+        unsafe { check_avx() };
+    }
+}
+
+// Validator binaries built on a machine with AVX support will generate invalid opcodes
+// when run on machines without AVX causing a non-obvious process abort.  Instead detect
+// the mismatch and error cleanly.
+#[target_feature(enable = "avx")]
+unsafe fn check_avx() {
+    if is_x86_feature_detected!("avx") {
+        info!("AVX detected");
+    } else {
+        error!(
+            "Your machine does not have AVX support, please rebuild from source on your machine"
+        );
+        abort();
     }
 }
 


### PR DESCRIPTION
This reverts commit 17a173ebb5cb87271069abdaa0fb9c01d4c8d9d4.

#### Problem

17a173ebb5cb87271069abdaa0fb9c01d4c8d9d4 inadvertently made AVX an x86* target requirement regardless of the build host's CPU features.  This makes it impossible to build binaries compatible with non-AVX CPUs

#### Summary of Changes

Since the build warning that motivated the initial change seems to be gone, revert it.
