### PR TITLE
feature: add new token program feature (v1.6 backport of #18780)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4895,8 +4895,8 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
-        if new_feature_activations.contains(&feature_set::spl_token_v2_self_transfer_fix::id()) {
-            self.apply_spl_token_v2_self_transfer_fix();
+        if new_feature_activations.contains(&feature_set::spl_token_v2_set_authority_fix::id()) {
+            self.apply_spl_token_v2_set_authority_fix();
         }
         // Remove me after a while around v1.6
         if !self.no_stake_rewrite.load(Relaxed)
@@ -4984,13 +4984,13 @@ impl Bank {
         }
     }
 
-    fn apply_spl_token_v2_self_transfer_fix(&mut self) {
+    fn apply_spl_token_v2_set_authority_fix(&mut self) {
         if let Some(old_account) = self.get_account(&inline_spl_token_v2_0::id()) {
             if let Some(new_account) =
                 self.get_account(&inline_spl_token_v2_0::new_token_program::id())
             {
                 datapoint_info!(
-                    "bank-apply_spl_token_v2_self_transfer_fix",
+                    "bank-apply_spl_token_v2_set_authority_fix",
                     ("slot", self.slot, i64),
                 );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -11350,7 +11350,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_spl_token_v2_self_transfer_fix() {
+    fn test_spl_token_v2_replacement() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
         let mut bank = Bank::new(&genesis_config);
 
@@ -11380,7 +11380,7 @@ pub(crate) mod tests {
 
         let original_capitalization = bank.capitalization();
 
-        bank.apply_spl_token_v2_self_transfer_fix();
+        bank.apply_spl_token_v2_set_authority_fix();
 
         // New token account is now empty
         assert_eq!(

--- a/runtime/src/inline_spl_token_v2_0.rs
+++ b/runtime/src/inline_spl_token_v2_0.rs
@@ -2,7 +2,7 @@
 solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 pub(crate) mod new_token_program {
-    solana_sdk::declare_id!("t31zsgDmRntje65uXV3LrnWaJtJJpMd4LyJxq2R2VrU");
+    solana_sdk::declare_id!("NToKV6K2hAz79S73NtC9vVWrAGn77mBduBn95xQFGSZ");
 }
 
 /*

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -166,6 +166,10 @@ pub mod merge_nonce_error_into_system_error {
     solana_sdk::declare_id!("21AWDosvp3pBamFW91KB35pNoaoZVTM7ess8nr2nt53B");
 }
 
+pub mod spl_token_v2_set_authority_fix {
+    solana_sdk::declare_id!("FToKNBYyiF4ky9s8WsmLBXHCht17Ek7RXaLZGHzzQhJ1");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -206,6 +210,7 @@ lazy_static! {
         (updated_verify_policy::id(), "Update verify policy"),
         (libsecp256k1_0_5_upgrade_enabled::id(), "upgrade libsecp256k1 to v0.5.0"),
         (merge_nonce_error_into_system_error::id(), "merge NonceError into SystemError"),
+        (spl_token_v2_set_authority_fix::id(), "spl-token set_authority fix"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -74,7 +74,6 @@ fn main() {
                         ("commit", git_commit_hash.trim().to_string(), String)
                     );
                     */
-                    
                 }
                 let last_median = get_last_metrics(&"median".to_string(), &db, &name, &branch)
                     .unwrap_or_default();

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -74,7 +74,7 @@ fn main() {
                         ("commit", git_commit_hash.trim().to_string(), String)
                     );
                     */
-
+                    
                 }
                 let last_median = get_last_metrics(&"median".to_string(), &db, &name, &branch)
                     .unwrap_or_default();

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -74,6 +74,7 @@ fn main() {
                         ("commit", git_commit_hash.trim().to_string(), String)
                     );
                     */
+
                 }
                 let last_median = get_last_metrics(&"median".to_string(), &db, &name, &branch)
                     .unwrap_or_default();


### PR DESCRIPTION
#### Problem

We need the new token program feature in 1.6, to have it running on a hacked validator (at least).  And depending on the release cadence for 1.7, this gives us the possibility of using the new token program separately.

#### Summary of Changes

Add a (limited) manual backport of #18780 

Fixes #
