### PR TITLE
Explorer: localize token supply numbers on token account page

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -118,8 +118,11 @@ function MintAccountCard({
             {info.mintAuthority === null ? "Fixed Supply" : "Current Supply"}
           </td>
           <td className="text-lg-right">
-            {normalizeTokenAmount(info.supply, info.decimals).toFixed(
-              info.decimals
+            {normalizeTokenAmount(info.supply, info.decimals).toLocaleString(
+              "en-US",
+              {
+                minimumFractionDigits: info.decimals,
+              }
             )}
           </td>
         </tr>


### PR DESCRIPTION
#### Problem
Token supply numbers on the token account details page are difficult to read.

#### Summary of Changes
Apply localization to the numbers to include commas.

Fixes https://github.com/solana-labs/solana/issues/16656
