### PR TITLE
implements an unbiased weighted shuffle using binary indexed tree

### DIFF
--- a/gossip/benches/weighted_shuffle.rs
+++ b/gossip/benches/weighted_shuffle.rs
@@ -1,0 +1,39 @@
+#![feature(test)]
+
+extern crate test;
+
+use {
+    rand::{Rng, SeedableRng},
+    rand_chacha::ChaChaRng,
+    solana_gossip::weighted_shuffle::{weighted_shuffle, WeightedShuffle},
+    std::iter::repeat_with,
+    test::Bencher,
+};
+
+fn make_weights<R: Rng>(rng: &mut R) -> Vec<u64> {
+    repeat_with(|| rng.gen_range(1, 100)).take(1000).collect()
+}
+
+#[bench]
+fn bench_weighted_shuffle_old(bencher: &mut Bencher) {
+    let mut seed = [0u8; 32];
+    let mut rng = rand::thread_rng();
+    let weights = make_weights(&mut rng);
+    bencher.iter(|| {
+        rng.fill(&mut seed[..]);
+        weighted_shuffle(&weights, seed);
+    });
+}
+
+#[bench]
+fn bench_weighted_shuffle_new(bencher: &mut Bencher) {
+    let mut seed = [0u8; 32];
+    let mut rng = rand::thread_rng();
+    let weights = make_weights(&mut rng);
+    bencher.iter(|| {
+        rng.fill(&mut seed[..]);
+        WeightedShuffle::new(&mut ChaChaRng::from_seed(seed), &weights)
+            .unwrap()
+            .collect::<Vec<_>>()
+    });
+}

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -29,7 +29,7 @@ use {
         gossip_error::GossipError,
         ping_pong::{self, PingCache, Pong},
         socketaddr, socketaddr_any,
-        weighted_shuffle::weighted_shuffle,
+        weighted_shuffle::{weighted_shuffle, WeightedShuffle},
     },
     bincode::{serialize, serialized_size},
     itertools::Itertools,
@@ -2093,11 +2093,8 @@ impl ClusterInfo {
         if responses.is_empty() {
             return packets;
         }
-        let shuffle = {
-            let mut seed = [0; 32];
-            rand::thread_rng().fill(&mut seed[..]);
-            weighted_shuffle(&scores, seed).into_iter()
-        };
+        let mut rng = rand::thread_rng();
+        let shuffle = WeightedShuffle::new(&mut rng, &scores).unwrap();
         let mut total_bytes = 0;
         let mut sent = 0;
         for (addr, response) in shuffle.map(|i| &responses[i]) {


### PR DESCRIPTION
#### Problem
Current implementation of weighted_shuffle:
https://github.com/solana-labs/solana/blob/b08f8bd1b/gossip/src/weighted_shuffle.rs#L11-L37
uses a heuristic which results in biased samples.

For example, if the weights are [1, 10, 100], then the 3rd index should
come first 100 times more often than the 1st index. However,
weighted_shuffle is picking the 3rd index 200+ times more often than the
1st index, showing a disproportional bias in favor of higher weights.

#### Summary of Changes

This commit implements weighted shuffle using binary indexed tree to
maintain cumulative sum of weights while sampling. The resulting samples
are demonstrably unbiased and precisely proportional to the weights.

Additionally the iterator interface allows to skip computations when
not all indices are processed.

Of the use cases of weighted_shuffle, changing turbine code requires
feature-gating to keep the cluster in sync. That is not updated in
this commit, but can be done together with future updates to turbine.

