### PR TITLE
Add NodeInstance program

### DIFF
--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::integer_arithmetic)]
 
 pub mod authorized_voters;
+pub mod node_instance;
 pub mod vote_instruction;
 pub mod vote_state;
 pub mod vote_transaction;

--- a/programs/vote/src/node_instance.rs
+++ b/programs/vote/src/node_instance.rs
@@ -1,0 +1,194 @@
+use {
+    bincode::{deserialize, serialize_into, serialized_size},
+    serde_derive::{Deserialize, Serialize},
+    solana_sdk::{
+        account::WritableAccount,
+        account_utils::State,
+        clock::Slot,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        keyed_account::keyed_account_at_index,
+        process_instruction::{get_sysvar, InvokeContext},
+        program_utils::limited_deserialize,
+        pubkey::{self, Pubkey},
+        rent::Rent,
+        system_instruction,
+        sysvar::{self, clock::Clock},
+    },
+};
+
+// NodeInstance program identifier
+solana_sdk::declare_id!("Node1nstance1111111111111111111111111111111");
+
+pub type InstanceId = u64;
+
+#[frozen_abi(digest = "AiiUDTocFRGuH18iv5PNPf2CnkMchpzqQsdAaun2WUW7")]
+#[derive(Serialize, Debug, Deserialize, Default, PartialEq, AbiExample)]
+pub struct NodeInstanceState {
+    pub identity: Pubkey,
+    pub instance_id: InstanceId,
+    pub slot: Slot, // Slot that `instance_id` acquired the lock
+}
+
+impl NodeInstanceState {
+    fn get_rent_exempt_balance(rent: &Rent) -> u64 {
+        rent.minimum_balance(Self::size_of() as usize)
+    }
+
+    pub fn size_of() -> u64 {
+        serialized_size(&Self::default()).unwrap()
+    }
+
+    pub fn deserialize(input: &[u8]) -> Result<Self, InstructionError> {
+        deserialize::<NodeInstanceState>(input).map_err(|_| InstructionError::InvalidAccountData)
+    }
+
+    pub fn serialize(&self, output: &mut [u8]) -> Result<(), InstructionError> {
+        serialize_into(output, self).map_err(|_| InstructionError::GenericError)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum NodeInstanceInstruction {
+    /// Acquire the lock
+    ///
+    /// This instruction will succeed if:
+    /// 1. The NodeInstance account is uninitialized, or
+    /// 2. The NodeInstance account is initialized, and the provided identity matches the account
+    ///    identity, and the provided instance id does not match the instance id currently in the
+    ///    account
+    ///
+    /// On success, the `NodeInstanceState::instance_id` and `NodeInstanceState::slot` account
+    /// fields are updated.
+    ///
+    /// # Account references
+    ///   0. [WRITE] NodeInstance to acquire
+    ///   2. [SIGNER] Identity
+    Acquire(InstanceId),
+
+    /// Deallocate the account and refund the lamports it holds to the identity
+    ///
+    /// # Account references
+    ///   0. [WRITE] NodeInstance to close
+    ///   1. [SIGNER] Identity
+    Close,
+}
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    data: &[u8],
+    invoke_context: &mut dyn InvokeContext,
+) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
+
+    let node_instance_account = keyed_account_at_index(keyed_accounts, 0)?;
+    if node_instance_account.owner()? != id() {
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+
+    // Identity must be a signer
+    let identity_account = keyed_account_at_index(keyed_accounts, 1)?;
+    let identity = *identity_account
+        .signer_key()
+        .ok_or(InstructionError::MissingRequiredSignature)?;
+
+    let node_instance_state = State::<NodeInstanceState>::state(node_instance_account)?;
+    if node_instance_state != NodeInstanceState::default() {
+        // Ensure the provided identity matches if the account is initialized
+        if node_instance_state.identity != identity {
+            return Err(InstructionError::InvalidArgument);
+        }
+    }
+
+    match limited_deserialize(data)? {
+        NodeInstanceInstruction::Acquire(instance_id) => {
+            if instance_id == node_instance_state.instance_id {
+                // Already acquired
+                return Err(InstructionError::Custom(1));
+            }
+            if node_instance_state.slot == Slot::MAX {
+                // Account closed
+                return Err(InstructionError::Custom(2));
+            }
+            node_instance_account.set_state(&NodeInstanceState {
+                identity,
+                instance_id,
+                slot: get_sysvar::<Clock>(invoke_context, &sysvar::clock::id())?.slot,
+            })
+        }
+        NodeInstanceInstruction::Close => {
+            // Return account lamports to the identity
+            identity_account
+                .try_account_ref_mut()?
+                .checked_add_lamports(node_instance_account.lamports()?)?;
+            node_instance_account.try_account_ref_mut()?.set_lamports(0);
+
+            // Mark the account as unusable by all
+            node_instance_account.set_state(&NodeInstanceState {
+                slot: Slot::MAX,
+                ..NodeInstanceState::default()
+            })
+        }
+    }
+}
+
+fn node_instance_address_seed(identity: &Pubkey) -> String {
+    let seed = format!("{:.32}", identity.to_string());
+    assert_eq!(seed.len(), pubkey::MAX_SEED_LEN);
+    seed
+}
+
+/// Client-side convention to derive the NodeInstance address from an identity
+pub fn get_node_instance_address(identity: &Pubkey) -> Pubkey {
+    Pubkey::create_with_seed(identity, &node_instance_address_seed(identity), &id()).unwrap()
+}
+
+pub fn create_and_acquire(
+    identity: &Pubkey,
+    instance_id: InstanceId,
+    rent: &Rent,
+) -> Vec<Instruction> {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+
+    vec![
+        system_instruction::create_account_with_seed(
+            identity,
+            &node_instance,
+            identity,
+            &node_instance_address_seed(identity),
+            NodeInstanceState::get_rent_exempt_balance(rent),
+            NodeInstanceState::size_of(),
+            &id(),
+        ),
+        Instruction::new_with_bincode(
+            id(),
+            &NodeInstanceInstruction::Acquire(instance_id),
+            account_metas,
+        ),
+    ]
+}
+
+pub fn acquire(identity: &Pubkey, instance_id: InstanceId) -> Instruction {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+    Instruction::new_with_bincode(
+        id(),
+        &NodeInstanceInstruction::Acquire(instance_id),
+        account_metas,
+    )
+}
+
+pub fn close(identity: &Pubkey) -> Instruction {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+    Instruction::new_with_bincode(id(), &NodeInstanceInstruction::Close, account_metas)
+}

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -37,8 +37,12 @@ pub fn parse_vote_transaction(tx: &Transaction) -> Option<(Pubkey, Vote, Option<
                     .and_then(|key| {
                         let vote_instruction = limited_deserialize(&first_instruction.data).ok();
                         vote_instruction.and_then(|vote_instruction| match vote_instruction {
-                            VoteInstruction::Vote(vote) => Some((*key, vote, None)),
-                            VoteInstruction::VoteSwitch(vote, hash) => {
+                            VoteInstruction::Vote(vote)
+                            | VoteInstruction::VoteWithInstance(vote, ..) => {
+                                Some((*key, vote, None))
+                            }
+                            VoteInstruction::VoteSwitch(vote, hash)
+                            | VoteInstruction::VoteSwitchWithInstance(vote, .., hash) => {
                                 Some((*key, vote, Some(hash)))
                             }
                             _ => None,

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -87,15 +87,26 @@ pub enum ActivationType {
 /// normal child Bank creation.
 /// https://github.com/solana-labs/solana/blob/84b139cc94b5be7c9e0c18c2ad91743231b85a0d/runtime/src/bank.rs#L1723
 fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
-    vec![(
-        Builtin::new(
-            "compute_budget_program",
-            solana_sdk::compute_budget::id(),
-            solana_compute_budget_program::process_instruction,
+    vec![
+        (
+            Builtin::new(
+                "compute_budget_program",
+                solana_sdk::compute_budget::id(),
+                solana_compute_budget_program::process_instruction,
+            ),
+            feature_set::tx_wide_compute_cap::id(),
+            ActivationType::NewProgram,
         ),
-        feature_set::tx_wide_compute_cap::id(),
-        ActivationType::NewProgram,
-    )]
+        (
+            Builtin::new(
+                "node_instance_program",
+                solana_vote_program::node_instance::id(),
+                solana_vote_program::node_instance::process_instruction,
+            ),
+            feature_set::node_instance_program::id(),
+            ActivationType::NewProgram,
+        ),
+    ]
 }
 
 pub(crate) fn get() -> Builtins {

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -61,6 +61,11 @@ pub mod vote {
         crate::declare_id!("Vote111111111111111111111111111111111111111");
     }
 }
+pub mod node_instance {
+    pub mod program {
+        crate::declare_id!("Node1nstance1111111111111111111111111111111");
+    }
+}
 
 /// Convenience macro to declare a static public key and functions to interact with it
 ///

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -119,6 +119,10 @@ pub mod upgradeable_close_instruction {
     solana_sdk::declare_id!("FsPaByos3gA9bUEhp3EimQpQPCoSvCEigHod496NmABQ");
 }
 
+pub mod node_instance_program {
+    solana_sdk::declare_id!("CMAkEUMRLp8bpvTUzFcZ8sXpEYWxN8twCjbWTsnpkC2j");
+}
+
 pub mod sysvar_via_syscall {
     solana_sdk::declare_id!("7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf");
 }
@@ -220,6 +224,7 @@ lazy_static! {
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
+        (node_instance_program::id(), "node instance program"),
         (sysvar_via_syscall::id(), "provide sysvars via syscalls"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
         (update_data_on_realloc::id(), "Retain updated data values modified after realloc via CPI"),

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -134,6 +134,43 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::VoteWithInstance(vote, instance_id) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            let vote = json!({
+                "slots": vote.slots,
+                "hash": vote.hash.to_string(),
+                "timestamp": vote.timestamp,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "voteWithInstance".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "voteAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "nodeInstance": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "vote": vote,
+                    "instanceId": instance_id,
+                }),
+            })
+        }
+        VoteInstruction::VoteSwitchWithInstance(vote, instance_id, hash) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            let vote = json!({
+                "slots": vote.slots,
+                "hash": vote.hash.to_string(),
+                "timestamp": vote.timestamp,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "voteSwitchWithInstance".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "voteAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "nodeInstance": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "vote": vote,
+                    "instanceId": instance_id,
+                    "hash": hash.to_string(),
+                }),
+            })
+        }
     }
 }
 


### PR DESCRIPTION
The NodeInstance program tracks a validator instance on-chain similarly to how `CrdsData::NodeInstance` does for gossip.

Votes may now be optionally submitted with a NodeInstance.  This'll be used to enable ReplayStage to make assumptions about inflight vote transactions that'll be useful to enable failover to a backup validator, without risk of a lockout violation even when the primary node's tower.bin file is inaccessible. 
