### PR TITLE
Tiny typo fix

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -334,7 +334,7 @@ impl ProgramSubCommands for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("close")
-                        .about("Close an acount and withdraw all lamports")
+                        .about("Close an account and withdraw all lamports")
                         .arg(
                             Arg::with_name("account")
                                 .index(1)


### PR DESCRIPTION
#### Problem
Typo in solana cli subcommand output

#### Summary of Changes
"acount" to "account"
