### PR TITLE
updates cluster-slots with root-bank instead of root-slot + bank-forks

### DIFF
--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -91,7 +91,6 @@ impl ClusterSlotsService {
                     break;
                 }
             };
-            let new_root = bank_forks.read().unwrap().root();
             let mut lowest_slot_elapsed = Measure::start("lowest_slot_elapsed");
             let lowest_slot = blockstore.lowest_slot();
             Self::update_lowest_slot(lowest_slot, &cluster_info);
@@ -105,7 +104,8 @@ impl ClusterSlotsService {
                     &cluster_info,
                 );
             }
-            cluster_slots.update(new_root, &cluster_info, &bank_forks);
+            let root_bank = bank_forks.read().unwrap().root_bank();
+            cluster_slots.update(&root_bank, &cluster_info);
             process_cluster_slots_updates_elapsed.stop();
 
             cluster_slots_service_timing.update(


### PR DESCRIPTION
#### Problem
ClusterSlots::update is taking both root-slot and bank-forks only to
later lookup root-bank from bank-forks, which is redundant. Also
potentially by the time bank-forks is locked to obtain root-bank,
root-slot may have already changed and so be inconsistent with the
root-slot passed in as the argument.
https://github.com/solana-labs/solana/blob/6d95d679c/core/src/cluster_slots.rs#L32-L39
https://github.com/solana-labs/solana/blob/6d95d679c/core/src/cluster_slots.rs#L122

#### Summary of Changes
* update cluster-slots with root-bank instead of root-slot + bank-forks.
* removed unused code.