### PR TITLE
Move tower save into the VotingService

### DIFF
--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -5,8 +5,7 @@ extern crate test;
 
 use {
     solana_core::{
-        consensus::{FileTowerStorage, Tower},
-        vote_simulator::VoteSimulator,
+        consensus::Tower, tower_storage::FileTowerStorage, vote_simulator::VoteSimulator,
     },
     solana_runtime::bank::Bank,
     solana_runtime::bank_forks::BankForks,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1231,6 +1231,21 @@ pub trait TowerStorage: Sync + Send {
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
+pub struct NullTowerStorage {}
+
+impl TowerStorage for NullTowerStorage {
+    fn load(&self, _node_pubkey: &Pubkey) -> Result<SavedTower> {
+        Err(TowerError::WrongTower(
+            "NullTowerStorage has no storage".into(),
+        ))
+    }
+
+    fn store(&self, _saved_tower: &SavedTower) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct FileTowerStorage {
     pub tower_path: PathBuf,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod sigverify_shreds;
 pub mod sigverify_stage;
 pub mod snapshot_packager_service;
 pub mod test_validator;
+pub mod tower_storage;
 pub mod tpu;
 pub mod tree_diff;
 pub mod tvu;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -12,8 +12,7 @@ use {
         cluster_slots_service::ClusterSlotsUpdateSender,
         commitment_service::{AggregateCommitmentService, CommitmentAggregationData},
         consensus::{
-            ComputedBankState, SavedTower, Stake, SwitchForkDecision, Tower, TowerStorage,
-            VotedStakes, SWITCH_FORK_THRESHOLD,
+            ComputedBankState, Stake, SwitchForkDecision, Tower, VotedStakes, SWITCH_FORK_THRESHOLD,
         },
         fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
@@ -21,6 +20,7 @@ use {
         progress_map::{ForkProgress, ProgressMap, PropagatedStats},
         repair_service::DuplicateSlotsResetReceiver,
         rewards_recorder_service::RewardsRecorderSender,
+        tower_storage::{SavedTower, TowerStorage},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
         voting_service::VoteOp,
         window_service::DuplicateSlotReceiver,
@@ -2738,7 +2738,7 @@ impl ReplayStage {
 pub mod tests {
     use super::*;
     use crate::{
-        consensus::{NullTowerStorage, Tower},
+        consensus::Tower,
         progress_map::ValidatorStakeInfo,
         replay_stage::ReplayStage,
         tree_diff::TreeDiff,
@@ -5419,7 +5419,7 @@ pub mod tests {
             vote_simulator,
             ..
         } = replay_blockstore_components(None, 10, None::<GenerateVotes>);
-        let tower_storage = NullTowerStorage::default();
+        let tower_storage = crate::tower_storage::NullTowerStorage::default();
 
         let VoteSimulator {
             mut validator_keypairs,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -12,8 +12,8 @@ use {
         cluster_slots_service::ClusterSlotsUpdateSender,
         commitment_service::{AggregateCommitmentService, CommitmentAggregationData},
         consensus::{
-            ComputedBankState, Stake, SwitchForkDecision, Tower, TowerStorage, VotedStakes,
-            SWITCH_FORK_THRESHOLD,
+            ComputedBankState, SavedTower, Stake, SwitchForkDecision, Tower, TowerStorage,
+            VotedStakes, SWITCH_FORK_THRESHOLD,
         },
         fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
         heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
@@ -598,7 +598,6 @@ impl ReplayStage {
                             switch_fork_decision,
                             &bank_forks,
                             &mut tower,
-                            tower_storage.as_ref(),
                             &mut progress,
                             &vote_account,
                             &identity_keypair,
@@ -1488,7 +1487,6 @@ impl ReplayStage {
         switch_fork_decision: &SwitchForkDecision,
         bank_forks: &Arc<RwLock<BankForks>>,
         tower: &mut Tower,
-        tower_storage: &dyn TowerStorage,
         progress: &mut ProgressMap,
         vote_account_pubkey: &Pubkey,
         identity_keypair: &Keypair,
@@ -1516,15 +1514,10 @@ impl ReplayStage {
         trace!("handle votable bank {}", bank.slot());
         let new_root = tower.record_bank_vote(bank, vote_account_pubkey);
 
-        {
-            let mut measure = Measure::start("tower_save-ms");
-            if let Err(err) = tower.save(tower_storage, identity_keypair) {
-                error!("Unable to save tower: {:?}", err);
-                std::process::exit(1);
-            }
-            measure.stop();
-            inc_new_counter_info!("tower_save-ms", measure.as_ms() as usize);
-        }
+        let saved_tower = SavedTower::new(tower, identity_keypair).unwrap_or_else(|err| {
+            error!("Unable to create saved tower: {:?}", err);
+            std::process::exit(1);
+        });
 
         if let Some(new_root) = new_root {
             // get the root bank before squash
@@ -1594,6 +1587,7 @@ impl ReplayStage {
             identity_keypair,
             authorized_voter_keypairs,
             tower,
+            saved_tower,
             switch_fork_decision,
             vote_signatures,
             *has_new_vote_been_rooted,
@@ -1782,6 +1776,7 @@ impl ReplayStage {
         identity_keypair: &Keypair,
         authorized_voter_keypairs: &[Arc<Keypair>],
         tower: &mut Tower,
+        saved_tower: SavedTower,
         switch_fork_decision: &SwitchForkDecision,
         vote_signatures: &mut Vec<Signature>,
         has_new_vote_been_rooted: bool,
@@ -1809,6 +1804,7 @@ impl ReplayStage {
                 .send(VoteOp::PushVote {
                     tx: vote_tx,
                     tower_slots,
+                    saved_tower,
                 })
                 .unwrap_or_else(|err| warn!("Error: {:?}", err));
         }
@@ -2742,7 +2738,7 @@ impl ReplayStage {
 pub mod tests {
     use super::*;
     use crate::{
-        consensus::Tower,
+        consensus::{NullTowerStorage, Tower},
         progress_map::ValidatorStakeInfo,
         replay_stage::ReplayStage,
         tree_diff::TreeDiff,
@@ -5423,6 +5419,7 @@ pub mod tests {
             vote_simulator,
             ..
         } = replay_blockstore_components(None, 10, None::<GenerateVotes>);
+        let tower_storage = NullTowerStorage::default();
 
         let VoteSimulator {
             mut validator_keypairs,
@@ -5465,6 +5462,7 @@ pub mod tests {
             &identity_keypair,
             &my_vote_keypair,
             &mut tower,
+            SavedTower::default(),
             &SwitchForkDecision::SameFork,
             &mut voted_signatures,
             has_new_vote_been_rooted,
@@ -5474,7 +5472,12 @@ pub mod tests {
         let vote_info = voting_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        crate::voting_service::VotingService::handle_vote(&cluster_info, &poh_recorder, vote_info);
+        crate::voting_service::VotingService::handle_vote(
+            &cluster_info,
+            &poh_recorder,
+            &tower_storage,
+            vote_info,
+        );
 
         let mut cursor = Cursor::default();
         let (_, votes) = cluster_info.get_votes(&mut cursor);
@@ -5522,6 +5525,7 @@ pub mod tests {
             &identity_keypair,
             &my_vote_keypair,
             &mut tower,
+            SavedTower::default(),
             &SwitchForkDecision::SameFork,
             &mut voted_signatures,
             has_new_vote_been_rooted,
@@ -5531,7 +5535,12 @@ pub mod tests {
         let vote_info = voting_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        crate::voting_service::VotingService::handle_vote(&cluster_info, &poh_recorder, vote_info);
+        crate::voting_service::VotingService::handle_vote(
+            &cluster_info,
+            &poh_recorder,
+            &tower_storage,
+            vote_info,
+        );
         let (_, votes) = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
         let vote_tx = &votes[0];
@@ -5593,7 +5602,12 @@ pub mod tests {
         let vote_info = voting_receiver
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        crate::voting_service::VotingService::handle_vote(&cluster_info, &poh_recorder, vote_info);
+        crate::voting_service::VotingService::handle_vote(
+            &cluster_info,
+            &poh_recorder,
+            &tower_storage,
+            vote_info,
+        );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
         let (_, votes) = cluster_info.get_votes(&mut cursor);

--- a/core/src/tower_storage.rs
+++ b/core/src/tower_storage.rs
@@ -1,0 +1,128 @@
+use {
+    crate::consensus::{Result, Tower, TowerError},
+    solana_sdk::{
+        pubkey::Pubkey,
+        signature::{Signature, Signer},
+    },
+    std::{
+        fs::{self, File},
+        io::BufReader,
+        path::PathBuf,
+    },
+};
+
+#[frozen_abi(digest = "Gaxfwvx5MArn52mKZQgzHmDCyn5YfCuTHvp5Et3rFfpp")]
+#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
+pub struct SavedTower {
+    signature: Signature,
+    data: Vec<u8>,
+    #[serde(skip)]
+    node_pubkey: Pubkey,
+}
+
+impl SavedTower {
+    pub fn new<T: Signer>(tower: &Tower, keypair: &T) -> Result<Self> {
+        let node_pubkey = keypair.pubkey();
+        if tower.node_pubkey != node_pubkey {
+            return Err(TowerError::WrongTower(format!(
+                "node_pubkey is {:?} but found tower for {:?}",
+                node_pubkey, tower.node_pubkey
+            )));
+        }
+
+        let data = bincode::serialize(tower)?;
+        let signature = keypair.sign_message(&data);
+        Ok(Self {
+            signature,
+            data,
+            node_pubkey,
+        })
+    }
+
+    pub fn try_into_tower(self, node_pubkey: &Pubkey) -> Result<Tower> {
+        // This method assumes that `self` was just deserialized
+        assert_eq!(self.node_pubkey, Pubkey::default());
+
+        if !self.signature.verify(node_pubkey.as_ref(), &self.data) {
+            return Err(TowerError::InvalidSignature);
+        }
+        bincode::deserialize(&self.data)
+            .map_err(|e| e.into())
+            .and_then(|tower: Tower| {
+                if tower.node_pubkey != *node_pubkey {
+                    return Err(TowerError::WrongTower(format!(
+                        "node_pubkey is {:?} but found tower for {:?}",
+                        node_pubkey, tower.node_pubkey
+                    )));
+                }
+                Ok(tower)
+            })
+    }
+}
+
+pub trait TowerStorage: Sync + Send {
+    fn load(&self, node_pubkey: &Pubkey) -> Result<SavedTower>;
+    fn store(&self, saved_tower: &SavedTower) -> Result<()>;
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct NullTowerStorage {}
+
+impl TowerStorage for NullTowerStorage {
+    fn load(&self, _node_pubkey: &Pubkey) -> Result<SavedTower> {
+        Err(TowerError::WrongTower(
+            "NullTowerStorage has no storage".into(),
+        ))
+    }
+
+    fn store(&self, _saved_tower: &SavedTower) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct FileTowerStorage {
+    pub tower_path: PathBuf,
+}
+
+impl FileTowerStorage {
+    pub fn new(tower_path: PathBuf) -> Self {
+        Self { tower_path }
+    }
+
+    pub fn filename(&self, node_pubkey: &Pubkey) -> PathBuf {
+        self.tower_path
+            .join(format!("tower-{}", node_pubkey))
+            .with_extension("bin")
+    }
+}
+
+impl TowerStorage for FileTowerStorage {
+    fn load(&self, node_pubkey: &Pubkey) -> Result<SavedTower> {
+        let filename = self.filename(node_pubkey);
+        trace!("load {}", filename.display());
+
+        // Ensure to create parent dir here, because restore() precedes save() always
+        fs::create_dir_all(&filename.parent().unwrap())?;
+
+        let file = File::open(&filename)?;
+        let mut stream = BufReader::new(file);
+        bincode::deserialize_from(&mut stream).map_err(|e| e.into())
+    }
+
+    fn store(&self, saved_tower: &SavedTower) -> Result<()> {
+        let filename = self.filename(&saved_tower.node_pubkey);
+        trace!("store: {}", filename.display());
+        let new_filename = filename.with_extension("bin.new");
+
+        {
+            // overwrite anything if exists
+            let mut file = File::create(&new_filename)?;
+            bincode::serialize_into(&mut file, saved_tower)?;
+            // file.sync_all() hurts performance; pipeline sync-ing and submitting votes to the cluster!
+        }
+        fs::rename(&new_filename, &filename)?;
+        // self.path.parent().sync_all() hurts performance same as the above sync
+        Ok(())
+    }
+}

--- a/core/src/tower_storage.rs
+++ b/core/src/tower_storage.rs
@@ -6,7 +6,7 @@ use {
     },
     std::{
         fs::{self, File},
-        io::BufReader,
+        io::{self, BufReader},
         path::PathBuf,
     },
 };
@@ -70,9 +70,10 @@ pub struct NullTowerStorage {}
 
 impl TowerStorage for NullTowerStorage {
     fn load(&self, _node_pubkey: &Pubkey) -> Result<SavedTower> {
-        Err(TowerError::WrongTower(
-            "NullTowerStorage has no storage".into(),
-        ))
+        Err(TowerError::IoError(io::Error::new(
+            io::ErrorKind::Other,
+            "NullTowerStorage::load() not available",
+        )))
     }
 
     fn store(&self, _saved_tower: &SavedTower) -> Result<()> {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -278,12 +278,16 @@ impl Tvu {
             bank_notification_sender,
             wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
             ancestor_hashes_replay_update_sender,
-            tower_storage,
+            tower_storage: tower_storage.clone(),
         };
 
         let (voting_sender, voting_receiver) = channel();
-        let voting_service =
-            VotingService::new(voting_receiver, cluster_info.clone(), poh_recorder.clone());
+        let voting_service = VotingService::new(
+            voting_receiver,
+            cluster_info.clone(),
+            poh_recorder.clone(),
+            tower_storage,
+        );
 
         let (cost_update_sender, cost_update_receiver): (
             Sender<ExecuteTimings>,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     cluster_slots::ClusterSlots,
     completed_data_sets_service::CompletedDataSetsSender,
-    consensus::{Tower, TowerStorage},
+    consensus::Tower,
     cost_model::CostModel,
     cost_update_service::CostUpdateService,
     ledger_cleanup_service::LedgerCleanupService,
@@ -22,6 +22,7 @@ use crate::{
     sigverify_shreds::ShredSigVerifier,
     sigverify_stage::SigVerifyStage,
     snapshot_packager_service::PendingSnapshotPackage,
+    tower_storage::TowerStorage,
     voting_service::VotingService,
 };
 use crossbeam_channel::unbounded;
@@ -455,7 +456,7 @@ pub mod tests {
             )),
             &poh_recorder,
             tower,
-            Arc::new(crate::consensus::FileTowerStorage::default()),
+            Arc::new(crate::tower_storage::FileTowerStorage::default()),
             &leader_schedule_cache,
             &exit,
             block_commitment_cache,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -5,7 +5,7 @@ use crate::{
     cache_block_meta_service::{CacheBlockMetaSender, CacheBlockMetaService},
     cluster_info_vote_listener::VoteTracker,
     completed_data_sets_service::CompletedDataSetsService,
-    consensus::{reconcile_blockstore_roots_with_tower, FileTowerStorage, Tower, TowerStorage},
+    consensus::{reconcile_blockstore_roots_with_tower, Tower},
     cost_model::CostModel,
     rewards_recorder_service::{RewardsRecorderSender, RewardsRecorderService},
     sample_performance_service::SamplePerformanceService,
@@ -13,6 +13,7 @@ use crate::{
     serve_repair_service::ServeRepairService,
     sigverify,
     snapshot_packager_service::{PendingSnapshotPackage, SnapshotPackagerService},
+    tower_storage::{FileTowerStorage, TowerStorage},
     tpu::{Tpu, DEFAULT_TPU_COALESCE_MS},
     tvu::{Sockets, Tvu, TvuConfig},
 };

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -13,7 +13,7 @@ use crate::{
     serve_repair_service::ServeRepairService,
     sigverify,
     snapshot_packager_service::{PendingSnapshotPackage, SnapshotPackagerService},
-    tower_storage::{FileTowerStorage, TowerStorage},
+    tower_storage::TowerStorage,
     tpu::{Tpu, DEFAULT_TPU_COALESCE_MS},
     tvu::{Sockets, Tvu, TvuConfig},
 };
@@ -183,7 +183,7 @@ impl Default for ValidatorConfig {
             wal_recovery_mode: None,
             poh_verify: true,
             require_tower: false,
-            tower_storage: Arc::new(FileTowerStorage::new(PathBuf::default())),
+            tower_storage: Arc::new(crate::tower_storage::NullTowerStorage::default()),
             debug_keys: None,
             contact_debug_interval: DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS,
             contact_save_interval: DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS,

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -1,4 +1,6 @@
+use crate::consensus::{SavedTower, TowerStorage};
 use solana_gossip::cluster_info::ClusterInfo;
+use solana_measure::measure::Measure;
 use solana_poh::poh_recorder::PohRecorder;
 use solana_sdk::{clock::Slot, transaction::Transaction};
 use std::{
@@ -10,6 +12,7 @@ pub enum VoteOp {
     PushVote {
         tx: Transaction,
         tower_slots: Vec<Slot>,
+        saved_tower: SavedTower,
     },
     RefreshVote {
         tx: Transaction,
@@ -20,11 +23,8 @@ pub enum VoteOp {
 impl VoteOp {
     fn tx(&self) -> &Transaction {
         match self {
-            VoteOp::PushVote { tx, tower_slots: _ } => tx,
-            VoteOp::RefreshVote {
-                tx,
-                last_voted_slot: _,
-            } => tx,
+            VoteOp::PushVote { tx, .. } => tx,
+            VoteOp::RefreshVote { tx, .. } => tx,
         }
     }
 }
@@ -38,12 +38,18 @@ impl VotingService {
         vote_receiver: Receiver<VoteOp>,
         cluster_info: Arc<ClusterInfo>,
         poh_recorder: Arc<Mutex<PohRecorder>>,
+        tower_storage: Arc<dyn TowerStorage>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("sol-vote-service".to_string())
             .spawn(move || {
                 for vote_op in vote_receiver.iter() {
-                    Self::handle_vote(&cluster_info, &poh_recorder, vote_op);
+                    Self::handle_vote(
+                        &cluster_info,
+                        &poh_recorder,
+                        tower_storage.as_ref(),
+                        vote_op,
+                    );
                 }
             })
             .unwrap();
@@ -53,15 +59,28 @@ impl VotingService {
     pub fn handle_vote(
         cluster_info: &ClusterInfo,
         poh_recorder: &Mutex<PohRecorder>,
+        tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
     ) {
+        if let VoteOp::PushVote { saved_tower, .. } = &vote_op {
+            let mut measure = Measure::start("tower_save-ms");
+            if let Err(err) = tower_storage.store(saved_tower) {
+                error!("Unable to save tower to storage: {:?}", err);
+                std::process::exit(1);
+            }
+            measure.stop();
+            inc_new_counter_info!("tower_save-ms", measure.as_ms() as usize);
+        }
+
         let _ = cluster_info.send_transaction(
             vote_op.tx(),
             crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder),
         );
 
         match vote_op {
-            VoteOp::PushVote { tx, tower_slots } => {
+            VoteOp::PushVote {
+                tx, tower_slots, ..
+            } => {
                 cluster_info.push_vote(&tower_slots, tx);
             }
             VoteOp::RefreshVote {

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -1,4 +1,4 @@
-use crate::consensus::{SavedTower, TowerStorage};
+use crate::tower_storage::{SavedTower, TowerStorage};
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_measure::measure::Measure;
 use solana_poh::poh_recorder::PohRecorder;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -8,7 +8,7 @@ use {
     log::*,
     solana_client::thin_client::{create_client, ThinClient},
     solana_core::{
-        consensus::FileTowerStorage,
+        tower_storage::FileTowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
     },
     solana_gossip::{

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2890,7 +2890,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
     let slots_per_epoch = 2048;
     let node_stakes = match cluster_mode {
         ClusterMode::MasterOnly => vec![100],
-        ClusterMode::MasterSlave => vec![100, 0],
+        ClusterMode::MasterSlave => vec![100, 1],
     };
 
     let validator_keys = vec![

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -16,9 +16,10 @@ use {
         broadcast_stage::{
             broadcast_duplicates_run::BroadcastDuplicatesConfig, BroadcastStageType,
         },
-        consensus::{FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD, VOTE_THRESHOLD_DEPTH},
+        consensus::{Tower, SWITCH_FORK_THRESHOLD, VOTE_THRESHOLD_DEPTH},
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
+        tower_storage::FileTowerStorage,
         validator::ValidatorConfig,
     },
     solana_download_utils::download_snapshot,

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -6,8 +6,7 @@ use {
     jsonrpc_server_utils::tokio,
     log::*,
     solana_core::{
-        consensus::{Tower, TowerStorage},
-        validator::ValidatorStartProgress,
+        consensus::Tower, tower_storage::TowerStorage, validator::ValidatorStartProgress,
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_sdk::{

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -8,7 +8,7 @@ use {
         },
     },
     solana_client::rpc_client::RpcClient,
-    solana_core::consensus::FileTowerStorage,
+    solana_core::tower_storage::FileTowerStorage,
     solana_faucet::faucet::{run_local_faucet_with_port, FAUCET_PORT},
     solana_rpc::rpc::JsonRpcConfig,
     solana_sdk::{

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -509,6 +509,8 @@ fn main() {
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
 
+    let tower_storage = Arc::new(FileTowerStorage::new(ledger_path.clone()));
+
     let admin_service_cluster_info = Arc::new(RwLock::new(None));
     admin_rpc_service::run(
         &ledger_path,
@@ -522,7 +524,7 @@ fn main() {
             validator_exit: genesis.validator_exit.clone(),
             authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
             cluster_info: admin_service_cluster_info.clone(),
-            tower_storage: Arc::new(FileTowerStorage::new(ledger_path.clone())),
+            tower_storage: tower_storage.clone(),
         },
     );
     let dashboard = if output == Output::Dashboard {
@@ -540,6 +542,7 @@ fn main() {
 
     genesis
         .ledger_path(&ledger_path)
+        .tower_storage(tower_storage)
         .add_account(
             faucet_pubkey,
             AccountSharedData::new(faucet_lamports, 0, &system_program::id()),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -20,8 +20,8 @@ use {
         rpc_request::MAX_MULTIPLE_ACCOUNTS,
     },
     solana_core::{
-        consensus::FileTowerStorage,
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
+        tower_storage::FileTowerStorage,
         tpu::DEFAULT_TPU_COALESCE_MS,
         validator::{
             is_snapshot_config_invalid, Validator, ValidatorConfig, ValidatorStartProgress,


### PR DESCRIPTION
Building on #18847, the first commit in this PR moves tower saving into the VotingService to avoid blocking replay stage progress.  

This is not super important with the current `FileTowerStorage` implementation, but once `EtcdTowerStorage` is implemented then it'll be no good to be blocking replay stage with network activity with an etcd cluster