### PR TITLE
Reject transactions with extra signatures

### DIFF
--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -18,6 +18,7 @@ pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED: i64 = -32009;
 pub const JSON_RPC_SERVER_ERROR_KEY_EXCLUDED_FROM_SECONDARY_INDEX: i64 = -32010;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_HISTORY_NOT_AVAILABLE: i64 = -32011;
 pub const JSON_RPC_SCAN_ERROR: i64 = -32012;
+pub const JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_LEN_MISMATCH: i64 = -32013;
 
 #[derive(Error, Debug)]
 pub enum RpcCustomError {
@@ -51,6 +52,8 @@ pub enum RpcCustomError {
     TransactionHistoryNotAvailable,
     #[error("ScanError")]
     ScanError { message: String },
+    #[error("TransactionSignatureLenMismatch")]
+    TransactionSignatureLenMismatch,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -149,6 +152,13 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::ScanError { message } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SCAN_ERROR),
                 message,
+                data: None,
+            },
+            RpcCustomError::TransactionSignatureLenMismatch => Self {
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_LEN_MISMATCH,
+                ),
+                message: "Transaction signature length mismatch".to_string(),
                 data: None,
             },
         }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -791,8 +791,11 @@ pub fn confirm_slot(
     };
 
     let check_start = Instant::now();
-    let check_result =
-        entries.verify_and_hash_transactions(skip_verification, bank.secp256k1_program_enabled());
+    let check_result = entries.verify_and_hash_transactions(
+        skip_verification,
+        bank.secp256k1_program_enabled(),
+        bank.verify_tx_signatures_len_enabled(),
+    );
     if check_result.is_none() {
         warn!("Ledger proof of history failed at slot: {}", slot);
         return Err(BlockError::InvalidEntryHash.into());

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -927,7 +927,7 @@ mod tests {
         // No signatures.
         {
             let tx = make_transaction(TestCase::RemoveSignature);
-            let entries = vec![next_entry(&recent_blockhash, 1, vec![tx.clone()])];
+            let entries = vec![next_entry(&recent_blockhash, 1, vec![tx])];
             assert!(entries[..]
                 .verify_and_hash_transactions(false, false, false)
                 .is_some());
@@ -938,7 +938,7 @@ mod tests {
         // Too many signatures.
         {
             let tx = make_transaction(TestCase::AddSignature);
-            let entries = vec![next_entry(&recent_blockhash, 1, vec![tx.clone()])];
+            let entries = vec![next_entry(&recent_blockhash, 1, vec![tx])];
             assert!(entries[..]
                 .verify_and_hash_transactions(false, false, false)
                 .is_some());

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -528,9 +528,7 @@ impl EntrySlice for [Entry] {
                     // Verify tx precompiles if secp256k1 program is enabled.
                     tx.verify_precompiles().ok()?;
                 }
-                if verify_tx_signatures_len
-                    && tx.signatures.len() != tx.message.header.num_required_signatures as usize
-                {
+                if verify_tx_signatures_len && !tx.verify_signatures_len() {
                     return None;
                 }
                 tx.verify_and_hash_message().ok()?

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1899,7 +1899,7 @@ fn verify_transaction(transaction: &Transaction) -> Result<()> {
         return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
     }
 
-    if transaction.signatures.len() != transaction.message.header.num_required_signatures as usize {
+    if !transaction.verify_signatures_len() {
         return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1899,6 +1899,10 @@ fn verify_transaction(transaction: &Transaction) -> Result<()> {
         return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
     }
 
+    if transaction.signatures.len() != transaction.message.header.num_required_signatures {
+        return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
+    }
+
     Ok(())
 }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1899,7 +1899,7 @@ fn verify_transaction(transaction: &Transaction) -> Result<()> {
         return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
     }
 
-    if transaction.signatures.len() != transaction.message.header.num_required_signatures {
+    if transaction.signatures.len() != transaction.message.header.num_required_signatures as usize {
         return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5051,6 +5051,11 @@ impl Bank {
             .is_active(&feature_set::check_init_vote_data::id())
     }
 
+    pub fn verify_tx_signatures_len_enabled(&self) -> bool {
+        self.feature_set
+            .is_active(&feature_set::verify_tx_signatures_len::id())
+    }
+
     // Check if the wallclock time from bank creation to now has exceeded the allotted
     // time for transaction processing
     pub fn should_bank_still_be_processing_txs(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -147,6 +147,10 @@ pub mod dedupe_config_program_signers {
     solana_sdk::declare_id!("8kEuAshXLsgkUEdcFVLqrjCGGHVWFW99ZZpxvAzzMtBp");
 }
 
+pub mod verify_tx_signatures_len {
+    solana_sdk::declare_id!("EVW9B5xD9FFK7vw1SBARwMA4s5eRo5eKJdKpsBikzKBz");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -363,7 +363,7 @@ impl Transaction {
 
     /// Verify the length of signatures matches the value in the message header
     pub fn verify_signatures_len(&self) -> bool {
-        self.signatures.len() == transaction.message.header.num_required_signatures as usize
+        self.signatures.len() == self.message.header.num_required_signatures as usize
     }
 
     /// Verify the transaction and hash its message

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -361,6 +361,11 @@ impl Transaction {
         }
     }
 
+    /// Verify the length of signatures matches the value in the message header
+    pub fn verify_signatures_len(&self) -> bool {
+        self.signatures.len() == transaction.message.header.num_required_signatures as usize
+    }
+
     /// Verify the transaction and hash its message
     pub fn verify_and_hash_message(&self) -> Result<Hash> {
         let message_bytes = self.message_data();


### PR DESCRIPTION
#### Problem
Transactions with extra signatures can be replayed

#### Summary of Changes
- Reject transactions with extra signatures during replay
- Return simulation error if transaction has extra signatures and sig verify is enabled

Fixes https://github.com/solana-labs/solana/issues/18303
