### PR TITLE
passes through --allow-private-addr to validators in system perf tests

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -217,7 +217,7 @@ fn process_spy_results(
     }
 }
 
-fn process_spy(matches: &ArgMatches) -> std::io::Result<()> {
+fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std::io::Result<()> {
     let num_nodes_exactly = matches
         .value_of("num_nodes_exactly")
         .map(|num| num.to_string().parse().unwrap());
@@ -231,7 +231,6 @@ fn process_spy(matches: &ArgMatches) -> std::io::Result<()> {
     let pubkey = matches
         .value_of("node_pubkey")
         .map(|pubkey_str| pubkey_str.parse::<Pubkey>().unwrap());
-    let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
     let shred_version = value_t_or_exit!(matches, "shred_version", u16);
     let identity_keypair = keypair_of(matches, "identity");
 
@@ -276,13 +275,15 @@ fn parse_entrypoint(matches: &ArgMatches) -> Option<SocketAddr> {
     })
 }
 
-fn process_rpc_url(matches: &ArgMatches) -> std::io::Result<()> {
+fn process_rpc_url(
+    matches: &ArgMatches,
+    socket_addr_space: SocketAddrSpace,
+) -> std::io::Result<()> {
     let any = matches.is_present("any");
     let all = matches.is_present("all");
     let entrypoint_addr = parse_entrypoint(matches);
     let timeout = value_t_or_exit!(matches, "timeout", u64);
     let shred_version = value_t_or_exit!(matches, "shred_version", u16);
-    let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
     let (_all_peers, validators) = discover(
         None, // keypair
         entrypoint_addr.as_ref(),
@@ -326,13 +327,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup_with_default("solana=info");
 
     let matches = parse_matches();
-
+    let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
     match matches.subcommand() {
         ("spy", Some(matches)) => {
-            process_spy(matches)?;
+            process_spy(matches, socket_addr_space)?;
         }
         ("rpc-url", Some(matches)) => {
-            process_rpc_url(matches)?;
+            process_rpc_url(matches, socket_addr_space)?;
         }
         _ => unreachable!(),
     }

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -78,6 +78,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --no-snapshot-fetch ]]; then
       args+=("$1")
       shift
+    elif [[ $1 == --allow-private-addr ]]; then
+      args+=("$1")
+      shift
     else
       echo "Unknown argument: $1"
       $program --help

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -18,6 +18,7 @@ vote_account=
 no_restart=0
 gossip_entrypoint=
 ledger_dir=
+maybe_allow_private_addr=
 
 usage() {
   if [[ -n $1 ]]; then
@@ -155,6 +156,10 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --expected-bank-hash ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --allow-private-addr ]]; then
+      args+=("$1")
+      maybe_allow_private_addr=$1
+      shift
     elif [[ $1 = -h ]]; then
       usage "$@"
     else
@@ -294,7 +299,8 @@ setup_validator_accounts() {
   return 0
 }
 
-rpc_url=$($solana_gossip rpc-url --timeout 180 --entrypoint "$gossip_entrypoint")
+# shellcheck disable=SC2086 # Don't want to double quote "$maybe_allow_private_addr"
+rpc_url=$($solana_gossip $maybe_allow_private_addr rpc-url --timeout 180 --entrypoint "$gossip_entrypoint")
 
 [[ -r "$identity" ]] || $solana_keygen new --no-passphrase -so "$identity"
 [[ -r "$vote_account" ]] || $solana_keygen new --no-passphrase -so "$vote_account"

--- a/net/net.sh
+++ b/net/net.sh
@@ -307,7 +307,7 @@ startBootstrapLeader() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -378,7 +378,7 @@ startNode() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -775,6 +775,7 @@ maybeLimitLedgerSize=""
 maybeSkipLedgerVerify=""
 maybeDisableAirdrops=""
 maybeWaitForSupermajority=""
+maybeAllowPrivateAddr=""
 debugBuild=false
 doBuild=true
 gpuMode=auto
@@ -899,6 +900,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --extra-primordial-stakes ]]; then
       extraPrimordialStakes=$2
       shift 2
+    elif [[ $1 = --allow-private-addr ]]; then
+      maybeAllowPrivateAddr="$1"
+      shift 1
     else
       usage "Unknown long option: $1"
     fi

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -97,7 +97,7 @@ echo "--- $sanityTargetIp: node count ($numSanityNodes expected)"
     nodeArg="num-nodes-exactly"
   fi
 
-  $solana_gossip spy --entrypoint "$sanityTargetIp:8001" \
+  $solana_gossip --allow-private-addr spy --entrypoint "$sanityTargetIp:8001" \
     --$nodeArg "$numSanityNodes" --timeout 60 \
 )
 

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -15,5 +15,6 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
+      ALLOW_PRIVATE_ADDR: "true"
     agents:
       - "queue=gce-deploy"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -131,6 +131,11 @@ function launch_testnet() {
     maybeAsyncNodeInit="--async-node-init"
   fi
 
+  declare maybeAllowPrivateAddr
+  if [[ "$ALLOW_PRIVATE_ADDR" = "true" ]]; then
+    maybeAllowPrivateAddr="--allow-private-addr"
+  fi
+
   declare maybeExtraPrimordialStakes
   if [[ -n "$EXTRA_PRIMORDIAL_STAKES" ]]; then
     maybeExtraPrimordialStakes="--extra-primordial-stakes $EXTRA_PRIMORDIAL_STAKES"
@@ -140,7 +145,8 @@ function launch_testnet() {
   # shellcheck disable=SC2086
   "${REPO_ROOT}"/net/net.sh start $version_args \
     -c idle=$NUMBER_OF_CLIENT_NODES $maybeStartAllowBootFailures \
-    --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit $maybeExtraPrimordialStakes
+    --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit \
+    $maybeExtraPrimordialStakes $maybeAllowPrivateAddr
 
   if [[ -n "$WAIT_FOR_EQUAL_STAKE" ]]; then
     wait_for_equal_stake


### PR DESCRIPTION
#### Problem
`system-performance-tests` has been broken since https://github.com/solana-labs/solana/pull/18728

#### Summary of Changes
This commit passes through `--allow-private-addr` which was added in https://github.com/solana-labs/solana/pull/18850 down to validators in system perf tests.

Successful run of the buildkite job:
https://buildkite.com/solana-labs/system-performance-tests/builds/5129
