### PR TITLE
Make set roots an iterator

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2641,7 +2641,7 @@ mod tests {
 
             let shreds = entries_to_test_shreds(entries, bank.slot(), 0, true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
-            blockstore.set_roots(&[bank.slot()]).unwrap();
+            blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 
             let (transaction_status_sender, transaction_status_receiver) = unbounded();
             let transaction_status_service = TransactionStatusService::new(

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1337,7 +1337,7 @@ pub fn reconcile_blockstore_roots_with_tower(
                 "Reconciling slots as root based on tower root: {:?} ({}..{}) ",
                 new_roots, tower_root, last_blockstore_root
             );
-            blockstore.set_roots(&new_roots)?;
+            blockstore.set_roots(new_roots.iter())?;
         } else {
             // This indicates we're in bad state; but still don't panic here.
             // That's because we might have a chance of recovering properly with
@@ -3177,7 +3177,7 @@ pub mod test {
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let (shreds, _) = make_slot_entries(4, 1, 42);
             blockstore.insert_shreds(shreds, None, false).unwrap();
-            blockstore.set_roots(&[3]).unwrap();
+            blockstore.set_roots(std::iter::once(&3)).unwrap();
             assert!(!blockstore.is_root(0));
             assert!(!blockstore.is_root(1));
             assert!(blockstore.is_root(3));

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -316,7 +316,7 @@ mod test {
             assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
 
             // If we know set the root in blockstore, should return nothing
-            blockstore.set_roots(&[1, 3]).unwrap();
+            blockstore.set_roots(vec![1, 3].iter()).unwrap();
             optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(optimistic_slots);
             assert!(optimistic_confirmation_verifier
                 .verify_for_unrooted_optimistic_slots(&bank7, &blockstore)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1339,7 +1339,7 @@ impl ReplayStage {
             // get dropped.
             leader_schedule_cache.set_root(rooted_banks.last().unwrap());
             blockstore
-                .set_roots(&rooted_slots)
+                .set_roots(rooted_slots.iter())
                 .expect("Ledger set roots failed");
             let highest_confirmed_root = Some(
                 block_commitment_cache

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2985,10 +2985,12 @@ fn main() {
                 eprintln!("{} slots to be rooted", roots_to_fix.len());
                 for chunk in roots_to_fix.chunks(100) {
                     eprintln!("{:?}", chunk);
-                    blockstore.set_roots(&roots_to_fix).unwrap_or_else(|err| {
-                        eprintln!("Unable to set roots {:?}: {}", roots_to_fix, err);
-                        exit(1);
-                    });
+                    blockstore
+                        .set_roots(roots_to_fix.iter())
+                        .unwrap_or_else(|err| {
+                            eprintln!("Unable to set roots {:?}: {}", roots_to_fix, err);
+                            exit(1);
+                        });
                 }
             } else {
                 println!(

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -60,7 +60,7 @@ mod tests {
     fn test_ancestor_iterator() {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
+        blockstore.set_roots(std::iter::once(&0)).unwrap();
         let ticks_per_slot = 5;
 
         /*

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3095,7 +3095,7 @@ impl Blockstore {
                     return Ok(());
                 }
                 trace!("{:?}", chunk);
-                self.set_roots(roots_to_fix.iter())?;
+                self.set_roots(chunk.iter())?;
             }
         } else {
             debug!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2926,9 +2926,11 @@ impl Blockstore {
         }
     }
 
-    pub fn set_roots(&self, rooted_slots: &[u64]) -> Result<()> {
+    pub fn set_roots<'a>(&self, rooted_slots: impl Iterator<Item = &'a Slot>) -> Result<()> {
         let mut write_batch = self.db.batch()?;
+        let mut max_new_rooted_slot = 0;
         for slot in rooted_slots {
+            max_new_rooted_slot = std::cmp::max(max_new_rooted_slot, *slot);
             write_batch.put::<cf::Root>(*slot, &true)?;
         }
 
@@ -2938,7 +2940,7 @@ impl Blockstore {
         if *last_root == std::u64::MAX {
             *last_root = 0;
         }
-        *last_root = cmp::max(*rooted_slots.iter().max().unwrap(), *last_root);
+        *last_root = cmp::max(max_new_rooted_slot, *last_root);
         Ok(())
     }
 
@@ -3093,7 +3095,7 @@ impl Blockstore {
                     return Ok(());
                 }
                 trace!("{:?}", chunk);
-                self.set_roots(chunk)?;
+                self.set_roots(roots_to_fix.iter())?;
             }
         } else {
             debug!(
@@ -3617,7 +3619,7 @@ pub fn create_new_ledger(
     assert!(shreds.last().unwrap().last_in_slot());
 
     blockstore.insert_shreds(shreds, None, false)?;
-    blockstore.set_roots(&[0])?;
+    blockstore.set_roots(std::iter::once(&0))?;
     // Explicitly close the blockstore before we create the archived genesis file
     drop(blockstore);
 
@@ -5868,7 +5870,7 @@ pub mod tests {
         let chained_slots = vec![0, 2, 4, 7, 12, 15];
         assert_eq!(blockstore.last_root(), 0);
 
-        blockstore.set_roots(&chained_slots).unwrap();
+        blockstore.set_roots(chained_slots.iter()).unwrap();
 
         assert_eq!(blockstore.last_root(), 15);
 
@@ -5885,7 +5887,7 @@ pub mod tests {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
         let roots = vec![2, 4, 7, 12, 15];
-        blockstore.set_roots(&roots).unwrap();
+        blockstore.set_roots(roots.iter()).unwrap();
 
         for i in 0..20 {
             if i < 2 || roots.contains(&i) || i > 15 {
@@ -6054,7 +6056,7 @@ pub mod tests {
         let last_root = 100;
         {
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
-            blockstore.set_roots(&[last_root]).unwrap();
+            blockstore.set_roots(std::iter::once(&last_root)).unwrap();
 
             // Insert will fail, slot < root
             blockstore
@@ -6083,7 +6085,9 @@ pub mod tests {
         ledger.insert_shreds(shreds, None, false).unwrap();
         ledger.insert_shreds(more_shreds, None, false).unwrap();
         ledger.insert_shreds(unrooted_shreds, None, false).unwrap();
-        ledger.set_roots(&[slot - 1, slot, slot + 1]).unwrap();
+        ledger
+            .set_roots(vec![slot - 1, slot, slot + 1].iter())
+            .unwrap();
 
         let parent_meta = SlotMeta {
             parent_slot: std::u64::MAX,
@@ -6638,7 +6642,7 @@ pub mod tests {
             let meta3 = SlotMeta::new(3, 2);
             blockstore.meta_cf.put(3, &meta3).unwrap();
 
-            blockstore.set_roots(&[0, 2]).unwrap();
+            blockstore.set_roots(vec![0, 2].iter()).unwrap();
 
             // Initialize index 0, including:
             //   signature2 in non-root and root,
@@ -6823,7 +6827,7 @@ pub mod tests {
             let meta3 = SlotMeta::new(3, 2);
             blockstore.meta_cf.put(3, &meta3).unwrap();
 
-            blockstore.set_roots(&[0, 1, 2, 3]).unwrap();
+            blockstore.set_roots(vec![0, 1, 2, 3].iter()).unwrap();
 
             let lowest_cleanup_slot = 1;
             let lowest_available_slot = lowest_cleanup_slot + 1;
@@ -6961,7 +6965,7 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         blockstore.insert_shreds(shreds, None, false).unwrap();
-        blockstore.set_roots(&[slot - 1, slot]).unwrap();
+        blockstore.set_roots(vec![slot - 1, slot].iter()).unwrap();
 
         let expected_transactions: Vec<TransactionWithStatusMeta> = entries
             .iter()
@@ -7149,7 +7153,7 @@ pub mod tests {
     fn test_empty_transaction_status() {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
+        blockstore.set_roots(std::iter::once(&0)).unwrap();
         assert_eq!(
             blockstore
                 .get_rooted_transaction(Signature::default())
@@ -7195,7 +7199,7 @@ pub mod tests {
                     )
                     .unwrap();
             }
-            blockstore.set_roots(&[slot0, slot1]).unwrap();
+            blockstore.set_roots(vec![slot0, slot1].iter()).unwrap();
 
             let all0 = blockstore
                 .get_confirmed_signatures_for_address(address0, 0, 50)
@@ -7288,7 +7292,7 @@ pub mod tests {
                     )
                     .unwrap();
             }
-            blockstore.set_roots(&[21, 22, 23, 24]).unwrap();
+            blockstore.set_roots(vec![21, 22, 23, 24].iter()).unwrap();
             let mut past_slot = 0;
             for (slot, _) in blockstore.find_address_signatures(address0, 1, 25).unwrap() {
                 assert!(slot >= past_slot);
@@ -7360,7 +7364,7 @@ pub mod tests {
                     )
                     .unwrap();
             }
-            blockstore.set_roots(&[slot1]).unwrap();
+            blockstore.set_roots(std::iter::once(&slot1)).unwrap();
 
             let slot1_signatures = blockstore
                 .find_address_signatures_for_slot(address0, 1)
@@ -7466,7 +7470,9 @@ pub mod tests {
             }
 
             // Leave one slot unrooted to test only returns confirmed signatures
-            blockstore.set_roots(&[1, 2, 4, 5, 6, 7, 8]).unwrap();
+            blockstore
+                .set_roots(vec![1, 2, 4, 5, 6, 7, 8].iter())
+                .unwrap();
             let highest_confirmed_root = 8;
 
             // Fetch all rooted signatures for address 0 at once...

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -485,7 +485,7 @@ fn do_process_blockstore_from_root(
     // ensure start_slot is rooted for correct replay
     if blockstore.is_primary_access() {
         blockstore
-            .set_roots(&[start_slot])
+            .set_roots(std::iter::once(&start_slot))
             .expect("Couldn't set root slot on startup");
     } else if !blockstore.is_root(start_slot) {
         panic!("starting slot isn't root and can't update due to being secondary blockstore access: {}", start_slot);
@@ -1027,13 +1027,13 @@ fn load_frozen_forks(
                                 if new_root_bank.slot() == *root { break; } // Found the last root in the chain, yay!
                                 assert!(new_root_bank.slot() > *root);
 
-                                rooted_slots.push(new_root_bank.slot());
+                                rooted_slots.push((new_root_bank.slot(), new_root_bank.hash()));
                                 // As noted, the cluster confirmed root should be descended from
                                 // our last root; therefore parent should be set
                                 new_root_bank = new_root_bank.parent().unwrap();
                             }
                             inc_new_counter_info!("load_frozen_forks-cluster-confirmed-root", rooted_slots.len());
-                            blockstore.set_roots(&rooted_slots).expect("Blockstore::set_roots should succeed");
+                            blockstore.set_roots(rooted_slots.iter().map(|(slot, _hash)| slot)).expect("Blockstore::set_roots should succeed");
                             Some(cluster_root_bank)
                         } else {
                             None
@@ -1637,7 +1637,7 @@ pub mod tests {
         info!("last_fork1_entry.hash: {:?}", last_fork1_entry_hash);
         info!("last_fork2_entry.hash: {:?}", last_fork2_entry_hash);
 
-        blockstore.set_roots(&[0, 1, 4]).unwrap();
+        blockstore.set_roots(vec![0, 1, 4].iter()).unwrap();
 
         let opts = ProcessOptions {
             poh_verify: true,
@@ -1717,7 +1717,7 @@ pub mod tests {
         info!("last_fork1_entry.hash: {:?}", last_fork1_entry_hash);
         info!("last_fork2_entry.hash: {:?}", last_fork2_entry_hash);
 
-        blockstore.set_roots(&[0, 1]).unwrap();
+        blockstore.set_roots(vec![0, 1].iter()).unwrap();
 
         let opts = ProcessOptions {
             poh_verify: true,
@@ -1927,11 +1927,13 @@ pub mod tests {
         }
 
         // Set a root on the last slot of the last confirmed epoch
-        let rooted_slots: Vec<_> = (0..=last_slot).collect();
-        blockstore.set_roots(&rooted_slots).unwrap();
+        let rooted_slots: Vec<Slot> = (0..=last_slot).collect();
+        blockstore.set_roots(rooted_slots.iter()).unwrap();
 
         // Set a root on the next slot of the confirmed epoch
-        blockstore.set_roots(&[last_slot + 1]).unwrap();
+        blockstore
+            .set_roots(std::iter::once(&(last_slot + 1)))
+            .unwrap();
 
         // Check that we can properly restart the ledger / leader scheduler doesn't fail
         let opts = ProcessOptions {
@@ -2857,7 +2859,7 @@ pub mod tests {
             genesis_config.ticks_per_slot,
             genesis_config.hash(),
         );
-        blockstore.set_roots(&[0, 1]).unwrap();
+        blockstore.set_roots(vec![0, 1].iter()).unwrap();
 
         // Specify halting at slot 0
         let opts = ProcessOptions {
@@ -2908,7 +2910,7 @@ pub mod tests {
             last_hash =
                 fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, i + 1, i, last_hash);
         }
-        blockstore.set_roots(&[3, 5]).unwrap();
+        blockstore.set_roots(vec![3, 5].iter()).unwrap();
 
         // Set up bank1
         let bank0 = Arc::new(Bank::new(&genesis_config));
@@ -3364,7 +3366,9 @@ pub mod tests {
         blockstore.add_tree(forks, false, true, ticks_per_slot, genesis_config.hash());
 
         if let Some(blockstore_root) = blockstore_root {
-            blockstore.set_roots(&[blockstore_root]).unwrap();
+            blockstore
+                .set_roots(std::iter::once(&blockstore_root))
+                .unwrap();
         }
 
         let opts = ProcessOptions {

--- a/ledger/src/next_slots_iterator.rs
+++ b/ledger/src/next_slots_iterator.rs
@@ -43,7 +43,7 @@ mod tests {
     fn test_next_slots_iterator() {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
+        blockstore.set_roots(std::iter::once(&0)).unwrap();
         let ticks_per_slot = 5;
         /*
             Build a blockstore in the ledger with the following fork structure:

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -84,7 +84,7 @@ mod tests {
     fn test_rooted_slot_iterator() {
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
+        blockstore.set_roots(std::iter::once(&0)).unwrap();
         let ticks_per_slot = 5;
         /*
             Build a blockstore in the ledger with the following fork structure:
@@ -131,7 +131,7 @@ mod tests {
             fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 4, fork_point, fork_hash);
 
         // Set a root
-        blockstore.set_roots(&[1, 2, 3]).unwrap();
+        blockstore.set_roots(vec![1, 2, 3].iter()).unwrap();
 
         // Trying to get an iterator on a different fork will error
         assert!(RootedSlotIterator::new(4, &blockstore).is_err());
@@ -196,11 +196,11 @@ mod tests {
         }
 
         // Set roots
-        blockstore.set_roots(&[0, 1, 2, 3]).unwrap();
+        blockstore.set_roots(vec![0, 1, 2, 3].iter()).unwrap();
 
         // Create one post-skip slot at 10, simulating starting from a snapshot
         // at 10
-        blockstore.set_roots(&[10]).unwrap();
+        blockstore.set_roots(std::iter::once(&10)).unwrap();
         // Try to get an iterator from before the skip. The post-skip slot
         // should not return a SlotMeta
         let result: Vec<_> = RootedSlotIterator::new(3, &blockstore)
@@ -214,7 +214,7 @@ mod tests {
         fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 11, 10, Hash::default());
 
         // Set roots
-        blockstore.set_roots(&[11]).unwrap();
+        blockstore.set_roots(std::iter::once(&11)).unwrap();
 
         let result: Vec<_> = RootedSlotIterator::new(0, &blockstore)
             .unwrap()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3855,7 +3855,7 @@ pub fn create_test_transactions_and_populate_blockstore(
         0,
     );
     blockstore.insert_shreds(shreds, None, false).unwrap();
-    blockstore.set_roots(&[slot]).unwrap();
+    blockstore.set_roots(std::iter::once(&slot)).unwrap();
 
     let (transaction_status_sender, transaction_status_receiver) = crossbeam_channel::unbounded();
     let (replay_vote_sender, _replay_vote_receiver) = crossbeam_channel::unbounded();
@@ -4019,7 +4019,7 @@ pub mod tests {
                 let parent = if i > 0 { roots[i - 1] } else { 0 };
                 fill_blockstore_slot_with_ticks(&blockstore, 5, *root, parent, Hash::default());
             }
-            blockstore.set_roots(&roots).unwrap();
+            blockstore.set_roots(roots.iter()).unwrap();
             let new_bank = Bank::new_from_parent(
                 &parent_bank,
                 parent_bank.collector_id(),
@@ -6693,7 +6693,7 @@ pub mod tests {
         let bank = Arc::new(Bank::default());
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        blockstore.set_roots(&[0, 1]).unwrap();
+        blockstore.set_roots(vec![0, 1].iter()).unwrap();
         // Build BlockCommitmentCache with rooted slots
         let mut cache0 = BlockCommitment::default();
         cache0.increase_rooted_stake(50);


### PR DESCRIPTION
#### Problem
Blockstore `set_roots` could be more generic

#### Summary of Changes
Make `set_roots` take any iterator

Fixes #
