### PR TITLE
Add cli-output helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,6 +4333,7 @@ dependencies = [
  "Inflector",
  "base64 0.13.0",
  "chrono",
+ "clap 2.33.3",
  "console",
  "humantime",
  "indicatif",

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/solana-cli-output"
 [dependencies]
 base64 = "0.13.0"
 chrono = { version = "0.4.11", features = ["serde"] }
+clap = "2.33.0"
 console = "0.14.1"
 humantime = "2.0.1"
 Inflector = "0.11.4"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -200,18 +200,7 @@ pub fn parse_args<'a>(
     }
 
     let verbose = matches.is_present("verbose");
-    let output_format = matches
-        .value_of("output_format")
-        .map(|value| match value {
-            "json" => OutputFormat::Json,
-            "json-compact" => OutputFormat::JsonCompact,
-            _ => unreachable!(),
-        })
-        .unwrap_or(if verbose {
-            OutputFormat::DisplayVerbose
-        } else {
-            OutputFormat::Display
-        });
+    let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
 
     let (_, commitment) = CliConfig::compute_commitment_config(
         matches.value_of("commitment").unwrap_or(""),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -385,18 +385,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let verbose = matches.is_present("verbose");
-    let output_format = matches
-        .value_of("output_format")
-        .map(|value| match value {
-            "json" => OutputFormat::Json,
-            "json-compact" => OutputFormat::JsonCompact,
-            _ => unreachable!(),
-        })
-        .unwrap_or(if verbose {
-            OutputFormat::DisplayVerbose
-        } else {
-            OutputFormat::Display
-        });
+    let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
 
     let future = match matches.subcommand() {
         ("upload", Some(arg_matches)) => {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2786,6 +2786,7 @@ dependencies = [
  "Inflector",
  "base64 0.13.0",
  "chrono",
+ "clap",
  "console",
  "humantime",
  "indicatif",


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana-program-library/pull/2130 exposed a couple cli-output needs:
- There is no good way to package multiple signer-datas (CliSignOnlyData) for a nice json array (see `spl-token gc`)
- A OutputFormat::from_matches could reduce several sections of copy-pasta

#### Summary of Changes
- Add `solana_cli_output::return_signers_data(..) -> CliSignOnlyData`
- Add `OutputFormat::from_matches(..) -> Self`
