### PR TITLE
Pass SnapshotConfig to AccountsHashVerifier

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -10,6 +10,7 @@ use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
     accounts_db,
     snapshot_archive_info::SnapshotArchiveInfoGetter,
+    snapshot_config::SnapshotConfig,
     snapshot_package::{AccountsPackage, AccountsPackagePre, AccountsPackageReceiver},
 };
 use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
@@ -37,7 +38,7 @@ impl AccountsHashVerifier {
         trusted_validators: Option<HashSet<Pubkey>>,
         halt_on_trusted_validators_accounts_hash_mismatch: bool,
         fault_injection_rate_slots: u64,
-        snapshot_interval_slots: u64,
+        snapshot_config: Option<SnapshotConfig>,
     ) -> Self {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
@@ -63,13 +64,13 @@ impl AccountsHashVerifier {
                             Self::process_accounts_package_pre(
                                 accounts_package,
                                 &cluster_info,
-                                &trusted_validators,
+                                trusted_validators.as_ref(),
                                 halt_on_trusted_validators_accounts_hash_mismatch,
-                                &pending_snapshot_package,
+                                pending_snapshot_package.as_ref(),
                                 &mut hashes,
                                 &exit,
                                 fault_injection_rate_slots,
-                                snapshot_interval_slots,
+                                snapshot_config.as_ref(),
                                 thread_pool_storage.as_ref(),
                             );
                         }
@@ -88,13 +89,13 @@ impl AccountsHashVerifier {
     fn process_accounts_package_pre(
         accounts_package: AccountsPackagePre,
         cluster_info: &ClusterInfo,
-        trusted_validators: &Option<HashSet<Pubkey>>,
+        trusted_validators: Option<&HashSet<Pubkey>>,
         halt_on_trusted_validator_accounts_hash_mismatch: bool,
-        pending_snapshot_package: &Option<PendingSnapshotPackage>,
+        pending_snapshot_package: Option<&PendingSnapshotPackage>,
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         fault_injection_rate_slots: u64,
-        snapshot_interval_slots: u64,
+        snapshot_config: Option<&SnapshotConfig>,
         thread_pool: Option<&ThreadPool>,
     ) {
         let accounts_package = solana_runtime::snapshot_utils::process_accounts_package_pre(
@@ -111,20 +112,20 @@ impl AccountsHashVerifier {
             hashes,
             exit,
             fault_injection_rate_slots,
-            snapshot_interval_slots,
+            snapshot_config,
         );
     }
 
     fn process_accounts_package(
         accounts_package: AccountsPackage,
         cluster_info: &ClusterInfo,
-        trusted_validators: &Option<HashSet<Pubkey>>,
+        trusted_validators: Option<&HashSet<Pubkey>>,
         halt_on_trusted_validator_accounts_hash_mismatch: bool,
-        pending_snapshot_package: &Option<PendingSnapshotPackage>,
+        pending_snapshot_package: Option<&PendingSnapshotPackage>,
         hashes: &mut Vec<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         fault_injection_rate_slots: u64,
-        snapshot_interval_slots: u64,
+        snapshot_config: Option<&SnapshotConfig>,
     ) {
         let hash = *accounts_package.hash();
         if fault_injection_rate_slots != 0
@@ -155,9 +156,13 @@ impl AccountsHashVerifier {
             }
         }
 
-        if accounts_package.block_height % snapshot_interval_slots == 0 {
-            if let Some(pending_snapshot_package) = pending_snapshot_package.as_ref() {
-                *pending_snapshot_package.lock().unwrap() = Some(accounts_package);
+        if let Some(snapshot_config) = snapshot_config {
+            if accounts_package.block_height % snapshot_config.full_snapshot_archive_interval_slots
+                == 0
+            {
+                if let Some(pending_snapshot_package) = pending_snapshot_package {
+                    *pending_snapshot_package.lock().unwrap() = Some(accounts_package);
+                }
             }
         }
 
@@ -166,12 +171,12 @@ impl AccountsHashVerifier {
 
     fn should_halt(
         cluster_info: &ClusterInfo,
-        trusted_validators: &Option<HashSet<Pubkey>>,
+        trusted_validators: Option<&HashSet<Pubkey>>,
         slot_to_hash: &mut HashMap<Slot, Hash>,
     ) -> bool {
         let mut verified_count = 0;
         let mut highest_slot = 0;
-        if let Some(trusted_validators) = trusted_validators.as_ref() {
+        if let Some(trusted_validators) = trusted_validators {
             for trusted_validator in trusted_validators {
                 let is_conflicting = cluster_info.get_accounts_hash_for_node(trusted_validator, |accounts_hashes|
                 {
@@ -246,7 +251,7 @@ mod tests {
         let mut slot_to_hash = HashMap::new();
         assert!(!AccountsHashVerifier::should_halt(
             &cluster_info,
-            &Some(trusted_validators.clone()),
+            Some(&trusted_validators),
             &mut slot_to_hash,
         ));
 
@@ -262,7 +267,7 @@ mod tests {
         trusted_validators.insert(validator1.pubkey());
         assert!(AccountsHashVerifier::should_halt(
             &cluster_info,
-            &Some(trusted_validators),
+            Some(&trusted_validators),
             &mut slot_to_hash,
         ));
     }
@@ -281,9 +286,19 @@ mod tests {
         let trusted_validators = HashSet::new();
         let exit = Arc::new(AtomicBool::new(false));
         let mut hashes = vec![];
+        let full_snapshot_archive_interval_slots = 100;
+        let snapshot_config = SnapshotConfig {
+            full_snapshot_archive_interval_slots,
+            incremental_snapshot_archive_interval_slots: Slot::MAX,
+            snapshot_package_output_path: PathBuf::default(),
+            snapshot_path: PathBuf::default(),
+            archive_format: ArchiveFormat::Tar,
+            snapshot_version: SnapshotVersion::default(),
+            maximum_snapshots_to_retain: usize::MAX,
+        };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
-            let slot = 100 + i as u64;
-            let block_height = 100 + i as u64;
+            let slot = full_snapshot_archive_interval_slots + i as u64;
+            let block_height = full_snapshot_archive_interval_slots + i as u64;
             let slot_deltas = vec![];
             let snapshot_links = TempDir::new().unwrap();
             let storages = vec![];
@@ -306,13 +321,13 @@ mod tests {
             AccountsHashVerifier::process_accounts_package(
                 accounts_package,
                 &cluster_info,
-                &Some(trusted_validators.clone()),
+                Some(&trusted_validators),
                 false,
-                &None,
+                None,
                 &mut hashes,
                 &exit,
                 0,
-                100,
+                Some(&snapshot_config),
             );
             // sleep for 1ms to create a newer timestmap for gossip entry
             // otherwise the timestamp won't be newer.
@@ -325,11 +340,14 @@ mod tests {
         info!("{:?}", cluster_hashes);
         assert_eq!(hashes.len(), MAX_SNAPSHOT_HASHES);
         assert_eq!(cluster_hashes.len(), MAX_SNAPSHOT_HASHES);
-        assert_eq!(cluster_hashes[0], (101, hash(&[1])));
+        assert_eq!(
+            cluster_hashes[0],
+            (full_snapshot_archive_interval_slots + 1, hash(&[1]))
+        );
         assert_eq!(
             cluster_hashes[MAX_SNAPSHOT_HASHES - 1],
             (
-                100 + MAX_SNAPSHOT_HASHES as u64,
+                full_snapshot_archive_interval_slots + MAX_SNAPSHOT_HASHES as u64,
                 hash(&[MAX_SNAPSHOT_HASHES as u8])
             )
         );

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -220,7 +220,7 @@ impl Tvu {
             tvu_config.trusted_validators.clone(),
             tvu_config.halt_on_trusted_validators_accounts_hash_mismatch,
             tvu_config.accounts_hash_fault_injection_slots,
-            snapshot_interval_slots,
+            snapshot_config.clone(),
         );
 
         let (snapshot_request_sender, snapshot_request_handler) = {


### PR DESCRIPTION
AccountsHashVerifier will need access to both the full and incremental
snapshot archive interval slots config values, which is in the
SnapshotConfig.

Also, cleanup some `Option<>` params and their references.
