### PR TITLE
Change ShredIndex to use BitVector for underlying storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,6 +4940,7 @@ version = "1.8.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "bv",
  "byteorder",
  "chrono",
  "chrono-humanize",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.3.3"
+bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.4.3"
 chrono = { version = "0.4.11", features = ["serde"] }
 chrono-humanize = "0.2.1"

--- a/ledger/benches/shred_index.rs
+++ b/ledger/benches/shred_index.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 use rand::seq::SliceRandom;
-use solana_ledger::blockstore_meta::ShredIndex;
+use solana_ledger::blockstore_meta::ShredIndex2;
 use test::Bencher;
 
 fn get_shuffled_vector(size: usize) -> Vec<u64> {
@@ -18,7 +18,7 @@ fn get_shuffled_vector(size: usize) -> Vec<u64> {
 fn bench_shred_index_is_present(bencher: &mut Bencher) {
     let values = get_shuffled_vector(500);
     bencher.iter(|| {
-        let index = ShredIndex::default();
+        let index = ShredIndex2::default();
         for value in values.iter() {
             index.is_present(*value);
         }
@@ -29,7 +29,7 @@ fn bench_shred_index_is_present(bencher: &mut Bencher) {
 fn bench_shred_index_set_present(bencher: &mut Bencher) {
     let values = get_shuffled_vector(500);
     bencher.iter(|| {
-        let mut index = ShredIndex::default();
+        let mut index = ShredIndex2::default();
         for value in values.iter() {
             index.set_present(*value, true);
         }

--- a/ledger/benches/shred_index.rs
+++ b/ledger/benches/shred_index.rs
@@ -1,0 +1,37 @@
+#![feature(test)]
+
+extern crate test;
+use rand::seq::SliceRandom;
+use solana_ledger::blockstore_meta::ShredIndex;
+use test::Bencher;
+
+fn get_shuffled_vector(size: usize) -> Vec<u64> {
+    let mut values: Vec<u64> = Vec::with_capacity(size);
+    for i in 0..size {
+        values.push(i as u64);
+    }
+    values.shuffle(&mut rand::thread_rng());
+    values
+}
+
+#[bench]
+fn bench_shred_index_is_present(bencher: &mut Bencher) {
+    let values = get_shuffled_vector(500);
+    bencher.iter(|| {
+        let index = ShredIndex::default();
+        for value in values.iter() {
+            index.is_present(*value);
+        }
+    })
+}
+
+#[bench]
+fn bench_shred_index_set_present(bencher: &mut Bencher) {
+    let values = get_shuffled_vector(500);
+    bencher.iter(|| {
+        let mut index = ShredIndex::default();
+        for value in values.iter() {
+            index.set_present(*value, true);
+        }
+    })
+}

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5864,10 +5864,10 @@ pub mod tests {
                     DataShredHeader::default(),
                     coding.clone(),
                 );
-                coding_shred.common_header.fec_set_index = std::u32::MAX - 1;
+                coding_shred.common_header.fec_set_index = MAX_DATA_SHREDS_PER_SLOT as u32 - 1;
                 coding_shred.coding_header.num_coding_shreds = 3;
-                coding_shred.common_header.index = std::u32::MAX - 1;
-                assert!(!Blockstore::should_insert_coding_shred(
+                coding_shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32 - 1;
+                assert!(Blockstore::should_insert_coding_shred(
                     &coding_shred,
                     &last_root
                 ));

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -173,6 +173,10 @@ impl Blockstore {
                 .is_ok()
             & self
                 .db
+                .delete_range_cf::<cf::Index2>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
                 .delete_range_cf::<cf::Rewards>(&mut write_batch, from_slot, to_slot)
                 .is_ok()
             & self
@@ -461,6 +465,13 @@ pub mod tests {
             & blockstore
                 .db
                 .iter::<cf::Index>(IteratorMode::Start)
+                .unwrap()
+                .next()
+                .map(|(slot, _)| slot >= min_slot)
+                .unwrap_or(true)
+            & blockstore
+                .db
+                .iter::<cf::Index2>(IteratorMode::Start)
                 .unwrap()
                 .next()
                 .map(|(slot, _)| slot >= min_slot)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -51,8 +51,10 @@ const ORPHANS_CF: &str = "orphans";
 const BANK_HASH_CF: &str = "bank_hashes";
 // Column family for root data
 const ROOT_CF: &str = "root";
-/// Column family for indexes
+/// (Deprecated) Column family for indexes
 const INDEX_CF: &str = "index";
+/// Column family for indexes
+const INDEX_CF2: &str = "index2";
 /// Column family for Data Shreds
 const DATA_SHRED_CF: &str = "data_shred";
 /// Column family for Code Shreds
@@ -144,8 +146,12 @@ pub mod columns {
     pub struct Root;
 
     #[derive(Debug)]
-    /// The index column
+    /// (Deprecated) The index column
     pub struct Index;
+
+    #[derive(Debug)]
+    /// The index column
+    pub struct Index2;
 
     #[derive(Debug)]
     /// The shred data column
@@ -316,6 +322,10 @@ impl Rocks {
             Index::NAME,
             get_cf_options::<Index>(&access_type, &oldest_slot),
         );
+        let index2_cf_descriptor = ColumnFamilyDescriptor::new(
+            Index2::NAME,
+            get_cf_options::<Index2>(&access_type, &oldest_slot),
+        );
         let shred_data_cf_descriptor = ColumnFamilyDescriptor::new(
             ShredData::NAME,
             get_cf_options::<ShredData>(&access_type, &oldest_slot),
@@ -368,6 +378,7 @@ impl Rocks {
             (BankHash::NAME, bank_hash_cf_descriptor),
             (Root::NAME, root_cf_descriptor),
             (Index::NAME, index_cf_descriptor),
+            (Index2::NAME, index2_cf_descriptor),
             (ShredData::NAME, shred_data_cf_descriptor),
             (ShredCode::NAME, shred_code_cf_descriptor),
             (TransactionStatus::NAME, transaction_status_cf_descriptor),
@@ -486,6 +497,7 @@ impl Rocks {
             DeadSlots::NAME,
             DuplicateSlots::NAME,
             Index::NAME,
+            Index2::NAME,
             Orphans::NAME,
             BankHash::NAME,
             Root::NAME,
@@ -865,6 +877,14 @@ impl ColumnName for columns::Index {
 }
 impl TypedColumn for columns::Index {
     type Type = blockstore_meta::Index;
+}
+
+impl SlotColumn for columns::Index2 {}
+impl ColumnName for columns::Index2 {
+    const NAME: &'static str = INDEX_CF2;
+}
+impl TypedColumn for columns::Index2 {
+    type Type = blockstore_meta::Index2;
 }
 
 impl SlotColumn for columns::DeadSlots {}

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -436,7 +436,7 @@ mod test {
         assert_eq!(index.num_shreds(), 0);
 
         // Check boundary conditions; start is inclusive, end is inclusive
-        index.set_many_present((5..10 as u64).zip(repeat(true)));
+        index.set_many_present((5..10_u64).zip(repeat(true)));
         assert_eq!(index.present_in_bounds(0..5), 0);
         assert_eq!(index.present_in_bounds(2..7), 2);
         assert_eq!(index.present_in_bounds(5..10), 5);


### PR DESCRIPTION
#### Problem
The blockstore uses ShredIndex structures to track whether shreds have been received or not. The elements that we store are the indices (u64) themselves so we can use a BitVector instead of a BTreeSet.

Here are some results for running the benchmark (on my machine) that is included as part of this change; I ran with size of 500 and 5000 (these sizes would be the slot size in shreds). The reported execution times would be per slot.

**Current tip of master**
```
Results for 500
test bench_shred_index_is_present  ... bench:         743 ns/iter (+/- 62)
test bench_shred_index_set_present ... bench:      31,303 ns/iter (+/- 5,349)
Results for 5000
test bench_shred_index_is_present  ... bench:       7,282 ns/iter (+/- 612)
test bench_shred_index_set_present ... bench:     460,156 ns/iter (+/- 19,850)
```
**this branch**
```
Results for 500
test bench_shred_index_is_present  ... bench:         801 ns/iter (+/- 65)
test bench_shred_index_set_present ... bench:       2,860 ns/iter (+/- 184)
Results for 5000
test bench_shred_index_is_present  ... bench:       8,850 ns/iter (+/- 303)
test bench_shred_index_set_present ... bench:      28,112 ns/iter (+/- 4,920)
```
Fairly comparable on `is_present()`; 10x speedup for `set_present()` at slot size of 500 (and more pronounced at 5000), although it isn't a large chunk of time to start with. This should save us some space too though; with a a BTreeSet<u64> and assuming 500 shreds / slot, that would be 4k bytes / slot for each index, 8k total (data and coding). Hypothetically, should be some time savings in serialize/deserialize too.

### Upgrade / Downgrade
This is a breaking change since the ShredIndex gets serialized out of Rocks. Per some suggestions in this PR and conversation in Discord, I have implemented the following strategy:
- Introduce a second column family that uses BitVec, keeping the original BTreeSet column around
- Make a backport PR that stubs new column into older releases (this still creates a break point, but hopefully less painful)
   - Older validator binary would open DB with new column (RocksDB requires specifying all columns at open), but never use that column (except in purge maybe)

In the future once this change is reflected on a given network ...
- Strip out the original (BTreeSet) CF and only use the new (BitVec) one. Accomplish this with a feature switch (disabled state of feature writes both columns, enabled state of feature will only write new column)