### PR TITLE
Rename AccountsPacakge to SnapshotPackage and AccountsPackagePre to AccountsPackage

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,6 +1,6 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::AccountsPackage,
+    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::SnapshotPackage,
     snapshot_utils,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 
-pub type PendingSnapshotPackage = Arc<Mutex<Option<AccountsPackage>>>;
+pub type PendingSnapshotPackage = Arc<Mutex<Option<SnapshotPackage>>>;
 
 pub struct SnapshotPackagerService {
     t_snapshot_packager: JoinHandle<()>,
@@ -81,7 +81,7 @@ mod tests {
     use solana_runtime::{
         accounts_db::AccountStorageEntry,
         bank::BankSlotDelta,
-        snapshot_package::AccountsPackage,
+        snapshot_package::SnapshotPackage,
         snapshot_utils::{self, ArchiveFormat, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_sdk::hash::Hash;
@@ -165,7 +165,7 @@ mod tests {
             &Hash::default(),
             ArchiveFormat::TarBzip2,
         );
-        let snapshot_package = AccountsPackage::new(
+        let snapshot_package = SnapshotPackage::new(
             5,
             5,
             vec![],

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -66,7 +66,7 @@ mod tests {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         snapshot_archive_info::FullSnapshotArchiveInfo,
         snapshot_config::SnapshotConfig,
-        snapshot_package::AccountsPackagePre,
+        snapshot_package::AccountsPackage,
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -275,7 +275,7 @@ mod tests {
         let snapshot_path = &snapshot_config.snapshot_path;
         let last_bank_snapshot_info = snapshot_utils::get_highest_bank_snapshot_info(snapshot_path)
             .expect("no snapshots found in path");
-        let snapshot_package = AccountsPackagePre::new_full_snapshot_package(
+        let accounts_package = AccountsPackage::new_for_full_snapshot(
             last_bank,
             &last_bank_snapshot_info,
             snapshot_path,
@@ -287,8 +287,8 @@ mod tests {
             None,
         )
         .unwrap();
-        let snapshot_package = snapshot_utils::process_accounts_package_pre(
-            snapshot_package,
+        let snapshot_package = snapshot_utils::process_accounts_package(
+            accounts_package,
             Some(last_bank.get_thread_pool()),
             None,
         );
@@ -508,18 +508,17 @@ mod tests {
         let _package_receiver = std::thread::Builder::new()
             .name("package-receiver".to_string())
             .spawn(move || {
-                while let Ok(mut snapshot_package) = receiver.recv() {
+                while let Ok(mut accounts_package) = receiver.recv() {
                     // Only package the latest
-                    while let Ok(new_snapshot_package) = receiver.try_recv() {
-                        snapshot_package = new_snapshot_package;
+                    while let Ok(new_accounts_package) = receiver.try_recv() {
+                        accounts_package = new_accounts_package;
                     }
 
-                    let snapshot_package =
-                        solana_runtime::snapshot_utils::process_accounts_package_pre(
-                            snapshot_package,
-                            Some(&thread_pool),
-                            None,
-                        );
+                    let snapshot_package = solana_runtime::snapshot_utils::process_accounts_package(
+                        accounts_package,
+                        Some(&thread_pool),
+                        None,
+                    );
                     *pending_snapshot_package.lock().unwrap() = Some(snapshot_package);
                 }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -20,12 +20,12 @@ use std::{
 };
 use tempfile::TempDir;
 
-pub type AccountsPackageSender = Sender<AccountsPackagePre>;
-pub type AccountsPackageReceiver = Receiver<AccountsPackagePre>;
-pub type AccountsPackageSendError = SendError<AccountsPackagePre>;
+pub type AccountsPackageSender = Sender<AccountsPackage>;
+pub type AccountsPackageReceiver = Receiver<AccountsPackage>;
+pub type AccountsPackageSendError = SendError<AccountsPackage>;
 
 #[derive(Debug)]
-pub struct AccountsPackagePre {
+pub struct AccountsPackage {
     pub slot: Slot,
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
@@ -40,8 +40,8 @@ pub struct AccountsPackagePre {
     pub cluster_type: ClusterType,
 }
 
-impl AccountsPackagePre {
-    /// Create a snapshot package
+impl AccountsPackage {
+    /// Create an accounts package
     #[allow(clippy::too_many_arguments)]
     fn new(
         bank: &Bank,
@@ -84,7 +84,7 @@ impl AccountsPackagePre {
 
     /// Package up bank snapshot files, snapshot storages, and slot deltas for a full snapshot.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_full_snapshot_package(
+    pub fn new_for_full_snapshot(
         bank: &Bank,
         bank_snapshot_info: &BankSnapshotInfo,
         snapshots_dir: impl AsRef<Path>,
@@ -120,7 +120,7 @@ impl AccountsPackagePre {
 
     /// Package up bank snapshot files, snapshot storages, and slot deltas for an incremental snapshot.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_incremental_snapshot_package(
+    pub fn new_for_incremental_snapshot(
         bank: &Bank,
         incremental_snapshot_base_slot: Slot,
         bank_snapshot_info: &BankSnapshotInfo,
@@ -169,7 +169,7 @@ impl AccountsPackagePre {
     }
 }
 
-pub struct AccountsPackage {
+pub struct SnapshotPackage {
     pub snapshot_archive_info: SnapshotArchiveInfo,
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
@@ -178,7 +178,7 @@ pub struct AccountsPackage {
     pub snapshot_version: SnapshotVersion,
 }
 
-impl AccountsPackage {
+impl SnapshotPackage {
     pub fn new(
         slot: Slot,
         block_height: u64,
@@ -206,7 +206,7 @@ impl AccountsPackage {
     }
 }
 
-impl SnapshotArchiveInfoGetter for AccountsPackage {
+impl SnapshotArchiveInfoGetter for SnapshotPackage {
     fn snapshot_archive_info(&self) -> &SnapshotArchiveInfo {
         &self.snapshot_archive_info
     }


### PR DESCRIPTION
Renaming these types to better communicate their usages, which will
further diverge as incremental snapshot support is added.

With the new names, AccountsPacakge now refers to the type between
AccountsBackgroundProcess and AccountsHashVerifier, and SnapshotPackage
refers to the type between AccountsHashVerifier and
SnapshotPackagerService.

### **Note: Zero functional changes**