### PR TITLE
removes use of public ip addresses from perf tests

### DIFF
--- a/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
+++ b/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
@@ -13,7 +13,7 @@ steps:
       CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       ALLOW_BOOT_FAILURES: "true"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/partition-testcases/gce-5-node-3-partition.yml
+++ b/system-test/partition-testcases/gce-5-node-3-partition.yml
@@ -12,7 +12,6 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
-      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -12,7 +12,6 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
-      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -12,7 +12,6 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
-      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/gce-partition-with-offline.yml
+++ b/system-test/partition-testcases/gce-partition-with-offline.yml
@@ -12,7 +12,6 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
-      ALLOW_PRIVATE_ADDR: "true"
       ADDITIONAL_FLAGS: "--dedicated"
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"

--- a/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
@@ -13,7 +13,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
@@ -13,7 +13,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "westus"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node-single-region.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-25-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node.yml
@@ -12,7 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
@@ -13,7 +13,7 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       ALLOW_BOOT_FAILURES: "true"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-gpu-perf-50-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node.yml
@@ -13,7 +13,7 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       ALLOW_BOOT_FAILURES: "true"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -15,6 +15,5 @@ steps:
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
-      ALLOW_PRIVATE_ADDR: "true"
     agents:
       - "queue=gce-deploy"

--- a/system-test/stability-testcases/gce-stability-5-node.yml
+++ b/system-test/stability-testcases/gce-stability-5-node.yml
@@ -11,7 +11,7 @@ steps:
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 0
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
-      USE_PUBLIC_IP_ADDRESSES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
       TEST_TYPE: "fixed_duration"
     agents:


### PR DESCRIPTION
#### Problem
Using global IPs causes outbound traffic which costs money: https://github.com/solana-labs/solana/pull/18728#issuecomment-884290209

Also, following https://github.com/solana-labs/solana/pull/19130 if `gce.sh creat` is invoked without `-P` then `--allow-private-addr` is implied:
https://github.com/solana-labs/solana/blob/4cc1b1504/net/common.sh#L68-L73

Therefore tests only need to specify:
```yaml
USE_PUBLIC_IP_ADDRESSES: "false"
```


#### Summary of Changes
* Set `USE_PUBLIC_IP_ADDRESSES: "false"`.
* Remove redundant `ALLOW_PRIVATE_ADDR`