### PR TITLE
Drop default_on_eof attribute from Reward struct

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -339,7 +339,6 @@ pub struct Reward {
     pub lamports: i64,
     pub post_balance: u64, // Account balance in lamports after `lamports` was applied
     pub reward_type: Option<RewardType>,
-    #[serde(deserialize_with = "default_on_eof")]
     pub commission: Option<u8>, // Vote account commission when the reward was credited, only present for voting and staking rewards
 }
 


### PR DESCRIPTION
`solana_transaction_status::Reward` doesn't need `#[serde(deserialize_with = "default_on_eof")]` because it's used by JSON RPC only (the clue being the `#[serde(rename_all = "camelCase")]` attribute).

I added `default_on_eof` for BigTable/Blockstore backwards compatibility but these two databases actually use `solana_storage_proto::StoredExtendedReward`, which is already correctly annotated with `default_on_eof`

Fixes #18669
