### PR TITLE
update ledger tool to restore cost table from blockstore

### DIFF
--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -477,29 +477,19 @@ mod tests {
     #[test]
     fn test_cost_model_init_cost_table() {
         // build cost table
-        let instruction_ids = vec![
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
+        let cost_table = vec![
+            (Pubkey::new_unique(), 10),
+            (Pubkey::new_unique(), 20),
+            (Pubkey::new_unique(), 30),
         ];
-        let instruction_costs = vec![10, 20, 30];
-        let cost_table: Vec<(Pubkey, u64)> = instruction_ids
-            .iter()
-            .enumerate()
-            .map(|(index, id)| (*id, instruction_costs[index]))
-            .collect();
 
         // init cost model
         let mut cost_model = CostModel::default();
         cost_model.initialize_cost_table(&cost_table);
-        let cost_model = Arc::new(RwLock::new(cost_model));
 
         // verify
-        instruction_ids.iter().enumerate().for_each(|(index, id)| {
-            assert_eq!(
-                instruction_costs[index],
-                cost_model.read().unwrap().find_instruction_cost(id)
-            );
-        });
+        for (id, cost) in cost_table.iter() {
+            assert_eq!(*cost, cost_model.find_instruction_cost(id));
+        }
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -741,6 +741,31 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
         ACCOUNT_MAX_COST,
         BLOCK_MAX_COST,
     )));
+    // init cost_model from blockstore
+    {
+        let cost_table = &blockstore.read_program_costs().unwrap();
+        let mut cost_model = cost_model.write().unwrap();
+        for (program_id, cost) in cost_table {
+            match cost_model.upsert_instruction_cost(program_id, cost) {
+                Ok(c) => {
+                    debug!(
+                        "initiating cost table, instruction {:?} has cost {}",
+                        program_id, c
+                    );
+                }
+                Err(err) => {
+                    debug!(
+                        "initiating cost table, failed for instruction {:?}, err: {}",
+                        program_id, err
+                    );
+                }
+            }
+        }
+    }
+    debug!(
+        "restored cost model instruction cost table from blockstore, current values: {:?}",
+        cost_model.read().unwrap().get_instruction_cost_table()
+    );
     let mut cost_tracker = CostTracker::new(cost_model.clone());
 
     for entry in &entries {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -14,7 +14,7 @@ use solana_clap_utils::{
         is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
     },
 };
-use solana_core::cost_model::{CostModel, ACCOUNT_MAX_COST, BLOCK_MAX_COST};
+use solana_core::cost_model::CostModel;
 use solana_core::cost_tracker::CostTracker;
 use solana_ledger::entry::Entry;
 use solana_ledger::{
@@ -737,35 +737,9 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
     let mut transactions = 0;
     let mut programs = 0;
     let mut program_ids = HashMap::new();
-    let cost_model = Arc::new(RwLock::new(CostModel::new(
-        ACCOUNT_MAX_COST,
-        BLOCK_MAX_COST,
-    )));
-    // init cost_model from blockstore
-    {
-        let cost_table = &blockstore.read_program_costs().unwrap();
-        let mut cost_model = cost_model.write().unwrap();
-        for (program_id, cost) in cost_table {
-            match cost_model.upsert_instruction_cost(program_id, cost) {
-                Ok(c) => {
-                    debug!(
-                        "initiating cost table, instruction {:?} has cost {}",
-                        program_id, c
-                    );
-                }
-                Err(err) => {
-                    debug!(
-                        "initiating cost table, failed for instruction {:?}, err: {}",
-                        program_id, err
-                    );
-                }
-            }
-        }
-    }
-    debug!(
-        "restored cost model instruction cost table from blockstore, current values: {:?}",
-        cost_model.read().unwrap().get_instruction_cost_table()
-    );
+    let mut cost_model = CostModel::default();
+    cost_model.initialize_cost_table(&blockstore.read_program_costs().unwrap());
+    let cost_model = Arc::new(RwLock::new(cost_model));
     let mut cost_tracker = CostTracker::new(cost_model.clone());
 
     for entry in &entries {


### PR DESCRIPTION
#### Problem
Instruction executing costs are persisted in blockstore as CF `cost_table`, ledger-tool's `compute-slot-cost` command could get more accurate results if restore that table from blockstore.

#### Summary of Changes
- initialize cost_model from blockstore::cost_table before computing slot cost. No negative impact if cost-table is empty or doesn't exist in blockstore.

Fixes #
