### PR TITLE
implements fifo rwlock

### DIFF
--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -10,9 +10,9 @@ use {
         crds::Crds,
         crds_gossip_pull::{CrdsFilter, CrdsGossipPull},
         crds_value::CrdsValue,
+        sync::RwLock,
     },
     solana_sdk::hash,
-    std::sync::RwLock,
     test::Bencher,
 };
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -31,6 +31,7 @@ use {
         gossip_error::GossipError,
         ping_pong::{self, PingCache, Pong},
         socketaddr, socketaddr_any,
+        sync::RwLock,
         weighted_shuffle::WeightedShuffle,
     },
     bincode::{serialize, serialized_size},
@@ -82,7 +83,7 @@ use {
         sync::{
             atomic::{AtomicBool, Ordering},
             mpsc::{Receiver, RecvTimeoutError, Sender},
-            {Arc, Mutex, RwLock, RwLockReadGuard},
+            {Arc, Mutex, RwLockReadGuard},
         },
         thread::{sleep, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -1582,7 +1583,7 @@ impl ClusterInfo {
     fn handle_purge(
         &self,
         thread_pool: &ThreadPool,
-        bank_forks: Option<&RwLock<BankForks>>,
+        bank_forks: Option<&std::sync::RwLock<BankForks>>,
         stakes: &HashMap<Pubkey, u64>,
     ) {
         let self_pubkey = self.id();
@@ -1632,7 +1633,7 @@ impl ClusterInfo {
     /// randomly pick a node and ask them for updates asynchronously
     pub fn gossip(
         self: Arc<Self>,
-        bank_forks: Option<Arc<RwLock<BankForks>>>,
+        bank_forks: Option<Arc<std::sync::RwLock<BankForks>>>,
         sender: PacketSender,
         gossip_validators: Option<HashSet<Pubkey>>,
         exit: Arc<AtomicBool>,
@@ -2461,7 +2462,7 @@ impl ClusterInfo {
     fn run_listen(
         &self,
         recycler: &PacketsRecycler,
-        bank_forks: Option<&RwLock<BankForks>>,
+        bank_forks: Option<&std::sync::RwLock<BankForks>>,
         receiver: &Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         response_sender: &PacketSender,
         thread_pool: &ThreadPool,
@@ -2539,7 +2540,7 @@ impl ClusterInfo {
 
     pub(crate) fn listen(
         self: Arc<Self>,
-        bank_forks: Option<Arc<RwLock<BankForks>>>,
+        bank_forks: Option<Arc<std::sync::RwLock<BankForks>>>,
         requests_receiver: Receiver<Vec<(/*from:*/ SocketAddr, Protocol)>>,
         response_sender: PacketSender,
         should_check_duplicate_instance: bool,
@@ -2634,7 +2635,7 @@ impl ClusterInfo {
 // Returns root bank's epoch duration. Falls back on
 //     DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT
 // if there are no working banks.
-fn get_epoch_duration(bank_forks: Option<&RwLock<BankForks>>) -> Duration {
+fn get_epoch_duration(bank_forks: Option<&std::sync::RwLock<BankForks>>) -> Duration {
     let num_slots = match bank_forks {
         None => {
             inc_new_counter_info!("cluster_info-purge-no_working_bank", 1);

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -15,6 +15,7 @@ use {
         crds_value::{CrdsData, CrdsValue},
         duplicate_shred::{self, DuplicateShredIndex, LeaderScheduleFn, MAX_DUPLICATE_SHREDS},
         ping_pong::PingCache,
+        sync::RwLock,
     },
     rayon::ThreadPool,
     solana_ledger::shred::Shred,
@@ -28,7 +29,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         net::SocketAddr,
-        sync::{Mutex, RwLock},
+        sync::Mutex,
         time::Duration,
     },
 };

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -20,6 +20,7 @@ use {
         crds_gossip_error::CrdsGossipError,
         crds_value::CrdsValue,
         ping_pong::PingCache,
+        sync::RwLock,
         weighted_shuffle::WeightedShuffle,
     },
     lru::LruCache,
@@ -39,7 +40,7 @@ use {
         net::SocketAddr,
         sync::{
             atomic::{AtomicI64, AtomicUsize, Ordering},
-            Mutex, RwLock,
+            Mutex,
         },
         time::{Duration, Instant},
     },

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -19,6 +19,7 @@ use {
         crds_gossip::{get_stake, get_weight},
         crds_gossip_error::CrdsGossipError,
         crds_value::CrdsValue,
+        sync::RwLock,
         weighted_shuffle::WeightedShuffle,
     },
     bincode::serialized_size,
@@ -36,7 +37,7 @@ use {
         ops::{DerefMut, RangeBounds},
         sync::{
             atomic::{AtomicUsize, Ordering},
-            Mutex, RwLock,
+            Mutex,
         },
     },
 };

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -21,7 +21,7 @@ use {
         sync::{
             atomic::{AtomicBool, Ordering},
             mpsc::channel,
-            {Arc, RwLock},
+            Arc, RwLock,
         },
         thread::{self, sleep, JoinHandle},
         time::{Duration, Instant},

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -20,6 +20,7 @@ pub mod epoch_slots;
 pub mod gossip_error;
 pub mod gossip_service;
 pub mod ping_pong;
+pub mod sync;
 pub mod weighted_shuffle;
 
 #[macro_use]

--- a/gossip/src/sync.rs
+++ b/gossip/src/sync.rs
@@ -1,0 +1,151 @@
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Condvar, LockResult, Mutex, PoisonError, RwLockReadGuard, RwLockWriteGuard,
+        TryLockError, TryLockResult,
+    },
+};
+
+/// FIFO reader-writer lock.
+#[derive(Default)]
+pub struct RwLock<T> {
+    inner: std::sync::RwLock<T>,
+    queue: Mutex<VecDeque<Arc<Condvar>>>,
+}
+
+impl<T> RwLock<T> {
+    pub fn new(t: T) -> Self {
+        Self {
+            inner: std::sync::RwLock::new(t),
+            queue: Mutex::default(),
+        }
+    }
+
+    pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
+        use std::sync::RwLock;
+        self.lock(RwLock::read, RwLock::try_read)
+    }
+
+    pub fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
+        use std::sync::RwLock;
+        self.lock(RwLock::write, RwLock::try_write)
+    }
+
+    fn lock<'a, F1, F2, R: 'a>(&'a self, lock: F1, try_lock: F2) -> LockResult<R>
+    where
+        F1: Fn(&'a std::sync::RwLock<T>) -> LockResult<R>,
+        F2: Fn(&'a std::sync::RwLock<T>) -> TryLockResult<R>,
+    {
+        let mut queue = match self.queue.lock() {
+            Ok(queue) => queue,
+            Err(_) => {
+                let guard = lock(&self.inner);
+                return guard.and_then(|r| Err(PoisonError::new(r)));
+            }
+        };
+        // If the queue is empty and no one is waiting, then try lock the inner
+        // and return if it does not block.
+        if queue.is_empty() {
+            match try_lock(&self.inner) {
+                Ok(inner) => return Ok(inner),
+                Err(TryLockError::Poisoned(err)) => return Err(err),
+                Err(TryLockError::WouldBlock) => (),
+            }
+        };
+        // Add self at the end of the queue and
+        // wait until reach head of the queue.
+        let cvar: Arc<Condvar> = Arc::default();
+        queue.push_back(Arc::clone(&cvar));
+        while !Arc::ptr_eq(&cvar, queue.front().unwrap()) {
+            queue = match cvar.wait(queue) {
+                Ok(queue) => queue,
+                Err(_) => {
+                    let guard = lock(&self.inner);
+                    return guard.and_then(|r| Err(PoisonError::new(r)));
+                }
+            };
+            // Check if it is in fact in front of the queue;
+            // Otherwise this has been a spurious wakeup.
+        }
+        // Should drop queue lock here, so that other threads are not blocked
+        // and are queued in order of their arrival.
+        drop(queue);
+        let guard = lock(&self.inner);
+        // Pop self from the queue, and notify the next one in line that it is
+        // now head of the queue.
+        let cvar: Arc<Condvar> = match self.queue.lock() {
+            Err(_) => {
+                return guard.and_then(|r| Err(PoisonError::new(r)));
+            }
+            Ok(mut queue) => {
+                debug_assert!(Arc::ptr_eq(&cvar, queue.front().unwrap()));
+                queue.pop_front();
+                match queue.front() {
+                    Some(cvar) => Arc::clone(cvar),
+                    None => return guard, // Queue is empty; no one to notify.
+                }
+            }
+        };
+        cvar.notify_one();
+        guard
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        rand::Rng,
+        std::{sync::Barrier, thread},
+    };
+
+    #[test]
+    fn test_fifo_rwlock() {
+        const NUM_READERS: usize = 10;
+        const NUM_WRITERS: usize = 10;
+        const NUM_REPS: usize = 10000;
+        let mut writer_handles = Vec::with_capacity(NUM_WRITERS);
+        let mut reader_handles = Vec::with_capacity(NUM_READERS);
+        let barrier = Arc::new(Barrier::new(NUM_READERS + NUM_WRITERS));
+        let var: Arc<RwLock<i64>> = Arc::default();
+        for _ in 0..NUM_WRITERS {
+            let barrier = Arc::clone(&barrier);
+            let var = Arc::clone(&var);
+            writer_handles.push(thread::spawn(move || {
+                let mut rng = rand::thread_rng();
+                barrier.wait();
+                let mut out = 0;
+                for _ in 0..NUM_REPS {
+                    let mut var = var.write().unwrap();
+                    let sample = rng.gen_range(1, 100);
+                    *var += sample;
+                    out += sample;
+                }
+                out
+            }));
+        }
+        for _ in 0..NUM_READERS {
+            let barrier = Arc::clone(&barrier);
+            let var = Arc::clone(&var);
+            reader_handles.push(thread::spawn(move || {
+                barrier.wait();
+                let mut out = 0;
+                for _ in 0..NUM_REPS {
+                    let var = var.read().unwrap();
+                    out = *var;
+                }
+                out
+            }))
+        }
+        let mut acc = 0;
+        for handle in writer_handles {
+            acc += handle.join().unwrap();
+        }
+        assert_eq!(acc, *var.read().unwrap());
+        for handle in reader_handles {
+            let val = handle.join().unwrap();
+            assert!(val <= acc);
+            assert!(val * 5 > acc);
+        }
+    }
+}


### PR DESCRIPTION

#### Problem
Reader threads can run ahead of writer thread causing write-starvation.


#### Summary of Changes
This commit implements a fifo rwlock by adding an additional queue of
condition variables. Each thread:
  - adds its condition variable to this queue.
  - waits until it is head of the queue.
  - obtains the read or write lock on underlying std::sync::RwLock.
  - removes itself from the queue.
  - and, notifies the next in line that it is now head of the queue.
