### PR TITLE
test-validator: hold rent constant with `--slots-per-epoch`

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -69,7 +69,7 @@ impl Default for TestValidatorNodeConfig {
 pub struct TestValidatorGenesis {
     fee_rate_governor: FeeRateGovernor,
     ledger_path: Option<PathBuf>,
-    rent: Rent,
+    pub rent: Rent,
     rpc_config: JsonRpcConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
     warp_slot: Option<Slot>,

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 //! configuration for network rent
+use crate::clock::DEFAULT_SLOTS_PER_EPOCH;
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, PartialEq, Clone, Copy, Debug, AbiExample)]
@@ -80,6 +81,17 @@ impl Rent {
         Self {
             lamports_per_byte_year: 0,
             ..Rent::default()
+        }
+    }
+
+    pub fn with_slots_per_epoch(slots_per_epoch: u64) -> Self {
+        let ratio = slots_per_epoch as f64 / DEFAULT_SLOTS_PER_EPOCH as f64;
+        let exemption_threshold = DEFAULT_EXEMPTION_THRESHOLD as f64 * ratio;
+        let lamports_per_byte_year = (DEFAULT_LAMPORTS_PER_BYTE_YEAR as f64 / ratio) as u64;
+        Self {
+            lamports_per_byte_year,
+            exemption_threshold,
+            ..Self::default()
         }
     }
 }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -17,6 +17,7 @@ use {
         epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
         native_token::sol_to_lamports,
         pubkey::Pubkey,
+        rent::Rent,
         rpc_port,
         signature::{read_keypair_file, write_keypair_file, Keypair, Signer},
         system_program,
@@ -561,6 +562,8 @@ fn main() {
             slots_per_epoch,
             /* enable_warmup_epochs = */ false,
         ));
+
+        genesis.rent = Rent::with_slots_per_epoch(slots_per_epoch);
     }
 
     if let Some(gossip_host) = gossip_host {


### PR DESCRIPTION
#### Problem

`solana-test-validator` rent parameters are skewed when `--slots-per-epoch` is in effect

#### Summary of Changes

Hold rent constant with `--slots-per-epoch`