### PR TITLE
token: Swap new token program id for consistency on all networks

### DIFF
--- a/runtime/src/inline_spl_token_v2_0.rs
+++ b/runtime/src/inline_spl_token_v2_0.rs
@@ -2,7 +2,7 @@
 solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 pub(crate) mod new_token_program {
-    solana_sdk::declare_id!("NToKV6K2hAz79S73NtC9vVWrAGn77mBduBn95xQFGSZ");
+    solana_sdk::declare_id!("nTokHfnBtpt4V6xiEbBSduiGCrQ6wSF3rxC8WeWAQ9F");
 }
 
 /*


### PR DESCRIPTION
#### Problem

I deployed the new token program to `NToK...` on devnet with `solana program deploy --final`, which uses the upgradeable loader.  It should use `solana deploy` to use BPF Loader 2.

#### Summary of Changes

Update the key to a new one for consistency across all networks.

Fixes #
