### PR TITLE
remove unnecessary generic args to make refactoring easier

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -647,7 +647,7 @@ impl<T> Default for AccountsIndex<T> {
         Self {
             account_maps: (0..BINS)
                 .into_iter()
-                .map(|_| RwLock::new(AccountMap::<Pubkey, AccountMapEntry<T>>::default()))
+                .map(|_| RwLock::new(AccountMap::default()))
                 .collect::<Vec<_>>(),
             program_id_index: SecondaryIndex::<DashMapSecondaryIndexEntry>::new(
                 "program_id_index_stats",


### PR DESCRIPTION
#### Problem
The specifics around AccountsIndex are in flux as we move to an on-disk implementation.
#### Summary of Changes
Make it less noisy to change the implementation by removing unnecessary specificity.
Fixes #
