### PR TITLE
Fix transaction logs and inner ixs for leader nodes

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1198,8 +1198,8 @@ pub struct TransactionStatusBatch {
     pub statuses: Vec<TransactionExecutionResult>,
     pub balances: TransactionBalancesSet,
     pub token_balances: TransactionTokenBalancesSet,
-    pub inner_instructions: Vec<Option<InnerInstructionsList>>,
-    pub transaction_logs: Vec<Option<TransactionLogMessages>>,
+    pub inner_instructions: Option<Vec<Option<InnerInstructionsList>>>,
+    pub transaction_logs: Option<Vec<Option<TransactionLogMessages>>>,
     pub rent_debits: Vec<RentDebits>,
 }
 
@@ -1222,6 +1222,11 @@ impl TransactionStatusSender {
         rent_debits: Vec<RentDebits>,
     ) {
         let slot = bank.slot();
+        let (inner_instructions, transaction_logs) = if !self.enable_cpi_and_log_storage {
+            (None, None)
+        } else {
+            (Some(inner_instructions), Some(transaction_logs))
+        };
         if let Err(e) = self
             .sender
             .send(TransactionStatusMessage::Batch(TransactionStatusBatch {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1198,8 +1198,8 @@ pub struct TransactionStatusBatch {
     pub statuses: Vec<TransactionExecutionResult>,
     pub balances: TransactionBalancesSet,
     pub token_balances: TransactionTokenBalancesSet,
-    pub inner_instructions: Option<Vec<Option<InnerInstructionsList>>>,
-    pub transaction_logs: Option<Vec<TransactionLogMessages>>,
+    pub inner_instructions: Vec<Option<InnerInstructionsList>>,
+    pub transaction_logs: Vec<Option<TransactionLogMessages>>,
     pub rent_debits: Vec<RentDebits>,
 }
 
@@ -1218,15 +1218,10 @@ impl TransactionStatusSender {
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
         inner_instructions: Vec<Option<InnerInstructionsList>>,
-        transaction_logs: Vec<TransactionLogMessages>,
+        transaction_logs: Vec<Option<TransactionLogMessages>>,
         rent_debits: Vec<RentDebits>,
     ) {
         let slot = bank.slot();
-        let (inner_instructions, transaction_logs) = if !self.enable_cpi_and_log_storage {
-            (None, None)
-        } else {
-            (Some(inner_instructions), Some(transaction_logs))
-        };
         if let Err(e) = self
             .sender
             .send(TransactionStatusMessage::Batch(TransactionStatusBatch {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -292,26 +292,24 @@ fn process_transaction_and_record_inner(
     let signature = tx.signatures.get(0).unwrap().clone();
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch(txs.iter());
-    let (mut results, _, mut inner, _transaction_logs) = bank.load_execute_and_commit_transactions(
-        &tx_batch,
-        MAX_PROCESSING_AGE,
-        false,
-        true,
-        false,
-        &mut ExecuteTimings::default(),
-    );
-    let inner_instructions = if inner.is_empty() {
-        Some(vec![vec![]])
-    } else {
-        inner.swap_remove(0)
-    };
+    let (mut results, _, mut inner_instructions, _transaction_logs) = bank
+        .load_execute_and_commit_transactions(
+            &tx_batch,
+            MAX_PROCESSING_AGE,
+            false,
+            true,
+            false,
+            &mut ExecuteTimings::default(),
+        );
     let result = results
         .fee_collection_results
         .swap_remove(0)
         .and_then(|_| bank.get_signature_status(&signature).unwrap());
     (
         result,
-        inner_instructions.expect("cpi recording should be enabled"),
+        inner_instructions
+            .swap_remove(0)
+            .expect("cpi recording should be enabled"),
     )
 }
 
@@ -329,8 +327,8 @@ fn execute_transactions(bank: &Bank, txs: &[Transaction]) -> Vec<ConfirmedTransa
             post_balances,
             ..
         },
-        mut inner_instructions,
-        mut transaction_logs,
+        inner_instructions,
+        transaction_logs,
     ) = bank.load_execute_and_commit_transactions(
         &batch,
         std::usize::MAX,
@@ -340,13 +338,6 @@ fn execute_transactions(bank: &Bank, txs: &[Transaction]) -> Vec<ConfirmedTransa
         &mut timings,
     );
     let tx_post_token_balances = collect_token_balances(&bank, &batch, &mut mint_decimals);
-
-    for _ in 0..(txs.len() - transaction_logs.len()) {
-        transaction_logs.push(vec![]);
-    }
-    for _ in 0..(txs.len() - inner_instructions.len()) {
-        inner_instructions.push(None);
-    }
 
     izip!(
         txs.iter(),
@@ -395,7 +386,7 @@ fn execute_transactions(bank: &Bank, txs: &[Transaction]) -> Vec<ConfirmedTransa
                 pre_token_balances: Some(pre_token_balances),
                 post_token_balances: Some(post_token_balances),
                 inner_instructions,
-                log_messages: Some(log_messages),
+                log_messages,
                 rewards: None,
             };
 


### PR DESCRIPTION
#### Problem
Leader nodes with **rpc transaction history enabled** can return corrupted transaction logs and inner instructions when they create and process a transaction batch which contains some invalid transactions.

Notes:
- Since transaction entries with invalid transactions are rejected during replay by other validators, this doesn't impact non-leader nodes.
- Leader nodes without rpc transaction history enabled won't return logs or inner instructions over rpc so the corrupted logs and inner instructions aren't an issue.

#### Summary of Changes
- Ensure that the tx log collector and inner instruction recorder lists are appended to even when iterating over invalid transactions

Fixes #
