### PR TITLE
Fix serialization of parameters in RpcClient::get_block_production_with_config

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -5,7 +5,8 @@ use {
         client_error::Result,
         rpc_request::RpcRequest,
         rpc_response::{
-            Response, RpcResponseContext, RpcSimulateTransactionResult, RpcVersionInfo,
+            Response, RpcBlockProduction, RpcBlockProductionRange, RpcResponseContext,
+            RpcSimulateTransactionResult, RpcVersionInfo,
         },
         rpc_sender::RpcSender,
     },
@@ -184,6 +185,19 @@ impl RpcSender for MockSender {
                 json!(RpcVersionInfo {
                     solana_core: version.to_string(),
                     feature_set: Some(version.feature_set),
+                })
+            }
+            "getBlockProduction" => {
+                let map = vec![(PUBKEY.to_string(), (1, 1))].into_iter().collect();
+                json!(Response {
+                    context: RpcResponseContext { slot: 1 },
+                    value: RpcBlockProduction {
+                        by_identity: map,
+                        range: RpcBlockProductionRange {
+                            first_slot: 0,
+                            last_slot: 0,
+                        },
+                    },
                 })
             }
             _ => Value::Null,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -895,7 +895,7 @@ impl RpcClient {
         &self,
         config: RpcBlockProductionConfig,
     ) -> RpcResult<RpcBlockProduction> {
-        self.send(RpcRequest::GetBlockProduction, json!(config))
+        self.send(RpcRequest::GetBlockProduction, json!([config]))
     }
 
     pub fn get_stake_activation(
@@ -2657,5 +2657,24 @@ mod tests {
     fn test_rpc_client_thread() {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
         thread::spawn(move || rpc_client);
+    }
+
+    // Regression test that the get_block_production_with_config
+    // method internally creates the json params array correctly.
+    #[test]
+    fn get_block_production_with_config_no_error() -> ClientResult<()> {
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+
+        let config = RpcBlockProductionConfig {
+            identity: None,
+            range: None,
+            commitment: None,
+        };
+
+        let prod = rpc_client.get_block_production_with_config(config)?.value;
+
+        assert!(!prod.by_identity.is_empty());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
#### Problem

RpcClient::get_block_production_with_config always fails because the RPC params must be an array.

This function is not used anywhere in Solana or the SPL.

#### Summary of Changes

Change the function to provide the correct type for the RPC params.

Add a unit test to capture the fix.

I also have an integration test for this using TestValidator in another patch to be submitted later.