### PR TITLE
Use rustup default profile in travis ci mac image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ jobs:
         - readlink -f .
       script:
         - source ci/env.sh
+        - rustup set profile default
         - ci/publish-tarball.sh
       deploy:
         - provider: s3


### PR DESCRIPTION
#### Problem
Mac release artifacts are failing to build, due to rustfmt requirement in `solana-storage-proto`. The Travis CI rust image uses the minimal `rustup` profile, which doesn't include rustfmt.

#### Summary of Changes
Switch to default `rustup` profile
