### PR TITLE
Explicitly sanitize program id indexes before usage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1217,7 +1217,14 @@ impl BankingStage {
                 cost_tracker
                     .write()
                     .unwrap()
-                    .add_transaction_cost(tx.transaction());
+                    .add_transaction_cost(tx.transaction())
+                    .unwrap_or_else(|err| {
+                        warn!(
+                            "failed to track transaction cost, err {:?}, tx {:?}",
+                            err,
+                            tx.transaction()
+                        )
+                    });
             }
         });
         cost_tracking_time.stop();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -751,7 +751,16 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
         let mut cost_model = cost_model.write().unwrap();
         for transaction in &entry.transactions {
             programs += transaction.message().instructions.len();
-            let tx_cost = cost_model.calculate_cost(transaction);
+            let tx_cost = match cost_model.calculate_cost(transaction) {
+                Err(err) => {
+                    warn!(
+                        "failed to calculate transaction cost, err {:?}, tx {:?}",
+                        err, transaction
+                    );
+                    continue;
+                }
+                Ok(cost) => cost,
+            };
             if cost_tracker.try_add(tx_cost).is_err() {
                 println!(
                     "Slot: {}, CostModel rejected transaction {:?}, stats {:?}!",


### PR DESCRIPTION
#### Problem
for issue https://github.com/solana-labs/solana/issues/18638

#### Summary of Changes
1. check transaction has valid program_id before using it to avoid possible panic;
2. change calculate_cost function signature to return Result;
3. add CostModelError enum, update return type from Result<_, str> to Result<_, CostModelError>

Fixes #18638
