### PR TITLE
Explorer: support uninitialized upgradeable program account in AccountSection

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -13,6 +13,7 @@ import { Slot } from "components/common/Slot";
 import { addressLabel } from "utils/tx";
 import { useCluster } from "providers/cluster";
 import { ErrorCard } from "components/common/ErrorCard";
+import { UnknownAccountCard } from "components/account/UnknownAccountCard";
 
 export function UpgradeableLoaderAccountSection({
   account,
@@ -51,6 +52,9 @@ export function UpgradeableLoaderAccountSection({
           programBuffer={parsedData.info}
         />
       );
+    }
+    case "uninitialized": {
+      return <UnknownAccountCard account={account} />;
     }
   }
 }

--- a/explorer/src/validators/accounts/upgradeable-program.ts
+++ b/explorer/src/validators/accounts/upgradeable-program.ts
@@ -9,6 +9,7 @@ import {
   union,
   coerce,
   create,
+  any,
 } from "superstruct";
 import { ParsedInfo } from "validators";
 import { PublicKeyFromString } from "validators/pubkey";
@@ -49,9 +50,27 @@ export const ProgramBufferAccount = type({
   info: ProgramBufferAccountInfo,
 });
 
+export type ProgramUninitializedAccountInfo = Infer<
+  typeof ProgramUninitializedAccountInfo
+>;
+export const ProgramUninitializedAccountInfo = any();
+
+export type ProgramUninitializedAccount = Infer<
+  typeof ProgramUninitializedAccount
+>;
+export const ProgramUninitializedAccount = type({
+  type: literal("uninitialized"),
+  info: ProgramUninitializedAccountInfo,
+});
+
 export type UpgradeableLoaderAccount = Infer<typeof UpgradeableLoaderAccount>;
 export const UpgradeableLoaderAccount = coerce(
-  union([ProgramAccount, ProgramDataAccount, ProgramBufferAccount]),
+  union([
+    ProgramAccount,
+    ProgramDataAccount,
+    ProgramBufferAccount,
+    ProgramUninitializedAccount,
+  ]),
   ParsedInfo,
   (value) => {
     // Coercions like `PublicKeyFromString` are not applied within
@@ -73,6 +92,12 @@ export const UpgradeableLoaderAccount = coerce(
         return {
           type: value.type,
           info: create(value.info, ProgramBufferAccountInfo),
+        };
+      }
+      case "uninitialized": {
+        return {
+          type: value.type,
+          info: create(value.info, ProgramUninitializedAccountInfo),
         };
       }
       default: {


### PR DESCRIPTION
#### Problem
The `uninitialized` state of the parsed upgradeable loader state is not being accounted for in the type coercions of AccountSection.

#### Summary of Changes
Handle uninitialized state and render default account section.
