### PR TITLE
Offload cost_tracking to its own service from banking_stage main

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -26,7 +26,11 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use std::{
-    sync::{atomic::Ordering, mpsc::Receiver, Arc, Mutex, RwLock},
+    sync::{
+        atomic::Ordering,
+        mpsc::{channel, Receiver},
+        Arc, Mutex, RwLock,
+    },
     thread::sleep,
     time::{Duration, Instant},
 };
@@ -217,6 +221,7 @@ fn main() {
             create_test_recorder(&bank, &blockstore, None);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
         let cluster_info = Arc::new(cluster_info);
+        let (cost_tracking_sender, _) = channel();
         let banking_stage = BankingStage::new(
             &cluster_info,
             &poh_recorder,
@@ -227,6 +232,7 @@ fn main() {
             Arc::new(RwLock::new(CostTracker::new(Arc::new(RwLock::new(
                 CostModel::default(),
             ))))),
+            cost_tracking_sender,
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 

--- a/core/src/cost_tracker.rs
+++ b/core/src/cost_tracker.rs
@@ -73,6 +73,10 @@ impl CostTracker {
         }
     }
 
+    pub fn get_current_slot(&self) -> Slot {
+        self.current_bank_slot
+    }
+
     pub fn try_add(&mut self, transaction_cost: &TransactionCost) -> Result<u64, &'static str> {
         let cost = transaction_cost.account_access_cost + transaction_cost.execution_cost;
         self.would_fit(&transaction_cost.writable_accounts, &cost)?;

--- a/core/src/cost_tracking_service.rs
+++ b/core/src/cost_tracking_service.rs
@@ -1,0 +1,185 @@
+//! this service receives transactions that have been successfully added
+//! to a bank from banking_stage, it therefore calculates and applies the
+//! costs of these transactions to cost_tracker.
+//! This process has some overhead, being in its own service thread is to
+//! minimize impact on main TPU threads.
+
+use crate::cost_tracker::CostTracker;
+use solana_measure::measure::Measure;
+use solana_runtime::bank::TransactionExecutionResult;
+use solana_sdk::{timing::timestamp, transaction::Transaction};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::Receiver,
+        Arc, RwLock,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
+
+#[derive(Default)]
+pub struct CostTrackingServiceStats {
+    last_print: u64,
+    cost_tracker_update_count: u64,
+    cost_tracker_update_elapsed: u64,
+}
+
+impl CostTrackingServiceStats {
+    fn update(&mut self, cost_tracker_update_count: u64, cost_tracker_update_elapsed: u64) {
+        self.cost_tracker_update_count += cost_tracker_update_count;
+        self.cost_tracker_update_elapsed += cost_tracker_update_elapsed;
+
+        let now = timestamp();
+        let elapsed_ms = now - self.last_print;
+        if elapsed_ms > 1000 {
+            datapoint_info!(
+                "cost-tracking-service-stats",
+                ("total_elapsed_us", elapsed_ms * 1000, i64),
+                (
+                    "cost_tracker_update_count",
+                    self.cost_tracker_update_count as i64,
+                    i64
+                ),
+                (
+                    "cost_tracker_update_elapsed",
+                    self.cost_tracker_update_elapsed as i64,
+                    i64
+                ),
+            );
+
+            *self = CostTrackingServiceStats::default();
+            self.last_print = now;
+        }
+    }
+}
+
+pub struct CommittedTransactionBatch {
+    pub transactions: Vec<Transaction>,
+    pub execution_results: Vec<TransactionExecutionResult>,
+}
+
+pub type CostTrackingReceiver = Receiver<CommittedTransactionBatch>;
+
+pub struct CostTrackingService {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl CostTrackingService {
+    pub fn new(
+        exit: Arc<AtomicBool>,
+        cost_tracker: Arc<RwLock<CostTracker>>,
+        cost_tracking_receiver: CostTrackingReceiver,
+    ) -> Self {
+        let thread_hdl = Builder::new()
+            .name("solana-cost-tracking-service".to_string())
+            .spawn(move || {
+                Self::service_loop(exit, cost_tracker, cost_tracking_receiver);
+            })
+            .unwrap();
+
+        Self { thread_hdl }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+
+    fn service_loop(
+        exit: Arc<AtomicBool>,
+        cost_tracker: Arc<RwLock<CostTracker>>,
+        cost_tracking_receiver: CostTrackingReceiver,
+    ) {
+        let mut cost_tracking_service_stats = CostTrackingServiceStats::default();
+        let wait_timer = Duration::from_millis(10);
+
+        loop {
+            if exit.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let mut cost_tracker_update_time = Measure::start("cost_tracker_update_time");
+            let mut cost_tracker_update_count = 0_u64;
+            for batch in cost_tracking_receiver.try_iter() {
+                cost_tracker_update_count += batch.transactions.len() as u64;
+                Self::process_batch(&cost_tracker, &batch);
+            }
+            cost_tracker_update_time.stop();
+            debug!("cost_update_loop cleared update channel");
+
+            cost_tracking_service_stats
+                .update(cost_tracker_update_count, cost_tracker_update_time.as_us());
+
+            thread::sleep(wait_timer);
+        }
+    }
+
+    fn process_batch(cost_tracker: &RwLock<CostTracker>, batch: &CommittedTransactionBatch) {
+        debug!(
+            "cost_tracking_service processes a batch, size {}",
+            batch.transactions.len()
+        );
+        // only track the cost of transactions that were successfully executed and committed to
+        // bank
+        for ((result, _), tx) in batch
+            .execution_results
+            .iter()
+            .zip(batch.transactions.iter())
+        {
+            if result.is_err() {
+                continue;
+            }
+            cost_tracker.write().unwrap().add_transaction_cost(tx);
+            debug!(
+                "cost_update_loop updated for transaction {:?}, block cost {:?}",
+                tx,
+                cost_tracker.read().unwrap().get_stats()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cost_model::CostModel;
+    use solana_sdk::{
+        hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction,
+        transaction::TransactionError,
+    };
+
+    #[test]
+    fn test_cost_tracking_service_process_batch() {
+        let mint_keypair = Keypair::new();
+        let start_hash = Hash::new_unique();
+
+        // make three simple transfer transactions, the second one is not ok()
+        let transactions: Vec<_> = vec![
+            system_transaction::transfer(&mint_keypair, &Pubkey::new_unique(), 1, start_hash),
+            system_transaction::transfer(&mint_keypair, &Pubkey::new_unique(), 2, start_hash),
+            system_transaction::transfer(&mint_keypair, &Pubkey::new_unique(), 3, start_hash),
+        ];
+        let execution_results: Vec<TransactionExecutionResult> = vec![
+            (Ok(()), None),
+            (Err(TransactionError::AccountNotFound), None),
+            (Ok(()), None),
+        ];
+        let batch = CommittedTransactionBatch {
+            transactions,
+            execution_results,
+        };
+
+        let cost_tracker = Arc::new(RwLock::new(CostTracker::new(Arc::new(RwLock::new(
+            CostModel::default(),
+        )))));
+        CostTrackingService::process_batch(&cost_tracker, &batch);
+        let cost_stats = cost_tracker.read().unwrap().get_stats();
+
+        // each transfer tx has account access cost of 58 and 0 execution cost, 2 OK TXs
+        assert_eq!(116, cost_stats.total_cost);
+        // shared mint account, plus 2 transfer accounts
+        assert_eq!(3, cost_stats.number_of_accounts);
+        // the costest account is the mint account, which has both TXs
+        assert_eq!(116, cost_stats.costliest_account_cost);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod accounts_hash_verifier;
 pub mod banking_stage;
+pub mod block_generation_cost_tracking_service;
 pub mod broadcast_stage;
 pub mod cache_block_meta_service;
 pub mod cluster_info_vote_listener;
@@ -19,10 +20,9 @@ pub mod cluster_slots_service;
 pub mod commitment_service;
 pub mod completed_data_sets_service;
 pub mod consensus;
+pub mod cost_governing_service;
 pub mod cost_model;
 pub mod cost_tracker;
-pub mod cost_tracking_service;
-pub mod cost_update_service;
 pub mod execute_cost_table;
 pub mod fetch_stage;
 pub mod fork_choice;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod completed_data_sets_service;
 pub mod consensus;
 pub mod cost_model;
 pub mod cost_tracker;
+pub mod cost_tracking_service;
 pub mod cost_update_service;
 pub mod execute_cost_table;
 pub mod fetch_stage;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -12,8 +12,8 @@ use crate::{
     cluster_slots::ClusterSlots,
     completed_data_sets_service::CompletedDataSetsSender,
     consensus::Tower,
+    cost_governing_service::CostGoverningService,
     cost_model::CostModel,
-    cost_update_service::CostUpdateService,
     ledger_cleanup_service::LedgerCleanupService,
     replay_stage::{ReplayStage, ReplayStageConfig},
     retransmit_stage::RetransmitStage,
@@ -66,7 +66,7 @@ pub struct Tvu {
     ledger_cleanup_service: Option<LedgerCleanupService>,
     accounts_background_service: AccountsBackgroundService,
     accounts_hash_verifier: AccountsHashVerifier,
-    cost_update_service: CostUpdateService,
+    cost_governing_service: CostGoverningService,
 }
 
 pub struct Sockets {
@@ -277,7 +277,7 @@ impl Tvu {
             Sender<ExecuteTimings>,
             Receiver<ExecuteTimings>,
         ) = channel();
-        let cost_update_service = CostUpdateService::new(
+        let cost_governing_service = CostGoverningService::new(
             exit.clone(),
             blockstore.clone(),
             cost_model.clone(),
@@ -332,7 +332,7 @@ impl Tvu {
             ledger_cleanup_service,
             accounts_background_service,
             accounts_hash_verifier,
-            cost_update_service,
+            cost_governing_service,
         }
     }
 
@@ -346,7 +346,7 @@ impl Tvu {
         self.accounts_background_service.join()?;
         self.replay_stage.join()?;
         self.accounts_hash_verifier.join()?;
-        self.cost_update_service.join()?;
+        self.cost_governing_service.join()?;
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem
Currently banking_stage runs cost tracking logic inline in its main threads. This inline-ness may not be necessary, cost can be tracked on separate thread to minimize overhead. 

#### Summary of Changes
- add a `cost_tracking_service` module, running in its own thread;
- banking_stage sends a batch of processed transactions to `cost_tracking_serivce` immediately after transactions committed to bank;

Fixes #
