### PR TITLE
add traits required by IsCached

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -41,7 +41,7 @@ pub type AccountMap<K, V> = BTreeMap<K, V>;
 
 type AccountMapEntry<T> = Arc<AccountMapEntryInner<T>>;
 
-pub trait IsCached {
+pub trait IsCached: 'static + Clone + Debug {
     fn is_cached(&self) -> bool;
 }
 


### PR DESCRIPTION
#### Problem
AccountsIndex is undergoing changes. The slot list contains items of generic type. It is cumbersome to pass along a grab bag of traits to all functions or to add a new required trait (such as clone or debug).

#### Summary of Changes
Add required traits to the existing trait IsCached. We could also create a new trait AccountsIndexItem or something, which requires IsCached. That change seems a little messy and unnecessary atm.

Fixes #
