### PR TITLE
panic if we should not shrink a slot store

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2190,15 +2190,7 @@ impl AccountsDb {
 
         // This shouldn't happen if alive_bytes/approx_stored_count are accurate
         if Self::should_not_shrink(aligned_total, original_bytes, num_stores) {
-            self.shrink_stats
-                .skipped_shrink
-                .fetch_add(1, Ordering::Relaxed);
-            for pubkey in unrefed_pubkeys {
-                if let Some(locked_entry) = self.accounts_index.get_account_read_entry(pubkey) {
-                    locked_entry.addref();
-                }
-            }
-            return 0;
+            panic!("skipped shrink: alive_bytes/approx_stored_count is not accurate");
         }
 
         let total_starting_accounts = stored_accounts.len();


### PR DESCRIPTION
#### Problem
[we have not hit this metric in the last 30 days on mnb.](https://metrics.solana.com:8888/sources/23/chronograf/data-explorer?query=SELECT%20mean%28%22skipped_shrink%22%29%20AS%20%22mean_skipped_shrink%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22shrink_stats%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29)
this is the only external call to addref on the account index. Eliminating this call simplifies the interface and testing burden of account index changes.
#### Summary of Changes

Fixes #
