### PR TITLE
remove Bank::default()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1040,12 +1040,6 @@ pub struct Bank {
     pub freeze_started: AtomicBool,
 }
 
-impl Default for Bank {
-    fn default() -> Self {
-        Self::default_with_accounts(Accounts::default())
-    }
-}
-
 impl Default for BlockhashQueue {
     fn default() -> Self {
         Self::new(MAX_RECENT_BLOCKHASHES)
@@ -1054,8 +1048,7 @@ impl Default for BlockhashQueue {
 
 impl Bank {
     pub fn default_for_tests() -> Self {
-        // will diverge
-        Self::default()
+        Self::default_with_accounts(Accounts::default_for_tests())
     }
 
     pub fn new_for_benches(genesis_config: &GenesisConfig) -> Self {


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
