### PR TITLE
filters crds values in parallel when responding to gossip pull-requests

### DIFF
--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -240,11 +240,18 @@ impl CrdsGossip {
 
     pub fn generate_pull_responses(
         &self,
+        thread_pool: &ThreadPool,
         filters: &[(CrdsValue, CrdsFilter)],
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
     ) -> Vec<Vec<CrdsValue>> {
-        CrdsGossipPull::generate_pull_responses(&self.crds, filters, output_size_limit, now)
+        CrdsGossipPull::generate_pull_responses(
+            thread_pool,
+            &self.crds,
+            filters,
+            output_size_limit,
+            now,
+        )
     }
 
     pub fn filter_pull_responses(

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -58,27 +58,27 @@ impl GossipService {
             1,
             false,
         );
-        let (response_sender, response_receiver) = channel();
         let (consume_sender, listen_receiver) = channel();
+        // https://github.com/rust-lang/rust/issues/39364#issuecomment-634545136
+        let _consume_sender = consume_sender.clone();
         let t_socket_consume = cluster_info.clone().start_socket_consume_thread(
             request_receiver,
             consume_sender,
             exit.clone(),
         );
-        let t_listen = ClusterInfo::listen(
-            cluster_info.clone(),
+        let (response_sender, response_receiver) = channel();
+        let t_listen = cluster_info.clone().listen(
             bank_forks.clone(),
             listen_receiver,
             response_sender.clone(),
             should_check_duplicate_instance,
-            exit,
+            exit.clone(),
         );
-        let t_gossip = ClusterInfo::gossip(
-            cluster_info.clone(),
+        let t_gossip = cluster_info.clone().gossip(
             bank_forks,
             response_sender,
             gossip_validators,
-            exit,
+            exit.clone(),
         );
         // To work around:
         // https://github.com/rust-lang/rust/issues/54267

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -505,7 +505,7 @@ fn network_run_pull(
                 .collect()
         };
         let transfered: Vec<_> = requests
-            .into_par_iter()
+            .into_iter()
             .map(|(to, filters, caller_info)| {
                 let mut bytes: usize = 0;
                 let mut msgs: usize = 0;
@@ -527,8 +527,9 @@ fn network_run_pull(
                         let rsp = node
                             .gossip
                             .generate_pull_responses(
+                                thread_pool,
                                 &filters,
-                                /*output_size_limit=*/ usize::MAX,
+                                usize::MAX, // output_size_limit
                                 now,
                             )
                             .into_iter()


### PR DESCRIPTION
#### Problem
When responding to gossip pull-requests, `filter_crds_values` takes a lot of time while holding onto read-lock:
https://github.com/solana-labs/solana/blob/f51d64868/gossip/src/crds_gossip_pull.rs#L509-L566

#### Summary of Changes
* filter crds values in parallel.
