### PR TITLE
implements generic lookups into gossip crds table

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -179,7 +179,7 @@ impl ClusterSlotsService {
 mod test {
     use {
         super::*,
-        solana_gossip::{cluster_info::Node, crds_value::CrdsValueLabel},
+        solana_gossip::{cluster_info::Node, crds_value::LowestSlot},
         solana_sdk::pubkey::Pubkey,
     };
 
@@ -191,10 +191,8 @@ mod test {
         ClusterSlotsService::update_lowest_slot(5, &cluster_info);
         cluster_info.flush_push_queue();
         let lowest = {
-            let label = CrdsValueLabel::LowestSlot(pubkey);
             let gossip_crds = cluster_info.gossip.crds.read().unwrap();
-            let entry = gossip_crds.get(&label).unwrap();
-            entry.value.lowest_slot().unwrap().clone()
+            gossip_crds.get::<&LowestSlot>(pubkey).unwrap().clone()
         };
         assert_eq!(lowest.lowest, 5);
     }

--- a/gossip/benches/crds_shards.rs
+++ b/gossip/benches/crds_shards.rs
@@ -21,7 +21,7 @@ fn new_test_crds_value<R: Rng>(rng: &mut R) -> VersionedCrdsValue {
     let label = value.label();
     let mut crds = Crds::default();
     crds.insert(value, timestamp()).unwrap();
-    crds.get(&label).cloned().unwrap()
+    crds.get::<&VersionedCrdsValue>(&label).cloned().unwrap()
 }
 
 fn bench_crds_shards_find(bencher: &mut Bencher, num_values: usize, mask_bits: u32) {

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -27,8 +27,9 @@
 use {
     crate::{
         contact_info::ContactInfo,
+        crds_entry::CrdsEntry,
         crds_shards::CrdsShards,
-        crds_value::{CrdsData, CrdsValue, CrdsValueLabel, LowestSlot},
+        crds_value::{CrdsData, CrdsValue, CrdsValueLabel},
     },
     bincode::serialize,
     indexmap::{
@@ -241,31 +242,24 @@ impl Crds {
         }
     }
 
-    pub fn get(&self, label: &CrdsValueLabel) -> Option<&VersionedCrdsValue> {
-        self.table.get(label)
-    }
-
-    pub fn get_contact_info(&self, pubkey: Pubkey) -> Option<&ContactInfo> {
-        let label = CrdsValueLabel::ContactInfo(pubkey);
-        self.table.get(&label)?.value.contact_info()
+    pub fn get<'a, 'b, V>(&'a self, key: V::Key) -> Option<V>
+    where
+        V: CrdsEntry<'a, 'b>,
+    {
+        V::get_entry(&self.table, key)
     }
 
     pub(crate) fn get_shred_version(&self, pubkey: &Pubkey) -> Option<u16> {
         self.shred_versions.get(pubkey).copied()
     }
 
-    pub fn get_lowest_slot(&self, pubkey: Pubkey) -> Option<&LowestSlot> {
-        let lable = CrdsValueLabel::LowestSlot(pubkey);
-        self.table.get(&lable)?.value.lowest_slot()
-    }
-
     /// Returns all entries which are ContactInfo.
-    pub fn get_nodes(&self) -> impl Iterator<Item = &VersionedCrdsValue> {
+    pub(crate) fn get_nodes(&self) -> impl Iterator<Item = &VersionedCrdsValue> {
         self.nodes.iter().map(move |i| self.table.index(*i))
     }
 
     /// Returns ContactInfo of all known nodes.
-    pub fn get_nodes_contact_info(&self) -> impl Iterator<Item = &ContactInfo> {
+    pub(crate) fn get_nodes_contact_info(&self) -> impl Iterator<Item = &ContactInfo> {
         self.get_nodes().map(|v| match &v.value.data {
             CrdsData::ContactInfo(info) => info,
             _ => panic!("this should not happen!"),
@@ -337,7 +331,7 @@ impl Crds {
         self.table.values()
     }
 
-    pub fn par_values(&self) -> ParValues<'_, CrdsValueLabel, VersionedCrdsValue> {
+    pub(crate) fn par_values(&self) -> ParValues<'_, CrdsValueLabel, VersionedCrdsValue> {
         self.table.par_values()
     }
 
@@ -361,7 +355,7 @@ impl Crds {
 
     /// Returns all crds values which the first 'mask_bits'
     /// of their hash value is equal to 'mask'.
-    pub fn filter_bitmask(
+    pub(crate) fn filter_bitmask(
         &self,
         mask: u64,
         mask_bits: u32,
@@ -372,7 +366,7 @@ impl Crds {
     }
 
     /// Update the timestamp's of all the labels that are associated with Pubkey
-    pub fn update_record_timestamp(&mut self, pubkey: &Pubkey, now: u64) {
+    pub(crate) fn update_record_timestamp(&mut self, pubkey: &Pubkey, now: u64) {
         // It suffices to only overwrite the origin's timestamp since that is
         // used when purging old values. If the origin does not exist in the
         // table, fallback to exhaustive update on all associated records.
@@ -1075,7 +1069,7 @@ mod tests {
         // Remove contact-info. Shred version should stay there since there
         // are still values associated with the pubkey.
         crds.remove(&CrdsValueLabel::ContactInfo(pubkey), timestamp());
-        assert_eq!(crds.get_contact_info(pubkey), None);
+        assert_eq!(crds.get::<&ContactInfo>(pubkey), None);
         assert_eq!(crds.get_shred_version(&pubkey), Some(8));
         // Remove the remaining entry with the same pubkey.
         crds.remove(&CrdsValueLabel::SnapshotHashes(pubkey), timestamp());

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -1,0 +1,121 @@
+use {
+    crate::{
+        contact_info::ContactInfo,
+        crds::VersionedCrdsValue,
+        crds_value::{
+            CrdsData, CrdsValue, CrdsValueLabel, LegacyVersion, LowestSlot, SnapshotHash, Version,
+        },
+    },
+    indexmap::IndexMap,
+    solana_sdk::pubkey::Pubkey,
+};
+
+type CrdsTable = IndexMap<CrdsValueLabel, VersionedCrdsValue>;
+
+/// Represents types which can be looked up from crds table given a key. e.g.
+///   CrdsValueLabel -> VersionedCrdsValue, CrdsValue, CrdsData
+///   Pubkey -> ContactInfo, LowestSlot, SnapshotHash, ...
+pub trait CrdsEntry<'a, 'b>: Sized {
+    type Key; // Lookup key.
+    fn get_entry(table: &'a CrdsTable, key: Self::Key) -> Option<Self>;
+}
+
+macro_rules! impl_crds_entry (
+    // Lookup by CrdsValueLabel.
+    ($name:ident, |$entry:ident| $body:expr) => (
+        impl<'a, 'b> CrdsEntry<'a, 'b> for &'a $name {
+            type Key = &'b CrdsValueLabel;
+            fn get_entry(table:&'a CrdsTable, key: Self::Key) -> Option<Self> {
+                let $entry = table.get(key);
+                $body
+            }
+        }
+    );
+    // Lookup by Pubkey.
+    ($name:ident, $pat:pat, $expr:expr) => (
+        impl<'a, 'b> CrdsEntry<'a, 'b> for &'a $name {
+            type Key = Pubkey;
+            fn get_entry(table:&'a CrdsTable, key: Self::Key) -> Option<Self> {
+                let key = CrdsValueLabel::$name(key);
+                match &table.get(&key)?.value.data {
+                    $pat => Some($expr),
+                    _ => None,
+                }
+            }
+        }
+    );
+);
+
+// Lookup by CrdsValueLabel.
+impl_crds_entry!(CrdsData, |entry| Some(&entry?.value.data));
+impl_crds_entry!(CrdsValue, |entry| Some(&entry?.value));
+impl_crds_entry!(VersionedCrdsValue, |entry| entry);
+
+// Lookup by Pubkey.
+impl_crds_entry!(ContactInfo, CrdsData::ContactInfo(node), node);
+impl_crds_entry!(LegacyVersion, CrdsData::LegacyVersion(version), version);
+impl_crds_entry!(LowestSlot, CrdsData::LowestSlot(_, slot), slot);
+impl_crds_entry!(Version, CrdsData::Version(version), version);
+
+impl<'a, 'b> CrdsEntry<'a, 'b> for &'a SnapshotHash {
+    type Key = Pubkey;
+    fn get_entry(table: &'a CrdsTable, key: Self::Key) -> Option<Self> {
+        let key = CrdsValueLabel::SnapshotHashes(key);
+        match &table.get(&key)?.value.data {
+            CrdsData::SnapshotHashes(snapshot_hash) => Some(snapshot_hash),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{crds::Crds, crds_value::new_rand_timestamp},
+        rand::seq::SliceRandom,
+        solana_sdk::signature::Keypair,
+        std::collections::HashMap,
+    };
+
+    #[test]
+    fn test_get_crds_entry() {
+        let mut rng = rand::thread_rng();
+        let mut crds = Crds::default();
+        let keypairs: Vec<_> = std::iter::repeat_with(Keypair::new).take(32).collect();
+        let mut entries = HashMap::new();
+        for _ in 0..256 {
+            let keypair = keypairs.choose(&mut rng).unwrap();
+            let value = CrdsValue::new_rand(&mut rng, Some(keypair));
+            let key = value.label();
+            if let Ok(()) = crds.insert(value.clone(), new_rand_timestamp(&mut rng)) {
+                entries.insert(key, value);
+            }
+        }
+        assert!(crds.len() > 64);
+        assert_eq!(crds.len(), entries.len());
+        for entry in entries.values() {
+            let key = entry.label();
+            assert_eq!(crds.get::<&CrdsValue>(&key), Some(entry));
+            assert_eq!(crds.get::<&CrdsData>(&key), Some(&entry.data));
+            assert_eq!(crds.get::<&VersionedCrdsValue>(&key).unwrap().value, *entry);
+            let key = entry.pubkey();
+            match &entry.data {
+                CrdsData::ContactInfo(node) => {
+                    assert_eq!(crds.get::<&ContactInfo>(key), Some(node))
+                }
+                CrdsData::LowestSlot(_, slot) => {
+                    assert_eq!(crds.get::<&LowestSlot>(key), Some(slot))
+                }
+                CrdsData::Version(version) => assert_eq!(crds.get::<&Version>(key), Some(version)),
+                CrdsData::LegacyVersion(version) => {
+                    assert_eq!(crds.get::<&LegacyVersion>(key), Some(version))
+                }
+                CrdsData::SnapshotHashes(hash) => {
+                    assert_eq!(crds.get::<&SnapshotHash>(key), Some(hash))
+                }
+                _ => (),
+            }
+        }
+    }
+}

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -561,7 +561,7 @@ mod test {
             push.process_push_message(&crds, &Pubkey::default(), vec![value.clone()], 0),
             [Ok(label.pubkey())],
         );
-        assert_eq!(crds.read().unwrap().get(&label).unwrap().value, value);
+        assert_eq!(crds.read().unwrap().get::<&CrdsValue>(&label), Some(&value));
 
         // push it again
         assert_eq!(
@@ -956,7 +956,10 @@ mod test {
             push.process_push_message(&crds, &Pubkey::default(), vec![value.clone()], 0),
             [Ok(label.pubkey())]
         );
-        assert_eq!(crds.write().unwrap().get(&label).unwrap().value, value);
+        assert_eq!(
+            crds.write().unwrap().get::<&CrdsValue>(&label),
+            Some(&value)
+        );
 
         // push it again
         assert_eq!(

--- a/gossip/src/crds_shards.rs
+++ b/gossip/src/crds_shards.rs
@@ -145,7 +145,7 @@ mod test {
         let label = value.label();
         let mut crds = Crds::default();
         crds.insert(value, timestamp()).unwrap();
-        crds.get(&label).cloned().unwrap()
+        crds.get::<&VersionedCrdsValue>(&label).cloned().unwrap()
     }
 
     // Returns true if the first mask_bits most significant bits of hash is the

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -584,52 +584,16 @@ impl CrdsValue {
         }
     }
 
-    #[cfg(test)]
-    fn vote(&self) -> Option<&Vote> {
-        match &self.data {
-            CrdsData::Vote(_, vote) => Some(vote),
-            _ => None,
-        }
-    }
-
-    pub fn lowest_slot(&self) -> Option<&LowestSlot> {
-        match &self.data {
-            CrdsData::LowestSlot(_, slots) => Some(slots),
-            _ => None,
-        }
-    }
-
-    pub fn snapshot_hash(&self) -> Option<&SnapshotHash> {
-        match &self.data {
-            CrdsData::SnapshotHashes(slots) => Some(slots),
-            _ => None,
-        }
-    }
-
-    pub fn accounts_hash(&self) -> Option<&SnapshotHash> {
+    pub(crate) fn accounts_hash(&self) -> Option<&SnapshotHash> {
         match &self.data {
             CrdsData::AccountsHashes(slots) => Some(slots),
             _ => None,
         }
     }
 
-    pub fn epoch_slots(&self) -> Option<&EpochSlots> {
+    pub(crate) fn epoch_slots(&self) -> Option<&EpochSlots> {
         match &self.data {
             CrdsData::EpochSlots(_, slots) => Some(slots),
-            _ => None,
-        }
-    }
-
-    pub fn legacy_version(&self) -> Option<&LegacyVersion> {
-        match &self.data {
-            CrdsData::LegacyVersion(legacy_version) => Some(legacy_version),
-            _ => None,
-        }
-    }
-
-    pub fn version(&self) -> Option<&Version> {
-        match &self.data {
-            CrdsData::Version(version) => Some(version),
             _ => None,
         }
     }
@@ -641,7 +605,7 @@ impl CrdsValue {
 
     /// Returns true if, regardless of prunes, this crds-value
     /// should be pushed to the receiving node.
-    pub fn should_force_push(&self, peer: &Pubkey) -> bool {
+    pub(crate) fn should_force_push(&self, peer: &Pubkey) -> bool {
         match &self.data {
             CrdsData::NodeInstance(node) => node.from == *peer,
             _ => false,
@@ -710,7 +674,10 @@ mod test {
             Vote::new(Pubkey::default(), test_tx(), 0),
         ));
         assert_eq!(v.wallclock(), 0);
-        let key = v.vote().unwrap().from;
+        let key = match &v.data {
+            CrdsData::Vote(_, vote) => vote.from,
+            _ => panic!(),
+        };
         assert_eq!(v.label(), CrdsValueLabel::Vote(0, key));
 
         let v = CrdsValue::new_unsigned(CrdsData::LowestSlot(
@@ -718,7 +685,10 @@ mod test {
             LowestSlot::new(Pubkey::default(), 0, 0),
         ));
         assert_eq!(v.wallclock(), 0);
-        let key = v.lowest_slot().unwrap().from;
+        let key = match &v.data {
+            CrdsData::LowestSlot(_, data) => data.from,
+            _ => panic!(),
+        };
         assert_eq!(v.label(), CrdsValueLabel::LowestSlot(key));
     }
 

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -6,6 +6,7 @@ mod cluster_info_metrics;
 #[macro_use]
 pub mod contact_info;
 pub mod crds;
+pub mod crds_entry;
 pub mod crds_gossip;
 pub mod crds_gossip_error;
 pub mod crds_gossip_pull;

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -187,7 +187,7 @@ fn ring_network_create(num: usize) -> Network {
             let start_id = keys[k];
             let label = CrdsValueLabel::ContactInfo(start_id);
             let gossip_crds = start.gossip.crds.read().unwrap();
-            gossip_crds.get(&label).unwrap().value.clone()
+            gossip_crds.get::<&CrdsValue>(&label).unwrap().clone()
         };
         let end = network.get_mut(&keys[(k + 1) % keys.len()]).unwrap();
         let mut end_crds = end.gossip.crds.write().unwrap();
@@ -221,7 +221,7 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
             let start = &network[k];
             let start_label = CrdsValueLabel::ContactInfo(*k);
             let gossip_crds = start.gossip.crds.read().unwrap();
-            gossip_crds.get(&start_label).unwrap().value.clone()
+            gossip_crds.get::<&CrdsValue>(&start_label).unwrap().clone()
         })
         .collect();
     for (end_pubkey, end) in network.iter_mut() {
@@ -276,7 +276,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
             let node_pubkey = node.keypair.pubkey();
             let mut m = {
                 let node_crds = node.gossip.crds.read().unwrap();
-                node_crds.get_contact_info(node_pubkey).cloned().unwrap()
+                node_crds.get::<&ContactInfo>(node_pubkey).cloned().unwrap()
             };
             m.wallclock = now;
             node.gossip.process_push_message(
@@ -495,7 +495,7 @@ fn network_run_pull(
                     let from_pubkey = from.keypair.pubkey();
                     let label = CrdsValueLabel::ContactInfo(from_pubkey);
                     let gossip_crds = from.gossip.crds.read().unwrap();
-                    let self_info = gossip_crds.get(&label).unwrap().value.clone();
+                    let self_info = gossip_crds.get::<&CrdsValue>(&label).unwrap().clone();
                     Some((peer.id, filters, self_info))
                 })
                 .collect()


### PR DESCRIPTION

#### Problem
A lot of duplicate and boilerplate code for looking up values from crds table.

#### Summary of Changes
This commit adds `CrdsEntry` trait which allows generic lookups into crds
table. For example to get `ContactInfo` or `LowestSlot` associated with a
`Pubkey`, the lookup code would be respectively:
```
crds.get::<&ContactInfo>(pubkey)
crds.get::<&LowestSlot>(pubkey)
```
As a result a number of `Crds` and `CrdsValue` api become redundant,
and are so deleted.