### PR TITLE
Autolink URL in docs for sdk::feature_set

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -5,7 +5,7 @@
 //! - For features that are unambiguously good (ie bug fixes), these steps are sufficient.
 //! - For features that should go up for community vote (ie fee structure changes), more
 //!   information on the additional steps to follow can be found at:
-//!   https://spl.solana.com/feature-proposal#feature-proposal-life-cycle
+//!   <https://spl.solana.com/feature-proposal#feature-proposal-life-cycle>
 //!
 //! 1. Generate a new keypair with `solana-keygen new --outfile feature.json --no-passphrase`
 //!    - Keypairs should be held by core contributors only. If you're a non-core contirbutor going


### PR DESCRIPTION
#### Problem

`cargo doc` issues a warning about un-linked URL.

#### Summary of Changes

Put angle brackets around the URL to hyperlink it.