### PR TITLE
Add blockstore column for frozen hashes and duplicate confirmed

### DIFF
--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -76,10 +76,7 @@ impl<'a> Iterator for AncestorIteratorWithHash<'a> {
 mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
-    use std::{
-        collections::HashMap,
-        path::Path,
-    };
+    use std::{collections::HashMap, path::Path};
     use trees::tr;
 
     fn setup_forks(blockstore_path: &Path) -> Blockstore {
@@ -168,7 +165,8 @@ mod tests {
 
             // Test correctness
             assert!(
-                AncestorIteratorWithHash::from(AncestorIterator::new(0, &blockstore)).next()
+                AncestorIteratorWithHash::from(AncestorIterator::new(0, &blockstore))
+                    .next()
                     .is_none()
             );
             assert_eq!(

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -75,70 +75,52 @@ impl<'a> Iterator for AncestorIteratorWithHash<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blockstore_processor::fill_blockstore_slot_with_ticks;
     use solana_sdk::hash::Hash;
+    use std::{
+        collections::HashMap,
+        path::Path,
+    };
+    use trees::tr;
+
+    fn setup_forks(blockstore_path: &Path) -> Blockstore {
+        let blockstore = Blockstore::open(blockstore_path).unwrap();
+        /*
+            Build fork structure:
+
+                slot 0
+                    |
+                slot 1
+                /    \
+            slot 2    |
+                |       |
+            slot 3    |
+                        |
+                        |
+                    slot 4
+        */
+        let tree = tr(0) / (tr(1) / (tr(2) / (tr(3))) / (tr(4)));
+        blockstore.add_tree(tree, true, true, 2, Hash::default());
+        blockstore
+    }
 
     #[test]
     fn test_ancestor_iterator() {
         let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(std::iter::once(&0)).unwrap();
-        let ticks_per_slot = 5;
+        {
+            let blockstore = setup_forks(&blockstore_path);
 
-        /*
-            Build a blockstore in the ledger with the following fork structure:
-
-                 slot 0
-                   |
-                 slot 1
-                 /   \
-            slot 2   |
-               /     |
-            slot 3   |
-                     |
-                   slot 4
-
-        */
-
-        // Fork 1, ending at slot 3
-        let last_entry_hash = Hash::default();
-        let fork_point = 1;
-        let mut fork_hash = Hash::default();
-        for slot in 0..=3 {
-            let parent = {
-                if slot == 0 {
-                    0
-                } else {
-                    slot - 1
-                }
-            };
-            let last_entry_hash = fill_blockstore_slot_with_ticks(
-                &blockstore,
-                ticks_per_slot,
-                slot,
-                parent,
-                last_entry_hash,
+            // Test correctness
+            assert!(AncestorIterator::new(0, &blockstore).next().is_none());
+            assert_eq!(
+                AncestorIterator::new(4, &blockstore).collect::<Vec<Slot>>(),
+                vec![1, 0]
             );
-
-            if slot == fork_point {
-                fork_hash = last_entry_hash;
-            }
+            assert_eq!(
+                AncestorIterator::new(3, &blockstore).collect::<Vec<Slot>>(),
+                vec![2, 1, 0]
+            );
         }
-
-        // Fork 2, ending at slot 4
-        let _ =
-            fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 4, fork_point, fork_hash);
-
-        // Test correctness
-        assert!(AncestorIterator::new(0, &blockstore).next().is_none());
-        assert_eq!(
-            AncestorIterator::new(4, &blockstore).collect::<Vec<Slot>>(),
-            vec![1, 0]
-        );
-        assert_eq!(
-            AncestorIterator::new(3, &blockstore).collect::<Vec<Slot>>(),
-            vec![2, 1, 0]
-        );
+        Blockstore::destroy(&blockstore_path).unwrap();
     }
 
     #[test]
@@ -168,5 +150,42 @@ mod tests {
             AncestorIterator::new_inclusive(3, &blockstore).collect::<Vec<Slot>>(),
             vec![] as Vec<Slot>
         );
+    }
+
+    #[test]
+    fn test_ancestor_iterator_with_hash() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = setup_forks(&blockstore_path);
+
+            // Insert frozen hashes
+            let mut slot_to_bank_hash = HashMap::new();
+            for slot in 0..=4 {
+                let bank_hash = Hash::new_unique();
+                slot_to_bank_hash.insert(slot, bank_hash);
+                blockstore.insert_bank_hash(slot, bank_hash, false);
+            }
+
+            // Test correctness
+            assert!(
+                AncestorIteratorWithHash::from(AncestorIterator::new(0, &blockstore)).next()
+                    .is_none()
+            );
+            assert_eq!(
+                AncestorIteratorWithHash::from(AncestorIterator::new(4, &blockstore))
+                    .collect::<Vec<(Slot, Hash)>>(),
+                vec![(1, slot_to_bank_hash[&1]), (0, slot_to_bank_hash[&0])]
+            );
+            assert_eq!(
+                AncestorIteratorWithHash::from(AncestorIterator::new(3, &blockstore))
+                    .collect::<Vec<(Slot, Hash)>>(),
+                vec![
+                    (2, slot_to_bank_hash[&2]),
+                    (1, slot_to_bank_hash[&1]),
+                    (0, slot_to_bank_hash[&0])
+                ]
+            );
+        }
+        Blockstore::destroy(&blockstore_path).unwrap();
     }
 }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -269,6 +269,10 @@ impl Blockstore {
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false)
             && self
+                .bank_hash_cf
+                .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
                 .index_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false)

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -137,6 +137,10 @@ impl Blockstore {
             .is_ok()
             & self
                 .db
+                .delete_range_cf::<cf::BankHash>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
                 .delete_range_cf::<cf::Root>(&mut write_batch, from_slot, to_slot)
                 .is_ok()
             & self

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -47,6 +47,8 @@ const DUPLICATE_SLOTS_CF: &str = "duplicate_slots";
 const ERASURE_META_CF: &str = "erasure_meta";
 // Column family for orphans data
 const ORPHANS_CF: &str = "orphans";
+/// Column family for bank hashes
+const BANK_HASH_CF: &str = "bank_hash";
 // Column family for root data
 const ROOT_CF: &str = "root";
 /// Column family for indexes
@@ -132,6 +134,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The erasure meta column
     pub struct ErasureMeta;
+
+    #[derive(Debug)]
+    /// The bank hash column
+    pub struct BankHash;
 
     #[derive(Debug)]
     /// The root column
@@ -262,11 +268,7 @@ impl Rocks {
         access_type: AccessType,
         recovery_mode: Option<BlockstoreRecoveryMode>,
     ) -> Result<Rocks> {
-        use columns::{
-            AddressSignatures, BlockHeight, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta,
-            Index, Orphans, PerfSamples, ProgramCosts, Rewards, Root, ShredCode, ShredData,
-            SlotMeta, TransactionStatus, TransactionStatusIndex,
-        };
+        use columns::*;
 
         fs::create_dir_all(&path)?;
 
@@ -301,6 +303,10 @@ impl Rocks {
         let orphans_cf_descriptor = ColumnFamilyDescriptor::new(
             Orphans::NAME,
             get_cf_options::<Orphans>(&access_type, &oldest_slot),
+        );
+        let bank_hash_cf_descriptor = ColumnFamilyDescriptor::new(
+            BankHash::NAME,
+            get_cf_options::<BankHash>(&access_type, &oldest_slot),
         );
         let root_cf_descriptor = ColumnFamilyDescriptor::new(
             Root::NAME,
@@ -359,6 +365,7 @@ impl Rocks {
             (DuplicateSlots::NAME, duplicate_slots_cf_descriptor),
             (ErasureMeta::NAME, erasure_meta_cf_descriptor),
             (Orphans::NAME, orphans_cf_descriptor),
+            (BankHash::NAME, bank_hash_cf_descriptor),
             (Root::NAME, root_cf_descriptor),
             (Index::NAME, index_cf_descriptor),
             (ShredData::NAME, shred_data_cf_descriptor),
@@ -472,11 +479,7 @@ impl Rocks {
     }
 
     fn columns(&self) -> Vec<&'static str> {
-        use columns::{
-            AddressSignatures, BlockHeight, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta,
-            Index, Orphans, PerfSamples, ProgramCosts, Rewards, Root, ShredCode, ShredData,
-            SlotMeta, TransactionStatus, TransactionStatusIndex,
-        };
+        use columns::*;
 
         vec![
             ErasureMeta::NAME,
@@ -484,6 +487,7 @@ impl Rocks {
             DuplicateSlots::NAME,
             Index::NAME,
             Orphans::NAME,
+            BankHash::NAME,
             Root::NAME,
             SlotMeta::NAME,
             ShredData::NAME,
@@ -885,6 +889,14 @@ impl ColumnName for columns::Orphans {
 }
 impl TypedColumn for columns::Orphans {
     type Type = bool;
+}
+
+impl SlotColumn for columns::BankHash {}
+impl ColumnName for columns::BankHash {
+    const NAME: &'static str = BANK_HASH_CF;
+}
+impl TypedColumn for columns::BankHash {
+    type Type = blockstore_meta::FrozenHashVersioned;
 }
 
 impl SlotColumn for columns::Root {}

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -48,7 +48,7 @@ const ERASURE_META_CF: &str = "erasure_meta";
 // Column family for orphans data
 const ORPHANS_CF: &str = "orphans";
 /// Column family for bank hashes
-const BANK_HASH_CF: &str = "bank_hash";
+const BANK_HASH_CF: &str = "bank_hashes";
 // Column family for root data
 const ROOT_CF: &str = "root";
 /// Column family for indexes

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,6 +1,6 @@
 use crate::erasure::ErasureConfig;
 use serde::{Deserialize, Serialize};
-use solana_sdk::clock::Slot;
+use solana_sdk::{clock::Slot, hash::Hash};
 use std::{collections::BTreeSet, ops::RangeBounds};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
@@ -73,6 +73,33 @@ pub enum ErasureMetaStatus {
     CanRecover,
     DataFull,
     StillNeed(usize),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub enum FrozenHashVersioned {
+    Current(FrozenHashStatus),
+}
+
+impl FrozenHashVersioned {
+    pub fn frozen_hash(&self) -> Hash {
+        match self {
+            FrozenHashVersioned::Current(frozen_hash_status) => frozen_hash_status.frozen_hash,
+        }
+    }
+
+    pub fn is_duplicate_confirmed(&self) -> bool {
+        match self {
+            FrozenHashVersioned::Current(frozen_hash_status) => {
+                frozen_hash_status.is_duplicate_confirmed
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct FrozenHashStatus {
+    pub frozen_hash: Hash,
+    pub is_duplicate_confirmed: bool,
 }
 
 impl Index {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -862,6 +862,7 @@ fn process_bank_0(
     )
     .expect("processing for bank 0 must succeed");
     bank0.freeze();
+    blockstore.insert_bank_hash(bank0.slot(), bank0.hash(), false);
     cache_block_meta(bank0, cache_block_meta_sender);
 }
 
@@ -1034,6 +1035,7 @@ fn load_frozen_forks(
                             }
                             inc_new_counter_info!("load_frozen_forks-cluster-confirmed-root", rooted_slots.len());
                             blockstore.set_roots(rooted_slots.iter().map(|(slot, _hash)| slot)).expect("Blockstore::set_roots should succeed");
+                            blockstore.set_duplicate_confirmed_slots_and_hashes(rooted_slots.into_iter()).expect("Blockstore::set_duplicate_confirmed should succeed");
                             Some(cluster_root_bank)
                         } else {
                             None
@@ -1179,6 +1181,7 @@ fn process_single_slot(
     })?;
 
     bank.freeze(); // all banks handled by this routine are created from complete slots
+    blockstore.insert_bank_hash(bank.slot(), bank.hash(), false);
     cache_block_meta(bank, cache_block_meta_sender);
 
     Ok(())


### PR DESCRIPTION
#### Problem
Answering ancestor repair requests will require that validators know

1. Which version of a slot was frozen (frozen hash)
2. Whether slots have been duplicate confirmed

#### Summary of Changes
Add a column family to blockstore to track this information

Fixes #
