### PR TITLE
Bank::default_for_tests()

### DIFF
--- a/banks-server/src/rpc_banks_service.rs
+++ b/banks-server/src/rpc_banks_service.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_rpc_banks_server_exit() {
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::default())));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::default_for_tests())));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let exit = Arc::new(AtomicBool::new(false));
         let addr = "127.0.0.1:0".parse().unwrap();

--- a/banks-server/src/send_transaction_service.rs
+++ b/banks-server/src/send_transaction_service.rs
@@ -189,7 +189,7 @@ mod test {
     #[test]
     fn service_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
-        let bank = Bank::default();
+        let bank = Bank::default_for_tests();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let (sender, receiver) = channel();
 

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -25,7 +25,7 @@ fn bench_save_tower(bench: &mut Bencher) {
 
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new(Bank::default()).working_bank();
+    let heaviest_bank = BankForks::new(Bank::default_for_tests()).working_bank();
     let tower = Tower::new(
         &node_keypair.pubkey(),
         vote_account_pubkey,
@@ -47,7 +47,7 @@ fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
 
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new(Bank::default()).working_bank();
+    let heaviest_bank = BankForks::new(Bank::default_for_tests()).working_bank();
     let mut tower = Tower::new(
         &node_keypair.pubkey(),
         vote_account_pubkey,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2101,7 +2101,7 @@ mod tests {
     fn test_should_process_or_forward_packets() {
         let my_pubkey = solana_sdk::pubkey::new_rand();
         let my_pubkey1 = solana_sdk::pubkey::new_rand();
-        let bank = Arc::new(Bank::default());
+        let bank = Arc::new(Bank::default_for_tests());
         assert_matches!(
             BankingStage::consume_or_forward_packets(&my_pubkey, None, Some(&bank), false, false),
             BufferedPacketsDecision::Hold

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6854,7 +6854,7 @@ pub mod tests {
 
     #[test]
     fn test_is_finalized() {
-        let bank = Arc::new(Bank::default());
+        let bank = Arc::new(Bank::default_for_tests());
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         blockstore.set_roots(vec![0, 1].iter()).unwrap();

--- a/rpc/src/send_transaction_service.rs
+++ b/rpc/src/send_transaction_service.rs
@@ -340,7 +340,7 @@ mod test {
     #[test]
     fn service_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
-        let bank = Bank::default();
+        let bank = Bank::default_for_tests();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let (sender, receiver) = channel();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1047,6 +1047,11 @@ impl Default for BlockhashQueue {
 }
 
 impl Bank {
+    pub fn default_for_tests() -> Self {
+        // will diverge
+        Self::default()
+    }
+
     pub fn new_for_benches(genesis_config: &GenesisConfig) -> Self {
         // this will diverge
         Self::new_for_tests(genesis_config)


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
