### PR TITLE
sdk, programs/bpf_loader: add sol_remaining_compute_units syscall

### DIFF
--- a/docs/src/developing/on-chain-programs/developing-c.md
+++ b/docs/src/developing/on-chain-programs/developing-c.md
@@ -172,6 +172,8 @@ with program logs.
 
 ## Compute Budget
 
+Use the system call [`sol_remaining_compute_units`](invalid_link) to return a `u64` indicating the compute units remaining for the program to consume.
+
 Use the system call
 [`sol_log_compute_units()`](https://github.com/solana-labs/solana/blob/d3a3a7548c857f26ec2cb10e270da72d373020ec/sdk/bpf/c/inc/solana_sdk.h#L140)
 to log a message containing the remaining number of compute units the program

--- a/docs/src/developing/on-chain-programs/developing-rust.md
+++ b/docs/src/developing/on-chain-programs/developing-rust.md
@@ -374,6 +374,8 @@ fn custom_panic(info: &core::panic::PanicInfo<'_>) {
 
 ## Compute Budget
 
+Use the system call [`sol_remaining_compute_units`](invalid_link) to return a `u64` indicating the compute units remaining for the program to consume.
+
 Use the system call
 [`sol_log_compute_units()`](https://github.com/solana-labs/solana/blob/d3a3a7548c857f26ec2cb10e270da72d373020ec/sdk/program/src/log.rs#L102)
 to log a message containing the remaining number of compute units the program

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2879,6 +2879,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-early-terminate"
+version = "1.8.0"
+dependencies = [
+ "solana-program 1.8.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-error-handling"
 version = "1.8.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "rust/dep_crate",
     "rust/deprecated_loader",
     "rust/dup_accounts",
+    "rust/early_terminate",
     "rust/error_handling",
     "rust/external_spend",
     "rust/finalize",

--- a/programs/bpf/rust/early_terminate/Cargo.toml
+++ b/programs/bpf/rust/early_terminate/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-bpf-rust-early-terminate"
+version = "1.8.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-error-handling"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.8.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/early_terminate/src/lib.rs
+++ b/programs/bpf/rust/early_terminate/src/lib.rs
@@ -1,0 +1,28 @@
+//! @brief Example Rust-based BPF program that exercises instruction introspection
+
+extern crate solana_program;
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program_error::ProgramError,
+    program_inspection::sol_remaining_compute_units, pubkey::Pubkey,
+};
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let mut i = 0u32;
+    for _ in 0..1_000_000 {
+        if i % 1000 == 0 {
+            if sol_remaining_compute_units() < 25_000 {
+                break;
+            }
+        }
+        i += 1;
+    }
+
+    if i % 123143 != 0 {
+        return Err(ProgramError::Custom(i % 123143 as u32));
+    }
+    Ok(())
+}

--- a/programs/bpf/rust/early_terminate/src/lib.rs
+++ b/programs/bpf/rust/early_terminate/src/lib.rs
@@ -2,27 +2,30 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, program_error::ProgramError,
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg,
     program_inspection::sol_remaining_compute_units, pubkey::Pubkey,
 };
 entrypoint!(process_instruction);
-fn process_instruction(
+pub fn process_instruction(
     _program_id: &Pubkey,
     _accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     let mut i = 0u32;
-    for _ in 0..1_000_000 {
-        if i % 1000 == 0 {
-            if sol_remaining_compute_units() < 25_000 {
+    for _ in 0..100_000 {
+        if i % 500 == 0 {
+            let remaining = sol_remaining_compute_units();
+            if i % 500 == 0 {
+                msg!("remaining compute units: {:?}", remaining)
+            }
+            if remaining < 25_000 {
                 break;
             }
         }
         i += 1;
     }
 
-    if i % 123143 != 0 {
-        return Err(ProgramError::Custom(i % 123143 as u32));
-    }
+    msg!("i: {:?}", i);
+
     Ok(())
 }

--- a/programs/bpf/rust/early_terminate/src/lib.rs
+++ b/programs/bpf/rust/early_terminate/src/lib.rs
@@ -15,9 +15,7 @@ pub fn process_instruction(
     for _ in 0..100_000 {
         if i % 500 == 0 {
             let remaining = sol_remaining_compute_units();
-            if i % 500 == 0 {
-                msg!("remaining compute units: {:?}", remaining)
-            }
+            msg!("remaining compute units: {:?}", remaining);
             if remaining < 25_000 {
                 break;
             }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -120,6 +120,10 @@ pub fn register_syscalls(
     syscall_registry.register_syscall_by_name(b"sol_log_pubkey", SyscallLogPubkey::call)?;
 
     syscall_registry.register_syscall_by_name(
+        b"sol_remaining_compute_units_",
+        SyscallRemainingBpfComputeUnits::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
         b"sol_create_program_address",
         SyscallCreateProgramAddress::call,
     )?;
@@ -238,6 +242,15 @@ pub fn bind_syscall_context_objects<'a>(
             logger: invoke_context.get_logger(),
             loader_id,
             enforce_aligned_host_addrs,
+        }),
+        None,
+    )?;
+
+    vm.bind_syscall_context_object(
+        Box::new(SyscallRemainingBpfComputeUnits {
+            cost: 0,
+            compute_meter: invoke_context.get_compute_meter(),
+            loader_id,
         }),
         None,
     )?;
@@ -669,8 +682,7 @@ impl SyscallObject<BpfError> for SyscallLogU64 {
         *result = Ok(0);
     }
 }
-
-/// Log current compute consumption
+/// Log the remaining compute units a program may consume
 pub struct SyscallLogBpfComputeUnits {
     cost: u64,
     compute_meter: Rc<RefCell<dyn ComputeMeter>>,
@@ -737,7 +749,32 @@ impl<'a> SyscallObject<BpfError> for SyscallLogPubkey<'a> {
         *result = Ok(0);
     }
 }
-
+/// Return the remaining compute units a program may consume
+pub struct SyscallRemainingBpfComputeUnits<'a> {
+    cost: u64,
+    compute_meter: Rc<RefCell<dyn ComputeMeter>>,
+    loader_id: &'a Pubkey,
+}
+impl<'a> SyscallObject<BpfError> for SyscallRemainingBpfComputeUnits<'a> {
+    fn call(
+        &mut self,
+        result_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &MemoryMapping,
+        result: &mut Result<u64, EbpfError<BpfError>>,
+    ) {
+        question_mark!(self.compute_meter.consume(self.cost), result);
+        let compute_units_remaining = question_mark!(
+            translate_type_mut::<u64>(memory_mapping, result_addr, self.loader_id, true),
+            result
+        );
+        *compute_units_remaining = self.compute_meter.borrow().get_remaining();
+        *result = Ok(0);
+    }
+}
 /// Dynamic memory allocation syscall called when the BPF program calls
 /// `sol_alloc_free_()`.  The allocator is expected to allocate/free
 /// from/to a given chunk of memory and enforce size restrictions.  The

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -140,6 +140,11 @@ void sol_log_compute_units_();
 #define sol_log_compute_units() sol_log_compute_units_()
 
 /**
+ * Returns the current compute unit consumption
+ */
+uint64_t sol_remaining_compute_units_();
+#define sol_remaining_compute_units() sol_remaining_compute_units_()
+/**
  * Size of Public key in bytes
  */
 #define SIZE_PUBKEY 32
@@ -696,6 +701,9 @@ void sol_log_pubkey(const SolPubkey *pubkey) {
 }
 void sol_log_compute_units_() {
   printf("Program consumption: __ units remaining\n");
+}
+uint64_t sol_remaining_compute_units_() {
+  return UINT64_MAX;
 }
 void sol_panic_(const char *file, uint64_t len, uint64_t line, uint64_t column) {
   printf("Panic in %s at %d:%d\n", file, line, column);

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -31,6 +31,7 @@ pub mod native_token;
 pub mod nonce;
 pub mod program;
 pub mod program_error;
+pub mod program_inspection;
 pub mod program_memory;
 pub mod program_option;
 pub mod program_pack;

--- a/sdk/program/src/program_inspection.rs
+++ b/sdk/program/src/program_inspection.rs
@@ -8,9 +8,7 @@ pub fn sol_remaining_compute_units() -> u64 {
         extern "C" {
             fn sol_remaining_compute_units_(result: *mut u64);
         }
-        unsafe {
-            sol_remaining_compute_units_(&mut result as *mut u64);
-        }
+        sol_remaining_compute_units_(&mut result as *mut u64);
     }
     #[cfg(not(target_arch = "bpf"))]
     crate::program_stubs::sol_remaining_compute_units(&mut result);

--- a/sdk/program/src/program_inspection.rs
+++ b/sdk/program/src/program_inspection.rs
@@ -1,0 +1,19 @@
+/// Return the remaining compute units the program may consume
+#[inline]
+pub fn sol_remaining_compute_units() -> u64 {
+    let mut result = u64::MAX;
+
+    #[cfg(target_arch = "bpf")]
+    unsafe {
+        extern "C" {
+            fn sol_remaining_compute_units_(result: *mut u64);
+        }
+        unsafe {
+            sol_remaining_compute_units_(&mut result as *mut u64);
+        }
+    }
+    #[cfg(not(target_arch = "bpf"))]
+    crate::program_stubs::sol_remaining_compute_units(&mut result);
+
+    result
+}

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -26,6 +26,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_compute_units(&self) {
         sol_log("SyscallStubs: sol_log_compute_units() not available");
     }
+    fn sol_remaining_compute_units(&self, _var: &mut u64) {
+        sol_log("SyscallStubs: sol_remaining_compute_units() defaulting to u64::MAX");
+    }
     fn sol_invoke_signed(
         &self,
         _instruction: &Instruction,
@@ -98,6 +101,13 @@ pub(crate) fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) 
 
 pub(crate) fn sol_log_compute_units() {
     SYSCALL_STUBS.read().unwrap().sol_log_compute_units();
+}
+
+pub(crate) fn sol_remaining_compute_units(var: &mut u64) {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_remaining_compute_units(var);
 }
 
 pub(crate) fn sol_invoke_signed(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -159,6 +159,7 @@ pub mod dedupe_config_program_signers {
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
+        (expanded_compute_unit_syscalls::id(), "expanded set of compute unit-related syscalls"),
         (instructions_sysvar_enabled::id(), "instructions sysvar"),
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -6,6 +6,11 @@ use solana_sdk::{
 };
 use std::collections::{HashMap, HashSet};
 
+pub mod expanded_compute_unit_syscalls {
+    // TODO: replace by team
+    solana_sdk::declare_id!("GH4auHBrmun5EYthnRw8sQ6JZhGWGsUJNPzuNGKEq37C");
+}
+
 pub mod instructions_sysvar_enabled {
     solana_sdk::declare_id!("EnvhHCLvg55P7PDtbvR1NwuTuAeodqpusV3MR5QEK8gs");
 }

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -181,6 +181,12 @@ pub struct BpfComputeBudget {
     pub cpi_bytes_per_unit: u64,
     /// Base number of compute units consumed to get a sysvar
     pub sysvar_base_cost: u64,
+    /// Number of compute units consumed to return the remaining compute units in the
+    /// ComputeMeter to the program
+    pub get_compute_units_cost: u64,
+    /// Number of compute units consumed to log the remaining compute units in the
+    /// ComputerMeter
+    log_compute_units_cost: u64,
 }
 impl Default for BpfComputeBudget {
     fn default() -> Self {
@@ -204,6 +210,8 @@ impl BpfComputeBudget {
             max_cpi_instruction_size: 1280, // IPv6 Min MTU size
             cpi_bytes_per_unit: 250,        // ~50MB at 200,000 units
             sysvar_base_cost: 100,
+            get_compute_units_cost: 20,
+            log_compute_units_cost: 100,
         }
     }
 }

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -186,7 +186,7 @@ pub struct BpfComputeBudget {
     pub get_compute_units_cost: u64,
     /// Number of compute units consumed to log the remaining compute units in the
     /// ComputerMeter
-    log_compute_units_cost: u64,
+    pub log_compute_units_cost: u64,
 }
 impl Default for BpfComputeBudget {
     fn default() -> Self {


### PR DESCRIPTION
#### Problem
Instructions may want to maximise their use of the compute budget, without risking going over budget. To do so, they ought to be able to inspect the current budget consumed.
#### Summary of Changes
Implement a syscall that allows BPF programs to make queries of `sol_remaining_compute_units` at arbitrary points in execution.

#### Fixes
https://github.com/solana-labs/solana/issues/18134


#### TODOs: 
- [x] Feature gate (anything else that could piggyback? Maybe the proposed `invoke_signed_with_budget` syscall. Also increase `sol_log_compute_units` cost, and add budget field for it)
- [x] Update docs with usage example
- [x] Determine appropriate cost (something like 10 is probably fine, since `ComputeMeter` is likely to be in L1 cache).
- [x] C sdk
- [x] Set cost of `sol_log_compute_units` to 100 (as opposed to 0) to prevent abuse

Note that I have not actually tested the C sdk code