### PR TITLE
remove AccountsDb::new() from public api

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1407,7 +1407,8 @@ impl AccountsDb {
         }
     }
 
-    pub fn new(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
+    pub fn new_for_tests(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
+        // will diverge
         AccountsDb::new_with_config(
             paths,
             cluster_type,
@@ -1415,11 +1416,6 @@ impl AccountsDb {
             false,
             AccountShrinkThreshold::default(),
         )
-    }
-
-    pub fn new_for_tests(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
-        // will diverge
-        Self::new(paths, cluster_type)
     }
 
     pub fn new_with_config(
@@ -6186,6 +6182,10 @@ impl AccountsDb {
 
 #[cfg(test)]
 impl AccountsDb {
+    pub fn new(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
+        Self::new_for_tests(paths, cluster_type)
+    }
+
     pub fn new_sized(paths: Vec<PathBuf>, file_size: u64) -> Self {
         AccountsDb {
             file_size,

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -73,7 +73,7 @@ fn test_shrink_and_clean() {
 fn test_bad_bank_hash() {
     solana_logger::setup();
     use solana_sdk::signature::{Keypair, Signer};
-    let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
+    let db = AccountsDb::new_for_tests(Vec::new(), &ClusterType::Development);
 
     let some_slot: Slot = 0;
     let ancestors = Ancestors::from(vec![some_slot]);


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
