### PR TITLE
Fix deserialization of RPC errors in HttpSender

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -67,7 +67,6 @@ impl HttpSender {
 struct RpcErrorObject {
     code: i64,
     message: String,
-    data: serde_json::Value,
 }
 
 impl RpcSender for HttpSender {

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -423,7 +423,6 @@ fn test_tpu_send_transaction() {
     }
 }
 
-// #15576 - correctly deserialize RPC errors
 #[test]
 fn deserialize_rpc_error() -> ClientResult<()> {
     solana_logger::setup();

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -6,8 +6,10 @@ use reqwest::{self, header::CONTENT_TYPE};
 use serde_json::{json, Value};
 use solana_account_decoder::UiAccount;
 use solana_client::{
+    client_error::{ClientErrorKind, Result as ClientResult},
     rpc_client::RpcClient,
     rpc_config::{RpcAccountInfoConfig, RpcSignatureSubscribeConfig},
+    rpc_request::RpcError,
     rpc_response::{Response, RpcSignatureResult, SlotUpdate},
     tpu_client::{TpuClient, TpuClientConfig},
 };
@@ -417,6 +419,38 @@ fn test_tpu_send_transaction() {
         let statuses = rpc_client.get_signature_statuses(&signatures).unwrap();
         if statuses.value.get(0).is_some() {
             return;
+        }
+    }
+}
+
+// #15576 - correctly deserialize RPC errors
+#[test]
+fn deserialize_rpc_error() -> ClientResult<()> {
+    solana_logger::setup();
+
+    let alice = Keypair::new();
+    let validator = TestValidator::with_no_fees(alice.pubkey(), None, SocketAddrSpace::Unspecified);
+    let rpc_client = RpcClient::new(validator.rpc_url());
+
+    let bob = Keypair::new();
+    let lamports = 50;
+    let (recent_blockhash, _) = rpc_client.get_recent_blockhash()?;
+    let mut tx = system_transaction::transfer(&alice, &bob.pubkey(), lamports, recent_blockhash);
+
+    // This will cause an error
+    tx.signatures.clear();
+
+    let err = rpc_client.send_transaction(&tx);
+    let err = err.unwrap_err();
+
+    match err.kind {
+        ClientErrorKind::RpcError(RpcError::RpcRequestError { .. }) => {
+            // This is what used to happen
+            panic!()
+        }
+        ClientErrorKind::RpcError(RpcError::RpcResponseError { .. }) => Ok(()),
+        _ => {
+            panic!()
         }
     }
 }


### PR DESCRIPTION
#### Problem

HttpSender, and in turn RpcClient, fails to deserialize some, if not many, RPC errors, resulting in generic "failed to deserialize RPC error" errors.

The bug comes from expecting every error to contain a `data` field, but that field is optional.

#### Summary of Changes

Remove the data field from the `RpcErrorObject` type. This is an internal intermediate type, and its data field is not even used. The presence of the `data` field here only serves to create this deserialization error.

Fixes #15576 
