### PR TITLE
Add --acquire-node-instance-then-vote validator flag

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -501,6 +501,7 @@ impl TestValidator {
             rocksdb_compaction_interval: Some(100), // Compact every 100 slots
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
+            acquire_node_instance_then_vote: false,
             ..ValidatorConfig::default()
         };
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -91,7 +91,7 @@ pub struct TvuConfig {
     pub use_index_hash_calculation: bool,
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
-    pub wait_for_vote_to_start_leader: bool,
+    pub initial_replay_stage_state: crate::replay_stage::ReplayStageState,
     pub accounts_shrink_ratio: AccountShrinkThreshold,
 }
 
@@ -272,7 +272,7 @@ impl Tvu {
             rewards_recorder_sender,
             cache_block_meta_sender,
             bank_notification_sender,
-            wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
+            initial_stage_state: tvu_config.initial_replay_stage_state,
         };
 
         let (voting_sender, voting_receiver) = channel();

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -7,7 +7,7 @@ use crate::{
     heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
     latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
     progress_map::{ForkProgress, ProgressMap},
-    replay_stage::{HeaviestForkFailures, ReplayStage},
+    replay_stage::{HeaviestForkFailures, ReplayStage, ReplayStageState},
     unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
 };
 use solana_runtime::{
@@ -200,7 +200,7 @@ impl VoteSimulator {
             &mut DuplicateSlotsTracker::default(),
             &mut GossipDuplicateConfirmedSlots::default(),
             &mut UnfrozenGossipVerifiedVoteHashes::default(),
-            &mut true,
+            &mut ReplayStageState::Normal,
             &mut Vec::new(),
         )
     }

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -7,6 +7,9 @@ use std::{
 };
 
 pub enum VoteOp {
+    AcquireNodeInstance {
+        tx: Transaction,
+    },
     PushVote {
         tx: Transaction,
         tower_slots: Vec<Slot>,
@@ -20,6 +23,7 @@ pub enum VoteOp {
 impl VoteOp {
     fn tx(&self) -> &Transaction {
         match self {
+            VoteOp::AcquireNodeInstance { tx } => tx,
             VoteOp::PushVote { tx, tower_slots: _ } => tx,
             VoteOp::RefreshVote {
                 tx,
@@ -61,6 +65,7 @@ impl VotingService {
         );
 
         match vote_op {
+            VoteOp::AcquireNodeInstance { .. } => {}
             VoteOp::PushVote { tx, tower_slots } => {
                 cluster_info.push_vote(&tower_slots, tx);
             }

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -101,6 +101,7 @@ module.exports = {
       "running-validator/validator-stake",
       "running-validator/validator-monitor",
       "running-validator/validator-info",
+      "running-validator/validator-failover",
       "running-validator/validator-troubleshoot",
     ],
     Clusters: [

--- a/docs/src/running-validator/validator-failover.md
+++ b/docs/src/running-validator/validator-failover.md
@@ -1,0 +1,66 @@
+---
+title: Failover Setup
+---
+
+A simple two machine instance failover method is described here, which allows you to:
+* upgrade your validator software with virtually no down time, and
+* failover to the secondary instance when your monitoring detects a problem with
+  the primary instance
+without any safety issues that would otherwise be associated with running two
+instances of your validator.
+
+In order to begin you will need two machine instances, for your primary and
+secondary validator. It's assumed that both these machine instances are already
+configured and able to run a single validator
+
+## Setup
+
+## Primary Validator
+The only additional `solana-validator` flag required is `--acquire-node-instance-then-vote`.
+
+## Secondary Validator
+Configure the secondary validator like the primary with the exception of the
+following `solana-validator` command-line argument changes:
+* Use a secondary validator identity: `--identity secondary-validator-keypair.json`
+* Add `--no-check-vote-account`
+* Add `--authorized-voter validator-keypair.json` (where
+  `validator-keypair.json` is the identity keypair for your primary validator)
+
+## Triggering a failover manually
+When both validators are running normally and caught up to the cluster, a
+failover from primary to secondary can be triggered by running the following
+command on the secondary validator:
+```bash
+$ solana-validator wait-for-restart-window --identity validator-keypair.json \
+  && solana-validator set-identity validator-keypair.json
+```
+
+The secondary validator will then perform on-chain coordination to ensure voting
+and block production safely switches over from the primary validator.
+
+The primary validator will terminate as soon as it detects the secondary
+validator with its identity.
+
+Note: When the primary validator restarts (which may be immediate if you have
+configured your primary validator to do so) it will reclaim its identity
+from the secondary validator. This will in turn cause the secondary validator to
+exit. However if/when the secondary validator restarts, it will do so using the
+secondary validator identity and thus the restart cycle is broken.
+
+## Triggering a failover via monitoring
+Monitoring of your choosing can invoke the `solana-validator set-identity
+validator-keypair.json` command mentioned in the previous section.
+
+It is not necessary to guarantee the primary validator has halted before failing
+over to the secondary, as the failover process will prevent the primary
+validator from voting and producing blocks even if it is in an unknown state.
+
+## Validator Software Upgrades
+To perform a software upgrade using this failover method:
+1. Install the new software version on your primary validator system but do not
+   restart it yet.
+2. Trigger a manual failover to your secondary validator. This should cause your
+   primary validator to terminate.
+3. When your primary validator restarts it will now be using the new software version.
+4. Once the primary validator catches up upgrade the secondary validator at
+   your convenience.

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -609,6 +609,10 @@ impl ClusterInfo {
         self.keypair.read().unwrap()
     }
 
+    pub fn instance_id(&self) -> u64 {
+        self.instance.read().unwrap().token
+    }
+
     pub fn set_keypair(&self, new_keypair: Arc<Keypair>) {
         let id = new_keypair.pubkey();
         {

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -390,8 +390,8 @@ impl Version {
 pub struct NodeInstance {
     from: Pubkey,
     wallclock: u64,
-    timestamp: u64, // Timestamp when the instance was created.
-    token: u64,     // Randomly generated value at node instantiation.
+    timestamp: u64,        // Timestamp when the instance was created.
+    pub(crate) token: u64, // Randomly generated value at node instantiation.
 }
 
 impl NodeInstance {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -55,6 +55,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         tpu_coalesce_ms: config.tpu_coalesce_ms,
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
+        acquire_node_instance_then_vote: config.acquire_node_instance_then_vote,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
         accounts_shrink_ratio: config.accounts_shrink_ratio,
     }

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::integer_arithmetic)]
 
 pub mod authorized_voters;
+pub mod node_instance;
 pub mod vote_instruction;
 pub mod vote_state;
 pub mod vote_transaction;

--- a/programs/vote/src/node_instance.rs
+++ b/programs/vote/src/node_instance.rs
@@ -1,0 +1,194 @@
+use {
+    bincode::{deserialize, serialize_into, serialized_size},
+    serde_derive::{Deserialize, Serialize},
+    solana_sdk::{
+        account::WritableAccount,
+        account_utils::State,
+        clock::Slot,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        keyed_account::keyed_account_at_index,
+        process_instruction::{get_sysvar, InvokeContext},
+        program_utils::limited_deserialize,
+        pubkey::{self, Pubkey},
+        rent::Rent,
+        system_instruction,
+        sysvar::{self, clock::Clock},
+    },
+};
+
+// NodeInstance program identifier
+solana_sdk::declare_id!("Node1nstance1111111111111111111111111111111");
+
+pub type InstanceId = u64;
+
+#[frozen_abi(digest = "AiiUDTocFRGuH18iv5PNPf2CnkMchpzqQsdAaun2WUW7")]
+#[derive(Serialize, Debug, Deserialize, Default, PartialEq, AbiExample)]
+pub struct NodeInstanceState {
+    pub identity: Pubkey,
+    pub instance_id: InstanceId,
+    pub slot: Slot, // Slot that `instance_id` acquired the lock
+}
+
+impl NodeInstanceState {
+    fn get_rent_exempt_balance(rent: &Rent) -> u64 {
+        rent.minimum_balance(Self::size_of() as usize)
+    }
+
+    pub fn size_of() -> u64 {
+        serialized_size(&Self::default()).unwrap()
+    }
+
+    pub fn deserialize(input: &[u8]) -> Result<Self, InstructionError> {
+        deserialize::<NodeInstanceState>(input).map_err(|_| InstructionError::InvalidAccountData)
+    }
+
+    pub fn serialize(&self, output: &mut [u8]) -> Result<(), InstructionError> {
+        serialize_into(output, self).map_err(|_| InstructionError::GenericError)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum NodeInstanceInstruction {
+    /// Acquire the lock
+    ///
+    /// This instruction will succeed if:
+    /// 1. The NodeInstance account is uninitialized, or
+    /// 2. The NodeInstance account is initialized, and the provided identity matches the account
+    ///    identity, and the provided instance id does not match the instance id currently in the
+    ///    account
+    ///
+    /// On success, the `NodeInstanceState::instance_id` and `NodeInstanceState::slot` account
+    /// fields are updated.
+    ///
+    /// # Account references
+    ///   0. [WRITE] NodeInstance to acquire
+    ///   2. [SIGNER] Identity
+    Acquire(InstanceId),
+
+    /// Deallocate the account and refund the lamports it holds to the identity
+    ///
+    /// # Account references
+    ///   0. [WRITE] NodeInstance to close
+    ///   1. [SIGNER] Identity
+    Close,
+}
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    data: &[u8],
+    invoke_context: &mut dyn InvokeContext,
+) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
+
+    let node_instance_account = keyed_account_at_index(keyed_accounts, 0)?;
+    if node_instance_account.owner()? != id() {
+        return Err(InstructionError::InvalidAccountOwner);
+    }
+
+    // Identity must be a signer
+    let identity_account = keyed_account_at_index(keyed_accounts, 1)?;
+    let identity = *identity_account
+        .signer_key()
+        .ok_or(InstructionError::MissingRequiredSignature)?;
+
+    let node_instance_state = State::<NodeInstanceState>::state(node_instance_account)?;
+    if node_instance_state != NodeInstanceState::default() {
+        // Ensure the provided identity matches if the account is initialized
+        if node_instance_state.identity != identity {
+            return Err(InstructionError::InvalidArgument);
+        }
+    }
+
+    match limited_deserialize(data)? {
+        NodeInstanceInstruction::Acquire(instance_id) => {
+            if instance_id == node_instance_state.instance_id {
+                // Already acquired
+                return Err(InstructionError::Custom(1));
+            }
+            if node_instance_state.slot == Slot::MAX {
+                // Account closed
+                return Err(InstructionError::Custom(2));
+            }
+            node_instance_account.set_state(&NodeInstanceState {
+                identity,
+                instance_id,
+                slot: get_sysvar::<Clock>(invoke_context, &sysvar::clock::id())?.slot,
+            })
+        }
+        NodeInstanceInstruction::Close => {
+            // Return account lamports to the identity
+            identity_account
+                .try_account_ref_mut()?
+                .checked_add_lamports(node_instance_account.lamports()?)?;
+            node_instance_account.try_account_ref_mut()?.set_lamports(0);
+
+            // Mark the account as unusable by all
+            node_instance_account.set_state(&NodeInstanceState {
+                slot: Slot::MAX,
+                ..NodeInstanceState::default()
+            })
+        }
+    }
+}
+
+fn node_instance_address_seed(identity: &Pubkey) -> String {
+    let seed = format!("{:.32}", identity.to_string());
+    assert_eq!(seed.len(), pubkey::MAX_SEED_LEN);
+    seed
+}
+
+/// Client-side convention to derive the NodeInstance address from an identity
+pub fn get_node_instance_address(identity: &Pubkey) -> Pubkey {
+    Pubkey::create_with_seed(identity, &node_instance_address_seed(identity), &id()).unwrap()
+}
+
+pub fn create_and_acquire(
+    identity: &Pubkey,
+    instance_id: InstanceId,
+    rent: &Rent,
+) -> Vec<Instruction> {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+
+    vec![
+        system_instruction::create_account_with_seed(
+            identity,
+            &node_instance,
+            identity,
+            &node_instance_address_seed(identity),
+            NodeInstanceState::get_rent_exempt_balance(rent),
+            NodeInstanceState::size_of(),
+            &id(),
+        ),
+        Instruction::new_with_bincode(
+            id(),
+            &NodeInstanceInstruction::Acquire(instance_id),
+            account_metas,
+        ),
+    ]
+}
+
+pub fn acquire(identity: &Pubkey, instance_id: InstanceId) -> Instruction {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+    Instruction::new_with_bincode(
+        id(),
+        &NodeInstanceInstruction::Acquire(instance_id),
+        account_metas,
+    )
+}
+
+pub fn close(identity: &Pubkey) -> Instruction {
+    let node_instance = get_node_instance_address(identity);
+    let account_metas = vec![
+        AccountMeta::new(node_instance, false),
+        AccountMeta::new_readonly(*identity, true),
+    ];
+    Instruction::new_with_bincode(id(), &NodeInstanceInstruction::Close, account_metas)
+}

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -37,8 +37,12 @@ pub fn parse_vote_transaction(tx: &Transaction) -> Option<(Pubkey, Vote, Option<
                     .and_then(|key| {
                         let vote_instruction = limited_deserialize(&first_instruction.data).ok();
                         vote_instruction.and_then(|vote_instruction| match vote_instruction {
-                            VoteInstruction::Vote(vote) => Some((*key, vote, None)),
-                            VoteInstruction::VoteSwitch(vote, hash) => {
+                            VoteInstruction::Vote(vote)
+                            | VoteInstruction::VoteWithInstance(vote, ..) => {
+                                Some((*key, vote, None))
+                            }
+                            VoteInstruction::VoteSwitch(vote, hash)
+                            | VoteInstruction::VoteSwitchWithInstance(vote, .., hash) => {
                                 Some((*key, vote, Some(hash)))
                             }
                             _ => None,

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -86,7 +86,15 @@ pub enum ActivationType {
 /// normal child Bank creation.
 /// https://github.com/solana-labs/solana/blob/84b139cc94b5be7c9e0c18c2ad91743231b85a0d/runtime/src/bank.rs#L1723
 fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
-    vec![]
+    vec![(
+        Builtin::new(
+            "node_instance_program",
+            solana_vote_program::node_instance::id(),
+            solana_vote_program::node_instance::process_instruction,
+        ),
+        solana_sdk::feature_set::node_instance_program::id(),
+        ActivationType::NewProgram,
+    )]
 }
 
 pub(crate) fn get() -> Builtins {

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -61,6 +61,11 @@ pub mod vote {
         crate::declare_id!("Vote111111111111111111111111111111111111111");
     }
 }
+pub mod node_instance {
+    pub mod program {
+        crate::declare_id!("Node1nstance1111111111111111111111111111111");
+    }
+}
 
 /// Convenience macro to declare a static public key and functions to interact with it
 ///

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -99,6 +99,10 @@ pub mod upgradeable_close_instruction {
     solana_sdk::declare_id!("FsPaByos3gA9bUEhp3EimQpQPCoSvCEigHod496NmABQ");
 }
 
+pub mod node_instance_program {
+    solana_sdk::declare_id!("CMAkEUMRLp8bpvTUzFcZ8sXpEYWxN8twCjbWTsnpkC2j");
+}
+
 pub mod sysvar_via_syscall {
     solana_sdk::declare_id!("7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf");
 }
@@ -196,6 +200,7 @@ lazy_static! {
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
+        (node_instance_program::id(), "node instance program"),
         (sysvar_via_syscall::id(), "provide sysvars via syscalls"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
         (update_data_on_realloc::id(), "Retain updated data values modified after realloc via CPI"),

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -134,6 +134,43 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::VoteWithInstance(vote, instance_id) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            let vote = json!({
+                "slots": vote.slots,
+                "hash": vote.hash.to_string(),
+                "timestamp": vote.timestamp,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "voteWithInstance".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "voteAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "nodeInstance": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "vote": vote,
+                    "instanceId": instance_id,
+                }),
+            })
+        }
+        VoteInstruction::VoteSwitchWithInstance(vote, instance_id, hash) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            let vote = json!({
+                "slots": vote.slots,
+                "hash": vote.hash.to_string(),
+                "timestamp": vote.timestamp,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "voteSwitchWithInstance".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "voteAuthority": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "nodeInstance": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "vote": vote,
+                    "instanceId": instance_id,
+                    "hash": hash.to_string(),
+                }),
+            })
+        }
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1472,12 +1472,18 @@ pub fn main() {
                        supermajority of stake is visible on gossip before starting PoH"),
         )
         .arg(
+            Arg::with_name("acquire_node_instance_then_vote")
+                .long("acquire-node-instance-then-vote")
+                .help("Acquire the node instance lock before starting to vote.
+                      This helps prevents signing votes that could violate lockouts"),
+        )
+        .arg(
             Arg::with_name("no_wait_for_vote_to_start_leader")
                 .hidden(true)
                 .long("no-wait-for-vote-to-start-leader")
                 .help("If the validator starts up with no ledger, it will wait to start block
                       production until it sees a vote land in a rooted slot. This prevents
-                      double signing. Turn off to risk double signing a block."),
+                      double signing. Turn off to risk double signing a block"),
         )
         .arg(
             Arg::with_name("hard_forks")
@@ -2333,6 +2339,7 @@ pub fn main() {
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,
+        acquire_node_instance_then_vote: matches.is_present("acquire_node_instance_then_vote"),
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         accounts_shrink_ratio,
         ..ValidatorConfig::default()


### PR DESCRIPTION
This PR builds on #18445 to add a simple two validator instance failover method that allows for
* upgrades of your validator software with virtually no down time, and
* clean failover to the backup instance when your monitoring detects a problem with the primary instance
without any safety issues that would otherwise be associated with running two instances of your validator.

This coordination is accomplished by integrating knowledge of the `NodeInstance` program into ReplayStage to control when each instance votes and becomes leader.

When the `--acquire-node-instance-then-vote` arg is given the validator always votes with `VoteInstruction::VoteWithInstance`, which allows the vote program itself to reject votes when the validator no longer holds its `NodeInstance` lock.

The hand-off between validator instances is accomplished as follows.  Before starting to vote, the secondary instance:
1. Sends transactions to acquire the `NodeInstance` lock for its identity
2. Monitors until it sees a finalized block with its `NodeInstance` lock
3. Reads its vote account off-chain, and waits until all vote lockouts expire. This means it does not require the tower .bin file from the primary instance, as at this point any inflight votes from the primary instance cannot land. 
4. Once on-chain lockouts expire, resume the existing startup sequence of trying to root a vote before becoming leader.

Somewhere between 1 and 4, it's likely but not guaranteed that the primary instance will detect the secondary instance in gossip and self-terminate. However this is not required and even if the primary never exits then the secondary will still succeed in taking over voting and block production safely.

TODO:
* [ ] First pass design/concept review of this PR
* [ ] Remove #18445 from this PR, add tests and land it first
* [ ] Tests for this PR once the above two items are addressed