### PR TITLE
feat: add filters support to the connection.onProgramAccountChange method

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1725,7 +1725,7 @@ type ProgramAccountSubscriptionInfo = {
   callback: ProgramAccountChangeCallback;
   commitment?: Commitment;
   subscriptionId: SubscriptionId | null; // null when there's no current server subscription id
-  filters?: GetProgramAccountsFilter[]
+  filters?: GetProgramAccountsFilter[];
 };
 
 /**
@@ -3709,7 +3709,9 @@ export class Connection {
       this._subscribe(
         sub,
         'programSubscribe',
-        this._buildArgs([sub.programId], sub.commitment, 'base64', {filters: sub.filters}),
+        this._buildArgs([sub.programId], sub.commitment, 'base64', {
+          filters: sub.filters,
+        }),
       );
     }
 
@@ -3838,7 +3840,7 @@ export class Connection {
     programId: PublicKey,
     callback: ProgramAccountChangeCallback,
     commitment?: Commitment,
-    filters?: GetProgramAccountsFilter[]
+    filters?: GetProgramAccountsFilter[],
   ): number {
     const id = ++this._programAccountChangeSubscriptionCounter;
     this._programAccountChangeSubscriptions[id] = {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3831,6 +3831,7 @@ export class Connection {
    * @param programId Public key of the program to monitor
    * @param callback Function to invoke whenever the account is changed
    * @param commitment Specify the commitment level account changes must reach before notification
+   * @param filters The program account filters to pass into the RPC method
    * @return subscription id
    */
   onProgramAccountChange(

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1725,6 +1725,7 @@ type ProgramAccountSubscriptionInfo = {
   callback: ProgramAccountChangeCallback;
   commitment?: Commitment;
   subscriptionId: SubscriptionId | null; // null when there's no current server subscription id
+  filters?: GetProgramAccountsFilter[]
 };
 
 /**
@@ -3708,7 +3709,7 @@ export class Connection {
       this._subscribe(
         sub,
         'programSubscribe',
-        this._buildArgs([sub.programId], sub.commitment, 'base64'),
+        this._buildArgs([sub.programId], sub.commitment, 'base64', {filters: sub.filters}),
       );
     }
 
@@ -3836,6 +3837,7 @@ export class Connection {
     programId: PublicKey,
     callback: ProgramAccountChangeCallback,
     commitment?: Commitment,
+    filters?: GetProgramAccountsFilter[]
   ): number {
     const id = ++this._programAccountChangeSubscriptionCounter;
     this._programAccountChangeSubscriptions[id] = {
@@ -3843,6 +3845,7 @@ export class Connection {
       callback,
       commitment,
       subscriptionId: null,
+      filters,
     };
     this._updateSubscriptions();
     return id;


### PR DESCRIPTION
#### Problem
Looking to subscribe to a program via the web3.js Connection.onProgramAccountChange, but I'd like to use the optional filter that comes with the underlying RPC programSubscribe request.

#### Summary of Changes
Adds option _filters_ argument to `onProgramAccountChange` which gets built into the RPC arguments.

Fixes #18256 

(original tests pass but I haven't validated this code with an actual RPC connection yet)