### PR TITLE
[OLD] Make SnapshotPackagerService aware of Incremental Snapshots

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -4,14 +4,16 @@
 // hash on gossip. Monitor gossip for messages from validators in the --trusted-validators
 // set and halt the node if a mismatch is detected.
 
-use crate::snapshot_packager_service::PendingSnapshotPackage;
 use rayon::ThreadPool;
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
     accounts_db,
     snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
-    snapshot_package::{AccountsPackage, AccountsPackagePre, AccountsPackageReceiver},
+    snapshot_package::{
+        AccountsPackage, AccountsPackagePre, AccountsPackageReceiver, PendingSnapshotPackage,
+        SnapshotPackage,
+    },
 };
 use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::collections::{HashMap, HashSet};
@@ -161,7 +163,8 @@ impl AccountsHashVerifier {
                 == 0
             {
                 if let Some(pending_snapshot_package) = pending_snapshot_package {
-                    *pending_snapshot_package.lock().unwrap() = Some(accounts_package);
+                    *pending_snapshot_package.lock().unwrap() =
+                        Some(SnapshotPackage::FullSnapshotPackage(accounts_package));
                 }
             }
         }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,19 +1,16 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::AccountsPackage,
-    snapshot_utils,
+    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::PendingSnapshotPackage,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc,
     },
     thread::{self, Builder, JoinHandle},
     time::Duration,
 };
-
-pub type PendingSnapshotPackage = Arc<Mutex<Option<AccountsPackage>>>;
 
 pub struct SnapshotPackagerService {
     t_snapshot_packager: JoinHandle<()>,
@@ -45,17 +42,18 @@ impl SnapshotPackagerService {
 
                     let snapshot_package = pending_snapshot_package.lock().unwrap().take();
                     if let Some(snapshot_package) = snapshot_package {
-                        if let Err(err) = snapshot_utils::archive_snapshot_package(
-                            &snapshot_package,
-                            maximum_snapshots_to_retain,
-                        ) {
-                            warn!("Failed to create snapshot archive: {}", err);
-                        } else {
-                            hashes.push((snapshot_package.slot(), *snapshot_package.hash()));
-                            while hashes.len() > MAX_SNAPSHOT_HASHES {
-                                hashes.remove(0);
+                        match snapshot_package.archive_snapshot_package(maximum_snapshots_to_retain)
+                        {
+                            Ok(_) => {
+                                hashes.push((snapshot_package.slot(), *snapshot_package.hash()));
+                                while hashes.len() > MAX_SNAPSHOT_HASHES {
+                                    hashes.remove(0);
+                                }
+                                cluster_info.push_snapshot_hashes(hashes.clone());
                             }
-                            cluster_info.push_snapshot_hashes(hashes.clone());
+                            Err(err) => {
+                                warn!("Failed to create snapshot archive: {}", err);
+                            }
                         }
                     } else {
                         std::thread::sleep(Duration::from_millis(100));
@@ -81,7 +79,7 @@ mod tests {
     use solana_runtime::{
         accounts_db::AccountStorageEntry,
         bank::BankSlotDelta,
-        snapshot_package::AccountsPackage,
+        snapshot_package::{AccountsPackage, SnapshotPackage},
         snapshot_utils::{self, ArchiveFormat, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_sdk::hash::Hash;
@@ -165,7 +163,7 @@ mod tests {
             &Hash::default(),
             ArchiveFormat::TarBzip2,
         );
-        let snapshot_package = AccountsPackage::new(
+        let snapshot_package = SnapshotPackage::FullSnapshotPackage(AccountsPackage::new(
             5,
             5,
             vec![],
@@ -175,14 +173,12 @@ mod tests {
             Hash::default(),
             ArchiveFormat::TarBzip2,
             SnapshotVersion::default(),
-        );
+        ));
 
         // Make tarball from packageable snapshot
-        snapshot_utils::archive_snapshot_package(
-            &snapshot_package,
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        )
-        .unwrap();
+        snapshot_package
+            .archive_snapshot_package(snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN)
+            .unwrap();
 
         // before we compare, stick an empty status_cache in this dir so that the package comparison works
         // This is needed since the status_cache is added by the packager and is not collected from

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -21,7 +21,6 @@ use crate::{
     shred_fetch_stage::ShredFetchStage,
     sigverify_shreds::ShredSigVerifier,
     sigverify_stage::SigVerifyStage,
-    snapshot_packager_service::PendingSnapshotPackage,
     tower_storage::TowerStorage,
     voting_service::VotingService,
 };
@@ -45,6 +44,7 @@ use solana_runtime::{
     bank_forks::BankForks,
     commitment::BlockCommitmentCache,
     snapshot_config::SnapshotConfig,
+    snapshot_package::PendingSnapshotPackage,
     vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -12,7 +12,7 @@ use crate::{
     serve_repair::ServeRepair,
     serve_repair_service::ServeRepairService,
     sigverify,
-    snapshot_packager_service::{PendingSnapshotPackage, SnapshotPackagerService},
+    snapshot_packager_service::SnapshotPackagerService,
     tower_storage::TowerStorage,
     tpu::{Tpu, DEFAULT_TPU_COALESCE_MS},
     tvu::{Sockets, Tvu, TvuConfig},
@@ -63,6 +63,7 @@ use solana_runtime::{
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
+    snapshot_package::PendingSnapshotPackage,
     snapshot_utils,
 };
 use solana_sdk::{


### PR DESCRIPTION
Instead of `PendingSnapshotPackage` being an `AccountsPackage`, I've
created a new enum for either a FullSnapshotPackage or an
IncrementalSnapshotPackage.  This type with handle the actual call to
`snapshot_utils::archive_snapshot_package()` so it knows about full
snapshots vs incremental snapshots.

Fixes #19166
