### PR TITLE
Unignore spl downstream build

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -100,5 +100,5 @@ EOF
 
 
 _ example_helloworld
-#_ spl
+_ spl
 _ serum_dex


### PR DESCRIPTION
#### Problem
SPL downstream build was ignored due to breaking DefaultSigner changes. However, https://github.com/solana-labs/solana-program-library/pull/1870 removed the DefaultSigner usage.

#### Summary of Changes
Unignore SPL downstream build
