### PR TITLE
Remove outdated program verification

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1112,7 +1112,6 @@ impl MessageProcessor {
             Err(InstructionError::MissingAccount)
         };
         instruction.visit_each_account(&mut work)?;
-        work(0, instruction.program_id_index as usize)?;
 
         // Verify that the total sum of all the lamports did not change
         if pre_sum != post_sum {


### PR DESCRIPTION
#### Problem
The program account is now always loaded from the invoke context and therefore cannot be be modified by the caller or callee program unless passed as an instruction account input. Despite not being modifiable, its entire account state is checked for each cross program invocation.

#### Summary of Changes
- Remove unnecessary verification step for the program account

Fixes #
