### PR TITLE
Use timeout to allow RpcClient to retry initial transaction confirmation

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -63,6 +63,7 @@ use std::{
 use thiserror::Error;
 
 pub const DEFAULT_RPC_TIMEOUT_SECONDS: &str = "30";
+pub const DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS: &str = "5";
 
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -453,6 +454,7 @@ pub struct CliConfig<'a> {
     pub output_format: OutputFormat,
     pub commitment: CommitmentConfig,
     pub send_transaction_config: RpcSendTransactionConfig,
+    pub confirm_transaction_initial_timeout: Duration,
     pub address_labels: HashMap<String, String>,
 }
 
@@ -597,6 +599,9 @@ impl Default for CliConfig<'_> {
             output_format: OutputFormat::Display,
             commitment: CommitmentConfig::confirmed(),
             send_transaction_config: RpcSendTransactionConfig::default(),
+            confirm_transaction_initial_timeout: Duration::from_secs(
+                u64::from_str(DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS).unwrap(),
+            ),
             address_labels: HashMap::new(),
         }
     }
@@ -1288,10 +1293,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
     }
 
     let rpc_client = if config.rpc_client.is_none() {
-        Arc::new(RpcClient::new_with_timeout_and_commitment(
+        Arc::new(RpcClient::new_with_timeouts_and_commitment(
             config.json_rpc_url.to_string(),
             config.rpc_timeout,
             config.commitment,
+            config.confirm_transaction_initial_timeout,
         ))
     } else {
         // Primarily for testing

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,7 @@ use solana_clap_utils::{
 };
 use solana_cli::cli::{
     app, parse_command, process_command, CliCommandInfo, CliConfig, SettingType,
-    DEFAULT_RPC_TIMEOUT_SECONDS,
+    DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS, DEFAULT_RPC_TIMEOUT_SECONDS,
 };
 use solana_cli_config::{Config, CONFIG_FILE};
 use solana_cli_output::{display::println_name_value, OutputFormat};
@@ -167,6 +167,11 @@ pub fn parse_args<'a>(
     let rpc_timeout = value_t_or_exit!(matches, "rpc_timeout", u64);
     let rpc_timeout = Duration::from_secs(rpc_timeout);
 
+    let confirm_transaction_initial_timeout =
+        value_t_or_exit!(matches, "confirm_transaction_initial_timeout", u64);
+    let confirm_transaction_initial_timeout =
+        Duration::from_secs(confirm_transaction_initial_timeout);
+
     let (_, websocket_url) = CliConfig::compute_websocket_url_setting(
         matches.value_of("websocket_url").unwrap_or(""),
         &config.websocket_url,
@@ -235,6 +240,7 @@ pub fn parse_args<'a>(
                 preflight_commitment: Some(commitment.commitment),
                 ..RpcSendTransactionConfig::default()
             },
+            confirm_transaction_initial_timeout,
             address_labels,
         },
         signers,
@@ -349,6 +355,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .global(true)
             .hidden(true)
             .help("Timeout value for RPC requests"),
+    )
+    .arg(
+        Arg::with_name("confirm_transaction_initial_timeout")
+            .long("confirm-timeout")
+            .value_name("SECONDS")
+            .takes_value(true)
+            .default_value(DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS)
+            .global(true)
+            .hidden(true)
+            .help("Timeout value for initial transaction status"),
     )
     .subcommand(
         SubCommand::with_name("config")

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -181,7 +181,7 @@ impl RpcClient {
 
     pub fn confirm_transaction(&self, signature: &Signature) -> ClientResult<bool> {
         Ok(self
-            .confirm_transaction_with_commitment(signature, self.commitment_config)?
+            .confirm_transaction_with_commitment(signature, self.commitment())?
             .value)
     }
 
@@ -207,8 +207,7 @@ impl RpcClient {
             transaction,
             RpcSendTransactionConfig {
                 preflight_commitment: Some(
-                    self.maybe_map_commitment(self.commitment_config)?
-                        .commitment,
+                    self.maybe_map_commitment(self.commitment())?.commitment,
                 ),
                 ..RpcSendTransactionConfig::default()
             },
@@ -297,7 +296,7 @@ impl RpcClient {
         self.simulate_transaction_with_config(
             transaction,
             RpcSimulateTransactionConfig {
-                commitment: Some(self.commitment_config),
+                commitment: Some(self.commitment()),
                 ..RpcSimulateTransactionConfig::default()
             },
         )
@@ -335,7 +334,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
     ) -> ClientResult<Option<transaction::Result<()>>> {
-        self.get_signature_status_with_commitment(signature, self.commitment_config)
+        self.get_signature_status_with_commitment(signature, self.commitment())
     }
 
     pub fn get_signature_statuses(
@@ -393,7 +392,7 @@ impl RpcClient {
     }
 
     pub fn get_slot(&self) -> ClientResult<Slot> {
-        self.get_slot_with_commitment(self.commitment_config)
+        self.get_slot_with_commitment(self.commitment())
     }
 
     pub fn get_slot_with_commitment(
@@ -407,7 +406,7 @@ impl RpcClient {
     }
 
     pub fn get_block_height(&self) -> ClientResult<u64> {
-        self.get_block_height_with_commitment(self.commitment_config)
+        self.get_block_height_with_commitment(self.commitment())
     }
 
     pub fn get_block_height_with_commitment(
@@ -461,14 +460,14 @@ impl RpcClient {
                 stake_account.to_string(),
                 RpcEpochConfig {
                     epoch,
-                    commitment: Some(self.commitment_config),
+                    commitment: Some(self.commitment()),
                 }
             ]),
         )
     }
 
     pub fn supply(&self) -> RpcResult<RpcSupply> {
-        self.supply_with_commitment(self.commitment_config)
+        self.supply_with_commitment(self.commitment())
     }
 
     pub fn supply_with_commitment(
@@ -495,7 +494,7 @@ impl RpcClient {
     }
 
     pub fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
-        self.get_vote_accounts_with_commitment(self.commitment_config)
+        self.get_vote_accounts_with_commitment(self.commitment())
     }
 
     pub fn get_vote_accounts_with_commitment(
@@ -872,7 +871,7 @@ impl RpcClient {
     }
 
     pub fn get_epoch_info(&self) -> ClientResult<EpochInfo> {
-        self.get_epoch_info_with_commitment(self.commitment_config)
+        self.get_epoch_info_with_commitment(self.commitment())
     }
 
     pub fn get_epoch_info_with_commitment(
@@ -889,7 +888,7 @@ impl RpcClient {
         &self,
         slot: Option<Slot>,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.get_leader_schedule_with_commitment(slot, self.commitment_config)
+        self.get_leader_schedule_with_commitment(slot, self.commitment())
     }
 
     pub fn get_leader_schedule_with_commitment(
@@ -959,7 +958,7 @@ impl RpcClient {
                 addresses,
                 RpcEpochConfig {
                     epoch,
-                    commitment: Some(self.commitment_config),
+                    commitment: Some(self.commitment()),
                 }
             ]),
         )
@@ -1025,7 +1024,7 @@ impl RpcClient {
     /// Note that `get_account` returns `Err(..)` if the account does not exist whereas
     /// `get_account_with_commitment` returns `Ok(None)` if the account does not exist.
     pub fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
-        self.get_account_with_commitment(pubkey, self.commitment_config)?
+        self.get_account_with_commitment(pubkey, self.commitment())?
             .value
             .ok_or_else(|| RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into())
     }
@@ -1081,7 +1080,7 @@ impl RpcClient {
 
     pub fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> ClientResult<Vec<Option<Account>>> {
         Ok(self
-            .get_multiple_accounts_with_commitment(pubkeys, self.commitment_config)?
+            .get_multiple_accounts_with_commitment(pubkeys, self.commitment())?
             .value)
     }
 
@@ -1135,7 +1134,7 @@ impl RpcClient {
     /// Request the balance of the account `pubkey`.
     pub fn get_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
         Ok(self
-            .get_balance_with_commitment(pubkey, self.commitment_config)?
+            .get_balance_with_commitment(pubkey, self.commitment())?
             .value)
     }
 
@@ -1193,7 +1192,7 @@ impl RpcClient {
 
     /// Request the transaction count.
     pub fn get_transaction_count(&self) -> ClientResult<u64> {
-        self.get_transaction_count_with_commitment(self.commitment_config)
+        self.get_transaction_count_with_commitment(self.commitment())
     }
 
     pub fn get_transaction_count_with_commitment(
@@ -1208,7 +1207,7 @@ impl RpcClient {
 
     pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
         let (blockhash, fee_calculator, _last_valid_slot) = self
-            .get_recent_blockhash_with_commitment(self.commitment_config)?
+            .get_recent_blockhash_with_commitment(self.commitment())?
             .value;
         Ok((blockhash, fee_calculator))
     }
@@ -1281,7 +1280,7 @@ impl RpcClient {
         blockhash: &Hash,
     ) -> ClientResult<Option<FeeCalculator>> {
         Ok(self
-            .get_fee_calculator_for_blockhash_with_commitment(blockhash, self.commitment_config)?
+            .get_fee_calculator_for_blockhash_with_commitment(blockhash, self.commitment())?
             .value)
     }
 
@@ -1363,7 +1362,7 @@ impl RpcClient {
 
     pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
         Ok(self
-            .get_token_account_with_commitment(pubkey, self.commitment_config)?
+            .get_token_account_with_commitment(pubkey, self.commitment())?
             .value)
     }
 
@@ -1424,7 +1423,7 @@ impl RpcClient {
 
     pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
-            .get_token_account_balance_with_commitment(pubkey, self.commitment_config)?
+            .get_token_account_balance_with_commitment(pubkey, self.commitment())?
             .value)
     }
 
@@ -1451,7 +1450,7 @@ impl RpcClient {
             .get_token_accounts_by_delegate_with_commitment(
                 delegate,
                 token_account_filter,
-                self.commitment_config,
+                self.commitment(),
             )?
             .value)
     }
@@ -1490,7 +1489,7 @@ impl RpcClient {
             .get_token_accounts_by_owner_with_commitment(
                 owner,
                 token_account_filter,
-                self.commitment_config,
+                self.commitment(),
             )?
             .value)
     }
@@ -1522,7 +1521,7 @@ impl RpcClient {
 
     pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
-            .get_token_supply_with_commitment(mint, self.commitment_config)?
+            .get_token_supply_with_commitment(mint, self.commitment())?
             .value)
     }
 
@@ -1545,7 +1544,7 @@ impl RpcClient {
             pubkey,
             lamports,
             RpcRequestAirdropConfig {
-                commitment: Some(self.commitment_config),
+                commitment: Some(self.commitment()),
                 ..RpcRequestAirdropConfig::default()
             },
         )
@@ -1561,7 +1560,7 @@ impl RpcClient {
             pubkey,
             lamports,
             RpcRequestAirdropConfig {
-                commitment: Some(self.commitment_config),
+                commitment: Some(self.commitment()),
                 recent_blockhash: Some(recent_blockhash.to_string()),
             },
         )
@@ -1664,7 +1663,7 @@ impl RpcClient {
 
     /// Poll the server to confirm a transaction.
     pub fn poll_for_signature(&self, signature: &Signature) -> ClientResult<()> {
-        self.poll_for_signature_with_commitment(signature, self.commitment_config)
+        self.poll_for_signature_with_commitment(signature, self.commitment())
     }
 
     /// Poll the server to confirm a transaction.
@@ -1774,7 +1773,7 @@ impl RpcClient {
     ) -> ClientResult<Signature> {
         self.send_and_confirm_transaction_with_spinner_and_commitment(
             transaction,
-            self.commitment_config,
+            self.commitment(),
         )
     }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -55,26 +55,6 @@ pub struct RpcClient {
     node_version: RwLock<Option<semver::Version>>,
 }
 
-fn serialize_encode_transaction(
-    transaction: &Transaction,
-    encoding: UiTransactionEncoding,
-) -> ClientResult<String> {
-    let serialized = serialize(transaction)
-        .map_err(|e| ClientErrorKind::Custom(format!("transaction serialization failed: {}", e)))?;
-    let encoded = match encoding {
-        UiTransactionEncoding::Base58 => bs58::encode(serialized).into_string(),
-        UiTransactionEncoding::Base64 => base64::encode(serialized),
-        _ => {
-            return Err(ClientErrorKind::Custom(format!(
-                "unsupported transaction encoding: {}. Supported encodings: base58, base64",
-                encoding
-            ))
-            .into())
-        }
-    };
-    Ok(encoded)
-}
-
 impl RpcClient {
     fn new_sender<T: RpcSender + Send + Sync + 'static>(
         sender: T,
@@ -1931,6 +1911,26 @@ impl RpcClient {
         serde_json::from_value(response)
             .map_err(|err| ClientError::new_with_request(err.into(), request))
     }
+}
+
+fn serialize_encode_transaction(
+    transaction: &Transaction,
+    encoding: UiTransactionEncoding,
+) -> ClientResult<String> {
+    let serialized = serialize(transaction)
+        .map_err(|e| ClientErrorKind::Custom(format!("transaction serialization failed: {}", e)))?;
+    let encoded = match encoding {
+        UiTransactionEncoding::Base58 => bs58::encode(serialized).into_string(),
+        UiTransactionEncoding::Base64 => base64::encode(serialized),
+        _ => {
+            return Err(ClientErrorKind::Custom(format!(
+                "unsupported transaction encoding: {}. Supported encodings: base58, base64",
+                encoding
+            ))
+            .into())
+        }
+    };
+    Ok(encoded)
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
#### Problem
In a load-balanced RPC setup with imperfect or nonexistent session affinity, an RpcClient may query a recent-blockhash and send a transaction to one node, and attempt to confirm the transaction on another. If this second node is behind or on a short-lived fork, it may not have yet seen the blockhash, causing the client to exit early here: https://github.com/solana-labs/solana/blob/9d983a34a0be4626521edec05e51ce17645867ff/client/src/rpc_client.rs#L1858-L1864
even though the transaction may have actually landed.

#### Summary of Changes
Add a configurable timeout for initial transaction confirmation, allowing `get_signature_status` retries even when the blockhash cannot be found. In a single-node RPC setup, this shouldn't add any additional time.
Also, a little cleanup in RpcClient to use the commitment() method (this is most of the churn), and refactoring in RpcClient to make this cleaner to use and make adding additional RpcClient config parameters easier in the future.