### PR TITLE
removes redundant (mutable) self receivers

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -659,7 +659,7 @@ impl ClusterInfo {
         self.my_contact_info.read().unwrap().shred_version
     }
 
-    pub fn lookup_epoch_slots(&self, ix: EpochSlotsIndex) -> EpochSlots {
+    fn lookup_epoch_slots(&self, ix: EpochSlotsIndex) -> EpochSlots {
         let self_pubkey = self.id();
         let label = CrdsValueLabel::EpochSlots(ix, self_pubkey);
         let gossip = self.gossip.read().unwrap();
@@ -1141,28 +1141,14 @@ impl ClusterInfo {
     }
 
     pub fn get_node_version(&self, pubkey: &Pubkey) -> Option<solana_version::Version> {
-        let version = self
-            .gossip
-            .read()
-            .unwrap()
-            .crds
-            .get(&CrdsValueLabel::Version(*pubkey))
-            .map(|x| x.value.version())
-            .flatten()
-            .map(|version| version.version.clone());
-
-        if version.is_none() {
-            self.gossip
-                .read()
-                .unwrap()
-                .crds
-                .get(&CrdsValueLabel::LegacyVersion(*pubkey))
-                .map(|x| x.value.legacy_version())
-                .flatten()
-                .map(|version| version.version.clone().into())
-        } else {
-            version
+        let gossip = self.gossip.read().unwrap();
+        let version = gossip.crds.get(&CrdsValueLabel::Version(*pubkey));
+        if let Some(version) = version.and_then(|v| v.value.version()) {
+            return Some(version.version.clone());
         }
+        let version = gossip.crds.get(&CrdsValueLabel::LegacyVersion(*pubkey))?;
+        let version = version.value.legacy_version()?;
+        Some(version.version.clone().into())
     }
 
     /// all validators that have a valid rpc port regardless of `shred_version`.

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -238,8 +238,7 @@ impl CrdsGossip {
     where
         I: IntoIterator<Item = CrdsValue>,
     {
-        self.pull
-            .process_pull_requests(&mut self.crds, callers, now);
+        CrdsGossipPull::process_pull_requests(&mut self.crds, callers, now);
     }
 
     pub fn generate_pull_responses(
@@ -248,8 +247,7 @@ impl CrdsGossip {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
     ) -> Vec<Vec<CrdsValue>> {
-        self.pull
-            .generate_pull_responses(&self.crds, filters, output_size_limit, now)
+        CrdsGossipPull::generate_pull_responses(&self.crds, filters, output_size_limit, now)
     }
 
     pub fn filter_pull_responses(
@@ -313,9 +311,7 @@ impl CrdsGossip {
             //sanity check
             assert_eq!(timeouts[self_pubkey], std::u64::MAX);
             assert!(timeouts.contains_key(&Pubkey::default()));
-            rv = self
-                .pull
-                .purge_active(thread_pool, &mut self.crds, now, timeouts);
+            rv = CrdsGossipPull::purge_active(thread_pool, &mut self.crds, now, timeouts);
         }
         self.crds
             .trim_purged(now.saturating_sub(5 * self.pull.crds_timeout));

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -98,7 +98,7 @@ impl CrdsGossipPush {
         ((CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT * min_path_stake as f64).round() as u64).max(1)
     }
 
-    pub fn prune_received_cache(
+    pub(crate) fn prune_received_cache(
         &mut self,
         self_pubkey: &Pubkey,
         origin: &Pubkey,
@@ -254,7 +254,7 @@ impl CrdsGossipPush {
 
     /// refresh the push active set
     /// * ratio - active_set.len()/ratio is the number of actives to rotate
-    pub fn refresh_push_active_set(
+    pub(crate) fn refresh_push_active_set(
         &mut self,
         crds: &Crds,
         stakes: &HashMap<Pubkey, u64>,
@@ -359,7 +359,7 @@ impl CrdsGossipPush {
     }
 
     /// purge received push message cache
-    pub fn purge_old_received_cache(&mut self, min_time: u64) {
+    pub(crate) fn purge_old_received_cache(&mut self, min_time: u64) {
         self.received_cache.retain(|_, v| {
             v.retain(|_, (_, t)| *t > min_time);
             !v.is_empty()


### PR DESCRIPTION
#### Problem
Redundant `&self` (or `&mut self`) receivers will then require acquiring redundant (exclusive) locks on the object.

#### Summary of Changes
* removed redundant `&self` and `&mut self`.
* also removed redundant `pub`s.