### PR TITLE
Add method `id` to SysbarId trait

### DIFF
--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -32,6 +32,10 @@ macro_rules! declare_sysvar_id(
         $crate::declare_id!($name);
 
         impl $crate::sysvar::SysvarId for $type {
+            fn id() -> $crate::pubkey::Pubkey {
+                id()
+            }
+
             fn check_id(pubkey: &$crate::pubkey::Pubkey) -> bool {
                 check_id(pubkey)
             }
@@ -51,6 +55,8 @@ macro_rules! declare_sysvar_id(
 crate::declare_id!("Sysvar1111111111111111111111111111111111111");
 
 pub trait SysvarId {
+    fn id() -> Pubkey;
+
     fn check_id(pubkey: &Pubkey) -> bool;
 }
 
@@ -113,6 +119,10 @@ mod tests {
     }
     crate::declare_id!("TestSysvar111111111111111111111111111111111");
     impl crate::sysvar::SysvarId for TestSysvar {
+        fn id() -> crate::pubkey::Pubkey {
+            id()
+        }
+
         fn check_id(pubkey: &crate::pubkey::Pubkey) -> bool {
             check_id(pubkey)
         }

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -270,6 +270,9 @@ mod tests {
     }
     crate::declare_id!("TestSysvar111111111111111111111111111111111");
     impl solana_program::sysvar::SysvarId for TestSysvar {
+        fn id() -> crate::pubkey::Pubkey {
+            id()
+        }
         fn check_id(pubkey: &crate::pubkey::Pubkey) -> bool {
             check_id(pubkey)
         }


### PR DESCRIPTION
#### Problem

Yesterday I submitted https://github.com/solana-labs/solana/pull/18590 with the new method `BanksClient::get_clock` but today realize that instead of new method for each `Sysvar` it can be generic, like:
```rust
    pub fn get_sysvar<T: Sysvar>(&mut self) -> impl Future<Output = io::Result<T>> + '_ {
        self.get_account(T::id()).map(|result| {
            let sysvar = result?
                .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Sysvar not present"))?;
            from_account::<T, _>(&sysvar).ok_or_else(|| {
                io::Error::new(io::ErrorKind::Other, "Failed to deserialize sysvar")
            })
        })
    }
```

but `SysvarId` have only `check_id`, not `id`.

#### Summary of Changes

Add `SysvarId::id` method.
