### PR TITLE
Use option for account index bucket parameter

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -191,7 +191,7 @@ mod tests {
             check_hash_calculation,
             false,
             false,
-            solana_runtime::accounts_index::BINS_FOR_TESTING,
+            Some(solana_runtime::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
 
@@ -808,7 +808,7 @@ mod tests {
             false,
             false,
             false,
-            solana_runtime::accounts_index::BINS_FOR_TESTING,
+            Some(solana_runtime::accounts_index::BINS_FOR_TESTING),
         )?;
 
         assert_eq!(bank, &deserialized_bank);

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -132,7 +132,7 @@ fn load_from_snapshot(
         process_options.accounts_db_test_hash_calculation,
         process_options.accounts_db_skip_shrink,
         process_options.verify_index,
-        solana_runtime::accounts_index::BINS_DEFAULT,
+        None,
     )
     .expect("Load from snapshot failed");
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -416,7 +416,7 @@ pub fn process_blockstore(
         opts.accounts_db_caching_enabled,
         opts.shrink_ratio,
         false,
-        solana_runtime::accounts_index::BINS_DEFAULT,
+        None, // later, this will be passed from ProcessOptions
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -127,7 +127,7 @@ fn initialize_from_snapshot(
         process_options.accounts_db_test_hash_calculation,
         false,
         process_options.verify_index,
-        solana_runtime::accounts_index::BINS_DEFAULT,
+        None,
     )
     .unwrap();
 

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -5,7 +5,7 @@ extern crate test;
 use rand::{thread_rng, Rng};
 use solana_runtime::{
     accounts_db::AccountInfo,
-    accounts_index::{AccountSecondaryIndexes, AccountsIndex, BINS_DEFAULT},
+    accounts_index::{AccountSecondaryIndexes, AccountsIndex, BINS_FOR_BENCHMARKS},
 };
 use solana_sdk::pubkey::{self, Pubkey};
 use test::Bencher;
@@ -18,7 +18,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_FORKS: u64 = 16;
 
     let mut reclaims = vec![];
-    let index = AccountsIndex::<AccountInfo>::new(BINS_DEFAULT);
+    let index = AccountsIndex::<AccountInfo>::new(Some(BINS_FOR_BENCHMARKS));
     for f in 0..NUM_FORKS {
         for pubkey in pubkeys.iter().take(NUM_PUBKEYS) {
             index.upsert(

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -139,7 +139,7 @@ impl Accounts {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            BINS_FOR_TESTING,
+            Some(BINS_FOR_TESTING),
         )
     }
 
@@ -156,7 +156,7 @@ impl Accounts {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            BINS_FOR_BENCHMARKS,
+            Some(BINS_FOR_BENCHMARKS),
         )
     }
 
@@ -166,7 +166,7 @@ impl Accounts {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
-        accounts_index_bins: usize,
+        accounts_index_bins: Option<usize>,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1419,7 +1419,7 @@ impl AccountsDb {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
-            BINS_FOR_TESTING,
+            Some(BINS_FOR_TESTING),
         )
     }
 
@@ -1429,7 +1429,7 @@ impl AccountsDb {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
-        accounts_index_bins: usize,
+        accounts_index_bins: Option<usize>,
     ) -> Self {
         let accounts_index = AccountsIndex::new(accounts_index_bins);
         let mut new = if !paths.is_empty() {
@@ -6233,7 +6233,7 @@ impl AccountsDb {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            BINS_FOR_TESTING,
+            Some(BINS_FOR_TESTING),
         )
     }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -761,10 +761,10 @@ pub struct AccountsIndex<T> {
 
 impl<T: IsCached> AccountsIndex<T> {
     pub fn default_for_tests() -> Self {
-        Self::new(BINS_FOR_TESTING)
+        Self::new(Some(BINS_FOR_TESTING))
     }
 
-    pub fn new(bins: usize) -> Self {
+    pub fn new(bins: Option<usize>) -> Self {
         let (account_maps, bin_calculator) = Self::allocate_accounts_index(bins);
         Self {
             account_maps,
@@ -784,7 +784,8 @@ impl<T: IsCached> AccountsIndex<T> {
         }
     }
 
-    fn allocate_accounts_index(bins: usize) -> (LockMapType<T>, PubkeyBinCalculator16) {
+    fn allocate_accounts_index(bins: Option<usize>) -> (LockMapType<T>, PubkeyBinCalculator16) {
+        let bins = bins.unwrap_or(BINS_DEFAULT);
         let account_maps = (0..bins)
             .into_iter()
             .map(|_| RwLock::new(AccountMap::default()))
@@ -4023,6 +4024,6 @@ pub mod tests {
     #[test]
     #[should_panic(expected = "bins.is_power_of_two()")]
     fn test_illegal_bins() {
-        AccountsIndex::<bool>::new(3);
+        AccountsIndex::<bool>::new(Some(3));
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1190,7 +1190,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             debug_do_not_add_builtins,
-            BINS_FOR_TESTING,
+            Some(BINS_FOR_TESTING),
         )
     }
 
@@ -1215,7 +1215,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             debug_do_not_add_builtins,
-            BINS_FOR_BENCHMARKS,
+            Some(BINS_FOR_BENCHMARKS),
         )
     }
 
@@ -1230,7 +1230,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
         debug_do_not_add_builtins: bool,
-        accounts_index_bins: usize,
+        accounts_index_bins: Option<usize>,
     ) -> Self {
         let accounts = Accounts::new_with_config(
             paths,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -197,7 +197,7 @@ pub(crate) fn bank_from_streams<R>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -328,7 +328,7 @@ fn reconstruct_bank_from_fields<E>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -395,7 +395,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> Result<AccountsDb, Error>
 where
     E: SerializableStorage + std::marker::Sync,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -81,7 +81,7 @@ where
         None,
         AccountShrinkThreshold::default(),
         false,
-        crate::accounts_index::BINS_FOR_TESTING,
+        Some(crate::accounts_index::BINS_FOR_TESTING),
     )
 }
 
@@ -243,7 +243,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         None,
         AccountShrinkThreshold::default(),
         false,
-        crate::accounts_index::BINS_FOR_TESTING,
+        Some(crate::accounts_index::BINS_FOR_TESTING),
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -726,7 +726,7 @@ pub fn bank_from_snapshot_archives(
     test_hash_calculation: bool,
     accounts_db_skip_shrink: bool,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
@@ -833,7 +833,7 @@ pub fn bank_from_latest_snapshot_archives(
     test_hash_calculation: bool,
     accounts_db_skip_shrink: bool,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     let full_snapshot_archive_info = get_highest_full_snapshot_archive_info(&snapshot_archives_dir)
         .ok_or(SnapshotError::NoSnapshotArchives)?;
@@ -1371,7 +1371,7 @@ fn rebuild_bank_from_snapshots(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_bins: usize,
+    accounts_index_bins: Option<usize>,
 ) -> Result<Bank> {
     let (full_snapshot_version, full_snapshot_root_paths) =
         verify_unpacked_snapshots_dir_and_version(
@@ -2490,7 +2490,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
 
@@ -2581,7 +2581,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
 
@@ -2691,7 +2691,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
 
@@ -2790,7 +2790,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
 


### PR DESCRIPTION
#### Problem
We want account index num buckets to be specified by an optional cli arg. In its absence, we want a default.
#### Summary of Changes
Use Option<usize> instead of just usize and keep the default behavior in AccountsIndex
Fixes #
