### PR TITLE
Bank::new -> Bank::new_for_benches

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -167,7 +167,7 @@ fn main() {
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-    let bank0 = Bank::new(&genesis_config);
+    let bank0 = Bank::new_for_benches(&genesis_config);
     let mut bank_forks = BankForks::new(bank0);
     let mut bank = bank_forks.working_bank();
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -59,7 +59,7 @@ fn check_txs(receiver: &Arc<Receiver<WorkingBankEntry>>, ref_tx_count: usize) {
 #[bench]
 fn bench_consume_buffered(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
-    let bank = Arc::new(Bank::new(&genesis_config));
+    let bank = Arc::new(Bank::new_for_benches(&genesis_config));
     let ledger_path = get_tmp_ledger_path!();
     let my_pubkey = pubkey::new_rand();
     {
@@ -164,10 +164,10 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
 
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_benches(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench
     bank.ns_per_slot = std::u128::MAX;
-    let bank = Arc::new(Bank::new(&genesis_config));
+    let bank = Arc::new(Bank::new_for_benches(&genesis_config));
 
     debug!("threads: {} txs: {}", num_threads, txes);
 
@@ -293,7 +293,7 @@ fn simulate_process_entries(
     initial_lamports: u64,
     num_accounts: usize,
 ) {
-    let bank = Arc::new(Bank::new(genesis_config));
+    let bank = Arc::new(Bank::new_for_benches(genesis_config));
 
     for i in 0..(num_accounts / 2) {
         bank.transfer(initial_lamports, mint_keypair, &keypairs[i * 2].pubkey())

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -42,7 +42,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_benches(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
     const NUM_SHREDS: usize = 32;

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -72,7 +72,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     let cluster_info = Arc::new(cluster_info);
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
-    let bank0 = Bank::new(&genesis_config);
+    let bank0 = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new(bank0);
     let bank = bank_forks.working_bank();
     let bank_forks = Arc::new(RwLock::new(bank_forks));

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -169,7 +169,7 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_benches(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -124,7 +124,7 @@ fn do_bench_transactions(
     let ns_per_s = 1_000_000_000;
     let (mut genesis_config, mint_keypair) = create_genesis_config(100_000_000);
     genesis_config.ticks_per_slot = 100;
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_benches(&genesis_config);
     bank.add_builtin(
         "builtin_program",
         Pubkey::new(&BUILTIN_PROGRAM_ID),
@@ -181,7 +181,7 @@ fn bench_bank_async_process_native_loader_transactions(bencher: &mut Bencher) {
 #[ignore]
 fn bench_bank_update_recent_blockhashes(bencher: &mut Bencher) {
     let (genesis_config, _mint_keypair) = create_genesis_config(100);
-    let mut bank = Arc::new(Bank::new(&genesis_config));
+    let mut bank = Arc::new(Bank::new_for_benches(&genesis_config));
     goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
     let genesis_hash = bank.last_blockhash();
     // Prime blockhash_queue

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1052,6 +1052,11 @@ impl Bank {
         Self::new_for_tests(genesis_config)
     }
 
+    pub fn new_for_benches(genesis_config: &GenesisConfig) -> Self {
+        // this will diverge
+        Self::new_for_tests(genesis_config)
+    }
+
     pub fn new_for_tests(genesis_config: &GenesisConfig) -> Self {
         // this will diverge
         Self::new_with_paths(


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
