### PR TITLE
Add Rpc AccountHistory service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,6 +5528,7 @@ dependencies = [
  "bincode",
  "bs58 0.4.0",
  "crossbeam-channel",
+ "csv",
  "itertools 0.10.1",
  "jsonrpc-core 18.0.0",
  "jsonrpc-core-client 18.0.0",

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -681,7 +681,7 @@ mod tests {
             ..ProcessOptions::default()
         };
         let (bank_forks, cached_leader_schedule) =
-            process_blockstore(&genesis_config, &blockstore, Vec::new(), opts, None).unwrap();
+            process_blockstore(&genesis_config, &blockstore, Vec::new(), opts, None, None).unwrap();
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -27,7 +27,8 @@ use crate::{
 use crossbeam_channel::unbounded;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_ledger::{
-    blockstore::Blockstore, blockstore_processor::TransactionStatusSender,
+    blockstore::Blockstore,
+    blockstore_processor::{RpcAccountHistorySender, TransactionStatusSender},
     leader_schedule_cache::LeaderScheduleCache,
 };
 use solana_poh::poh_recorder::PohRecorder;
@@ -121,6 +122,7 @@ impl Tvu {
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
         cache_block_meta_sender: Option<CacheBlockMetaSender>,
+        rpc_account_history_sender: Option<RpcAccountHistorySender>,
         snapshot_config_and_pending_package: Option<(SnapshotConfig, PendingSnapshotPackage)>,
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: RetransmitSlotsSender,
@@ -274,6 +276,7 @@ impl Tvu {
             transaction_status_sender,
             rewards_recorder_sender,
             cache_block_meta_sender,
+            rpc_account_history_sender,
             bank_notification_sender,
             wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
             ancestor_hashes_replay_update_sender,
@@ -452,6 +455,7 @@ pub mod tests {
             &leader_schedule_cache,
             &exit,
             block_commitment_cache,
+            None,
             None,
             None,
             None,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1176,7 +1176,7 @@ fn new_banks_from_ledger(
 
     let rpc_account_history_services = match (
         config.rpc_addrs,
-        config.rpc_config.enable_rpc_account_history,
+        config.rpc_config.enable_rpc_account_history.as_ref(),
     ) {
         (Some(_), Some(account_history_config)) => {
             initialize_rpc_account_history_services(account_history_config, exit)
@@ -1405,11 +1405,11 @@ fn initialize_rpc_transaction_history_services(
 }
 
 fn initialize_rpc_account_history_services(
-    config: AccountHistoryConfig,
+    config: &AccountHistoryConfig,
     exit: &Arc<AtomicBool>,
 ) -> RpcAccountHistoryServices {
     let rpc_account_history = Arc::new(RwLock::new(AccountHistory::new()));
-    let rpc_account_keys = Arc::new(RwLock::new(AccountKeys::new()));
+    let rpc_account_keys = Arc::new(RwLock::new(config.account_keys.clone()));
     let (rpc_account_history_sender, rpc_account_history_receiver) = unbounded();
     let rpc_account_history_sender = Some(rpc_account_history_sender);
     let rpc_account_history_service = Some(RpcAccountHistoryService::new(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -731,6 +731,7 @@ fn load_bank_forks(
         process_options,
         None,
         None,
+        None,
     )
 }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -2,7 +2,7 @@ use crate::{
     blockstore::Blockstore,
     blockstore_processor::{
         self, BlockstoreProcessorError, BlockstoreProcessorResult, CacheBlockMetaSender,
-        ProcessOptions, TransactionStatusSender,
+        ProcessOptions, RpcAccountHistorySender, TransactionStatusSender,
     },
     leader_schedule_cache::LeaderScheduleCache,
 };
@@ -43,6 +43,7 @@ pub fn load(
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
+    rpc_account_history_sender: Option<&RpcAccountHistorySender>,
 ) -> LoadResult {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
@@ -67,6 +68,7 @@ pub fn load(
                 process_options,
                 transaction_status_sender,
                 cache_block_meta_sender,
+                rpc_account_history_sender,
                 &full_snapshot_archive_info,
             );
         } else {
@@ -82,6 +84,7 @@ pub fn load(
         account_paths,
         process_options,
         cache_block_meta_sender,
+        rpc_account_history_sender,
     )
 }
 
@@ -91,6 +94,7 @@ fn load_from_genesis(
     account_paths: Vec<PathBuf>,
     process_options: ProcessOptions,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
+    rpc_account_history_sender: Option<&RpcAccountHistorySender>,
 ) -> LoadResult {
     info!("Processing ledger from genesis");
     to_loadresult(
@@ -100,6 +104,7 @@ fn load_from_genesis(
             account_paths,
             process_options,
             cache_block_meta_sender,
+            rpc_account_history_sender,
         ),
         None,
     )
@@ -115,6 +120,7 @@ fn load_from_snapshot(
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
+    rpc_account_history_sender: Option<&RpcAccountHistorySender>,
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
 ) -> LoadResult {
     info!(
@@ -180,6 +186,7 @@ fn load_from_snapshot(
             &VerifyRecyclers::default(),
             transaction_status_sender,
             cache_block_meta_sender,
+            rpc_account_history_sender,
             timings,
         ),
         Some(deserialized_bank_slot_and_hash),

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -9,6 +9,7 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     solana_rpc::{
+        account_history::{AccountHistory, AccountKeys},
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::{
             OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
@@ -224,6 +225,8 @@ fn start_client_rpc_services(
             max_slots,
             leader_schedule_cache.clone(),
             max_complete_transaction_status_slot,
+            Arc::new(RwLock::new(AccountHistory::new())), // Replica nodes could support the RpcAccountHistoryService in the future
+            Arc::new(RwLock::new(AccountKeys::new())),
         )),
         Some(PubSubService::new(
             replica_config.pubsub_config.clone(),

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.12.3"
 bincode = "1.3.3"
 bs58 = "0.4.0"
 crossbeam-channel = "0.5"
+csv = "1.1.6"
 itertools = "0.10.1"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0", features = ["ipc", "ws"] }

--- a/rpc/src/account_history.rs
+++ b/rpc/src/account_history.rs
@@ -1,0 +1,206 @@
+use {
+    crossbeam_channel::{Receiver, RecvTimeoutError},
+    solana_measure::measure::Measure,
+    solana_metrics::datapoint_info,
+    solana_runtime::bank::Bank,
+    solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey},
+    std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock, RwLockWriteGuard,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::Duration,
+    },
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct AccountHistoryConfig {
+    pub num_slots: usize,
+    pub updates_only: bool,
+}
+
+pub type AccountHistory = BTreeMap<Slot, HashMap<Pubkey, Account>>;
+pub type AccountKeys = HashSet<Pubkey>;
+
+pub struct RpcAccountHistoryService {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl RpcAccountHistoryService {
+    pub fn new(
+        config: AccountHistoryConfig,
+        account_keys: Arc<RwLock<AccountKeys>>,
+        account_history: Arc<RwLock<AccountHistory>>,
+        account_history_receiver: Receiver<Arc<Bank>>,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let thread_hdl = Builder::new()
+            .name("solana-account-history".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(RecvTimeoutError::Disconnected) = Self::receive_bank(
+                    &config,
+                    &account_keys,
+                    &account_history,
+                    &account_history_receiver,
+                ) {
+                    break;
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    fn receive_bank(
+        config: &AccountHistoryConfig,
+        account_keys: &Arc<RwLock<AccountKeys>>,
+        account_history: &Arc<RwLock<AccountHistory>>,
+        account_history_receiver: &Receiver<Arc<Bank>>,
+    ) -> Result<(), RecvTimeoutError> {
+        let frozen_bank = account_history_receiver.recv_timeout(Duration::from_secs(1))?;
+        debug!(
+            "rpc account-history service received bank: {:?}",
+            frozen_bank.slot()
+        );
+
+        let r_account_keys = account_keys.read().unwrap();
+        let mut measure_collect = Measure::start("collect-account-history");
+        let slot_accounts =
+            Self::collect_accounts(&frozen_bank, &r_account_keys, config.updates_only);
+        measure_collect.stop();
+        drop(r_account_keys);
+
+        let mut measure_write = Measure::start("write-account-history");
+        let mut w_account_history = account_history.write().unwrap();
+        w_account_history.insert(frozen_bank.slot(), slot_accounts);
+        measure_write.stop();
+
+        let mut measure_prune = Measure::start("prune-account-history");
+        Self::remove_old_slots(w_account_history, &config.num_slots);
+        measure_prune.stop();
+
+        datapoint_info!(
+            "rpc-account-history",
+            ("collect", measure_collect.as_us(), i64),
+            ("write", measure_write.as_us(), i64),
+            ("prune", measure_prune.as_us(), i64),
+        );
+
+        Ok(())
+    }
+
+    fn collect_accounts(
+        frozen_bank: &Bank,
+        accounts: &HashSet<Pubkey>,
+        updates_only: bool,
+    ) -> HashMap<Pubkey, Account> {
+        let mut slot_accounts = HashMap::new();
+        for address in accounts.iter() {
+            let shared_account = if updates_only {
+                frozen_bank
+                    .get_account_modified_slot(address)
+                    .filter(|(_shared_account, slot)| *slot == frozen_bank.slot())
+                    .map(|(shared_account, _slot)| shared_account)
+            } else {
+                frozen_bank.get_account(address)
+            };
+            if let Some(shared_account) = shared_account {
+                slot_accounts.insert(*address, shared_account.into());
+            }
+        }
+        slot_accounts
+    }
+
+    fn remove_old_slots(
+        mut w_account_history: RwLockWriteGuard<AccountHistory>,
+        num_slots: &usize,
+    ) {
+        while w_account_history.len() > *num_slots {
+            let oldest_slot = w_account_history.keys().cloned().next().unwrap_or_default();
+            w_account_history.remove(&oldest_slot);
+        }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_runtime::bank::Bank, solana_sdk::genesis_config::create_genesis_config};
+
+    #[test]
+    fn test_collect_accounts() {
+        let (genesis_config, mint_keypair) = create_genesis_config(1_000);
+        let mut bank = Arc::new(Bank::new(&genesis_config));
+
+        let address = Pubkey::new_unique();
+        let account_keys = vec![address].into_iter().collect();
+
+        bank.transfer(42, &mint_keypair, &address).unwrap();
+        let all_accounts = RpcAccountHistoryService::collect_accounts(&bank, &account_keys, false);
+        let updated_accounts =
+            RpcAccountHistoryService::collect_accounts(&bank, &account_keys, true);
+        assert_eq!(all_accounts, updated_accounts);
+        assert_eq!(all_accounts.len(), 1);
+
+        bank = Arc::new(Bank::new_from_parent(
+            &bank,
+            &Pubkey::default(),
+            bank.slot() + 1,
+        ));
+        let all_accounts = RpcAccountHistoryService::collect_accounts(&bank, &account_keys, false);
+        let updated_accounts =
+            RpcAccountHistoryService::collect_accounts(&bank, &account_keys, true);
+        assert_ne!(all_accounts, updated_accounts);
+        assert_eq!(all_accounts.len(), 1);
+        assert_eq!(updated_accounts.len(), 0);
+    }
+
+    #[test]
+    fn test_remove_old_slots() {
+        let num_slots = 3;
+        let account_history = RwLock::new(BTreeMap::new());
+        assert_eq!(account_history.read().unwrap().len(), 0);
+        RpcAccountHistoryService::remove_old_slots(account_history.write().unwrap(), &num_slots);
+        assert_eq!(account_history.read().unwrap().len(), 0);
+
+        let accounts: HashMap<Pubkey, Account> = vec![
+            (Pubkey::new_unique(), Account::default()),
+            (Pubkey::new_unique(), Account::default()),
+        ]
+        .into_iter()
+        .collect();
+        account_history.write().unwrap().insert(0, accounts.clone());
+        assert_eq!(account_history.read().unwrap().len(), 1);
+        RpcAccountHistoryService::remove_old_slots(account_history.write().unwrap(), &num_slots);
+        assert_eq!(account_history.read().unwrap().len(), 1);
+
+        for slot in 1..num_slots {
+            account_history
+                .write()
+                .unwrap()
+                .insert(slot as Slot, accounts.clone());
+        }
+        assert_eq!(account_history.read().unwrap().len(), num_slots);
+        RpcAccountHistoryService::remove_old_slots(account_history.write().unwrap(), &num_slots);
+        assert_eq!(account_history.read().unwrap().len(), num_slots);
+
+        for slot in num_slots..num_slots + 2 {
+            account_history
+                .write()
+                .unwrap()
+                .insert(slot as Slot, accounts.clone());
+        }
+        assert_eq!(account_history.read().unwrap().len(), num_slots + 2);
+        RpcAccountHistoryService::remove_old_slots(account_history.write().unwrap(), &num_slots);
+        assert_eq!(account_history.read().unwrap().len(), num_slots);
+        assert_eq!(*account_history.read().unwrap().iter().next().unwrap().0, 2);
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
+pub mod account_history;
 pub mod max_slots;
 pub mod optimistically_confirmed_bank_tracker;
 pub mod parsed_token_accounts;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        account_history::{AccountHistory, AccountHistoryConfig, AccountKeys},
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*,
@@ -142,6 +143,7 @@ pub struct JsonRpcConfig {
     pub minimal_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
+    pub enable_rpc_account_history: Option<AccountHistoryConfig>,
 }
 
 #[derive(Clone)]
@@ -162,6 +164,8 @@ pub struct JsonRpcRequestProcessor {
     max_slots: Arc<MaxSlots>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     max_complete_transaction_status_slot: Arc<AtomicU64>,
+    account_history: Arc<RwLock<AccountHistory>>,
+    account_keys: Arc<RwLock<AccountKeys>>,
 }
 impl Metadata for JsonRpcRequestProcessor {}
 
@@ -247,6 +251,8 @@ impl JsonRpcRequestProcessor {
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
+        account_history: Arc<RwLock<AccountHistory>>,
+        account_keys: Arc<RwLock<AccountKeys>>,
     ) -> (Self, Receiver<TransactionInfo>) {
         let (sender, receiver) = channel();
         (
@@ -267,6 +273,8 @@ impl JsonRpcRequestProcessor {
                 max_slots,
                 leader_schedule_cache,
                 max_complete_transaction_status_slot,
+                account_history,
+                account_keys,
             },
             receiver,
         )
@@ -313,6 +321,8 @@ impl JsonRpcRequestProcessor {
             max_slots: Arc::new(MaxSlots::default()),
             leader_schedule_cache: Arc::new(LeaderScheduleCache::new_from_bank(bank)),
             max_complete_transaction_status_slot: Arc::new(AtomicU64::default()),
+            account_history: Arc::new(RwLock::new(AccountHistory::new())),
+            account_keys: Arc::new(RwLock::new(AccountKeys::new())),
         }
     }
 
@@ -1894,6 +1904,49 @@ impl JsonRpcRequestProcessor {
         } else {
             self.get_filtered_program_accounts(bank, &spl_token_id_v2_0(), filters)
         }
+    }
+
+    fn get_historical_account_info(
+        &self,
+        pubkey: &Pubkey,
+        slot: Slot,
+        config: Option<RpcAccountInfoConfig>,
+    ) -> Result<RpcResponse<Option<UiAccount>>> {
+        let config = config.unwrap_or_default();
+        let encoding = config.encoding.unwrap_or(UiAccountEncoding::Binary);
+        check_slice_and_encoding(&encoding, config.data_slice.is_some())?;
+
+        let response = match self
+            .account_history
+            .read()
+            .unwrap()
+            .get(&slot)
+            .and_then(|slot_accounts| slot_accounts.get(pubkey))
+        {
+            Some(account) => Some(encode_account(
+                account,
+                pubkey,
+                encoding,
+                config.data_slice,
+            )?),
+            None => None,
+        };
+        Ok(Response {
+            context: RpcResponseContext { slot },
+            value: response,
+        })
+    }
+
+    fn add_historical_address(&self, pubkey: &Pubkey) -> usize {
+        let mut w_account_keys = self.account_keys.write().unwrap();
+        w_account_keys.insert(*pubkey);
+        w_account_keys.len()
+    }
+
+    fn remove_historical_address(&self, pubkey: &Pubkey) -> usize {
+        let mut w_account_keys = self.account_keys.write().unwrap();
+        w_account_keys.remove(pubkey);
+        w_account_keys.len()
     }
 }
 
@@ -3864,6 +3917,81 @@ pub mod rpc_obsolete_v1_7 {
     }
 }
 
+// AccountHistory-related RPC methods
+pub mod rpc_account_history {
+    use super::*;
+    #[rpc]
+    pub trait RpcAccountHistory {
+        type Metadata;
+
+        #[rpc(meta, name = "getHistoricalAccountInfo")]
+        fn get_historical_account_info(
+            &self,
+            meta: Self::Metadata,
+            pubkey_str: String,
+            slot: Slot,
+            config: Option<RpcAccountInfoConfig>,
+        ) -> Result<RpcResponse<Option<UiAccount>>>;
+
+        #[rpc(meta, name = "addHistoricalAddress")]
+        fn add_historical_address(&self, meta: Self::Metadata, pubkey_str: String)
+            -> Result<usize>;
+
+        #[rpc(meta, name = "removeHistoricalAddress")]
+        fn remove_historical_address(
+            &self,
+            meta: Self::Metadata,
+            pubkey_str: String,
+        ) -> Result<usize>;
+    }
+
+    pub struct AccountHistoryImpl;
+    impl RpcAccountHistory for AccountHistoryImpl {
+        type Metadata = JsonRpcRequestProcessor;
+
+        fn get_historical_account_info(
+            &self,
+            meta: Self::Metadata,
+            pubkey_str: String,
+            slot: Slot,
+            config: Option<RpcAccountInfoConfig>,
+        ) -> Result<RpcResponse<Option<UiAccount>>> {
+            debug!(
+                "get_historical_account_info rpc request received: {:?}, {:?}",
+                pubkey_str, slot
+            );
+            let pubkey = verify_pubkey(&pubkey_str)?;
+            meta.get_historical_account_info(&pubkey, slot, config)
+        }
+
+        fn add_historical_address(
+            &self,
+            meta: Self::Metadata,
+            pubkey_str: String,
+        ) -> Result<usize> {
+            debug!(
+                "add_historical_account_key rpc request received: {:?}",
+                pubkey_str
+            );
+            let pubkey = verify_pubkey(&pubkey_str)?;
+            Ok(meta.add_historical_address(&pubkey))
+        }
+
+        fn remove_historical_address(
+            &self,
+            meta: Self::Metadata,
+            pubkey_str: String,
+        ) -> Result<usize> {
+            debug!(
+                "remove_historical_account_key rpc request received: {:?}",
+                pubkey_str
+            );
+            let pubkey = verify_pubkey(&pubkey_str)?;
+            Ok(meta.remove_historical_address(&pubkey))
+        }
+    }
+}
+
 const WORST_CASE_BASE58_TX: usize = 1683; // Golden, bump if PACKET_DATA_SIZE changes
 const WORST_CASE_BASE64_TX: usize = 1644; // Golden, bump if PACKET_DATA_SIZE changes
 fn deserialize_transaction(
@@ -4244,6 +4372,8 @@ pub mod tests {
             max_slots,
             Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
             max_complete_transaction_status_slot,
+            Arc::new(RwLock::new(AccountHistory::default())),
+            Arc::new(RwLock::new(AccountKeys::default())),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
@@ -5810,6 +5940,8 @@ pub mod tests {
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
             Arc::new(AtomicU64::default()),
+            Arc::new(RwLock::new(AccountHistory::default())),
+            Arc::new(RwLock::new(AccountKeys::default())),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
@@ -6092,6 +6224,8 @@ pub mod tests {
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
             Arc::new(AtomicU64::default()),
+            Arc::new(RwLock::new(AccountHistory::default())),
+            Arc::new(RwLock::new(AccountKeys::default())),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(
@@ -7517,6 +7651,8 @@ pub mod tests {
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
             Arc::new(AtomicU64::default()),
+            Arc::new(RwLock::new(AccountHistory::default())),
+            Arc::new(RwLock::new(AccountKeys::default())),
         );
 
         let mut io = MetaIoHandler::default();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -2,11 +2,12 @@
 
 use {
     crate::{
+        account_history::{AccountHistory, AccountKeys},
         max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         rpc::{
-            rpc_accounts::*, rpc_bank::*, rpc_deprecated_v1_7::*, rpc_full::*, rpc_minimal::*,
-            rpc_obsolete_v1_7::*, *,
+            rpc_account_history::*, rpc_accounts::*, rpc_bank::*, rpc_deprecated_v1_7::*,
+            rpc_full::*, rpc_minimal::*, rpc_obsolete_v1_7::*, *,
         },
         rpc_health::*,
         send_transaction_service::{LeaderInfo, SendTransactionService},
@@ -288,6 +289,8 @@ impl JsonRpcService {
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         current_transaction_status_slot: Arc<AtomicU64>,
+        account_history: Arc<RwLock<AccountHistory>>,
+        account_keys: Arc<RwLock<AccountKeys>>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -361,6 +364,7 @@ impl JsonRpcService {
 
         let minimal_api = config.minimal_api;
         let obsolete_v1_7_api = config.obsolete_v1_7_api;
+        let account_history_api = config.enable_rpc_account_history.is_some();
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             snapshot_config.clone(),
@@ -377,6 +381,8 @@ impl JsonRpcService {
             max_slots,
             leader_schedule_cache,
             current_transaction_status_slot,
+            account_history,
+            account_keys,
         );
 
         let leader_info =
@@ -410,6 +416,9 @@ impl JsonRpcService {
                 }
                 if obsolete_v1_7_api {
                     io.extend_with(rpc_obsolete_v1_7::ObsoleteV1_7Impl.to_delegate());
+                }
+                if account_history_api {
+                    io.extend_with(rpc_account_history::AccountHistoryImpl.to_delegate());
                 }
 
                 let request_middleware = RpcRequestMiddleware::new(
@@ -552,6 +561,8 @@ mod tests {
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
             Arc::new(AtomicU64::default()),
+            Arc::new(RwLock::new(AccountHistory::default())),
+            Arc::new(RwLock::new(AccountKeys::default())),
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2307,7 +2307,7 @@ pub fn main() {
         .ok()
         .or_else(|| get_cluster_shred_version(&entrypoint_addrs));
 
-    let rpc_account_history_config = if let Some(num_slots) =
+    let rpc_account_history_config = if let Some(max_slot_history) =
         value_of(&matches, "enable_rpc_account_history")
     {
         let account_keys = if let Some(path) = matches.value_of("rpc_account_history_addresses") {
@@ -2325,7 +2325,7 @@ pub fn main() {
             HashSet::new()
         };
         Some(AccountHistoryConfig {
-            num_slots,
+            max_slot_history,
             updates_only: matches.is_present("rpc_account_history_updates_only"),
             account_keys,
         })


### PR DESCRIPTION
#### Problem
For analytics/archival, a user often needs to capture the full history of account state over time, but there is no way to query historical account state (and pubsub subscriptions aren't guaranteed to catch all updates).

#### Summary of Changes
Add an in-memory cache of historical account state per slot, for a configurable number of slots

Fixes #18197
Towards #12211
