### PR TITLE
sdk: add `is_interactive()` method `Signer` trait

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2450,6 +2450,10 @@ mod tests {
             fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
                 Ok(Signature::new(&[1u8; 64]))
             }
+
+            fn is_interactive(&self) -> bool {
+                false
+            }
         }
 
         let present: Box<dyn Signer> = Box::new(keypair_from_seed(&[2u8; 32]).unwrap());

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -53,6 +53,10 @@ impl Signer for RemoteKeypair {
                 .map_err(|e| e.into()),
         }
     }
+
+    fn is_interactive(&self) -> bool {
+        true
+    }
 }
 
 pub fn generate_remote_keypair(

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -80,6 +80,10 @@ impl Signer for Keypair {
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {
         Ok(self.sign_message(message))
     }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
 }
 
 impl<T> PartialEq<T> for Keypair

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -68,6 +68,8 @@ pub trait Signer {
     }
     /// Fallibly produces an Ed25519 signature over the provided `message` bytes.
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError>;
+    /// Whether the impelmentation requires user interaction to sign
+    fn is_interactive(&self) -> bool;
 }
 
 impl<T> From<T> for Box<dyn Signer>

--- a/sdk/src/signer/null_signer.rs
+++ b/sdk/src/signer/null_signer.rs
@@ -28,6 +28,10 @@ impl Signer for NullSigner {
     fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
         Ok(Signature::default())
     }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
 }
 
 impl<T> PartialEq<T> for NullSigner

--- a/sdk/src/signer/presigner.rs
+++ b/sdk/src/signer/presigner.rs
@@ -46,6 +46,10 @@ impl Signer for Presigner {
             Err(PresignerError::VerificationFailure.into())
         }
     }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
 }
 
 impl<T> PartialEq<T> for Presigner

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -10,6 +10,7 @@ pub trait Signers {
     fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError>;
     fn sign_message(&self, message: &[u8]) -> Vec<Signature>;
     fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError>;
+    fn is_interactive(&self) -> bool;
 }
 
 macro_rules! default_keypairs_impl {
@@ -38,6 +39,10 @@ macro_rules! default_keypairs_impl {
                 signatures.push(keypair.try_sign_message(message)?);
             }
             Ok(signatures)
+        }
+
+        fn is_interactive(&self) -> bool {
+            self.iter().any(|s| s.is_interactive())
         }
     };
 }
@@ -118,6 +123,9 @@ mod tests {
         fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
             Ok(Signature::default())
         }
+        fn is_interactive(&self) -> bool {
+            false
+        }
     }
 
     struct Bar;
@@ -127,6 +135,9 @@ mod tests {
         }
         fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
             Ok(Signature::default())
+        }
+        fn is_interactive(&self) -> bool {
+            false
         }
     }
 


### PR DESCRIPTION
#### Problem

No way to tell whether a `Signer` implementation requires user interaction to sign, which is poor UX in some cases

#### Summary of Changes

Add an `is_interactive()` method to `Signer` and all implementations
