### PR TITLE
cli: Only print Foundation inflation rate if it is greater than 0

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1513,11 +1513,15 @@ impl fmt::Display for CliInflation {
             "Staking rate:            {:>5.2}%",
             self.current_rate.validator * 100.
         )?;
-        writeln!(
-            f,
-            "Foundation rate:         {:>5.2}%",
-            self.current_rate.foundation * 100.
-        )
+
+        if self.current_rate.foundation > 0. {
+            writeln!(
+                f,
+                "Foundation rate:         {:>5.2}%",
+                self.current_rate.foundation * 100.
+            )?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The "Foundation rate:" field in the `solana inflation` output is vestigial.  There are no credible plans to ever add a foundation cut into inflation at this point, and there's only incomplete code in the runtime to actually implement such a thing. So until this situation changes, displaying a "foundation rate" in `solana inflation` only serves to generate confusion and potentially misinformation.  
