### PR TITLE
AccountsIndex RefCount() returns u64 instead of atomic

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -149,16 +149,20 @@ impl<T: Clone> ReadAccountMapEntry<T> {
         &*self.borrow_slot_list_guard()
     }
 
-    pub fn ref_count(&self) -> &AtomicU64 {
-        &self.borrow_owned_entry().ref_count
+    pub fn ref_count(&self) -> RefCount {
+        self.borrow_owned_entry().ref_count.load(Ordering::Relaxed)
     }
 
     pub fn unref(&self) {
-        self.ref_count().fetch_sub(1, Ordering::Relaxed);
+        self.borrow_owned_entry()
+            .ref_count
+            .fetch_sub(1, Ordering::Relaxed);
     }
 
     pub fn addref(&self) {
-        self.ref_count().fetch_add(1, Ordering::Relaxed);
+        self.borrow_owned_entry()
+            .ref_count
+            .fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -1265,7 +1269,7 @@ impl<
     ) -> (SlotList<T>, RefCount) {
         (
             self.get_rooted_entries(locked_account_entry.slot_list(), max),
-            locked_account_entry.ref_count().load(Ordering::Relaxed),
+            locked_account_entry.ref_count(),
         )
     }
 
@@ -1577,7 +1581,7 @@ impl<
 
     pub fn ref_count_from_storage(&self, pubkey: &Pubkey) -> RefCount {
         if let Some(locked_entry) = self.get_account_read_entry(pubkey) {
-            locked_entry.ref_count().load(Ordering::Relaxed)
+            locked_entry.ref_count()
         } else {
             0
         }
@@ -2733,7 +2737,7 @@ pub mod tests {
 
         for (i, key) in [key0, key1].iter().enumerate() {
             let entry = index.get_account_read_entry(key).unwrap();
-            assert_eq!(entry.ref_count().load(Ordering::Relaxed), 1);
+            assert_eq!(entry.ref_count(), 1);
             assert_eq!(entry.slot_list().to_vec(), vec![(slot0, account_infos[i]),]);
         }
     }
@@ -2779,10 +2783,7 @@ pub mod tests {
         // verify the added entry matches expected
         {
             let entry = index.get_account_read_entry(&key).unwrap();
-            assert_eq!(
-                entry.ref_count().load(Ordering::Relaxed),
-                if is_cached { 0 } else { 1 }
-            );
+            assert_eq!(entry.ref_count(), if is_cached { 0 } else { 1 });
             let expected = vec![(slot0, account_infos[0].clone())];
             assert_eq!(entry.slot_list().to_vec(), expected);
             let new_entry =
@@ -2825,10 +2826,7 @@ pub mod tests {
                 index.get_account_read_entry(&key).unwrap()
             };
 
-            assert_eq!(
-                entry.ref_count().load(Ordering::Relaxed),
-                if is_cached { 0 } else { 2 }
-            );
+            assert_eq!(entry.ref_count(), if is_cached { 0 } else { 2 });
             assert_eq!(
                 entry.slot_list().to_vec(),
                 vec![


### PR DESCRIPTION
#### Problem
As we change the backing of AccountsIndex, it becomes difficult to support an api that allows a caller to get an AtomicU64 that they can modify at will. It is straightforward to transition to a model where callers tell the api to get, inc, or dec the refcount. The implementation of the api can then decide the best way to implement the behavior because it has the transition information.
#### Summary of Changes
RefCount() returns u64 value
Fixes #
