### PR TITLE
Fix example in docs for getInflationReward

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1383,7 +1383,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
     "id": 1,
     "method": "getInflationReward",
     "params": [
-       ["6dmNQ5jwLeLk5REvio1JcMshcbvkYMwy26sJ8pbkvStu", "BGsqMegLpV6n6Ve146sSX2dTjUMj3M92HnU8BbNRMhF2"], 2
+       ["6dmNQ5jwLeLk5REvio1JcMshcbvkYMwy26sJ8pbkvStu", "BGsqMegLpV6n6Ve146sSX2dTjUMj3M92HnU8BbNRMhF2"], {"epoch": 2}
     ]
   }
 '


### PR DESCRIPTION
#### Problem

The example in the docs returns the following error:

```
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: integer `2`, expected struct RpcEpochConfig."},"id":1}
```

#### Summary of Changes

This simply fixes it to use a working example
