### PR TITLE
accounts default stragglers

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {:?}", path);
     }
-    let accounts = Accounts::new_with_config(
+    let accounts = Accounts::new_with_config_for_benches(
         vec![path],
         &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1344,12 +1344,6 @@ impl<'a> ReadableAccount for StoredAccountMeta<'a> {
     }
 }
 
-impl Default for AccountsDb {
-    fn default() -> Self {
-        Self::default_with_accounts_index(AccountInfoAccountsIndex::new(BINS_DEFAULT))
-    }
-}
-
 type GenerateIndexAccountsMap<'a> =
     HashMap<Pubkey, (StoredMetaWriteVersion, AppendVecId, StoredAccountMeta<'a>)>;
 


### PR DESCRIPTION
#### Problem
It will become expensive to create many disk buckets for an AccountsIndex. For testing, we don't need to create as many. So, we want to make it clear which functions are for testing only. Benches and /test tests require public, non #[test] entry points, so it seems more clear and helpful to modify the name of test-only functions to make it clear how an api will be used. This pr is for one such function. There will be others.
#### Summary of Changes

Fixes #
