### PR TITLE
Fix unstable retransmit-num_nodes

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -322,7 +322,7 @@ fn retransmit(
         }
     }
     let cluster_nodes = cluster_nodes.read().unwrap();
-    let mut peers_len = 0;
+    let peers_len = cluster_nodes.num_peers();
     epoch_cache_update.stop();
 
     let my_id = cluster_info.id();
@@ -375,7 +375,6 @@ fn retransmit(
             // TODO: Consider forwarding the packet to the root node here.
             retransmit_tree_mismatch += 1;
         }
-        peers_len = peers_len.max(cluster_nodes.num_peers());
         compute_turbine_peers.stop();
         compute_turbine_peers_total += compute_turbine_peers.as_us();
 


### PR DESCRIPTION
#### Problem

`retransmit-num_nodes.count` is unstable/unreliable:

```
[2021-07-28T12:11:51.997693719Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:49.991045092Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:47.990149048Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:45.988192857Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:43.987438296Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:41.986478727Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:39.984660721Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:37.983004979Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:35.980393135Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:33.049061326Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:31.047425502Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:29.002999028Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:26.693358361Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:24.690415423Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=0i
[2021-07-28T12:11:22.689167833Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:20.689148987Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i
[2021-07-28T12:11:18.687420056Z INFO  solana_metrics::metrics] datapoint: retransmit-num_nodes count=2003i

```

That's because when there is no re-transmission action executed inside the loop. it reports `0`, which skews the metrics.

For example, this creates FALSE inverse correlation between repairs subsystem and retranmission stage, which is too confusing (and took my time...).
it turned out the relation is very delicate: as repairs increase, the likelihood of the retransmission loop being no-op for any particular batch (with all repair shreds) increases!

![image](https://user-images.githubusercontent.com/117807/127519210-975ce609-57cf-47ac-ae27-63bd1f116edd.png)


![image](https://user-images.githubusercontent.com/117807/127519290-48e84abd-7e92-4428-a69a-7b4fdaec0d20.png)

this is just illustration, leading enginners into rabbit's hole... lol


#### Summary of Changes

`peers_len` is invariant to the loop. so move it out of the loop while fixing the unstable metrics issue:


![image](https://user-images.githubusercontent.com/117807/127518720-5941a62b-7f05-4763-8594-dd2ed8d84eff.png)
