### PR TITLE
Fix master CI stable-bpf, remove unused import

### DIFF
--- a/programs/bpf/rust/sysvar/tests/lib.rs
+++ b/programs/bpf/rust/sysvar/tests/lib.rs
@@ -1,6 +1,6 @@
 use solana_bpf_rust_sysvar::process_instruction;
 use solana_program_test::*;
-use solana_sdk::sysvar::{fees, recent_blockhashes};
+use solana_sdk::sysvar::recent_blockhashes;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,


### PR DESCRIPTION
#### Problem
#18981 broke master CI (unclear to me how that PR passed CI itself...? cc @jackcmay )

#### Summary of Changes
Fix it by removing `unused sysvar::fees` import
