### PR TITLE
Use last_valid_block_height in services and client apps

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -62,7 +62,7 @@ impl BanksClient {
         &mut self,
         ctx: Context,
         commitment: CommitmentLevel,
-    ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, Slot)>> + '_ {
+    ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, u64)>> + '_ {
         self.inner
             .get_fees_with_commitment_and_context(ctx, commitment)
     }
@@ -82,6 +82,14 @@ impl BanksClient {
         commitment: CommitmentLevel,
     ) -> impl Future<Output = io::Result<Slot>> + '_ {
         self.inner.get_slot_with_context(ctx, commitment)
+    }
+
+    pub fn get_block_height_with_context(
+        &mut self,
+        ctx: Context,
+        commitment: CommitmentLevel,
+    ) -> impl Future<Output = io::Result<Slot>> + '_ {
+        self.inner.get_block_height_with_context(ctx, commitment)
     }
 
     pub fn process_transaction_with_commitment_and_context(
@@ -119,7 +127,7 @@ impl BanksClient {
     /// use them to calculate the transaction fee.
     pub fn get_fees(
         &mut self,
-    ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, Slot)>> + '_ {
+    ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, u64)>> + '_ {
         self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::default())
     }
 
@@ -195,10 +203,16 @@ impl BanksClient {
         self.process_transactions_with_commitment(transactions, CommitmentLevel::default())
     }
 
-    /// Return the most recent rooted slot height. All transactions at or below this height
-    /// are said to be finalized. The cluster will not fork to a higher slot height.
+    /// Return the most recent rooted slot. All transactions at or below this slot
+    /// are said to be finalized. The cluster will not fork to a higher slot.
     pub fn get_root_slot(&mut self) -> impl Future<Output = io::Result<Slot>> + '_ {
         self.get_slot_with_context(context::current(), CommitmentLevel::default())
+    }
+
+    /// Return the most recent rooted block height. All transactions at or below this height
+    /// are said to be finalized. The cluster will not fork to a higher block height.
+    pub fn get_root_block_height(&mut self) -> impl Future<Output = io::Result<Slot>> + '_ {
+        self.get_block_height_with_context(context::current(), CommitmentLevel::default())
     }
 
     /// Return the account at the given address at the slot corresponding to the given
@@ -386,7 +400,7 @@ mod tests {
         Runtime::new()?.block_on(async {
             let client_transport = start_local_server(bank_forks, block_commitment_cache).await;
             let mut banks_client = start_client(client_transport).await?;
-            let (_, recent_blockhash, last_valid_slot) = banks_client.get_fees().await?;
+            let (_, recent_blockhash, last_valid_block_height) = banks_client.get_fees().await?;
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);
             let signature = transaction.signatures[0];
             banks_client.send_transaction(transaction).await?;
@@ -394,8 +408,8 @@ mod tests {
             let mut status = banks_client.get_transaction_status(signature).await?;
 
             while status.is_none() {
-                let root_slot = banks_client.get_root_slot().await?;
-                if root_slot > last_valid_slot {
+                let root_block_height = banks_client.get_root_block_height().await?;
+                if root_block_height > last_valid_block_height {
                     break;
                 }
                 sleep(Duration::from_millis(100)).await;

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -34,6 +34,7 @@ pub trait Banks {
     async fn get_transaction_status_with_context(signature: Signature)
         -> Option<TransactionStatus>;
     async fn get_slot_with_context(commitment: CommitmentLevel) -> Slot;
+    async fn get_block_height_with_context(commitment: CommitmentLevel) -> u64;
     async fn process_transaction_with_commitment_and_context(
         transaction: Transaction,
         commitment: CommitmentLevel,

--- a/banks-server/src/send_transaction_service.rs
+++ b/banks-server/src/send_transaction_service.rs
@@ -2,7 +2,7 @@
 use log::*;
 use solana_metrics::{datapoint_warn, inc_new_counter_info};
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
-use solana_sdk::{clock::Slot, signature::Signature};
+use solana_sdk::signature::Signature;
 use std::{
     collections::HashMap,
     net::{SocketAddr, UdpSocket},
@@ -24,15 +24,19 @@ pub struct SendTransactionService {
 pub struct TransactionInfo {
     pub signature: Signature,
     pub wire_transaction: Vec<u8>,
-    pub last_valid_slot: Slot,
+    pub last_valid_block_height: u64,
 }
 
 impl TransactionInfo {
-    pub fn new(signature: Signature, wire_transaction: Vec<u8>, last_valid_slot: Slot) -> Self {
+    pub fn new(
+        signature: Signature,
+        wire_transaction: Vec<u8>,
+        last_valid_block_height: u64,
+    ) -> Self {
         Self {
             signature,
             wire_transaction,
-            last_valid_slot,
+            last_valid_block_height,
         }
     }
 }
@@ -124,7 +128,7 @@ impl SendTransactionService {
                 result.rooted += 1;
                 inc_new_counter_info!("send_transaction_service-rooted", 1);
                 false
-            } else if transaction_info.last_valid_slot < root_bank.slot() {
+            } else if transaction_info.last_valid_block_height < root_bank.block_height() {
                 info!("Dropping expired transaction: {}", signature);
                 result.expired += 1;
                 inc_new_counter_info!("send_transaction_service-expired", 1);

--- a/client/src/blockhash_query.rs
+++ b/client/src/blockhash_query.rs
@@ -122,10 +122,10 @@ mod tests {
     use crate::{
         blockhash_query,
         rpc_request::RpcRequest,
-        rpc_response::{Response, RpcFeeCalculator, RpcResponseContext},
+        rpc_response::{Response, RpcFeeCalculator, RpcFees, RpcResponseContext},
     };
     use clap::App;
-    use serde_json::{self, json, Value};
+    use serde_json::{self, json};
     use solana_account_decoder::{UiAccount, UiAccountEncoding};
     use solana_sdk::{account::Account, hash::hash, nonce, system_program};
     use std::collections::HashMap;
@@ -288,10 +288,12 @@ mod tests {
         let rpc_fee_calc = FeeCalculator::new(42);
         let get_recent_blockhash_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
-            value: json!((
-                Value::String(rpc_blockhash.to_string()),
-                serde_json::to_value(rpc_fee_calc.clone()).unwrap()
-            )),
+            value: json!(RpcFees {
+                blockhash: rpc_blockhash.to_string(),
+                fee_calculator: rpc_fee_calc.clone(),
+                last_valid_slot: 42,
+                last_valid_block_height: 42,
+            }),
         });
         let get_fee_calculator_for_blockhash_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
@@ -300,10 +302,7 @@ mod tests {
             }),
         });
         let mut mocks = HashMap::new();
-        mocks.insert(
-            RpcRequest::GetRecentBlockhash,
-            get_recent_blockhash_response.clone(),
-        );
+        mocks.insert(RpcRequest::GetFees, get_recent_blockhash_response.clone());
         let rpc_client = RpcClient::new_mock_with_mocks("".to_string(), mocks);
         assert_eq!(
             BlockhashQuery::default()
@@ -312,10 +311,7 @@ mod tests {
             (rpc_blockhash, rpc_fee_calc.clone()),
         );
         let mut mocks = HashMap::new();
-        mocks.insert(
-            RpcRequest::GetRecentBlockhash,
-            get_recent_blockhash_response.clone(),
-        );
+        mocks.insert(RpcRequest::GetFees, get_recent_blockhash_response.clone());
         mocks.insert(
             RpcRequest::GetFeeCalculatorForBlockhash,
             get_fee_calculator_for_blockhash_response,
@@ -328,10 +324,7 @@ mod tests {
             (test_blockhash, rpc_fee_calc),
         );
         let mut mocks = HashMap::new();
-        mocks.insert(
-            RpcRequest::GetRecentBlockhash,
-            get_recent_blockhash_response,
-        );
+        mocks.insert(RpcRequest::GetFees, get_recent_blockhash_response);
         let rpc_client = RpcClient::new_mock_with_mocks("".to_string(), mocks);
         assert_eq!(
             BlockhashQuery::None(test_blockhash)

--- a/client/src/fees.rs
+++ b/client/src/fees.rs
@@ -1,9 +1,0 @@
-use crate::{fee_calculator::FeeCalculator, hash::Hash};
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct Fees {
-    pub blockhash: Hash,
-    pub fee_calculator: FeeCalculator,
-    pub last_valid_block_height: u64,
-}

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -6,7 +6,7 @@ use {
         rpc_config::RpcBlockProductionConfig,
         rpc_request::RpcRequest,
         rpc_response::{
-            Response, RpcAccountBalance, RpcBlockProduction, RpcBlockProductionRange,
+            Response, RpcAccountBalance, RpcBlockProduction, RpcBlockProductionRange, RpcFees,
             RpcResponseContext, RpcSimulateTransactionResult, RpcStakeActivation, RpcSupply,
             RpcVersionInfo, RpcVoteAccountStatus, StakeActivationState,
         },
@@ -122,6 +122,16 @@ impl RpcSender for MockSender {
             "getFeeRateGovernor" => serde_json::to_value(Response {
                 context: RpcResponseContext { slot: 1 },
                 value: serde_json::to_value(FeeRateGovernor::default()).unwrap(),
+            })?,
+            "getFees" => serde_json::to_value(Response {
+                context: RpcResponseContext { slot: 1 },
+                value: serde_json::to_value(RpcFees {
+                    blockhash: PUBKEY.to_string(),
+                    fee_calculator: FeeCalculator::default(),
+                    last_valid_slot: 42,
+                    last_valid_block_height: 42,
+                })
+                .unwrap(),
             })?,
             "getSignatureStatuses" => {
                 let status: transaction::Result<()> = if self.url == "account_in_use" {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -544,6 +544,7 @@ impl JsonRpcRequestProcessor {
     fn get_fees(&self, commitment: Option<CommitmentConfig>) -> RpcResponse<RpcFees> {
         let bank = self.bank(commitment);
         let (blockhash, fee_calculator) = bank.confirmed_last_blockhash();
+        #[allow(deprecated)]
         let last_valid_slot = bank
             .get_blockhash_last_valid_slot(&blockhash)
             .expect("bank blockhash queue should contain blockhash");

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2140,7 +2140,7 @@ fn _send_transaction(
     meta: JsonRpcRequestProcessor,
     transaction: Transaction,
     wire_transaction: Vec<u8>,
-    last_valid_slot: Slot,
+    last_valid_block_height: u64,
     durable_nonce_info: Option<(Pubkey, Hash)>,
 ) -> Result<String> {
     if transaction.signatures.is_empty() {
@@ -2150,7 +2150,7 @@ fn _send_transaction(
     let transaction_info = TransactionInfo::new(
         signature,
         wire_transaction,
-        last_valid_slot,
+        last_valid_block_height,
         durable_nonce_info,
     );
     meta.transaction_sender
@@ -3233,7 +3233,9 @@ pub mod rpc_full {
             } else {
                 bank.confirmed_last_blockhash().0
             };
-            let last_valid_slot = bank.get_blockhash_last_valid_slot(&blockhash).unwrap_or(0);
+            let last_valid_block_height = bank
+                .get_blockhash_last_valid_block_height(&blockhash)
+                .unwrap_or(0);
 
             let transaction =
                 request_airdrop_transaction(&faucet_addr, &pubkey, lamports, blockhash).map_err(
@@ -3248,7 +3250,13 @@ pub mod rpc_full {
                 Error::internal_error()
             })?;
 
-            _send_transaction(meta, transaction, wire_transaction, last_valid_slot, None)
+            _send_transaction(
+                meta,
+                transaction,
+                wire_transaction,
+                last_valid_block_height,
+                None,
+            )
         }
 
         fn send_transaction(
@@ -3267,8 +3275,8 @@ pub mod rpc_full {
                 .map(|commitment| CommitmentConfig { commitment });
             let preflight_bank = &*meta.bank(preflight_commitment);
 
-            let mut last_valid_slot = preflight_bank
-                .get_blockhash_last_valid_slot(&transaction.message.recent_blockhash)
+            let mut last_valid_block_height = preflight_bank
+                .get_blockhash_last_valid_block_height(&transaction.message.recent_blockhash)
                 .unwrap_or(0);
 
             let durable_nonce_info = solana_sdk::transaction::uses_durable_nonce(&transaction)
@@ -3280,11 +3288,12 @@ pub mod rpc_full {
                 })
                 .map(|&pubkey| (pubkey, transaction.message.recent_blockhash));
             if durable_nonce_info.is_some() {
-                // While it uses a defined constant, this last_valid_slot value is chosen arbitrarily.
+                // While it uses a defined constant, this last_valid_block_height value is chosen arbitrarily.
                 // It provides a fallback timeout for durable-nonce transaction retries in case of
                 // malicious packing of the retry queue. Durable-nonce transactions are otherwise
                 // retried until the nonce is advanced.
-                last_valid_slot = preflight_bank.slot() + MAX_RECENT_BLOCKHASHES as u64;
+                last_valid_block_height =
+                    preflight_bank.block_height() + MAX_RECENT_BLOCKHASHES as u64;
             }
 
             if !config.skip_preflight {
@@ -3345,7 +3354,7 @@ pub mod rpc_full {
                 meta,
                 transaction,
                 wire_transaction,
-                last_valid_slot,
+                last_valid_block_height,
                 durable_nonce_info,
             )
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2692,7 +2692,10 @@ impl Bank {
         &self.fee_rate_governor
     }
 
-    // DEPRECATED
+    #[deprecated(
+        since = "1.6.11",
+        note = "Please use `get_blockhash_last_valid_block_height`"
+    )]
     pub fn get_blockhash_last_valid_slot(&self, blockhash: &Hash) -> Option<Slot> {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         // This calculation will need to be updated to consider epoch boundaries if BlockhashQueue

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -156,6 +156,7 @@ impl SyncClient for BankClient {
         _commitment_config: CommitmentConfig,
     ) -> Result<(Hash, FeeCalculator, u64)> {
         let (blockhash, fee_calculator) = self.bank.last_blockhash_with_fee_calculator();
+        #[allow(deprecated)]
         let last_valid_slot = self
             .bank
             .get_blockhash_last_valid_slot(&blockhash)

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -12,7 +12,7 @@ pub struct TransactionInfo {
     pub new_stake_account_address: Option<Pubkey>,
     pub finalized_date: Option<DateTime<Utc>>,
     pub transaction: Transaction,
-    pub last_valid_slot: Slot,
+    pub last_valid_block_height: Slot,
     pub lockup_date: Option<DateTime<Utc>>,
 }
 
@@ -38,7 +38,7 @@ impl Default for TransactionInfo {
             new_stake_account_address: None,
             finalized_date: None,
             transaction,
-            last_valid_slot: 0,
+            last_valid_block_height: 0,
             lockup_date: None,
         }
     }
@@ -108,7 +108,7 @@ pub fn set_transaction_info(
     transaction: &Transaction,
     new_stake_account_address: Option<&Pubkey>,
     finalized: bool,
-    last_valid_slot: Slot,
+    last_valid_block_height: u64,
     lockup_date: Option<DateTime<Utc>>,
 ) -> Result<(), Error> {
     let finalized_date = if finalized { Some(Utc::now()) } else { None };
@@ -118,7 +118,7 @@ pub fn set_transaction_info(
         new_stake_account_address: new_stake_account_address.cloned(),
         finalized_date,
         transaction: transaction.clone(),
-        last_valid_slot,
+        last_valid_block_height,
         lockup_date,
     };
     let signature = transaction.signatures[0];
@@ -134,11 +134,11 @@ pub fn update_finalized_transaction(
     db: &mut PickleDb,
     signature: &Signature,
     opt_transaction_status: Option<TransactionStatus>,
-    last_valid_slot: Slot,
-    root_slot: Slot,
+    last_valid_block_height: u64,
+    finalized_block_height: u64,
 ) -> Result<Option<usize>, Error> {
     if opt_transaction_status.is_none() {
-        if root_slot > last_valid_slot {
+        if finalized_block_height > last_valid_block_height {
             eprintln!(
                 "Signature not found {} and blockhash expired. Transaction either dropped or the validator purged the transaction status.",
                 signature


### PR DESCRIPTION
#### Problem
`last_valid_slot` is deprecated, and all clusters now support block-height RPCs.

#### Summary of Changes
Update SendTransactionService, `solana program`, and `solana-tokens` CLI to use last_valid_block_height
