### PR TITLE
Nonce gets blockhash from invoke_context

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3262,6 +3262,18 @@ impl Bank {
                             compute_budget.max_units,
                         )));
 
+                        let (blockhash, fee_calculator) = {
+                            let blockhash_queue = self.blockhash_queue.read().unwrap();
+                            let blockhash = blockhash_queue.last_hash();
+                            (
+                                blockhash,
+                                blockhash_queue
+                                    .get_fee_calculator(&blockhash)
+                                    .cloned()
+                                    .unwrap_or_else(|| self.fee_calculator.clone()),
+                            )
+                        };
+
                         process_result = self.message_processor.process_message(
                             tx.message(),
                             &loader_refcells,
@@ -3276,6 +3288,8 @@ impl Bank {
                             &mut timings.details,
                             self.rc.accounts.clone(),
                             &self.ancestors,
+                            blockhash,
+                            fee_calculator,
                         );
 
                         transaction_log_messages.push(Self::collect_log_messages(log_collector));

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,6 +1,4 @@
 use log::*;
-#[allow(deprecated)]
-use solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
     account_utils::StateMut,
@@ -12,7 +10,7 @@ use solana_sdk::{
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
-    system_instruction::{SystemError, SystemInstruction, MAX_PERMITTED_DATA_LENGTH},
+    system_instruction::{NonceError, SystemError, SystemInstruction, MAX_PERMITTED_DATA_LENGTH},
     system_program,
     sysvar::{self, rent::Rent},
 };
@@ -353,27 +351,30 @@ pub fn process_instruction(
         }
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
-            me.advance_nonce_account(
-                #[allow(deprecated)]
-                &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
-                    keyed_accounts,
-                    1,
-                )?)?,
-                &signers,
-                invoke_context,
-            )
+            #[allow(deprecated)]
+            if from_keyed_account::<solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes>(
+                keyed_account_at_index(keyed_accounts, 1)?,
+            )?
+            .is_empty()
+            {
+                ic_msg!(
+                    invoke_context,
+                    "Advance nonce account: recent blockhash list is empty",
+                );
+                return Err(NonceError::NoRecentBlockhashes.into());
+            }
+            me.advance_nonce_account(&signers, invoke_context)
         }
         SystemInstruction::WithdrawNonceAccount(lamports) => {
             let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
             let to = &mut keyed_account_at_index(keyed_accounts, 1)?;
+            #[allow(deprecated)]
+            let _ = from_keyed_account::<solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes>(
+                keyed_account_at_index(keyed_accounts, 2)?,
+            )?;
             me.withdraw_nonce_account(
                 lamports,
                 to,
-                #[allow(deprecated)]
-                &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
-                    keyed_accounts,
-                    2,
-                )?)?,
                 &from_keyed_account::<Rent>(keyed_account_at_index(keyed_accounts, 3)?)?,
                 &signers,
                 invoke_context,
@@ -381,13 +382,20 @@ pub fn process_instruction(
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
             let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
+            #[allow(deprecated)]
+            if from_keyed_account::<solana_sdk::sysvar::recent_blockhashes::RecentBlockhashes>(
+                keyed_account_at_index(keyed_accounts, 1)?,
+            )?
+            .is_empty()
+            {
+                ic_msg!(
+                    invoke_context,
+                    "Initialize nonce account: recent blockhash list is empty",
+                );
+                return Err(NonceError::NoRecentBlockhashes.into());
+            }
             me.initialize_nonce_account(
                 &authorized,
-                #[allow(deprecated)]
-                &from_keyed_account::<RecentBlockhashes>(keyed_account_at_index(
-                    keyed_accounts,
-                    1,
-                )?)?,
                 &from_keyed_account::<Rent>(keyed_account_at_index(keyed_accounts, 2)?)?,
                 invoke_context,
             )
@@ -1562,33 +1570,30 @@ mod tests {
             &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
         )
         .unwrap();
+        let blockhash = &hash(&serialize(&0).unwrap());
         let new_recent_blockhashes_account = RefCell::new(
             #[allow(deprecated)]
             solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
                 vec![
-                    IterItem(
-                        0u64,
-                        &hash(&serialize(&0).unwrap()),
-                        &FeeCalculator::default()
-                    );
+                    IterItem(0u64, blockhash, &FeeCalculator::default());
                     sysvar::recent_blockhashes::MAX_ENTRIES
                 ]
                 .into_iter(),
             ),
         );
+        let owner = Pubkey::default();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        let mut invoke_context = &mut MockInvokeContext::new(vec![
+            KeyedAccount::new(&owner, true, &nonce_acc),
+            KeyedAccount::new(&blockhash_id, false, &new_recent_blockhashes_account),
+        ]);
+        invoke_context.blockhash = *blockhash;
         assert_eq!(
-            process_instruction(
+            super::process_instruction(
                 &Pubkey::default(),
-                vec![
-                    KeyedAccount::new(&Pubkey::default(), true, &nonce_acc,),
-                    #[allow(deprecated)]
-                    KeyedAccount::new(
-                        &sysvar::recent_blockhashes::id(),
-                        false,
-                        &new_recent_blockhashes_account,
-                    ),
-                ],
                 &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+                invoke_context,
             ),
             Ok(()),
         );

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -14,10 +14,6 @@ use std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref
 )]
 pub const MAX_ENTRIES: usize = 150;
 
-#[deprecated(
-    since = "1.8.0",
-    note = "Please do not use, will no longer be available in the future"
-)]
 declare_deprecated_sysvar_id!(
     "SysvarRecentB1ockHashes11111111111111111111",
     RecentBlockhashes


### PR DESCRIPTION
#### Problem

Nonce instructions depend on the deprecated `SysvarRecentBlockhash` system variable.

#### Summary of Changes

- These changes are intended to have no change in behavior but eliminate the nonce dependency on the recently deprecated blockhashes sysvar.
- It is another step toward removing the nonce's dependency on the current `FeeCalculator` so that the overall fee structure can be evolved.  The latest blockhash and `FeeCalculator` now come from invoke context.
- The external nonce instructions are retained but the sysvar is no longer used to populate the nonce account.  A new set of instructions will be introduced that don't require the sysvar
- sysvar error cases are still retained so that the existing instruction processing behavior is maintained.

Fixes #
