### PR TITLE
`solana validators` output now includes average skip rate

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -347,6 +347,8 @@ pub struct CliValidators {
     pub total_current_stake: u64,
     pub total_delinquent_stake: u64,
     pub validators: Vec<CliValidator>,
+    pub average_skip_rate: f64,
+    pub average_stake_weighted_skip_rate: f64,
     #[serde(skip_serializing)]
     pub validators_sort_order: CliValidatorsSortOrder,
     #[serde(skip_serializing)]
@@ -509,6 +511,18 @@ impl fmt::Display for CliValidators {
         if self.validators.len() > 100 {
             writeln!(f, "{}", header)?;
         }
+
+        writeln!(f)?;
+        writeln_name_value(
+            f,
+            "Average Stake-Weighted Skip Rate:",
+            &format!("{:.2}%", self.average_stake_weighted_skip_rate,),
+        )?;
+        writeln_name_value(
+            f,
+            "Average Unweighted Skip Rate:    ",
+            &format!("{:.2}%", self.average_skip_rate),
+        )?;
 
         writeln!(f)?;
         writeln_name_value(


### PR DESCRIPTION
The average skip rate displayed on https://solanabeach.io/ is consistently wrong.  Fight misinformation by adding it to `solana validators` (including JSON output).

The true mainnet beta skiprate at this time:
```
Average Stake Weighted Skip Rate: 23.44%
Average Non-weighted Skip Rate:   18.99%
```
which is still demonstrates a fat whaley stake distribution where the little nodes are outperforming the whales on average, but a far cry from the 51% skip rate that solana beach currently reports