### PR TITLE
Expose StakeProgram.Merge in solana/web3.js

### DIFF
--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -167,13 +167,14 @@ export type DeactivateStakeParams = {
 };
 
 /**
- * Deactivate stake instruction params
+ * Merge stake instruction params
  */
 export type MergeStakeParams = {
   stakePubkey: PublicKey;
   sourceStakePubKey: PublicKey;
   authorizedPubkey: PublicKey;
 };
+
 /**
  * Stake Instruction class
  */
@@ -332,6 +333,21 @@ export class StakeInstruction {
       splitStakePubkey: instruction.keys[1].pubkey,
       authorizedPubkey: instruction.keys[2].pubkey,
       lamports,
+    };
+  }
+
+  /**
+   * Decode a merge stake instruction and retrieve the instruction params.
+   */
+  static decodeMerge(instruction: TransactionInstruction): MergeStakeParams {
+    this.checkProgramId(instruction.programId);
+    this.checkKeyLength(instruction.keys, 3);
+    decodeData(STAKE_INSTRUCTION_LAYOUTS.Merge, instruction.data);
+
+    return {
+      stakePubkey: instruction.keys[0].pubkey,
+      sourceStakePubKey: instruction.keys[1].pubkey,
+      authorizedPubkey: instruction.keys[4].pubkey,
     };
   }
 
@@ -723,7 +739,7 @@ export class StakeProgram {
    * Generate a Transaction that merges Stake accounts.
    */
   static merge(params: MergeStakeParams): Transaction {
-    const {stakePubkey, authorizedPubkey, sourceStakePubKey} = params;
+    const {stakePubkey, sourceStakePubKey, authorizedPubkey} = params;
     const type = STAKE_INSTRUCTION_LAYOUTS.Merge;
     const data = encodeData(type);
 

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -457,12 +457,7 @@ export const STAKE_INSTRUCTION_LAYOUTS: {
   },
   Merge: {
     index: 7,
-    layout: BufferLayout.struct([
-      BufferLayout.u32('instruction'),
-      Layout.publicKey('stakePubKey'),
-      Layout.publicKey('sourceStakePubKey'),
-      Layout.publicKey('authorityOwner'),
-    ]),
+    layout: BufferLayout.struct([BufferLayout.u32('instruction')]),
   },
   AuthorizeWithSeed: {
     index: 8,

--- a/web3.js/test/stake-program.test.ts
+++ b/web3.js/test/stake-program.test.ts
@@ -220,6 +220,21 @@ describe('StakeProgram', () => {
     expect(params).to.eql(StakeInstruction.decodeSplit(stakeInstruction));
   });
 
+  it('merge', () => {
+    const stakePubkey = Keypair.generate().publicKey;
+    const sourceStakePubKey = Keypair.generate().publicKey;
+    const authorizedPubkey = Keypair.generate().publicKey;
+    const params = {
+      stakePubkey,
+      sourceStakePubKey,
+      authorizedPubkey,
+    };
+    const transaction = StakeProgram.merge(params);
+    expect(transaction.instructions).to.have.length(1);
+    const [stakeInstruction] = transaction.instructions;
+    expect(params).to.eql(StakeInstruction.decodeMerge(stakeInstruction));
+  });
+
   it('withdraw', () => {
     const stakePubkey = Keypair.generate().publicKey;
     const authorizedPubkey = Keypair.generate().publicKey;

--- a/web3.js/test/stake-program.test.ts
+++ b/web3.js/test/stake-program.test.ts
@@ -504,6 +504,34 @@ describe('StakeProgram', () => {
       const balance = await connection.getBalance(newAccountPubkey);
       expect(balance).to.eq(minimumAmount + 2);
 
+      // Merge stake
+      let merge = StakeProgram.merge({
+        stakePubkey: newAccountPubkey,
+        sourceStakePubKey: newStake.publicKey,
+        authorizedPubkey: authorized.publicKey,
+      });
+      await sendAndConfirmTransaction(connection, merge, [authorized], {
+        preflightCommitment: 'confirmed',
+      });
+      const mergedBalance = await connection.getBalance(newAccountPubkey);
+      expect(mergedBalance).to.eq(2 * minimumAmount + 22);
+
+      // Resplit
+      split = StakeProgram.split({
+        stakePubkey: newAccountPubkey,
+        authorizedPubkey: authorized.publicKey,
+        splitStakePubkey: newStake.publicKey,
+        lamports: minimumAmount + 20,
+      });
+      await sendAndConfirmTransaction(
+        connection,
+        split,
+        [authorized, newStake],
+        {
+          preflightCommitment: 'confirmed',
+        },
+      );
+
       // Authorize to new account
       const newAuthorized = Keypair.generate();
       await connection.requestAirdrop(
@@ -540,6 +568,23 @@ describe('StakeProgram', () => {
         sendAndConfirmTransaction(
           connection,
           delegateNotAuthorized,
+          [authorized],
+          {
+            preflightCommitment: 'confirmed',
+          },
+        ),
+      ).to.be.rejected;
+
+      // Test accounts with different authorities can't be merged
+      let mergeNotAuthorized = StakeProgram.merge({
+        stakePubkey: newStake.publicKey,
+        sourceStakePubKey: newAccountPubkey,
+        authorizedPubkey: authorized.publicKey,
+      });
+      await expect(
+        sendAndConfirmTransaction(
+          connection,
+          mergeNotAuthorized,
           [authorized],
           {
             preflightCommitment: 'confirmed',


### PR DESCRIPTION
#### Problem

The `Merge` instruction from Stake Program is not exposed.

#### Summary of Changes

Add the `Merge` instruction.
Recreating PR to add live test cases. Thank you @AlexBHarley!

Closes #19050 