### PR TITLE
allows sendmmsg api taking owned values (as well as references)

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -414,7 +414,7 @@ pub fn broadcast_shreds(
             let seed = shred.seed(Some(self_pubkey), &root_bank);
             let node = cluster_nodes.get_broadcast_peer(seed)?;
             if socket_addr_space.check(&node.tvu) {
-                Some((&shred.payload[..], &node.tvu))
+                Some((&shred.payload, node.tvu))
             } else {
                 None
             }

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -288,7 +288,6 @@ impl RepairService {
                     })
                     .collect()
             };
-            let batch: Vec<(&[u8], &SocketAddr)> = batch.iter().map(|(v, s)| (&v[..], s)).collect();
             build_repairs_batch_elapsed.stop();
 
             let mut batch_send_repairs_elapsed = Measure::start("batch_send_repairs_elapsed");

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1250,13 +1250,13 @@ impl ClusterInfo {
         let dests: Vec<_> = if forwarded {
             peers
                 .iter()
-                .map(|peer| &peer.tvu_forwards)
+                .map(|peer| peer.tvu_forwards)
                 .filter(|addr| ContactInfo::is_valid_address(addr, socket_addr_space))
                 .collect()
         } else {
             peers
                 .iter()
-                .map(|peer| &peer.tvu)
+                .map(|peer| peer.tvu)
                 .filter(|addr| socket_addr_space.check(addr))
                 .collect()
         };


### PR DESCRIPTION

#### Problem
Current signature of api in sendmmsg requires a slice of inner
references:
https://github.com/solana-labs/solana/blob/fe1ee4980/streamer/src/sendmmsg.rs#L130-L152

That forces the call-site to convert owned values to references even
though doing so is redundant and adds an extra level of indirection:
https://github.com/solana-labs/solana/blob/fe1ee4980/core/src/repair_service.rs#L291


#### Summary of Changes
This commit expands the api using AsRef and Borrow traits to allow
calling the method with owned values (as well as references like
before).
