### PR TITLE
for all tests, bank::new -> bank::new_for_tests

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -340,7 +340,7 @@ mod tests {
         // `runtime.block_on()` just once, to run all the async code.
 
         let genesis = create_genesis_config(10);
-        let bank = Bank::new(&genesis.genesis_config);
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
         let slot = bank.slot();
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
@@ -371,7 +371,7 @@ mod tests {
         // server-side functionality is available to the client.
 
         let genesis = create_genesis_config(10);
-        let bank = Bank::new(&genesis.genesis_config);
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
         let slot = bank.slot();
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),

--- a/banks-server/src/send_transaction_service.rs
+++ b/banks-server/src/send_transaction_service.rs
@@ -203,7 +203,7 @@ mod test {
     #[test]
     fn process_transactions() {
         let (genesis_config, mint_keypair) = create_genesis_config(4);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let send_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let tpu_address = "127.0.0.1:0".parse().unwrap();

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -934,7 +934,7 @@ mod tests {
     #[test]
     fn test_bench_tps_bank_client() {
         let (genesis_config, id) = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let client = Arc::new(BankClient::new(bank));
 
         let config = Config {
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     fn test_bench_tps_fund_keys() {
         let (genesis_config, id) = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let client = Arc::new(BankClient::new(bank));
         let keypair_count = 20;
         let lamports = 20;
@@ -978,7 +978,7 @@ mod tests {
         let (mut genesis_config, id) = create_genesis_config(10_000);
         let fee_rate_governor = FeeRateGovernor::new(11, 0);
         genesis_config.fee_rate_governor = fee_rate_governor;
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let client = Arc::new(BankClient::new(bank));
         let keypair_count = 20;
         let lamports = 20;

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -532,7 +532,7 @@ pub mod test {
         let (transmit_sender, transmit_receiver) = channel();
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Make some shreds
         let updated_slot = 0;
@@ -608,7 +608,7 @@ pub mod test {
         let exit_sender = Arc::new(AtomicBool::new(false));
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank = bank_forks.read().unwrap().root_bank();
 

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -94,7 +94,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(2);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let tx = system_transaction::transfer(
             &mint_keypair,
             &solana_sdk::pubkey::new_rand(),

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -544,7 +544,7 @@ mod test {
         let mut genesis_config = create_genesis_config(10_000).genesis_config;
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().root_bank();
         (

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1037,7 +1037,7 @@ mod tests {
                 vec![stake_per_validator; validator_voting_keypairs.len()],
             );
 
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         // Votes for slots less than the provided root bank's slot should not be processed
         let bank3 = Arc::new(Bank::new_from_parent(
             &Arc::new(bank0),
@@ -1151,7 +1151,7 @@ mod tests {
                 &validator_voting_keypairs,
                 vec![stake_per_validator; validator_voting_keypairs.len()],
             );
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
 
         let gossip_vote_slots = vec![1, 2];
         let replay_vote_slots = vec![3, 4];
@@ -1286,7 +1286,7 @@ mod tests {
                 &validator_voting_keypairs,
                 vec![stake_per_validator; validator_voting_keypairs.len()],
             );
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
 
         // Send some votes to process
         let (votes_txs_sender, votes_txs_receiver) = unbounded();
@@ -1524,7 +1524,7 @@ mod tests {
                 &validator_keypairs,
                 vec![100; validator_keypairs.len()],
             );
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -1643,7 +1643,7 @@ mod tests {
                 &validator_voting_keypairs,
                 vec![100; validator_voting_keypairs.len()],
             );
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let vote_tracker = VoteTracker::new(&bank);
         let exit = Arc::new(AtomicBool::new(false));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -426,7 +426,7 @@ mod tests {
         );
 
         // Create bank
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
@@ -510,7 +510,7 @@ mod tests {
             vec![100; 1],
         );
 
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank0);
 
         // Fill bank_forks with banks with votes landing in the next slot

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3018,7 +3018,7 @@ pub mod tests {
     #[test]
     fn test_handle_new_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
 
         let root = 3;
@@ -3093,7 +3093,7 @@ pub mod tests {
     #[test]
     fn test_handle_new_root_ahead_of_highest_confirmed_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
         let confirmed_root = 1;
         let fork = 2;
@@ -3461,7 +3461,7 @@ pub mod tests {
         let leader_voting_pubkey = genesis_config_info.voting_keypair.pubkey();
         genesis_config.epoch_schedule.warmup = false;
         genesis_config.ticks_per_slot = 4;
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         for _ in 0..genesis_config.ticks_per_slot {
             bank0.register_tick(&Hash::default());
         }
@@ -3580,7 +3580,7 @@ pub mod tests {
             let keypair2 = Keypair::new();
             let keypair3 = Keypair::new();
 
-            let bank0 = Arc::new(Bank::new(&genesis_config));
+            let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
             bank0
                 .transfer(4, &mint_keypair, &keypair2.pubkey())
                 .unwrap();
@@ -4049,7 +4049,7 @@ pub mod tests {
     fn test_update_slot_propagated_threshold_from_votes2() {
         let mut empty: Vec<Pubkey> = vec![];
         let genesis_config = create_genesis_config(100_000_000).genesis_config;
-        let root_bank = Bank::new(&genesis_config);
+        let root_bank = Bank::new_for_tests(&genesis_config);
         let stake = 10_000;
         // Simulate a child slot seeing threshold (`child_reached_threshold` = true),
         // then the parent should also be marked as having reached threshold,
@@ -4431,7 +4431,7 @@ pub mod tests {
 
         // If the root is now set to `parent_slot`, this filters out `previous_leader_slot` from the progress map,
         // which implies confirmation
-        let bank0 = Bank::new(&genesis_config::create_genesis_config(10000).0);
+        let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
         let parent_slot_bank =
             Bank::new_from_parent(&Arc::new(bank0), &Pubkey::default(), parent_slot);
         let mut bank_forks = BankForks::new(parent_slot_bank);

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -112,8 +112,9 @@ pub mod tests {
     fn test_sigverify_shreds_verify_batch() {
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
-        let bank =
-            Bank::new(&create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config);
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let bf = Arc::new(RwLock::new(BankForks::new(bank)));
         let verifier = ShredSigVerifier::new(bf, cache);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -393,7 +393,7 @@ pub mod tests {
         let starting_balance = 10_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(starting_balance);
 
-        let bank_forks = BankForks::new(Bank::new(&genesis_config));
+        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
 
         //start cluster_info1
         let cluster_info1 = ClusterInfo::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1759,7 +1759,7 @@ mod tests {
         );
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut config = ValidatorConfig::default();
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -698,7 +698,7 @@ mod test {
         let me_id = solana_sdk::pubkey::new_rand();
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
-        let bank = Arc::new(Bank::new(
+        let bank = Arc::new(Bank::new_for_tests(
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
         ));
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -94,7 +94,7 @@ fn test_slot_subscription() {
     );
     let exit = Arc::new(AtomicBool::new(false));
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let optimistically_confirmed_bank =
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -267,7 +267,7 @@ pub fn cluster_info_scale() {
         &vote_keypairs,
         vec![100; vote_keypairs.len()],
     );
-    let bank0 = Bank::new(&genesis_config_info.genesis_config);
+    let bank0 = Bank::new_for_tests(&genesis_config_info.genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
 
     let nodes: Vec<_> = vote_keypairs

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8191,7 +8191,7 @@ pub mod tests {
             shredder.entries_to_shreds(&leader_keypair, &entries, true, 0);
 
         let genesis_config = create_genesis_config(2).genesis_config;
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
         let fixed_schedule = FixedSchedule {
             leader_schedule: Arc::new(LeaderSchedule::new_from_schedule(vec![

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2015,7 +2015,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair = Keypair::new();
         let mut slot_entries =
             create_ticks(genesis_config.ticks_per_slot, 1, genesis_config.hash());
@@ -2238,7 +2238,7 @@ pub mod tests {
     #[test]
     fn test_process_entries_tick() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // ensure bank can process a tick
         assert_eq!(bank.tick_height(), 0);
@@ -2257,7 +2257,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
 
@@ -2294,7 +2294,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
@@ -2357,7 +2357,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
@@ -2444,7 +2444,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
@@ -2541,7 +2541,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
@@ -2587,7 +2587,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1_000_000_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         const NUM_TRANSFERS_PER_ENTRY: usize = 8;
         const NUM_TRANSFERS: usize = NUM_TRANSFERS_PER_ENTRY * 32;
@@ -2654,7 +2654,7 @@ pub mod tests {
             ..
         } = create_genesis_config((num_accounts + 1) as u64 * initial_lamports);
 
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let mut keypairs: Vec<Keypair> = vec![];
 
@@ -2721,7 +2721,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
@@ -2786,7 +2786,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(11_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
@@ -2827,7 +2827,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(11_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let success_tx = system_transaction::transfer(
@@ -2930,7 +2930,7 @@ pub mod tests {
         blockstore.set_roots(vec![3, 5].iter()).unwrap();
 
         // Set up bank1
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let opts = ProcessOptions {
             poh_verify: true,
             accounts_db_test_hash_calculation: true,
@@ -2993,7 +2993,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1_000_000_000);
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         const NUM_TRANSFERS_PER_ENTRY: usize = 8;
         const NUM_TRANSFERS: usize = NUM_TRANSFERS_PER_ENTRY * 32;
@@ -3102,7 +3102,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let genesis_hash = genesis_config.hash();
         let keypair = Keypair::new();
 
@@ -3170,7 +3170,7 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(1_000_000_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let present_account_key = Keypair::new();
         let present_account = AccountSharedData::new(1, 10, &Pubkey::default());
@@ -3228,7 +3228,7 @@ pub mod tests {
             &validator_keypairs,
             vec![100; validator_keypairs.len()],
         );
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.freeze();
 
         let bank1 = Arc::new(Bank::new_from_parent(

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn test_new_cache() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let cache = LeaderScheduleCache::new_from_bank(&bank);
         assert_eq!(bank.slot(), 0);
         assert_eq!(cache.max_schedules(), MAX_SCHEDULES);
@@ -333,7 +333,7 @@ mod tests {
         let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH as u64;
         let epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch / 2, true);
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let cache = Arc::new(LeaderScheduleCache::new(epoch_schedule, &bank));
 
         let num_threads = 10;
@@ -380,7 +380,7 @@ mod tests {
             false,
         );
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
 
         assert_eq!(
@@ -426,7 +426,7 @@ mod tests {
                 .genesis_config;
         genesis_config.epoch_schedule.warmup = false;
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let ledger_path = get_tmp_ledger_path!();
         {
@@ -508,7 +508,7 @@ mod tests {
         } = create_genesis_config(10_000 * bootstrap_validator_stake_lamports());
         genesis_config.epoch_schedule.warmup = false;
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
 
         // Create new vote account
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn test_schedule_for_unconfirmed_epoch() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let cache = LeaderScheduleCache::new_from_bank(&bank);
 
         assert_eq!(*cache.max_epoch.read().unwrap(), 1);
@@ -607,7 +607,7 @@ mod tests {
     #[test]
     fn test_set_max_schedules() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut cache = LeaderScheduleCache::new_from_bank(&bank);
 
         // Max schedules must be greater than 0

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -86,7 +86,7 @@ mod tests {
         let genesis_config =
             create_genesis_config_with_leader(0, &pubkey, bootstrap_validator_stake_lamports())
                 .genesis_config;
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let pubkeys_and_stakes: Vec<_> = bank.staked_nodes().into_iter().collect();
         let seed = [0u8; 32];
@@ -108,7 +108,7 @@ mod tests {
         let genesis_config =
             create_genesis_config_with_leader(42, &pubkey, bootstrap_validator_stake_lamports())
                 .genesis_config;
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(slot_leader_at(bank.slot(), &bank).unwrap(), pubkey);
     }
 

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -163,7 +163,7 @@ pub(crate) mod tests {
             ..
         } = create_genesis_config(10_000 * bootstrap_validator_stake_lamports());
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let vote_account = Keypair::new();
 
         // Give the validator some stake but don't setup a staking account

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -879,7 +879,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -916,7 +916,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -968,7 +968,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1018,7 +1018,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1057,7 +1057,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1100,7 +1100,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1147,7 +1147,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1192,7 +1192,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1322,7 +1322,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
                 Hash::default(),
@@ -1356,7 +1356,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let (sender, receiver) = sync_channel(1);
             let (mut poh_recorder, _entry_receiver, _record_receiver) =
                 PohRecorder::new_with_clear_signal(
@@ -1391,7 +1391,7 @@ mod tests {
                 mut genesis_config, ..
             } = create_genesis_config(2);
             genesis_config.ticks_per_slot = ticks_per_slot;
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
@@ -1441,7 +1441,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
@@ -1505,7 +1505,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1635,7 +1635,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let prev_hash = bank.last_blockhash();
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
@@ -1685,7 +1685,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(2);
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
             let genesis_hash = bank.last_blockhash();
 
             let (mut poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -468,7 +468,7 @@ fn test_program_bpf_sanity() {
             ..
         } = create_genesis_config(50);
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank_client = BankClient::new(bank);
@@ -513,7 +513,7 @@ fn test_program_bpf_loader_deprecated() {
             mint_keypair,
             ..
         } = create_genesis_config(50);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_deprecated_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank_client = BankClient::new(bank);
@@ -553,7 +553,7 @@ fn test_program_bpf_duplicate_accounts() {
             mint_keypair,
             ..
         } = create_genesis_config(50);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank = Arc::new(bank);
@@ -653,7 +653,7 @@ fn test_program_bpf_error_handling() {
             mint_keypair,
             ..
         } = create_genesis_config(50);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank_client = BankClient::new(bank);
@@ -783,7 +783,7 @@ fn test_program_bpf_invoke_sanity() {
             mint_keypair,
             ..
         } = create_genesis_config(50);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank = Arc::new(bank);
@@ -1087,7 +1087,7 @@ fn test_program_bpf_program_id_spoofing() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
@@ -1140,7 +1140,7 @@ fn test_program_bpf_caller_has_access_to_cpi_program() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
@@ -1180,7 +1180,7 @@ fn test_program_bpf_ro_modify() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
@@ -1239,7 +1239,7 @@ fn test_program_bpf_call_depth() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
@@ -1274,7 +1274,7 @@ fn test_program_bpf_compute_budget() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
@@ -1375,7 +1375,7 @@ fn test_program_bpf_instruction_introspection() {
         mint_keypair,
         ..
     } = create_genesis_config(50_000);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
 
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
@@ -1446,7 +1446,7 @@ fn test_program_bpf_test_use_latest_executor() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
@@ -1543,7 +1543,7 @@ fn test_program_bpf_test_use_latest_executor2() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
@@ -1673,7 +1673,7 @@ fn test_program_bpf_upgrade() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
@@ -1767,7 +1767,7 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
@@ -1847,7 +1847,7 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
@@ -1962,7 +1962,7 @@ fn test_program_bpf_disguised_as_bpf_loader() {
             mint_keypair,
             ..
         } = create_genesis_config(50);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_deprecated_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank_client = BankClient::new(bank);
@@ -1994,7 +1994,7 @@ fn test_program_bpf_c_dup() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
 
@@ -2026,7 +2026,7 @@ fn test_program_bpf_upgrade_via_cpi() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
@@ -2140,7 +2140,7 @@ fn test_program_bpf_upgrade_self_via_cpi() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
@@ -2230,7 +2230,7 @@ fn test_program_bpf_set_upgrade_authority_via_cpi() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
@@ -2323,7 +2323,7 @@ fn test_program_upgradeable_locks() {
             mint_keypair,
             ..
         } = create_genesis_config(2_000_000_000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         let (name, id, entrypoint) = solana_bpf_loader_upgradeable_program!();
         bank.add_builtin(&name, id, entrypoint);
         let bank = Arc::new(bank);
@@ -2458,7 +2458,7 @@ fn test_program_bpf_finalize() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
@@ -2520,7 +2520,7 @@ fn test_program_bpf_ro_account_modify() {
         mint_keypair,
         ..
     } = create_genesis_config(50);
-    let mut bank = Bank::new(&genesis_config);
+    let mut bank = Bank::new_for_tests(&genesis_config);
     let (name, id, entrypoint) = solana_bpf_loader_program!();
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1512,7 +1512,7 @@ mod tests {
     #[test]
     fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         bank.feature_set = Arc::new(FeatureSet::all_enabled());
         bank.add_builtin(
             "solana_bpf_loader_upgradeable_program",

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -11,7 +11,7 @@ use solana_sdk::transaction::TransactionError;
 fn test_program_native_failure() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = solana_sdk::pubkey::new_rand();
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     bank.add_native_program("solana_failure_program", &program_id, false);
 
     // Call user program

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -73,7 +73,7 @@ mod tests {
 
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         bank.add_builtin("ownable_program", crate::id(), process_instruction);
         (bank, mint_keypair)
     }

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -205,7 +205,7 @@ mod tests {
     fn test_process_notification() {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4275,7 +4275,7 @@ pub mod tests {
     fn test_rpc_request_processor_new() {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(100);
-        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         bank.transfer(20, &genesis.mint_keypair, &bob_pubkey)
             .unwrap();
         let request_processor =
@@ -4287,7 +4287,7 @@ pub mod tests {
     fn test_rpc_get_balance() {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
-        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let meta = JsonRpcRequestProcessor::new_from_bank(&bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
@@ -4315,7 +4315,7 @@ pub mod tests {
     fn test_rpc_get_balance_via_client() {
         let genesis = create_genesis_config(20);
         let mint_pubkey = genesis.mint_keypair.pubkey();
-        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let meta = JsonRpcRequestProcessor::new_from_bank(&bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
@@ -4446,7 +4446,7 @@ pub mod tests {
     fn test_rpc_get_tx_count() {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(10);
-        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         // Add 4 transactions
         bank.transfer(1, &genesis.mint_keypair, &bob_pubkey)
             .unwrap();
@@ -5760,7 +5760,7 @@ pub mod tests {
     #[test]
     fn test_rpc_send_bad_tx() {
         let genesis = create_genesis_config(100);
-        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let meta = JsonRpcRequestProcessor::new_from_bank(&bank, SocketAddrSpace::Unspecified);
 
         let mut io = MetaIoHandler::default();
@@ -5975,7 +5975,7 @@ pub mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(TEST_SLOTS_PER_EPOCH, TEST_SLOTS_PER_EPOCH, false);
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         (
             Arc::new(RwLock::new(BankForks::new(bank))),
             mint_keypair,
@@ -7477,7 +7477,7 @@ pub mod tests {
             SocketAddrSpace::Unspecified,
         ));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -632,7 +632,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bob = Keypair::new();
         let bob_pubkey = bob.pubkey();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl {
@@ -757,7 +757,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let bob_pubkey = solana_sdk::pubkey::new_rand();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
@@ -807,7 +807,7 @@ mod tests {
         let from = Keypair::new();
         let stake_account = Keypair::new();
         let stake_program_id = stake::program::id();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -918,7 +918,7 @@ mod tests {
         } = create_genesis_config(10_000);
 
         let nonce_account = Keypair::new();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -1005,7 +1005,9 @@ mod tests {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let session = create_session();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(&genesis_config))));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new_for_tests(
+            &genesis_config,
+        ))));
 
         let mut io = PubSubHandler::default();
         let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
@@ -1045,7 +1047,7 @@ mod tests {
             mint_keypair: alice,
             ..
         } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bob = Keypair::new();
@@ -1094,7 +1096,7 @@ mod tests {
             mint_keypair: alice,
             ..
         } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -1172,7 +1174,7 @@ mod tests {
     #[serial]
     fn test_slot_subscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();
@@ -1200,7 +1202,7 @@ mod tests {
     #[serial]
     fn test_slot_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();
@@ -1245,7 +1247,7 @@ mod tests {
             vec![100; validator_voting_keypairs.len()],
         );
         let exit = Arc::new(AtomicBool::new(false));
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         // Setup RPC
@@ -1284,7 +1286,7 @@ mod tests {
     #[serial]
     fn test_vote_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -132,7 +132,7 @@ mod tests {
         let pubsub_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -515,7 +515,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let cluster_info = Arc::new(ClusterInfo::new(
             ContactInfo::default(),
             Arc::new(Keypair::new()),
@@ -572,7 +572,7 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config(10_000);
         genesis_config.cluster_type = ClusterType::MainnetBeta;
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         Arc::new(RwLock::new(BankForks::new(bank)))
     }
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1389,7 +1389,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -1534,7 +1534,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let alice = Keypair::new();
@@ -1627,7 +1627,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let mut bank_forks = BankForks::new(bank);
         let alice = Keypair::new();
@@ -1835,7 +1835,7 @@ pub(crate) mod tests {
         let sub_id = SubscriptionId::Number(0);
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1886,7 +1886,7 @@ pub(crate) mod tests {
         let sub_id = SubscriptionId::Number(0);
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1992,7 +1992,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
@@ -2197,7 +2197,7 @@ pub(crate) mod tests {
     #[test]
     fn test_total_subscriptions() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = RpcSubscriptions::default_with_bank_forks(bank_forks);
 

--- a/rpc/src/send_transaction_service.rs
+++ b/rpc/src/send_transaction_service.rs
@@ -356,7 +356,7 @@ mod test {
         solana_logger::setup();
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let send_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let tpu_address = "127.0.0.1:0".parse().unwrap();
@@ -510,7 +510,7 @@ mod test {
         solana_logger::setup();
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let send_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let tpu_address = "127.0.0.1:0".parse().unwrap();
@@ -803,7 +803,7 @@ mod test {
                 &validator_keypairs,
                 vec![10_000; 3],
             );
-            let bank = Arc::new(Bank::new(&genesis_config));
+            let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
             let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -457,7 +457,7 @@ mod test {
     #[test]
     fn test_accounts_background_service_remove_dead_slots() {
         let genesis = create_genesis_config(10);
-        let bank0 = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis.genesis_config));
         let (pruned_banks_sender, pruned_banks_receiver) = unbounded();
         let request_handler = AbsRequestHandler {
             snapshot_request_handler: None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1047,11 +1047,6 @@ impl Default for BlockhashQueue {
 }
 
 impl Bank {
-    pub fn new(genesis_config: &GenesisConfig) -> Self {
-        // this will go away in a coming pr where many replacements in test code will get made
-        Self::new_for_tests(genesis_config)
-    }
-
     pub fn new_for_benches(genesis_config: &GenesisConfig) -> Self {
         // this will diverge
         Self::new_for_tests(genesis_config)
@@ -5706,7 +5701,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_unix_timestamp_from_genesis() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         assert_eq!(
             genesis_config.creation_time,
@@ -5746,7 +5741,7 @@ pub(crate) mod tests {
             burn_percent: 5,
         };
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), mint_lamports);
         assert_eq!(
             bank.get_balance(&voting_keypair.pubkey()),
@@ -5764,7 +5759,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_block_height() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank0.block_height(), 0);
         let bank1 = Arc::new(new_from_parent(&bank0));
         assert_eq!(bank1.block_height(), 1);
@@ -5787,7 +5782,7 @@ pub(crate) mod tests {
         }
 
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let initial_epochs = bank.epoch_stake_keys();
         assert_eq!(initial_epochs, vec![0, 1]);
@@ -5834,7 +5829,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_bank_capitalization() {
-        let bank0 = Arc::new(Bank::new(&GenesisConfig {
+        let bank0 = Arc::new(Bank::new_for_tests(&GenesisConfig {
             accounts: (0..42)
                 .map(|_| {
                     (
@@ -5879,7 +5874,7 @@ pub(crate) mod tests {
             burn_percent: 10,
         };
 
-        let root_bank = Arc::new(Bank::new(&genesis_config));
+        let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank = Bank::new_from_parent(
             &root_bank,
             &Pubkey::default(),
@@ -5890,7 +5885,7 @@ pub(crate) mod tests {
             ) as u64,
         );
 
-        let root_bank_2 = Arc::new(Bank::new(&genesis_config));
+        let root_bank_2 = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank_with_success_txs = Bank::new_from_parent(
             &root_bank_2,
             &Pubkey::default(),
@@ -6167,7 +6162,7 @@ pub(crate) mod tests {
     #[test]
     fn test_store_account_and_update_capitalization_missing() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = solana_sdk::pubkey::new_rand();
 
         let some_lamports = 400;
@@ -6185,7 +6180,7 @@ pub(crate) mod tests {
     fn test_store_account_and_update_capitalization_increased() {
         let old_lamports = 400;
         let (genesis_config, mint_keypair) = create_genesis_config(old_lamports);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = mint_keypair.pubkey();
 
         let new_lamports = 500;
@@ -6203,7 +6198,7 @@ pub(crate) mod tests {
     fn test_store_account_and_update_capitalization_decreased() {
         let old_lamports = 400;
         let (genesis_config, mint_keypair) = create_genesis_config(old_lamports);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = mint_keypair.pubkey();
 
         let new_lamports = 100;
@@ -6221,7 +6216,7 @@ pub(crate) mod tests {
     fn test_store_account_and_update_capitalization_unchanged() {
         let lamports = 400;
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = mint_keypair.pubkey();
 
         let account = AccountSharedData::new(lamports, 1, &system_program::id());
@@ -6366,7 +6361,7 @@ pub(crate) mod tests {
             burn_percent: 10,
         };
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         // Enable rent collection
         bank.rent_collector.epoch = 5;
         bank.rent_collector.slots_per_year = 192.0;
@@ -6497,7 +6492,7 @@ pub(crate) mod tests {
             create_genesis_config_with_leader(10, &validator_pubkey, VALIDATOR_STAKE)
                 .genesis_config;
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let old_validator_lamports = bank.get_balance(&validator_pubkey);
         bank.distribute_rent_to_validators(bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
         let new_validator_lamports = bank.get_balance(&validator_pubkey);
@@ -6510,7 +6505,7 @@ pub(crate) mod tests {
             .accounts
             .remove(&feature_set::no_overflow_rent_distribution::id())
             .unwrap();
-        let bank = std::panic::AssertUnwindSafe(Bank::new(&genesis_config));
+        let bank = std::panic::AssertUnwindSafe(Bank::new_for_tests(&genesis_config));
         let old_validator_lamports = bank.get_balance(&validator_pubkey);
         let new_validator_lamports = std::panic::catch_unwind(|| {
             bank.distribute_rent_to_validators(bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
@@ -6537,7 +6532,7 @@ pub(crate) mod tests {
             burn_percent: 10,
         };
 
-        let root_bank = Arc::new(Bank::new(&genesis_config));
+        let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank = create_child_bank_for_rent_test(
             &root_bank,
             &genesis_config,
@@ -6587,7 +6582,7 @@ pub(crate) mod tests {
             burn_percent: 10,
         };
 
-        let root_bank = Bank::new(&genesis_config);
+        let root_bank = Bank::new_for_tests(&genesis_config);
         // until we completely transition to the eager rent collection,
         // we must ensure lazy rent collection doens't get broken!
         root_bank.restore_old_behavior_for_fragile_tests();
@@ -6747,7 +6742,7 @@ pub(crate) mod tests {
     fn test_rent_eager_across_epoch_without_gap() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
         bank = Arc::new(new_from_parent(&bank));
@@ -6765,7 +6760,7 @@ pub(crate) mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(1);
         activate_all_features(&mut genesis_config);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
         bank = Arc::new(new_from_parent(&bank));
@@ -6788,7 +6783,7 @@ pub(crate) mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(1);
         activate_all_features(&mut genesis_config);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
 
         bank = Arc::new(new_from_parent(&bank));
@@ -6820,7 +6815,7 @@ pub(crate) mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, false);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(DEFAULT_SLOTS_PER_EPOCH, 432_000);
         assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
         assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
@@ -6890,7 +6885,7 @@ pub(crate) mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, false);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(DEFAULT_SLOTS_PER_EPOCH, 432_000);
         assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
         assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
@@ -6948,7 +6943,7 @@ pub(crate) mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, true);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(DEFAULT_SLOTS_PER_EPOCH, 432_000);
         assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
         assert_eq!(bank.first_normal_epoch(), 3);
@@ -7004,7 +6999,7 @@ pub(crate) mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, true);
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank.get_slots_in_epoch(bank.epoch()), 32);
         assert_eq!(bank.first_normal_epoch(), 3);
         assert_eq!(bank.get_epoch_and_slot_index(bank.slot()), (0, 0));
@@ -7384,7 +7379,7 @@ pub(crate) mod tests {
         let rent_due_pubkey = solana_sdk::pubkey::new_rand();
         let rent_exempt_pubkey = solana_sdk::pubkey::new_rand();
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let zero_lamports = 0;
         let little_lamports = 1234;
         let large_lamports = 123_456_789;
@@ -7467,8 +7462,8 @@ pub(crate) mod tests {
 
         let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
 
-        let genesis_bank1 = Arc::new(Bank::new(&genesis_config));
-        let genesis_bank2 = Arc::new(Bank::new(&genesis_config));
+        let genesis_bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let genesis_bank2 = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank1_with_zero = Arc::new(new_from_parent(&genesis_bank1));
         let bank1_without_zero = Arc::new(new_from_parent(&genesis_bank2));
         let zero_lamports = 0;
@@ -7523,7 +7518,7 @@ pub(crate) mod tests {
         solana_logger::setup();
 
         // create a bank that ticks really slowly...
-        let bank0 = Arc::new(Bank::new(&GenesisConfig {
+        let bank0 = Arc::new(Bank::new_for_tests(&GenesisConfig {
             accounts: (0..42)
                 .map(|_| {
                     (
@@ -7646,7 +7641,7 @@ pub(crate) mod tests {
 
     fn do_test_bank_update_rewards_determinism() -> u64 {
         // create a bank that ticks really slowly...
-        let bank = Arc::new(Bank::new(&GenesisConfig {
+        let bank = Arc::new(Bank::new_for_tests(&GenesisConfig {
             accounts: (0..42)
                 .map(|_| {
                     (
@@ -7754,7 +7749,7 @@ pub(crate) mod tests {
     fn test_purge_empty_accounts() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500_000);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut bank = parent;
         for _ in 0..10 {
             let blockhash = bank.last_blockhash();
@@ -7827,7 +7822,7 @@ pub(crate) mod tests {
     fn test_two_payments_to_one_party() {
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
@@ -7843,7 +7838,7 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
         let key1 = solana_sdk::pubkey::new_rand();
         let key2 = solana_sdk::pubkey::new_rand();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
         let t1 = system_transaction::transfer(&mint_keypair, &key1, 1, genesis_config.hash());
@@ -7868,7 +7863,7 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
         let key1 = solana_sdk::pubkey::new_rand();
         let key2 = solana_sdk::pubkey::new_rand();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
         let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -7887,7 +7882,7 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
         let key1 = solana_sdk::pubkey::new_rand();
         let key2 = solana_sdk::pubkey::new_rand();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
         let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -7903,7 +7898,7 @@ pub(crate) mod tests {
     fn test_detect_failed_duplicate_transactions() {
         let (mut genesis_config, mint_keypair) = create_genesis_config(2);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(1, 0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let dest = Keypair::new();
 
@@ -7932,7 +7927,7 @@ pub(crate) mod tests {
     fn test_account_not_found() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let keypair = Keypair::new();
         assert_eq!(
             bank.transfer(1, &keypair, &mint_keypair.pubkey()),
@@ -7944,7 +7939,7 @@ pub(crate) mod tests {
     #[test]
     fn test_insufficient_funds() {
         let (genesis_config, mint_keypair) = create_genesis_config(11_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
@@ -7967,7 +7962,7 @@ pub(crate) mod tests {
     fn test_transfer_to_newb() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(500, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.get_balance(&pubkey), 500);
@@ -7977,7 +7972,7 @@ pub(crate) mod tests {
     fn test_transfer_to_sysvar() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let normal_pubkey = solana_sdk::pubkey::new_rand();
         let sysvar_pubkey = sysvar::clock::id();
@@ -7998,7 +7993,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_deposit() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         // Test new account
         let key = Keypair::new();
@@ -8015,7 +8010,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_withdraw() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         // Test no account
         let key = Keypair::new();
@@ -8042,7 +8037,7 @@ pub(crate) mod tests {
     fn test_bank_withdraw_from_nonce_account() {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
         genesis_config.rent.lamports_per_byte_year = 42;
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let min_balance = bank.get_minimum_balance_for_rent_exemption(nonce::State::size());
         let nonce = Keypair::new();
@@ -8096,7 +8091,7 @@ pub(crate) mod tests {
         let (expected_fee_collected, expected_fee_burned) =
             genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let capitalization = bank.capitalization();
 
@@ -8196,7 +8191,7 @@ pub(crate) mod tests {
             .target_lamports_per_signature = 1000;
         genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         goto_end_of_slot(&mut bank);
         let (cheap_blockhash, cheap_fee_calculator) = bank.last_blockhash_with_fee_calculator();
         assert_eq!(cheap_fee_calculator.lamports_per_signature, 0);
@@ -8244,7 +8239,7 @@ pub(crate) mod tests {
             ..
         } = create_genesis_config_with_leader(100, &leader, 3);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(2, 0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let key = Keypair::new();
         let tx1 =
@@ -8281,7 +8276,7 @@ pub(crate) mod tests {
     #[test]
     fn test_debits_before_credits() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let keypair = Keypair::new();
         let tx0 = system_transaction::transfer(
             &mint_keypair,
@@ -8310,7 +8305,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let vote_pubkey0 = solana_sdk::pubkey::new_rand();
         let vote_pubkey1 = solana_sdk::pubkey::new_rand();
@@ -8382,7 +8377,7 @@ pub(crate) mod tests {
     #[test]
     fn test_interleaving_locks() {
         let (genesis_config, mint_keypair) = create_genesis_config(3);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let alice = Keypair::new();
         let bob = Keypair::new();
 
@@ -8424,7 +8419,7 @@ pub(crate) mod tests {
     #[test]
     fn test_readonly_relaxed_locks() {
         let (genesis_config, _) = create_genesis_config(3);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let key0 = Keypair::new();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
@@ -8486,7 +8481,7 @@ pub(crate) mod tests {
     fn test_bank_invalid_account_index() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
         let keypair = Keypair::new();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let tx = system_transaction::transfer(
             &mint_keypair,
@@ -8514,7 +8509,7 @@ pub(crate) mod tests {
     fn test_bank_pay_to_self() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
         let key1 = Keypair::new();
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         bank.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
         assert_eq!(bank.get_balance(&key1.pubkey()), 1);
@@ -8535,7 +8530,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_parents() {
         let (genesis_config, _) = create_genesis_config(1);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let bank = new_from_parent(&parent);
         assert!(Arc::ptr_eq(&bank.parents()[0], &parent));
@@ -8545,7 +8540,7 @@ pub(crate) mod tests {
     #[test]
     fn test_tx_already_processed() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let key1 = Keypair::new();
         let mut tx =
@@ -8576,7 +8571,7 @@ pub(crate) mod tests {
     fn test_bank_parent_already_processed() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
         let key1 = Keypair::new();
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let tx =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_config.hash());
@@ -8594,7 +8589,7 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
         let key1 = Keypair::new();
         let key2 = Keypair::new();
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let tx =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_config.hash());
@@ -8608,8 +8603,8 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_hash_internal_state() {
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
-        let bank0 = Bank::new(&genesis_config);
-        let bank1 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
+        let bank1 = Bank::new_for_tests(&genesis_config);
         let initial_state = bank0.hash_internal_state();
         assert_eq!(bank1.hash_internal_state(), initial_state);
 
@@ -8634,7 +8629,7 @@ pub(crate) mod tests {
     fn test_bank_hash_internal_state_verify() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
 
         let pubkey = solana_sdk::pubkey::new_rand();
         info!("transfer 0 {} mint: {}", pubkey, mint_keypair.pubkey());
@@ -8670,7 +8665,7 @@ pub(crate) mod tests {
     #[should_panic(expected = "assertion failed: self.is_frozen()")]
     fn test_verify_hash_unfrozen() {
         let (genesis_config, _mint_keypair) = create_genesis_config(2_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         assert!(bank.verify_hash());
     }
 
@@ -8679,7 +8674,7 @@ pub(crate) mod tests {
         solana_logger::setup();
         let pubkey = solana_sdk::pubkey::new_rand();
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         bank.freeze();
         bank.update_accounts_hash();
@@ -8695,7 +8690,7 @@ pub(crate) mod tests {
     fn test_bank_hash_internal_state_same_account_different_fork() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let initial_state = bank0.hash_internal_state();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         assert_ne!(bank1.hash_internal_state(), initial_state);
@@ -8715,8 +8710,8 @@ pub(crate) mod tests {
 
     #[test]
     fn test_hash_internal_state_genesis() {
-        let bank0 = Bank::new(&create_genesis_config(10).0);
-        let bank1 = Bank::new(&create_genesis_config(20).0);
+        let bank0 = Bank::new_for_tests(&create_genesis_config(10).0);
+        let bank1 = Bank::new_for_tests(&create_genesis_config(20).0);
         assert_ne!(bank0.hash_internal_state(), bank1.hash_internal_state());
     }
 
@@ -8725,8 +8720,8 @@ pub(crate) mod tests {
     #[test]
     fn test_hash_internal_state_order() {
         let (genesis_config, mint_keypair) = create_genesis_config(100);
-        let bank0 = Bank::new(&genesis_config);
-        let bank1 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
+        let bank1 = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
         let key0 = solana_sdk::pubkey::new_rand();
         let key1 = solana_sdk::pubkey::new_rand();
@@ -8743,7 +8738,7 @@ pub(crate) mod tests {
     fn test_hash_internal_state_error() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let key0 = solana_sdk::pubkey::new_rand();
         bank.transfer(10, &mint_keypair, &key0).unwrap();
         let orig = bank.hash_internal_state();
@@ -8761,7 +8756,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_hash_internal_state_squash() {
         let collector_id = Pubkey::default();
-        let bank0 = Arc::new(Bank::new(&create_genesis_config(10).0));
+        let bank0 = Arc::new(Bank::new_for_tests(&create_genesis_config(10).0));
         let hash0 = bank0.hash_internal_state();
         // save hash0 because new_from_parent
         // updates sysvar entries
@@ -8783,7 +8778,7 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
         let key1 = Keypair::new();
         let key2 = Keypair::new();
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_config.hash());
@@ -8842,7 +8837,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_get_account_in_parent_after_squash() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let key1 = Keypair::new();
 
@@ -8857,7 +8852,7 @@ pub(crate) mod tests {
     fn test_bank_get_account_in_parent_after_squash2() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let key1 = Keypair::new();
 
@@ -8904,7 +8899,7 @@ pub(crate) mod tests {
         let pubkey = solana_sdk::pubkey::new_rand();
 
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let bank1 = Arc::new(Bank::new(&genesis_config));
+        let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank1.transfer(1, &mint_keypair, &pubkey).unwrap();
         let result = bank1.get_account_modified_since_parent_with_fixed_root(&pubkey);
         assert!(result.is_some());
@@ -8950,7 +8945,7 @@ pub(crate) mod tests {
 
         // First, initialize the clock sysvar
         activate_all_features(&mut genesis_config);
-        let bank1 = Arc::new(Bank::new(&genesis_config));
+        let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(bank1.calculate_capitalization(true), bank1.capitalization());
 
         assert_capitalization_diff(
@@ -9087,7 +9082,7 @@ pub(crate) mod tests {
         genesis_config.epoch_schedule =
             EpochSchedule::custom(SLOTS_PER_EPOCH, LEADER_SCHEDULE_SLOT_OFFSET, false);
 
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut leader_vote_stake: Vec<_> = parent
             .epoch_vote_accounts(0)
             .map(|accounts| {
@@ -9179,7 +9174,7 @@ pub(crate) mod tests {
     fn test_zero_signatures() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         bank.fee_calculator.lamports_per_signature = 2;
         let key = Keypair::new();
 
@@ -9200,7 +9195,7 @@ pub(crate) mod tests {
     fn test_bank_get_slots_in_epoch() {
         let (genesis_config, _) = create_genesis_config(500);
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         assert_eq!(bank.get_slots_in_epoch(0), MINIMUM_SLOTS_PER_EPOCH as u64);
         assert_eq!(
@@ -9216,7 +9211,7 @@ pub(crate) mod tests {
     #[test]
     fn test_is_delta_true() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let key1 = Keypair::new();
         let tx_transfer_mint_to_1 =
             system_transaction::transfer(&mint_keypair, &key1.pubkey(), 1, genesis_config.hash());
@@ -9236,7 +9231,7 @@ pub(crate) mod tests {
     #[test]
     fn test_is_empty() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let key1 = Keypair::new();
 
         // The zeroth bank is empty becasue there are no transactions
@@ -9252,7 +9247,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_inherit_tx_count() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Bank 1
         let bank1 = Arc::new(Bank::new_from_parent(
@@ -9299,7 +9294,7 @@ pub(crate) mod tests {
             .fee_rate_governor
             .target_lamports_per_signature = 123;
 
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank1 = Arc::new(new_from_parent(&bank0));
         assert_eq!(
             bank0.fee_rate_governor.target_lamports_per_signature / 2,
@@ -9317,7 +9312,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let vote_accounts = bank.vote_accounts();
         assert_eq!(vote_accounts.len(), 1); // bootstrap validator has
@@ -9365,7 +9360,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let stake_delegations = bank.cloned_stake_delegations();
         assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
@@ -9413,7 +9408,7 @@ pub(crate) mod tests {
     fn test_bank_fees_account() {
         let (mut genesis_config, _) = create_genesis_config(500);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(12345, 0);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let fees_account = bank.get_account(&sysvar::fees::id()).unwrap();
         let fees = from_account::<Fees, _>(&fees_account).unwrap();
@@ -9427,7 +9422,7 @@ pub(crate) mod tests {
     #[test]
     fn test_is_delta_with_no_committables() {
         let (genesis_config, mint_keypair) = create_genesis_config(8000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         bank.is_delta.store(false, Relaxed);
 
         let keypair1 = Keypair::new();
@@ -9462,7 +9457,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_get_program_accounts() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         parent.restore_old_behavior_for_fragile_tests();
 
         let genesis_accounts: Vec<_> = parent.get_all_accounts_with_modified_slots().unwrap();
@@ -9581,7 +9576,7 @@ pub(crate) mod tests {
     fn test_status_cache_ancestors() {
         solana_logger::setup();
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank1 = Arc::new(new_from_parent(&parent));
         let mut bank = bank1;
         for _ in 0..MAX_CACHE_ENTRIES * 2 {
@@ -9599,7 +9594,7 @@ pub(crate) mod tests {
     #[test]
     fn test_add_builtin() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_vote_program_id() -> Pubkey {
             Pubkey::new(&[42u8; 32])
@@ -9659,7 +9654,7 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_vote_processor(
             _pubkey: &Pubkey,
@@ -9709,7 +9704,7 @@ pub(crate) mod tests {
     #[test]
     fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
             _pubkey: &Pubkey,
@@ -9773,7 +9768,7 @@ pub(crate) mod tests {
     #[test]
     fn test_recent_blockhashes_sysvar() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         for i in 1..5 {
             let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
             let recent_blockhashes =
@@ -9793,7 +9788,7 @@ pub(crate) mod tests {
     #[test]
     fn test_blockhash_queue_sysvar_consistency() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
 
         let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
@@ -9808,7 +9803,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bank_inherit_last_vote_sync() {
         let (genesis_config, _) = create_genesis_config(500);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let last_ts = bank0.last_vote_sync.load(Relaxed);
         assert_eq!(last_ts, 0);
         bank0.last_vote_sync.store(1, Relaxed);
@@ -9821,7 +9816,7 @@ pub(crate) mod tests {
     #[test]
     fn test_hash_internal_state_unchanged() {
         let (genesis_config, _) = create_genesis_config(500);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.freeze();
         let bank0_hash = bank0.hash();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
@@ -9834,7 +9829,7 @@ pub(crate) mod tests {
     #[test]
     fn test_ticks_change_state() {
         let (genesis_config, _) = create_genesis_config(500);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank1 = new_from_parent(&bank);
         let hash1 = bank1.hash_internal_state();
         // ticks don't change its state unless a block boundary is crossed
@@ -9867,7 +9862,7 @@ pub(crate) mod tests {
         solana_logger::setup();
         let (mut genesis_config, _) = create_genesis_config(100_000_000_000_000);
         add_lotsa_stake_accounts(&mut genesis_config);
-        let mut bank = std::sync::Arc::new(Bank::new(&genesis_config));
+        let mut bank = std::sync::Arc::new(Bank::new_for_tests(&genesis_config));
         let mut num_banks = 0;
         let pid = std::process::id();
         #[cfg(not(target_os = "linux"))]
@@ -9959,7 +9954,7 @@ pub(crate) mod tests {
         let (mut genesis_config, mint_keypair) = create_genesis_config(supply_lamports);
         genesis_config.rent.lamports_per_byte_year = 0;
         genesis_cfg_fn(&mut genesis_config);
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Banks 0 and 1 have no fees, wait two blocks before
         // initializing our nonce accounts
@@ -10087,7 +10082,7 @@ pub(crate) mod tests {
     #[test]
     fn test_assign_from_nonce_account_fail() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let nonce = Keypair::new();
         let nonce_account = AccountSharedData::new_data(
             42_424_242,
@@ -10322,7 +10317,7 @@ pub(crate) mod tests {
     fn test_nonce_fee_calculator_updates() {
         let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000);
         genesis_config.rent.lamports_per_byte_year = 0;
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Deliberately use bank 0 to initialize nonce account, so that nonce account fee_calculator indicates 0 fees
         let (custodian_keypair, nonce_keypair) =
@@ -10389,7 +10384,7 @@ pub(crate) mod tests {
     #[test]
     fn test_collect_balances() {
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank0 = Arc::new(new_from_parent(&parent));
 
         let keypair = Keypair::new();
@@ -10439,7 +10434,7 @@ pub(crate) mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(500);
         let fee_rate_governor = FeeRateGovernor::new(1, 0);
         genesis_config.fee_rate_governor = fee_rate_governor;
-        let parent = Arc::new(Bank::new(&genesis_config));
+        let parent = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank0 = Arc::new(new_from_parent(&parent));
 
         let keypair0 = Keypair::new();
@@ -10500,7 +10495,7 @@ pub(crate) mod tests {
     #[test]
     fn test_transaction_with_duplicate_accounts_in_instruction() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_process_instruction(
             _program_id: &Pubkey,
@@ -10557,7 +10552,7 @@ pub(crate) mod tests {
     #[test]
     fn test_transaction_with_program_ids_passed_to_programs() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
@@ -10601,7 +10596,7 @@ pub(crate) mod tests {
     fn test_account_ids_after_program_ids() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -10637,7 +10632,7 @@ pub(crate) mod tests {
     #[test]
     fn test_incinerator() {
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Move to the first normal slot so normal rent behaviour applies
         let bank = Bank::new_from_parent(
@@ -10666,7 +10661,7 @@ pub(crate) mod tests {
     fn test_duplicate_account_key() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -10700,7 +10695,7 @@ pub(crate) mod tests {
     fn test_program_id_as_payer() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -10757,7 +10752,7 @@ pub(crate) mod tests {
     #[test]
     fn test_ref_account_key_after_program_id() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -10796,7 +10791,7 @@ pub(crate) mod tests {
         solana_logger::setup();
         use rand::{thread_rng, Rng};
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let max_programs = 5;
         let program_keys: Vec<_> = (0..max_programs)
@@ -10960,7 +10955,7 @@ pub(crate) mod tests {
         genesis_config.creation_time = 0;
         genesis_config.cluster_type = ClusterType::MainnetBeta;
         genesis_config.rent.burn_percent = 100;
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         // Check a few slots, cross an epoch boundary
         assert_eq!(bank.get_slots_in_epoch(0), 32);
         loop {
@@ -11009,7 +11004,7 @@ pub(crate) mod tests {
         }
 
         let (genesis_config, mint_keypair) = create_genesis_config(50000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         // Add a new program
         let program1_pubkey = solana_sdk::pubkey::new_rand();
@@ -11147,7 +11142,7 @@ pub(crate) mod tests {
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
 
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         bank.restore_old_behavior_for_fragile_tests();
         assert_eq!(bank.process_stale_slot_with_budget(0, 0), 0);
         assert_eq!(bank.process_stale_slot_with_budget(133, 0), 133);
@@ -11196,7 +11191,7 @@ pub(crate) mod tests {
             ..
         } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(1, 0);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         // Jump to the test-only upgrade epoch -- see `Bank::upgrade_epoch()`
         let bank = Bank::new_from_parent(
             &bank,
@@ -11296,7 +11291,7 @@ pub(crate) mod tests {
         let program_id = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new_from_parent(
-            &Arc::new(Bank::new(&genesis_config)),
+            &Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         ));
@@ -11341,7 +11336,7 @@ pub(crate) mod tests {
         let loader_id = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new_from_parent(
-            &Arc::new(Bank::new(&genesis_config)),
+            &Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         ));
@@ -11368,7 +11363,7 @@ pub(crate) mod tests {
         let program_id = solana_sdk::pubkey::new_rand();
 
         let bank = Arc::new(Bank::new_from_parent(
-            &Arc::new(Bank::new(&genesis_config)),
+            &Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         ));
@@ -11424,7 +11419,7 @@ pub(crate) mod tests {
     #[test]
     fn test_add_native_program_inherited_cap_while_replacing() {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let program_id = solana_sdk::pubkey::new_rand();
 
         bank.add_native_program("mock_program", &program_id, false);
@@ -11443,7 +11438,7 @@ pub(crate) mod tests {
     #[test]
     fn test_add_native_program_squatted_while_not_replacing() {
         let (genesis_config, mint_keypair) = create_genesis_config(100_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let program_id = solana_sdk::pubkey::new_rand();
 
         // someone managed to squat at program_id!
@@ -11470,7 +11465,7 @@ pub(crate) mod tests {
         let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
         let bank = Bank::new_from_parent(
-            &Arc::new(Bank::new(&genesis_config)),
+            &Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         );
@@ -11492,7 +11487,7 @@ pub(crate) mod tests {
         let program_id = Pubkey::from_str("CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre").unwrap();
 
         let bank = Bank::new_from_parent(
-            &Arc::new(Bank::new(&genesis_config)),
+            &Arc::new(Bank::new_for_tests(&genesis_config)),
             &Pubkey::default(),
             slot,
         );
@@ -11509,7 +11504,7 @@ pub(crate) mod tests {
 
         // ClusterType::Development - Native mint exists immediately
         assert_eq!(genesis_config.cluster_type, ClusterType::Development);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(
             bank.get_balance(&inline_spl_token_v2_0::native_mint::id()),
             1000000000
@@ -11517,7 +11512,7 @@ pub(crate) mod tests {
 
         // Testnet - Native mint blinks into existence at epoch 93
         genesis_config.cluster_type = ClusterType::Testnet;
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(
             bank.get_balance(&inline_spl_token_v2_0::native_mint::id()),
             0
@@ -11543,7 +11538,7 @@ pub(crate) mod tests {
 
         // MainnetBeta - Native mint blinks into existence at epoch 75
         genesis_config.cluster_type = ClusterType::MainnetBeta;
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         assert_eq!(
             bank.get_balance(&inline_spl_token_v2_0::native_mint::id()),
             0
@@ -11584,7 +11579,7 @@ pub(crate) mod tests {
             reward_pubkey,
             Account::new(u64::MAX, 0, &solana_sdk::pubkey::new_rand()),
         );
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         // because capitalization has been reset with bogus capitalization calculation allowing overflows,
         // deliberately substract 1 lamport to simulate it
         bank0.capitalization.fetch_sub(1, Relaxed);
@@ -11709,7 +11704,7 @@ pub(crate) mod tests {
         solana_logger::setup();
 
         let (genesis_config, _) = create_genesis_config(1);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let key1 = solana_sdk::pubkey::new_rand();
         let key2 = solana_sdk::pubkey::new_rand();
@@ -11789,7 +11784,7 @@ pub(crate) mod tests {
         solana_logger::setup();
 
         let (genesis_config, _) = create_genesis_config(1);
-        let root = Arc::new(Bank::new(&genesis_config));
+        let root = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let key1 = solana_sdk::pubkey::new_rand();
         let key2 = solana_sdk::pubkey::new_rand();
@@ -11837,7 +11832,7 @@ pub(crate) mod tests {
     #[test]
     fn test_compute_active_feature_set() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let mut bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
 
         let test_feature = "TestFeature11111111111111111111111111111111"
@@ -11892,7 +11887,7 @@ pub(crate) mod tests {
     #[test]
     fn test_spl_token_v2_replacement() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         // Setup original token account
         bank.store_account_and_update_capitalization(
@@ -11970,7 +11965,7 @@ pub(crate) mod tests {
     #[test]
     fn test_adjust_sysvar_balance_for_rent() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut smaller_sample_sysvar = bank.get_account(&sysvar::clock::id()).unwrap();
         assert_eq!(smaller_sample_sysvar.lamports(), 1);
         bank.adjust_sysvar_balance_for_rent(&mut smaller_sample_sysvar);
@@ -12008,7 +12003,7 @@ pub(crate) mod tests {
         genesis_config
             .accounts
             .remove(&feature_set::rent_for_sysvars::id());
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let bank1 = Arc::new(new_from_parent(&Arc::new(bank0)));
 
         // schedule activation of simple capitalization
@@ -12048,7 +12043,7 @@ pub(crate) mod tests {
             )),
         );
 
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let bank1 = Arc::new(new_from_parent(&Arc::new(bank0)));
 
         // schedule activation of rent_for_sysvars
@@ -12222,7 +12217,7 @@ pub(crate) mod tests {
             voting_keypair,
             ..
         } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         // Advance past slot 0, which has special handling.
         bank = new_from_parent(&Arc::new(bank));
         bank = new_from_parent(&Arc::new(bank));
@@ -12327,7 +12322,7 @@ pub(crate) mod tests {
             .remove(&feature_set::warp_timestamp_again::id())
             .unwrap();
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let recent_timestamp: UnixTimestamp = bank.unix_timestamp_from_genesis();
         let additional_secs = 8; // Greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE for full epoch
@@ -12421,7 +12416,7 @@ pub(crate) mod tests {
         } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
         let slots_in_epoch = 32;
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         let recent_timestamp: UnixTimestamp = bank.unix_timestamp_from_genesis();
         let additional_secs = 5; // Greater than MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST for full epoch
@@ -12450,7 +12445,7 @@ pub(crate) mod tests {
     #[test]
     fn test_program_is_native_loader() {
         let (genesis_config, mint_keypair) = create_genesis_config(50000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let tx = Transaction::new_signed_with_payer(
             &[Instruction::new_with_bincode(
@@ -12474,7 +12469,7 @@ pub(crate) mod tests {
     #[test]
     fn test_bad_native_loader() {
         let (genesis_config, mint_keypair) = create_genesis_config(50000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let to_keypair = Keypair::new();
 
         let tx = Transaction::new_signed_with_payer(
@@ -12535,7 +12530,7 @@ pub(crate) mod tests {
     #[test]
     fn test_debug_bank() {
         let (genesis_config, _mint_keypair) = create_genesis_config(50000);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         bank.finish_init(&genesis_config, None, false);
         let debug = format!("{:#?}", bank);
         assert!(!debug.is_empty());
@@ -13106,7 +13101,7 @@ pub(crate) mod tests {
     fn test_stake_rewrite() {
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // quickest way of creting bad stake account
         let bootstrap_stake_pubkey = bank
@@ -13140,7 +13135,7 @@ pub(crate) mod tests {
             genesis_config.accounts.remove(&pair.enable_id).unwrap();
         }
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         // Advance slot
         let mut bank = new_from_parent(&Arc::new(bank));
@@ -13221,7 +13216,7 @@ pub(crate) mod tests {
             genesis_config.accounts.remove(&pair.enable_id).unwrap();
         }
 
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         // Advance slot
         let mut bank = new_from_parent(&Arc::new(bank));
@@ -13308,7 +13303,7 @@ pub(crate) mod tests {
             genesis_config.accounts.remove(&pair.enable_id).unwrap();
         }
 
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.get_inflation_num_slots(), 0);
         for _ in 0..2 * slots_per_epoch {
             bank = new_from_parent(&Arc::new(bank));
@@ -13359,7 +13354,7 @@ pub(crate) mod tests {
         } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
         let slots_per_epoch = 32;
         genesis_config.epoch_schedule = EpochSchedule::new(slots_per_epoch);
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.get_inflation_num_slots(), 0);
         for _ in 0..slots_per_epoch {
             bank = new_from_parent(&Arc::new(bank));
@@ -13385,7 +13380,7 @@ pub(crate) mod tests {
             &validator_keypairs,
             vec![10_000; 2],
         );
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let stake_delegation_accounts = bank.stake_delegation_accounts(&mut null_tracer());
         assert_eq!(stake_delegation_accounts.len(), 2);
 
@@ -13440,7 +13435,7 @@ pub(crate) mod tests {
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let vote_keypair = keypair_from_seed(&[1u8; 32]).unwrap();
         let stake_keypair = keypair_from_seed(&[2u8; 32]).unwrap();
@@ -13508,7 +13503,7 @@ pub(crate) mod tests {
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         *bank.transaction_log_collector_config.write().unwrap() = TransactionLogCollectorConfig {
             mentioned_addresses: HashSet::new(),
             filter: TransactionLogCollectorFilter::All,
@@ -13568,7 +13563,7 @@ pub(crate) mod tests {
     fn test_get_largest_accounts() {
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let pubkeys: Vec<_> = (0..5).map(|_| Pubkey::new_unique()).collect();
         let pubkeys_hashset: HashSet<_> = pubkeys.iter().cloned().collect();
@@ -13688,7 +13683,7 @@ pub(crate) mod tests {
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
             _pubkey: &Pubkey,
@@ -13783,7 +13778,7 @@ pub(crate) mod tests {
         //!     - In this case, key5's ref-count should be decremented correctly
 
         let (genesis_config, mint_keypair) = create_genesis_config(100);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
         let collector = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
@@ -13897,7 +13892,7 @@ pub(crate) mod tests {
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
-        let mut bank = Bank::new(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
             _pubkey: &Pubkey,

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -316,7 +316,7 @@ mod tests {
         let jane_doe_keypair = Keypair::new();
         let jane_pubkey = jane_doe_keypair.pubkey();
         let doe_keypairs = vec![&john_doe_keypair, &jane_doe_keypair];
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_client = BankClient::new(bank);
 
         // Create 2-2 Multisig Transfer instruction.

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -372,7 +372,7 @@ mod tests {
     #[test]
     fn test_bank_forks_new() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
         let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         child_bank.register_tick(&Hash::default());
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn test_bank_forks_new_from_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let child_bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 1));
 
         let bank_forks = BankForks::new_from_banks(&[bank.clone(), child_bank.clone()], 0);
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn test_bank_forks_descendants() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
         let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn test_bank_forks_ancestors() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
         let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn test_bank_forks_frozen_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
         let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn test_bank_forks_active_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let mut bank_forks = BankForks::new(bank);
         let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
@@ -464,11 +464,11 @@ mod tests {
         let slots_in_epoch = 32;
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
 
-        let bank0 = Bank::new(&genesis_config);
+        let bank0 = Bank::new_for_tests(&genesis_config);
         let mut bank_forks0 = BankForks::new(bank0);
         bank_forks0.set_root(0, &AbsRequestSender::default(), None);
 
-        let bank1 = Bank::new(&genesis_config);
+        let bank1 = Bank::new_for_tests(&genesis_config);
         let mut bank_forks1 = BankForks::new(bank1);
 
         let additional_timestamp_secs = 2;
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_bank_forks_with_set_root() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let mut banks = vec![Arc::new(Bank::new(&genesis_config))];
+        let mut banks = vec![Arc::new(Bank::new_for_tests(&genesis_config))];
         assert_eq!(banks[0].slot(), 0);
         let mut bank_forks = BankForks::new_from_banks(&banks, 0);
         banks.push(bank_forks.insert(Bank::new_from_parent(&banks[0], &Pubkey::default(), 1)));
@@ -582,7 +582,7 @@ mod tests {
     #[test]
     fn test_bank_forks_with_highest_confirmed_root() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let mut banks = vec![Arc::new(Bank::new(&genesis_config))];
+        let mut banks = vec![Arc::new(Bank::new_for_tests(&genesis_config))];
         assert_eq!(banks[0].slot(), 0);
         let mut bank_forks = BankForks::new_from_banks(&banks, 0);
         banks.push(bank_forks.insert(Bank::new_from_parent(&banks[0], &Pubkey::default(), 1)));

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -272,7 +272,7 @@ mod tests {
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         };
-        let mut bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let sysvar_and_native_program_delta = 11;
         assert_eq!(
             bank.capitalization(),

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -180,7 +180,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
 fn test_bank_serialize_style(serde_style: SerdeStyle) {
     solana_logger::setup();
     let (genesis_config, _) = create_genesis_config(500);
-    let bank0 = Arc::new(Bank::new(&genesis_config));
+    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
     let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
     bank0.squash();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2460,7 +2460,7 @@ mod tests {
     fn test_roundtrip_bank_to_and_from_full_snapshot_simple() {
         solana_logger::setup();
         let genesis_config = GenesisConfig::default();
-        let original_bank = Bank::new(&genesis_config);
+        let original_bank = Bank::new_for_tests(&genesis_config);
 
         while !original_bank.is_complete() {
             original_bank.register_tick(&Hash::new_unique());
@@ -2519,7 +2519,7 @@ mod tests {
         let key5 = Keypair::new();
 
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
         bank0.transfer(2, &mint_keypair, &key2.pubkey()).unwrap();
         bank0.transfer(3, &mint_keypair, &key3.pubkey()).unwrap();
@@ -2616,7 +2616,7 @@ mod tests {
         let key5 = Keypair::new();
 
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000);
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         bank0.transfer(1, &mint_keypair, &key1.pubkey()).unwrap();
         bank0.transfer(2, &mint_keypair, &key2.pubkey()).unwrap();
         bank0.transfer(3, &mint_keypair, &key3.pubkey()).unwrap();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1290,7 +1290,7 @@ mod tests {
     #[test]
     fn test_allocate() {
         let (genesis_config, mint_keypair) = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_client = BankClient::new(bank);
 
         let alice_keypair = Keypair::new();
@@ -1346,7 +1346,7 @@ mod tests {
 
         // create initial bank and fund the alice account
         let (genesis_config, mint_keypair) = create_genesis_config(mint_lamports);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank_client = BankClient::new_shared(&bank);
         bank_client
             .transfer_and_confirm(mint_lamports, &mint_keypair, &alice_pubkey)
@@ -1402,7 +1402,7 @@ mod tests {
     #[test]
     fn test_assign_with_seed() {
         let (genesis_config, mint_keypair) = create_genesis_config(100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_client = BankClient::new(bank);
 
         let alice_keypair = Keypair::new();
@@ -1438,7 +1438,7 @@ mod tests {
         let mallory_pubkey = mallory_keypair.pubkey();
 
         // Fund to account to bypass AccountNotFound error
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let bank_client = BankClient::new(bank);
         bank_client
             .transfer_and_confirm(50, &alice_keypair, &mallory_pubkey)

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -111,7 +111,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(500, &dummy_leader_pubkey, 100);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let pubkey = solana_sdk::pubkey::new_rand();
         let keypair2 = Keypair::new();

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -12,7 +12,7 @@ fn test_race_register_tick_freeze() {
     let hash = hash(p.as_ref());
 
     for _ in 0..1000 {
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
         let bank0_ = bank0.clone();
         let freeze_thread = Builder::new()
             .name("freeze".to_string())

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -9,7 +9,7 @@ fn test_program_native_noop() {
 
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = solana_sdk::pubkey::new_rand();
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     bank.add_native_program("solana_noop_program", &program_id, false);
 
     // Call user program

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -116,7 +116,7 @@ fn test_stake_create_and_split_single_signature() {
 
     let staker_pubkey = staker_keypair.pubkey();
 
-    let bank_client = BankClient::new_shared(&Arc::new(Bank::new(&genesis_config)));
+    let bank_client = BankClient::new_shared(&Arc::new(Bank::new_for_tests(&genesis_config)));
 
     let stake_address =
         Pubkey::create_with_seed(&staker_pubkey, "stake", &stake::program::id()).unwrap();
@@ -186,7 +186,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
 
     let staker_pubkey = staker_keypair.pubkey();
 
-    let bank_client = BankClient::new_shared(&Arc::new(Bank::new(&genesis_config)));
+    let bank_client = BankClient::new_shared(&Arc::new(Bank::new_for_tests(&genesis_config)));
 
     let stake_address =
         Pubkey::create_with_seed(&staker_pubkey, "stake", &stake::program::id()).unwrap();
@@ -265,7 +265,7 @@ fn test_stake_account_lifetime() {
         &solana_sdk::pubkey::new_rand(),
         1_000_000,
     );
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let mut bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
@@ -509,7 +509,7 @@ fn test_create_stake_account_from_seed() {
         &solana_sdk::pubkey::new_rand(),
         1_000_000,
     );
-    let bank = Bank::new(&genesis_config);
+    let bank = Bank::new_for_tests(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -294,7 +294,7 @@ mod tests {
 
     fn create_bank(lamports: u64) -> (Bank, Keypair, u64) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
-        let bank = Bank::new(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
         let rent = bank.get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>());
         (bank, mint_keypair, rent)
     }


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.

#### Summary of Changes
remove Bank::new()
replace all callers, which were only in tests (not benches), with Bank::new_for_tests()
Fixes #
