### PR TITLE
Cli: Remove dead solana airdrop parameters

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2023,22 +2023,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
         .stake_subcommands()
         .subcommand(
             SubCommand::with_name("airdrop")
-                .about("Request lamports")
-                .arg(
-                    Arg::with_name("faucet_host")
-                        .long("faucet-host")
-                        .value_name("URL")
-                        .takes_value(true)
-                        .help("Faucet host to use [default: the --url host]"),
-                )
-                .arg(
-                    Arg::with_name("faucet_port")
-                        .long("faucet-port")
-                        .value_name("PORT_NUMBER")
-                        .takes_value(true)
-                        .default_value(solana_faucet::faucet::FAUCET_PORT_STR)
-                        .help("Faucet port to use"),
-                )
+                .about("Request SOL from a faucet")
                 .arg(
                     Arg::with_name("amount")
                         .index(1)


### PR DESCRIPTION
#### Problem
Solana-cli was transitioned to RPC airdrops without changing the user interface. This means there are a couple existing parameters that don't do anything.

#### Summary of Changes
Take out the trash
Also improve airdrop about text slightly
