### PR TITLE
Don't update if already an executable

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -227,6 +227,10 @@ impl PreAccount {
         self.account.borrow().lamports()
     }
 
+    pub fn executable(&self) -> bool {
+        self.account.borrow().executable()
+    }
+
     pub fn is_zeroed(buf: &[u8]) -> bool {
         const ZEROS_LEN: usize = 1024;
         static ZEROS: [u8; ZEROS_LEN] = [0; ZEROS_LEN];
@@ -1109,7 +1113,7 @@ impl MessageProcessor {
                             })?;
                         pre_sum += u128::from(pre_account.lamports());
                         post_sum += u128::from(account.lamports());
-                        if is_writable && !account.executable() {
+                        if is_writable && !pre_account.executable() {
                             pre_account.update(&account);
                         }
                         return Ok(());


### PR DESCRIPTION
#### Problem

The pre-account is not updated when an account is marked executable

#### Summary of Changes

Update unless the account was already an executable

Fixes #
