### PR TITLE
add validator option --accounts-db-skip-shrink

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -138,6 +138,7 @@ pub struct ValidatorConfig {
     pub accounts_db_caching_enabled: bool,
     pub warp_slot: Option<Slot>,
     pub accounts_db_test_hash_calculation: bool,
+    pub accounts_db_skip_shrink: bool,
     pub accounts_db_use_index_hash_calculation: bool,
     pub tpu_coalesce_ms: u64,
     pub validator_exit: Arc<RwLock<Exit>>,
@@ -194,6 +195,7 @@ impl Default for ValidatorConfig {
             accounts_db_caching_enabled: false,
             warp_slot: None,
             accounts_db_test_hash_calculation: false,
+            accounts_db_skip_shrink: false,
             accounts_db_use_index_hash_calculation: true,
             tpu_coalesce_ms: DEFAULT_TPU_COALESCE_MS,
             validator_exit: Arc::new(RwLock::new(Exit::default())),
@@ -1131,6 +1133,8 @@ fn new_banks_from_ledger(
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,
         shrink_ratio: config.accounts_shrink_ratio,
+        accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
+        accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         ..blockstore_processor::ProcessOptions::default()
     };
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -184,6 +184,7 @@ mod tests {
             accounts_db::AccountShrinkThreshold::default(),
             check_hash_calculation,
             false,
+            false,
         )
         .unwrap();
 
@@ -838,6 +839,7 @@ mod tests {
             false,
             None,
             accounts_db::AccountShrinkThreshold::default(),
+            false,
             false,
             false,
         )?;

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -143,6 +143,7 @@ fn load_from_snapshot(
         process_options.limit_load_slot_count_from_snapshot,
         process_options.shrink_ratio,
         process_options.accounts_db_test_hash_calculation,
+        process_options.accounts_db_skip_shrink,
         process_options.verify_index,
     )
     .expect("Load from snapshot failed");

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -384,6 +384,7 @@ pub struct ProcessOptions {
     pub limit_load_slot_count_from_snapshot: Option<usize>,
     pub allow_dead_slots: bool,
     pub accounts_db_test_hash_calculation: bool,
+    pub accounts_db_skip_shrink: bool,
     pub verify_index: bool,
     pub shrink_ratio: AccountShrinkThreshold,
 }

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -50,6 +50,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,
         warp_slot: config.warp_slot,
         accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
+        accounts_db_skip_shrink: config.accounts_db_skip_shrink,
         accounts_db_use_index_hash_calculation: config.accounts_db_use_index_hash_calculation,
         tpu_coalesce_ms: config.tpu_coalesce_ms,
         validator_exit: Arc::new(RwLock::new(Exit::default())),

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -126,6 +126,7 @@ fn initialize_from_snapshot(
         process_options.limit_load_slot_count_from_snapshot,
         process_options.shrink_ratio,
         process_options.accounts_db_test_hash_calculation,
+        false,
         process_options.verify_index,
     )
     .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4870,7 +4870,11 @@ impl Bank {
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
-    pub fn verify_snapshot_bank(&self, test_hash_calculation: bool) -> bool {
+    pub fn verify_snapshot_bank(
+        &self,
+        test_hash_calculation: bool,
+        accounts_db_skip_shrink: bool,
+    ) -> bool {
         info!("cleaning..");
         let mut clean_time = Measure::start("clean");
         if self.slot() > 0 {
@@ -4878,9 +4882,9 @@ impl Bank {
         }
         clean_time.stop();
 
-        info!("shrinking..");
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
-        if self.slot() > 0 {
+        if !accounts_db_skip_shrink && self.slot() > 0 {
+            info!("shrinking..");
             self.shrink_all_slots(true);
         }
         shrink_all_slots_time.stop();
@@ -8668,11 +8672,11 @@ pub(crate) mod tests {
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         bank.freeze();
         bank.update_accounts_hash();
-        assert!(bank.verify_snapshot_bank(true));
+        assert!(bank.verify_snapshot_bank(true, false));
 
         // tamper the bank after freeze!
         bank.increment_signature_count(1);
-        assert!(!bank.verify_snapshot_bank(true));
+        assert!(!bank.verify_snapshot_bank(true, false));
     }
 
     // Test that two bank forks with the same accounts should not hash to the same value.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1005,6 +1005,7 @@ pub fn bank_from_snapshot_archives<P>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     test_hash_calculation: bool,
+    accounts_db_skip_shrink: bool,
     verify_index: bool,
 ) -> Result<(Bank, BankFromArchiveTimings)>
 where
@@ -1077,7 +1078,7 @@ where
     info!("{}", measure_rebuild);
 
     let mut measure_verify = Measure::start("verify");
-    if !bank.verify_snapshot_bank(test_hash_calculation)
+    if !bank.verify_snapshot_bank(test_hash_calculation, accounts_db_skip_shrink)
         && limit_load_slot_count_from_snapshot.is_none()
     {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
@@ -2610,6 +2611,7 @@ mod tests {
             AccountShrinkThreshold::default(),
             false,
             false,
+            false,
         )
         .unwrap();
 
@@ -2698,6 +2700,7 @@ mod tests {
             false,
             None,
             AccountShrinkThreshold::default(),
+            false,
             false,
             false,
         )
@@ -2807,6 +2810,7 @@ mod tests {
             false,
             None,
             AccountShrinkThreshold::default(),
+            false,
             false,
             false,
         )

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1816,7 +1816,7 @@ pub fn main() {
             Arg::with_name("accounts_db_skip_shrink")
                 .long("accounts-db-skip-shrink")
                 .help("Enables faster starting of validators by skipping shrink. \
-                      This option if for use during testing."),
+                      This option is for use during testing."),
         )
         .arg(
             Arg::with_name("accounts_db_test_hash_calculation")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1813,6 +1813,12 @@ pub fn main() {
                 .help("Disables accounts caching"),
         )
         .arg(
+            Arg::with_name("accounts_db_skip_shrink")
+                .long("accounts-db-skip-shrink")
+                .help("Enables faster starting of validators by skipping shrink. \
+                      This option if for use during testing."),
+        )
+        .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
                 .help("Enables testing of hash calculation using stores in \
@@ -2379,6 +2385,7 @@ pub fn main() {
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
+        accounts_db_skip_shrink: matches.is_present("accounts_db_skip_shrink"),
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),


### PR DESCRIPTION
#### Problem
When restarting validators with large snapshots, shrink can take hours. This option is useful to more quickly get to other troublesome parts of validator startup while debugging the system.
#### Summary of Changes

Fixes #
