### PR TITLE
bug: `sysvar::Instructions` is not owned by `Sysvar1111111111111111111111111111111111111`

### DIFF
--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -10,6 +10,7 @@ use solana_program::{
     msg,
     program_error::ProgramError,
     pubkey::Pubkey,
+    system_program,
     sysvar::{
         self, clock::Clock, epoch_schedule::EpochSchedule, instructions, rent::Rent,
         slot_hashes::SlotHashes, slot_history::SlotHistory, stake_history::StakeHistory, Sysvar,
@@ -46,6 +47,7 @@ pub fn process_instruction(
     // Instructions
     msg!("Instructions identifier:");
     sysvar::instructions::id().log();
+    assert_eq!(*accounts[4].owner, system_program::id());
     let index = instructions::load_current_index(&accounts[4].try_borrow_data()?);
     assert_eq!(0, index);
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -30,6 +30,10 @@ pub mod instructions_sysvar_enabled {
     solana_sdk::declare_id!("EnvhHCLvg55P7PDtbvR1NwuTuAeodqpusV3MR5QEK8gs");
 }
 
+pub mod instructions_sysvar_owned_by_sysvar {
+    solana_sdk::declare_id!("DMrxRAhXK5DNeDtqdnsL8ygRdYCnS2cNUyjvh2FK8keY");
+}
+
 pub mod deprecate_rewards_sysvar {
     solana_sdk::declare_id!("GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu");
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -31,7 +31,7 @@ pub mod instructions_sysvar_enabled {
 }
 
 pub mod instructions_sysvar_owned_by_sysvar {
-    solana_sdk::declare_id!("DMrxRAhXK5DNeDtqdnsL8ygRdYCnS2cNUyjvh2FK8keY");
+    solana_sdk::declare_id!("H3kBSaKdeiUsyHmeHqjJYNc27jesXZ6zWj3zWkowQbkV");
 }
 
 pub mod deprecate_rewards_sysvar {


### PR DESCRIPTION
#### Problem
The instructions sysvar is not owned by the sysvar id, instead, it is owned by system program.

#### Summary of Changes
When loading it from `bank.accounts`, load it as owned by `Sysvar1111111111111111111111111111111111111`.