### PR TITLE
`solana-validator set-identity` now works for voting validators

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -177,14 +177,6 @@ impl Tower {
     }
 
     #[cfg(test)]
-    pub fn new_with_key(node_pubkey: &Pubkey) -> Self {
-        Self {
-            node_pubkey: *node_pubkey,
-            ..Tower::default()
-        }
-    }
-
-    #[cfg(test)]
     pub fn new_for_tests(threshold_depth: usize, threshold_size: f64) -> Self {
         Self {
             threshold_depth,
@@ -1205,7 +1197,7 @@ impl Tower {
             .with_extension("bin")
     }
 
-    pub fn get_tmp_filename(path: &Path) -> PathBuf {
+    fn get_tmp_filename(path: &Path) -> PathBuf {
         path.with_extension("bin.new")
     }
 
@@ -1464,7 +1456,7 @@ pub mod test {
         // Init state
         let mut vote_simulator = VoteSimulator::new(1);
         let node_pubkey = vote_simulator.node_pubkeys[0];
-        let mut tower = Tower::new_with_key(&node_pubkey);
+        let mut tower = Tower::default();
 
         // Create the tree of banks
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(3) / (tr(4) / tr(5)))));
@@ -1547,7 +1539,7 @@ pub mod test {
             .unwrap()
             .descendants()
             .clone();
-        let mut tower = Tower::new_with_key(&vote_simulator.node_pubkeys[0]);
+        let mut tower = Tower::default();
 
         // Last vote is 47
         tower.record_vote(
@@ -1653,7 +1645,7 @@ pub mod test {
             .unwrap()
             .descendants()
             .clone();
-        let mut tower = Tower::new_with_key(&vote_simulator.node_pubkeys[0]);
+        let mut tower = Tower::default();
         let other_vote_account = vote_simulator.vote_pubkeys[1];
 
         // Last vote is 47
@@ -1833,7 +1825,7 @@ pub mod test {
             .unwrap()
             .descendants()
             .clone();
-        let mut tower = Tower::new_with_key(&vote_simulator.node_pubkeys[0]);
+        let mut tower = Tower::default();
         let other_vote_account = vote_simulator.vote_pubkeys[1];
 
         // Last vote is 47
@@ -1934,7 +1926,7 @@ pub mod test {
         // Init state
         let mut vote_simulator = VoteSimulator::new(4);
         let my_pubkey = vote_simulator.node_pubkeys[0];
-        let mut tower = Tower::new_with_key(&my_pubkey);
+        let mut tower = Tower::default();
         let forks = tr(0)
             / (tr(1)
                 / (tr(2)
@@ -1989,7 +1981,7 @@ pub mod test {
         let mut vote_simulator = VoteSimulator::new(2);
         let node_pubkey = vote_simulator.node_pubkeys[0];
         let vote_pubkey = vote_simulator.vote_pubkeys[0];
-        let mut tower = Tower::new_with_key(&node_pubkey);
+        let mut tower = Tower::default();
 
         let num_slots_to_try = 200;
         // Create the tree of banks
@@ -2544,7 +2536,6 @@ pub mod test {
         solana_logger::setup();
         // Init state
         let mut vote_simulator = VoteSimulator::new(2);
-        let my_pubkey = vote_simulator.node_pubkeys[0];
         let other_vote_account = vote_simulator.vote_pubkeys[1];
         let bank0 = vote_simulator
             .bank_forks
@@ -2583,7 +2574,7 @@ pub mod test {
             .unwrap()
             .descendants()
             .clone();
-        let mut tower = Tower::new_with_key(&my_pubkey);
+        let mut tower = Tower::default();
 
         tower.record_vote(43, Hash::default());
         tower.record_vote(44, Hash::default());
@@ -2763,7 +2754,7 @@ pub mod test {
     #[test]
     fn test_load_tower_wrong_identity() {
         let identity_keypair = Arc::new(Keypair::new());
-        let tower = Tower::new_with_key(&Pubkey::default());
+        let tower = Tower::default();
         assert_matches!(
             tower.save(&identity_keypair),
             Err(TowerError::WrongTower(_))
@@ -2834,7 +2825,7 @@ pub mod test {
             assert!(!blockstore.is_root(3));
             assert!(!blockstore.is_root(4));
 
-            let mut tower = Tower::new_with_key(&Pubkey::default());
+            let mut tower = Tower::default();
             tower.vote_state.root_slot = Some(4);
             reconcile_blockstore_roots_with_tower(&tower, &blockstore).unwrap();
 
@@ -2866,7 +2857,7 @@ pub mod test {
             assert!(blockstore.is_root(3));
             assert!(!blockstore.is_root(4));
 
-            let mut tower = Tower::new_with_key(&Pubkey::default());
+            let mut tower = Tower::default();
             tower.vote_state.root_slot = Some(4);
             reconcile_blockstore_roots_with_tower(&tower, &blockstore).unwrap();
         }
@@ -2888,7 +2879,7 @@ pub mod test {
             assert!(!blockstore.is_root(1));
             assert!(!blockstore.is_root(3));
 
-            let mut tower = Tower::new_with_key(&Pubkey::default());
+            let mut tower = Tower::default();
             tower.vote_state.root_slot = Some(4);
             assert_eq!(blockstore.last_root(), 0);
             reconcile_blockstore_roots_with_tower(&tower, &blockstore).unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3680,8 +3680,7 @@ mod tests {
     fn test_same_weight_select_lower_slot() {
         // Init state
         let mut vote_simulator = VoteSimulator::new(1);
-        let my_node_pubkey = vote_simulator.node_pubkeys[0];
-        let tower = Tower::new_with_key(&my_node_pubkey);
+        let tower = Tower::default();
 
         // Create the tree of banks in a BankForks object
         let forks = tr(0) / (tr(1)) / (tr(2));
@@ -3753,7 +3752,7 @@ mod tests {
         // Init state
         let mut vote_simulator = VoteSimulator::new(1);
         let my_node_pubkey = vote_simulator.node_pubkeys[0];
-        let mut tower = Tower::new_with_key(&my_node_pubkey);
+        let mut tower = Tower::default();
 
         // Create the tree of banks in a BankForks object
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(3))));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -635,6 +635,7 @@ impl ReplayStage {
                                 identity_keypair = cluster_info.keypair().clone();
                                 let my_old_pubkey = my_pubkey;
                                 my_pubkey = identity_keypair.pubkey();
+                                tower.set_identity(my_pubkey);
                                 warn!("Identity changed from {} to {}", my_old_pubkey, my_pubkey);
                             }
 
@@ -1576,6 +1577,16 @@ impl ReplayStage {
             }
             Ok(vote_state) => vote_state,
         };
+
+        if vote_state.node_pubkey != node_keypair.pubkey() {
+            info!(
+                "Vote account node_pubkey mismatch: {} (expected: {}).  Unable to vote",
+                vote_state.node_pubkey,
+                node_keypair.pubkey()
+            );
+            return None;
+        }
+
         let authorized_voter_pubkey =
             if let Some(authorized_voter_pubkey) = vote_state.get_authorized_voter(bank.epoch()) {
                 authorized_voter_pubkey

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -407,7 +407,7 @@ pub mod tests {
         let (completed_data_sets_sender, _completed_data_sets_receiver) = unbounded();
         let (_, gossip_confirmed_slots_receiver) = unbounded();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
-        let tower = Tower::new_with_key(&target1_keypair.pubkey());
+        let tower = Tower::default();
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),


### PR DESCRIPTION
* Clean up some minor tower nits
* Remove an overprotective sanity check