### PR TITLE
fixup! Handle cleaning of zero-lamport accounts w.r.t. Incremental Sn…

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2950,7 +2950,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
         assert_eq!(
@@ -3012,7 +3012,7 @@ mod tests {
             false,
             false,
             false,
-            crate::accounts_index::BINS_FOR_TESTING,
+            Some(crate::accounts_index::BINS_FOR_TESTING),
         )
         .unwrap();
         assert_eq!(


### PR DESCRIPTION
…apshots (#18870)

Fixes some forgotten `Some(...)`'s:

```
error[E0308]: mismatched types
--
  | --> runtime/src/snapshot_utils.rs:2953:13
  | \|
  | 2953 \|             crate::accounts_index::BINS_FOR_TESTING,
  | \|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | \|             \|
  | \|             expected enum `std::option::Option`, found `usize`
  | \|             help: try using a variant of the expected enum: `accounts_db::_::_serde::__private::Some(crate::accounts_index::BINS_FOR_TESTING)`
  | \|
  | = note: expected enum `std::option::Option<usize>`
  | found type `usize`
  |  
  | error[E0308]: mismatched types
  | --> runtime/src/snapshot_utils.rs:3015:13
  | \|
  | 3015 \|             crate::accounts_index::BINS_FOR_TESTING,
  | \|             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | \|             \|
  | \|             expected enum `std::option::Option`, found `usize`
  | \|             help: try using a variant of the expected enum: `accounts_db::_::_serde::__private::Some(crate::accounts_index::BINS_FOR_TESTING)`
  | \|
  | = note: expected enum `std::option::Option<usize>`
  | found type `usize`
```
