### PR TITLE
docs: Correct integration validator cli reference

### DIFF
--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -30,6 +30,7 @@ To run an api node:
 ```bash
 solana-validator \
   --ledger <LEDGER_PATH> \
+  --identity <VALIDATOR_IDENTITY_KEYPAIR> \
   --entrypoint <CLUSTER_ENTRYPOINT> \
   --expected-genesis-hash <EXPECTED_GENESIS_HASH> \
   --rpc-port 8899 \


### PR DESCRIPTION
#### Problem

Validator CLI reference in integrations of the docs is out of date

#### Summary of Changes

Add `--identity ...` arg

Fixes #18434
