### PR TITLE
Explorer: Fix inspector simulation for system transactions with a single logs line

### DIFF
--- a/explorer/src/pages/inspector/SimulatorCard.tsx
+++ b/explorer/src/pages/inspector/SimulatorCard.tsx
@@ -230,6 +230,13 @@ function useSimulator(message: Message) {
               }
               depth--;
             } else {
+              if (depth === 0) {
+                instructionLogs.push({
+                  logs: [],
+                  failed: false,
+                });
+                depth++;
+              }
               // system transactions don't start with "Program log:"
               instructionLogs[instructionLogs.length - 1].logs.push({
                 prefix: prefixBuilder(depth),


### PR DESCRIPTION
#### Problem

When inspecting system instructions with a single line log simulation throws an error:

`Failed to run simulation:Cannot read property 'logs' of undefined`


#### Summary of Changes

Ensure `instructionLogs` has an entry before adding an instruction
