### PR TITLE
excludes votes from gossip if they have already landed in blocks

### DIFF
--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -312,6 +312,10 @@ impl Vote {
     pub(crate) fn slots(&self) -> &[Slot] {
         &self.slots
     }
+
+    pub(crate) fn vote_account(&self) -> Option<Pubkey> {
+        self.vote_account
+    }
 }
 
 impl<'de> Deserialize<'de> for Vote {

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -339,7 +339,11 @@ fn network_run_push(
                     Duration::from_millis(node.gossip.pull.crds_timeout),
                 );
                 node.gossip.purge(&node_pubkey, thread_pool, now, &timeouts);
-                (node_pubkey, node.gossip.new_push_messages(vec![], now))
+                (
+                    node_pubkey,
+                    node.gossip
+                        .new_push_messages(vec![], /*bank_forks=*/ None, now),
+                )
             })
             .collect();
         let transfered: Vec<_> = requests
@@ -529,6 +533,7 @@ fn network_run_pull(
                             .generate_pull_responses(
                                 thread_pool,
                                 &filters,
+                                None,       // bank_forks
                                 usize::MAX, // output_size_limit
                                 now,
                             )


### PR DESCRIPTION
#### Problem
* Gossip traffic is high, and most of the packets are votes.
* Votes are sent directly to the leader through TPU socket as well. So if we can identify that the votes are already landing with the leader, then there is no need to broadcast them through gossip as well. (To be confirmed that this will not break optimistic confirmations).

#### Summary of Changes
* Starting with something conservative: 
   * exclude votes from gossip if their slot is before last voted slot in root bank.
* Future commits will further relax this predicate and/or add more signals.