### PR TITLE
remove avx error on macos

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1470,6 +1470,7 @@ fn report_target_features() {
 // Validator binaries built on a machine with AVX support will generate invalid opcodes
 // when run on machines without AVX causing a non-obvious process abort.  Instead detect
 // the mismatch and error cleanly.
+#[allow(dead_code)]
 #[target_feature(enable = "avx")]
 unsafe fn check_avx() {
     if is_x86_feature_detected!("avx") {


### PR DESCRIPTION
#### Problem

On Macos `check_avx` throws a warning about unused code

#### Summary of Changes

mark to allow dead code

Fixes #
