### PR TITLE
unifies cluster-nodes computation & caching across turbine stages

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -124,7 +124,7 @@ impl BroadcastStageType {
     }
 }
 
-pub type TransmitShreds = (Option<Arc<HashMap<Pubkey, u64>>>, Arc<Vec<Shred>>);
+type TransmitShreds = (Slot, Arc<Vec<Shred>>);
 trait BroadcastRun {
     fn run(
         &mut self,
@@ -339,27 +339,25 @@ impl BroadcastStage {
         }
 
         for (_, bank) in retransmit_slots.iter() {
-            let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
-            let stakes = bank.epoch_staked_nodes(bank_epoch);
-            let stakes = stakes.map(Arc::new);
+            let slot = bank.slot();
             let data_shreds = Arc::new(
                 blockstore
-                    .get_data_shreds_for_slot(bank.slot(), 0)
+                    .get_data_shreds_for_slot(slot, 0)
                     .expect("My own shreds must be reconstructable"),
             );
 
             if !data_shreds.is_empty() {
-                socket_sender.send(((stakes.clone(), data_shreds), None))?;
+                socket_sender.send(((slot, data_shreds), None))?;
             }
 
             let coding_shreds = Arc::new(
                 blockstore
-                    .get_coding_shreds_for_slot(bank.slot(), 0)
+                    .get_coding_shreds_for_slot(slot, 0)
                     .expect("My own shreds must be reconstructable"),
             );
 
             if !coding_shreds.is_empty() {
-                socket_sender.send(((stakes.clone(), coding_shreds), None))?;
+                socket_sender.send(((slot, coding_shreds), None))?;
             }
         }
 
@@ -464,10 +462,9 @@ pub mod test {
     };
 
     #[allow(clippy::implicit_hasher)]
-    pub fn make_transmit_shreds(
+    fn make_transmit_shreds(
         slot: Slot,
         num: u64,
-        stakes: Option<Arc<HashMap<Pubkey, u64>>>,
     ) -> (
         Vec<Shred>,
         Vec<Shred>,
@@ -489,11 +486,11 @@ pub mod test {
             coding_shreds.clone(),
             data_shreds
                 .into_iter()
-                .map(|s| (stakes.clone(), Arc::new(vec![s])))
+                .map(|s| (slot, Arc::new(vec![s])))
                 .collect(),
             coding_shreds
                 .into_iter()
-                .map(|s| (stakes.clone(), Arc::new(vec![s])))
+                .map(|s| (slot, Arc::new(vec![s])))
                 .collect(),
         )
     }
@@ -537,7 +534,7 @@ pub mod test {
         // Make some shreds
         let updated_slot = 0;
         let (all_data_shreds, all_coding_shreds, _, _all_coding_transmit_shreds) =
-            make_transmit_shreds(updated_slot, 10, None);
+            make_transmit_shreds(updated_slot, 10);
         let num_data_shreds = all_data_shreds.len();
         let num_coding_shreds = all_coding_shreds.len();
         assert!(num_data_shreds >= 10);

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -44,6 +44,9 @@ pub(crate) mod broadcast_utils;
 mod fail_entry_verification_broadcast_run;
 mod standard_broadcast_run;
 
+const CLUSTER_NODES_CACHE_NUM_EPOCH_CAP: usize = 8;
+const CLUSTER_NODES_CACHE_TTL: Duration = Duration::from_secs(5);
+
 pub(crate) const NUM_INSERT_THREADS: usize = 2;
 pub(crate) type RetransmitSlotsSender = CrossbeamSender<HashMap<Slot, Arc<Bank>>>;
 pub(crate) type RetransmitSlotsReceiver = CrossbeamReceiver<HashMap<Slot, Arc<Bank>>>;

--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -49,70 +49,6 @@ impl BroadcastDuplicatesRun {
             num_slots_broadcasted: 0,
         }
     }
-
-    fn get_non_partitioned_batches(
-        &self,
-        my_pubkey: &Pubkey,
-        bank: &Bank,
-        data_shreds: Arc<Vec<Shred>>,
-    ) -> TransmitShreds {
-        let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
-        let mut stakes: HashMap<Pubkey, u64> = bank.epoch_staked_nodes(bank_epoch).unwrap();
-        stakes.retain(|pubkey, _stake| pubkey != my_pubkey);
-        (Some(Arc::new(stakes)), data_shreds)
-    }
-
-    fn get_partitioned_batches(
-        &self,
-        my_pubkey: &Pubkey,
-        bank: &Bank,
-        original_shreds: Arc<Vec<Shred>>,
-        partition_shreds: Arc<Vec<Shred>>,
-    ) -> (TransmitShreds, TransmitShreds) {
-        // On the last shred, partition network with duplicate and real shreds
-        let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
-        let mut original_recipients = HashMap::new();
-        let mut partition_recipients = HashMap::new();
-
-        let mut stakes: Vec<(Pubkey, u64)> = bank
-            .epoch_staked_nodes(bank_epoch)
-            .unwrap()
-            .into_iter()
-            .filter(|(pubkey, _)| pubkey != my_pubkey)
-            .collect();
-        stakes.sort_by(|(l_key, l_stake), (r_key, r_stake)| {
-            if r_stake == l_stake {
-                l_key.cmp(r_key)
-            } else {
-                l_stake.cmp(r_stake)
-            }
-        });
-
-        let mut cumulative_stake: u64 = 0;
-        for (pubkey, stake) in stakes.into_iter() {
-            cumulative_stake += stake;
-            if cumulative_stake <= self.config.stake_partition {
-                partition_recipients.insert(pubkey, stake);
-            } else {
-                original_recipients.insert(pubkey, stake);
-            }
-        }
-
-        warn!(
-            "{} sent duplicate slot {} to nodes: {:?}",
-            my_pubkey,
-            bank.slot(),
-            &partition_recipients,
-        );
-
-        let original_recipients = Arc::new(original_recipients);
-        let original_transmit_shreds = (Some(original_recipients), original_shreds);
-
-        let partition_recipients = Arc::new(partition_recipients);
-        let partition_transmit_shreds = (Some(partition_recipients), partition_shreds);
-
-        (original_transmit_shreds, partition_transmit_shreds)
-    }
 }
 
 impl BroadcastRun for BroadcastDuplicatesRun {
@@ -243,8 +179,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         blockstore_sender.send((data_shreds.clone(), None))?;
 
         // 3) Start broadcast step
-        let transmit_shreds =
-            self.get_non_partitioned_batches(&keypair.pubkey(), &bank, data_shreds.clone());
+        let transmit_shreds = (bank.slot(), data_shreds.clone());
         info!(
             "{} Sending good shreds for slot {} to network",
             keypair.pubkey(),
@@ -260,13 +195,15 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             // Store the original shreds that this node replayed
             blockstore_sender.send((original_last_data_shred.clone(), None))?;
 
-            let (original_transmit_shreds, partition_transmit_shreds) = self
-                .get_partitioned_batches(
-                    &keypair.pubkey(),
-                    &bank,
-                    original_last_data_shred,
-                    partition_last_data_shred,
-                );
+            // TODO: Previously, on the last shred, the code here was using
+            // stakes to partition the network with duplicate and real shreds
+            // at self.config.stake_partition of cumulative stake. This is no
+            // longer possible here as stakes are computed elsewhere further
+            // down the stream. Figure out how to replicate old behaviour to
+            // preserve test coverage.
+            // https://github.com/solana-labs/solana/blob/cde146155/core/src/broadcast_stage/broadcast_duplicates_run.rs#L65-L116
+            let original_transmit_shreds = (bank.slot(), original_last_data_shred);
+            let partition_transmit_shreds = (bank.slot(), partition_last_data_shred);
 
             socket_sender.send((original_transmit_shreds, None))?;
             socket_sender.send((partition_transmit_shreds, None))?;
@@ -281,12 +218,13 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         sock: &UdpSocket,
         bank_forks: &Arc<RwLock<BankForks>>,
     ) -> Result<()> {
-        let ((stakes, shreds), _) = receiver.lock().unwrap().recv()?;
+        let ((slot, shreds), _) = receiver.lock().unwrap().recv()?;
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        let epoch = root_bank.get_leader_schedule_epoch(slot);
+        let stakes = root_bank.epoch_staked_nodes(epoch);
         // Broadcast data
-        let cluster_nodes = ClusterNodes::<BroadcastStage>::new(
-            cluster_info,
-            stakes.as_deref().unwrap_or(&HashMap::default()),
-        );
+        let cluster_nodes =
+            ClusterNodes::<BroadcastStage>::new(cluster_info, &stakes.unwrap_or_default());
         broadcast_shreds(
             sock,
             &shreds,

--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -228,9 +228,14 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         bank_forks: &Arc<RwLock<BankForks>>,
     ) -> Result<()> {
         let ((slot, shreds), _) = receiver.lock().unwrap().recv()?;
-        let root_bank = bank_forks.read().unwrap().root_bank();
+        let (root_bank, working_bank) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.working_bank())
+        };
         // Broadcast data
-        let cluster_nodes = self.cluster_nodes_cache.get(slot, &root_bank, cluster_info);
+        let cluster_nodes =
+            self.cluster_nodes_cache
+                .get(slot, &root_bank, &working_bank, cluster_info);
         broadcast_shreds(
             sock,
             &shreds,

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -138,9 +138,14 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         bank_forks: &Arc<RwLock<BankForks>>,
     ) -> Result<()> {
         let ((slot, shreds), _) = receiver.lock().unwrap().recv()?;
-        let root_bank = bank_forks.read().unwrap().root_bank();
+        let (root_bank, working_bank) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.working_bank())
+        };
         // Broadcast data
-        let cluster_nodes = self.cluster_nodes_cache.get(slot, &root_bank, cluster_info);
+        let cluster_nodes =
+            self.cluster_nodes_cache
+                .get(slot, &root_bank, &working_bank, cluster_info);
         broadcast_shreds(
             sock,
             &shreds,

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -347,8 +347,13 @@ impl StandardBroadcastRun {
         trace!("Broadcasting {:?} shreds", shreds.len());
         // Get the list of peers to broadcast to
         let mut get_peers_time = Measure::start("broadcast::get_peers");
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        let cluster_nodes = self.cluster_nodes_cache.get(slot, &root_bank, cluster_info);
+        let (root_bank, working_bank) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.working_bank())
+        };
+        let cluster_nodes =
+            self.cluster_nodes_cache
+                .get(slot, &root_bank, &working_bank, cluster_info);
         get_peers_time.stop();
 
         let mut transmit_stats = TransmitShredsStats::default();

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -5,7 +5,9 @@ use {
         broadcast_utils::{self, ReceiveResults},
         *,
     },
-    crate::{broadcast_stage::broadcast_utils::UnfinishedSlotInfo, cluster_nodes::ClusterNodes},
+    crate::{
+        broadcast_stage::broadcast_utils::UnfinishedSlotInfo, cluster_nodes::ClusterNodesCache,
+    },
     solana_entry::entry::Entry,
     solana_ledger::shred::{
         ProcessShredsStats, Shred, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
@@ -29,12 +31,16 @@ pub struct StandardBroadcastRun {
     shred_version: u16,
     last_datapoint_submit: Arc<AtomicInterval>,
     num_batches: usize,
-    cluster_nodes: Arc<RwLock<ClusterNodes<BroadcastStage>>>,
+    cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
     last_peer_update: Arc<AtomicInterval>,
 }
 
 impl StandardBroadcastRun {
     pub(super) fn new(shred_version: u16) -> Self {
+        let cluster_nodes_cache = Arc::new(ClusterNodesCache::<BroadcastStage>::new(
+            CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
+            CLUSTER_NODES_CACHE_TTL,
+        ));
         Self {
             process_shreds_stats: ProcessShredsStats::default(),
             transmit_shreds_stats: Arc::default(),
@@ -45,7 +51,7 @@ impl StandardBroadcastRun {
             shred_version,
             last_datapoint_submit: Arc::default(),
             num_batches: 0,
-            cluster_nodes: Arc::default(),
+            cluster_nodes_cache,
             last_peer_update: Arc::new(AtomicInterval::default()),
         }
     }
@@ -342,12 +348,8 @@ impl StandardBroadcastRun {
         // Get the list of peers to broadcast to
         let mut get_peers_time = Measure::start("broadcast::get_peers");
         let root_bank = bank_forks.read().unwrap().root_bank();
-        let epoch = root_bank.get_leader_schedule_epoch(slot);
-        let stakes = root_bank.epoch_staked_nodes(epoch);
-        *self.cluster_nodes.write().unwrap() =
-            ClusterNodes::<BroadcastStage>::new(cluster_info, &stakes.unwrap_or_default());
+        let cluster_nodes = self.cluster_nodes_cache.get(slot, &root_bank, cluster_info);
         get_peers_time.stop();
-        let cluster_nodes = self.cluster_nodes.read().unwrap();
 
         let mut transmit_stats = TransmitShredsStats::default();
         // Broadcast the shreds
@@ -363,7 +365,6 @@ impl StandardBroadcastRun {
             bank_forks,
             cluster_info.socket_addr_space(),
         )?;
-        drop(cluster_nodes);
         transmit_time.stop();
 
         transmit_stats.transmit_elapsed = transmit_time.as_us();

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -1,14 +1,26 @@
 use {
     crate::{broadcast_stage::BroadcastStage, retransmit_stage::RetransmitStage},
     itertools::Itertools,
+    lru::LruCache,
     solana_gossip::{
         cluster_info::{compute_retransmit_peers, ClusterInfo},
         contact_info::ContactInfo,
         crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
         weighted_shuffle::{weighted_best, weighted_shuffle},
     },
-    solana_sdk::pubkey::Pubkey,
-    std::{any::TypeId, cmp::Reverse, collections::HashMap, marker::PhantomData},
+    solana_runtime::bank::Bank,
+    solana_sdk::{
+        clock::{Epoch, Slot},
+        pubkey::Pubkey,
+    },
+    std::{
+        any::TypeId,
+        cmp::Reverse,
+        collections::HashMap,
+        marker::PhantomData,
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    },
 };
 
 enum NodeId {
@@ -33,6 +45,12 @@ pub struct ClusterNodes<T> {
     // weights and exclude nodes with no contact-info.
     index: Vec<(/*weight:*/ u64, /*index:*/ usize)>,
     _phantom: PhantomData<T>,
+}
+
+pub struct ClusterNodesCache<T> {
+    #[allow(clippy::type_complexity)]
+    cache: Mutex<LruCache<Epoch, (Instant, Arc<ClusterNodes<T>>)>>,
+    ttl: Duration, // Time to live.
 }
 
 impl Node {
@@ -209,6 +227,77 @@ fn get_nodes(cluster_info: &ClusterInfo, stakes: &HashMap<Pubkey, u64>) -> Vec<N
     // will keep nodes with contact-info.
     .dedup_by(|a, b| a.pubkey() == b.pubkey())
     .collect()
+}
+
+impl<T> ClusterNodesCache<T> {
+    pub fn new(
+        // Capacity of underlying LRU-cache in terms of number of epochs.
+        cap: usize,
+        // A time-to-live eviction policy is enforced to refresh entries in
+        // case gossip contact-infos are updated.
+        ttl: Duration,
+    ) -> Self {
+        Self {
+            cache: Mutex::new(LruCache::new(cap)),
+            ttl,
+        }
+    }
+}
+
+impl ClusterNodesCache<RetransmitStage> {
+    pub fn get(
+        &self,
+        cluster_info: &ClusterInfo,
+        working_bank: &Bank,
+    ) -> Arc<ClusterNodes<RetransmitStage>> {
+        let slot = working_bank.slot();
+        let epoch = working_bank.get_leader_schedule_epoch(slot);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some((asof, nodes)) = cache.get(&epoch) {
+                if asof.elapsed() < self.ttl {
+                    return Arc::clone(nodes);
+                }
+                cache.pop(&epoch);
+            }
+        }
+        let epoch_staked_nodes = working_bank.epoch_staked_nodes(epoch).unwrap_or_default();
+        let nodes = ClusterNodes::<RetransmitStage>::new(cluster_info, &epoch_staked_nodes);
+        let nodes = Arc::new(nodes);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(epoch, (Instant::now(), Arc::clone(&nodes)));
+        }
+        nodes
+    }
+}
+
+impl ClusterNodesCache<BroadcastStage> {
+    pub fn get(
+        &self,
+        shred_slot: Slot,
+        root_bank: &Bank,
+        cluster_info: &ClusterInfo,
+    ) -> Arc<ClusterNodes<BroadcastStage>> {
+        let epoch = root_bank.get_leader_schedule_epoch(shred_slot);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some((asof, nodes)) = cache.get(&epoch) {
+                if asof.elapsed() < self.ttl {
+                    return Arc::clone(nodes);
+                }
+                cache.pop(&epoch);
+            }
+        }
+        let epoch_staked_nodes = root_bank.epoch_staked_nodes(epoch).unwrap_or_default();
+        let nodes = ClusterNodes::<BroadcastStage>::new(cluster_info, &epoch_staked_nodes);
+        let nodes = Arc::new(nodes);
+        {
+            let mut cache = self.cache.lock().unwrap();
+            cache.put(epoch, (Instant::now(), Arc::clone(&nodes)));
+        }
+        nodes
+    }
 }
 
 impl From<ContactInfo> for NodeId {

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -378,7 +378,8 @@ fn retransmit(
 
         let mut compute_turbine_peers = Measure::start("turbine_start");
         let slot_leader = leader_schedule_cache.slot_leader_at(shred_slot, Some(&working_bank));
-        let cluster_nodes = cluster_nodes_cache.get(shred_slot, &root_bank, cluster_info);
+        let cluster_nodes =
+            cluster_nodes_cache.get(shred_slot, &root_bank, &working_bank, cluster_info);
         let (neighbors, children) =
             cluster_nodes.get_retransmit_peers(packet.meta.seed, DATA_PLANE_FANOUT, slot_leader);
         // If the node is on the critical path (i.e. the first node in each
@@ -432,7 +433,8 @@ fn retransmit(
         retransmit_total,
         id,
     );
-    let cluster_nodes = cluster_nodes_cache.get(root_bank.slot(), &root_bank, cluster_info);
+    let cluster_nodes =
+        cluster_nodes_cache.get(root_bank.slot(), &root_bank, &working_bank, cluster_info);
     update_retransmit_stats(
         stats,
         timer_start.as_us(),

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -337,7 +337,6 @@ fn retransmit(
 
     let mut epoch_cache_update = Measure::start("retransmit_epoch_cach_update");
     maybe_reset_shreds_received_cache(shreds_received, hasher_reset_ts);
-    let cluster_nodes = cluster_nodes_cache.get(cluster_info, &working_bank);
     epoch_cache_update.stop();
 
     let my_id = cluster_info.id();
@@ -379,6 +378,7 @@ fn retransmit(
 
         let mut compute_turbine_peers = Measure::start("turbine_start");
         let slot_leader = leader_schedule_cache.slot_leader_at(shred_slot, Some(&working_bank));
+        let cluster_nodes = cluster_nodes_cache.get(shred_slot, &root_bank, cluster_info);
         let (neighbors, children) =
             cluster_nodes.get_retransmit_peers(packet.meta.seed, DATA_PLANE_FANOUT, slot_leader);
         // If the node is on the critical path (i.e. the first node in each
@@ -432,6 +432,7 @@ fn retransmit(
         retransmit_total,
         id,
     );
+    let cluster_nodes = cluster_nodes_cache.get(root_bank.slot(), &root_bank, cluster_info);
     update_retransmit_stats(
         stats,
         timer_start.as_us(),


### PR DESCRIPTION
#### Problem
1. Broadcast-stage is using `epoch_staked_nodes` based on the same slot that shreds belong to:
https://github.com/solana-labs/solana/blob/049fb0417/core/src/broadcast_stage/standard_broadcast_run.rs#L208-L228
https://github.com/solana-labs/solana/blob/0cf52e206/core/src/broadcast_stage.rs#L342-L349

    But retransmit-stage is using bank-epoch of the working-bank:
https://github.com/solana-labs/solana/blob/19bd30262/core/src/retransmit_stage.rs#L272-L289

    So the two are not consistent at epoch boundaries where some nodes may have a working bank (or similarly a root bank) lagging other nodes.

2. Both retransmit and broadcast stages cache _peers sorted by stake_, but they do not update the cache when the epoch (and so epoch staked nodes, and therefore order of peers) changes; The order of peers is crucial in order to consistently shuffle nodes over the propagation tree.
https://github.com/solana-labs/solana/blob/19bd30262/core/src/broadcast_stage/standard_broadcast_run.rs#L332-L344
https://github.com/solana-labs/solana/blob/19bd30262/core/src/retransmit_stage.rs#L272-L309

3. Cache update has a concurrency bug in which the thread which does `compare_and_swap` may be blocked when it tries to obtain the write-lock on cache, while other threads will keep running ahead with the outdated cache (since the atomic timestamp is already updated):
https://github.com/solana-labs/solana/blob/19bd30262/core/src/broadcast_stage/standard_broadcast_run.rs#L332-L344 

#### Summary of Changes
* This commit adds a new `ClusterNodesCache` which caches cluster-nodes for each epoch.
* The cache entries are keyed by epoch, and so if epoch changes cluster-nodes will be recalculated.
* A time-to-live eviction policy is enforced to refresh entries in case gossip contact-infos are updated.
    * Follow up changes will reduce turbine peer computations dependency on gossip propagation of contact-infos.
* Broadcast and retransmit stages will compute stakes (and so cluster nodes) consistently as both stages call into the same implementation.