### PR TITLE
Rpc: Fix erroneous default start_slot in getBlocks

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1064,7 +1064,10 @@ impl JsonRpcRequestProcessor {
             .map_err(|_| Error::internal_error())?
             .filter(|&slot| slot <= end_slot && slot <= highest_confirmed_root)
             .collect();
-        let last_element = blocks.last().cloned().unwrap_or_default();
+        let last_element = blocks
+            .last()
+            .cloned()
+            .unwrap_or_else(|| start_slot.saturating_sub(1));
 
         // Maybe add confirmed blocks
         if commitment.is_confirmed() && last_element < end_slot {


### PR DESCRIPTION
#### Problem
`getBlocks` has the same bug that `getBlocksWithLimit` did 🤕 https://github.com/solana-labs/solana/pull/16408/commits/039e4d8437ee255d43a57ae5cdee788480039fa7

#### Summary of Changes
If `getBlocks` doesn't find any finalized blocks in range, use `start_slot` to filter confirmed blocks instead of default

Fixes #18946
