### PR TITLE
fix merge error: libsecp256k1 to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,7 +5455,7 @@ name = "solana-secp256k1-program"
 version = "1.7.5"
 dependencies = [
  "bincode",
- "libsecp256k1 0.3.5",
+ "libsecp256k1 0.5.0",
  "rand 0.7.3",
  "solana-logger 1.7.5",
  "solana-sdk",

--- a/programs/secp256k1/Cargo.toml
+++ b/programs/secp256k1/Cargo.toml
@@ -14,7 +14,7 @@ solana-sdk = { path = "../../sdk", version = "=1.7.5" }
 
 [dev-dependencies]
 bincode = "1.3.1"
-libsecp256k1 = "0.3.5"
+libsecp256k1 = "0.5.0"
 rand = "0.7.0"
 solana-logger = { path = "../../logger", version = "=1.7.5" }
 


### PR DESCRIPTION
#### Problem
#18625 appears to have had a manual merge conflict
[failing 1.7 build](https://buildkite.com/solana-labs/solana/builds/51032#32687a3b-5ce1-4c93-9866-de06a66627c7)
#### Summary of Changes

Fixes #
