### PR TITLE
Docs: fix link to Native Programs page in transactions.md

### DIFF
--- a/docs/src/developing/programming-model/transactions.md
+++ b/docs/src/developing/programming-model/transactions.md
@@ -139,7 +139,7 @@ accounts are permanently marked as executable by the loader once they are
 successfully deployed. The runtime will reject transactions that specify programs
 that are not executable.
 
-Unlike on-chain programs, [Native Programs](developing/runtime-facilities/programs)
+Unlike on-chain programs, [Native Programs](developing/runtime-facilities/programs.md)
 are handled differently in that they are built directly into the Solana runtime.
 
 ### Accounts


### PR DESCRIPTION
#### Problem
In the current documentation, in the `Developing > Programming Model > Transactions` page there is a link to `Native Programs` that 404s. It's currently duplicating the URL and linking to `developing/programming-model/developing/runtime-facilities/programs` instead of just to `developing/runtime-facilities/programs`.

#### Summary of Changes
The link in the markdown file should be updated to point to the markdown file `programs.md` instead of to the link itself.

Fixes #
`Native Programs` now links to the markdown file instead of the link.
