### PR TITLE
Transaction simulation includes cost

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -328,6 +328,7 @@ pub struct RpcSimulateTransactionResult {
     pub err: Option<TransactionError>,
     pub logs: Option<Vec<String>>,
     pub accounts: Option<Vec<Option<UiAccount>>>,
+    pub units_consumed: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -328,7 +328,7 @@ pub struct RpcSimulateTransactionResult {
     pub err: Option<TransactionError>,
     pub logs: Option<Vec<String>>,
     pub accounts: Option<Vec<Option<UiAccount>>>,
-    pub units_consumed: u64,
+    pub units_consumed: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3029,7 +3029,9 @@ pub mod rpc_full {
                     }
                 }
 
-                if let (Err(err), logs, _) = preflight_bank.simulate_transaction(&transaction) {
+                if let (Err(err), logs, _, units_consumed) =
+                    preflight_bank.simulate_transaction(&transaction)
+                {
                     match err {
                         TransactionError::BlockhashNotFound => {
                             inc_new_counter_info!("rpc-send-tx_err-blockhash-not-found", 1);
@@ -3044,6 +3046,7 @@ pub mod rpc_full {
                             err: Some(err),
                             logs: Some(logs),
                             accounts: None,
+                            units_consumed,
                         },
                     }
                     .into());
@@ -3087,7 +3090,8 @@ pub mod rpc_full {
             if config.replace_recent_blockhash {
                 transaction.message.recent_blockhash = bank.last_blockhash();
             }
-            let (result, logs, post_simulation_accounts) = bank.simulate_transaction(&transaction);
+            let (result, logs, post_simulation_accounts, units_consumed) =
+                bank.simulate_transaction(&transaction);
 
             let accounts = if let Some(config_accounts) = config.accounts {
                 let accounts_encoding = config_accounts
@@ -3142,6 +3146,7 @@ pub mod rpc_full {
                     err: result.err(),
                     logs: Some(logs),
                     accounts,
+                    units_consumed,
                 },
             ))
         }
@@ -5183,7 +5188,8 @@ pub mod tests {
                     "logs":[
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
-                    ]
+                    ],
+                    "unitsConsumed":0
                 }
             },
             "id": 1,
@@ -5262,10 +5268,15 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"accounts": null, "err":null, "logs":[
-                    "Program 11111111111111111111111111111111 invoke [1]",
-                    "Program 11111111111111111111111111111111 success"
-                ]}
+                "value":{
+                    "accounts":null,
+                    "err":null,
+                    "logs":[
+                        "Program 11111111111111111111111111111111 invoke [1]",
+                        "Program 11111111111111111111111111111111 success"
+                    ],
+                    "unitsConsumed":0
+                }
             },
             "id": 1,
         });
@@ -5285,10 +5296,15 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"accounts": null, "err":null, "logs":[
-                    "Program 11111111111111111111111111111111 invoke [1]",
-                    "Program 11111111111111111111111111111111 success"
-                ]}
+                "value":{
+                    "accounts":null,
+                    "err":null,
+                    "logs":[
+                        "Program 11111111111111111111111111111111 invoke [1]",
+                        "Program 11111111111111111111111111111111 success"
+                    ],
+                    "unitsConsumed":0
+                }
             },
             "id": 1,
         });
@@ -5333,7 +5349,12 @@ pub mod tests {
             "jsonrpc":"2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"err": "BlockhashNotFound", "accounts": null, "logs":[]}
+                "value":{
+                    "err":"BlockhashNotFound",
+                    "accounts":null,
+                    "logs":[],
+                    "unitsConsumed":0
+                }
             },
             "id":1
         });
@@ -5354,10 +5375,15 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"accounts": null, "err":null, "logs":[
-                    "Program 11111111111111111111111111111111 invoke [1]",
-                    "Program 11111111111111111111111111111111 success"
-                ]}
+                "value":{
+                    "accounts":null,
+                    "err":null,
+                    "logs":[
+                        "Program 11111111111111111111111111111111 invoke [1]",
+                        "Program 11111111111111111111111111111111 success"
+                    ],
+                    "unitsConsumed":0
+                }
             },
             "id": 1,
         });
@@ -5698,7 +5724,7 @@ pub mod tests {
         assert_eq!(
             res,
             Some(
-                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","logs":[]}},"id":1}"#.to_string(),
+                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","logs":[],"unitsConsumed":0}},"id":1}"#.to_string(),
             )
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -138,7 +138,6 @@ pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct RentDebits(pub Vec<(Pubkey, RewardInfo)>);
-
 impl RentDebits {
     pub fn push(&mut self, account: &Pubkey, rent: u64, post_balance: u64) {
         if rent != 0 {
@@ -168,7 +167,6 @@ pub struct ExecuteTimings {
     pub num_execute_batches: u64,
     pub details: ExecuteDetailsTimings,
 }
-
 impl ExecuteTimings {
     pub fn accumulate(&mut self, other: &ExecuteTimings) {
         self.check_us += other.check_us;
@@ -415,15 +413,15 @@ impl CachedExecutors {
     }
 }
 
-pub struct TxComputeMeter {
+pub struct TransactionComputeMeter {
     remaining: u64,
 }
-impl TxComputeMeter {
+impl TransactionComputeMeter {
     pub fn new(cap: u64) -> Self {
         Self { remaining: cap }
     }
 }
-impl ComputeMeter for TxComputeMeter {
+impl ComputeMeter for TransactionComputeMeter {
     fn consume(&mut self, amount: u64) -> std::result::Result<(), InstructionError> {
         let exceeded = self.remaining < amount;
         self.remaining = self.remaining.saturating_sub(amount);
@@ -523,6 +521,12 @@ pub struct TransactionResults {
     pub execution_results: Vec<TransactionExecutionResult>,
     pub overwritten_vote_accounts: Vec<OverwrittenVoteAccount>,
     pub rent_debits: Vec<RentDebits>,
+}
+pub struct TransactionSimulationResult {
+    pub result: Result<()>,
+    pub logs: TransactionLogMessages,
+    pub post_simulation_accounts: Vec<(Pubkey, AccountSharedData)>,
+    pub units_consumed: u64,
 }
 pub struct TransactionBalancesSet {
     pub pre_balances: TransactionBalances,
@@ -2705,37 +2709,36 @@ impl Bank {
 
     pub(crate) fn prepare_simulation_batch<'a, 'b>(
         &'a self,
-        tx: SanitizedTransaction<'b>,
+        transaction: SanitizedTransaction<'b>,
     ) -> TransactionBatch<'a, 'b> {
-        let mut batch = TransactionBatch::new(vec![Ok(())], self, Cow::Owned(vec![tx]));
+        let mut batch = TransactionBatch::new(vec![Ok(())], self, Cow::Owned(vec![transaction]));
         batch.needs_unlock = false;
         batch
     }
 
     /// Run transactions against a frozen bank without committing the results
-    pub fn simulate_transaction(
-        &self,
-        transaction: &Transaction,
-    ) -> (
-        Result<()>,
-        TransactionLogMessages,
-        Vec<(Pubkey, AccountSharedData)>,
-        u64,
-    ) {
+    pub fn simulate_transaction(&self, transaction: &Transaction) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
 
         let batch = match SanitizedTransaction::try_from(transaction) {
             Ok(sanitized_tx) => self.prepare_simulation_batch(sanitized_tx),
-            Err(err) => return (Err(err), vec![], vec![], 0),
+            Err(err) => {
+                return TransactionSimulationResult {
+                    result: Err(err),
+                    logs: vec![],
+                    post_simulation_accounts: vec![],
+                    units_consumed: 0,
+                }
+            }
         };
 
         let mut timings = ExecuteTimings::default();
 
         let (
-            loaded_txs,
+            loaded_transactions,
             executed,
             _inner_instructions,
-            log_messages,
+            logs,
             _retryable_transactions,
             _transaction_count,
             _signature_count,
@@ -2750,9 +2753,9 @@ impl Bank {
             &mut timings,
         );
 
-        let transaction_result = executed[0].0.clone().map(|_| ());
-        let log_messages = log_messages.get(0).cloned().flatten().unwrap_or_default();
-        let post_transaction_accounts = loaded_txs
+        let result = executed[0].0.clone().map(|_| ());
+        let logs = logs.get(0).cloned().flatten().unwrap_or_default();
+        let post_simulation_accounts = loaded_transactions
             .into_iter()
             .next()
             .unwrap()
@@ -2761,9 +2764,7 @@ impl Bank {
             .map(|loaded_transaction| loaded_transaction.accounts.into_iter().collect::<Vec<_>>())
             .unwrap_or_default();
 
-        debug!("simulate_transaction: {:?}", timings);
-
-        let transaction_cost = timings
+        let units_consumed = timings
             .details
             .per_program_timings
             .iter()
@@ -2771,12 +2772,14 @@ impl Bank {
                 acc + program_timing.accumulated_units
             });
 
-        (
-            transaction_result,
-            log_messages,
-            post_transaction_accounts,
-            transaction_cost,
-        )
+        debug!("simulate_transaction: {:?}", timings);
+
+        TransactionSimulationResult {
+            result,
+            logs,
+            post_simulation_accounts,
+            units_consumed,
+        }
     }
 
     pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {
@@ -3259,7 +3262,7 @@ impl Bank {
                             None
                         };
 
-                        let compute_meter = Rc::new(RefCell::new(TxComputeMeter::new(
+                        let compute_meter = Rc::new(RefCell::new(TransactionComputeMeter::new(
                             bpf_compute_budget.max_units,
                         )));
 


### PR DESCRIPTION
#### Problem

Transaction simulation does not return any information about how much the transaction will cost in terms of compute units.  Developes will want to know this information in order to request the appropriate transaction-wide compute budget.

#### Summary of Changes

Return the calculated cost of the transaction in compute units

Fixes #
