### PR TITLE
Rename ClusterInfo::send_vote to ClusterInfo::send_transaction

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1551,7 +1551,7 @@ impl ReplayStage {
                 ("target_bank_slot", heaviest_bank_on_same_fork.slot(), i64),
                 ("target_bank_hash", hash_string, String),
             );
-            let _ = cluster_info.send_vote(
+            let _ = cluster_info.send_transaction(
                 &vote_tx,
                 crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder),
             );
@@ -1589,7 +1589,7 @@ impl ReplayStage {
         if let Some(vote_tx) = vote_tx {
             tower.refresh_last_vote_tx_blockhash(vote_tx.message.recent_blockhash);
             let mut send_time = Measure::start("send_vote");
-            let _ = cluster_info.send_vote(
+            let _ = cluster_info.send_transaction(
                 &vote_tx,
                 crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder),
             );

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1101,13 +1101,13 @@ impl ClusterInfo {
         }
     }
 
-    pub fn send_vote(
+    pub fn send_transaction(
         &self,
-        vote: &Transaction,
+        transaction: &Transaction,
         tpu: Option<SocketAddr>,
     ) -> Result<(), GossipError> {
         let tpu = tpu.unwrap_or_else(|| self.my_contact_info().tpu);
-        let buf = serialize(vote)?;
+        let buf = serialize(transaction)?;
         self.socket.send_to(&buf, &tpu)?;
         Ok(())
     }


### PR DESCRIPTION
Nit. This function operates on any transaction, not just a vote
