### PR TITLE
Record vote account commission with voting/staking rewards and surface in RPC

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1832,6 +1832,7 @@ pub fn make_cli_reward(
             post_balance: reward.post_balance,
             percent_change: rate_change * 100.0,
             apr: Some(apr * 100.0),
+            commission: reward.commission,
         })
     } else {
         None

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -394,8 +394,9 @@ pub struct RpcPerfSample {
 pub struct RpcInflationReward {
     pub epoch: Epoch,
     pub effective_slot: Slot,
-    pub amount: u64,       // lamports
-    pub post_balance: u64, // lamports
+    pub amount: u64,            // lamports
+    pub post_balance: u64,      // lamports
+    pub commission: Option<u8>, // Vote account commission when the reward was credited
 }
 
 impl From<ConfirmedTransactionStatusWithSignature> for RpcConfirmedTransactionStatusWithSignature {

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -55,6 +55,7 @@ impl RewardsRecorderService {
                 lamports: reward_info.lamports,
                 post_balance: reward_info.post_balance,
                 reward_type: Some(reward_info.reward_type),
+                commission: reward_info.commission,
             })
             .collect();
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -402,6 +402,7 @@ The result field will be an object with the following fields:
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
     - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting", "staking"
+    - `commission: <u8|undefined>` - vote account commission when the reward was credited, only present for voting and staking rewards
   - `blockTime: <i64 | null>` - estimated production time, as Unix timestamp (seconds since the Unix epoch). null if not available
   - `blockHeight: <u64 | null>` - the number of blocks beneath this block
 
@@ -1372,6 +1373,7 @@ The result field will be a JSON array with the following fields:
 - `effectiveSlot: <u64>`, the slot in which the rewards are effective
 - `amount: <u64>`, reward amount in lamports
 - `postBalance: <u64>`, post balance of the account in lamports
+- `commission: <u8|undefined>` - vote account commission when the reward was credited
 
 #### Example
 
@@ -2820,6 +2822,7 @@ Returns transaction details for a confirmed transaction
       - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
       - `postBalance: <u64>` - account balance in lamports after the reward was applied
       - `rewardType: <string>` - type of reward: currently only "rent", other types may be added in the future
+      - `commission: <u8|undefined>` - vote account commission when the reward was credited, only present for voting and staking rewards
 
 
 #### Example:
@@ -4164,6 +4167,7 @@ The result field will be an object with the following fields:
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
     - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting", "staking"
+    - `commission: <u8|undefined>` - vote account commission when the reward was credited, only present for voting and staking rewards
   - `blockTime: <i64 | null>` - estimated production time, as Unix timestamp (seconds since the Unix epoch). null if not available
 
 #### Example:

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -79,14 +79,14 @@ fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &LedgerOutpu
             if !rewards.is_empty() {
                 println!("  Rewards:");
                 println!(
-                    "    {:<44}  {:^15}  {:<15}  {:<20}",
-                    "Address", "Type", "Amount", "New Balance"
+                    "    {:<44}  {:^15}  {:<15}  {:<20}  {:>10}",
+                    "Address", "Type", "Amount", "New Balance", "Commission",
                 );
 
                 for reward in rewards {
                     let sign = if reward.lamports < 0 { "-" } else { "" };
                     println!(
-                        "    {:<44}  {:^15}  {:<15}  {}",
+                        "    {:<44}  {:^15}  {:<15}  {}   {}",
                         reward.pubkey,
                         if let Some(reward_type) = reward.reward_type {
                             format!("{}", reward_type)
@@ -98,7 +98,11 @@ fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &LedgerOutpu
                             sign,
                             lamports_to_sol(reward.lamports.abs() as u64)
                         ),
-                        format!("◎{:<18.9}", lamports_to_sol(reward.post_balance))
+                        format!("◎{:<18.9}", lamports_to_sol(reward.post_balance)),
+                        reward
+                            .commission
+                            .map(|commission| format!("{:>9}%", commission))
+                            .unwrap_or_else(|| "    -".to_string())
                     );
                 }
             }

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -21,6 +21,7 @@ fn create_rewards() -> Rewards {
             lamports: 42 + i,
             post_balance: std::u64::MAX,
             reward_type: Some(RewardType::Fee),
+            commission: None,
         })
         .collect()
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8346,6 +8346,7 @@ pub mod tests {
                     lamports: 42 + i,
                     post_balance: std::u64::MAX,
                     reward_type: Some(RewardType::Fee),
+                    commission: None,
                 })
                 .collect();
             let protobuf_rewards: generated::Rewards = rewards.into();
@@ -8412,6 +8413,7 @@ pub mod tests {
                     lamports: -42,
                     post_balance: 42,
                     reward_type: Some(RewardType::Rent),
+                    commission: None,
                 }]),
             };
             let deprecated_status: StoredTransactionStatusMeta = status.clone().into();

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1029,14 +1029,13 @@ pub fn redeem_rewards(
     rewarded_epoch: Epoch,
     stake_account: &mut AccountSharedData,
     vote_account: &mut AccountSharedData,
+    vote_state: &VoteState,
     point_value: &PointValue,
     stake_history: Option<&StakeHistory>,
     inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
     fix_stake_deactivate: bool,
 ) -> Result<(u64, u64), InstructionError> {
     if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
-        let vote_state: VoteState =
-            StateMut::<VoteStateVersions>::state(vote_account)?.convert_to_current();
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer {
             inflation_point_calc_tracer(
                 &InflationPointCalculationEvent::EffectiveStakeAtRewardedEpoch(stake.stake(
@@ -1056,7 +1055,7 @@ pub fn redeem_rewards(
         if let Some((stakers_reward, voters_reward)) = redeem_stake_rewards(
             &mut stake,
             point_value,
-            &vote_state,
+            vote_state,
             stake_history,
             inflation_point_calc_tracer,
             fix_stake_deactivate,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -480,6 +480,7 @@ impl JsonRpcRequestProcessor {
                         effective_slot: first_confirmed_block_in_epoch,
                         amount: reward.lamports.abs() as u64,
                         post_balance: reward.post_balance,
+                        commission: reward.commission,
                     });
                 }
                 None

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -136,6 +136,7 @@ impl TransactionStatusService {
                                     lamports: reward_info.lamports,
                                     post_balance: reward_info.post_balance,
                                     reward_type: Some(reward_info.reward_type),
+                                    commission: reward_info.commission,
                                 })
                                 .collect(),
                         );

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -238,6 +238,7 @@ impl From<StoredConfirmedBlockReward> for Reward {
             lamports,
             post_balance: 0,
             reward_type: None,
+            commission: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -88,6 +88,7 @@ message Reward {
     int64 lamports = 2;
     uint64 post_balance = 3;
     RewardType reward_type = 4;
+    string commission = 5;
 }
 
 message Rewards {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -89,6 +89,7 @@ impl From<Reward> for generated::Reward {
                 Some(RewardType::Staking) => generated::RewardType::Staking,
                 Some(RewardType::Voting) => generated::RewardType::Voting,
             } as i32,
+            commission: reward.commission.map(|c| c.to_string()).unwrap_or_default(),
         }
     }
 }
@@ -107,6 +108,7 @@ impl From<generated::Reward> for Reward {
                 4 => Some(RewardType::Voting),
                 _ => None,
             },
+            commission: reward.commission.parse::<u8>().ok(),
         }
     }
 }
@@ -841,6 +843,7 @@ mod test {
             lamports: 123,
             post_balance: 321,
             reward_type: None,
+            commission: None,
         };
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -23,6 +23,8 @@ pub struct StoredExtendedReward {
     post_balance: u64,
     #[serde(deserialize_with = "default_on_eof")]
     reward_type: Option<RewardType>,
+    #[serde(deserialize_with = "default_on_eof")]
+    commission: Option<u8>,
 }
 
 impl From<StoredExtendedReward> for Reward {
@@ -32,12 +34,14 @@ impl From<StoredExtendedReward> for Reward {
             lamports,
             post_balance,
             reward_type,
+            commission,
         } = value;
         Self {
             pubkey,
             lamports,
             post_balance,
             reward_type,
+            commission,
         }
     }
 }
@@ -49,13 +53,14 @@ impl From<Reward> for StoredExtendedReward {
             lamports,
             post_balance,
             reward_type,
-            ..
+            commission,
         } = value;
         Self {
             pubkey,
             lamports,
             post_balance,
             reward_type,
+            commission,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -339,6 +339,8 @@ pub struct Reward {
     pub lamports: i64,
     pub post_balance: u64, // Account balance in lamports after `lamports` was applied
     pub reward_type: Option<RewardType>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub commission: Option<u8>, // Vote account commission when the reward was credited, only present for voting and staking rewards
 }
 
 pub type Rewards = Vec<Reward>;


### PR DESCRIPTION
#### Problem
It's not trivial to detect if the validator you staked with is defrauding you by raising their commission immediately before an epoch boundary, and restoring it as soon as possible in the new epoch.

#### Summary of Changes
Record the vote account's commission in both voting and staking rewards, and surface the commission in all RPC methods that provide reward information.  Also include the _epoch_ commission in the output of `solana vote-account --with-rewards` and `solana stake-account --with-rewards`

Freebie: The Everstake vote account is no longer decoded more than forty two thousand times on an epoch boundary!
