### PR TITLE
Cleanup loader features

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -31,7 +31,7 @@ use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Clock,
     entrypoint::{HEAP_LENGTH, SUCCESS},
-    feature_set::{add_missing_program_error_mappings, upgradeable_close_instruction},
+    feature_set::add_missing_program_error_mappings,
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
     keyed_account::{from_keyed_account, keyed_account_at_index},
@@ -620,9 +620,6 @@ fn process_loader_upgradeable_instruction(
             ic_logger_msg!(logger, "New authority {:?}", new_authority);
         }
         UpgradeableLoaderInstruction::Close => {
-            if !invoke_context.is_feature_active(&upgradeable_close_instruction::id()) {
-                return Err(InstructionError::InvalidInstructionData);
-            }
             let close_account = keyed_account_at_index(keyed_accounts, 0)?;
             let recipient_account = keyed_account_at_index(keyed_accounts, 1)?;
             let authority = keyed_account_at_index(keyed_accounts, 2)?;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -107,28 +107,8 @@ pub mod require_stake_for_gossip {
     solana_sdk::declare_id!("6oNzd5Z3M2L1xo4Q5hoox7CR2DuW7m1ETLWH5jHJthwa");
 }
 
-pub mod cpi_data_cost {
-    solana_sdk::declare_id!("Hrg5bXePPGiAVWZfDHbvjqytSeyBDPAGAQ7v6N5i4gCX");
-}
-
-pub mod upgradeable_close_instruction {
-    solana_sdk::declare_id!("FsPaByos3gA9bUEhp3EimQpQPCoSvCEigHod496NmABQ");
-}
-
-pub mod sysvar_via_syscall {
-    solana_sdk::declare_id!("7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf");
-}
-
 pub mod enforce_aligned_host_addrs {
     solana_sdk::declare_id!("6Qob9Z4RwGdf599FDVCqsjuKjR8ZFR3oVs2ByRLWBsua");
-}
-
-pub mod update_data_on_realloc {
-    solana_sdk::declare_id!("BkPcYCrwHXBoTsv9vMhiRF9gteZmDj3Uwisz9CDjoMKp");
-}
-
-pub mod keccak256_syscall_enabled {
-    solana_sdk::declare_id!("7Ua8mFtahVfA3WCY9LoXDAJJdvJRJHckvSSr1dD8FTWc");
 }
 
 pub mod stake_program_v4 {
@@ -217,12 +197,7 @@ lazy_static! {
         (check_init_vote_data::id(), "check initialized Vote data"),
         (check_program_owner::id(), "limit programs to operating on accounts owned by itself"),
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
-        (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
-        (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
-        (sysvar_via_syscall::id(), "provide sysvars via syscalls"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
-        (update_data_on_realloc::id(), "Retain updated data values modified after realloc via CPI"),
-        (keccak256_syscall_enabled::id(), "keccak256 syscall"),
         (stake_program_v4::id(), "solana_stake_program v4"),
         (memory_ops_syscalls::id(), "add syscalls for memory operations"),
         (secp256k1_recover_syscall_enabled::id(), "secp256k1_recover syscall"),


### PR DESCRIPTION
#### Problem

Features that have been activated on all public networks are cluttering the code:

```
7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf | active since slot 83376000  | provide sysvars via syscalls
7Ua8mFtahVfA3WCY9LoXDAJJdvJRJHckvSSr1dD8FTWc | active since slot 86832000  | keccak256 syscall
BkPcYCrwHXBoTsv9vMhiRF9gteZmDj3Uwisz9CDjoMKp | active since slot 83376000  | Retain updated data values modified after realloc via CPI
FsPaByos3gA9bUEhp3EimQpQPCoSvCEigHod496NmABQ | active since slot 76032002  | close upgradeable buffer accounts
Hrg5bXePPGiAVWZfDHbvjqytSeyBDPAGAQ7v6N5i4gCX | active since slot 76032002  | charge the compute budget for data passed via CPI
```

#### Summary of Changes

Remove these features from the codebase

Fixes #
