### PR TITLE
Explorer: include loader ids in program labels

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -157,6 +157,8 @@ export function programLabel(
   if (programName && PROGRAM_DEPLOYMENTS[programName].includes(cluster)) {
     return programName;
   }
+
+  return LOADER_IDS[address];
 }
 
 export function tokenLabel(
@@ -179,7 +181,6 @@ export function addressLabel(
 ): string | undefined {
   return (
     programLabel(address, cluster) ||
-    LOADER_IDS[address] ||
     SYSVAR_IDS[address] ||
     SYSVAR_ID[address] ||
     tokenLabel(address, tokenRegistry) ||


### PR DESCRIPTION
#### Problem

`BPF Upgradable Loader` and other loaders instructions are displayed as `Unknown` 

#### Summary of Changes

Move `LOADER_IDS` check to `programLabel`
