### PR TITLE
Actively manage dead slots in AncestorHashesService

### DIFF
--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -59,7 +59,7 @@ fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
     let num_banks = 500;
     let forks = tr(0);
     let mut vote_simulator = VoteSimulator::new(2);
-    vote_simulator.fill_bank_forks(forks, &HashMap::new());
+    vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
     vote_simulator.create_and_vote_new_branch(
         0,
         num_banks,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1469,7 +1469,7 @@ pub mod test {
         let mut cluster_votes = HashMap::new();
         let votes = vec![0, 1, 2, 3, 4, 5];
         cluster_votes.insert(node_pubkey, votes.clone());
-        vote_simulator.fill_bank_forks(forks, &cluster_votes);
+        vote_simulator.fill_bank_forks(forks, &cluster_votes, true);
 
         // Simulate the votes
         for vote in votes {
@@ -1526,7 +1526,7 @@ pub mod test {
                         / tr(112))));
 
         // Fill the BankForks according to the above fork structure
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         for (_, fork_progress) in vote_simulator.progress.iter_mut() {
             fork_progress.fork_stats.computed = true;
         }
@@ -1947,7 +1947,7 @@ pub mod test {
         let mut cluster_votes: HashMap<Pubkey, Vec<Slot>> = HashMap::new();
         cluster_votes.insert(vote_simulator.node_pubkeys[1], vec![46]);
         cluster_votes.insert(vote_simulator.node_pubkeys[2], vec![47]);
-        vote_simulator.fill_bank_forks(forks, &cluster_votes);
+        vote_simulator.fill_bank_forks(forks, &cluster_votes, true);
 
         // Vote on the first minor fork at slot 14, should succeed
         assert!(vote_simulator
@@ -2023,7 +2023,7 @@ pub mod test {
         // Make the other validator vote fork to pass the threshold checks
         let other_votes = my_votes.clone();
         cluster_votes.insert(vote_simulator.node_pubkeys[1], other_votes);
-        vote_simulator.fill_bank_forks(forks, &cluster_votes);
+        vote_simulator.fill_bank_forks(forks, &cluster_votes, true);
 
         // Simulate the votes.
         for vote in &my_votes {
@@ -2567,7 +2567,7 @@ pub mod test {
                             / (tr(110) / tr(111))))));
 
         // Fill the BankForks according to the above fork structure
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         for (_, fork_progress) in vote_simulator.progress.iter_mut() {
             fork_progress.fork_stats.computed = true;
         }
@@ -2667,7 +2667,7 @@ pub mod test {
         let replayed_root_slot = 44;
 
         // Fill the BankForks according to the above fork structure
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         for (_, fork_progress) in vote_simulator.progress.iter_mut() {
             fork_progress.fork_stats.computed = true;
         }

--- a/core/src/duplicate_repair_status.rs
+++ b/core/src/duplicate_repair_status.rs
@@ -325,6 +325,11 @@ impl DeadSlotAncestorRequestStatus {
     pub fn is_expired(&self) -> bool {
         timestamp() - self.start_ts > RETRY_INTERVAL_SECONDS as u64 * 1000
     }
+
+    #[cfg(test)]
+    pub fn make_expired(&mut self) {
+        self.start_ts = timestamp() - RETRY_INTERVAL_SECONDS as u64 * 1000 - 1;
+    }
 }
 
 #[cfg(test)]

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -1237,7 +1237,7 @@ mod test {
         */
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3)));
         let mut vote_simulator = VoteSimulator::new(1);
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         let bank_forks = vote_simulator.bank_forks;
         let mut frozen_banks: Vec<_> = bank_forks
             .read()

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -343,7 +343,7 @@ mod test {
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3) / (tr(5) / (tr(6)))));
 
         let mut vote_simulator = VoteSimulator::new(1);
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         vote_simulator
     }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -853,7 +853,7 @@ impl ReplayStage {
         (progress, heaviest_subtree_fork_choice)
     }
 
-    fn dump_then_repair_correct_slots(
+    pub fn dump_then_repair_correct_slots(
         duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
         ancestors: &mut HashMap<Slot, HashSet<Slot>>,
         descendants: &mut HashMap<Slot, HashSet<Slot>>,
@@ -2800,8 +2800,8 @@ pub mod tests {
         assert!(ReplayStage::is_partition_detected(&ancestors, 4, 3));
     }
 
-    struct ReplayBlockstoreComponents {
-        blockstore: Arc<Blockstore>,
+    pub struct ReplayBlockstoreComponents {
+        pub blockstore: Arc<Blockstore>,
         validator_node_to_vote_keys: HashMap<Pubkey, Pubkey>,
         my_pubkey: Pubkey,
         cluster_info: ClusterInfo,
@@ -2809,10 +2809,10 @@ pub mod tests {
         poh_recorder: Mutex<PohRecorder>,
         tower: Tower,
         rpc_subscriptions: Arc<RpcSubscriptions>,
-        vote_simulator: VoteSimulator,
+        pub vote_simulator: VoteSimulator,
     }
 
-    fn replay_blockstore_components(
+    pub fn replay_blockstore_components(
         forks: Option<Tree<Slot>>,
         num_validators: usize,
         generate_votes: Option<GenerateVotes>,
@@ -3764,7 +3764,7 @@ pub mod tests {
 
         // Create the tree of banks in a BankForks object
         let forks = tr(0) / (tr(1)) / (tr(2));
-        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
         let mut frozen_banks: Vec<_> = vote_simulator
             .bank_forks
             .read()
@@ -3841,7 +3841,7 @@ pub mod tests {
         let mut cluster_votes = HashMap::new();
         let votes = vec![0, 2];
         cluster_votes.insert(my_node_pubkey, votes.clone());
-        vote_simulator.fill_bank_forks(forks, &cluster_votes);
+        vote_simulator.fill_bank_forks(forks, &cluster_votes, true);
 
         // Fill banks with votes
         for vote in votes {
@@ -4821,7 +4821,7 @@ pub mod tests {
         ]
         .into_iter()
         .collect();
-        vote_simulator.fill_bank_forks(forks, &validator_votes);
+        vote_simulator.fill_bank_forks(forks, &validator_votes, true);
 
         let (bank_forks, mut progress) = (vote_simulator.bank_forks, vote_simulator.progress);
         let ledger_path = get_tmp_ledger_path!();
@@ -5721,7 +5721,7 @@ pub mod tests {
         let cluster_votes = generate_votes
             .map(|generate_votes| generate_votes(pubkeys))
             .unwrap_or_default();
-        vote_simulator.fill_bank_forks(tree.clone(), &cluster_votes);
+        vote_simulator.fill_bank_forks(tree.clone(), &cluster_votes, true);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         blockstore.add_tree(tree, false, true, 2, Hash::default());

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -102,7 +102,7 @@ impl AncestorHashesRepairType {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum AncestorHashesResponseVersion {
     Current(Vec<SlotHash>),
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -284,7 +284,7 @@ impl Blockstore {
         self.db
     }
 
-    pub fn ledger_path(&self) -> &Path {
+    pub fn ledger_path(&self) -> &PathBuf {
         &self.ledger_path
     }
 


### PR DESCRIPTION
#### Problem
AncestorHashesService doesn't currently make ancestor requests

#### Summary of Changes
1. AncestorHashesService listens for dead slots from ReplayStage, added to a dead pool `dead_slot_pool`
2.  DuplicateConfirmed and EpochSlots frozen dead slots will be moved from the `dead_slot_pool` to an eligible repair pool, `repairable_dead_slot_pool`
3. `repairable_dead_slot_pool` slots are removed once an `AncestorHashes` request is made for that slot. The status of the request is tracked in `ancestor_hashes_request_statuses`
4.  On request completion, regardless of result, it is removed from the `ancestor_hashes_request_statuses`.
5. If the request fails, the slot is moved back to the `repairable_dead_slot_pool`, and will be retried later.

Fixes #
#18783