### PR TITLE
docs: validator: Remove 'Disable snapshot compression' section

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -433,15 +433,6 @@ Once your validator is operating normally, you can reduce the time it takes to
 restart your validator by adding the `--no-port-check` flag to your
 `solana-validator` command-line.
 
-### Disable snapshot compression to reduce CPU usage
-
-If you are not serving snapshots to other validators, snapshot compression can
-be disabled to reduce CPU load at the expense of slightly more disk usage for
-local snapshot storage.
-
-Add the `--snapshot-compression none` argument to your `solana-validator`
-command-line arguments and restart the validator.
-
 ### Using a ramdisk with spill-over into swap for the accounts database to reduce SSD wear
 
 If your machine has plenty of RAM, a tmpfs ramdisk


### PR DESCRIPTION
`--snapshot-compression none` is not the right trade-off between CPU/IOPS for mainnet, remove this section entirely to avoid new users from thinking it might help them (IOPS is generally the bottleneck, not CPU)