### PR TITLE
Bump bpf-tools version to 1.12

### DIFF
--- a/programs/bpf/c/src/float/float.c
+++ b/programs/bpf/c/src/float/float.c
@@ -5,6 +5,8 @@
  */
 #include <solana_sdk.h>
 
+extern double log2(double arg);
+
 extern uint64_t entrypoint(const uint8_t *input) {
   SolAccountInfo ka[1];
   SolParameters params = (SolParameters) { .ka = ka };
@@ -22,6 +24,10 @@ extern uint64_t entrypoint(const uint8_t *input) {
   double value = (double)new_data + 1.0;
   value /= -2.0;
   sol_assert(value < 0.0);
+
+  /* test that standard math functions are available */
+  value = *data + 1.0;
+  sol_assert(log2(value) == 1.0);
 
   return SUCCESS;
 }

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.11
+version=v1.12
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -414,7 +414,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     install_if_missing(
         config,
         "bpf-tools",
-        "v1.11",
+        "v1.12",
         "https://github.com/solana-labs/bpf-tools/releases/download",
         &PathBuf::from(bpf_tools_filename),
     )


### PR DESCRIPTION
#### Problem

Standard math functions such as log2, ln, etc are not available to BPF programs

#### Summary of Changes

Release a new version of bpf-tools that adds the missing math functions.  Add a simple test of math functions in programs tests.

Fixes #17793
