### PR TITLE
Move SnapshotArchiveInfo and friends into its own module

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -9,8 +9,8 @@ use rayon::ThreadPool;
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
     accounts_db,
+    snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_package::{AccountsPackage, AccountsPackagePre, AccountsPackageReceiver},
-    snapshot_utils::SnapshotArchiveInfoGetter,
 };
 use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::collections::{HashMap, HashSet};

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,7 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_package::AccountsPackage,
-    snapshot_utils::{self, SnapshotArchiveInfoGetter},
+    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::AccountsPackage,
+    snapshot_utils,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -60,8 +60,9 @@ use solana_runtime::{
     bank_forks::BankForks,
     commitment::BlockCommitmentCache,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
-    snapshot_utils::{self, SnapshotArchiveInfoGetter},
+    snapshot_utils,
 };
 use solana_sdk::{
     clock::Slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -54,6 +54,7 @@ mod tests {
         bank::{Bank, BankSlotDelta},
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_config::SnapshotConfig,
         snapshot_package::AccountsPackagePre,
         snapshot_utils::{
@@ -168,8 +169,7 @@ mod tests {
             ArchiveFormat::TarBzip2,
         );
         let full_snapshot_archive_info =
-            snapshot_utils::FullSnapshotArchiveInfo::new_from_path(full_snapshot_archive_path)
-                .unwrap();
+            FullSnapshotArchiveInfo::new_from_path(full_snapshot_archive_path).unwrap();
 
         let (deserialized_bank, _timing) = snapshot_utils::bank_from_snapshot_archives(
             account_paths,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -29,10 +29,10 @@ use solana_runtime::{
     bank::{Bank, RewardCalculationEvent},
     bank_forks::BankForks,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
     snapshot_utils::{
-        self, ArchiveFormat, SnapshotArchiveInfoGetter, SnapshotVersion,
-        DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
 };
 use solana_sdk::{

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -41,8 +41,9 @@ use {
         validator_configs::*,
     },
     solana_runtime::{
+        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
-        snapshot_utils::{self, ArchiveFormat, SnapshotArchiveInfoGetter},
+        snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
         account::AccountSharedData,

--- a/replica-node/src/replica_util.rs
+++ b/replica-node/src/replica_util.rs
@@ -6,7 +6,7 @@ use {
         contact_info::ContactInfo,
         gossip_service::GossipService,
     },
-    solana_runtime::snapshot_utils::{self, SnapshotArchiveInfoGetter},
+    solana_runtime::{snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_utils},
     solana_sdk::{
         clock::Slot,
         hash::Hash,

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -16,8 +16,9 @@ use {
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
         accounts_index::AccountSecondaryIndexes,
+        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
-        snapshot_utils::{self, ArchiveFormat, SnapshotArchiveInfoGetter},
+        snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
         client::SyncClient,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -26,10 +26,9 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::{
-        bank_forks::BankForks,
-        commitment::BlockCommitmentCache,
-        snapshot_config::SnapshotConfig,
-        snapshot_utils::{self, SnapshotArchiveInfoGetter},
+        bank_forks::BankForks, commitment::BlockCommitmentCache,
+        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
+        snapshot_utils,
     },
     solana_sdk::{
         exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ pub mod rent_collector;
 pub mod secondary_index;
 pub mod serde_snapshot;
 mod shared_buffer_reader;
+pub mod snapshot_archive_info;
 pub mod snapshot_config;
 pub mod snapshot_package;
 pub mod snapshot_runtime_info;

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -1,0 +1,149 @@
+//! Information about snapshot archives
+
+use crate::snapshot_utils::{self, ArchiveFormat, Result};
+use solana_sdk::{clock::Slot, hash::Hash};
+use std::{cmp::Ordering, path::PathBuf};
+
+/// Trait to query the snapshot archive information
+pub trait SnapshotArchiveInfoGetter {
+    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo;
+
+    fn path(&self) -> &PathBuf {
+        &self.snapshot_archive_info().path
+    }
+
+    fn slot(&self) -> Slot {
+        self.snapshot_archive_info().slot
+    }
+
+    fn hash(&self) -> &Hash {
+        &self.snapshot_archive_info().hash
+    }
+
+    fn archive_format(&self) -> ArchiveFormat {
+        self.snapshot_archive_info().archive_format
+    }
+}
+
+/// Common information about a snapshot archive
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct SnapshotArchiveInfo {
+    /// Path to the snapshot archive file
+    pub path: PathBuf,
+
+    /// Slot that the snapshot was made
+    pub slot: Slot,
+
+    /// Hash of the accounts at this slot
+    pub hash: Hash,
+
+    /// Archive format for the snapshot file
+    pub archive_format: ArchiveFormat,
+}
+
+/// Information about a full snapshot archive: its path, slot, hash, and archive format
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct FullSnapshotArchiveInfo(SnapshotArchiveInfo);
+
+impl FullSnapshotArchiveInfo {
+    /// Parse the path to a full snapshot archive and return a new `FullSnapshotArchiveInfo`
+    pub fn new_from_path(path: PathBuf) -> Result<Self> {
+        let filename = snapshot_utils::path_to_file_name_str(path.as_path())?;
+        let (slot, hash, archive_format) =
+            snapshot_utils::parse_full_snapshot_archive_filename(filename)?;
+
+        Ok(Self::new(SnapshotArchiveInfo {
+            path,
+            slot,
+            hash,
+            archive_format,
+        }))
+    }
+
+    pub(crate) fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
+        Self(snapshot_archive_info)
+    }
+}
+
+impl SnapshotArchiveInfoGetter for FullSnapshotArchiveInfo {
+    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
+        &self.0
+    }
+}
+
+impl PartialOrd for FullSnapshotArchiveInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Order `FullSnapshotArchiveInfo` by slot (ascending), which practially is sorting chronologically
+impl Ord for FullSnapshotArchiveInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.slot().cmp(&other.slot())
+    }
+}
+
+/// Information about an incremental snapshot archive: its path, slot, base slot, hash, and archive format
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct IncrementalSnapshotArchiveInfo {
+    /// The slot that the incremental snapshot was based from.  This is the same as the full
+    /// snapshot slot used when making the incremental snapshot.
+    base_slot: Slot,
+
+    /// Use the `SnapshotArchiveInfo` struct for the common fields: path, slot, hash, and
+    /// archive_format, but as they pertain to the incremental snapshot.
+    inner: SnapshotArchiveInfo,
+}
+
+impl IncrementalSnapshotArchiveInfo {
+    /// Parse the path to an incremental snapshot archive and return a new `IncrementalSnapshotArchiveInfo`
+    pub fn new_from_path(path: PathBuf) -> Result<Self> {
+        let filename = snapshot_utils::path_to_file_name_str(path.as_path())?;
+        let (base_slot, slot, hash, archive_format) =
+            snapshot_utils::parse_incremental_snapshot_archive_filename(filename)?;
+
+        Ok(Self::new(
+            base_slot,
+            SnapshotArchiveInfo {
+                path,
+                slot,
+                hash,
+                archive_format,
+            },
+        ))
+    }
+
+    pub(crate) fn new(base_slot: Slot, snapshot_archive_info: SnapshotArchiveInfo) -> Self {
+        Self {
+            base_slot,
+            inner: snapshot_archive_info,
+        }
+    }
+
+    pub fn base_slot(&self) -> Slot {
+        self.base_slot
+    }
+}
+
+impl SnapshotArchiveInfoGetter for IncrementalSnapshotArchiveInfo {
+    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
+        &self.inner
+    }
+}
+
+impl PartialOrd for IncrementalSnapshotArchiveInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Order `IncrementalSnapshotArchiveInfo` by base slot (ascending), then slot (ascending), which
+// practially is sorting chronologically
+impl Ord for IncrementalSnapshotArchiveInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.base_slot()
+            .cmp(&other.base_slot())
+            .then(self.slot().cmp(&other.slot()))
+    }
+}

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,10 +1,13 @@
-use crate::snapshot_utils::{
-    ArchiveFormat, BankSnapshotInfo, Result, SnapshotArchiveInfo, SnapshotArchiveInfoGetter,
-    SnapshotVersion, TMP_FULL_SNAPSHOT_PREFIX, TMP_INCREMENTAL_SNAPSHOT_PREFIX,
-};
 use crate::{
     accounts_db::SnapshotStorages,
     bank::{Bank, BankSlotDelta},
+};
+use crate::{
+    snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
+    snapshot_utils::{
+        ArchiveFormat, BankSnapshotInfo, Result, SnapshotVersion, TMP_FULL_SNAPSHOT_PREFIX,
+        TMP_INCREMENTAL_SNAPSHOT_PREFIX,
+    },
 };
 use log::*;
 use solana_sdk::clock::Slot;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -9,6 +9,9 @@ use {
             SnapshotStreams,
         },
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
+        snapshot_archive_info::{
+            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
+        },
         snapshot_package::{
             AccountsPackage, AccountsPackagePre, AccountsPackageSendError, AccountsPackageSender,
         },
@@ -38,149 +41,6 @@ use {
     tempfile::TempDir,
     thiserror::Error,
 };
-
-/// Trait to query the snapshot archive information
-pub trait SnapshotArchiveInfoGetter {
-    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo;
-
-    fn path(&self) -> &PathBuf {
-        &self.snapshot_archive_info().path
-    }
-
-    fn slot(&self) -> Slot {
-        self.snapshot_archive_info().slot
-    }
-
-    fn hash(&self) -> &Hash {
-        &self.snapshot_archive_info().hash
-    }
-
-    fn archive_format(&self) -> ArchiveFormat {
-        self.snapshot_archive_info().archive_format
-    }
-}
-
-/// Common information about a snapshot archive
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct SnapshotArchiveInfo {
-    /// Path to the snapshot archive file
-    pub path: PathBuf,
-
-    /// Slot that the snapshot was made
-    pub slot: Slot,
-
-    /// Hash of the accounts at this slot
-    pub hash: Hash,
-
-    /// Archive format for the snapshot file
-    pub archive_format: ArchiveFormat,
-}
-
-/// Information about a full snapshot archive: its path, slot, hash, and archive format
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct FullSnapshotArchiveInfo(SnapshotArchiveInfo);
-
-impl FullSnapshotArchiveInfo {
-    /// Parse the path to a full snapshot archive and return a new `FullSnapshotArchiveInfo`
-    pub fn new_from_path(path: PathBuf) -> Result<Self> {
-        let filename = path_to_file_name_str(path.as_path())?;
-        let (slot, hash, archive_format) = parse_full_snapshot_archive_filename(filename)?;
-
-        Ok(Self::new(SnapshotArchiveInfo {
-            path,
-            slot,
-            hash,
-            archive_format,
-        }))
-    }
-
-    fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
-        Self(snapshot_archive_info)
-    }
-}
-
-impl SnapshotArchiveInfoGetter for FullSnapshotArchiveInfo {
-    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
-        &self.0
-    }
-}
-
-impl PartialOrd for FullSnapshotArchiveInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-// Order `FullSnapshotArchiveInfo` by slot (ascending), which practially is sorting chronologically
-impl Ord for FullSnapshotArchiveInfo {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.slot().cmp(&other.slot())
-    }
-}
-
-/// Information about an incremental snapshot archive: its path, slot, base slot, hash, and archive format
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct IncrementalSnapshotArchiveInfo {
-    /// The slot that the incremental snapshot was based from.  This is the same as the full
-    /// snapshot slot used when making the incremental snapshot.
-    base_slot: Slot,
-
-    /// Use the `SnapshotArchiveInfo` struct for the common fields: path, slot, hash, and
-    /// archive_format, but as they pertain to the incremental snapshot.
-    inner: SnapshotArchiveInfo,
-}
-
-impl IncrementalSnapshotArchiveInfo {
-    /// Parse the path to an incremental snapshot archive and return a new `IncrementalSnapshotArchiveInfo`
-    pub fn new_from_path(path: PathBuf) -> Result<Self> {
-        let filename = path_to_file_name_str(path.as_path())?;
-        let (base_slot, slot, hash, archive_format) =
-            parse_incremental_snapshot_archive_filename(filename)?;
-
-        Ok(Self::new(
-            base_slot,
-            SnapshotArchiveInfo {
-                path,
-                slot,
-                hash,
-                archive_format,
-            },
-        ))
-    }
-
-    fn new(base_slot: Slot, snapshot_archive_info: SnapshotArchiveInfo) -> Self {
-        Self {
-            base_slot,
-            inner: snapshot_archive_info,
-        }
-    }
-
-    pub fn base_slot(&self) -> Slot {
-        self.base_slot
-    }
-}
-
-impl SnapshotArchiveInfoGetter for IncrementalSnapshotArchiveInfo {
-    fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
-        &self.inner
-    }
-}
-
-impl PartialOrd for IncrementalSnapshotArchiveInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-// Order `IncrementalSnapshotArchiveInfo` by base slot (ascending), then slot (ascending), which
-// practially is sorting chronologically
-impl Ord for IncrementalSnapshotArchiveInfo {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.base_slot()
-            .cmp(&other.base_slot())
-            .then(self.slot().cmp(&other.slot()))
-    }
-}
 
 pub const SNAPSHOT_STATUS_CACHE_FILE_NAME: &str = "status_cache";
 
@@ -1119,7 +979,7 @@ fn check_are_snapshots_compatible(
 }
 
 /// Get the `&str` from a `&Path`
-fn path_to_file_name_str(path: &Path) -> Result<&str> {
+pub fn path_to_file_name_str(path: &Path) -> Result<&str> {
     path.file_name()
         .ok_or_else(|| SnapshotError::PathToFileNameError(path.to_path_buf()))?
         .to_str()
@@ -1172,7 +1032,7 @@ fn archive_format_from_str(archive_format: &str) -> Option<ArchiveFormat> {
 }
 
 /// Parse a full snapshot archive filename into its Slot, Hash, and Archive Format
-fn parse_full_snapshot_archive_filename(
+pub fn parse_full_snapshot_archive_filename(
     archive_filename: &str,
 ) -> Result<(Slot, Hash, ArchiveFormat)> {
     lazy_static! {
@@ -1203,7 +1063,7 @@ fn parse_full_snapshot_archive_filename(
 }
 
 /// Parse an incremental snapshot archive filename into its base Slot, actual Slot, Hash, and Archive Format
-fn parse_incremental_snapshot_archive_filename(
+pub fn parse_incremental_snapshot_archive_filename(
     archive_filename: &str,
 ) -> Result<(Slot, Slot, Hash, ArchiveFormat)> {
     lazy_static! {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -47,10 +47,10 @@ use {
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
         },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+        snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_utils::{
-            self, ArchiveFormat, SnapshotArchiveInfoGetter, SnapshotVersion,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
     },
     solana_sdk::{


### PR DESCRIPTION
`SnapshotArchiveInfo` has grown quite a bit, plus I will be making more additions to support Incremental Snapshots in the background services. Moving `SnapshotArchiveInfo` and friends into its own module makes sense at this point.