### PR TITLE
docs: create key with docker

### DIFF
--- a/docs/src/wallet-guide/file-system-wallet.md
+++ b/docs/src/wallet-guide/file-system-wallet.md
@@ -23,6 +23,15 @@ mkdir ~/my-solana-wallet
 solana-keygen new --outfile ~/my-solana-wallet/my-keypair.json
 ```
 
+or use docker instead of cli install:
+```
+SOLANA_WALLET_DIR=~/my-solana-wallet
+SOLANA_KEYPAIR_FILENAME=my-keypair.json
+mkdir -p ${SOLANA_WALLET_DIR}
+docker run -it --rm --entrypoint "solana-keygen" --volume ${SOLANA_WALLET_DIR}:/tmp/solana \
+  solanalabs/solana:stable new --outfile /tmp/solana/${SOLANA_KEYPAIR_FILENAME}
+```
+
 This file contains your **unencrypted** keypair. In fact, even if you specify
 a password, that password applies to the recovery seed phrase, not the file. Do
 not share this file with others. Anyone with access to this file will have access


### PR DESCRIPTION
#### Problem

When installing the client, there may be dependency issues, for example:
```
$ sh -c "$(curl -sSfL https://release.solana.com/v1.7.10/install)"
downloading v1.7.10 installer
/tmp/tmp.oIAuUMaDxs/solana-install-init: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory

yum install openssl11-libs

$ sh -c "$(curl -sSfL https://release.solana.com/v1.7.10/install)"
downloading v1.7.10 installer
/tmp/tmp.rS1nYVEjKR/solana-install-init: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /tmp/tmp.rS1nYVEjKR/solana-install-init)

can`t install on CentOS7
```

#### Summary of Changes

How to use docker instead of cli installation
