### PR TITLE
Cli: expose `--with-memo` to nonce and stake commands

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2250,7 +2250,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 )
                 .offline_args()
                 .nonce_args(false)
-		.arg(memo_arg())
+                .arg(memo_arg())
                 .arg(fee_payer_arg()),
         )
         .subcommand(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -12,7 +12,7 @@ use solana_clap_utils::{
     input_parsers::*,
     input_validators::*,
     keypair::{DefaultSigner, SignerIndex},
-    memo::MEMO_ARG,
+    memo::{memo_arg, MEMO_ARG},
     nonce::*,
 };
 use solana_cli_output::CliNonceAccount;
@@ -56,7 +56,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .required(true),
                         "Account to be granted authority of the nonce account. "),
                 )
-                .arg(nonce_authority_arg()),
+                .arg(nonce_authority_arg())
+                .arg(memo_arg()),
         )
         .subcommand(
             SubCommand::with_name("create-nonce-account")
@@ -91,7 +92,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .value_name("STRING")
                         .takes_value(true)
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
-                ),
+                )
+                .arg(memo_arg()),
         )
         .subcommand(
             SubCommand::with_name("nonce")
@@ -115,7 +117,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .required(true),
                         "Address of the nonce account. "),
                 )
-                .arg(nonce_authority_arg()),
+                .arg(nonce_authority_arg())
+                .arg(memo_arg()),
         )
         .subcommand(
             SubCommand::with_name("nonce-account")
@@ -161,7 +164,8 @@ impl NonceSubCommands for App<'_, '_> {
                         .validator(is_amount)
                         .help("The amount to withdraw from the nonce account, in SOL"),
                 )
-                .arg(nonce_authority_arg()),
+                .arg(nonce_authority_arg())
+                .arg(memo_arg()),
         )
     }
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -14,7 +14,7 @@ use solana_clap_utils::{
     input_parsers::*,
     input_validators::*,
     keypair::{DefaultSigner, SignerIndex},
-    memo::MEMO_ARG,
+    memo::{memo_arg, MEMO_ARG},
     nonce::*,
     offline::*,
     ArgConstant,
@@ -179,6 +179,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("delegate-stake")
@@ -208,6 +209,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("stake-authorize")
@@ -245,6 +247,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(false)
                         .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
                 )
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("deactivate-stake")
@@ -268,6 +271,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("split-stake")
@@ -309,6 +313,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("merge-stake")
@@ -332,6 +337,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")
@@ -372,6 +378,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(custodian_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("stake-set-lockup")
@@ -419,6 +426,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("stake-account")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -82,7 +82,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the VOTE ACCOUNT pubkey")
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-voter")
@@ -109,7 +109,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .required(true),
                         "New authorized vote signer. "),
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer")
@@ -136,7 +136,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .required(true),
                         "New authorized withdrawer. "),
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("vote-update-validator")
@@ -166,7 +166,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Authorized withdrawer keypair"),
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("vote-update-commission")
@@ -196,7 +196,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Authorized withdrawer keypair"),
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
         .subcommand(
             SubCommand::with_name("vote-account")
@@ -266,7 +266,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Authorized withdrawer [default: cli config keypair]"),
                 )
-		.arg(memo_arg())
+                .arg(memo_arg())
         )
     }
 }


### PR DESCRIPTION
#### Problem
Cli nonce and stake commands that submit transactions support attaching a memo instruction, but the memo arg isn't exposed to the user 🤕 

#### Summary of Changes
Expose it (evidently there hasn't been much demand for this, but still...)
(cc #16291)
