### PR TITLE
Automatically request review for community PR's

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,9 @@ pull_request_rules:
       label:
         add:
           - community
+      request_reviews:
+        teams:
+          - "@solana-labs/community-pr-subscribers"
   - name: automatic merge (squash) on CI success
     conditions:
       - status-success=buildkite/solana


### PR DESCRIPTION
#### Problem
Community members need to notify devs in chat about new PR's because there's no designated reviewer/triager for community PR's

#### Summary of Changes

Fixes #
