### PR TITLE
introduce Bank::new_for_tests

### DIFF
--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -344,7 +344,7 @@ pub fn initialize_state(
     );
 
     genesis_config.poh_config.hashes_per_tick = Some(2);
-    let bank0 = Bank::new(&genesis_config);
+    let bank0 = Bank::new_for_tests(&genesis_config);
 
     for pubkey in validator_keypairs_map.keys() {
         bank0.transfer(10_000, &mint_keypair, pubkey).unwrap();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -754,7 +754,7 @@ impl ProgramTest {
         debug!("Payer address: {}", mint_keypair.pubkey());
         debug!("Genesis config: {}", genesis_config);
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         // Add loaders
         macro_rules! add_builtin {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1048,6 +1048,12 @@ impl Default for BlockhashQueue {
 
 impl Bank {
     pub fn new(genesis_config: &GenesisConfig) -> Self {
+        // this will go away in a coming pr where many replacements in test code will get made
+        Self::new_for_tests(genesis_config)
+    }
+
+    pub fn new_for_tests(genesis_config: &GenesisConfig) -> Self {
+        // this will diverge
         Self::new_with_paths(
             genesis_config,
             Vec::new(),

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -22,7 +22,7 @@ pub fn setup_bank_and_vote_pubkeys(num_vote_accounts: usize, stake: u64) -> (Ban
             &validator_voting_keypairs,
             vec![stake; validator_voting_keypairs.len()],
         );
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     (bank, vote_pubkeys)
 }
 


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others. Seems useful to make sure we agree on this example before I do more.
#### Summary of Changes

Fixes #
