### PR TITLE
Allow a `solana-validator` to join a cluster established by `solana-test-validator`

### DIFF
--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -164,7 +164,11 @@ impl RpcRequestMiddleware {
             should_validate_hosts: true,
             response: Box::pin(async {
                 match Self::open_no_follow(filename).await {
-                    Err(_) => Ok(Self::internal_server_error()),
+                    Err(err) => Ok(if err.kind() == std::io::ErrorKind::NotFound {
+                        Self::not_found()
+                    } else {
+                        Self::internal_server_error()
+                    }),
                     Ok(file) => {
                         let stream =
                             FramedRead::new(file, BytesCodec::new()).map_ok(|b| b.freeze());


### PR DESCRIPTION
`solana-test-validator` only creates uncompressed snapshots, so `solana-validator` needs to attempt to download uncompressed snapshots as a last resort.

Also improve the HTTP GET response when snapshot files are not found: 
* Return a 404 instead of 502
* Better info! logging on the client side on snapshot download failures