### PR TITLE
rework bank::new_with_paths

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -110,7 +110,7 @@ mod tests {
             let snapshot_archives_dir = TempDir::new().unwrap();
             let mut genesis_config_info = create_genesis_config(10_000);
             genesis_config_info.genesis_config.cluster_type = cluster_type;
-            let bank0 = Bank::new_with_paths(
+            let bank0 = Bank::new_with_paths_for_tests(
                 &genesis_config_info.genesis_config,
                 vec![accounts_dir.path().to_path_buf()],
                 &[],

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -406,7 +406,7 @@ pub fn process_blockstore(
     }
 
     // Setup bank for slot 0
-    let bank0 = Bank::new_with_paths(
+    let bank0 = Bank::new_with_paths_production(
         genesis_config,
         account_paths,
         &opts.frozen_accounts,
@@ -3126,7 +3126,7 @@ pub mod tests {
         genesis_config: &GenesisConfig,
         account_paths: Vec<PathBuf>,
     ) -> EpochSchedule {
-        let bank = Bank::new_with_paths(
+        let bank = Bank::new_with_paths_for_tests(
             genesis_config,
             account_paths,
             &[],

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -44,7 +44,7 @@ fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) -> Result<()
 #[bench]
 fn test_accounts_create(bencher: &mut Bencher) {
     let (genesis_config, _) = create_genesis_config(10_000);
-    let bank0 = Bank::new_with_paths(
+    let bank0 = Bank::new_with_paths_for_benches(
         &genesis_config,
         vec![PathBuf::from("bench_a0")],
         &[],
@@ -65,7 +65,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
 fn test_accounts_squash(bencher: &mut Bencher) {
     let (mut genesis_config, _) = create_genesis_config(100_000);
     genesis_config.rent.burn_percent = 100; // Avoid triggering an assert in Bank::distribute_rent_to_validators()
-    let mut prev_bank = Arc::new(Bank::new_with_paths(
+    let mut prev_bank = Arc::new(Bank::new_with_paths_for_benches(
         &genesis_config,
         vec![PathBuf::from("bench_a1")],
         &[],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1065,7 +1065,7 @@ impl Bank {
 
     pub fn new_for_tests(genesis_config: &GenesisConfig) -> Self {
         // this will diverge
-        Self::new_with_paths(
+        Self::new_with_paths_for_tests(
             genesis_config,
             Vec::new(),
             &[],
@@ -1079,7 +1079,7 @@ impl Bank {
     }
 
     pub fn new_no_wallclock_throttle_for_tests(genesis_config: &GenesisConfig) -> Self {
-        let mut bank = Self::new_with_paths(
+        let mut bank = Self::new_with_paths_for_tests(
             genesis_config,
             Vec::new(),
             &[],
@@ -1102,7 +1102,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
     ) -> Self {
-        Self::new_with_paths(
+        Self::new_with_paths_for_tests(
             genesis_config,
             Vec::new(),
             &[],
@@ -1174,7 +1174,31 @@ impl Bank {
         }
     }
 
-    pub fn new_with_paths(
+    pub fn new_with_paths_for_tests(
+        genesis_config: &GenesisConfig,
+        paths: Vec<PathBuf>,
+        frozen_account_pubkeys: &[Pubkey],
+        debug_keys: Option<Arc<HashSet<Pubkey>>>,
+        additional_builtins: Option<&Builtins>,
+        account_indexes: AccountSecondaryIndexes,
+        accounts_db_caching_enabled: bool,
+        shrink_ratio: AccountShrinkThreshold,
+        debug_do_not_add_builtins: bool,
+    ) -> Self {
+        Self::new_with_paths_production(
+            genesis_config,
+            paths,
+            frozen_account_pubkeys,
+            debug_keys,
+            additional_builtins,
+            account_indexes,
+            accounts_db_caching_enabled,
+            shrink_ratio,
+            debug_do_not_add_builtins,
+        )
+    }
+
+    pub fn new_with_paths_production(
         genesis_config: &GenesisConfig,
         paths: Vec<PathBuf>,
         frozen_account_pubkeys: &[Pubkey],
@@ -12211,7 +12235,7 @@ pub(crate) mod tests {
             feature_builtins: (vec![]),
         };
 
-        let bank0 = Arc::new(Bank::new_with_paths(
+        let bank0 = Arc::new(Bank::new_with_paths_for_tests(
             &genesis_config,
             Vec::new(),
             &[],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1198,6 +1198,30 @@ impl Bank {
         )
     }
 
+    pub fn new_with_paths_for_benches(
+        genesis_config: &GenesisConfig,
+        paths: Vec<PathBuf>,
+        frozen_account_pubkeys: &[Pubkey],
+        debug_keys: Option<Arc<HashSet<Pubkey>>>,
+        additional_builtins: Option<&Builtins>,
+        account_indexes: AccountSecondaryIndexes,
+        accounts_db_caching_enabled: bool,
+        shrink_ratio: AccountShrinkThreshold,
+        debug_do_not_add_builtins: bool,
+    ) -> Self {
+        Self::new_with_paths_production(
+            genesis_config,
+            paths,
+            frozen_account_pubkeys,
+            debug_keys,
+            additional_builtins,
+            account_indexes,
+            accounts_db_caching_enabled,
+            shrink_ratio,
+            debug_do_not_add_builtins,
+        )
+    }
+
     pub fn new_with_paths_production(
         genesis_config: &GenesisConfig,
         paths: Vec<PathBuf>,


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
