### PR TITLE
Bump tonic-build for build-proto

### DIFF
--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -12,4 +12,4 @@ version = "1.8.0"
 [workspace]
 
 [dependencies]
-tonic-build = "0.5.0"
+tonic-build = "0.5.2"


### PR DESCRIPTION
#### Problem
Dependabot didn't catch this tonic-build dependency, and I didn't get this fixed in the bump PR.

#### Summary of Changes
Sync tonic-build version
