### PR TITLE
renames solana_runtime::vote_account::VoteAccount and makes it private

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -8,7 +8,7 @@ use {
     solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE,
-        vote_account::ArcVoteAccount,
+        vote_account::VoteAccount,
     },
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
@@ -209,7 +209,7 @@ impl Tower {
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
     ) -> ComputedBankState
     where
-        F: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
+        F: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
     {
         let mut vote_slots = HashSet::new();
         let mut voted_stakes = HashMap::new();
@@ -555,7 +555,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
         heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
@@ -825,7 +825,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
         heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
@@ -1398,7 +1398,7 @@ pub mod test {
     use tempfile::TempDir;
     use trees::tr;
 
-    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, ArcVoteAccount))> {
+    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, VoteAccount))> {
         let mut stakes = vec![];
         for (lamports, votes) in stake_votes {
             let mut account = AccountSharedData::from(Account {
@@ -1417,7 +1417,7 @@ pub mod test {
             .expect("serialize state");
             stakes.push((
                 solana_sdk::pubkey::new_rand(),
-                (*lamports, ArcVoteAccount::from(account)),
+                (*lamports, VoteAccount::from(account)),
             ));
         }
         stakes

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -1,15 +1,17 @@
-use crate::{
-    cluster_info_vote_listener::SlotVoteTracker,
-    cluster_slots::SlotPubkeys,
-    replay_stage::SUPERMINORITY_THRESHOLD,
-    {consensus::Stake, consensus::VotedStakes},
-};
-use solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming};
-use solana_runtime::{bank::Bank, bank_forks::BankForks, vote_account::ArcVoteAccount};
-use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::{Arc, RwLock},
+use {
+    crate::{
+        cluster_info_vote_listener::SlotVoteTracker,
+        cluster_slots::SlotPubkeys,
+        replay_stage::SUPERMINORITY_THRESHOLD,
+        {consensus::Stake, consensus::VotedStakes},
+    },
+    solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming},
+    solana_runtime::{bank::Bank, bank_forks::BankForks, vote_account::VoteAccount},
+    solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
+    std::{
+        collections::{BTreeMap, HashMap, HashSet},
+        sync::{Arc, RwLock},
+    },
 };
 
 type VotedSlot = Slot;
@@ -326,7 +328,7 @@ impl PropagatedStats {
         &mut self,
         node_pubkey: &Pubkey,
         vote_account_pubkeys: &[Pubkey],
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
     ) {
         self.propagated_node_ids.insert(*node_pubkey);
         for vote_account_pubkey in vote_account_pubkeys.iter() {
@@ -522,7 +524,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, ArcVoteAccount::default())))
+            .map(|pubkey| (*pubkey, (1, VoteAccount::default())))
             .collect();
 
         let mut stats = PropagatedStats::default();
@@ -564,7 +566,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, ArcVoteAccount::default())))
+            .map(|pubkey| (*pubkey, (1, VoteAccount::default())))
             .collect();
         stats.add_node_pubkey_internal(&node_pubkey, &vote_account_pubkeys, &epoch_vote_accounts);
         assert!(stats.propagated_node_ids.contains(&node_pubkey));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -26,7 +26,7 @@ use solana_runtime::{
     commitment::VOTE_THRESHOLD_SIZE,
     snapshot_utils::BankFromArchiveTimings,
     transaction_batch::TransactionBatch,
-    vote_account::ArcVoteAccount,
+    vote_account::VoteAccount,
     vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{
@@ -1140,7 +1140,7 @@ fn supermajority_root_from_vote_accounts<I>(
     vote_accounts: I,
 ) -> Option<Slot>
 where
-    I: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
+    I: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
 {
     let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts
         .into_iter()
@@ -3501,7 +3501,7 @@ pub mod tests {
     #[allow(clippy::field_reassign_with_default)]
     fn test_supermajority_root_from_vote_accounts() {
         let convert_to_vote_accounts =
-            |roots_stakes: Vec<(Slot, u64)>| -> Vec<(Pubkey, (u64, ArcVoteAccount))> {
+            |roots_stakes: Vec<(Slot, u64)>| -> Vec<(Pubkey, (u64, VoteAccount))> {
                 roots_stakes
                     .into_iter()
                     .map(|(root, stake)| {
@@ -3516,7 +3516,7 @@ pub mod tests {
                         VoteState::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
                         (
                             solana_sdk::pubkey::new_rand(),
-                            (stake, ArcVoteAccount::from(vote_account)),
+                            (stake, VoteAccount::from(vote_account)),
                         )
                     })
                     .collect_vec()

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -61,31 +61,33 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
-    use crate::genesis_utils::{
-        bootstrap_validator_stake_lamports, create_genesis_config, GenesisConfigInfo,
-    };
-    use rand::Rng;
-    use solana_runtime::vote_account::{ArcVoteAccount, VoteAccounts};
-    use solana_sdk::{
-        account::{from_account, AccountSharedData},
-        clock::Clock,
-        instruction::Instruction,
-        pubkey::Pubkey,
-        signature::{Keypair, Signer},
-        signers::Signers,
-        stake::{
-            instruction as stake_instruction,
-            state::{Authorized, Delegation, Lockup, Stake},
+    use {
+        super::*,
+        crate::genesis_utils::{
+            bootstrap_validator_stake_lamports, create_genesis_config, GenesisConfigInfo,
         },
-        sysvar::stake_history::{self, StakeHistory},
-        transaction::Transaction,
+        rand::Rng,
+        solana_runtime::vote_account::{VoteAccount, VoteAccounts},
+        solana_sdk::{
+            account::{from_account, AccountSharedData},
+            clock::Clock,
+            instruction::Instruction,
+            pubkey::Pubkey,
+            signature::{Keypair, Signer},
+            signers::Signers,
+            stake::{
+                instruction as stake_instruction,
+                state::{Authorized, Delegation, Lockup, Stake},
+            },
+            sysvar::stake_history::{self, StakeHistory},
+            transaction::Transaction,
+        },
+        solana_vote_program::{
+            vote_instruction,
+            vote_state::{VoteInit, VoteState, VoteStateVersions},
+        },
+        std::sync::Arc,
     };
-    use solana_vote_program::{
-        vote_instruction,
-        vote_state::{VoteInit, VoteState, VoteStateVersions},
-    };
-    use std::sync::Arc;
 
     fn new_from_parent(parent: &Arc<Bank>, slot: Slot) -> Bank {
         Bank::new_from_parent(parent, &Pubkey::default(), slot)
@@ -317,7 +319,7 @@ pub(crate) mod tests {
             )
             .unwrap();
             let vote_pubkey = Pubkey::new_unique();
-            (vote_pubkey, (stake, ArcVoteAccount::from(account)))
+            (vote_pubkey, (stake, VoteAccount::from(account)))
         });
         let result = vote_accounts.collect::<VoteAccounts>().staked_nodes();
         assert_eq!(result.len(), 2);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -59,7 +59,7 @@ use crate::{
     status_cache::{SlotDelta, StatusCache},
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
     transaction_batch::TransactionBatch,
-    vote_account::ArcVoteAccount,
+    vote_account::VoteAccount,
 };
 use byteorder::{ByteOrder, LittleEndian};
 use itertools::Itertools;
@@ -538,7 +538,7 @@ pub struct TransactionBalancesSet {
     pub post_balances: TransactionBalances,
 }
 pub struct OverwrittenVoteAccount {
-    pub account: ArcVoteAccount,
+    pub account: VoteAccount,
     pub transaction_index: usize,
     pub transaction_result_index: usize,
 }
@@ -3713,7 +3713,7 @@ impl Bank {
     #[allow(clippy::needless_collect)]
     fn distribute_rent_to_validators<I>(&self, vote_accounts: I, rent_to_be_distributed: u64)
     where
-        I: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
+        I: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
     {
         let mut total_staked = 0;
 
@@ -5145,7 +5145,7 @@ impl Bank {
     ///   attributed to each account
     /// Note: This clones the entire vote-accounts hashmap. For a single
     /// account lookup use get_vote_account instead.
-    pub fn vote_accounts(&self) -> Vec<(Pubkey, (u64 /*stake*/, ArcVoteAccount))> {
+    pub fn vote_accounts(&self) -> Vec<(Pubkey, (/*stake:*/ u64, VoteAccount))> {
         self.stakes
             .read()
             .unwrap()
@@ -5156,10 +5156,7 @@ impl Bank {
     }
 
     /// Vote account for the given vote account pubkey along with the stake.
-    pub fn get_vote_account(
-        &self,
-        vote_account: &Pubkey,
-    ) -> Option<(u64 /*stake*/, ArcVoteAccount)> {
+    pub fn get_vote_account(&self, vote_account: &Pubkey) -> Option<(/*stake:*/ u64, VoteAccount)> {
         self.stakes
             .read()
             .unwrap()
@@ -5186,7 +5183,7 @@ impl Bank {
     pub fn epoch_vote_accounts(
         &self,
         epoch: Epoch,
-    ) -> Option<&HashMap<Pubkey, (u64, ArcVoteAccount)>> {
+    ) -> Option<&HashMap<Pubkey, (u64, VoteAccount)>> {
         self.epoch_stakes
             .get(&epoch)
             .map(|epoch_stakes| Stakes::vote_accounts(epoch_stakes.stakes()))

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,9 @@
-use crate::{stakes::Stakes, vote_account::ArcVoteAccount};
-use serde::{Deserialize, Serialize};
-use solana_sdk::{clock::Epoch, pubkey::Pubkey};
-use std::{collections::HashMap, sync::Arc};
+use {
+    crate::{stakes::Stakes, vote_account::VoteAccount},
+    serde::{Deserialize, Serialize},
+    solana_sdk::{clock::Epoch, pubkey::Pubkey},
+    std::{collections::HashMap, sync::Arc},
+};
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
 pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
@@ -57,7 +59,7 @@ impl EpochStakes {
     }
 
     fn parse_epoch_vote_accounts(
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
         leader_schedule_epoch: Epoch,
     ) -> (u64, NodeIdToVoteAccounts, EpochAuthorizedVoters) {
         let mut node_id_to_vote_accounts: NodeIdToVoteAccounts = HashMap::new();
@@ -188,7 +190,7 @@ pub(crate) mod tests {
                 vote_accounts.iter().map(|v| {
                     (
                         v.vote_account,
-                        (stake_per_account, ArcVoteAccount::from(v.account.clone())),
+                        (stake_per_account, VoteAccount::from(v.account.clone())),
                     )
                 })
             })

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -306,7 +306,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "9i743Qsin8qndpSGqXM3ATkX6fL8dDKtqUwJ8DPjuRam")]
+    #[frozen_abi(digest = "7XCv7DU27QC6iNJ1WYkXY3X4bKu8j6CxAn6morP2u4hu")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]

--- a/runtime/src/stake_weighted_timestamp.rs
+++ b/runtime/src/stake_weighted_timestamp.rs
@@ -22,7 +22,7 @@ pub(crate) struct MaxAllowableDrift {
 
 pub(crate) fn calculate_stake_weighted_timestamp<I, K, V, T>(
     unique_timestamps: I,
-    stakes: &HashMap<Pubkey, (u64, T /*Account|ArcVoteAccount*/)>,
+    stakes: &HashMap<Pubkey, (u64, T /*Account|VoteAccount*/)>,
     slot: Slot,
     slot_duration: Duration,
     epoch_start_timestamp: Option<(Slot, UnixTimestamp)>,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1,7 +1,7 @@
 //! Stakes serve as a cache of stake and vote accounts to derive
 //! node stakes
 use {
-    crate::vote_account::{ArcVoteAccount, VoteAccounts},
+    crate::vote_account::{VoteAccount, VoteAccounts},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         clock::Epoch,
@@ -127,7 +127,7 @@ impl Stakes {
         account: &AccountSharedData,
         fix_stake_deactivate: bool,
         check_vote_init: bool,
-    ) -> Option<ArcVoteAccount> {
+    ) -> Option<VoteAccount> {
         if solana_vote_program::check_id(account.owner()) {
             // unconditionally remove existing at first; there is no dependent calculated state for
             // votes, not like stakes (stake codepath maintains calculated stake value grouped by
@@ -151,7 +151,7 @@ impl Stakes {
                 );
 
                 self.vote_accounts
-                    .insert(*pubkey, (stake, ArcVoteAccount::from(account.clone())));
+                    .insert(*pubkey, (stake, VoteAccount::from(account.clone())));
             }
             old.map(|(_, account)| account)
         } else if stake::program::check_id(account.owner()) {
@@ -211,7 +211,7 @@ impl Stakes {
         }
     }
 
-    pub fn vote_accounts(&self) -> &HashMap<Pubkey, (u64, ArcVoteAccount)> {
+    pub fn vote_accounts(&self) -> &HashMap<Pubkey, (u64, VoteAccount)> {
         self.vote_accounts.borrow()
     }
 


### PR DESCRIPTION
#### Problem
`VoteAccount` is an implementation detail; should not be public.
Only `ArcVoteAccount` should be public.

#### Summary of Changes
* Renamed to `VoteAccountInner`.
* Made `VoteAccountInner` private.
* Renamed `ArcVoteAccount` (the public type) to `VoteAccount`.