### PR TITLE
serial insertion of bins into accounts index

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -7,7 +7,6 @@ use crate::{
 use bv::BitVec;
 use log::*;
 use ouroboros::self_referencing;
-use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_sdk::{
     clock::{BankId, Slot},
@@ -1400,7 +1399,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport + std::marker::Sync + std::mark
         let insertion_time = AtomicU64::new(0);
 
         let duplicate_keys = binned
-            .into_par_iter()
+            .into_iter()
             .map(|(pubkey_bin, items)| {
                 let mut _reclaims = SlotList::new();
 


### PR DESCRIPTION
#### Problem
Accounts index generation is slow. Looks like we end up with too few items per bin to insert to be efficiently done in parallel. At 72M accounts, 400k slots, we end up with an average of ~11 accounts per bin per slot.
#### Summary of Changes
Rely on parallelism at storage level instead of within index generation. This can be tuned over time. We could collect multiple storages/slots together to reduce lock grabbing cost. We could chunk multiple bins into a thread and spin up something like 4 or 8 or 16 threads total instead of BINS (currently 16) threads per insert.
Fixes #
