### PR TITLE
backport new column families from master to 1.6

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -125,6 +125,7 @@ pub struct BlockstoreSignals {
 //
 // NOTE: allowing dead_code only because stubbing bank_hash_cf and program_cost_cf
 // to 1.6 for rocksdb backward compatibility
+#[allow(dead_code)]
 pub struct Blockstore {
     ledger_path: PathBuf,
     db: Arc<Database>,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -122,6 +122,9 @@ pub struct BlockstoreSignals {
 }
 
 // ledger window
+//
+// NOTE: allowing dead_code only because stubbing bank_hash_cf and program_cost_cf
+// to 1.6 for rocksdb backward compatibility
 pub struct Blockstore {
     ledger_path: PathBuf,
     db: Arc<Database>,
@@ -141,6 +144,8 @@ pub struct Blockstore {
     blocktime_cf: LedgerColumn<cf::Blocktime>,
     perf_samples_cf: LedgerColumn<cf::PerfSamples>,
     block_height_cf: LedgerColumn<cf::BlockHeight>,
+    program_costs_cf: LedgerColumn<cf::ProgramCosts>,
+    bank_hash_cf: LedgerColumn<cf::BankHash>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
@@ -312,6 +317,8 @@ impl Blockstore {
         let blocktime_cf = db.column();
         let perf_samples_cf = db.column();
         let block_height_cf = db.column();
+        let program_costs_cf = db.column();
+        let bank_hash_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -360,6 +367,8 @@ impl Blockstore {
             blocktime_cf,
             perf_samples_cf,
             block_height_cf,
+            program_costs_cf,
+            bank_hash_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
             insert_shreds_lock: Arc::new(Mutex::new(())),

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -137,6 +137,10 @@ impl Blockstore {
             .is_ok()
             & self
                 .db
+                .delete_range_cf::<cf::BankHash>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
                 .delete_range_cf::<cf::Root>(&mut write_batch, from_slot, to_slot)
                 .is_ok()
             & self
@@ -262,6 +266,10 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .orphans_cf
+                .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
+                .bank_hash_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false)
             && self

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,6 +1,6 @@
 use crate::erasure::ErasureConfig;
 use serde::{Deserialize, Serialize};
-use solana_sdk::clock::Slot;
+use solana_sdk::{clock::Slot, hash::Hash};
 use std::{collections::BTreeSet, ops::RangeBounds};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
@@ -73,6 +73,33 @@ pub enum ErasureMetaStatus {
     CanRecover,
     DataFull,
     StillNeed(usize),
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub enum FrozenHashVersioned {
+    Current(FrozenHashStatus),
+}
+
+impl FrozenHashVersioned {
+    pub fn frozen_hash(&self) -> Hash {
+        match self {
+            FrozenHashVersioned::Current(frozen_hash_status) => frozen_hash_status.frozen_hash,
+        }
+    }
+
+    pub fn is_duplicate_confirmed(&self) -> bool {
+        match self {
+            FrozenHashVersioned::Current(frozen_hash_status) => {
+                frozen_hash_status.is_duplicate_confirmed
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+pub struct FrozenHashStatus {
+    pub frozen_hash: Hash,
+    pub is_duplicate_confirmed: bool,
 }
 
 impl Index {
@@ -247,6 +274,11 @@ pub struct PerfSample {
     pub num_transactions: u64,
     pub num_slots: u64,
     pub sample_period_secs: u16,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct ProgramCost {
+    pub cost: u64,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
New columns added to master creates ledgers that are incompatible with v1.6, as described in issue #18729.

#### Summary of Changes
backporting bank_hash and program_costs column families from master to 1.6 for backward compatibility

Fixes #18729 (for v1.6 only, same fix for v1.7 is in PR #18724)
