### PR TITLE
Fixing missing pubsub notification for programSubscribe and logsSubscribe

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -157,14 +157,18 @@ impl OptimisticallyConfirmedBankTracker {
                         );
 
                         for parent in bank.parents().iter() {
-                            info!("notify_or_defer for parent {:?}", parent.slot());
-                            Self::notify_or_defer(
-                                subscriptions,
-                                bank_forks,
-                                parent,
-                                *last_notified_slot,
-                                &mut pending_optimistically_confirmed_banks,
-                            );
+                            if parent.slot() > *last_notified_slot {
+                                info!("notify_or_defer for parent {:?}", parent.slot());
+                                Self::notify_or_defer(
+                                    subscriptions,
+                                    bank_forks,
+                                    parent,
+                                    *last_notified_slot,
+                                    &mut pending_optimistically_confirmed_banks,
+                                );
+                            } else {
+                                break;
+                            }
                         }
                         *last_notified_slot = slot;
                     }

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -143,9 +143,9 @@ impl OptimisticallyConfirmedBankTracker {
         mut last_notified_confirmed_slot: &mut Slot,
         mut pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
     ) {
-        for parent in bank.clone().parents_inclusive().iter().rev() {
-            if parent.slot() > slot_threshold {
-                debug!("Calling notify_or_defer for parent {:?}", parent.slot());
+        for confirmed_bank in bank.clone().parents_inclusive().iter().rev() {
+            if confirmed_bank.slot() > slot_threshold {
+                debug!("Calling notify_or_defer for confirmed_bank {:?}", confirmed_bank.slot());
                 Self::notify_or_defer(
                     subscriptions,
                     bank_forks,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -145,7 +145,10 @@ impl OptimisticallyConfirmedBankTracker {
     ) {
         for confirmed_bank in bank.clone().parents_inclusive().iter().rev() {
             if confirmed_bank.slot() > slot_threshold {
-                debug!("Calling notify_or_defer for confirmed_bank {:?}", confirmed_bank.slot());
+                debug!(
+                    "Calling notify_or_defer for confirmed_bank {:?}",
+                    confirmed_bank.slot()
+                );
                 Self::notify_or_defer(
                     subscriptions,
                     bank_forks,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -118,11 +118,14 @@ impl OptimisticallyConfirmedBankTracker {
     ) {
         if bank.slot() > last_notified_slot {
             if bank.is_frozen() {
-                info!("notify_or_defer notifying {:?}", bank.slot());
+                debug!(
+                    "notify_or_defer notifying via notify_gossip_subscribers for slot {:?}",
+                    bank.slot()
+                );
                 subscriptions.notify_gossip_subscribers(bank.slot());
             } else if bank.slot() > bank_forks.read().unwrap().root_bank().slot() {
                 pending_optimistically_confirmed_banks.insert(bank.slot());
-                info!("notify_or_defer defer notifying {:?}", bank.slot());
+                debug!("notify_or_defer defer notifying for slot {:?}", bank.slot());
             }
         }
     }
@@ -135,7 +138,7 @@ impl OptimisticallyConfirmedBankTracker {
         mut pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
         last_notified_slot: &mut Slot,
     ) {
-        info!("received bank notification: {:?}", notification);
+        debug!("received bank notification: {:?}", notification);
         match notification {
             BankNotification::OptimisticallyConfirmed(slot) => {
                 if let Some(bank) = bank_forks.read().unwrap().get(slot) {
@@ -158,7 +161,7 @@ impl OptimisticallyConfirmedBankTracker {
 
                         for parent in bank.parents().iter() {
                             if parent.slot() > *last_notified_slot {
-                                info!("notify_or_defer for parent {:?}", parent.slot());
+                                debug!("Calling notify_or_defer for parent {:?}", parent.slot());
                                 Self::notify_or_defer(
                                     subscriptions,
                                     bank_forks,
@@ -209,8 +212,8 @@ impl OptimisticallyConfirmedBankTracker {
                     if frozen_slot > w_optimistically_confirmed_bank.bank.slot() {
                         w_optimistically_confirmed_bank.bank = bank;
                     }
-                    info!(
-                        "notify_or_defer sending deferred notification {:?}",
+                    debug!(
+                        "Calling notify_gossip_subscribers to send deferred notification {:?}",
                         frozen_slot
                     );
                     subscriptions.notify_gossip_subscribers(frozen_slot);

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -149,7 +149,7 @@ impl OptimisticallyConfirmedBankTracker {
                 Self::notify_or_defer(
                     subscriptions,
                     bank_forks,
-                    parent,
+                    confirmed_bank,
                     &mut last_notified_confirmed_slot,
                     &mut pending_optimistically_confirmed_banks,
                 );

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -143,7 +143,7 @@ impl OptimisticallyConfirmedBankTracker {
         mut last_notified_confirmed_slot: &mut Slot,
         mut pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
     ) {
-        for parent in bank.parents().iter().rev() {
+        for parent in bank.clone().parents_inclusive().iter().rev() {
             if parent.slot() > slot_threshold {
                 debug!("Calling notify_or_defer for parent {:?}", parent.slot());
                 Self::notify_or_defer(
@@ -155,13 +155,6 @@ impl OptimisticallyConfirmedBankTracker {
                 );
             }
         }
-        Self::notify_or_defer(
-            subscriptions,
-            bank_forks,
-            bank,
-            &mut last_notified_confirmed_slot,
-            &mut pending_optimistically_confirmed_banks,
-        );
     }
 
     pub fn process_notification(

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -150,16 +150,9 @@ impl OptimisticallyConfirmedBankTracker {
                         w_optimistically_confirmed_bank.bank = bank.clone();
                     }
 
-                    if slot > *last_notified_slot {
-                        Self::notify_or_defer(
-                            subscriptions,
-                            bank_forks,
-                            bank,
-                            *last_notified_slot,
-                            &mut pending_optimistically_confirmed_banks,
-                        );
 
-                        for parent in bank.parents().iter() {
+                    if slot > *last_notified_slot {
+                        for parent in bank.parents().iter().rev() {
                             if parent.slot() > *last_notified_slot {
                                 debug!("Calling notify_or_defer for parent {:?}", parent.slot());
                                 Self::notify_or_defer(
@@ -169,10 +162,16 @@ impl OptimisticallyConfirmedBankTracker {
                                     *last_notified_slot,
                                     &mut pending_optimistically_confirmed_banks,
                                 );
-                            } else {
-                                break;
                             }
                         }
+                        Self::notify_or_defer(
+                            subscriptions,
+                            bank_forks,
+                            bank,
+                            *last_notified_slot,
+                            &mut pending_optimistically_confirmed_banks,
+                        );
+
                         *last_notified_slot = slot;
                     }
                     drop(w_optimistically_confirmed_bank);

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -150,7 +150,6 @@ impl OptimisticallyConfirmedBankTracker {
                         w_optimistically_confirmed_bank.bank = bank.clone();
                     }
 
-
                     if slot > *last_notified_slot {
                         for parent in bank.parents().iter().rev() {
                             if parent.slot() > *last_notified_slot {

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -122,7 +122,7 @@ impl OptimisticallyConfirmedBankTracker {
     ) {
         if bank.is_frozen() {
             if bank.slot() > *last_notified_confirmed_slot {
-                println!(
+                debug!(
                     "notify_or_defer notifying via notify_gossip_subscribers for slot {:?}",
                     bank.slot()
                 );
@@ -131,7 +131,7 @@ impl OptimisticallyConfirmedBankTracker {
             }
         } else if bank.slot() > bank_forks.read().unwrap().root_bank().slot() {
             pending_optimistically_confirmed_banks.insert(bank.slot());
-            println!("notify_or_defer defer notifying for slot {:?}", bank.slot());
+            debug!("notify_or_defer defer notifying for slot {:?}", bank.slot());
         }
     }
 
@@ -229,9 +229,9 @@ impl OptimisticallyConfirmedBankTracker {
                 }
 
                 if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
-                    println!(
-                        "Calling notify_gossip_subscribers to send deferred notification {:?} {:?}",
-                        frozen_slot, pending_optimistically_confirmed_banks
+                    debug!(
+                        "Calling notify_gossip_subscribers to send deferred notification {:?}",
+                        frozen_slot
                     );
 
                     Self::notify_or_defer_confirmed_banks(
@@ -371,7 +371,6 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(highest_confirmed_slot, 3);
-        println!("zzzzzzz {:?}", pending_optimistically_confirmed_banks);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
 
         // Test higher root will be cached and clear pending_optimistically_confirmed_banks

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7530,6 +7530,7 @@ pub mod tests {
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
         assert_eq!(slot, 0);
         let mut highest_confirmed_slot: Slot = 0;
+        let mut last_notified_confirmed_slot: Slot = 0;
 
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
@@ -7537,6 +7538,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
         let req =
@@ -7553,6 +7555,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
         let req =
@@ -7569,6 +7572,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
         let req =
@@ -7586,6 +7590,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
         let req =

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7529,7 +7529,7 @@ pub mod tests {
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
         assert_eq!(slot, 0);
-        let mut last_notified_slot: Slot = 0;
+        let mut highest_confirmed_slot: Slot = 0;
 
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
@@ -7537,7 +7537,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7553,7 +7553,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7569,7 +7569,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7586,7 +7586,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7529,6 +7529,7 @@ pub mod tests {
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
         assert_eq!(slot, 0);
+        let mut last_notified_slot: Slot = 0;
 
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
@@ -7536,6 +7537,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7551,6 +7553,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7566,6 +7569,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
@@ -7582,6 +7586,7 @@ pub mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
         let req =
             r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -2062,21 +2062,25 @@ pub(crate) mod tests {
             .unwrap();
 
         // First, notify the unfrozen bank first to queue pending notification
+        let mut last_notified_slot: Slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
 
         // Now, notify the frozen bank and ensure its notifications are processed
+        last_notified_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(1),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
 
         let (response, _) = robust_poll_or_panic(transport_receiver0);
@@ -2113,12 +2117,14 @@ pub(crate) mod tests {
         );
 
         let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        last_notified_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::Frozen(bank2),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
         );
         let (response, _) = robust_poll_or_panic(transport_receiver1);
         let expected = json!({

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1346,7 +1346,10 @@ pub(crate) mod tests {
             stake, system_instruction, system_program, system_transaction,
             transaction::Transaction,
         },
-        std::{fmt::Debug, sync::mpsc::channel},
+        std::{
+            fmt::Debug,
+            sync::{atomic::Ordering::Relaxed, mpsc::channel},
+        },
         tokio::{
             runtime::Runtime,
             time::{sleep, timeout},
@@ -1617,6 +1620,172 @@ pub(crate) mod tests {
             .read()
             .unwrap()
             .contains_key(&stake::program::id()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_program_subscribe_for_missing_optimistically_confirmed_slot() {
+        // Testing if we can get the pubsub notification if a slot does not
+        // receive OptimisticallyConfirmed but its descendant slot get the confirmed
+        // notification.
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.lazy_rent_collection.store(true, Relaxed);
+
+        let blockhash = bank.last_blockhash();
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+
+        // add account for alice and process the transaction at bank1
+        let alice = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &alice,
+            blockhash,
+            1,
+            16,
+            &stake::program::id(),
+        );
+
+        bank1.process_transaction(&tx).unwrap();
+
+        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+
+        // add account for bob and process the transaction at bank2
+        let bob = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &bob,
+            blockhash,
+            2,
+            16,
+            &stake::program::id(),
+        );
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+
+        bank2.process_transaction(&tx).unwrap();
+
+        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        bank_forks.write().unwrap().insert(bank3);
+
+        // add account for joe and process the transaction at bank3
+        let joe = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &joe,
+            blockhash,
+            3,
+            16,
+            &stake::program::id(),
+        );
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+
+        bank3.process_transaction(&tx).unwrap();
+
+        // now add programSubscribe at the "confirmed" commitment level
+        let (subscriber, _id_receiver, transport_receiver) =
+            Subscriber::new_test("programNotification");
+        let sub_id = SubscriptionId::Number(0);
+        let exit = Arc::new(AtomicBool::new(false));
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
+            ))),
+            optimistically_confirmed_bank.clone(),
+        ));
+        subscriptions.add_program_subscription(
+            stake::program::id(),
+            Some(RpcProgramAccountsConfig {
+                account_config: RpcAccountInfoConfig {
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    ..RpcAccountInfoConfig::default()
+                },
+                ..RpcProgramAccountsConfig::default()
+            }),
+            sub_id.clone(),
+            subscriber,
+        );
+
+        assert!(subscriptions
+            .subscriptions
+            .gossip_program_subscriptions
+            .read()
+            .unwrap()
+            .contains_key(&stake::program::id()));
+
+        let mut last_notified_slot: Slot = 0;
+        // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is unfrozen, we expect
+        // to see transaction for alice and bob to be notified in order.
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
+        );
+
+        // a closure to reduce code duplications in building expected responses:
+        let build_expected_resp = |slot: Slot, lamports: u64, pubkey: &str, subscription: i32| {
+            json!({
+               "jsonrpc": "2.0",
+               "method": "programNotification",
+               "params": {
+                   "result": {
+                       "context": { "slot": slot },
+                       "value": {
+                           "account": {
+                              "data": "1111111111111111",
+                              "executable": false,
+                              "lamports": lamports,
+                              "owner": "Stake11111111111111111111111111111111111111",
+                              "rentEpoch": 0,
+                           },
+                           "pubkey": pubkey,
+                        },
+                   },
+                   "subscription": subscription,
+               }
+            })
+        };
+
+        let (response, transport_receiver) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(1, 1, &alice.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
+
+        let (response, transport_receiver) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(2, 2, &bob.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
+
+        bank3.freeze();
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::Frozen(bank3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_slot,
+        );
+
+        let (response, _) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(3, 3, &joe.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
+        subscriptions.remove_program_subscription(&sub_id);
     }
 
     #[test]

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1871,7 +1871,7 @@ pub(crate) mod tests {
                 },
                 ..RpcProgramAccountsConfig::default()
             }),
-            sub_id.clone(),
+            sub_id,
             subscriber,
         );
 

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1729,6 +1729,7 @@ pub(crate) mod tests {
             .contains_key(&stake::program::id()));
 
         let mut highest_confirmed_slot: Slot = 0;
+        let mut last_notified_confirmed_slot: Slot = 0;
         // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is unfrozen, we expect
         // to see transaction for alice and bob to be notified in order.
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -1737,6 +1738,7 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
 
@@ -1779,8 +1781,288 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
+
+        let (response, _) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(3, 3, &joe.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
+        subscriptions.remove_program_subscription(&sub_id);
+    }
+
+    #[test]
+    #[serial]
+    #[should_panic]
+    fn test_check_program_subscribe_for_missing_optimistically_confirmed_slot_with_no_banks_no_notifications(
+    ) {
+        // Testing if we can get the pubsub notification if a slot does not
+        // receive OptimisticallyConfirmed but its descendant slot get the confirmed
+        // notification with a bank in the BankForks. We are not expecting to receive any notifications -- should panic.
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.lazy_rent_collection.store(true, Relaxed);
+
+        let blockhash = bank.last_blockhash();
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+
+        // add account for alice and process the transaction at bank1
+        let alice = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &alice,
+            blockhash,
+            1,
+            16,
+            &stake::program::id(),
+        );
+
+        bank1.process_transaction(&tx).unwrap();
+
+        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+
+        // add account for bob and process the transaction at bank2
+        let bob = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &bob,
+            blockhash,
+            2,
+            16,
+            &stake::program::id(),
+        );
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+
+        bank2.process_transaction(&tx).unwrap();
+
+        // now add programSubscribe at the "confirmed" commitment level
+        let (subscriber, _id_receiver, transport_receiver) =
+            Subscriber::new_test("programNotification");
+        let sub_id = SubscriptionId::Number(0);
+        let exit = Arc::new(AtomicBool::new(false));
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
+            ))),
+            optimistically_confirmed_bank.clone(),
+        ));
+        subscriptions.add_program_subscription(
+            stake::program::id(),
+            Some(RpcProgramAccountsConfig {
+                account_config: RpcAccountInfoConfig {
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    ..RpcAccountInfoConfig::default()
+                },
+                ..RpcProgramAccountsConfig::default()
+            }),
+            sub_id.clone(),
+            subscriber,
+        );
+
+        assert!(subscriptions
+            .subscriptions
+            .gossip_program_subscriptions
+            .read()
+            .unwrap()
+            .contains_key(&stake::program::id()));
+
+        let mut highest_confirmed_slot: Slot = 0;
+        let mut last_notified_confirmed_slot: Slot = 0;
+        // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is not in the bankforks, we do not
+        // expect to see any RPC notifications.
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
+            &mut highest_confirmed_slot,
+        );
+
+        // The following should panic
+        let (_response, _transport_receiver) = robust_poll_or_panic(transport_receiver);
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_program_subscribe_for_missing_optimistically_confirmed_slot_with_no_banks() {
+        // Testing if we can get the pubsub notification if a slot does not
+        // receive OptimisticallyConfirmed but its descendant slot get the confirmed
+        // notification. It differs from the test_check_program_subscribe_for_missing_optimistically_confirmed_slot
+        // test in that when the descendant get confirmed, the descendant does not have a bank yet.
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(100);
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.lazy_rent_collection.store(true, Relaxed);
+
+        let blockhash = bank.last_blockhash();
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+
+        // add account for alice and process the transaction at bank1
+        let alice = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &alice,
+            blockhash,
+            1,
+            16,
+            &stake::program::id(),
+        );
+
+        bank1.process_transaction(&tx).unwrap();
+
+        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+
+        // add account for bob and process the transaction at bank2
+        let bob = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &bob,
+            blockhash,
+            2,
+            16,
+            &stake::program::id(),
+        );
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+
+        bank2.process_transaction(&tx).unwrap();
+
+        // now add programSubscribe at the "confirmed" commitment level
+        let (subscriber, _id_receiver, transport_receiver) =
+            Subscriber::new_test("programNotification");
+        let sub_id = SubscriptionId::Number(0);
+        let exit = Arc::new(AtomicBool::new(false));
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
+            ))),
+            optimistically_confirmed_bank.clone(),
+        ));
+        subscriptions.add_program_subscription(
+            stake::program::id(),
+            Some(RpcProgramAccountsConfig {
+                account_config: RpcAccountInfoConfig {
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    ..RpcAccountInfoConfig::default()
+                },
+                ..RpcProgramAccountsConfig::default()
+            }),
+            sub_id.clone(),
+            subscriber,
+        );
+
+        assert!(subscriptions
+            .subscriptions
+            .gossip_program_subscriptions
+            .read()
+            .unwrap()
+            .contains_key(&stake::program::id()));
+
+        let mut highest_confirmed_slot: Slot = 0;
+        let mut last_notified_confirmed_slot: Slot = 0;
+        // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is not in the bankforks, we expect
+        // to see transaction for alice and bob to be notified only when bank3 is added to the fork and
+        // frozen. The notifications should be in the increasing order of the slot.
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
+            &mut highest_confirmed_slot,
+        );
+
+        // a closure to reduce code duplications in building expected responses:
+        let build_expected_resp = |slot: Slot, lamports: u64, pubkey: &str, subscription: i32| {
+            json!({
+               "jsonrpc": "2.0",
+               "method": "programNotification",
+               "params": {
+                   "result": {
+                       "context": { "slot": slot },
+                       "value": {
+                           "account": {
+                              "data": "1111111111111111",
+                              "executable": false,
+                              "lamports": lamports,
+                              "owner": "Stake11111111111111111111111111111111111111",
+                              "rentEpoch": 0,
+                           },
+                           "pubkey": pubkey,
+                        },
+                   },
+                   "subscription": subscription,
+               }
+            })
+        };
+
+        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        bank_forks.write().unwrap().insert(bank3);
+
+        // add account for joe and process the transaction at bank3
+        let joe = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &joe,
+            blockhash,
+            3,
+            16,
+            &stake::program::id(),
+        );
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+
+        bank3.process_transaction(&tx).unwrap();
+        bank3.freeze();
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::Frozen(bank3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
+            &mut highest_confirmed_slot,
+        );
+
+        let (response, transport_receiver) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(1, 1, &alice.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
+
+        let (response, transport_receiver) = robust_poll_or_panic(transport_receiver);
+        let expected = build_expected_resp(2, 2, &bob.pubkey().to_string(), 0);
+        assert_eq!(serde_json::to_string(&expected).unwrap(), response);
 
         let (response, _) = robust_poll_or_panic(transport_receiver);
         let expected = build_expected_resp(3, 3, &joe.pubkey().to_string(), 0);
@@ -2232,12 +2514,14 @@ pub(crate) mod tests {
 
         // First, notify the unfrozen bank first to queue pending notification
         let mut highest_confirmed_slot: Slot = 0;
+        let mut last_notified_confirmed_slot: Slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
 
@@ -2249,6 +2533,7 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
 
@@ -2286,6 +2571,7 @@ pub(crate) mod tests {
         );
 
         let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        bank2.freeze();
         highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::Frozen(bank2),
@@ -2293,6 +2579,7 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
+            &mut last_notified_confirmed_slot,
             &mut highest_confirmed_slot,
         );
         let (response, _) = robust_poll_or_panic(transport_receiver1);

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1728,7 +1728,7 @@ pub(crate) mod tests {
             .unwrap()
             .contains_key(&stake::program::id()));
 
-        let mut last_notified_slot: Slot = 0;
+        let mut highest_confirmed_slot: Slot = 0;
         // Optimistically notifying slot 3 without notifying slot 1 and 2, bank3 is unfrozen, we expect
         // to see transaction for alice and bob to be notified in order.
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -1737,7 +1737,7 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
 
         // a closure to reduce code duplications in building expected responses:
@@ -1779,7 +1779,7 @@ pub(crate) mod tests {
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
 
         let (response, _) = robust_poll_or_panic(transport_receiver);
@@ -2231,25 +2231,25 @@ pub(crate) mod tests {
             .unwrap();
 
         // First, notify the unfrozen bank first to queue pending notification
-        let mut last_notified_slot: Slot = 0;
+        let mut highest_confirmed_slot: Slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(2),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
 
         // Now, notify the frozen bank and ensure its notifications are processed
-        last_notified_slot = 0;
+        highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(1),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
 
         let (response, _) = robust_poll_or_panic(transport_receiver0);
@@ -2286,14 +2286,14 @@ pub(crate) mod tests {
         );
 
         let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
-        last_notified_slot = 0;
+        highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::Frozen(bank2),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
-            &mut last_notified_slot,
+            &mut highest_confirmed_slot,
         );
         let (response, _) = robust_poll_or_panic(transport_receiver1);
         let expected = json!({


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/18587: programSubscribe is missing notifications randomly. The issue is because of two reasons

1. Not all rooted slots get OptimisticallyConfirmed notifications
2. The OptimisticallyConfirmed notifications can be out of order for slots: slot A and B with A < B can see notification for B first before A.

#### Summary of Changes

Changed OptimisticallyConfirmedBankTracker to send notifications for parent banks if they have not been notified yet. We use a new variable last_notified_slot to track that.

Tests:
With my validator running against testnet, before the fix, it was failing 75% of time, with the fix, it is passing consistently. Using the program mentioned in https://github.com/solana-labs/solana/issues/18587.

Fixes # 18587
