### PR TITLE
Explorer: regression in rewards provider where lowestFetched is off by one

### DIFF
--- a/explorer/src/providers/accounts/rewards.tsx
+++ b/explorer/src/providers/accounts/rewards.tsx
@@ -137,7 +137,7 @@ async function fetchRewards(
   }
 
   const results = await Promise.all(requests);
-  const lowestFetchedEpoch = fromEpoch - requests.length;
+  const lowestFetchedEpoch = fromEpoch - requests.length + 1;
 
   dispatch({
     type: ActionType.Update,


### PR DESCRIPTION
#### Problem
Pagination for rewards was off by one (gaps).

#### Summary of Changes
Make sure lowest epoch in provider is correct.

Fixes https://github.com/solana-labs/solana/issues/18378
