### PR TITLE
cli: Align vote-account output with stake-account output

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1325,8 +1325,8 @@ impl fmt::Display for CliVoteAccount {
             build_balance_message(self.account_balance, self.use_lamports_unit, true)
         )?;
         writeln!(f, "Validator Identity: {}", self.validator_identity)?;
-        writeln!(f, "Authorized Voters: {}", self.authorized_voters)?;
-        writeln!(f, "Authorized Withdrawer: {}", self.authorized_withdrawer)?;
+        writeln!(f, "Vote Authority: {}", self.authorized_voters)?;
+        writeln!(f, "Withdraw Authority: {}", self.authorized_withdrawer)?;
         writeln!(f, "Credits: {}", self.credits)?;
         writeln!(f, "Commission: {}%", self.commission)?;
         writeln!(


### PR DESCRIPTION
Old `solana vote-account` output:
```
Authorized Voters: {196: "ABC1U4cf9DZMwqy8ktEr4WJj8VHmVBQibbC57gEJthwY"}
Authorized Withdrawer: A653QDDu9um752jMh7iNdG46UYwHFZJ4knSzHYgmR65t
```
New `solana vote-account` output:
```
Vote Authority: {196: "ABC1U4cf9DZMwqy8ktEr4WJj8VHmVBQibbC57gEJthwY"}
Withdraw Authority: A653QDDu9um752jMh7iNdG46UYwHFZJ4knSzHYgmR65t
```