### PR TITLE
rework bank test to specifically use BTreeMap

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5695,9 +5695,7 @@ pub(crate) mod tests {
     use crate::{
         accounts_background_service::{AbsRequestHandler, SendDroppedBankCallback},
         accounts_db::DEFAULT_ACCOUNTS_SHRINK_RATIO,
-        accounts_index::{
-            AccountIndex, AccountMap, AccountSecondaryIndexes, ScanError, ITER_BATCH_SIZE,
-        },
+        accounts_index::{AccountIndex, AccountSecondaryIndexes, ScanError, ITER_BATCH_SIZE},
         ancestors::Ancestors,
         genesis_utils::{
             activate_all_features, bootstrap_validator_stake_lamports,
@@ -7266,9 +7264,9 @@ pub(crate) mod tests {
         }
     }
 
-    fn map_to_test_bad_range() -> AccountMap<Pubkey, i8> {
-        let mut map: AccountMap<Pubkey, i8> = AccountMap::new();
-        // when empty, AccountMap (= std::collections::BTreeMap) doesn't sanitize given range...
+    fn map_to_test_bad_range() -> std::collections::BTreeMap<Pubkey, i8> {
+        let mut map = std::collections::BTreeMap::new();
+        // when empty, std::collections::BTreeMap doesn't sanitize given range...
         map.insert(solana_sdk::pubkey::new_rand(), 1);
         map
     }


### PR DESCRIPTION
#### Problem
AccountsIndex already doesn't work quite like this since we are now binning the index by pubkeys. Now that we plan to no longer use btree, that makes this code even less applicable. I could add a fn on AccountsIndex that returns a range, but I think references are going to get difficult to deal with since individual bins are behind their own rwlocks. If the purpose of this code is to verify that the ranges are being created correctly, then using a btree here is fine. If the purpose is to do more integration testing and test that the AccountsIndex is checking ranges correctly, then we have to rework this.
#### Summary of Changes

Fixes #
