### PR TITLE
chore: add examples folder and two example scripts

### DIFF
--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -2,30 +2,36 @@ import * as web3 from '@solana/web3.js';
 
 (async () => {
   // Connect to cluster
-  var connection = new web3.Connection(web3.clusterApiUrl('devnet'), 'confirmed');
+  var connection = new web3.Connection(
+    web3.clusterApiUrl('devnet'),
+    'confirmed',
+  );
 
   // Generate a new random public key
   var from = web3.Keypair.generate();
-  var airdropSignature = await connection.requestAirdrop(from.publicKey, web3.LAMPORTS_PER_SOL);
+  var airdropSignature = await connection.requestAirdrop(
+    from.publicKey,
+    web3.LAMPORTS_PER_SOL,
+  );
   await connection.confirmTransaction(airdropSignature);
 
   // Generate a new random public key
   var to = web3.Keypair.generate();
 
-    // Add transfer instruction to transaction
-    var transaction = new web3.Transaction().add(
-      web3.SystemProgram.transfer({
-        fromPubkey: from.publicKey,
-        toPubkey: to.publicKey,
-        lamports: web3.LAMPORTS_PER_SOL / 100,
-      }),
-    );
+  // Add transfer instruction to transaction
+  var transaction = new web3.Transaction().add(
+    web3.SystemProgram.transfer({
+      fromPubkey: from.publicKey,
+      toPubkey: to.publicKey,
+      lamports: web3.LAMPORTS_PER_SOL / 100,
+    }),
+  );
 
-    // Sign transaction, broadcast, and confirm
-    var signature = await web3.sendAndConfirmTransaction(
-      connection,
-      transaction,
-      [from],
-    );
-    console.log('SIGNATURE', signature);
+  // Sign transaction, broadcast, and confirm
+  var signature = await web3.sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [from],
+  );
+  console.log('SIGNATURE', signature);
 })();

--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -11,7 +11,6 @@ import * as web3 from '@solana/web3.js';
 
   // Generate a new random public key
   var to = web3.Keypair.generate();
-  await connection.requestAirdrop(to.publicKey, 1000000000);
 
   //waiting 1000 miliseconds to make the the airdrop transactions are complete
   setTimeout(async function () {

--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -2,7 +2,7 @@ import * as web3 from '@solana/web3.js';
 
 (async () => {
   // Connect to cluster
-  var connection = new web3.Connection(web3.clusterApiUrl('devnet'));
+  var connection = new web3.Connection(web3.clusterApiUrl('devnet'), 'confirmed');
 
   // Generate a new random public key
   var from = web3.Keypair.generate();

--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -1,0 +1,35 @@
+import * as web3 from '@solana/web3.js';
+
+(async () => {
+  // Connect to cluster
+  var connection = new web3.Connection(web3.clusterApiUrl('devnet'));
+
+  // Generate a new random public key
+  var from = web3.Keypair.generate();
+  await connection.requestAirdrop(from.publicKey, 1000000000);
+
+  // Generate a new random public key
+  var to = web3.Keypair.generate();
+  await connection.requestAirdrop(to.publicKey, 1000000000);
+
+  //waiting 1000 miliseconds to make the the airdrop transactions are complete
+  setTimeout(async function () {
+    // Add transfer instruction to transaction
+    var transaction = new web3.Transaction().add(
+      web3.SystemProgram.transfer({
+        fromPubkey: from.publicKey,
+        toPubkey: to.publicKey,
+        lamports: web3.LAMPORTS_PER_SOL / 100,
+      }),
+    );
+
+    // Sign transaction, broadcast, and confirm
+    var signature = await web3.sendAndConfirmTransaction(
+      connection,
+      transaction,
+      [from],
+      {commitment: 'confirmed'},
+    );
+    console.log('SIGNATURE', signature);
+  }, 1000);
+})();

--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -12,8 +12,6 @@ import * as web3 from '@solana/web3.js';
   // Generate a new random public key
   var to = web3.Keypair.generate();
 
-  //waiting 1000 miliseconds to make the the airdrop transactions are complete
-  setTimeout(async function () {
     // Add transfer instruction to transaction
     var transaction = new web3.Transaction().add(
       web3.SystemProgram.transfer({
@@ -28,8 +26,6 @@ import * as web3 from '@solana/web3.js';
       connection,
       transaction,
       [from],
-      {commitment: 'confirmed'},
     );
     console.log('SIGNATURE', signature);
-  }, 1000);
 })();

--- a/web3.js/examples/send_sol.js
+++ b/web3.js/examples/send_sol.js
@@ -6,7 +6,8 @@ import * as web3 from '@solana/web3.js';
 
   // Generate a new random public key
   var from = web3.Keypair.generate();
-  await connection.requestAirdrop(from.publicKey, 1000000000);
+  var airdropSignature = await connection.requestAirdrop(from.publicKey, web3.LAMPORTS_PER_SOL);
+  await connection.confirmTransaction(airdropSignature);
 
   // Generate a new random public key
   var to = web3.Keypair.generate();


### PR DESCRIPTION
#### Problem

the web3 repo has no examples for how to use it and developers have been asking for them

#### Summary of Changes

created examples folder and added two example scripts for sending sol and minting tokens

Fixes #
