### PR TITLE
Add AsRef<AccountInfo> for AccountInfo

### DIFF
--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -266,4 +266,13 @@ mod tests {
         assert_eq!(k4, *info2_3_4[2].key);
         assert_eq!(k5, *info5.key);
     }
+
+    #[test]
+    fn test_account_info_as_ref() {
+        let k = Pubkey::new_unique();
+        let l = &mut 0;
+        let d = &mut [0u8];
+        let info = AccountInfo::new(&k, false, false, l, d, &k, false, 0);
+        assert_eq!(info.key, info.as_ref().key);
+    }
 }

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -220,6 +220,12 @@ pub fn next_account_infos<'a, 'b: 'a>(
     Ok(accounts)
 }
 
+impl<'a> AsRef<AccountInfo<'a>> for AccountInfo<'a> {
+    fn as_ref(&self) -> &AccountInfo<'a> {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Ref https://github.com/project-serum/anchor/issues/608

#### Problem

In [project-serum/anchor](https://github.com/project-serum/anchor/) we want to optimize code generation with something like:
```rust
pub trait KeyRef<'info> {
    fn key(&self) -> &'info Pubkey;
}

impl<'info, T> KeyRef<'info> for T
where
    T: AsRef<AccountInfo<'info>>,
{
    fn key(&self) -> &'info Pubkey {
        self.as_ref().key
    }
}
```

of course this produce error:
```
upstream crates may add a new impl of trait `std::convert::AsRef<solana_program::account_info::AccountInfo<'_>>` for type `solana_program::account_info::AccountInfo<'_>` in future versions
```

#### Summary of Changes

Implement `AsRef<AccountInfo<'a>>` for `AccountInfo<'a>`.
