### PR TITLE
Add macros for deprecacted ids

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -62,6 +62,8 @@ pub mod vote {
     }
 }
 
+/// Same as `declare_id` except report that this id has been deprecated
+pub use solana_sdk_macro::program_declare_deprecated_id as declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it
 ///
 /// Input: a single literal base58 string representation of a program's id

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -51,6 +51,34 @@ macro_rules! declare_sysvar_id(
     )
 );
 
+#[macro_export]
+macro_rules! declare_deprecated_sysvar_id(
+    ($name:expr, $type:ty) => (
+        $crate::declare_deprecated_id!($name);
+
+        impl $crate::sysvar::SysvarId for $type {
+            fn id() -> $crate::pubkey::Pubkey {
+                #[allow(deprecated)]
+                id()
+            }
+
+            fn check_id(pubkey: &$crate::pubkey::Pubkey) -> bool {
+                #[allow(deprecated)]
+                check_id(pubkey)
+            }
+        }
+
+        #[cfg(test)]
+        #[test]
+        fn test_sysvar_id() {
+            #[allow(deprecated)]
+            if !$crate::sysvar::is_sysvar_id(&id()) {
+                panic!("sysvar::is_sysvar_id() doesn't know about {}", $name);
+            }
+        }
+    )
+);
+
 // Owner pubkey for sysvar accounts
 crate::declare_id!("Sysvar1111111111111111111111111111111111111");
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -50,6 +50,8 @@ pub mod timing;
 pub mod transaction;
 pub mod transport;
 
+/// Same as `declare_id` except report that this id has been deprecated
+pub use solana_sdk_macro::declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it
 ///
 /// Input: a single literal base58 string representation of a program's id


### PR DESCRIPTION
#### Problem

Static pubkey based Ids may be deprecated but there is no compile-time mechanism to alert developers that they have been.

#### Summary of Changes

Add macros that will continue to define the ids but warn developers if they try and use them

Fixes #
