### PR TITLE
ABI v2 Proposal

### DIFF
--- a/docs/src/proposals/abi-v2.md
+++ b/docs/src/proposals/abi-v2.md
@@ -16,10 +16,10 @@ Information about each entry (attribute value pair) which is either encoded expl
 
 Some [binary data-serialization formats](https://en.wikipedia.org/wiki/Comparison_of_data-serialization_formats#Comparison_of_binary_formats) are [CBOR](https://cbor.io), [Ion](https://amzn.github.io/ion-docs/), [MsgPack](https://msgpack.org), [Protobuf](https://github.com/protocolbuffers/protobuf).
 We currently only have CBOR in our Cargo.lock, so everything else would add a dependency.
-However, non of these support indirections / references / offsets / pointers and they are all in row-major order (see next point). Therefor, we should design and implement our own extensibile serialization format.
+However, none of these support indirections / references / offsets / pointers and they are all in row-major order (see next point). Therefore, we should design and implement our own extensibile serialization format.
 
 ## Nesting order
-Borrowing the terms from table based data base systems:
+Borrowing the terms from table based database systems:
 - Row-major encoding (inner loop over attributes, outer loop over accounts) means first the values of all attributes of one account are encoded, then comes the next account.
 - Column-major encoding (inner loop over accounts, outer loop over attributes) means first the values of one attribute for all accounts are encoded, then comes the next attribute.
 
@@ -34,45 +34,53 @@ This section describes how the new encoding works in general and how we would us
 ### Encoding
 Everything is in little endian.
 
-Associative map:
-- `u16`: number_of_entries (attribute value pairs)
-- `[u16; number_of_entries]`: Attributes sorted ascending (for binary search)
-- `[u8; number_of_entries]`: Branching of values: Direct nesting, indirect nesting, direct leaf, indirect leaf
-- `[u32; number_of_entries]`: Offsets into values (cummulative value lengths)
-- Values
+```Rust
+struct Map {
+  number_of_entries: u16,
+  attribute: [u16; number_of_entries],
+  value_offset: [u32; number_of_entries + 1],
+  is_value_indirect: [u8; number_of_entries],
+  values: [Value],
+}
+
+enum Value {
+  Direct([u8]),
+  Indirect({ pointer: u64, length: u32 }),
+}
+```
 
 ### Memory Mapping / Regions
 Additional to the mandatory RBPF memory regions (null, program, stack, heap) we would add `2 + number_of_accounts_in_instruction` memory regions to the VM mapping.
 
 #### Read-only meta data region:
 - Transaction context:
-  - `number_of_accounts`: Natural number
-  - `account_key`: Vector of pubkeys for all accounts
-  - `account_is_executable`: Bit vector for all accounts
-  - `account_owner`: Vector of pubkeys for all accounts
-  - `account_lamports`: Vector of natural numbers for all accounts
-  - `account_data_length`: Vector of natural numbers for all accounts
-  - `account_data`: Vector of pointers for all accounts
-  - `account_rent_epoch` (deprecated): Vector of natural numbers for all accounts
+  - `NumberOfAccountsInTransaction = 1`: `u32`
+  - `AccountKey = 2`: `[Pubkey; NumberOfAccountsInTransaction]`
+  - `AccountIsExecutable = 3`: `[bool; NumberOfAccountsInTransaction]`
+  - `AccountOwner = 4`: `[Pubkey; NumberOfAccountsInTransaction]`
+  - `AccountLamports = 5`: `[u64; NumberOfAccountsInTransaction]`
+  - `AccountData = 6`: `[&[u8]; NumberOfAccountsInTransaction]`
+  - `InvocationStackFrame = 7`: `Map`
 - Instruction context:
-  - `invoke_stack_frame`: Offset into nested structure
-  - Invoke stack frames:
-    - `program_account_index`: Natural number index into the transaction accounts
-    - `instruction_data`: Blob
-    - `number_of_accounts`: Natural number
-    - `account_indices`: Vector of natural number indices into the transaction accounts
-    - `account_is_signer`: Bit vector for all accounts referenced by account_indices
-    - `account_is_writable`: Bit vector for all accounts referenced by account_indices
+  - `ParentStackFrame = 8`: `Map`
+  - `InstructionData = 9`: `[u8]`
+  - `NumberOfAccountsInInstruction = 10`: `u32`
+  - `InstructionAccountIndices = 11`: `[u32; NumberOfAccountsInInstruction]`
+  - `ProgramAccountIndex = 12`: `u32`
+  - `AccountIsSigner = 13`: `[bool; NumberOfAccountsInInstruction]`
+  - `AccountIsWritable = 14`: `[bool; NumberOfAccountsInInstruction]`
+  - `WritableAttributes = 15`: `Map`
 
 #### Read-write meta data region:
 - Instruction context:
-    - `account_owner`: Vector of pubkeys for writable accounts
-    - `account_lamports`: Vector of natural numbers for writable accounts
+  - `AccountOwner`,
+  - `AccountLamports`,
 
 #### Individual account data regions:
-- One for each account in the instruction
-- Read-only or read-write depends on instruction context
-- `data`: Blob
+- One mapped memory region for each account in the instruction
+- But virtual and physical addresses stay the same throughout the transaction
+- Read-only or read-write depends on the instruction context
+- Content: `[u8]`
 
 ### Usage / Integration
 Replace `KeyedAccounts`, `serialize_parameters`, `deserialize_parameters` and parts of the `InvokeContext` with a new interface which directly operates on the new encoding. It would be used by the runtime and programs alike.

--- a/docs/src/proposals/abi-v2.md
+++ b/docs/src/proposals/abi-v2.md
@@ -1,0 +1,80 @@
+---
+title: ABI v2
+---
+
+ABI between loader and program entrypoint, as well as syscalls such as (cross program) invocation and account reallocation.
+
+## Motivation
+The reason we need a new serialization format and thus also a new ABI is because the existing one is not extensibile and stores the account data in-place / in-stream. This prevents accounts from being memory mapped individually and also hinders reallocation of accounts (changing their size). Furthermore, there is a lot of potential for optimizations such as encoding the meta data only once per transaction and partially per instruction.
+
+## Existing Encoding Standards
+Information about each entry (attribute value pair) which is either encoded explicitly or can be implicitly gained from the context:
+- Attribute (semantics) as a tag or name string
+- Data type / encoding
+- Value length
+- Value content
+
+Some [binary data-serialization formats](https://en.wikipedia.org/wiki/Comparison_of_data-serialization_formats#Comparison_of_binary_formats) are [CBOR](https://cbor.io), [Ion](https://amzn.github.io/ion-docs/), [MsgPack](https://msgpack.org), [Protobuf](https://github.com/protocolbuffers/protobuf).
+We currently only have CBOR in our Cargo.lock, so everything else would add a dependency.
+However, non of these support indirections / references / offsets / pointers and they are all in row-major order (see next point). Therefor, we should design and implement our own extensibile serialization format.
+
+## Nesting order
+Borrowing the terms from table based data base systems:
+- Row-major encoding (inner loop over attributes, outer loop over accounts) means first the values of all attributes of one account are encoded, then comes the next account.
+- Column-major encoding (inner loop over accounts, outer loop over attributes) means first the values of one attribute for all accounts are encoded, then comes the next attribute.
+
+Column-major encoding has the following advantages in our use case:
+- Extensibility on an attribute level (but not per account level as that would be wasteful).
+- Read / write access control per attribute (not per account meta data, but the account data is handled separately).
+- Splitting meta data into a local instruction context and a global transaction context.
+
+## Design
+This section describes how the new encoding works in general and how we would use it for the new ABI specifically.
+
+### Encoding
+Everything is in little endian.
+
+Associative map:
+- `u16`: number_of_entries (attribute value pairs)
+- `[u16; number_of_entries]`: Attributes sorted ascending (for binary search)
+- `[u8; number_of_entries]`: Branching of values: Direct nesting, indirect nesting, direct leaf, indirect leaf
+- `[u32; number_of_entries]`: Offsets into values (cummulative value lengths)
+- Values
+
+### Memory Mapping / Regions
+Additional to the mandatory RBPF memory regions (null, program, stack, heap) we would add `2 + number_of_accounts_in_instruction` memory regions to the VM mapping.
+
+#### Read-only meta data region:
+- Transaction context:
+  - `number_of_accounts`: Natural number
+  - `account_key`: Vector of pubkeys for all accounts
+  - `account_is_executable`: Bit vector for all accounts
+  - `account_owner`: Vector of pubkeys for all accounts
+  - `account_lamports`: Vector of natural numbers for all accounts
+  - `account_data_length`: Vector of natural numbers for all accounts
+  - `account_data`: Vector of pointers for all accounts
+  - `account_rent_epoch` (deprecated): Vector of natural numbers for all accounts
+- Instruction context:
+  - `invoke_stack_frame`: Offset into nested structure
+  - Invoke stack frames:
+    - `program_account_index`: Natural number index into the transaction accounts
+    - `instruction_data`: Blob
+    - `number_of_accounts`: Natural number
+    - `account_indices`: Vector of natural number indices into the transaction accounts
+    - `account_is_signer`: Bit vector for all accounts referenced by account_indices
+    - `account_is_writable`: Bit vector for all accounts referenced by account_indices
+
+#### Read-write meta data region:
+- Instruction context:
+    - `account_owner`: Vector of pubkeys for writable accounts
+    - `account_lamports`: Vector of natural numbers for writable accounts
+
+#### Individual account data regions:
+- One for each account in the instruction
+- Read-only or read-write depends on instruction context
+- `data`: Blob
+
+### Usage / Integration
+Replace `KeyedAccounts`, `serialize_parameters`, `deserialize_parameters` and parts of the `InvokeContext` with a new interface which directly operates on the new encoding. It would be used by the runtime and programs alike.
+
+As we have already seen in [#15410](https://github.com/solana-labs/solana/pull/15410) this will most likely cause problems with the Rust borrow checker, because we can not have multiple mutable references to the `InvokeContext`. So the workaround using indices as account handles might continue to be necessary.

--- a/docs/src/proposals/sbf-program-abi-v2.md
+++ b/docs/src/proposals/sbf-program-abi-v2.md
@@ -89,6 +89,24 @@ The idea is to serialize the meta data of all accounts once per transaction, and
 - Read-only or read-write depends on the instruction context
 - Content: `[u8]`
 
+### Writable Attributes
+Alternative options:
+- Three regions per account: Read-only metadata, writable metadata, account data
+- All meta data in readonly region, plus duplicate for writable metadata in extra region
+- Two regions: Definitely read-only metadata and potentially writable metadata including readonly accounts and unmapped accounts
+
+### Encoding Alignment
+Alternative options:
+- Tightly pack everything
+- Tightly pack attributes, pad values
+- Pad attributes and their values
+
+### Host and Guest (VM) Address Space for Indirections / Pointers
+Alternative options:
+- Store guest pointers only, map host on demand
+- Translate on every context switch (invocation, exit, syscall)
+- Store both guest and host, but encrypt host pointers
+
 ### Syscalls
 
 #### Cross Program Invocation

--- a/docs/src/proposals/sbf-program-abi-v2.md
+++ b/docs/src/proposals/sbf-program-abi-v2.md
@@ -85,23 +85,33 @@ The idea is to serialize the meta data of all accounts once per transaction, and
   - Read-only or read-write depends on the instruction context
   - Content: `[u8]`
 
-### Writable Attributes
+#### Writable Attributes
 Alternative options:
 - Three regions per account: Read-only metadata, writable metadata, account data
 - All meta data in readonly region, plus duplicate for writable metadata in extra region
 - Two regions: Definitely read-only metadata and potentially writable metadata including readonly accounts and unmapped accounts
 
-### Encoding Alignment
+#### Encoding Alignment
 Alternative options:
 - Tightly pack everything
 - Tightly pack attributes, pad values
 - Pad attributes and their values
 
-### Host and Guest (VM) Address Space for Indirections / Pointers
+#### Host and Guest (VM) Address Space for Indirections / Pointers
 Alternative options:
 - Store guest pointers only, map host on demand
 - Translate on every context switch (invocation, exit, syscall)
 - Store both guest and host, but encrypt host pointers
+
+### Interface
+
+#### Instruction Structs
+TODO: Design a structured interface to deal with the account indices of different instructions.
+Replacing: `keyed_account_at_index(keyed_accounts, first_instruction_account + x)`
+
+#### Tests & Mockups
+TODO: Design a better way to create the mocked instruction accounts.
+Replacing: `create_keyed_accounts_unified(&keyed_account_tuples)`
 
 ### Syscalls
 
@@ -113,8 +123,3 @@ In the old ABI return data was implemented by a setter and a getter syscall for 
 
 #### Account Reallocation / Resizing
 TODO
-
-### Usage / Integration
-Replace `KeyedAccounts`, `serialize_parameters`, `deserialize_parameters` and parts of the `InvokeContext` with a new interface which directly operates on the new encoding. It would be used by the runtime and programs alike.
-
-As we have already seen in [#15410](https://github.com/solana-labs/solana/pull/15410) this will most likely cause problems with the Rust borrow checker, because we can not have multiple mutable references to the `InvokeContext`. So the workaround using indices as account handles might continue to be necessary.


### PR DESCRIPTION
Fixes: #14523

## Roadmap

### Design
See [document](https://github.com/Lichtso/solana/blob/docs/abi-v2-proposal/docs/src/proposals/sbf-program-abi-v2.md) of this PR.

### Preparation
#15410, #17898, https://github.com/solana-labs/rbpf/pull/196 and #19469, #19762, #20034, #20165, #20290, #20308, #20448, #20540, #20598, #20785, #20881, #20954, #21108, #21180, #21185, #21205, #21395, #21404, #21545, #21563, #21574, #21671, #21882, #21927, #22102, #22107, #22111, #22165

### Runtime
Implementation of ABI v2 internals and inter-operation with ABI v1 by mounting the old ABI on top of the new one.
#21706, #22226, #22274

### Native programs
Replace the use of `InvokeContext` and `KeyedAccount` of ABI v1 by `InstructionContext` and `BorrowedAccount` of ABI v2.

### BPF programs
Add a new loader with a different entrypoint and syscalls: CPI, return data, realloc.
See [dev branch](https://github.com/Lichtso/solana/tree/feature/direct_mapping).

### Testing
Migrate and adjust the entire test suite around message processing.

### Benchmarking
Measure the limits of ABIv2.