### PR TITLE
make CrdsGossip thread-safe

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -296,12 +296,12 @@ mod tests {
         let cluster_info = ClusterInfo::new_with_invalid_keypair(this_node);
         {
             let now = timestamp();
-            let mut gossip = cluster_info.gossip.write().unwrap();
+            let mut gossip_crds = cluster_info.gossip.crds.write().unwrap();
             // First node is pushed to crds table by ClusterInfo constructor.
             for node in nodes.iter().skip(1) {
                 let node = CrdsData::ContactInfo(node.clone());
                 let node = CrdsValue::new_unsigned(node);
-                assert_eq!(gossip.crds.insert(node, now), Ok(()));
+                assert_eq!(gossip_crds.insert(node, now), Ok(()));
             }
         }
         (nodes, stakes, cluster_info)

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -192,8 +192,8 @@ mod test {
         cluster_info.flush_push_queue();
         let lowest = {
             let label = CrdsValueLabel::LowestSlot(pubkey);
-            let gossip = cluster_info.gossip.read().unwrap();
-            let entry = gossip.crds.get(&label).unwrap();
+            let gossip_crds = cluster_info.gossip.crds.read().unwrap();
+            let entry = gossip_crds.get(&label).unwrap();
             entry.value.lowest_slot().unwrap().clone()
         };
         assert_eq!(lowest.lowest, 5);

--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -12,6 +12,7 @@ use {
         crds_value::CrdsValue,
     },
     solana_sdk::hash,
+    std::sync::RwLock,
     test::Bencher,
 };
 
@@ -45,6 +46,7 @@ fn bench_build_crds_filters(bencher: &mut Bencher) {
         }
     }
     assert_eq!(num_inserts, 90_000);
+    let crds = RwLock::new(crds);
     bencher.iter(|| {
         let filters = crds_gossip_pull.build_crds_filters(&thread_pool, &crds, MAX_BLOOM_SIZE);
         assert_eq!(filters.len(), 128);

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -5,10 +5,7 @@ use {
     std::{
         collections::HashMap,
         ops::{Deref, DerefMut},
-        sync::{
-            atomic::{AtomicU64, Ordering},
-            RwLock,
-        },
+        sync::atomic::{AtomicU64, Ordering},
         time::Instant,
     },
 };
@@ -160,15 +157,15 @@ pub(crate) struct GossipStats {
 
 pub(crate) fn submit_gossip_stats(
     stats: &GossipStats,
-    gossip: &RwLock<CrdsGossip>,
+    gossip: &CrdsGossip,
     stakes: &HashMap<Pubkey, u64>,
 ) {
     let (table_size, num_nodes, purged_values_size, failed_inserts_size) = {
-        let gossip = gossip.read().unwrap();
+        let gossip_crds = gossip.crds.read().unwrap();
         (
-            gossip.crds.len(),
-            gossip.crds.num_nodes(),
-            gossip.crds.num_purged(),
+            gossip_crds.len(),
+            gossip_crds.num_nodes(),
+            gossip_crds.num_purged(),
             gossip.pull.failed_inserts_size(),
         )
     };

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -26,14 +26,14 @@ use {
     std::{
         collections::{HashMap, HashSet},
         net::SocketAddr,
-        sync::Mutex,
+        sync::{Mutex, RwLock},
         time::Duration,
     },
 };
 
 #[derive(Default)]
 pub struct CrdsGossip {
-    pub crds: Crds,
+    pub crds: RwLock<Crds>,
     pub push: CrdsGossipPush,
     pub pull: CrdsGossipPull,
 }
@@ -42,13 +42,13 @@ impl CrdsGossip {
     /// process a push message to the network
     /// Returns unique origins' pubkeys of upserted values.
     pub fn process_push_message(
-        &mut self,
+        &self,
         from: &Pubkey,
         values: Vec<CrdsValue>,
         now: u64,
     ) -> HashSet<Pubkey> {
         self.push
-            .process_push_message(&mut self.crds, from, values, now)
+            .process_push_message(&self.crds, from, values, now)
             .into_iter()
             .filter_map(Result::ok)
             .collect()
@@ -69,18 +69,21 @@ impl CrdsGossip {
     }
 
     pub fn new_push_messages(
-        &mut self,
+        &self,
         pending_push_messages: Vec<CrdsValue>,
         now: u64,
     ) -> HashMap<Pubkey, Vec<CrdsValue>> {
-        for entry in pending_push_messages {
-            let _ = self.crds.insert(entry, now);
+        {
+            let mut crds = self.crds.write().unwrap();
+            for entry in pending_push_messages {
+                let _ = crds.insert(entry, now);
+            }
         }
         self.push.new_push_messages(&self.crds, now)
     }
 
     pub(crate) fn push_duplicate_shred(
-        &mut self,
+        &self,
         keypair: &Keypair,
         shred: &Shred,
         other_payload: &[u8],
@@ -91,8 +94,8 @@ impl CrdsGossip {
         let pubkey = keypair.pubkey();
         // Skip if there are already records of duplicate shreds for this slot.
         let shred_slot = shred.slot();
-        if self
-            .crds
+        let mut crds = self.crds.write().unwrap();
+        if crds
             .get_records(&pubkey)
             .any(|value| match &value.value.data {
                 CrdsData::DuplicateShred(_, value) => value.slot == shred_slot,
@@ -111,8 +114,7 @@ impl CrdsGossip {
         )?;
         // Find the index of oldest duplicate shred.
         let mut num_dup_shreds = 0;
-        let offset = self
-            .crds
+        let offset = crds
             .get_records(&pubkey)
             .filter_map(|value| match &value.value.data {
                 CrdsData::DuplicateShred(ix, value) => {
@@ -136,7 +138,7 @@ impl CrdsGossip {
         });
         let now = timestamp();
         for entry in entries {
-            if let Err(err) = self.crds.insert(entry, now) {
+            if let Err(err) = crds.insert(entry, now) {
                 error!("push_duplicate_shred faild: {:?}", err);
             }
         }
@@ -174,13 +176,14 @@ impl CrdsGossip {
         stakes: &HashMap<Pubkey, u64>,
         gossip_validators: Option<&HashSet<Pubkey>>,
     ) {
+        let network_size = self.crds.read().unwrap().num_nodes();
         self.push.refresh_push_active_set(
             &self.crds,
             stakes,
             gossip_validators,
             self_pubkey,
             self_shred_version,
-            self.crds.num_nodes(),
+            network_size,
             CRDS_GOSSIP_NUM_ACTIVE,
         )
     }
@@ -221,11 +224,11 @@ impl CrdsGossip {
         self.pull.mark_pull_request_creation_time(from, now)
     }
     /// process a pull request and create a response
-    pub fn process_pull_requests<I>(&mut self, callers: I, now: u64)
+    pub fn process_pull_requests<I>(&self, callers: I, now: u64)
     where
         I: IntoIterator<Item = CrdsValue>,
     {
-        CrdsGossipPull::process_pull_requests(&mut self.crds, callers, now);
+        CrdsGossipPull::process_pull_requests(&self.crds, callers, now);
     }
 
     pub fn generate_pull_responses(
@@ -254,7 +257,7 @@ impl CrdsGossip {
 
     /// process a pull response
     pub fn process_pull_responses(
-        &mut self,
+        &self,
         from: &Pubkey,
         responses: Vec<CrdsValue>,
         responses_expired_timeout: Vec<CrdsValue>,
@@ -263,7 +266,7 @@ impl CrdsGossip {
         process_pull_stats: &mut ProcessPullStats,
     ) {
         self.pull.process_pull_responses(
-            &mut self.crds,
+            &self.crds,
             from,
             responses,
             responses_expired_timeout,
@@ -283,7 +286,7 @@ impl CrdsGossip {
     }
 
     pub fn purge(
-        &mut self,
+        &self,
         self_pubkey: &Pubkey,
         thread_pool: &ThreadPool,
         now: u64,
@@ -298,9 +301,11 @@ impl CrdsGossip {
             //sanity check
             assert_eq!(timeouts[self_pubkey], std::u64::MAX);
             assert!(timeouts.contains_key(&Pubkey::default()));
-            rv = CrdsGossipPull::purge_active(thread_pool, &mut self.crds, now, timeouts);
+            rv = CrdsGossipPull::purge_active(thread_pool, &self.crds, now, timeouts);
         }
         self.crds
+            .write()
+            .unwrap()
             .trim_purged(now.saturating_sub(5 * self.pull.crds_timeout));
         self.pull.purge_failed_inserts(now);
         rv
@@ -308,8 +313,9 @@ impl CrdsGossip {
 
     // Only for tests and simulations.
     pub(crate) fn mock_clone(&self) -> Self {
+        let crds = self.crds.read().unwrap().clone();
         Self {
-            crds: self.crds.clone(),
+            crds: RwLock::new(crds),
             push: self.push.mock_clone(),
             pull: self.pull.mock_clone(),
         }
@@ -343,12 +349,14 @@ mod test {
 
     #[test]
     fn test_prune_errors() {
-        let mut crds_gossip = CrdsGossip::default();
+        let crds_gossip = CrdsGossip::default();
         let id = Pubkey::new(&[0; 32]);
         let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
         let prune_pubkey = Pubkey::new(&[2; 32]);
         crds_gossip
             .crds
+            .write()
+            .unwrap()
             .insert(
                 CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone())),
                 0,

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -33,24 +33,20 @@ use {
 struct Node {
     keypair: Arc<Keypair>,
     contact_info: ContactInfo,
-    gossip: Arc<Mutex<CrdsGossip>>,
+    gossip: Arc<CrdsGossip>,
     ping_cache: Arc<Mutex<PingCache>>,
     stake: u64,
 }
 
 impl Node {
-    fn new(
-        keypair: Arc<Keypair>,
-        contact_info: ContactInfo,
-        gossip: Arc<Mutex<CrdsGossip>>,
-    ) -> Self {
+    fn new(keypair: Arc<Keypair>, contact_info: ContactInfo, gossip: Arc<CrdsGossip>) -> Self {
         Self::staked(keypair, contact_info, gossip, 0)
     }
 
     fn staked(
         keypair: Arc<Keypair>,
         contact_info: ContactInfo,
-        gossip: Arc<Mutex<CrdsGossip>>,
+        gossip: Arc<CrdsGossip>,
         stake: u64,
     ) -> Self {
         let ping_cache = Arc::new(Mutex::new(PingCache::new(
@@ -64,14 +60,6 @@ impl Node {
             ping_cache,
             stake,
         }
-    }
-}
-
-impl Deref for Node {
-    type Target = Arc<Mutex<CrdsGossip>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.gossip
     }
 }
 
@@ -116,17 +104,24 @@ fn star_network_create(num: usize) -> Network {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info.clone()));
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), timestamp()).unwrap();
-            node.crds.insert(entry.clone(), timestamp()).unwrap();
-            let node = Node::new(node_keypair, contact_info, Arc::new(Mutex::new(node)));
+            let node = CrdsGossip::default();
+            {
+                let mut node_crds = node.crds.write().unwrap();
+                node_crds.insert(new.clone(), timestamp()).unwrap();
+                node_crds.insert(entry.clone(), timestamp()).unwrap();
+            }
+            let node = Node::new(node_keypair, contact_info, Arc::new(node));
             (new.label().pubkey(), node)
         })
         .collect();
-    let mut node = CrdsGossip::default();
+    let node = CrdsGossip::default();
     let id = entry.label().pubkey();
-    node.crds.insert(entry, timestamp()).unwrap();
-    let node = Node::new(node_keypair, contact_info, Arc::new(Mutex::new(node)));
+    node.crds
+        .write()
+        .unwrap()
+        .insert(entry, timestamp())
+        .unwrap();
+    let node = Node::new(node_keypair, contact_info, Arc::new(node));
     network.insert(id, node);
     Network::new(network)
 }
@@ -135,22 +130,36 @@ fn rstar_network_create(num: usize) -> Network {
     let node_keypair = Arc::new(Keypair::new());
     let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info.clone()));
-    let mut origin = CrdsGossip::default();
+    let origin = CrdsGossip::default();
     let id = entry.label().pubkey();
-    origin.crds.insert(entry, timestamp()).unwrap();
+    origin
+        .crds
+        .write()
+        .unwrap()
+        .insert(entry, timestamp())
+        .unwrap();
     let mut network: HashMap<_, _> = (1..num)
         .map(|_| {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info.clone()));
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), timestamp()).unwrap();
-            origin.crds.insert(new.clone(), timestamp()).unwrap();
-            let node = Node::new(node_keypair, contact_info, Arc::new(Mutex::new(node)));
+            let node = CrdsGossip::default();
+            node.crds
+                .write()
+                .unwrap()
+                .insert(new.clone(), timestamp())
+                .unwrap();
+            origin
+                .crds
+                .write()
+                .unwrap()
+                .insert(new.clone(), timestamp())
+                .unwrap();
+            let node = Node::new(node_keypair, contact_info, Arc::new(node));
             (new.label().pubkey(), node)
         })
         .collect();
-    let node = Node::new(node_keypair, contact_info, Arc::new(Mutex::new(origin)));
+    let node = Node::new(node_keypair, contact_info, Arc::new(origin));
     network.insert(id, node);
     Network::new(network)
 }
@@ -161,9 +170,13 @@ fn ring_network_create(num: usize) -> Network {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info.clone()));
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), timestamp()).unwrap();
-            let node = Node::new(node_keypair, contact_info, Arc::new(Mutex::new(node)));
+            let node = CrdsGossip::default();
+            node.crds
+                .write()
+                .unwrap()
+                .insert(new.clone(), timestamp())
+                .unwrap();
+            let node = Node::new(node_keypair, contact_info, Arc::new(node));
             (new.label().pubkey(), node)
         })
         .collect();
@@ -173,15 +186,12 @@ fn ring_network_create(num: usize) -> Network {
             let start = &network[&keys[k]];
             let start_id = keys[k];
             let label = CrdsValueLabel::ContactInfo(start_id);
-            let gossip = start.gossip.lock().unwrap();
-            gossip.crds.get(&label).unwrap().value.clone()
+            let gossip_crds = start.gossip.crds.read().unwrap();
+            gossip_crds.get(&label).unwrap().value.clone()
         };
         let end = network.get_mut(&keys[(k + 1) % keys.len()]).unwrap();
-        end.lock()
-            .unwrap()
-            .crds
-            .insert(start_info, timestamp())
-            .unwrap();
+        let mut end_crds = end.gossip.crds.write().unwrap();
+        end_crds.insert(start_info, timestamp()).unwrap();
     }
     Network::new(network)
 }
@@ -193,14 +203,13 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
             let node_keypair = Arc::new(Keypair::new());
             let contact_info = ContactInfo::new_localhost(&node_keypair.pubkey(), 0);
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info.clone()));
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), timestamp()).unwrap();
-            let node = Node::staked(
-                node_keypair,
-                contact_info,
-                Arc::new(Mutex::new(node)),
-                stakes[n],
-            );
+            let node = CrdsGossip::default();
+            node.crds
+                .write()
+                .unwrap()
+                .insert(new.clone(), timestamp())
+                .unwrap();
+            let node = Node::staked(node_keypair, contact_info, Arc::new(node), stakes[n]);
             (new.label().pubkey(), node)
         })
         .collect();
@@ -209,17 +218,18 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
     let start_entries: Vec<_> = keys
         .iter()
         .map(|k| {
-            let start = &network[k].lock().unwrap();
+            let start = &network[k];
             let start_label = CrdsValueLabel::ContactInfo(*k);
-            start.crds.get(&start_label).unwrap().value.clone()
+            let gossip_crds = start.gossip.crds.read().unwrap();
+            gossip_crds.get(&start_label).unwrap().value.clone()
         })
         .collect();
     for (end_pubkey, end) in network.iter_mut() {
+        let mut end_crds = end.gossip.crds.write().unwrap();
         for k in 0..keys.len() {
-            let mut end = end.lock().unwrap();
             if keys[k] != *end_pubkey {
                 let start_info = start_entries[k].clone();
-                end.crds.insert(start_info, timestamp()).unwrap();
+                end_crds.insert(start_info, timestamp()).unwrap();
             }
         }
     }
@@ -247,7 +257,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     let network_values: Vec<Node> = network.values().cloned().collect();
     network_values.par_iter().for_each(|node| {
         let node_pubkey = node.keypair.pubkey();
-        node.lock().unwrap().refresh_push_active_set(
+        node.gossip.refresh_push_active_set(
             &node_pubkey,
             0,               // shred version
             &HashMap::new(), // stakes
@@ -262,14 +272,14 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
         let now = (start * 100) as u64;
         ts += 1000;
         // push a message to the network
-        network_values.par_iter().for_each(|locked_node| {
-            let node_pubkey = locked_node.keypair.pubkey();
-            let node = &mut locked_node.lock().unwrap();
-            let label = CrdsValueLabel::ContactInfo(node_pubkey);
-            let entry = node.crds.get(&label).unwrap();
-            let mut m = entry.value.contact_info().cloned().unwrap();
+        network_values.par_iter().for_each(|node| {
+            let node_pubkey = node.keypair.pubkey();
+            let mut m = {
+                let node_crds = node.gossip.crds.read().unwrap();
+                node_crds.get_contact_info(node_pubkey).cloned().unwrap()
+            };
             m.wallclock = now;
-            node.process_push_message(
+            node.gossip.process_push_message(
                 &Pubkey::default(),
                 vec![CrdsValue::new_unsigned(CrdsData::ContactInfo(m))],
                 now,
@@ -321,14 +331,13 @@ fn network_run_push(
             .par_iter()
             .map(|node| {
                 let node_pubkey = node.keypair.pubkey();
-                let mut node_lock = node.lock().unwrap();
-                let timeouts = node_lock.make_timeouts(
+                let timeouts = node.gossip.make_timeouts(
                     node_pubkey,
                     &HashMap::default(), // stakes
-                    Duration::from_millis(node_lock.pull.crds_timeout),
+                    Duration::from_millis(node.gossip.pull.crds_timeout),
                 );
-                node_lock.purge(&node_pubkey, thread_pool, now, &timeouts);
-                (node_pubkey, node_lock.new_push_messages(vec![], now))
+                node.gossip.purge(&node_pubkey, thread_pool, now, &timeouts);
+                (node_pubkey, node.gossip.new_push_messages(vec![], now))
             })
             .collect();
         let transfered: Vec<_> = requests
@@ -344,8 +353,7 @@ fn network_run_push(
                     let origins: HashSet<_> = network
                         .get(&to)
                         .unwrap()
-                        .lock()
-                        .unwrap()
+                        .gossip
                         .process_push_message(&from, msgs.clone(), now)
                         .into_iter()
                         .collect();
@@ -353,11 +361,8 @@ fn network_run_push(
                         .get(&to)
                         .map(|node| {
                             let node_pubkey = node.keypair.pubkey();
-                            node.lock().unwrap().prune_received_cache(
-                                &node_pubkey,
-                                origins,
-                                &stakes,
-                            )
+                            node.gossip
+                                .prune_received_cache(&node_pubkey, origins, &stakes)
                         })
                         .unwrap();
 
@@ -374,18 +379,18 @@ fn network_run_push(
                             .get(&from)
                             .map(|node| {
                                 let node_pubkey = node.keypair.pubkey();
-                                let node = node.lock().unwrap();
                                 let destination = node_pubkey;
                                 let now = timestamp();
-                                node.process_prune_msg(
-                                    &node_pubkey,
-                                    &to,
-                                    &destination,
-                                    &prune_keys,
-                                    now,
-                                    now,
-                                )
-                                .unwrap()
+                                node.gossip
+                                    .process_prune_msg(
+                                        &node_pubkey,
+                                        &to,
+                                        &destination,
+                                        &prune_keys,
+                                        now,
+                                        now,
+                                    )
+                                    .unwrap()
                             })
                             .unwrap();
                     }
@@ -410,7 +415,7 @@ fn network_run_push(
         if now % CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS == 0 && now > 0 {
             network_values.par_iter().for_each(|node| {
                 let node_pubkey = node.keypair.pubkey();
-                node.lock().unwrap().refresh_push_active_set(
+                node.gossip.refresh_push_active_set(
                     &node_pubkey,
                     0,               // shred version
                     &HashMap::new(), // stakes
@@ -420,10 +425,7 @@ fn network_run_push(
         }
         total = network_values
             .par_iter()
-            .map(|node| {
-                let gossip = node.gossip.lock().unwrap();
-                gossip.push.num_pending(&gossip.crds)
-            })
+            .map(|node| node.gossip.push.num_pending(&node.gossip.crds))
             .sum();
         trace!(
                 "network_run_push_{}: now: {} queue: {} bytes: {} num_msgs: {} prunes: {} stake_pruned: {} delivered: {}",
@@ -477,8 +479,7 @@ fn network_run_pull(
                 .filter_map(|from| {
                     let mut pings = Vec::new();
                     let (peer, filters) = from
-                        .lock()
-                        .unwrap()
+                        .gossip
                         .new_pull_request(
                             thread_pool,
                             from.keypair.deref(),
@@ -492,9 +493,9 @@ fn network_run_pull(
                         )
                         .ok()?;
                     let from_pubkey = from.keypair.pubkey();
-                    let gossip = from.gossip.lock().unwrap();
                     let label = CrdsValueLabel::ContactInfo(from_pubkey);
-                    let self_info = gossip.crds.get(&label).unwrap().value.clone();
+                    let gossip_crds = from.gossip.crds.read().unwrap();
+                    let self_info = gossip_crds.get(&label).unwrap().value.clone();
                     Some((peer.id, filters, self_info))
                 })
                 .collect()
@@ -520,8 +521,7 @@ fn network_run_pull(
                     .get(&to)
                     .map(|node| {
                         let rsp = node
-                            .lock()
-                            .unwrap()
+                            .gossip
                             .generate_pull_responses(
                                 &filters,
                                 /*output_size_limit=*/ usize::MAX,
@@ -530,7 +530,7 @@ fn network_run_pull(
                             .into_iter()
                             .flatten()
                             .collect();
-                        node.lock().unwrap().process_pull_requests(
+                        node.gossip.process_pull_requests(
                             filters.into_iter().map(|(caller, _)| caller),
                             now,
                         );
@@ -540,12 +540,12 @@ fn network_run_pull(
                 bytes += serialized_size(&rsp).unwrap() as usize;
                 msgs += rsp.len();
                 if let Some(node) = network.get(&from) {
-                    let mut node = node.lock().unwrap();
-                    node.mark_pull_request_creation_time(from, now);
+                    node.gossip.mark_pull_request_creation_time(from, now);
                     let mut stats = ProcessPullStats::default();
-                    let (vers, vers_expired_timeout, failed_inserts) =
-                        node.filter_pull_responses(&timeouts, rsp, now, &mut stats);
-                    node.process_pull_responses(
+                    let (vers, vers_expired_timeout, failed_inserts) = node
+                        .gossip
+                        .filter_pull_responses(&timeouts, rsp, now, &mut stats);
+                    node.gossip.process_pull_responses(
                         &from,
                         vers,
                         vers_expired_timeout,
@@ -566,7 +566,7 @@ fn network_run_pull(
         }
         let total: usize = network_values
             .par_iter()
-            .map(|v| v.lock().unwrap().crds.len())
+            .map(|v| v.gossip.crds.read().unwrap().len())
             .sum();
         convergance = total as f64 / ((num * num) as f64);
         if convergance > max_convergance {
@@ -692,12 +692,14 @@ fn test_star_network_large_push() {
 }
 #[test]
 fn test_prune_errors() {
-    let mut crds_gossip = CrdsGossip::default();
+    let crds_gossip = CrdsGossip::default();
     let id = Pubkey::new(&[0; 32]);
     let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
     let prune_pubkey = Pubkey::new(&[2; 32]);
     crds_gossip
         .crds
+        .write()
+        .unwrap()
         .insert(
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone())),
             0,

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -321,11 +321,10 @@ pub fn cluster_info_scale() {
                     .iter()
                     .filter(|v| v.message.account_keys == tx.message.account_keys)
                     .count();
-                let gossip = node.gossip.read().unwrap();
-                num_old += gossip.push.num_old.load(Ordering::Relaxed);
-                num_push_total += gossip.push.num_total.load(Ordering::Relaxed);
-                num_pushes += gossip.push.num_pushes.load(Ordering::Relaxed);
-                num_pulls += gossip.pull.num_pulls.load(Ordering::Relaxed);
+                num_old += node.gossip.push.num_old.load(Ordering::Relaxed);
+                num_push_total += node.gossip.push.num_total.load(Ordering::Relaxed);
+                num_pushes += node.gossip.push.num_pushes.load(Ordering::Relaxed);
+                num_pulls += node.gossip.pull.num_pulls.load(Ordering::Relaxed);
                 if has_tx == 0 {
                     not_done += 1;
                 }
@@ -348,11 +347,10 @@ pub fn cluster_info_scale() {
         );
         sleep(Duration::from_millis(200));
         for (node, _, _) in nodes.iter() {
-            let gossip = node.gossip.read().unwrap();
-            gossip.push.num_old.store(0, Ordering::Relaxed);
-            gossip.push.num_total.store(0, Ordering::Relaxed);
-            gossip.push.num_pushes.store(0, Ordering::Relaxed);
-            gossip.pull.num_pulls.store(0, Ordering::Relaxed);
+            node.gossip.push.num_old.store(0, Ordering::Relaxed);
+            node.gossip.push.num_total.store(0, Ordering::Relaxed);
+            node.gossip.push.num_pushes.store(0, Ordering::Relaxed);
+            node.gossip.pull.num_pulls.store(0, Ordering::Relaxed);
         }
     }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -745,9 +745,9 @@ mod tests {
         // This node is ahead of the trusted validators
         cluster_info
             .gossip
+            .crds
             .write()
             .unwrap()
-            .crds
             .insert(
                 CrdsValue::new_unsigned(CrdsData::AccountsHashes(SnapshotHash::new(
                     trusted_validators[0],
@@ -765,9 +765,9 @@ mod tests {
         // Node is slightly behind the trusted validators
         cluster_info
             .gossip
+            .crds
             .write()
             .unwrap()
-            .crds
             .insert(
                 CrdsValue::new_unsigned(CrdsData::AccountsHashes(SnapshotHash::new(
                     trusted_validators[1],
@@ -781,9 +781,9 @@ mod tests {
         // Node is far behind the trusted validators
         cluster_info
             .gossip
+            .crds
             .write()
             .unwrap()
-            .crds
             .insert(
                 CrdsValue::new_unsigned(CrdsData::AccountsHashes(SnapshotHash::new(
                     trusted_validators[2],


### PR DESCRIPTION
#### Problem
Working towards reducing lock contention in gossip.

#### Summary of Changes
This commit makes `CrdsGossip` thread safe by wrapping inner crds field in `RwLock`.
