### PR TITLE
Explorer: only bind cluster stats on working connections

### DIFF
--- a/explorer/src/providers/stats/solanaClusterStats.tsx
+++ b/explorer/src/providers/stats/solanaClusterStats.tsx
@@ -74,6 +74,13 @@ const PerformanceContext = React.createContext<PerformanceState | undefined>(
 );
 
 type Props = { children: React.ReactNode };
+
+function getConnection(url: string): Connection | undefined {
+  try {
+    return new Connection(url);
+  } catch (error) {}
+}
+
 export function SolanaClusterStatsProvider({ children }: Props) {
   const { cluster, url } = useCluster();
   const [active, setActive] = React.useState(false);
@@ -89,7 +96,10 @@ export function SolanaClusterStatsProvider({ children }: Props) {
   React.useEffect(() => {
     if (!active || !url) return;
 
-    const connection = new Connection(url);
+    const connection = getConnection(url);
+
+    if (!connection) return;
+
     let lastSlot: number | null = null;
 
     const getPerformanceSamples = async () => {


### PR DESCRIPTION
#### Problem
Entering a URL into the Choose a Cluster panel causes Explorer to crash on the cluster stats page.

#### Summary of Changes
Wrap connection creation in a try block and only bind timeouts if connection is valid.
