### PR TITLE
accounts_db calls AccountsDb::new(bins)

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1352,7 +1352,7 @@ impl Default for AccountsDb {
         let mut bank_hashes = HashMap::new();
         bank_hashes.insert(0, BankHashInfo::default());
         AccountsDb {
-            accounts_index: AccountsIndex::default(),
+            accounts_index: AccountsIndex::new(crate::accounts_index::BINS_DEFAULT),
             storage: AccountStorage::default(),
             accounts_cache: AccountsCache::default(),
             sender_bg_hasher: None,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -32,7 +32,7 @@ use std::{
 use thiserror::Error;
 
 pub const ITER_BATCH_SIZE: usize = 1000;
-const BINS_DEFAULT: usize = 16;
+pub const BINS_DEFAULT: usize = 16;
 const BINS_FOR_TESTING: usize = BINS_DEFAULT;
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
@@ -695,7 +695,7 @@ impl<
         Self::new(BINS_FOR_TESTING)
     }
 
-    fn new(bins: usize) -> Self {
+    pub fn new(bins: usize) -> Self {
         let (account_maps, bin_calculator) = Self::allocate_accounts_index(bins);
         Self {
             account_maps,
@@ -3934,5 +3934,11 @@ pub mod tests {
         let iter = AccountsIndexIterator::new(&index, Some((Excluded(key), Excluded(key))));
         assert_eq!(iter.start_bin(), bins - 1); // start at highest possible pubkey, so bins - 1
         assert_eq!(iter.end_bin_inclusive(), bins - 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "bins.is_power_of_two()")]
+    fn test_illegal_bins() {
+        AccountsIndex::<bool>::new(3);
     }
 }


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
