### PR TITLE
`solana-validator set-identity` now loads the tower file for the new identity

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -119,7 +119,7 @@ pub struct Tower {
     last_vote_tx_blockhash: Hash,
     last_timestamp: BlockTimestamp,
     #[serde(skip)]
-    ledger_path: PathBuf,
+    pub(crate) ledger_path: PathBuf,
     #[serde(skip)]
     path: PathBuf,
     #[serde(skip)]
@@ -175,7 +175,7 @@ impl Tower {
         tower
     }
 
-    pub(crate) fn set_identity(&mut self, node_pubkey: Pubkey) {
+    fn set_identity(&mut self, node_pubkey: Pubkey) {
         let path = Self::get_filename(&self.ledger_path, &node_pubkey);
         let tmp_path = Self::get_tmp_filename(&path);
         self.node_pubkey = node_pubkey;

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -513,6 +513,7 @@ fn main() {
             validator_exit: genesis.validator_exit.clone(),
             authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
             cluster_info: admin_service_cluster_info.clone(),
+            tower_path: ledger_path.clone(),
         },
     );
     let dashboard = if output == Output::Dashboard {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2234,7 +2234,9 @@ pub fn main() {
 
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
-        tower_path: value_t!(matches, "tower", PathBuf).ok(),
+        tower_path: value_t!(matches, "tower", PathBuf)
+            .ok()
+            .or_else(|| Some(ledger_path.clone())),
         dev_halt_at_slot: value_t!(matches, "dev_halt_at_slot", Slot).ok(),
         cuda: matches.is_present("cuda"),
         expected_genesis_hash: matches
@@ -2539,6 +2541,7 @@ pub fn main() {
             start_progress: start_progress.clone(),
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
             cluster_info: admin_service_cluster_info.clone(),
+            tower_path: validator_config.tower_path.clone().unwrap(),
         },
     );
 


### PR DESCRIPTION
When `solana-validator set-identity` is used to change the validator identity at runtime, insist on loading a tower file for the new identity to make it less likely that vote lockouts will be violated. 

This of course still requires the operator to copy in the correct tower file, so overall there's still some major friction wrt. tower file management to be addressed in future work.