### PR TITLE
skips bad addresses before sending packets

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -64,6 +64,7 @@ use {
     solana_streamer::{
         packet,
         sendmmsg::{multi_target_send, SendPktsError},
+        socket::is_global,
         streamer::{PacketReceiver, PacketSender},
     },
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
@@ -1178,7 +1179,7 @@ impl ClusterInfo {
             .filter(|node| {
                 node.id != self_pubkey
                     && node.shred_version == self_shred_version
-                    && ContactInfo::is_valid_address(&node.tvu)
+                    && ContactInfo::is_valid_tvu_address(&node.tvu)
             })
             .cloned()
             .collect()
@@ -1235,9 +1236,14 @@ impl ClusterInfo {
                 .iter()
                 .map(|peer| &peer.tvu_forwards)
                 .filter(|addr| ContactInfo::is_valid_address(addr))
+                .filter(|addr| is_global(addr))
                 .collect()
         } else {
-            peers.iter().map(|peer| &peer.tvu).collect()
+            peers
+                .iter()
+                .map(|peer| &peer.tvu)
+                .filter(|addr| is_global(addr))
+                .collect()
         };
         let data = &packet.data[..packet.meta.size];
 

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -193,8 +193,15 @@ impl ContactInfo {
     /// port must not be 0
     /// ip must be specified and not multicast
     /// loopback ip is only allowed in tests
-    pub fn is_valid_address(addr: &SocketAddr) -> bool {
+    // Keeping this for now not to break tvu-peers and turbine shuffle order of
+    // nodes when arranging nodes on retransmit tree. Private IP addresses in
+    // turbine are filtered out just before sending packets.
+    pub(crate) fn is_valid_tvu_address(addr: &SocketAddr) -> bool {
         (addr.port() != 0) && Self::is_valid_ip(addr.ip())
+    }
+
+    pub fn is_valid_address(addr: &SocketAddr) -> bool {
+        Self::is_valid_tvu_address(addr) && solana_streamer::socket::is_global(addr)
     }
 
     pub fn client_facing_addr(&self) -> (SocketAddr, SocketAddr) {

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod packet;
 pub mod recvmmsg;
 pub mod sendmmsg;
+pub mod socket;
 pub mod streamer;
 
 #[macro_use]

--- a/streamer/src/socket.rs
+++ b/streamer/src/socket.rs
@@ -1,0 +1,28 @@
+use std::net::SocketAddr;
+
+// TODO: remove these once IpAddr::is_global is stable.
+
+#[cfg(test)]
+pub fn is_global(_: &SocketAddr) -> bool {
+    true
+}
+
+#[cfg(not(test))]
+pub fn is_global(addr: &SocketAddr) -> bool {
+    use std::net::IpAddr;
+
+    match addr.ip() {
+        IpAddr::V4(addr) => {
+            // TODO: Consider excluding:
+            //    addr.is_loopback() || addr.is_link_local()
+            // || addr.is_broadcast() || addr.is_documentation()
+            // || addr.is_unspecified()
+            !addr.is_private()
+        }
+        IpAddr::V6(_) => {
+            // TODO: Consider excluding:
+            // addr.is_loopback() || addr.is_unspecified(),
+            true
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
bad ip addresses in nodes contact-info.

#### Summary of Changes
* partially emulating current nightly `std::net::IpAddr::is_global` to filter addresses before sending packets.
https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.is_global