### PR TITLE
Deprecate SysvarFees

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1,6 +1,8 @@
 //! The solana-program-test provides a BanksClient-based test framework BPF programs
 #![allow(clippy::integer_arithmetic)]
 
+#[allow(deprecated)]
+use solana_sdk::sysvar::fees::Fees;
 use {
     async_trait::async_trait,
     chrono_humanize::{Accuracy, HumanTime, Tense},
@@ -34,7 +36,7 @@ use {
         signature::{Keypair, Signer},
         sysvar::{
             clock, epoch_schedule,
-            fees::{self, Fees},
+            fees::{self},
             rent, Sysvar,
         },
     },
@@ -377,6 +379,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         get_sysvar::<EpochSchedule>(&epoch_schedule::id(), var_addr)
     }
 
+    #[allow(deprecated)]
     fn sol_get_fees_sysvar(&self, var_addr: *mut u8) -> u64 {
         get_sysvar::<Fees>(&fees::id(), var_addr)
     }

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -1,17 +1,11 @@
+#[allow(deprecated)]
+use solana_sdk::sysvar::fees::Fees;
 use {
     solana_program_test::{processor, ProgramTest},
     solana_sdk::{
-        account_info::AccountInfo,
-        clock::Clock,
-        entrypoint::ProgramResult,
-        epoch_schedule::EpochSchedule,
-        fee_calculator::FeeCalculator,
-        instruction::Instruction,
-        msg,
-        pubkey::Pubkey,
-        rent::Rent,
-        signature::Signer,
-        sysvar::{fees::Fees, Sysvar},
+        account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
+        epoch_schedule::EpochSchedule, fee_calculator::FeeCalculator, instruction::Instruction,
+        msg, pubkey::Pubkey, rent::Rent, signature::Signer, sysvar::Sysvar,
         transaction::Transaction,
     },
 };
@@ -30,13 +24,16 @@ fn sysvar_getter_process_instruction(
     let epoch_schedule = EpochSchedule::get()?;
     assert_eq!(epoch_schedule, EpochSchedule::default());
 
-    let fees = Fees::get()?;
-    assert_eq!(
-        fees.fee_calculator,
-        FeeCalculator {
-            lamports_per_signature: 5000
-        }
-    );
+    #[allow(deprecated)]
+    {
+        let fees = Fees::get()?;
+        assert_eq!(
+            fees.fee_calculator,
+            FeeCalculator {
+                lamports_per_signature: 5000
+            }
+        );
+    }
 
     let rent = Rent::get()?;
     assert_eq!(rent, Rent::default());

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate solana_program;
 #[allow(deprecated)]
-use solana_program::sysvar::recent_blockhashes::RecentBlockhashes;
+use solana_program::sysvar::{fees::Fees, recent_blockhashes::RecentBlockhashes};
 use solana_program::{
     account_info::AccountInfo,
     entrypoint,
@@ -12,7 +12,7 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     sysvar::{
-        self, clock::Clock, epoch_schedule::EpochSchedule, fees::Fees, instructions, rent::Rent,
+        self, clock::Clock, epoch_schedule::EpochSchedule, instructions, rent::Rent,
         slot_hashes::SlotHashes, slot_history::SlotHistory, stake_history::StakeHistory, Sysvar,
     },
 };
@@ -45,6 +45,7 @@ pub fn process_instruction(
     }
 
     // Fees
+    #[allow(deprecated)]
     {
         msg!("Fees identifier:");
         sysvar::fees::id().log();

--- a/programs/bpf/rust/sysvar/tests/lib.rs
+++ b/programs/bpf/rust/sysvar/tests/lib.rs
@@ -1,13 +1,11 @@
 use solana_bpf_rust_sysvar::process_instruction;
 use solana_program_test::*;
+use solana_sdk::sysvar::{fees, recent_blockhashes};
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::Signer,
-    sysvar::{
-        clock, epoch_schedule, fees, instructions, recent_blockhashes, rent, slot_hashes,
-        slot_history, stake_history,
-    },
+    sysvar::{clock, epoch_schedule, instructions, rent, slot_hashes, slot_history, stake_history},
     transaction::Transaction,
 };
 
@@ -30,8 +28,10 @@ async fn test_sysvars() {
                 AccountMeta::new(Pubkey::new_unique(), false),
                 AccountMeta::new_readonly(clock::id(), false),
                 AccountMeta::new_readonly(epoch_schedule::id(), false),
+                #[allow(deprecated)]
                 AccountMeta::new_readonly(fees::id(), false),
                 AccountMeta::new_readonly(instructions::id(), false),
+                #[allow(deprecated)]
                 AccountMeta::new_readonly(recent_blockhashes::id(), false),
                 AccountMeta::new_readonly(rent::id(), false),
                 AccountMeta::new_readonly(slot_hashes::id(), false),

--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -2,12 +2,8 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    msg,
-    pubkey::Pubkey,
-    sysvar::{clock, fees},
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+    sysvar::clock,
 };
 
 entrypoint!(process_instruction);
@@ -17,9 +13,8 @@ fn process_instruction(
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgradeable program");
-    assert_eq!(accounts.len(), 3);
+    assert_eq!(accounts.len(), 2);
     assert_eq!(accounts[0].key, program_id);
     assert_eq!(*accounts[1].key, clock::id());
-    assert_eq!(*accounts[2].key, fees::id());
     Err(42.into())
 }

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -2,12 +2,8 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    msg,
-    pubkey::Pubkey,
-    sysvar::{clock, fees},
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+    sysvar::clock,
 };
 
 entrypoint!(process_instruction);
@@ -17,9 +13,8 @@ fn process_instruction(
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgraded program");
-    assert_eq!(accounts.len(), 3);
+    assert_eq!(accounts.len(), 2);
     assert_eq!(accounts[0].key, program_id);
     assert_eq!(*accounts[1].key, clock::id());
-    assert_eq!(*accounts[2].key, fees::id());
     Err(43.into())
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -42,7 +42,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{keypair_from_seed, Keypair, Signer},
     system_instruction,
-    sysvar::{clock, fees, rent},
+    sysvar::{clock, rent},
     transaction::{Transaction, TransactionError},
 };
 use solana_transaction_status::{
@@ -1258,11 +1258,8 @@ fn test_program_bpf_call_depth() {
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_ok());
 
-    let instruction = Instruction::new_with_bincode(
-        program_id,
-        &ComputeBudget::default().max_call_depth,
-        vec![],
-    );
+    let instruction =
+        Instruction::new_with_bincode(program_id, &ComputeBudget::default().max_call_depth, vec![]);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_err());
 }
@@ -1701,7 +1698,6 @@ fn test_program_bpf_upgrade() {
         vec![
             AccountMeta::new(program_id.clone(), false),
             AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
         ],
     );
 
@@ -1797,7 +1793,6 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
         vec![
             AccountMeta::new(program_id.clone(), false),
             AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
         ],
     );
 
@@ -1886,7 +1881,6 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
             AccountMeta::new(program_id, false),
             AccountMeta::new(program_id, false),
             AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
         ],
     );
 
@@ -2077,7 +2071,6 @@ fn test_program_bpf_upgrade_via_cpi() {
             AccountMeta::new(program_id, false),
             AccountMeta::new(program_id, false),
             AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
         ],
     );
 
@@ -2182,7 +2175,6 @@ fn test_program_bpf_upgrade_self_via_cpi() {
             AccountMeta::new(noop_program_id, false),
             AccountMeta::new(noop_program_id, false),
             AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
         ],
     );
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -9,6 +9,8 @@ use solana_rbpf::{
     vm::{EbpfVm, SyscallObject, SyscallRegistry},
 };
 use solana_runtime::message_processor::MessageProcessor;
+#[allow(deprecated)]
+use solana_sdk::sysvar::fees::Fees;
 use solana_sdk::{
     account::{Account, AccountSharedData, ReadableAccount},
     account_info::AccountInfo,
@@ -35,7 +37,7 @@ use solana_sdk::{
     secp256k1_recover::{
         Secp256k1RecoverError, SECP256K1_PUBLIC_KEY_LENGTH, SECP256K1_SIGNATURE_LENGTH,
     },
-    sysvar::{self, fees::Fees, Sysvar, SysvarId},
+    sysvar::{self, Sysvar, SysvarId},
 };
 use std::{
     alloc::Layout,
@@ -1114,6 +1116,7 @@ struct SyscallGetFeesSysvar<'a> {
     invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
     loader_id: &'a Pubkey,
 }
+#[allow(deprecated)]
 impl<'a> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a> {
     fn call(
         &mut self,
@@ -3365,6 +3368,7 @@ mod tests {
         }
 
         // Test fees sysvar
+        #[allow(deprecated)]
         {
             let got_fees = Fees::default();
             let got_fees_va = 2048;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1752,6 +1752,7 @@ impl Bank {
         }
     }
 
+    #[allow(deprecated)]
     fn update_fees(&self) {
         self.update_sysvar_account(&sysvar::fees::id(), |account| {
             create_account(
@@ -5286,6 +5287,7 @@ impl Bank {
         for sysvar_id in &[
             sysvar::clock::id(),
             sysvar::epoch_schedule::id(),
+            #[allow(deprecated)]
             sysvar::fees::id(),
             #[allow(deprecated)]
             sysvar::recent_blockhashes::id(),
@@ -5560,6 +5562,8 @@ pub(crate) mod tests {
         status_cache::MAX_CACHE_ENTRIES,
     };
     use crossbeam_channel::{bounded, unbounded};
+    #[allow(deprecated)]
+    use solana_sdk::sysvar::fees::Fees;
     use solana_sdk::{
         account::Account,
         clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
@@ -5580,7 +5584,7 @@ pub(crate) mod tests {
         },
         system_instruction::{self, SystemError},
         system_program,
-        sysvar::{fees::Fees, rewards::Rewards},
+        sysvar::rewards::Rewards,
         timing::duration_as_s,
     };
     use solana_vote_program::{
@@ -9364,6 +9368,7 @@ pub(crate) mod tests {
         assert!(stake_delegations.get(&stake_keypair.pubkey()).is_some());
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_bank_fees_account() {
         let (mut genesis_config, _) = create_genesis_config(500);
@@ -11978,6 +11983,7 @@ pub(crate) mod tests {
                         &[
                             sysvar::clock::id(),
                             sysvar::epoch_schedule::id(),
+                            #[allow(deprecated)]
                             sysvar::fees::id(),
                             #[allow(deprecated)]
                             sysvar::recent_blockhashes::id(),
@@ -12089,6 +12095,7 @@ pub(crate) mod tests {
                         &[
                             sysvar::clock::id(),
                             sysvar::epoch_schedule::id(),
+                            #[allow(deprecated)]
                             sysvar::fees::id(),
                             #[allow(deprecated)]
                             sysvar::recent_blockhashes::id(),
@@ -13605,9 +13612,11 @@ pub(crate) mod tests {
         bank.add_builtin("mock_program1", program_id, mock_ix_processor);
 
         let blockhash = bank.last_blockhash();
-        let blockhash_sysvar = sysvar::fees::id();
-        let orig_lamports = bank.get_account(&sysvar::fees::id()).unwrap().lamports();
-        info!("{:?}", bank.get_account(&sysvar::fees::id()));
+        #[allow(deprecated)]
+        let blockhash_sysvar = sysvar::clock::id();
+        #[allow(deprecated)]
+        let orig_lamports = bank.get_account(&sysvar::clock::id()).unwrap().lamports();
+        info!("{:?}", bank.get_account(&sysvar::clock::id()));
         let tx = system_transaction::transfer(&mint_keypair, &blockhash_sysvar, 10, blockhash);
         assert_eq!(
             bank.process_transaction(&tx),
@@ -13616,11 +13625,13 @@ pub(crate) mod tests {
                 InstructionError::ReadonlyLamportChange
             ))
         );
+        #[allow(deprecated)]
         assert_eq!(
-            bank.get_account(&sysvar::fees::id()).unwrap().lamports(),
+            bank.get_account(&sysvar::clock::id()).unwrap().lamports(),
             orig_lamports
         );
-        info!("{:?}", bank.get_account(&sysvar::fees::id()));
+        #[allow(deprecated)]
+        info!("{:?}", bank.get_account(&sysvar::clock::id()));
 
         let accounts = vec![
             AccountMeta::new(mint_keypair.pubkey(), true),

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -1,11 +1,17 @@
 //! This account contains the current cluster fees
 //!
+#![allow(deprecated)]
+
 use crate::{
     fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
 };
 
-crate::declare_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
+crate::declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
 
+#[deprecated(
+    since = "1.8.0",
+    note = "Please do not use, will no longer be available in the future"
+)]
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct Fees {
@@ -13,6 +19,7 @@ pub struct Fees {
 }
 impl Fees {
     pub fn new(fee_calculator: &FeeCalculator) -> Self {
+        #[allow(deprecated)]
         Self {
             fee_calculator: fee_calculator.clone(),
         }


### PR DESCRIPTION
#### Problem

`SysvarFees` exposes the fee structure internals and thus locks the Solana blockchain down to the current fee structure.

#### Summary of Changes

This sysvar has seen no use on any of the public networks.  Deprecate the sysvar so no new developers start to use it.
