### PR TITLE
`solana-validator wait-for-restart-window` command now accepts an optional --identity argument

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -105,6 +105,7 @@ fn monitor_validator(ledger_path: &Path) {
 
 fn wait_for_restart_window(
     ledger_path: &Path,
+    identity: Option<Pubkey>,
     min_idle_time_in_minutes: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sleep_interval = Duration::from_secs(5);
@@ -122,7 +123,9 @@ fn wait_for_restart_window(
         Some(rpc_addr) => RpcClient::new_socket(rpc_addr),
     };
 
-    let identity = rpc_client.get_identity()?;
+    let my_identity = rpc_client.get_identity()?;
+    let identity = identity.unwrap_or(my_identity);
+    let monitoring_another_validator = identity != my_identity;
     println_name_value("Identity:", &identity.to_string());
     println_name_value(
         "Minimum Idle Time:",
@@ -275,7 +278,7 @@ fn wait_for_restart_window(
                             restart_snapshot = snapshot_slot;
                         }
 
-                        if restart_snapshot == snapshot_slot {
+                        if restart_snapshot == snapshot_slot && !monitoring_another_validator {
                             "Waiting for a new snapshot".to_string()
                         } else if delinquent_stake_percentage >= min_delinquency_percentage {
                             style("Delinquency too high").red().to_string()
@@ -289,7 +292,7 @@ fn wait_for_restart_window(
         };
 
         progress_bar.set_message(format!(
-            "{} | Processed Slot: {} | Snapshot Slot: {} | {:.2}% delinquent stake | {}",
+            "{} | Processed Slot: {} {} | {:.2}% delinquent stake | {}",
             {
                 let elapsed =
                     chrono::Duration::from_std(monitor_start_time.elapsed().unwrap()).unwrap();
@@ -302,9 +305,16 @@ fn wait_for_restart_window(
                 )
             },
             epoch_info.absolute_slot,
-            snapshot_slot
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "-".to_string()),
+            if monitoring_another_validator {
+                "".to_string()
+            } else {
+                format!(
+                    "| Snapshot Slot: {}",
+                    snapshot_slot
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                )
+            },
             delinquent_stake_percentage * 100.,
             status
         ));
@@ -1868,8 +1878,8 @@ pub fn main() {
                 Arg::with_name("min_idle_time")
                     .takes_value(true)
                     .long("min-idle-time")
-                    .value_name("MINUTES")
                     .validator(is_parsable::<usize>)
+                    .value_name("MINUTES")
                     .default_value("10")
                     .help("Minimum time that the validator should not be leader before restarting")
             )
@@ -1949,6 +1959,14 @@ pub fn main() {
                     .default_value("10")
                     .help("Minimum time that the validator should not be leader before restarting")
             )
+            .arg(
+                Arg::with_name("identity")
+                    .long("identity")
+                    .value_name("ADDRESS")
+                    .takes_value(true)
+                    .validator(is_pubkey_or_keypair)
+                    .help("Validator identity to monitor [default: your validator]")
+            )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")
         )
@@ -2016,7 +2034,7 @@ pub fn main() {
             let monitor = subcommand_matches.is_present("monitor");
 
             if !force {
-                wait_for_restart_window(&ledger_path, min_idle_time).unwrap_or_else(|err| {
+                wait_for_restart_window(&ledger_path, None, min_idle_time).unwrap_or_else(|err| {
                     println!("{}", err);
                     exit(1);
                 });
@@ -2076,7 +2094,8 @@ pub fn main() {
         }
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
-            wait_for_restart_window(&ledger_path, min_idle_time).unwrap_or_else(|err| {
+            let identity = pubkey_of(subcommand_matches, "identity");
+            wait_for_restart_window(&ledger_path, identity, min_idle_time).unwrap_or_else(|err| {
                 println!("{}", err);
                 exit(1);
             });


### PR DESCRIPTION
This allows one to wait for the restart window of some other validator.