### PR TITLE
Use private IP addresses for the partition gce test

### DIFF
--- a/system-test/partition-testcases/gce-5-node-3-partition.yml
+++ b/system-test/partition-testcases/gce-5-node-3-partition.yml
@@ -11,7 +11,8 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
+      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -12,6 +12,7 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
+      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -11,7 +11,8 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
+      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/gce-partition-with-offline.yml
+++ b/system-test/partition-testcases/gce-partition-with-offline.yml
@@ -11,7 +11,8 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
+      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"


### PR DESCRIPTION
#### Problem
The recent gossip change requires an additional flag `--allow-private-addr` in order to discover private IP addresses.
We modify the gce cluster tests to pass this additional flag and set IP addresses to private. 

#### Summary of Changes
Use private IP addresses for this test.

Fixes #
