### PR TITLE
Use tempfile to make unique temps in download utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,6 +4656,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "tar",
+ "tempfile",
 ]
 
 [[package]]

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["blocking"
 solana-sdk = { path = "../sdk", version = "=1.8.0" }
 solana-runtime = { path = "../runtime", version = "=1.8.0" }
 tar = "0.4.35"
+tempfile = "3"
 
 [lib]
 crate-type = ["lib"]

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -10,6 +10,7 @@ use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
 
 static TRUCK: Emoji = Emoji("🚚 ", "");
 static SPARKLE: Emoji = Emoji("✨ ", "");
@@ -65,17 +66,9 @@ pub fn download_file<'a, 'b>(
 
     fs::create_dir_all(destination_file.parent().expect("parent"))
         .map_err(|err| err.to_string())?;
-
-    let mut temp_destination_file = destination_file.to_path_buf();
-    temp_destination_file.set_file_name(format!(
-        "tmp-{}",
-        destination_file
-            .file_name()
-            .expect("file_name")
-            .to_str()
-            .expect("to_str")
-    ));
-
+    let temp_destination_file = NamedTempFile::new()
+        .map_err(|err| err.to_string())?;
+    let temp_destination_file = temp_destination_file.into_temp_path();
     let progress_bar = new_spinner_progress_bar();
     if use_progress_bar {
         progress_bar.set_message(format!("{}Downloading {}...", TRUCK, url));


### PR DESCRIPTION
download utils create temporary files to store downloaded data until
all data is downloaded.  These files should be uniquely named to avoid
being overwritten if multiple processes happen to download the same
file simultaneously.

