### PR TITLE
Cli: expose last valid block height

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1720,6 +1720,7 @@ pub struct CliFeesInner {
     pub blockhash: String,
     pub lamports_per_signature: u64,
     pub last_valid_slot: Option<Slot>,
+    pub last_valid_block_height: Option<Slot>,
 }
 
 impl QuietDisplay for CliFeesInner {}
@@ -1733,11 +1734,11 @@ impl fmt::Display for CliFeesInner {
             "Lamports per signature:",
             &self.lamports_per_signature.to_string(),
         )?;
-        let last_valid_slot = self
-            .last_valid_slot
+        let last_valid_block_height = self
+            .last_valid_block_height
             .map(|s| s.to_string())
             .unwrap_or_default();
-        writeln_name_value(f, "Last valid slot:", &last_valid_slot)
+        writeln_name_value(f, "Last valid block height:", &last_valid_block_height)
     }
 }
 
@@ -1766,6 +1767,7 @@ impl CliFees {
         blockhash: Hash,
         lamports_per_signature: u64,
         last_valid_slot: Option<Slot>,
+        last_valid_block_height: Option<Slot>,
     ) -> Self {
         Self {
             inner: Some(CliFeesInner {
@@ -1773,6 +1775,7 @@ impl CliFees {
                 blockhash: blockhash.to_string(),
                 lamports_per_signature,
                 last_valid_slot,
+                last_valid_block_height,
             }),
         }
     }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -936,18 +936,19 @@ pub fn process_fees(
                 *recent_blockhash,
                 fee_calculator.lamports_per_signature,
                 None,
+                None,
             )
         } else {
             CliFees::none()
         }
     } else {
-        let result = rpc_client.get_recent_blockhash_with_commitment(config.commitment)?;
-        let (recent_blockhash, fee_calculator, last_valid_slot) = result.value;
+        let result = rpc_client.get_fees_with_commitment(config.commitment)?;
         CliFees::some(
             result.context.slot,
-            recent_blockhash,
-            fee_calculator.lamports_per_signature,
-            Some(last_valid_slot),
+            result.value.blockhash,
+            result.value.fee_calculator.lamports_per_signature,
+            None,
+            Some(result.value.last_valid_block_height),
         )
     };
     Ok(config.output_format.formatted_string(&fees))

--- a/client/src/fees.rs
+++ b/client/src/fees.rs
@@ -1,0 +1,9 @@
+use crate::{fee_calculator::FeeCalculator, hash::Hash};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Fees {
+    pub blockhash: Hash,
+    pub fee_calculator: FeeCalculator,
+    pub last_valid_block_height: u64,
+}

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -4,6 +4,7 @@ use {
     solana_sdk::{
         clock::{Epoch, Slot, UnixTimestamp},
         fee_calculator::{FeeCalculator, FeeRateGovernor},
+        hash::Hash,
         inflation::Inflation,
         transaction::{Result, TransactionError},
     },
@@ -55,6 +56,14 @@ pub struct DeprecatedRpcFees {
     pub blockhash: String,
     pub fee_calculator: FeeCalculator,
     pub last_valid_slot: Slot,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Fees {
+    pub blockhash: Hash,
+    pub fee_calculator: FeeCalculator,
+    pub last_valid_block_height: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
#### Problem
The `lastValidSlot` field returned from the `getFees` rpc has been deprecated. However, solana-cli still reports this value exclusively in non-json responses:
```
$ solana fees

Blockhash: 5yC46JNB5XYNNdfZCjDuTvDjTb7ZZueEn95JFPEgPkFf
Lamports per signature: 5000
Last valid slot: 86798918
```

#### Summary of Changes
- Update solana-cli to return last valid block height:

```
$ solana fees

Blockhash: 7BvMD73ZFVuZHJUpZyGcNc4QvWM8TS35FHpAXNpDNAVQ
Lamports per signature: 5000
Last valid block height: 7794751

// JSON response retains deprecated field for backward compatibility
$ solana fees --output json

{
  "slot": 86798889,
  "blockhash": "9EMv6dBvaUnRVHrpxbkwkeBVucT9ujNn5Kj9DiyfoyYF",
  "lamportsPerSignature": 5000,
  "lastValidSlot": null,
  "lastValidBlockHeight": 77947583
}
```
- Adds new sdk struct and client methods -> Next steps are to deprecate `RpcClient::get_recent_blockhash` methods, and update monorepo to `RpcClient::get_fees` and last_valid_block_height logic.

