### PR TITLE
Deprecate SysvarRecentBlockhashes

### DIFF
--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use bincode::deserialize;
 use bv::BitVec;
+#[allow(deprecated)]
+use solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_sdk::{
     clock::{Clock, Epoch, Slot, UnixTimestamp},
     epoch_schedule::EpochSchedule,
@@ -12,10 +14,11 @@ use solana_sdk::{
     slot_hashes::SlotHashes,
     slot_history::{self, SlotHistory},
     stake_history::{StakeHistory, StakeHistoryEntry},
-    sysvar::{self, fees::Fees, recent_blockhashes::RecentBlockhashes, rewards::Rewards},
+    sysvar::{self, fees::Fees, rewards::Rewards},
 };
 
 pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, ParseAccountError> {
+    #[allow(deprecated)]
     let parsed_account = {
         if pubkey == &sysvar::clock::id() {
             deserialize::<Clock>(data)
@@ -213,10 +216,9 @@ pub struct UiStakeHistoryEntry {
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_sdk::{
-        account::create_account_for_test, fee_calculator::FeeCalculator, hash::Hash,
-        sysvar::recent_blockhashes::IterItem,
-    };
+    #[allow(deprecated)]
+    use solana_sdk::sysvar::recent_blockhashes::IterItem;
+    use solana_sdk::{account::create_account_for_test, fee_calculator::FeeCalculator, hash::Hash};
 
     #[test]
     fn test_parse_sysvars() {
@@ -249,6 +251,7 @@ mod test {
         let fee_calculator = FeeCalculator {
             lamports_per_signature: 10,
         };
+        #[allow(deprecated)]
         let recent_blockhashes: RecentBlockhashes = vec![IterItem(0, &hash, &fee_calculator)]
             .into_iter()
             .collect();
@@ -256,6 +259,7 @@ mod test {
         assert_eq!(
             parse_sysvar(
                 &recent_blockhashes_sysvar.data,
+                #[allow(deprecated)]
                 &sysvar::recent_blockhashes::id()
             )
             .unwrap(),

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -1,6 +1,8 @@
 //! @brief Example Rust-based BPF program that tests sysvar use
 
 extern crate solana_program;
+#[allow(deprecated)]
+use solana_program::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_program::{
     account_info::AccountInfo,
     entrypoint,
@@ -10,9 +12,8 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     sysvar::{
-        self, clock::Clock, epoch_schedule::EpochSchedule, fees::Fees, instructions,
-        recent_blockhashes::RecentBlockhashes, rent::Rent, slot_hashes::SlotHashes,
-        slot_history::SlotHistory, stake_history::StakeHistory, Sysvar,
+        self, clock::Clock, epoch_schedule::EpochSchedule, fees::Fees, instructions, rent::Rent,
+        slot_hashes::SlotHashes, slot_history::SlotHistory, stake_history::StakeHistory, Sysvar,
     },
 };
 
@@ -61,6 +62,7 @@ pub fn process_instruction(
     assert_eq!(0, index);
 
     // Recent Blockhashes
+    #[allow(deprecated)]
     {
         msg!("RecentBlockhashes identifier:");
         sysvar::recent_blockhashes::id().log();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -65,6 +65,8 @@ use log::*;
 use rayon::ThreadPool;
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_info};
+#[allow(deprecated)]
+use solana_sdk::recent_blockhashes_account;
 use solana_sdk::{
     account::{
         create_account_shared_data_with_fields as create_account, from_account, Account,
@@ -96,7 +98,6 @@ use solana_sdk::{
     process_instruction::{ComputeMeter, Executor, ProcessInstructionWithContext},
     program_utils::limited_deserialize,
     pubkey::Pubkey,
-    recent_blockhashes_account,
     sanitized_transaction::{SanitizedTransaction, SanitizedTransactionSlice},
     signature::{Keypair, Signature},
     slot_hashes::SlotHashes,
@@ -2157,6 +2158,7 @@ impl Bank {
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
+        #[allow(deprecated)]
         self.update_sysvar_account(&sysvar::recent_blockhashes::id(), |account| {
             let recent_blockhash_iter = locked_blockhash_queue.get_recent_blockhashes();
             recent_blockhashes_account::create_account_with_data_and_fields(
@@ -5292,6 +5294,7 @@ impl Bank {
             sysvar::clock::id(),
             sysvar::epoch_schedule::id(),
             sysvar::fees::id(),
+            #[allow(deprecated)]
             sysvar::recent_blockhashes::id(),
             sysvar::rent::id(),
             sysvar::rewards::id(),
@@ -9737,6 +9740,7 @@ pub(crate) mod tests {
         );
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_recent_blockhashes_sysvar() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
@@ -9756,6 +9760,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_blockhash_queue_sysvar_consistency() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
@@ -11990,6 +11995,7 @@ pub(crate) mod tests {
                             sysvar::clock::id(),
                             sysvar::epoch_schedule::id(),
                             sysvar::fees::id(),
+                            #[allow(deprecated)]
                             sysvar::recent_blockhashes::id(),
                             sysvar::rent::id(),
                             sysvar::slot_hashes::id(),
@@ -12100,6 +12106,7 @@ pub(crate) mod tests {
                             sysvar::clock::id(),
                             sysvar::epoch_schedule::id(),
                             sysvar::fees::id(),
+                            #[allow(deprecated)]
                             sysvar::recent_blockhashes::id(),
                             sysvar::rent::id(),
                             sysvar::rewards::id(),
@@ -13614,12 +13621,9 @@ pub(crate) mod tests {
         bank.add_builtin("mock_program1", program_id, mock_ix_processor);
 
         let blockhash = bank.last_blockhash();
-        let blockhash_sysvar = sysvar::recent_blockhashes::id();
-        let orig_lamports = bank
-            .get_account(&sysvar::recent_blockhashes::id())
-            .unwrap()
-            .lamports();
-        info!("{:?}", bank.get_account(&sysvar::recent_blockhashes::id()));
+        let blockhash_sysvar = sysvar::fees::id();
+        let orig_lamports = bank.get_account(&sysvar::fees::id()).unwrap().lamports();
+        info!("{:?}", bank.get_account(&sysvar::fees::id()));
         let tx = system_transaction::transfer(&mint_keypair, &blockhash_sysvar, 10, blockhash);
         assert_eq!(
             bank.process_transaction(&tx),
@@ -13629,12 +13633,10 @@ pub(crate) mod tests {
             ))
         );
         assert_eq!(
-            bank.get_account(&sysvar::recent_blockhashes::id())
-                .unwrap()
-                .lamports(),
+            bank.get_account(&sysvar::fees::id()).unwrap().lamports(),
             orig_lamports
         );
-        info!("{:?}", bank.get_account(&sysvar::recent_blockhashes::id()));
+        info!("{:?}", bank.get_account(&sysvar::fees::id()));
 
         let accounts = vec![
             AccountMeta::new(mint_keypair.pubkey(), true),

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
-use solana_sdk::{
-    fee_calculator::FeeCalculator, hash::Hash, sysvar::recent_blockhashes, timing::timestamp,
-};
+#[allow(deprecated)]
+use solana_sdk::sysvar::recent_blockhashes;
+use solana_sdk::{fee_calculator::FeeCalculator, hash::Hash, timing::timestamp};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, AbiExample)]
@@ -121,6 +121,11 @@ impl BlockhashQueue {
         None
     }
 
+    #[deprecated(
+        since = "1.8.0",
+        note = "Please do not use, will no longer be available in the future"
+    )]
+    #[allow(deprecated)]
     pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem> {
         (&self.ages)
             .iter()
@@ -135,9 +140,9 @@ impl BlockhashQueue {
 mod tests {
     use super::*;
     use bincode::serialize;
-    use solana_sdk::{
-        clock::MAX_RECENT_BLOCKHASHES, hash::hash, sysvar::recent_blockhashes::IterItem,
-    };
+    #[allow(deprecated)]
+    use solana_sdk::sysvar::recent_blockhashes::IterItem;
+    use solana_sdk::{clock::MAX_RECENT_BLOCKHASHES, hash::hash};
 
     #[test]
     fn test_register_hash() {
@@ -180,6 +185,7 @@ mod tests {
     #[test]
     fn test_get_recent_blockhashes() {
         let mut blockhash_queue = BlockhashQueue::new(MAX_RECENT_BLOCKHASHES);
+        #[allow(deprecated)]
         let recent_blockhashes = blockhash_queue.get_recent_blockhashes();
         // Sanity-check an empty BlockhashQueue
         assert_eq!(recent_blockhashes.count(), 0);
@@ -187,8 +193,10 @@ mod tests {
             let hash = hash(&serialize(&i).unwrap());
             blockhash_queue.register_hash(&hash, &FeeCalculator::default());
         }
+        #[allow(deprecated)]
         let recent_blockhashes = blockhash_queue.get_recent_blockhashes();
         // Verify that the returned hashes are most recent
+        #[allow(deprecated)]
         for IterItem(_slot, hash, _fee_calc) in recent_blockhashes {
             assert_eq!(
                 Some(true),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,4 +1,6 @@
 use log::*;
+#[allow(deprecated)]
+use solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
     account_utils::StateMut,
@@ -12,7 +14,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     system_instruction::{SystemError, SystemInstruction, MAX_PERMITTED_DATA_LENGTH},
     system_program,
-    sysvar::{self, recent_blockhashes::RecentBlockhashes, rent::Rent},
+    sysvar::{self, rent::Rent},
 };
 use std::collections::HashSet;
 
@@ -352,6 +354,7 @@ pub fn process_instruction(
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
             me.advance_nonce_account(
+                #[allow(deprecated)]
                 &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
                     keyed_accounts,
                     1,
@@ -366,6 +369,7 @@ pub fn process_instruction(
             me.withdraw_nonce_account(
                 lamports,
                 to,
+                #[allow(deprecated)]
                 &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
                     keyed_accounts,
                     2,
@@ -379,6 +383,7 @@ pub fn process_instruction(
             let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
             me.initialize_nonce_account(
                 &authorized,
+                #[allow(deprecated)]
                 &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
                     keyed_accounts,
                     1,
@@ -462,6 +467,8 @@ mod tests {
     use super::*;
     use crate::{bank::Bank, bank_client::BankClient};
     use bincode::serialize;
+    #[allow(deprecated)]
+    use solana_sdk::sysvar::recent_blockhashes::IterItem;
     use solana_sdk::{
         account::{self, Account, AccountSharedData},
         client::SyncClient,
@@ -475,7 +482,6 @@ mod tests {
         recent_blockhashes_account,
         signature::{Keypair, Signer},
         system_instruction, system_program, sysvar,
-        sysvar::recent_blockhashes::IterItem,
         transaction::TransactionError,
     };
     use std::cell::RefCell;
@@ -507,6 +513,7 @@ mod tests {
     }
     fn create_default_recent_blockhashes_account() -> RefCell<AccountSharedData> {
         RefCell::new(
+            #[allow(deprecated)]
             recent_blockhashes_account::create_account_with_data_for_test(
                 vec![
                     IterItem(0u64, &Hash::default(), &FeeCalculator::default());
@@ -1456,6 +1463,7 @@ mod tests {
             .accounts
             .iter()
             .map(|meta| {
+                #[allow(deprecated)]
                 RefCell::new(if sysvar::recent_blockhashes::check_id(&meta.pubkey) {
                     create_default_recent_blockhashes_account().into_inner()
                 } else if sysvar::rent::check_id(&meta.pubkey) {
@@ -1524,6 +1532,7 @@ mod tests {
                 vec![
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_account(),
@@ -1543,6 +1552,7 @@ mod tests {
             vec![
                 KeyedAccount::new(&Pubkey::default(), true, &nonce_acc),
                 KeyedAccount::new(
+                    #[allow(deprecated)]
                     &sysvar::recent_blockhashes::id(),
                     false,
                     &create_default_recent_blockhashes_account(),
@@ -1553,6 +1563,7 @@ mod tests {
         )
         .unwrap();
         let new_recent_blockhashes_account = RefCell::new(
+            #[allow(deprecated)]
             solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
                 vec![
                     IterItem(
@@ -1570,6 +1581,7 @@ mod tests {
                 &Pubkey::default(),
                 vec![
                     KeyedAccount::new(&Pubkey::default(), true, &nonce_acc,),
+                    #[allow(deprecated)]
                     KeyedAccount::new(
                         &sysvar::recent_blockhashes::id(),
                         false,
@@ -1632,6 +1644,7 @@ mod tests {
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(&Pubkey::default(), false, &create_default_account()),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_account()
@@ -1656,6 +1669,7 @@ mod tests {
                     ),
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_recent_blockhashes_account(),
@@ -1681,6 +1695,7 @@ mod tests {
                     ),
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_recent_blockhashes_account(),
@@ -1733,6 +1748,7 @@ mod tests {
                         &nonce_account::create_account(1_000_000),
                     ),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_account()
@@ -1756,6 +1772,7 @@ mod tests {
                         &nonce_account::create_account(1_000_000),
                     ),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_recent_blockhashes_account(),
@@ -1780,6 +1797,7 @@ mod tests {
                         &nonce_account::create_account(1_000_000),
                     ),
                     KeyedAccount::new(
+                        #[allow(deprecated)]
                         &sysvar::recent_blockhashes::id(),
                         false,
                         &create_default_recent_blockhashes_account(),
@@ -1800,6 +1818,7 @@ mod tests {
             vec![
                 KeyedAccount::new(&Pubkey::default(), true, &nonce_acc),
                 KeyedAccount::new(
+                    #[allow(deprecated)]
                     &sysvar::recent_blockhashes::id(),
                     false,
                     &create_default_recent_blockhashes_account(),

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -1,10 +1,12 @@
+#[allow(deprecated)]
+use crate::sysvar::recent_blockhashes;
 use crate::{
     decode_error::DecodeError,
     instruction::{AccountMeta, Instruction},
     nonce,
     pubkey::Pubkey,
     system_program,
-    sysvar::{recent_blockhashes, rent},
+    sysvar::rent,
 };
 use num_derive::{FromPrimitive, ToPrimitive};
 use thiserror::Error;
@@ -400,6 +402,7 @@ pub fn create_nonce_account_with_seed(
             &SystemInstruction::InitializeNonceAccount(*authority),
             vec![
                 AccountMeta::new(*nonce_pubkey, false),
+                #[allow(deprecated)]
                 AccountMeta::new_readonly(recent_blockhashes::id(), false),
                 AccountMeta::new_readonly(rent::id(), false),
             ],
@@ -426,6 +429,7 @@ pub fn create_nonce_account(
             &SystemInstruction::InitializeNonceAccount(*authority),
             vec![
                 AccountMeta::new(*nonce_pubkey, false),
+                #[allow(deprecated)]
                 AccountMeta::new_readonly(recent_blockhashes::id(), false),
                 AccountMeta::new_readonly(rent::id(), false),
             ],
@@ -436,6 +440,7 @@ pub fn create_nonce_account(
 pub fn advance_nonce_account(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*nonce_pubkey, false),
+        #[allow(deprecated)]
         AccountMeta::new_readonly(recent_blockhashes::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
@@ -455,6 +460,7 @@ pub fn withdraw_nonce_account(
     let account_metas = vec![
         AccountMeta::new(*nonce_pubkey, false),
         AccountMeta::new(*to_pubkey, false),
+        #[allow(deprecated)]
         AccountMeta::new_readonly(recent_blockhashes::id(), false),
         AccountMeta::new_readonly(rent::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -13,6 +13,7 @@ pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
 
+#[allow(deprecated)]
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     clock::check_id(id)
         || epoch_schedule::check_id(id)

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -1,26 +1,38 @@
+#![allow(deprecated)]
 #![allow(clippy::integer_arithmetic)]
 use crate::{
-    declare_sysvar_id,
+    declare_deprecated_sysvar_id,
     fee_calculator::FeeCalculator,
     hash::{hash, Hash},
     sysvar::Sysvar,
 };
 use std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref};
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
 pub const MAX_ENTRIES: usize = 150;
 
-declare_sysvar_id!(
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
+declare_deprecated_sysvar_id!(
     "SysvarRecentB1ockHashes11111111111111111111",
     RecentBlockhashes
 );
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct Entry {
     pub blockhash: Hash,
     pub fee_calculator: FeeCalculator,
 }
-
 impl Entry {
     pub fn new(blockhash: &Hash, fee_calculator: &FeeCalculator) -> Self {
         Self {
@@ -30,6 +42,10 @@ impl Entry {
     }
 }
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
 #[derive(Clone, Debug)]
 pub struct IterItem<'a>(pub u64, pub &'a Hash, pub &'a FeeCalculator);
 
@@ -57,6 +73,10 @@ impl<'a> PartialOrd for IterItem<'a> {
 ///
 /// The entries are ordered by descending block height, so the first entry holds
 /// the most recent block hash, and the last entry holds an old block hash.
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RecentBlockhashes(Vec<Entry>);

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -13,10 +13,13 @@ use solana_program::{
     nonce::{self, state::Versions, State},
     pubkey::Pubkey,
     system_instruction::NonceError,
-    sysvar::{recent_blockhashes::RecentBlockhashes, rent::Rent},
+    sysvar::rent::Rent,
 };
+#[allow(deprecated)]
+use solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes;
 use std::collections::HashSet;
 
+#[allow(deprecated)]
 pub trait NonceKeyedAccount {
     fn advance_nonce_account(
         &self,
@@ -49,6 +52,7 @@ pub trait NonceKeyedAccount {
 }
 
 impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
+    #[allow(deprecated)]
     fn advance_nonce_account(
         &self,
         recent_blockhashes: &RecentBlockhashes,
@@ -101,6 +105,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         }
     }
 
+    #[allow(deprecated)]
     fn withdraw_nonce_account(
         &self,
         lamports: u64,
@@ -175,6 +180,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         Ok(())
     }
 
+    #[allow(deprecated)]
     fn initialize_nonce_account(
         &self,
         nonce_authority: &Pubkey,
@@ -268,6 +274,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    #[allow(deprecated)]
+    use crate::sysvar::recent_blockhashes::create_test_recent_blockhashes;
     use crate::{
         account::ReadableAccount,
         account_utils::State as AccountUtilsState,
@@ -276,7 +284,6 @@ mod test {
         nonce_account::verify_nonce_account,
         process_instruction::MockInvokeContext,
         system_instruction::NonceError,
-        sysvar::recent_blockhashes::create_test_recent_blockhashes,
     };
     use solana_program::hash::Hash;
 
@@ -304,6 +311,7 @@ mod test {
                 .convert_to_current();
             // New is in Uninitialzed state
             assert_eq!(state, State::Uninitialized);
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = keyed_account.unsigned_key();
             keyed_account
@@ -317,6 +325,7 @@ mod test {
             let state = AccountUtilsState::<Versions>::state(keyed_account)
                 .unwrap()
                 .convert_to_current();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
                 fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
@@ -324,6 +333,7 @@ mod test {
             };
             // First nonce instruction drives state from Uninitialized to Initialized
             assert_eq!(state, State::Initialized(data.clone()));
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(63);
             keyed_account
                 .advance_nonce_account(
@@ -335,6 +345,7 @@ mod test {
             let state = AccountUtilsState::<Versions>::state(keyed_account)
                 .unwrap()
                 .convert_to_current();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
                 fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
@@ -342,6 +353,7 @@ mod test {
             };
             // Second nonce instruction consumes and replaces stored nonce
             assert_eq!(state, State::Initialized(data.clone()));
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             keyed_account
                 .advance_nonce_account(
@@ -353,6 +365,7 @@ mod test {
             let state = AccountUtilsState::<Versions>::state(keyed_account)
                 .unwrap()
                 .convert_to_current();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
                 fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
@@ -361,6 +374,7 @@ mod test {
             // Third nonce instruction for fun and profit
             assert_eq!(state, State::Initialized(data));
             with_test_keyed_account(42, false, |to_keyed| {
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let withdraw_lamports = keyed_account.account.borrow().lamports();
                 let expect_nonce_lamports =
@@ -400,6 +414,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authority = *nonce_account.unsigned_key();
             nonce_account
@@ -415,6 +430,7 @@ mod test {
             let state = AccountUtilsState::<Versions>::state(&nonce_account)
                 .unwrap()
                 .convert_to_current();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
@@ -422,6 +438,7 @@ mod test {
             };
             assert_eq!(state, State::Initialized(data));
             let signers = HashSet::new();
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let result = nonce_account.advance_nonce_account(
                 &recent_blockhashes,
@@ -442,6 +459,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
             let mut signers = HashSet::new();
             signers.insert(*keyed_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = *keyed_account.unsigned_key();
             keyed_account
@@ -472,6 +490,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
             let mut signers = HashSet::new();
             signers.insert(*keyed_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = *keyed_account.unsigned_key();
             keyed_account
@@ -501,6 +520,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
             let mut signers = HashSet::new();
             signers.insert(*keyed_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
@@ -522,6 +542,7 @@ mod test {
             with_test_keyed_account(42, true, |nonce_authority| {
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_account.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = *nonce_authority.unsigned_key();
                 nonce_account
@@ -534,6 +555,7 @@ mod test {
                     .unwrap();
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_authority.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(31);
                 let result = nonce_account.advance_nonce_account(
                     &recent_blockhashes,
@@ -556,6 +578,7 @@ mod test {
             with_test_keyed_account(42, false, |nonce_authority| {
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_account.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let authorized = *nonce_authority.unsigned_key();
                 nonce_account
@@ -591,6 +614,7 @@ mod test {
             with_test_keyed_account(42, false, |to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports();
                 let expect_nonce_lamports =
@@ -637,6 +661,7 @@ mod test {
             assert_eq!(state, State::Uninitialized);
             with_test_keyed_account(42, false, |to_keyed| {
                 let signers = HashSet::new();
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports();
                 let result = nonce_keyed.withdraw_nonce_account(
@@ -667,6 +692,7 @@ mod test {
             with_test_keyed_account(42, false, |to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let lamports = nonce_keyed.account.borrow().lamports() + 1;
                 let result = nonce_keyed.withdraw_nonce_account(
@@ -693,6 +719,7 @@ mod test {
             with_test_keyed_account(42, false, |to_keyed| {
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports() / 2;
                 let nonce_expect_lamports =
@@ -754,6 +781,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
             let mut signers = HashSet::new();
             signers.insert(*nonce_keyed.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authority = *nonce_keyed.unsigned_key();
             nonce_keyed
@@ -767,6 +795,7 @@ mod test {
             let state = AccountUtilsState::<Versions>::state(nonce_keyed)
                 .unwrap()
                 .convert_to_current();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
@@ -791,6 +820,7 @@ mod test {
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
                     .unwrap()
                     .convert_to_current();
+                #[allow(deprecated)]
                 let data = nonce::state::Data {
                     blockhash: recent_blockhashes[0].blockhash,
                     fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
@@ -802,6 +832,7 @@ mod test {
                     nonce_expect_lamports
                 );
                 assert_eq!(to_keyed.account.borrow().lamports(), to_expect_lamports);
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(0);
                 let withdraw_lamports = nonce_keyed.account.borrow().lamports();
                 let nonce_expect_lamports =
@@ -838,6 +869,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = *nonce_keyed.unsigned_key();
             nonce_keyed
@@ -873,6 +905,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = *nonce_keyed.unsigned_key();
             nonce_keyed
@@ -884,6 +917,7 @@ mod test {
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
@@ -909,6 +943,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = *nonce_keyed.unsigned_key();
             nonce_keyed
@@ -920,6 +955,7 @@ mod test {
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
@@ -945,6 +981,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_keyed| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(95);
             let authorized = *nonce_keyed.unsigned_key();
             nonce_keyed
@@ -956,6 +993,7 @@ mod test {
                 )
                 .unwrap();
             with_test_keyed_account(55, false, |to_keyed| {
+                #[allow(deprecated)]
                 let recent_blockhashes = create_test_recent_blockhashes(63);
                 let mut signers = HashSet::new();
                 signers.insert(*nonce_keyed.signer_key().unwrap());
@@ -987,6 +1025,7 @@ mod test {
             assert_eq!(state, State::Uninitialized);
             let mut signers = HashSet::new();
             signers.insert(*keyed_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authority = *keyed_account.unsigned_key();
             let result = keyed_account.initialize_nonce_account(
@@ -995,6 +1034,7 @@ mod test {
                 &rent,
                 &MockInvokeContext::new(vec![]),
             );
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
@@ -1038,6 +1078,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |keyed_account| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = *keyed_account.unsigned_key();
             keyed_account
@@ -1048,6 +1089,7 @@ mod test {
                     &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let result = keyed_account.initialize_nonce_account(
                 &authorized,
@@ -1067,6 +1109,7 @@ mod test {
         };
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports - 42, true, |keyed_account| {
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(63);
             let authorized = *keyed_account.unsigned_key();
             let result = keyed_account.initialize_nonce_account(
@@ -1089,6 +1132,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let mut signers = HashSet::new();
             signers.insert(*nonce_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = *nonce_account.unsigned_key();
             nonce_account
@@ -1100,6 +1144,7 @@ mod test {
                 )
                 .unwrap();
             let authority = Pubkey::default();
+            #[allow(deprecated)]
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
@@ -1147,6 +1192,7 @@ mod test {
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let mut signers = HashSet::new();
             signers.insert(*nonce_account.signer_key().unwrap());
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(31);
             let authorized = &Pubkey::default().clone();
             nonce_account
@@ -1174,6 +1220,7 @@ mod test {
             let state: State = nonce_account.state().unwrap();
             // New is in Uninitialzed state
             assert_eq!(state, State::Uninitialized);
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key();
             nonce_account
@@ -1186,6 +1233,7 @@ mod test {
                 .unwrap();
             assert!(verify_nonce_account(
                 &nonce_account.account.borrow(),
+                #[allow(deprecated)]
                 &recent_blockhashes[0].blockhash,
             ));
         });
@@ -1209,6 +1257,7 @@ mod test {
             let state: State = nonce_account.state().unwrap();
             // New is in Uninitialzed state
             assert_eq!(state, State::Uninitialized);
+            #[allow(deprecated)]
             let recent_blockhashes = create_test_recent_blockhashes(0);
             let authorized = nonce_account.unsigned_key();
             nonce_account
@@ -1221,6 +1270,7 @@ mod test {
                 .unwrap();
             assert!(!verify_nonce_account(
                 &nonce_account.account.borrow(),
+                #[allow(deprecated)]
                 &recent_blockhashes[1].blockhash,
             ));
         });

--- a/sdk/src/recent_blockhashes_account.rs
+++ b/sdk/src/recent_blockhashes_account.rs
@@ -3,11 +3,17 @@ use crate::account::{
     InheritableAccountFields, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
 };
 use crate::clock::INITIAL_RENT_EPOCH;
+#[allow(deprecated)]
 use solana_program::sysvar::recent_blockhashes::{
     IntoIterSorted, IterItem, RecentBlockhashes, MAX_ENTRIES,
 };
 use std::{collections::BinaryHeap, iter::FromIterator};
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
+#[allow(deprecated)]
 pub fn update_account<'a, I>(
     account: &mut AccountSharedData,
     recent_blockhash_iter: I,
@@ -16,8 +22,11 @@ where
     I: IntoIterator<Item = IterItem<'a>>,
 {
     let sorted = BinaryHeap::from_iter(recent_blockhash_iter);
+    #[allow(deprecated)]
     let sorted_iter = IntoIterSorted::new(sorted);
+    #[allow(deprecated)]
     let recent_blockhash_iter = sorted_iter.take(MAX_ENTRIES);
+    #[allow(deprecated)]
     let recent_blockhashes: RecentBlockhashes = recent_blockhash_iter.collect();
     to_account(&recent_blockhashes, account)
 }
@@ -26,13 +35,20 @@ where
     since = "1.5.17",
     note = "Please use `create_account_with_data_for_test` instead"
 )]
+#[allow(deprecated)]
 pub fn create_account_with_data<'a, I>(lamports: u64, recent_blockhash_iter: I) -> AccountSharedData
 where
     I: IntoIterator<Item = IterItem<'a>>,
 {
+    #[allow(deprecated)]
     create_account_with_data_and_fields(recent_blockhash_iter, (lamports, INITIAL_RENT_EPOCH))
 }
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
+#[allow(deprecated)]
 pub fn create_account_with_data_and_fields<'a, I>(
     recent_blockhash_iter: I,
     fields: InheritableAccountFields,
@@ -48,6 +64,11 @@ where
     account
 }
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
+#[allow(deprecated)]
 pub fn create_account_with_data_for_test<'a, I>(recent_blockhash_iter: I) -> AccountSharedData
 where
     I: IntoIterator<Item = IterItem<'a>>,
@@ -57,6 +78,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(deprecated)]
     use super::*;
     use crate::account::from_account;
     use rand::{seq::SliceRandom, thread_rng};


### PR DESCRIPTION
#### Problem

`SysvarRecentBlockhashes` exposes the fee structure internals and thus locks the Solana blockchain down to the current fee structure.

#### Summary of Changes

This sysvar is mostly used by Nonce accounts (only as far as I can tell) and Nonce accounts don't even need it since they could get the information from `InvokeContext`.  Deprecate the sysvar so no new developers start to use it.

Next step is to switch nonce handling over to getting the blockhash/fee calculator from InvokeContext and then hopefully drop fee_calculator altogether and just use the fee calculator available at the time the transaction is submitted for processing.

Fixes #18817
