### PR TITLE
remove par iter for 32k wide code path

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5021,7 +5021,7 @@ impl AccountsDb {
         let time = AtomicU64::new(0);
         (
             accum
-                .into_par_iter()
+                .into_iter()
                 .map(|mut items| {
                     let mut sort_time = Measure::start("sort");
                     {


### PR DESCRIPTION
#### Problem
Number of bins could easily be 32k or more in implementations that are coming. That would cause this code to perform poorly. The code calling this is already running in parallel.
#### Summary of Changes
Get rid of parallel iterator.
Fixes #
