### PR TITLE
Plumb channel for updates from ReplayStage to AncestorHashesService

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -1,7 +1,7 @@
 //! The `repair_service` module implements the tools necessary to generate a thread which
 //! regularly finds missing shreds in the ledger and sends repair requests for those shreds
 use crate::{
-    ancestor_hashes_service::AncestorHashesService,
+    ancestor_hashes_service::{AncestorHashesReplayUpdateReceiver, AncestorHashesService},
     cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_slots::ClusterSlots,
     duplicate_repair_status::DuplicateSlotRepairStatus,
@@ -155,6 +155,7 @@ impl RepairService {
         repair_info: RepairInfo,
         verified_vote_receiver: VerifiedVoteReceiver,
         outstanding_requests: Arc<RwLock<OutstandingShredRepairs>>,
+        ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
     ) -> Self {
         let t_repair = {
             let blockstore = blockstore.clone();
@@ -181,6 +182,7 @@ impl RepairService {
             blockstore,
             ancestor_hashes_request_socket,
             repair_info,
+            ancestor_hashes_replay_update_receiver,
         );
 
         RepairService {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1,6 +1,7 @@
 //! The `replay_stage` replays transactions broadcast by the leader.
 
 use crate::{
+    ancestor_hashes_service::AncestorHashesReplayUpdateSender,
     broadcast_stage::RetransmitSlotsSender,
     cache_block_meta_service::CacheBlockMetaSender,
     cluster_info_vote_listener::{
@@ -126,6 +127,7 @@ pub struct ReplayStageConfig {
     pub cache_block_meta_sender: Option<CacheBlockMetaSender>,
     pub bank_notification_sender: Option<BankNotificationSender>,
     pub wait_for_vote_to_start_leader: bool,
+    pub ancestor_hashes_replay_update_sender: AncestorHashesReplayUpdateSender,
 }
 
 #[derive(Default)]
@@ -333,6 +335,7 @@ impl ReplayStage {
             cache_block_meta_sender,
             bank_notification_sender,
             wait_for_vote_to_start_leader,
+            ancestor_hashes_replay_update_sender,
         } = config;
 
         trace!("replay stage");
@@ -417,7 +420,8 @@ impl ReplayStage {
                         &mut latest_validator_votes_for_frozen_banks,
                         &cluster_slots_update_sender,
                         &cost_update_sender,
-                        &mut duplicate_slots_to_repair
+                        &mut duplicate_slots_to_repair,
+                        &ancestor_hashes_replay_update_sender,
                     );
                     replay_active_banks_time.stop();
 
@@ -433,7 +437,8 @@ impl ReplayStage {
                         &bank_forks,
                         &mut progress,
                         &mut heaviest_subtree_fork_choice,
-                        &mut duplicate_slots_to_repair
+                        &mut duplicate_slots_to_repair,
+                        &ancestor_hashes_replay_update_sender,
                     );
                     process_gossip_duplicate_confirmed_slots_time.stop();
 
@@ -463,7 +468,8 @@ impl ReplayStage {
                             &bank_forks,
                             &mut progress,
                             &mut heaviest_subtree_fork_choice,
-                            &mut duplicate_slots_to_repair
+                            &mut duplicate_slots_to_repair,
+                            &ancestor_hashes_replay_update_sender,
                         );
                     }
                     process_duplicate_slots_time.stop();
@@ -505,7 +511,7 @@ impl ReplayStage {
                             &bank_forks,
                         );
 
-                        Self::mark_slots_confirmed(&confirmed_forks, &blockstore, &bank_forks, &mut progress, &mut duplicate_slots_tracker, &mut heaviest_subtree_fork_choice,  &mut duplicate_slots_to_repair);
+                        Self::mark_slots_confirmed(&confirmed_forks, &blockstore, &bank_forks, &mut progress, &mut duplicate_slots_tracker, &mut heaviest_subtree_fork_choice,  &mut duplicate_slots_to_repair, &ancestor_hashes_replay_update_sender);
                     }
                     compute_slot_stats_time.stop();
 
@@ -1075,6 +1081,7 @@ impl ReplayStage {
         progress: &mut ProgressMap,
         fork_choice: &mut HeaviestSubtreeForkChoice,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
     ) {
         let root = bank_forks.read().unwrap().root();
         for new_confirmed_slots in gossip_duplicate_confirmed_slots_receiver.try_iter() {
@@ -1101,6 +1108,7 @@ impl ReplayStage {
                     duplicate_slots_tracker,
                     fork_choice,
                     duplicate_slots_to_repair,
+                    ancestor_hashes_replay_update_sender,
                     SlotStateUpdate::DuplicateConfirmed(duplicate_confirmed_state),
                 );
             }
@@ -1136,6 +1144,7 @@ impl ReplayStage {
         progress: &mut ProgressMap,
         fork_choice: &mut HeaviestSubtreeForkChoice,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
     ) {
         let new_duplicate_slots: Vec<Slot> = duplicate_slots_receiver.try_iter().collect();
         let (root_slot, bank_hashes) = {
@@ -1165,6 +1174,7 @@ impl ReplayStage {
                 duplicate_slots_tracker,
                 fork_choice,
                 duplicate_slots_to_repair,
+                ancestor_hashes_replay_update_sender,
                 SlotStateUpdate::Duplicate(duplicate_state),
             );
         }
@@ -1413,6 +1423,7 @@ impl ReplayStage {
         progress: &mut ProgressMap,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
     ) {
         // Do not remove from progress map when marking dead! Needed by
         // `process_gossip_duplicate_confirmed_slots()`
@@ -1460,6 +1471,7 @@ impl ReplayStage {
             duplicate_slots_tracker,
             heaviest_subtree_fork_choice,
             duplicate_slots_to_repair,
+            ancestor_hashes_replay_update_sender,
             SlotStateUpdate::Dead(dead_state),
         );
     }
@@ -1859,6 +1871,7 @@ impl ReplayStage {
         cluster_slots_update_sender: &ClusterSlotsUpdateSender,
         cost_update_sender: &Sender<ExecuteTimings>,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
     ) -> bool {
         let mut did_complete_bank = false;
         let mut tx_count = 0;
@@ -1926,6 +1939,7 @@ impl ReplayStage {
                             progress,
                             heaviest_subtree_fork_choice,
                             duplicate_slots_to_repair,
+                            ancestor_hashes_replay_update_sender,
                         );
                         // If the bank was corrupted, don't try to run the below logic to check if the
                         // bank is completed
@@ -1974,6 +1988,7 @@ impl ReplayStage {
                     duplicate_slots_tracker,
                     heaviest_subtree_fork_choice,
                     duplicate_slots_to_repair,
+                    ancestor_hashes_replay_update_sender,
                     SlotStateUpdate::BankFrozen(bank_frozen_state),
                 );
                 if let Some(sender) = bank_notification_sender {
@@ -2490,6 +2505,7 @@ impl ReplayStage {
         duplicate_slots_tracker: &mut DuplicateSlotsTracker,
         fork_choice: &mut HeaviestSubtreeForkChoice,
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        ancestor_hashes_replay_update_sender: &AncestorHashesReplayUpdateSender,
     ) {
         let root_slot = bank_forks.read().unwrap().root();
         for (slot, frozen_hash) in confirmed_forks.iter() {
@@ -2515,6 +2531,7 @@ impl ReplayStage {
                     duplicate_slots_tracker,
                     fork_choice,
                     duplicate_slots_to_repair,
+                    ancestor_hashes_replay_update_sender,
                     SlotStateUpdate::DuplicateConfirmed(duplicate_confirmed_state),
                 );
             }
@@ -3393,6 +3410,8 @@ pub mod tests {
                 block_commitment_cache,
                 OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             ));
+            let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
+                unbounded();
             if let Err(err) = &res {
                 ReplayStage::mark_dead_slot(
                     &blockstore,
@@ -3405,6 +3424,7 @@ pub mod tests {
                     &mut progress,
                     &mut heaviest_subtree_fork_choice,
                     &mut DuplicateSlotsToRepair::default(),
+                    &ancestor_hashes_replay_update_sender,
                 );
             }
 
@@ -4842,6 +4862,8 @@ pub mod tests {
             || progress.is_dead(4).unwrap_or(false),
             || Some(bank4_hash),
         );
+        let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
+            unbounded();
         check_slot_agrees_with_cluster(
             4,
             bank_forks.read().unwrap().root(),
@@ -4849,6 +4871,7 @@ pub mod tests {
             &mut duplicate_slots_tracker,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             &mut DuplicateSlotsToRepair::default(),
+            &ancestor_hashes_replay_update_sender,
             SlotStateUpdate::Duplicate(duplicate_state),
         );
 
@@ -4880,6 +4903,7 @@ pub mod tests {
             &mut duplicate_slots_tracker,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             &mut DuplicateSlotsToRepair::default(),
+            &ancestor_hashes_replay_update_sender,
             SlotStateUpdate::Duplicate(duplicate_state),
         );
 
@@ -4912,6 +4936,7 @@ pub mod tests {
             &mut duplicate_slots_tracker,
             &mut vote_simulator.heaviest_subtree_fork_choice,
             &mut duplicate_slots_to_repair,
+            &ancestor_hashes_replay_update_sender,
             SlotStateUpdate::DuplicateConfirmed(duplicate_confirmed_state),
         );
         // The confirmed hash is detected in `progress`, which means
@@ -5048,6 +5073,8 @@ pub mod tests {
             || progress.is_dead(2).unwrap_or(false),
             || Some(our_bank2_hash),
         );
+        let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
+            unbounded();
         check_slot_agrees_with_cluster(
             2,
             bank_forks.read().unwrap().root(),
@@ -5055,6 +5082,7 @@ pub mod tests {
             &mut duplicate_slots_tracker,
             heaviest_subtree_fork_choice,
             &mut duplicate_slots_to_repair,
+            &ancestor_hashes_replay_update_sender,
             SlotStateUpdate::DuplicateConfirmed(duplicate_confirmed_state),
         );
         assert!(duplicate_slots_to_repair.contains(&(2, duplicate_confirmed_bank2_hash)));

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::rc_buffer)]
 
 use crate::{
+    ancestor_hashes_service::AncestorHashesReplayUpdateReceiver,
     cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_nodes::ClusterNodes,
     cluster_slots::ClusterSlots,
@@ -545,6 +546,7 @@ impl RetransmitStage {
         max_slots: &Arc<MaxSlots>,
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         duplicate_slots_sender: Sender<Slot>,
+        ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 
@@ -603,6 +605,7 @@ impl RetransmitStage {
             verified_vote_receiver,
             completed_data_sets_sender,
             duplicate_slots_sender,
+            ancestor_hashes_replay_update_receiver,
         );
 
         Self {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -169,6 +169,8 @@ impl Tvu {
         let max_compaction_jitter = tvu_config.rocksdb_max_compaction_jitter;
         let (duplicate_slots_sender, duplicate_slots_receiver) = unbounded();
         let (cluster_slots_update_sender, cluster_slots_update_receiver) = unbounded();
+        let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
+            unbounded();
         let retransmit_stage = RetransmitStage::new(
             bank_forks.clone(),
             leader_schedule_cache,
@@ -190,6 +192,7 @@ impl Tvu {
             max_slots,
             Some(rpc_subscriptions.clone()),
             duplicate_slots_sender,
+            ancestor_hashes_replay_update_receiver,
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();
@@ -273,6 +276,7 @@ impl Tvu {
             cache_block_meta_sender,
             bank_notification_sender,
             wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
+            ancestor_hashes_replay_update_sender,
         };
 
         let (voting_sender, voting_receiver) = channel();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -2,6 +2,7 @@
 //!   blockstore and retransmitting where required
 //!
 use crate::{
+    ancestor_hashes_service::AncestorHashesReplayUpdateReceiver,
     cluster_info_vote_listener::VerifiedVoteReceiver,
     completed_data_sets_service::CompletedDataSetsSender,
     outstanding_requests::OutstandingRequests,
@@ -341,6 +342,7 @@ impl WindowService {
         verified_vote_receiver: VerifiedVoteReceiver,
         completed_data_sets_sender: CompletedDataSetsSender,
         duplicate_slots_sender: DuplicateSlotSender,
+        ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
     ) -> WindowService
     where
         F: 'static
@@ -362,6 +364,7 @@ impl WindowService {
             repair_info,
             verified_vote_receiver,
             outstanding_requests.clone(),
+            ancestor_hashes_replay_update_receiver,
         );
 
         let (insert_sender, insert_receiver) = unbounded();


### PR DESCRIPTION
#### Problem
AncestorHashesService needs to know about dead slots and dead + duplicate confirmed slots to initiate ancestor repairs

#### Summary of Changes
Plumb channel notification through ReplayStage state machine

Fixes #
