### PR TITLE
--accounts-index-memory-limit-mb

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -880,6 +880,12 @@ fn main() {
         .validator(is_bin)
         .takes_value(true)
         .help("Number of bins to divide the accounts index into");
+    let accounts_index_limit = Arg::with_name("accounts_index_memory_limit_mb")
+        .long("accounts-index-memory-limit-mb")
+        .value_name("MEGABYTES")
+        .validator(is_parsable::<usize>)
+        .takes_value(true)
+        .help("How much memory the accounts index can consume. If this is exceeded, some account index entries will be stored on disk. If missing, the entire index is stored in memory.");
     let account_paths_arg = Arg::with_name("account_paths")
         .long("accounts")
         .value_name("PATHS")
@@ -1192,6 +1198,7 @@ fn main() {
             .arg(&halt_at_slot_arg)
             .arg(&limit_load_slot_count_from_snapshot_arg)
             .arg(&accounts_index_bins)
+            .arg(&accounts_index_limit)
             .arg(&verify_index_arg)
             .arg(&hard_forks_arg)
             .arg(&no_accounts_db_caching_arg)
@@ -1911,6 +1918,10 @@ fn main() {
             let mut accounts_index_config = AccountsIndexConfig::default();
             if let Some(bins) = value_t!(matches, "accounts_index_bins", usize).ok() {
                 accounts_index_config.bins = Some(bins);
+            }
+
+            if let Some(limit) = value_t!(matches, "accounts_index_memory_limit_mb", usize).ok() {
+                accounts_index_config.index_limit_mb = Some(limit);
             }
 
             {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -40,11 +40,13 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
+    index_limit_mb: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
+    index_limit_mb: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
@@ -101,6 +103,7 @@ pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub flush_threads: Option<usize>,
     pub drives: Option<Vec<PathBuf>>,
+    pub index_limit_mb: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1991,6 +1991,14 @@ pub fn main() {
                       This option is for use during testing."),
         )
         .arg(
+            Arg::with_name("accounts_index_memory_limit_mb")
+                .long("accounts-index-memory-limit-mb")
+                .value_name("MEGABYTES")
+                .validator(is_parsable::<usize>)
+                .takes_value(true)
+                .help("How much memory the accounts index can consume. If this is exceeded, some account index entries will be stored on disk. If missing, the entire index is stored in memory."),
+        )
+        .arg(
             Arg::with_name("accounts_index_bins")
                 .long("accounts-index-bins")
                 .value_name("BINS")
@@ -2510,6 +2518,10 @@ pub fn main() {
     let mut accounts_index_config = AccountsIndexConfig::default();
     if let Some(bins) = value_t!(matches, "accounts_index_bins", usize).ok() {
         accounts_index_config.bins = Some(bins);
+    }
+
+    if let Some(limit) = value_t!(matches, "accounts_index_memory_limit_mb", usize).ok() {
+        accounts_index_config.index_limit_mb = Some(limit);
     }
 
     {


### PR DESCRIPTION
#### Problem
As we move to a disk-based accounts index, we will want to allow a budget for the in-memory portion of the index.
This will get hooked up to accounts index, which will be all in memory initially (as it is now).
#### Summary of Changes
Allow a validator option for mb budget for accounts index.
atm, missing means 'all in memory'. Any limit will soon cause us to put accounts on disk. Later this option will be more precise in its tuning.
Fixes #
