### PR TITLE
makes CrdsGossipPull thread-safe

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1430,8 +1430,7 @@ impl ClusterInfo {
         let num_requests = pulls.iter().map(|(_, filters)| filters.len() as u64).sum();
         self.stats.new_pull_requests_count.add_relaxed(num_requests);
         {
-            let mut gossip =
-                self.time_gossip_write_lock("mark_pull", &self.stats.mark_pull_request);
+            let gossip = self.time_gossip_read_lock("mark_pull", &self.stats.mark_pull_request);
             for (peer, _) in &pulls {
                 gossip.mark_pull_request_creation_time(peer.id, now);
             }
@@ -4380,14 +4379,9 @@ mod tests {
                 .unwrap()
                 .mark_pull_request_creation_time(peer, now);
         }
+        let gossip = cluster_info.gossip.read().unwrap();
         assert_eq!(
-            cluster_info
-                .gossip
-                .read()
-                .unwrap()
-                .pull
-                .pull_request_time
-                .len(),
+            gossip.pull.pull_request_time().len(),
             CRDS_UNIQUE_PUBKEY_CAPACITY
         );
     }

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -169,7 +169,7 @@ pub(crate) fn submit_gossip_stats(
             gossip.crds.len(),
             gossip.crds.num_nodes(),
             gossip.crds.num_purged(),
-            gossip.pull.failed_inserts.len(),
+            gossip.pull.failed_inserts_size(),
         )
     };
     let num_nodes_staked = stakes.values().filter(|stake| **stake > 0).count();

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -230,7 +230,7 @@ impl CrdsGossip {
     /// This is used for weighted random selection during `new_pull_request`
     /// It's important to use the local nodes request creation time as the weight
     /// instead of the response received time otherwise failed nodes will increase their weight.
-    pub fn mark_pull_request_creation_time(&mut self, from: Pubkey, now: u64) {
+    pub fn mark_pull_request_creation_time(&self, from: Pubkey, now: u64) {
         self.pull.mark_pull_request_creation_time(from, now)
     }
     /// process a pull request and create a response


### PR DESCRIPTION
#### Problem
Working towards reducing lock contention in gossip.

#### Summary of Changes
* This  commit makes `CrdsGossipPull` thread safe by adding `RwLock` to inner fields. This is in preparation of making `CrdsGossip` thread-safe, and implementing more granular locking in gossip.
* Inner fields are pretty independent, so this commit should not add any race conditions.
* No two inner fields are locked together, so this commit should not cause any deadlocks.
* The number of times inner fields should be locked is similar to the number of times the outer struct needs to be locked. So this more granular locking should not add significant overhead.