### PR TITLE
Document order of recent blockhashes sysvar

### DIFF
--- a/docs/src/developing/runtime-facilities/sysvars.md
+++ b/docs/src/developing/runtime-facilities/sysvars.md
@@ -97,7 +97,9 @@ other instructions in the same transaction. Read more information on
 ## RecentBlockhashes
 
 The RecentBlockhashes sysvar contains the active recent blockhashes as well as
-their associated fee calculators. It is updated every slot.
+their associated fee calculators. It is updated every slot. Entries are ordered
+by descending block height, so the first entry holds the most recent block hash,
+and the last entry holds an old block hash.
 
 - Address: `SysvarRecentB1ockHashes11111111111111111111`
 - Layout:

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -53,6 +53,10 @@ impl<'a> PartialOrd for IterItem<'a> {
     }
 }
 
+/// Contains recent block hashes and fee calculators.
+///
+/// The entries are ordered by descending block height, so the first entry holds
+/// the most recent block hash, and the last entry holds an old block hash.
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RecentBlockhashes(Vec<Entry>);


### PR DESCRIPTION




#### Problem

I wanted to use this sysvar to get a recent block hash, but I didn't know whether the first or the last entry contains the most recent block hash.

By calling it for mainnet, printing the results, and comparing that to the recent blocks on https://solanabeach.io/blocks, I discovered that the entries are ordered from most recent to least recent. Document this to save future readers the trouble.

#### Summary of Changes

* Add doc comment to [`RecentBlockhashes`](https://docs.rs/solana-sdk/1.7.4/solana_sdk/sysvar/recent_blockhashes/struct.RecentBlockhashes.html). 
* Mention the order in [the sysvar development documentation](https://docs.solana.com/developing/runtime-facilities/sysvars#recentblockhashes).