### PR TITLE
Explorer: Show simulation error for upgrade instruction with none existing buffer 

### DIFF
--- a/explorer/src/pages/inspector/SimulatorCard.tsx
+++ b/explorer/src/pages/inspector/SimulatorCard.tsx
@@ -247,6 +247,15 @@ function useSimulator(message: Message) {
           }
         });
 
+        // If the instruction's simulation returned an error without any logs then add an empty log entry for Runtime error
+        // For example BpfUpgradableLoader fails without returning any logs for Upgrade instruction with buffer that doesn't exist
+        if (instructionError && instructionLogs.length === 0) {
+          instructionLogs.push({
+            logs: [],
+            failed: true,
+          });
+        }
+
         if (
           instructionError &&
           instructionError.index === instructionLogs.length - 1


### PR DESCRIPTION
#### Problem

Transaction simulation for BpfUpgradableLoader Upgrade instruction with none existing buffer doesn't show error.

[Inspect Upgrade](https://explorer.solana.com/tx/inspector?cluster=devnet&signatures=%255B%25221111111111111111111111111111111111111111111111111111111111111111%2522%252C%25221111111111111111111111111111111111111111111111111111111111111111%2522%255D&message=AgEDCGNz1gsesqEB3F8RN0gYdM0SpprNniWmWfvlyMxuChM9MKmFeuoHg3MsOIdBGHAGhsJjJOIuJFBPW47FP5jlGv38dOPJaQz01AA0rleLoKiuCX9uCqkQHUl68gQYPNmfVLt7U5LAr7bp%252F7XttsahWoOu%252B%252F64ucPDPMjoiAyT1Oon1pVo5zwK3IaSeJ1GMV3hK4Y%252BlI7ME%252B7rZAkRVIkOK9kGp9UXGSxcUSGMyUw9SvF%252FWNruCJuh%252FUTj29mKAAAAAAan1RcYx3TJKFZjmGkdXraLXrijm0ttXHNVWyEAAAAAAqj2kU6IobDiEBU%252B92OuKwDCuT0WwSTSwFN6EASAAAByLttoccsDgPuAfm9VV9Rn38RKYC3%252FkTlvD6uj14XjzgEHBwIDBAAFBgEEAwAAAA%253D%253D)

![image](https://user-images.githubusercontent.com/5817016/126630528-3197d562-2e6c-4fe1-ae8b-d317f9d7b0e0.png)

#### Summary of Changes

Add an empty log entry to show runtime error 

![image](https://user-images.githubusercontent.com/5817016/126630765-7ece8c10-212f-4a82-b0cc-82ae221632ac.png)

