### PR TITLE
adds feature for allowing private addresses for ci tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,25 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.5",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
@@ -4330,7 +4349,7 @@ version = "1.8.0"
 dependencies = [
  "bincode",
  "byteorder",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5227,7 +5246,7 @@ dependencies = [
  "hex",
  "itertools 0.9.0",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5261,7 +5280,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "num-derive",
  "num-traits",
@@ -5464,7 +5483,7 @@ dependencies = [
  "hmac 0.11.0",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log 0.4.14",
  "memmap2 0.3.0",
  "num-derive",
@@ -5522,7 +5541,7 @@ name = "solana-secp256k1-program"
 version = "1.8.0"
 dependencies = [
  "bincode",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "rand 0.7.3",
  "solana-logger 1.8.0",
  "solana-sdk",

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -22,6 +22,14 @@ if [[ -z $CI_BRANCH ]]; then
   CHANNEL=unknown
 fi
 
+maybeAllowPrivateAddr=
+if [[ -z $ALLOW_PRIVATE_ADDR ]]; then
+  ALLOW_PRIVATE_ADDR=false
+fi
+if [[ "$ALLOW_PRIVATE_ADDR" = "true" ]]; then
+  maybeAllowPrivateAddr="--allow-private-addr"
+fi
+
 eval "$(ci/channel-info.sh)"
 
 TAG=
@@ -83,7 +91,7 @@ echo --- Creating release tarball
   export CHANNEL
 
   source ci/rust-version.sh stable
-  scripts/cargo-install-all.sh stable "${RELEASE_BASENAME}"
+  scripts/cargo-install-all.sh stable "${maybeAllowPrivateAddr}" "${RELEASE_BASENAME}"
 
   tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
   bzip2 "${TARBALL_BASENAME}"-$TARGET.tar

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1417,6 +1417,25 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
@@ -2603,7 +2622,7 @@ version = "1.8.0"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3203,7 +3222,7 @@ dependencies = [
  "hex",
  "itertools 0.9.0",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3236,7 +3255,7 @@ dependencies = [
  "hex",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "num-derive",
  "num-traits",
@@ -3377,7 +3396,7 @@ dependencies = [
  "hmac 0.11.0",
  "itertools 0.10.1",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.6.0",
  "log",
  "memmap2 0.3.0",
  "num-derive",

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -20,7 +20,7 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [+<cargo version>] [--debug] [--validator-only] <install directory>
+usage: $0 [+<cargo version>] [--debug] [--validator-only] [--allow-private-addr] <install directory>
 EOF
   exit $exitcode
 }
@@ -30,6 +30,7 @@ installDir=
 buildVariant=release
 maybeReleaseFlag=--release
 validatorOnly=
+maybeFeatures=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -39,6 +40,9 @@ while [[ -n $1 ]]; do
       shift
     elif [[ $1 = --validator-only ]]; then
       validatorOnly=true
+      shift
+    elif [[ $1 = --allow-private-addr ]]; then
+      maybeFeatures='--features=allow_private_addr'
       shift
     else
       usage "Unknown option: $1"
@@ -126,7 +130,7 @@ mkdir -p "$installDir/bin"
 (
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
+  "$cargo" $maybeRustVersion build $maybeReleaseFlag ${maybeFeatures} "${binArgs[@]}"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-streamer"
 edition = "2018"
 
+[features]
+allow_private_addr = []
+
 [dependencies]
 log = "0.4.14"
 solana-metrics = { path = "../metrics", version = "=1.8.0" }

--- a/streamer/src/socket.rs
+++ b/streamer/src/socket.rs
@@ -2,12 +2,12 @@ use std::net::SocketAddr;
 
 // TODO: remove these once IpAddr::is_global is stable.
 
-#[cfg(test)]
+#[cfg(any(test, feature = "allow_private_addr"))]
 pub fn is_global(_: &SocketAddr) -> bool {
     true
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "allow_private_addr")))]
 pub fn is_global(addr: &SocketAddr) -> bool {
     use std::net::IpAddr;
 


### PR DESCRIPTION
#### Problem
To address mainnet issue, https://github.com/solana-labs/solana/pull/18728 excludes private ip addresses.
As a side effect, `system-performance-tests` broke:
https://github.com/solana-labs/solana/pull/18728#issuecomment-883848858

#### Summary of Changes
* This commit adds a _development only_ build feature `allow_private_addr` to allow private ip address for development and ci tests.
