### PR TITLE
Allocate can re-allocate accounts that are non-empty, only not nonces

### DIFF
--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -79,7 +79,7 @@ fn allocate(
 
     // if it looks like the `to` account is already in use, bail
     //   (note that the id check is also enforced by message_processor)
-    if !account.data().is_empty() || !system_program::check_id(account.owner()) {
+    if !system_program::check_id(account.owner()) {
         ic_msg!(
             invoke_context,
             "Allocate: account {:?} already in use",
@@ -406,6 +406,13 @@ pub fn process_instruction(
         }
         SystemInstruction::Allocate { space } => {
             let keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
+            if keyed_account.is_nonce_account() {
+                ic_msg!(
+                    invoke_context,
+                    "Allocate: cannot re-allocate data for existing nonce account",
+                );
+                return Err(SystemError::AccountAlreadyInUse.into());
+            }
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(keyed_account.unsigned_key(), None, invoke_context)?;
             allocate(&mut account, &address, space, &signers, invoke_context)
@@ -417,6 +424,13 @@ pub fn process_instruction(
             owner,
         } => {
             let keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
+            if keyed_account.is_nonce_account() {
+                ic_msg!(
+                    invoke_context,
+                    "Allocate: cannot re-allocate data for existing nonce account",
+                );
+                return Err(SystemError::AccountAlreadyInUse.into());
+            }
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(
                 keyed_account.unsigned_key(),

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -43,9 +43,20 @@ pub trait NonceKeyedAccount {
         signers: &HashSet<Pubkey>,
         invoke_context: &dyn InvokeContext,
     ) -> Result<(), InstructionError>;
+    fn is_nonce_account(&self) -> bool;
 }
 
 impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
+    fn is_nonce_account(&self) -> bool {
+        let state = AccountUtilsState::<Versions>::state(self)
+            .map(|x| x.convert_to_current())
+            .ok();
+        if Some(State::Uninitialized) == state || state.is_none() {
+            false
+        } else {
+            true
+        }
+    }
     fn advance_nonce_account(
         &self,
         signers: &HashSet<Pubkey>,

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -51,11 +51,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         let state = AccountUtilsState::<Versions>::state(self)
             .map(|x| x.convert_to_current())
             .ok();
-        if Some(State::Uninitialized) == state || state.is_none() {
-            false
-        } else {
-            true
-        }
+        !(Some(State::Uninitialized) == state || state.is_none())
     }
     fn advance_nonce_account(
         &self,


### PR DESCRIPTION
#### Problem
We'd like non-nonce accounts to be able to reallocate their data

#### Summary of Changes
Allow arbitrary reallocations as long as system account is not nonce account

Fixes https://github.com/solana-labs/solana/issues/19217

@jstarry 