### PR TITLE
allows private addresses if not public network

### DIFF
--- a/net/common.sh
+++ b/net/common.sh
@@ -69,6 +69,7 @@ loadConfigFile() {
     entrypointIp=${validatorIpList[0]}
   else
     entrypointIp=${validatorIpListPrivate[0]}
+    maybeAllowPrivateAddr='--allow-private-addr'
   fi
 
   buildSshOptions

--- a/net/net.sh
+++ b/net/net.sh
@@ -901,6 +901,8 @@ while [[ -n $1 ]]; do
       extraPrimordialStakes=$2
       shift 2
     elif [[ $1 = --allow-private-addr ]]; then
+      # May also be added by loadConfigFile if 'gce.sh create' was invoked
+      # without -P.
       maybeAllowPrivateAddr="$1"
       shift 1
     else


### PR DESCRIPTION
#### Problem
`./net.sh` needs `--allow-private-addr` if `gce.sh create` was invoked without `-P`.

#### Summary of Changes
When loading config file, if not a public network add `--allow-private-addr`.