### PR TITLE
remove AccountsIndex::default

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -5,7 +5,7 @@ extern crate test;
 use rand::{thread_rng, Rng};
 use solana_runtime::{
     accounts_db::AccountInfo,
-    accounts_index::{AccountSecondaryIndexes, AccountsIndex},
+    accounts_index::{AccountSecondaryIndexes, AccountsIndex, BINS_DEFAULT},
 };
 use solana_sdk::pubkey::{self, Pubkey};
 use test::Bencher;
@@ -18,7 +18,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_FORKS: u64 = 16;
 
     let mut reclaims = vec![];
-    let index = AccountsIndex::<AccountInfo>::default();
+    let index = AccountsIndex::<AccountInfo>::new(BINS_DEFAULT);
     for f in 0..NUM_FORKS {
         for pubkey in pubkeys.iter().take(NUM_PUBKEYS) {
             index.upsert(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1352,7 +1352,7 @@ impl Default for AccountsDb {
         let mut bank_hashes = HashMap::new();
         bank_hashes.insert(0, BankHashInfo::default());
         AccountsDb {
-            accounts_index: AccountsIndex::default(),
+            accounts_index: AccountsIndex::new(crate::accounts_index::BINS_DEFAULT),
             storage: AccountStorage::default(),
             accounts_cache: AccountsCache::default(),
             sender_bg_hasher: None,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -9810,7 +9810,7 @@ pub mod tests {
     #[test]
     fn test_delete_dependencies() {
         solana_logger::setup();
-        let accounts_index = AccountsIndex::default();
+        let accounts_index = AccountsIndex::default_for_tests();
         let key0 = Pubkey::new_from_array([0u8; 32]);
         let key1 = Pubkey::new_from_array([1u8; 32]);
         let key2 = Pubkey::new_from_array([2u8; 32]);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -32,7 +32,7 @@ use std::{
 use thiserror::Error;
 
 pub const ITER_BATCH_SIZE: usize = 1000;
-const BINS_DEFAULT: usize = 16;
+pub const BINS_DEFAULT: usize = 16;
 const BINS_FOR_TESTING: usize = BINS_DEFAULT;
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
@@ -695,7 +695,7 @@ impl<
         Self::new(BINS_FOR_TESTING)
     }
 
-    fn new(bins: usize) -> Self {
+    pub fn new(bins: usize) -> Self {
         let (account_maps, bin_calculator) = Self::allocate_accounts_index(bins);
         Self {
             account_maps,
@@ -3934,5 +3934,11 @@ pub mod tests {
         let iter = AccountsIndexIterator::new(&index, Some((Excluded(key), Excluded(key))));
         assert_eq!(iter.start_bin(), bins - 1); // start at highest possible pubkey, so bins - 1
         assert_eq!(iter.end_bin_inclusive(), bins - 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "bins.is_power_of_two()")]
+    fn test_illegal_bins() {
+        AccountsIndex::<bool>::new(3);
     }
 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -679,16 +679,6 @@ pub struct AccountsIndex<T> {
 
 impl<
         T: 'static + Clone + IsCached + ZeroLamport + std::marker::Sync + std::marker::Send + Debug,
-    > Default for AccountsIndex<T>
-{
-    fn default() -> Self {
-        // all test callers will move to default_for_tests
-        Self::new(BINS_DEFAULT)
-    }
-}
-
-impl<
-        T: 'static + Clone + IsCached + ZeroLamport + std::marker::Sync + std::marker::Send + Debug,
     > AccountsIndex<T>
 {
     pub fn default_for_tests() -> Self {
@@ -1856,7 +1846,7 @@ pub mod tests {
     fn create_dashmap_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
         {
             // Check that we're actually testing the correct variant
-            let index = AccountsIndex::<bool>::default();
+            let index = AccountsIndex::<bool>::default_for_tests();
             let _type_check = SecondaryIndexTypes::DashMap(&index.spl_token_mint_index);
         }
 
@@ -1866,7 +1856,7 @@ pub mod tests {
     fn create_rwlock_secondary_index_state() -> (usize, usize, AccountSecondaryIndexes) {
         {
             // Check that we're actually testing the correct variant
-            let index = AccountsIndex::<bool>::default();
+            let index = AccountsIndex::<bool>::default_for_tests();
             let _type_check = SecondaryIndexTypes::RwLock(&index.spl_token_owner_index);
         }
 
@@ -2520,7 +2510,7 @@ pub mod tests {
     #[test]
     fn test_get_empty() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let ancestors = Ancestors::default();
         assert!(index.get(&key.pubkey(), Some(&ancestors), None).is_none());
         assert!(index.get(&key.pubkey(), None, None).is_none());
@@ -2578,7 +2568,7 @@ pub mod tests {
     #[test]
     fn test_insert_no_ancestors() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
             0,
@@ -2619,7 +2609,7 @@ pub mod tests {
         let pubkey = &key.pubkey();
         let slot = 0;
 
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let account_info = true;
         let items = vec![(*pubkey, account_info)];
         index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
@@ -2638,7 +2628,7 @@ pub mod tests {
         assert_eq!(num, 1);
 
         // not zero lamports
-        let index = AccountsIndex::<AccountInfoTest>::default();
+        let index = AccountsIndex::<AccountInfoTest>::default_for_tests();
         let account_info: AccountInfoTest = 0 as AccountInfoTest;
         let items = vec![(*pubkey, account_info)];
         index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
@@ -2689,7 +2679,7 @@ pub mod tests {
         let key0 = Keypair::new().pubkey();
         let key1 = Keypair::new().pubkey();
 
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let account_infos = [true, false];
 
         let items = vec![(key0, account_infos[0]), (key1, account_infos[1])];
@@ -2720,7 +2710,7 @@ pub mod tests {
         let slot1 = 1;
         let key = Keypair::new().pubkey();
 
-        let index = AccountsIndex::<T>::default();
+        let index = AccountsIndex::<T>::default_for_tests();
         let mut gc = Vec::new();
 
         if upsert {
@@ -2821,7 +2811,7 @@ pub mod tests {
     #[test]
     fn test_insert_with_lock_no_ancestors() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let slot = 0;
         let account_info = true;
 
@@ -2851,7 +2841,7 @@ pub mod tests {
     #[test]
     fn test_insert_wrong_ancestors() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
             0,
@@ -2875,7 +2865,7 @@ pub mod tests {
     #[test]
     fn test_insert_with_ancestors() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
             0,
@@ -2905,7 +2895,7 @@ pub mod tests {
     }
 
     fn setup_accounts_index_keys(num_pubkeys: usize) -> (AccountsIndex<bool>, Vec<Pubkey>) {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let root_slot = 0;
 
         let mut pubkeys: Vec<Pubkey> = std::iter::repeat_with(|| {
@@ -3071,7 +3061,7 @@ pub mod tests {
 
     #[test]
     fn test_is_root() {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         assert!(!index.is_root(0));
         index.add_root(0, false);
         assert!(index.is_root(0));
@@ -3080,7 +3070,7 @@ pub mod tests {
     #[test]
     fn test_insert_with_root() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
             0,
@@ -3100,7 +3090,7 @@ pub mod tests {
 
     #[test]
     fn test_clean_first() {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         index.add_root(0, false);
         index.add_root(1, false);
         index.clean_dead_slot(0);
@@ -3111,7 +3101,7 @@ pub mod tests {
     #[test]
     fn test_clean_last() {
         //this behavior might be undefined, clean up should only occur on older slots
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         index.add_root(0, false);
         index.add_root(1, false);
         index.clean_dead_slot(1);
@@ -3121,7 +3111,7 @@ pub mod tests {
 
     #[test]
     fn test_clean_and_unclean_slot() {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         assert_eq!(0, index.roots_tracker.read().unwrap().uncleaned_roots.len());
         index.add_root(0, false);
         index.add_root(1, false);
@@ -3193,7 +3183,7 @@ pub mod tests {
     #[test]
     fn test_update_last_wins() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
         index.upsert(
@@ -3229,7 +3219,7 @@ pub mod tests {
     fn test_update_new_slot() {
         solana_logger::setup();
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let ancestors = vec![(0, 0)].into_iter().collect();
         let mut gc = Vec::new();
         index.upsert(
@@ -3262,7 +3252,7 @@ pub mod tests {
     #[test]
     fn test_update_gc_purged_slot() {
         let key = Keypair::new();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut gc = Vec::new();
         index.upsert(
             0,
@@ -3355,7 +3345,7 @@ pub mod tests {
     #[test]
     fn test_purge() {
         let key = Keypair::new();
-        let index = AccountsIndex::<u64>::default();
+        let index = AccountsIndex::<u64>::default_for_tests();
         let mut gc = Vec::new();
         assert_eq!(0, account_maps_len_expensive(&index));
         index.upsert(
@@ -3403,7 +3393,7 @@ pub mod tests {
     #[test]
     fn test_latest_slot() {
         let slot_slice = vec![(0, true), (5, true), (3, true), (7, true)];
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
 
         // No ancestors, no root, should return None
         assert!(index.latest_slot(None, &slot_slice, None).is_none());
@@ -3505,7 +3495,7 @@ pub mod tests {
     #[test]
     fn test_purge_exact_dashmap_secondary_index() {
         let (key_start, key_end, secondary_indexes) = create_dashmap_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_purge_exact_secondary_index(
             &index,
             &index.spl_token_mint_index,
@@ -3518,7 +3508,7 @@ pub mod tests {
     #[test]
     fn test_purge_exact_rwlock_secondary_index() {
         let (key_start, key_end, secondary_indexes) = create_rwlock_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_purge_exact_secondary_index(
             &index,
             &index.spl_token_owner_index,
@@ -3531,7 +3521,7 @@ pub mod tests {
     #[test]
     fn test_purge_older_root_entries() {
         // No roots, should be no reclaims
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let mut slot_list = vec![(1, true), (2, true), (5, true), (9, true)];
         let mut reclaims = vec![];
         index.purge_older_root_entries(&mut slot_list, &mut reclaims, None);
@@ -3726,7 +3716,7 @@ pub mod tests {
     #[test]
     fn test_dashmap_secondary_index() {
         let (key_start, key_end, secondary_indexes) = create_dashmap_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_secondary_indexes(
             &index,
             &index.spl_token_mint_index,
@@ -3739,7 +3729,7 @@ pub mod tests {
     #[test]
     fn test_rwlock_secondary_index() {
         let (key_start, key_end, secondary_indexes) = create_rwlock_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_secondary_indexes(
             &index,
             &index.spl_token_owner_index,
@@ -3840,7 +3830,7 @@ pub mod tests {
     #[test]
     fn test_dashmap_secondary_index_same_slot_and_forks() {
         let (key_start, key_end, account_index) = create_dashmap_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_secondary_indexes_same_slot_and_forks(
             &index,
             &index.spl_token_mint_index,
@@ -3853,7 +3843,7 @@ pub mod tests {
     #[test]
     fn test_rwlock_secondary_index_same_slot_and_forks() {
         let (key_start, key_end, account_index) = create_rwlock_secondary_index_state();
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         run_test_secondary_indexes_same_slot_and_forks(
             &index,
             &index.spl_token_owner_index,
@@ -3877,7 +3867,7 @@ pub mod tests {
 
     #[test]
     fn test_bin_start_and_range() {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         let iter = AccountsIndexIterator::new(&index, None::<RangeInclusive<Pubkey>>);
         assert_eq!((0, usize::MAX), iter.bin_start_and_range());
 
@@ -3906,7 +3896,7 @@ pub mod tests {
 
     #[test]
     fn test_start_end_bin() {
-        let index = AccountsIndex::<bool>::default();
+        let index = AccountsIndex::<bool>::default_for_tests();
         assert_eq!(index.bins(), BINS_DEFAULT);
         let iter = AccountsIndexIterator::new(&index, None::<RangeInclusive<Pubkey>>);
         assert_eq!(iter.start_bin(), 0); // no range, so 0


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
