### PR TITLE
improves parallelism in window-service recv_window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,25 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.5",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
@@ -4330,7 +4349,7 @@ version = "1.8.0"
 dependencies = [
  "bincode",
  "byteorder",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5227,7 +5246,7 @@ dependencies = [
  "hex",
  "itertools 0.9.0",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5261,7 +5280,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5464,7 +5483,7 @@ dependencies = [
  "hmac 0.11.0",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "memmap2 0.3.0",
  "num-derive",
@@ -5522,7 +5541,7 @@ name = "solana-secp256k1-program"
 version = "1.8.0"
 dependencies = [
  "bincode",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "rand 0.7.3",
  "solana-logger 1.8.0",
  "solana-sdk",

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -84,13 +84,7 @@ impl SigVerifyStage {
             len,
             id
         );
-
-        let verified_batch = verifier.verify_batch(batch);
-
-        for v in verified_batch {
-            sendr.send(vec![v])?;
-        }
-
+        sendr.send(verifier.verify_batch(batch))?;
         verify_batch_time.stop();
 
         debug!(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -13,9 +13,7 @@ use crate::{
 use crossbeam_channel::{
     unbounded, Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
 };
-use rayon::iter::IntoParallelRefMutIterator;
-use rayon::iter::ParallelIterator;
-use rayon::ThreadPool;
+use rayon::{prelude::*, ThreadPool};
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_ledger::{
     blockstore::{self, Blockstore, BlockstoreInsertionMetrics, MAX_DATA_SHREDS_PER_SLOT},
@@ -23,7 +21,7 @@ use solana_ledger::{
     shred::{Nonce, Shred},
 };
 use solana_metrics::{inc_new_counter_debug, inc_new_counter_error};
-use solana_perf::packet::Packets;
+use solana_perf::packet::{Packet, Packets};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, pubkey::Pubkey, timing::duration_as_ms};
@@ -31,6 +29,7 @@ use solana_streamer::streamer::PacketSender;
 use std::collections::HashSet;
 use std::{
     net::{SocketAddr, UdpSocket},
+    ops::Deref,
     sync::atomic::{AtomicBool, Ordering},
     sync::{Arc, RwLock},
     thread::{self, Builder, JoinHandle},
@@ -227,74 +226,52 @@ where
 {
     let timer = Duration::from_millis(200);
     let mut packets = verified_receiver.recv_timeout(timer)?;
-    let mut total_packets: usize = packets.iter().map(|p| p.packets.len()).sum();
-
-    while let Ok(mut more_packets) = verified_receiver.try_recv() {
-        let count: usize = more_packets.iter().map(|p| p.packets.len()).sum();
-        total_packets += count;
-        packets.append(&mut more_packets)
-    }
-
+    packets.extend(verified_receiver.try_iter().flatten());
+    let total_packets: usize = packets.iter().map(|p| p.packets.len()).sum();
     let now = Instant::now();
     inc_new_counter_debug!("streamer-recv_window-recv", total_packets);
 
     let root_bank = bank_forks.read().unwrap().root_bank();
     let last_root = blockstore.last_root();
+    let handle_packet = |packet: &mut Packet| {
+        if packet.meta.discard {
+            inc_new_counter_debug!("streamer-recv_window-invalid_or_unnecessary_packet", 1);
+            return None;
+        }
+        // shred fetch stage should be sending packets
+        // with sufficiently large buffers. Needed to ensure
+        // call to `new_from_serialized_shred` is safe.
+        assert_eq!(packet.data.len(), PACKET_DATA_SIZE);
+        let serialized_shred = packet.data.to_vec();
+        let shred = match Shred::new_from_serialized_shred(serialized_shred) {
+            Ok(shred) if shred_filter(&shred, last_root) => {
+                let leader_pubkey =
+                    leader_schedule_cache.slot_leader_at(shred.slot(), Some(root_bank.deref()));
+                packet.meta.slot = shred.slot();
+                packet.meta.seed = shred.seed(leader_pubkey, root_bank.deref());
+                shred
+            }
+            Ok(_) | Err(_) => {
+                packet.meta.discard = true;
+                return None;
+            }
+        };
+        if packet.meta.repair {
+            let repair_info = RepairMeta {
+                _from_addr: packet.meta.addr(),
+                // If can't parse the nonce, dump the packet.
+                nonce: repair_response::nonce(&packet.data)?,
+            };
+            Some((shred, Some(repair_info)))
+        } else {
+            Some((shred, None))
+        }
+    };
     let (shreds, repair_infos): (Vec<_>, Vec<_>) = thread_pool.install(|| {
         packets
             .par_iter_mut()
-            .flat_map(|packets| {
-                packets
-                    .packets
-                    .iter_mut()
-                    .filter_map(|packet| {
-                        if packet.meta.discard {
-                            inc_new_counter_debug!(
-                                "streamer-recv_window-invalid_or_unnecessary_packet",
-                                1
-                            );
-                            None
-                        } else {
-                            // shred fetch stage should be sending packets
-                            // with sufficiently large buffers. Needed to ensure
-                            // call to `new_from_serialized_shred` is safe.
-                            assert_eq!(packet.data.len(), PACKET_DATA_SIZE);
-                            let serialized_shred = packet.data.to_vec();
-                            if let Ok(shred) = Shred::new_from_serialized_shred(serialized_shred) {
-                                let repair_info = {
-                                    if packet.meta.repair {
-                                        if let Some(nonce) = repair_response::nonce(&packet.data) {
-                                            let repair_info = RepairMeta {
-                                                _from_addr: packet.meta.addr(),
-                                                nonce,
-                                            };
-                                            Some(repair_info)
-                                        } else {
-                                            // If can't parse the nonce, dump the packet
-                                            return None;
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                };
-                                if shred_filter(&shred, last_root) {
-                                    let leader_pubkey = leader_schedule_cache
-                                        .slot_leader_at(shred.slot(), Some(&root_bank));
-                                    packet.meta.slot = shred.slot();
-                                    packet.meta.seed = shred.seed(leader_pubkey, &root_bank);
-                                    Some((shred, repair_info))
-                                } else {
-                                    packet.meta.discard = true;
-                                    None
-                                }
-                            } else {
-                                packet.meta.discard = true;
-                                None
-                            }
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
+            .flat_map(|packet| &mut packet.packets)
+            .filter_map(handle_packet)
             .unzip()
     });
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -270,8 +270,7 @@ where
     let (shreds, repair_infos): (Vec<_>, Vec<_>) = thread_pool.install(|| {
         packets
             .par_iter_mut()
-            .flat_map(|packet| &mut packet.packets)
-            .filter_map(handle_packet)
+            .flat_map_iter(|packet| packet.packets.iter_mut().filter_map(handle_packet))
             .unzip()
     });
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1417,6 +1417,25 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
@@ -2603,7 +2622,7 @@ version = "1.8.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3203,7 +3222,7 @@ dependencies = [
  "hex",
  "itertools 0.9.0",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3236,7 +3255,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3377,7 +3396,7 @@ dependencies = [
  "hmac 0.11.0",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "memmap2 0.3.0",
  "num-derive",


### PR DESCRIPTION
#### Problem
sigverify-stage is breaking batches to single-item vectors before
sending them down the channel:
https://github.com/solana-labs/solana/blob/d451363dc/core/src/sigverify_stage.rs#L88-L92

In addition, window-service is processing inner packets.packets in
serial (only outer packets are parallelized):
https://github.com/solana-labs/solana/blob/d451363dc/core/src/window_service.rs#L244-L246

#### Summary of Changes
This commit:
  * sends the packets in batches from sigverify-stage.
  * uses `flat_map` to parallelize window-service processing of packets
    down to individual packets.
  * simplifies window-service code, reducing number of nested branches.
