### PR TITLE
Accumulate consumed units

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -218,6 +218,7 @@ mod tests {
         // add new program
         {
             let accumulated_us: u64 = 1000;
+            let accumulated_units: u64 = 100;
             let count: u32 = 10;
             expected_cost = accumulated_us / count as u64;
 
@@ -225,6 +226,7 @@ mod tests {
                 program_key_1,
                 ProgramTiming {
                     accumulated_us,
+                    accumulated_units,
                     count,
                 },
             );
@@ -250,6 +252,7 @@ mod tests {
         // update program
         {
             let accumulated_us: u64 = 2000;
+            let accumulated_units: u64 = 200;
             let count: u32 = 10;
             // to expect new cost is Average(new_value, existing_value)
             expected_cost = ((accumulated_us / count as u64) + expected_cost) / 2;
@@ -258,6 +261,7 @@ mod tests {
                 program_key_1,
                 ProgramTiming {
                     accumulated_us,
+                    accumulated_units,
                     count,
                 },
             );


### PR DESCRIPTION
#### Problem


#### Summary of Changes

Record compute units consumed in the timing metrics so that the information is available to transaction simulation and cost model

Fixes #
