### PR TITLE
change untar to use unpack instead of unpack_in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -6225,9 +6225,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.14"
 reqwest = { version = "0.11.4", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "=1.8.0" }
 solana-runtime = { path = "../runtime", version = "=1.8.0" }
-tar = "0.4.35"
+tar = "0.4.37"
 
 [lib]
 crate-type = ["lib"]

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -32,7 +32,7 @@ solana-logger = { path = "../logger", version = "=1.8.0" }
 solana-sdk = { path = "../sdk", version = "=1.8.0" }
 solana-version = { path = "../version", version = "=1.8.0" }
 semver = "1.0.4"
-tar = "0.4.35"
+tar = "0.4.37"
 tempfile = "3.2.0"
 url = "2.2.2"
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3486,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d779dc6aeff029314570f666ec83f19df7280bb36ef338442cfa8c604021b80"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
  "libc",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -49,7 +49,7 @@ solana-secp256k1-program = { path = "../programs/secp256k1", version = "=1.8.0" 
 solana-stake-program = { path = "../programs/stake", version = "=1.8.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.8.0" }
 symlink = "0.1.0"
-tar = "0.4.35"
+tar = "0.4.37"
 tempfile = "3.2.0"
 thiserror = "1.0"
 zstd = "0.9.0"

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -246,12 +246,17 @@ fn sanitize_path(entry_path: &Path, dst: &Path) -> Result<Option<PathBuf>> {
     };
 
     fs::create_dir_all(parent)?;
+
+    // Here we are different than untar_in. The code for tar::unpack_in internally calling unpack is a little different.
+    // ignore return value here
     validate_inside_dst(dst, parent)?;
     let target = parent.join(entry_path.file_name().unwrap());
 
     Ok(Some(target))
 }
 
+// copied from:
+// https://github.com/alexcrichton/tar-rs/blob/d90a02f582c03dfa0fd11c78d608d0974625ae5d/src/entry.rs#L781
 fn validate_inside_dst(dst: &Path, file_dst: &Path) -> Result<PathBuf> {
     // Abort if target (canonical) parent is outside of `dst`
     let canon_parent = file_dst.canonicalize().map_err(|err| {

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -9,8 +9,7 @@ use {
         fs::{self, File},
         io::{BufReader, Read},
         path::{
-            Component,
-            Component::{CurDir, Normal},
+            Component::{self, CurDir, Normal},
             Path, PathBuf,
         },
         time::Instant,

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -210,7 +210,6 @@ where
 fn sanitize_path(entry_path: &Path, dst: &Path) -> Result<Option<PathBuf>> {
     // We cannot call unpack_in because it errors if we try to use 2 account paths.
     // So, this code is borrowed from unpack_in
-    // code from: unpack_in does its own sanitization
     // ref: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack_in
     let mut file_dst = dst.to_path_buf();
     const SKIP: Result<Option<PathBuf>> = Ok(None);

--- a/sdk/cargo-build-bpf/Cargo.toml
+++ b/sdk/cargo-build-bpf/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.5.4"
 cargo_metadata = "0.14.0"
 solana-sdk = { path = "..", version = "=1.8.0" }
 solana-download-utils = { path = "../../download-utils", version = "=1.8.0" }
-tar = "0.4.35"
+tar = "0.4.37"
 
 [dev-dependencies]
 serial_test = "*"


### PR DESCRIPTION
#### Problem
tar crate changed its behavior as part of a security update. An internal call in `unpack_in` call was changed from:
`fs::create_dir_all(...)` // does NOT return error if path already exists
to
`fs::create_dir(...)` // returns error if path already exists

The goal was to fix a security hole where items could be unpacked in folders outside the destination folder.

There are possibly concerns with how we unpack to several configurable directories, which may be on different drives completely. That would seem to also trigger an error.

This pr switches from using unpack_in to unpack so that we control sanitizing.

#19175
[tar crate change](https://github.com/alexcrichton/tar-rs/commit/d90a02f582c03dfa0fd11c78d608d0974625ae5d#diff-3dcefa956e75e2171b83e5134b542405a2adb7909a16dc03fad7fd92e8e2d945R776)
[PR by @CriesofCarrots against tar crate](https://github.com/alexcrichton/tar-rs/pull/260)


#### Summary of Changes

Closes #19230 
