### PR TITLE
Use max releases per page on GH API

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -860,7 +860,7 @@ fn check_for_newer_github_release(
     prerelease_allowed: bool,
 ) -> reqwest::Result<Option<String>> {
     let url =
-        reqwest::Url::parse("https://api.github.com/repos/solana-labs/solana/releases").unwrap();
+        reqwest::Url::parse("https://api.github.com/repos/solana-labs/solana/releases?per_page=100").unwrap();
     let client = reqwest::blocking::Client::builder()
         .user_agent("solana-install")
         .build()?;

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -859,8 +859,10 @@ fn check_for_newer_github_release(
     version_filter: Option<semver::VersionReq>,
     prerelease_allowed: bool,
 ) -> reqwest::Result<Option<String>> {
-    let url =
-        reqwest::Url::parse("https://api.github.com/repos/solana-labs/solana/releases?per_page=100").unwrap();
+    let url = reqwest::Url::parse(
+        "https://api.github.com/repos/solana-labs/solana/releases?per_page=100",
+    )
+    .unwrap();
     let client = reqwest::blocking::Client::builder()
         .user_agent("solana-install")
         .build()?;


### PR DESCRIPTION
This allows us to install older versions. What we really need is to use the pagination in the API but this is a simple improvement for now

#### Problem

We can't install anything older than the last 30 releases with `solana-install init`

#### Summary of Changes

Just changed the URL so now we can install any of the last 100 releases