### PR TITLE
Fix link typo in program README

### DIFF
--- a/sdk/program/README.md
+++ b/sdk/program/README.md
@@ -6,7 +6,7 @@
 
 # Solana Program
 
-Use the Solana Program Crate to write on-chain programs in Rust.  If writing client-side applications, use the [Solana SDK Crate](https://crates.io/crates/solana-program) instead.
+Use the Solana Program Crate to write on-chain programs in Rust.  If writing client-side applications, use the [Solana SDK Crate](https://crates.io/crates/solana-sdk) instead.
 
 More information about Solana is available in the [Solana documentation](https://docs.solana.com/).
 


### PR DESCRIPTION

#### Problem
link typo in solana-program README

#### Summary of Changes
linked to https://crates.io/crates/solana-sdk