### PR TITLE
sdk: refactor pda generation

### DIFF
--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -263,8 +263,10 @@ fn process_instruction(
                     )?,
                     accounts[DERIVED_KEY1_INDEX].key
                 );
+                let not_native_program_id = Pubkey::new_from_array([6u8; 32]);
+                assert!(!not_native_program_id.is_native_program_id());
                 assert_eq!(
-                    Pubkey::create_program_address(&[b"You pass butter"], &Pubkey::default())
+                    Pubkey::create_program_address(&[b"You pass butter"], &not_native_program_id)
                         .unwrap_err(),
                     PubkeyError::InvalidSeeds
                 );
@@ -276,8 +278,10 @@ fn process_instruction(
                     Pubkey::try_find_program_address(&[b"You pass butter"], program_id).unwrap();
                 assert_eq!(&address, accounts[DERIVED_KEY1_INDEX].key);
                 assert_eq!(bump_seed, bump_seed1);
+                let not_native_program_id = Pubkey::new_from_array([6u8; 32]);
+                assert!(!not_native_program_id.is_native_program_id());
                 assert_eq!(
-                    Pubkey::create_program_address(&[b"You pass butter"], &Pubkey::default())
+                    Pubkey::create_program_address(&[b"You pass butter"], &not_native_program_id)
                         .unwrap_err(),
                     PubkeyError::InvalidSeeds
                 );

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1305,13 +1305,13 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_external_spend", 504),
             ("solana_bpf_rust_iter", 724),
             ("solana_bpf_rust_many_args", 233),
-            ("solana_bpf_rust_mem", 3119),
+            ("solana_bpf_rust_mem", 3117),
             ("solana_bpf_rust_membuiltins", 4065),
             ("solana_bpf_rust_noop", 478),
             ("solana_bpf_rust_param_passing", 46),
             ("solana_bpf_rust_rand", 481),
             ("solana_bpf_rust_sanity", 873),
-            ("solana_bpf_rust_sha", 32295),
+            ("solana_bpf_rust_sha", 32301),
         ]);
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -2192,8 +2192,10 @@ mod tests {
         let upgrade_authority_address = Pubkey::new_unique();
         let buffer_address = Pubkey::new_unique();
         let program_address = Pubkey::new_unique();
-        let (programdata_address, _) =
-            Pubkey::find_program_address(&[program_address.as_ref()], &id());
+        let (programdata_address, _) = Pubkey::find_program_address(
+            &[program_address.as_ref()],
+            &bpf_loader_upgradeable::id(),
+        );
         let spill_address = Pubkey::new_unique();
         let upgrade_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let rent_id = sysvar::rent::id();
@@ -2846,8 +2848,10 @@ mod tests {
         let new_upgrade_authority_address = Pubkey::new_unique();
         let new_upgrade_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let program_address = Pubkey::new_unique();
-        let (programdata_address, _) =
-            Pubkey::find_program_address(&[program_address.as_ref()], &id());
+        let (programdata_address, _) = Pubkey::find_program_address(
+            &[program_address.as_ref()],
+            &bpf_loader_upgradeable::id(),
+        );
         let programdata_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::programdata_len(0).unwrap(),

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
     stake::config::Config as StakeConfig,
 };
 
-solana_sdk::declare_id!("Config1111111111111111111111111111111111111");
+pub use solana_sdk::config::program::id;
 
 pub trait ConfigState: serde::Serialize + Default {
     /// Maximum space that the serialized representation will require

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -12,4 +12,4 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate solana_frozen_abi_macro;
 
-solana_sdk::declare_id!("Vote111111111111111111111111111111111111111");
+pub use solana_sdk::vote::program::{check_id, id};

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -175,7 +175,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "F3Ubz2Sx973pKSYNHTEmj6LY3te1DKUo3fs3cgzQ1uqJ")]
+#[frozen_abi(digest = "HhY4tMP5KZU9fw9VLpMMUikfvNVCLksocZBUKjt8ZjYH")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<Rc<RefCell<AccountSharedData>>>;
 type TransactionAccountDepRefCells = Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>;

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -231,6 +231,10 @@ pub enum InstructionError {
     /// Unsupported sysvar
     #[error("Unsupported sysvar")]
     UnsupportedSysvar,
+
+    /// Illegal account owner
+    #[error("Provided owner is not allowed")]
+    IllegalOwner,
     // Note: For any new error added here an equivilent ProgramError and it's
     // conversions must also be added
 }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -49,6 +49,18 @@ pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;
 
+pub mod config {
+    pub mod program {
+        crate::declare_id!("Config1111111111111111111111111111111111111");
+    }
+}
+
+pub mod vote {
+    pub mod program {
+        crate::declare_id!("Vote111111111111111111111111111111111111111");
+    }
+}
+
 /// Convenience macro to declare a static public key and functions to interact with it
 ///
 /// Input: a single literal base58 string representation of a program's id

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -45,6 +45,8 @@ pub enum ProgramError {
     AccountNotRentExempt,
     #[error("Unsupported sysvar")]
     UnsupportedSysvar,
+    #[error("Provided owner is not allowed")]
+    IllegalOwner,
 }
 
 pub trait PrintProgramError {
@@ -82,6 +84,7 @@ impl PrintProgramError for ProgramError {
             Self::BorshIoError(_) => msg!("Error: BorshIoError"),
             Self::AccountNotRentExempt => msg!("Error: AccountNotRentExempt"),
             Self::UnsupportedSysvar => msg!("Error: UnsupportedSysvar"),
+            Self::IllegalOwner => msg!("Error: IllegalOwner"),
         }
     }
 }
@@ -111,6 +114,7 @@ pub const INVALID_SEEDS: u64 = to_builtin!(14);
 pub const BORSH_IO_ERROR: u64 = to_builtin!(15);
 pub const ACCOUNT_NOT_RENT_EXEMPT: u64 = to_builtin!(16);
 pub const UNSUPPORTED_SYSVAR: u64 = to_builtin!(17);
+pub const ILLEGAL_OWNER: u64 = to_builtin!(18);
 // Warning: Any new program errors added here must also be:
 // - Added to the below conversions
 // - Added as an equivilent to InstructionError
@@ -136,6 +140,7 @@ impl From<ProgramError> for u64 {
             ProgramError::BorshIoError(_) => BORSH_IO_ERROR,
             ProgramError::AccountNotRentExempt => ACCOUNT_NOT_RENT_EXEMPT,
             ProgramError::UnsupportedSysvar => UNSUPPORTED_SYSVAR,
+            ProgramError::IllegalOwner => ILLEGAL_OWNER,
             ProgramError::Custom(error) => {
                 if error == 0 {
                     CUSTOM_ZERO
@@ -167,6 +172,7 @@ impl From<u64> for ProgramError {
             BORSH_IO_ERROR => Self::BorshIoError("Unkown".to_string()),
             ACCOUNT_NOT_RENT_EXEMPT => Self::AccountNotRentExempt,
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
+            ILLEGAL_OWNER => Self::IllegalOwner,
             _ => Self::Custom(error as u32),
         }
     }
@@ -194,6 +200,7 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::BorshIoError(err) => Ok(Self::BorshIoError(err)),
             Self::Error::AccountNotRentExempt => Ok(Self::AccountNotRentExempt),
             Self::Error::UnsupportedSysvar => Ok(Self::UnsupportedSysvar),
+            Self::Error::IllegalOwner => Ok(Self::IllegalOwner),
             _ => Err(error),
         }
     }
@@ -223,6 +230,7 @@ where
             BORSH_IO_ERROR => Self::BorshIoError("Unkown".to_string()),
             ACCOUNT_NOT_RENT_EXEMPT => Self::AccountNotRentExempt,
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
+            ILLEGAL_OWNER => Self::IllegalOwner,
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {
@@ -240,6 +248,7 @@ impl From<PubkeyError> for ProgramError {
         match error {
             PubkeyError::MaxSeedLengthExceeded => Self::MaxSeedLengthExceeded,
             PubkeyError::InvalidSeeds => Self::InvalidSeeds,
+            PubkeyError::IllegalOwner => Self::IllegalOwner,
         }
     }
 }

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -120,4 +120,5 @@ pub enum InstructionErrorType {
     InvalidAccountOwner = 46,
     ArithmeticOverflow = 47,
     UnsupportedSysvar = 48,
+    IllegalOwner = 49,
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -753,6 +753,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             InstructionError::UnsupportedSysvar => {
                                 tx_by_addr::InstructionErrorType::UnsupportedSysvar
                             }
+                            InstructionError::IllegalOwner => {
+                                tx_by_addr::InstructionErrorType::IllegalOwner
+                            }
                         } as i32,
                         custom: match instruction_error {
                             InstructionError::Custom(custom) => {


### PR DESCRIPTION
#### Problem

PDA's can be constructed to collide with `*WithSeed` derived addresses

#### Summary of Changes

Prevent PDA suffix from suffixing `*WithSeed` derivation material