### PR TITLE
bump recommended maps/nofiles

### DIFF
--- a/ci/setup-new-buildkite-agent/setup-buildkite.sh
+++ b/ci/setup-new-buildkite-agent/setup-buildkite.sh
@@ -76,7 +76,7 @@ RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
 TimeoutStopSec=0
 KillMode=process
-LimitNOFILE=700000
+LimitNOFILE=1000000
 
 [Install]
 WantedBy=multi-user.target

--- a/ci/setup-new-buildkite-agent/setup-limits.sh
+++ b/ci/setup-new-buildkite-agent/setup-limits.sh
@@ -8,5 +8,5 @@ source "$HERE"/utils.sh
 ensure_env || exit 1
 
 # Allow more files to be opened by a user
-echo "* - nofile 700000" > /etc/security/limits.d/90-solana-nofiles.conf
+echo "* - nofile 1000000" > /etc/security/limits.d/90-solana-nofiles.conf
 

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -89,7 +89,7 @@ sudo sysctl -p /etc/sysctl.d/20-solana-udp-buffers.conf
 ```bash
 sudo bash -c "cat >/etc/sysctl.d/20-solana-mmaps.conf <<EOF
 # Increase memory mapped files limit
-vm.max_map_count = 700000
+vm.max_map_count = 1000000
 EOF"
 ```
 
@@ -100,14 +100,14 @@ sudo sysctl -p /etc/sysctl.d/20-solana-mmaps.conf
 Add
 
 ```
-LimitNOFILE=700000
+LimitNOFILE=1000000
 ```
 
 to the `[Service]` section of your systemd service file, if you use one,
 otherwise add
 
 ```
-DefaultLimitNOFILE=700000
+DefaultLimitNOFILE=1000000
 ```
 
 to the `[Manager]` section of `/etc/systemd/system.conf`.
@@ -119,7 +119,7 @@ sudo systemctl daemon-reload
 ```bash
 sudo bash -c "cat >/etc/security/limits.d/90-solana-nofiles.conf <<EOF
 # Increase process file descriptor count limit
-* - nofile 700000
+* - nofile 1000000
 EOF"
 ```
 
@@ -349,7 +349,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=sol
-LimitNOFILE=700000
+LimitNOFILE=1000000
 LogRateLimitIntervalSec=0
 Environment="PATH=/bin:/usr/bin:/home/sol/.local/share/solana/install/active_release/bin"
 ExecStart=/home/sol/bin/validator.sh

--- a/sdk/docker-solana/README.md
+++ b/sdk/docker-solana/README.md
@@ -6,12 +6,12 @@ https://hub.docker.com/r/solanalabs/solana/
 ### Usage:
 Run the latest beta image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=700000 solanalabs/solana:beta
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:beta
 ```
 
 Run the latest edge image:
 ```bash
-$ docker run --rm -p 8899:8899 --ulimit nofile=700000 solanalabs/solana:edge
+$ docker run --rm -p 8899:8899 --ulimit nofile=1000000 solanalabs/solana:edge
 ```
 
 Port *8899* is the JSON RPC port, which is used by clients to communicate with the network.

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -93,7 +93,7 @@ fn tune_kernel_udp_buffers_and_vmmap() {
     sysctl_write("net.core.wmem_default", "134217728");
 
     // increase mmap counts for many append_vecs
-    sysctl_write("vm.max_map_count", "700000");
+    sysctl_write("vm.max_map_count", "1000000");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Problem

A recent bug introduced an mmap leak that could quickly consume our recommended nofiles and max_map_count limits at startup.

#### Summary of Changes

The root cause should be resolved by #19041 and #19042, but we'll bump recommendations here out of an abundance of caution
