### PR TITLE
Cli: Support checked stake and vote operations

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -344,6 +344,8 @@ pub enum CliCommand {
         new_authorized_pubkey: Pubkey,
         vote_authorize: VoteAuthorize,
         memo: Option<String>,
+        authorized: SignerIndex,
+        new_authorized: Option<SignerIndex>,
     },
     VoteUpdateValidator {
         vote_account_pubkey: Pubkey,
@@ -768,12 +770,28 @@ pub fn parse_command(
             default_signer,
             wallet_manager,
             VoteAuthorize::Voter,
+            false,
         ),
         ("vote-authorize-withdrawer", Some(matches)) => parse_vote_authorize(
             matches,
             default_signer,
             wallet_manager,
             VoteAuthorize::Withdrawer,
+            false,
+        ),
+        ("vote-authorize-voter-checked", Some(matches)) => parse_vote_authorize(
+            matches,
+            default_signer,
+            wallet_manager,
+            VoteAuthorize::Voter,
+            true,
+        ),
+        ("vote-authorize-withdrawer-checked", Some(matches)) => parse_vote_authorize(
+            matches,
+            default_signer,
+            wallet_manager,
+            VoteAuthorize::Withdrawer,
+            true,
         ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches, wallet_manager),
         ("withdraw-from-vote-account", Some(matches)) => {
@@ -1839,12 +1857,16 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             new_authorized_pubkey,
             vote_authorize,
             memo,
+            authorized,
+            new_authorized,
         } => process_vote_authorize(
             &rpc_client,
             config,
             vote_account_pubkey,
             new_authorized_pubkey,
             *vote_authorize,
+            *authorized,
+            *new_authorized,
             memo.as_ref(),
         ),
         CliCommand::VoteUpdateValidator {
@@ -2648,6 +2670,8 @@ mod tests {
             new_authorized_pubkey,
             vote_authorize: VoteAuthorize::Voter,
             memo: None,
+            authorized: 0,
+            new_authorized: None,
         };
         let result = process_command(&config);
         assert!(result.is_ok());
@@ -2843,6 +2867,8 @@ mod tests {
             new_authorized_pubkey: bob_pubkey,
             vote_authorize: VoteAuthorize::Voter,
             memo: None,
+            authorized: 0,
+            new_authorized: None,
         };
         assert!(process_command(&config).is_err());
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -200,6 +200,7 @@ pub enum CliCommand {
         seed: Option<String>,
         staker: Option<Pubkey>,
         withdrawer: Option<Pubkey>,
+        withdrawer_signer: Option<SignerIndex>,
         lockup: Lockup,
         amount: SpendAmount,
         sign_only: bool,
@@ -723,7 +724,10 @@ pub fn parse_command(
         }
         // Stake Commands
         ("create-stake-account", Some(matches)) => {
-            parse_create_stake_account(matches, default_signer, wallet_manager)
+            parse_create_stake_account(matches, default_signer, wallet_manager, !CHECKED)
+        }
+        ("create-stake-account-checked", Some(matches)) => {
+            parse_create_stake_account(matches, default_signer, wallet_manager, CHECKED)
         }
         ("delegate-stake", Some(matches)) => {
             parse_stake_delegate_stake(matches, default_signer, wallet_manager)
@@ -1553,6 +1557,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             staker,
             withdrawer,
+            withdrawer_signer,
             lockup,
             amount,
             sign_only,
@@ -1570,6 +1575,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             staker,
             withdrawer,
+            *withdrawer_signer,
             lockup,
             *amount,
             *sign_only,
@@ -2696,6 +2702,7 @@ mod tests {
             seed: None,
             staker: None,
             withdrawer: None,
+            withdrawer_signer: None,
             lockup: Lockup {
                 epoch: 0,
                 unix_timestamp: 0,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -64,6 +64,7 @@ use thiserror::Error;
 
 pub const DEFAULT_RPC_TIMEOUT_SECONDS: &str = "30";
 pub const DEFAULT_CONFIRM_TX_TIMEOUT_SECONDS: &str = "5";
+const CHECKED: bool = true;
 
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
@@ -770,28 +771,28 @@ pub fn parse_command(
             default_signer,
             wallet_manager,
             VoteAuthorize::Voter,
-            false,
+            !CHECKED,
         ),
         ("vote-authorize-withdrawer", Some(matches)) => parse_vote_authorize(
             matches,
             default_signer,
             wallet_manager,
             VoteAuthorize::Withdrawer,
-            false,
+            !CHECKED,
         ),
         ("vote-authorize-voter-checked", Some(matches)) => parse_vote_authorize(
             matches,
             default_signer,
             wallet_manager,
             VoteAuthorize::Voter,
-            true,
+            CHECKED,
         ),
         ("vote-authorize-withdrawer-checked", Some(matches)) => parse_vote_authorize(
             matches,
             default_signer,
             wallet_manager,
             VoteAuthorize::Withdrawer,
-            true,
+            CHECKED,
         ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches, wallet_manager),
         ("withdraw-from-vote-account", Some(matches)) => {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -45,11 +45,7 @@ use solana_sdk::{
     message::Message,
     pubkey::Pubkey,
     signature::{Signature, Signer, SignerError},
-    stake::{
-        self,
-        instruction::LockupArgs,
-        state::{Lockup, StakeAuthorize},
-    },
+    stake::{self, instruction::LockupArgs, state::Lockup},
     system_instruction::{self, SystemError},
     system_program,
     transaction::{Transaction, TransactionError},
@@ -274,7 +270,7 @@ pub enum CliCommand {
     },
     StakeAuthorize {
         stake_account_pubkey: Pubkey,
-        new_authorizations: Vec<(StakeAuthorize, Pubkey, SignerIndex)>,
+        new_authorizations: Vec<StakeAuthorizationIndexed>,
         sign_only: bool,
         dump_transaction_message: bool,
         blockhash_query: BlockhashQuery,
@@ -746,7 +742,10 @@ pub fn parse_command(
             parse_merge_stake(matches, default_signer, wallet_manager)
         }
         ("stake-authorize", Some(matches)) => {
-            parse_stake_authorize(matches, default_signer, wallet_manager)
+            parse_stake_authorize(matches, default_signer, wallet_manager, !CHECKED)
+        }
+        ("stake-authorize-checked", Some(matches)) => {
+            parse_stake_authorize(matches, default_signer, wallet_manager, CHECKED)
         }
         ("stake-set-lockup", Some(matches)) => {
             parse_stake_set_lockup(matches, default_signer, wallet_manager, !CHECKED)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1741,7 +1741,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,
-            mut lockup,
+            lockup,
             custodian,
             new_custodian_signer,
             sign_only,
@@ -1755,7 +1755,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             stake_account_pubkey,
-            &mut lockup,
+            lockup,
             *new_custodian_signer,
             *custodian,
             *sign_only,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -289,6 +289,7 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         lockup: LockupArgs,
         custodian: SignerIndex,
+        new_custodian_signer: Option<SignerIndex>,
         sign_only: bool,
         dump_transaction_message: bool,
         blockhash_query: BlockhashQuery,
@@ -748,7 +749,10 @@ pub fn parse_command(
             parse_stake_authorize(matches, default_signer, wallet_manager)
         }
         ("stake-set-lockup", Some(matches)) => {
-            parse_stake_set_lockup(matches, default_signer, wallet_manager)
+            parse_stake_set_lockup(matches, default_signer, wallet_manager, !CHECKED)
+        }
+        ("stake-set-lockup-checked", Some(matches)) => {
+            parse_stake_set_lockup(matches, default_signer, wallet_manager, CHECKED)
         }
         ("stake-account", Some(matches)) => parse_show_stake_account(matches, wallet_manager),
         ("stake-history", Some(matches)) => parse_show_stake_history(matches),
@@ -1739,6 +1743,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             mut lockup,
             custodian,
+            new_custodian_signer,
             sign_only,
             dump_transaction_message,
             blockhash_query,
@@ -1751,6 +1756,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             stake_account_pubkey,
             &mut lockup,
+            *new_custodian_signer,
             *custodian,
             *sign_only,
             *dump_transaction_message,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1778,7 +1778,7 @@ pub fn process_stake_set_lockup(
     rpc_client: &RpcClient,
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
-    lockup: &mut LockupArgs,
+    lockup: &LockupArgs,
     new_custodian_signer: Option<SignerIndex>,
     custodian: SignerIndex,
     sign_only: bool,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,6 +1,7 @@
 use solana_cli::{
     cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
     spend_utils::SpendAmount,
+    stake::StakeAuthorizationIndexed,
     test_utils::{check_ready, check_recent_balance},
 };
 use solana_cli_output::{parse_sign_only_reply_string, OutputFormat};
@@ -606,7 +607,12 @@ fn test_stake_authorize() {
     config.signers.pop();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: online_authority_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::default(),
@@ -635,8 +641,18 @@ fn test_stake_authorize() {
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorizations: vec![
-            (StakeAuthorize::Staker, online_authority2_pubkey, 1),
-            (StakeAuthorize::Withdrawer, withdraw_authority_pubkey, 0),
+            StakeAuthorizationIndexed {
+                authorization_type: StakeAuthorize::Staker,
+                new_authority_pubkey: online_authority2_pubkey,
+                authority: 1,
+                new_authority_signer: None,
+            },
+            StakeAuthorizationIndexed {
+                authorization_type: StakeAuthorize::Withdrawer,
+                new_authority_pubkey: withdraw_authority_pubkey,
+                authority: 0,
+                new_authority_signer: None,
+            },
         ],
         sign_only: false,
         dump_transaction_message: false,
@@ -663,7 +679,12 @@ fn test_stake_authorize() {
     config.signers.push(&online_authority2);
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, offline_authority_pubkey, 1)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: offline_authority_pubkey,
+            authority: 1,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::default(),
@@ -689,7 +710,12 @@ fn test_stake_authorize() {
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, nonced_authority_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: nonced_authority_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: true,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::None(blockhash),
@@ -708,7 +734,12 @@ fn test_stake_authorize() {
     config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, nonced_authority_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: nonced_authority_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash_query::Source::Cluster, blockhash),
@@ -759,7 +790,12 @@ fn test_stake_authorize() {
     config_offline.signers.push(&nonced_authority);
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 1)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: online_authority_pubkey,
+            authority: 1,
+            new_authority_signer: None,
+        }],
         sign_only: true,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::None(nonce_hash),
@@ -779,7 +815,12 @@ fn test_stake_authorize() {
     config.signers = vec![&offline_presigner, &nonced_authority_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 1)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: online_authority_pubkey,
+            authority: 1,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::FeeCalculator(
@@ -887,7 +928,12 @@ fn test_stake_authorize_with_fee_payer() {
     config.signers = vec![&default_signer, &payer_keypair];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, offline_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: offline_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
@@ -909,7 +955,12 @@ fn test_stake_authorize_with_fee_payer() {
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, payer_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: payer_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: true,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::None(blockhash),
@@ -928,7 +979,12 @@ fn test_stake_authorize_with_fee_payer() {
     config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorizations: vec![(StakeAuthorize::Staker, payer_pubkey, 0)],
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: payer_pubkey,
+            authority: 0,
+            new_authority_signer: None,
+        }],
         sign_only: false,
         dump_transaction_message: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash_query::Source::Cluster, blockhash),
@@ -1646,6 +1702,113 @@ fn test_stake_checked_instructions() {
     };
     process_command(&config).unwrap();
 
+    // Re-authorize account, checking new authority
+    let staker_keypair = Keypair::new();
+    let staker_pubkey = staker_keypair.pubkey();
+    config.signers = vec![&default_signer];
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: staker_pubkey,
+            authority: 0,
+            new_authority_signer: Some(0),
+        }],
+        sign_only: false,
+        dump_transaction_message: false,
+        blockhash_query: BlockhashQuery::default(),
+        nonce_account: None,
+        nonce_authority: 0,
+        memo: None,
+        fee_payer: 0,
+        custodian: None,
+        no_wait: false,
+    };
+    process_command(&config).unwrap_err(); // unsigned authority should fail
+
+    config.signers = vec![&default_signer, &staker_keypair];
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Staker,
+            new_authority_pubkey: staker_pubkey,
+            authority: 0,
+            new_authority_signer: Some(1),
+        }],
+        sign_only: false,
+        dump_transaction_message: false,
+        blockhash_query: BlockhashQuery::default(),
+        nonce_account: None,
+        nonce_authority: 0,
+        memo: None,
+        fee_payer: 0,
+        custodian: None,
+        no_wait: false,
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.staker,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, staker_pubkey);
+
+    let new_withdrawer_keypair = Keypair::new();
+    let new_withdrawer_pubkey = new_withdrawer_keypair.pubkey();
+    config.signers = vec![&default_signer, &withdrawer_keypair];
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Withdrawer,
+            new_authority_pubkey: new_withdrawer_pubkey,
+            authority: 1,
+            new_authority_signer: Some(1),
+        }],
+        sign_only: false,
+        dump_transaction_message: false,
+        blockhash_query: BlockhashQuery::default(),
+        nonce_account: None,
+        nonce_authority: 0,
+        memo: None,
+        fee_payer: 0,
+        custodian: None,
+        no_wait: false,
+    };
+    process_command(&config).unwrap_err(); // unsigned authority should fail
+
+    config.signers = vec![
+        &default_signer,
+        &withdrawer_keypair,
+        &new_withdrawer_keypair,
+    ];
+    config.command = CliCommand::StakeAuthorize {
+        stake_account_pubkey,
+        new_authorizations: vec![StakeAuthorizationIndexed {
+            authorization_type: StakeAuthorize::Withdrawer,
+            new_authority_pubkey: new_withdrawer_pubkey,
+            authority: 1,
+            new_authority_signer: Some(2),
+        }],
+        sign_only: false,
+        dump_transaction_message: false,
+        blockhash_query: BlockhashQuery::default(),
+        nonce_account: None,
+        nonce_authority: 0,
+        memo: None,
+        fee_payer: 0,
+        custodian: None,
+        no_wait: false,
+    };
+    process_command(&config).unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
+    let stake_state: StakeState = stake_account.state().unwrap();
+    let current_authority = match stake_state {
+        StakeState::Initialized(meta) => meta.authorized.withdrawer,
+        _ => panic!("Unexpected stake state!"),
+    };
+    assert_eq!(current_authority, new_withdrawer_pubkey);
+
     // Set lockup, checking new custodian
     let custodian = Keypair::new();
     let custodian_pubkey = custodian.pubkey();
@@ -1654,7 +1817,7 @@ fn test_stake_checked_instructions() {
         epoch: Some(200),
         custodian: Some(custodian_pubkey),
     };
-    config.signers = vec![&default_signer, &withdrawer_keypair];
+    config.signers = vec![&default_signer, &new_withdrawer_keypair];
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
@@ -1670,7 +1833,7 @@ fn test_stake_checked_instructions() {
     };
     process_command(&config).unwrap_err(); // unsigned new custodian should fail
 
-    config.signers = vec![&default_signer, &withdrawer_keypair, &custodian];
+    config.signers = vec![&default_signer, &new_withdrawer_keypair, &custodian];
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
@@ -1687,7 +1850,6 @@ fn test_stake_checked_instructions() {
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
-    println!("{:?}", stake_state);
     let current_lockup = match stake_state {
         StakeState::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),


### PR DESCRIPTION
#### Problem
New checked stake and vote instructions aren't exposed in the solana-cli

#### Summary of Changes
Add new checked subcommands
- [x] Vote AuthorizeChecked
- [x] Stake InitializeChecked
- [x] Stake AuthorizeChecked
- [x] Stake SetLockupChecked
- [x] Integration tests
- [x] Try with hardware wallet

~~Needs rebase on #18345~~
