### PR TITLE
Rpc simulation with injected accounts

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -30,7 +30,7 @@ pub type StringAmount = String;
 pub type StringDecimals = String;
 
 /// A duplicate representation of an Account for pretty JSON serialization
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UiAccount {
     pub lamports: u64,

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -28,7 +28,14 @@ pub struct RpcSendTransactionConfig {
 pub struct RpcSimulateTransactionAccountsConfig {
     pub encoding: Option<UiAccountEncoding>,
     pub addresses: Vec<String>,
-    pub injected_accounts: Option<Vec<(String, UiAccount)>>,
+    pub injected_accounts: Option<Vec<RpcSimulateTransactionInjectedAccount>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcSimulateTransactionInjectedAccount {
+    pub address: String,
+    pub account_data: UiAccount,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -1,6 +1,6 @@
 use {
     crate::rpc_filter::RpcFilterType,
-    solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
+    solana_account_decoder::{UiAccountEncoding, UiAccount, UiDataSliceConfig},
     solana_sdk::{
         clock::{Epoch, Slot},
         commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -28,6 +28,7 @@ pub struct RpcSendTransactionConfig {
 pub struct RpcSimulateTransactionAccountsConfig {
     pub encoding: Option<UiAccountEncoding>,
     pub addresses: Vec<String>,
+    pub injected_accounts: Option<Vec<(String, UiAccount)>>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -19,6 +19,7 @@ pub const JSON_RPC_SERVER_ERROR_KEY_EXCLUDED_FROM_SECONDARY_INDEX: i64 = -32010;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_HISTORY_NOT_AVAILABLE: i64 = -32011;
 pub const JSON_RPC_SCAN_ERROR: i64 = -32012;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_LEN_MISMATCH: i64 = -32013;
+pub const JSON_RPC_SERVER_ERROR_TRANSACTION_SIMULATION_ACCOUNT_DATA_INVALID: i64 = -32014;
 
 #[derive(Error, Debug)]
 pub enum RpcCustomError {
@@ -54,6 +55,8 @@ pub enum RpcCustomError {
     ScanError { message: String },
     #[error("TransactionSignatureLenMismatch")]
     TransactionSignatureLenMismatch,
+    #[error("TransactionSimulationAccountDataInvalid")]
+    TransactionSimulationAccountDataInvalid,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -161,6 +164,13 @@ impl From<RpcCustomError> for Error {
                 message: "Transaction signature length mismatch".to_string(),
                 data: None,
             },
+            RpcCustomError::TransactionSimulationAccountDataInvalid => Self {
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_TRANSACTION_SIMULATION_ACCOUNT_DATA_INVALID,
+                ),
+                message: "Transaction simulation injected account data invalid".to_string(),
+                data: None,
+            }
         }
     }
 }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3287,6 +3287,15 @@ Simulate sending a transaction
      - `encoding: <string>` - (optional) encoding for returned Account data, either  "base64" (default), "base64+zstd" or "jsonParsed".
         "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
      - `addresses: <array>` - An array of accounts to return, as base-58 encoded strings
+     - `injected_accounts: <array>` - (optional) array of accounts to be injected into the transaction simulation request
+       - `<object>`: a JSON object containing:
+          - `address: <string>` - the injected account address
+          - `account_data: <object>` - the account data, a JSON object containing:
+             - `lamports: <u64>`, number of lamports assigned to this account, as a u64
+             - `owner: <string>`, base-58 encoded Pubkey of the program this account has been assigned to
+             - `data: <[string, encoding]|object>`, data associated with the account, either as encoded binary data or JSON format `{<program>: <state>}`, depending on encoding parameter
+             - `executable: <bool>`, boolean indicating if the account contains a program \(and is strictly read-only\)
+             - `rentEpoch: <u64>`, the epoch at which this account will next owe rent, as u64
 
 #### Results:
 
@@ -3295,7 +3304,7 @@ The result will be an RpcResponse JSON object with `value` set to a JSON object 
 
 - `err: <object | string | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
 - `logs: <array | null>` - Array of log messages the transaction instructions output during execution, null if simulation failed before the transaction was able to execute (for example due to an invalid blockhash or signature verification failure)
-- `accounts: <array> | null>` - array of accounts with the same length as the `accounts.addresses` array in the request
+- `accounts: <array> | <null>` - array of accounts with the same length as the `accounts.addresses` array in the request
   - `<null>` - if the account doesn't exist or if `err` is not null
   - `<object>` - otherwise, a JSON object containing:
     - `lamports: <u64>`, number of lamports assigned to this account, as a u64

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3287,10 +3287,10 @@ Simulate sending a transaction
      - `encoding: <string>` - (optional) encoding for returned Account data, either  "base64" (default), "base64+zstd" or "jsonParsed".
         "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data. If "jsonParsed" is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
      - `addresses: <array>` - An array of accounts to return, as base-58 encoded strings
-     - `injected_accounts: <array>` - (optional) array of accounts to be injected into the transaction simulation request
+     - `injectedAccounts: <array>` - (optional) array of accounts to be injected into the transaction simulation request
        - `<object>`: a JSON object containing:
           - `address: <string>` - the injected account address
-          - `account_data: <object>` - the account data, a JSON object containing:
+          - `accountData: <object>` - the account data, a JSON object containing:
              - `lamports: <u64>`, number of lamports assigned to this account, as a u64
              - `owner: <string>`, base-58 encoded Pubkey of the program this account has been assigned to
              - `data: <[string, encoding]|object>`, data associated with the account, either as encoded binary data or JSON format `{<program>: <state>}`, depending on encoding parameter

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3406,11 +3406,14 @@ pub mod rpc_full {
                     }
 
                     let mut loaded_accounts = vec![];
-                    for (address_str, account_encoding) in injected_accounts {
-                        let address = verify_pubkey(&address_str)?;
+                    for RpcSimulateTransactionInjectedAccount {
+                        address,
+                        account_data,
+                    } in injected_accounts {
+                        let address = verify_pubkey(&address)?;
                         loaded_accounts.push((
                             address,
-                            UiAccount::decode(account_encoding)
+                            UiAccount::decode(account_data)
                                 .ok_or(RpcCustomError::TransactionSimulationAccountDataInvalid)?
                         ));
                     }


### PR DESCRIPTION
#### Problem
Users may want to simulate transactions based on hypothetical data.

For instance, they may like to see the program logs when running governance proposal instructions.
Else, they might like to simulate the effective price when executing a swap on Serum or Raydium.

There are many examples one can think of where this would be useful.

#### Summary of Changes
Implement an RPC->Bank pathway for injecting account data into transaction simulation.

Fixes https://github.com/solana-labs/solana/issues/18746

@ryoqun @jstarry @mvines 