### PR TITLE
eliminate unnecessary copies in accounts index generation

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5982,21 +5982,22 @@ impl AccountsDb {
         }
 
         let mut stored_sizes_and_counts = HashMap::new();
-        for account_entry in self
-            .accounts_index
-            .account_maps
-            .iter()
-            .map(|i| i.read().unwrap().values().cloned().collect::<Vec<_>>())
-            .flatten()
-        {
-            for (_slot, account_entry) in account_entry.slot_list.read().unwrap().iter() {
-                let storage_entry_meta = stored_sizes_and_counts
-                    .entry(account_entry.store_id)
-                    .or_insert((0, 0));
-                storage_entry_meta.0 += account_entry.stored_size;
-                storage_entry_meta.1 += 1;
-            }
-        }
+        self.accounts_index.account_maps.iter().for_each(|i| {
+            i.read().unwrap().values().for_each(|entry| {
+                entry
+                    .slot_list
+                    .read()
+                    .unwrap()
+                    .iter()
+                    .for_each(|(_slot, account_entry)| {
+                        let storage_entry_meta = stored_sizes_and_counts
+                            .entry(account_entry.store_id)
+                            .or_insert((0, 0));
+                        storage_entry_meta.0 += account_entry.stored_size;
+                        storage_entry_meta.1 += 1;
+                    })
+            })
+        });
         for slot_stores in self.storage.0.iter() {
             for (id, store) in slot_stores.value().read().unwrap().iter() {
                 // Should be default at this point


### PR DESCRIPTION
#### Problem
instead of making copies while iterating, just iterate and do what needs to be done while iterating.
#### Summary of Changes

Fixes #
