### PR TITLE
Move Bank::get_incremental_snapshot_storages() into snapshot_utils

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -771,13 +771,21 @@ mod tests {
             .into_iter()
             .find(|elem| elem.slot == slot)
             .ok_or_else(|| Error::new(ErrorKind::Other, "did not find snapshot with this path"))?;
+        let storages = {
+            let mut storages = bank.get_snapshot_storages();
+            snapshot_utils::filter_snapshot_storages_for_incremental_snapshot(
+                &mut storages,
+                incremental_snapshot_base_slot,
+            );
+            storages
+        };
         snapshot_utils::package_process_and_archive_incremental_snapshot(
             bank,
             incremental_snapshot_base_slot,
             &bank_snapshot_info,
             &snapshot_config.snapshot_path,
             &snapshot_config.snapshot_package_output_path,
-            bank.get_incremental_snapshot_storages(incremental_snapshot_base_slot),
+            storages,
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
             None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,7 +38,7 @@ use crate::{
         AccountAddressFilter, Accounts, TransactionAccounts, TransactionLoadResult,
         TransactionLoaders,
     },
-    accounts_db::{AccountShrinkThreshold, ErrorCounters, SnapshotStorage, SnapshotStorages},
+    accounts_db::{AccountShrinkThreshold, ErrorCounters, SnapshotStorages},
     accounts_index::{
         AccountSecondaryIndexes, IndexKey, ScanResult, BINS_FOR_BENCHMARKS, BINS_FOR_TESTING,
     },
@@ -4875,21 +4875,6 @@ impl Bank {
 
     pub fn get_snapshot_storages(&self) -> SnapshotStorages {
         self.rc.get_snapshot_storages(self.slot())
-    }
-
-    /// Get the snapshot storages _higher than_ the `full_snapshot_slot`.  This is used when making an
-    /// incremental snapshot.
-    pub fn get_incremental_snapshot_storages(&self, full_snapshot_slot: Slot) -> SnapshotStorages {
-        self.get_snapshot_storages()
-            .into_iter()
-            .map(|storage| {
-                storage
-                    .into_iter()
-                    .filter(|entry| entry.slot() > full_snapshot_slot)
-                    .collect::<SnapshotStorage>()
-            })
-            .filter(|storage| !storage.is_empty())
-            .collect()
     }
 
     #[must_use]


### PR DESCRIPTION
Filtering out storages for incremental snapshots will be needed by the
background services for incremental snapshot support, but there is not a
Bank at that point.  Since the filtering doesn't apply only to Bank, and
more to snapshots, move the functionality into snapshot_utils.