### PR TITLE
Shorten long SerializeWith type paths in abi digest

### DIFF
--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -49,6 +49,17 @@ impl DigestError {
 
 const INDENT_WIDTH: usize = 4;
 
+pub(crate) fn shorten_serialize_with(type_name: &str) -> &str {
+    // Fully qualified type names for the generated `__SerializeWith` types are very
+    // long and do not add extra value to the digest. They also cause the digest
+    // to change when a struct is moved to an inner module.
+    if type_name.ends_with("__SerializeWith") {
+        "__SerializeWith"
+    } else {
+        type_name
+    }
+}
+
 impl AbiDigester {
     pub fn create() -> Self {
         AbiDigester {
@@ -164,7 +175,8 @@ impl AbiDigester {
         key: Sstr,
         v: &T,
     ) -> Result<(), DigestError> {
-        self.update_with_string(format!("field {}: {}", key, type_name::<T>()));
+        let field_type_name = shorten_serialize_with(type_name::<T>());
+        self.update_with_string(format!("field {}: {}", key, field_type_name));
         self.create_child()?
             .digest_data(v)
             .map(|_| ())

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -256,7 +256,7 @@ pub fn make_accounts_hashes_message(
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[frozen_abi(digest = "GANv3KVkTYF84kmg1bAuWEZd9MaiYzPquuu13hup3379")]
+#[frozen_abi(digest = "4khbdefBamDC8XpdahkW4bzkGX6N5c8PcHp3kBXJGg46")]
 #[derive(Serialize, Deserialize, Debug, AbiEnumVisitor, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -295,7 +295,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "6msodEzE7YzFtorBhiP6ax4PKBaPZTkmYdGAdpoxLCvV")]
+    #[frozen_abi(digest = "9i743Qsin8qndpSGqXM3ATkX6fL8dDKtqUwJ8DPjuRam")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -184,7 +184,7 @@ pub struct MessageHeader {
     pub num_readonly_unsigned_accounts: u8,
 }
 
-#[frozen_abi(digest = "BPBJZxpRQ4JS7LGJtsgoyctg4BXyBbbY4uc7FjowtxLV")]
+#[frozen_abi(digest = "2KnLEqfLcTBQqitE22Pp8JYkaqVVbAkGbCfdeHoyxcAU")]
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone, AbiExample)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -8,7 +8,7 @@ use std::{cell::Ref, cell::RefCell, cmp, fmt, rc::Rc, sync::Arc};
 
 /// An Account with data that is stored on chain
 #[repr(C)]
-#[frozen_abi(digest = "AXJTWWXfp49rHb34ayFzFLSEuaRbMUsVPNzBDyP3UPjc")]
+#[frozen_abi(digest = "HawRVHh7t4d3H3bitWHFt25WhhoDmbJMCfWdESQQoYEy")]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Default, AbiExample)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -66,7 +66,7 @@ impl FromStr for ClusterType {
     }
 }
 
-#[frozen_abi(digest = "FX48h9vjJZPvka4J9UvcPQkVcMdYLQujhbvUmVFq6qLx")]
+#[frozen_abi(digest = "3V3ZVRyzNhRfe8RJwDeGpeTP8xBWGGFBEbwTkvKKVjEa")]
 #[derive(Serialize, Deserialize, Debug, Clone, AbiExample)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -109,7 +109,7 @@ impl From<SanitizeError> for TransactionError {
 }
 
 /// An atomic transaction
-#[frozen_abi(digest = "2Kr1C1pRytLsmUbg8p2nLoZyrjrEQCriAYLTCYvwj1Fo")]
+#[frozen_abi(digest = "AAeVxvWiiotwxDLxKLxsfgkA6ndW74nVbaAEb6cwJYqR")]
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, AbiExample)]
 pub struct Transaction {
     /// A set of digital signatures of `account_keys`, `program_ids`, `recent_blockhash`, and `instructions`, signed by the first


### PR DESCRIPTION
#### Problem
Struct fields annotated with custom serialization (ie short_vec) are wrapped in a super long module-specific type called `__SerializeWith` and that long type path is added to the ABI digest macro. The extra long type path doesn't add any value and it prevents moving a struct into an inner module without breaking the abi digest.

#### Summary of Changes
- Shorten type paths to `__SerializeWith` and update all the modified digest hashes

Before:
```
    field accountKeys: solana_program::message::_::<impl serde::ser::Serialize for solana_program::message::Message>::serialize::__SerializeWith
```

After:

```
    field accountKeys: __SerializeWith
```

Fixes #
