### PR TITLE
implements AsRef (instead of Borrow) for VoteAccounts

### DIFF
--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_stake_program::stake_state,
     solana_vote_program::vote_state::VoteState,
-    std::{borrow::Borrow, collections::HashMap, sync::Arc},
+    std::{collections::HashMap, sync::Arc},
 };
 
 #[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]
@@ -212,7 +212,7 @@ impl Stakes {
     }
 
     pub fn vote_accounts(&self) -> &HashMap<Pubkey, (u64, VoteAccount)> {
-        self.vote_accounts.borrow()
+        self.vote_accounts.as_ref()
     }
 
     pub fn stake_delegations(&self) -> &HashMap<Pubkey, Delegation> {

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -7,7 +7,6 @@ use {
     },
     solana_vote_program::vote_state::VoteState,
     std::{
-        borrow::Borrow,
         cmp::Ordering,
         collections::{hash_map::Entry, HashMap},
         iter::FromIterator,
@@ -268,8 +267,8 @@ impl From<VoteAccountsHashMap> for VoteAccounts {
     }
 }
 
-impl Borrow<VoteAccountsHashMap> for VoteAccounts {
-    fn borrow(&self) -> &VoteAccountsHashMap {
+impl AsRef<VoteAccountsHashMap> for VoteAccounts {
+    fn as_ref(&self) -> &VoteAccountsHashMap {
         &self.vote_accounts
     }
 }


### PR DESCRIPTION

#### Problem
According to the docs:
> if you want to borrow only a single field of a struct you can
> implement AsRef, but not Borrow.

https://doc.rust-lang.org/std/convert/trait.AsRef.html

#### Summary of Changes
`AsRef` instead of `Borrow`.