### PR TITLE
experiment: refcount is no longer an atomic

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2288,7 +2288,8 @@ impl AccountsDb {
                 .skipped_shrink
                 .fetch_add(1, Ordering::Relaxed);
             for pubkey in unrefed_pubkeys {
-                if let Some(locked_entry) = self.accounts_index.get_account_write_entry(pubkey) {
+                if let Some(mut locked_entry) = self.accounts_index.get_account_write_entry(pubkey)
+                {
                     locked_entry.addref();
                 }
             }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2259,8 +2259,8 @@ impl AccountsDb {
         let mut alive_accounts: Vec<_> = Vec::with_capacity(stored_accounts.len());
         let mut unrefed_pubkeys = vec![];
         for (pubkey, stored_account) in &stored_accounts {
-            let lookup = self.accounts_index.get_account_read_entry(pubkey);
-            if let Some(locked_entry) = lookup {
+            let lookup = self.accounts_index.get_account_write_entry(pubkey);
+            if let Some(mut locked_entry) = lookup {
                 let is_alive = locked_entry.slot_list().iter().any(|(_slot, i)| {
                     i.store_id == stored_account.store_id
                         && i.offset == stored_account.account.offset
@@ -2288,7 +2288,7 @@ impl AccountsDb {
                 .skipped_shrink
                 .fetch_add(1, Ordering::Relaxed);
             for pubkey in unrefed_pubkeys {
-                if let Some(locked_entry) = self.accounts_index.get_account_read_entry(pubkey) {
+                if let Some(locked_entry) = self.accounts_index.get_account_write_entry(pubkey) {
                     locked_entry.addref();
                 }
             }
@@ -6152,7 +6152,7 @@ impl AccountsDb {
                                 let (key, account_info) = account;
                                 let lock = self.accounts_index.get_account_maps_read_lock(&key);
                                 let x = lock.get(&key).unwrap();
-                                let sl = x.slot_list.read().unwrap();
+                                let sl = &x.slot_list;
                                 let mut count = 0;
                                 for (slot2, account_info2) in sl.iter() {
                                     if slot2 == slot {
@@ -6313,10 +6313,7 @@ impl AccountsDb {
         self.accounts_index.account_maps.iter().for_each(|i| {
             for (pubkey, account_entry) in i.read().unwrap().iter() {
                 info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
-                info!(
-                    "      slots: {:?}",
-                    *account_entry.slot_list.read().unwrap()
-                );
+                info!("      slots: {:?}", account_entry.slot_list);
             }
         });
     }


### PR DESCRIPTION
#### Problem
Some advantages:
less memory per accounts index entry.
simpler api to clients - write lock to modify, read lock to read
allows flexibility on the implementation
#### Summary of Changes

Fixes #
