### PR TITLE
Make AccountsHashVerifier aware of Incremental Snapshots

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -298,7 +298,10 @@ impl AccountsHashVerifier {
 mod tests {
     use super::*;
     use solana_gossip::{cluster_info::make_accounts_hashes_message, contact_info::ContactInfo};
-    use solana_runtime::snapshot_utils::{ArchiveFormat, SnapshotVersion};
+    use solana_runtime::{
+        snapshot_config::LastFullSnapshotSlot,
+        snapshot_utils::{ArchiveFormat, SnapshotVersion},
+    };
     use solana_sdk::{
         genesis_config::ClusterType,
         hash::hash,
@@ -370,7 +373,7 @@ mod tests {
             archive_format: ArchiveFormat::Tar,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: usize::MAX,
-            last_full_snapshot_slot: Default::default(),
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -102,7 +102,7 @@ impl AccountsHashVerifier {
     ) {
         Self::verify_accounts_package_hash(&accounts_package, thread_pool);
 
-        Self::push_hashes_to_cluster(
+        Self::push_accounts_hashes_to_cluster(
             &accounts_package,
             cluster_info,
             trusted_validators,
@@ -141,7 +141,7 @@ impl AccountsHashVerifier {
         );
     }
 
-    fn push_hashes_to_cluster(
+    fn push_accounts_hashes_to_cluster(
         accounts_package: &AccountsPackage,
         cluster_info: &ClusterInfo,
         trusted_validators: Option<&HashSet<Pubkey>>,

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -112,7 +112,7 @@ impl AccountsHashVerifier {
             fault_injection_rate_slots,
         );
 
-        Self::handle_snapshot(accounts_package, pending_snapshot_package, snapshot_config);
+        Self::submit_for_packaging(accounts_package, pending_snapshot_package, snapshot_config);
     }
 
     fn verify_accounts_package_hash(
@@ -182,7 +182,7 @@ impl AccountsHashVerifier {
         cluster_info.push_accounts_hashes(hashes.clone());
     }
 
-    fn handle_snapshot(
+    fn submit_for_packaging(
         accounts_package: AccountsPackage,
         pending_snapshot_package: Option<&PendingSnapshotPackage>,
         snapshot_config: Option<&SnapshotConfig>,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -15,7 +15,7 @@ use {
     solana_runtime::{
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{
             ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -528,7 +528,7 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: Default::default(),
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -528,6 +528,7 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: Default::default(),
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1212,7 +1212,6 @@ fn new_banks_from_ledger(
             None,
             &snapshot_config.snapshot_package_output_path,
             snapshot_config.archive_format,
-            Some(bank_forks.root_bank().get_thread_pool()),
             snapshot_config.maximum_snapshots_to_retain,
         )
         .unwrap_or_else(|err| {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -634,7 +634,7 @@ impl Validator {
                     snapshot_hash,
                     &exit,
                     &cluster_info,
-                    snapshot_config.maximum_snapshots_to_retain,
+                    snapshot_config.clone(),
                 );
                 (
                     Some(snapshot_packager_service),
@@ -1218,6 +1218,8 @@ fn new_banks_from_ledger(
             error!("Unable to create snapshot: {}", err);
             abort();
         });
+        *snapshot_config.last_full_snapshot_slot.write().unwrap() =
+            Some(full_snapshot_archive_info.slot());
         info!(
             "created snapshot: {}",
             full_snapshot_archive_info.path().display()

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -65,7 +65,7 @@ mod tests {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         snapshot_archive_info::FullSnapshotArchiveInfo,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_package::{AccountsPackage, PendingSnapshotPackage, SnapshotPackage},
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -146,7 +146,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: Default::default(),
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -146,6 +146,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: Default::default(),
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {
@@ -498,7 +499,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            snapshot_test_config.snapshot_config.clone(),
         );
 
         let snapshot_archives_dir = snapshot_config.snapshot_package_output_path.clone();
@@ -909,9 +910,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            snapshot_test_config
-                .snapshot_config
-                .maximum_snapshots_to_retain,
+            snapshot_test_config.snapshot_config.clone(),
         );
 
         let accounts_hash_verifier = AccountsHashVerifier::new(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2239,7 +2239,6 @@ fn main() {
                         Some(snapshot_version),
                         output_directory,
                         ArchiveFormat::TarZstd,
-                        None,
                         maximum_snapshots_to_retain,
                     )
                     .unwrap_or_else(|err| {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -31,7 +31,7 @@ use solana_runtime::{
     bank_forks::BankForks,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_archive_info::SnapshotArchiveInfoGetter,
-    snapshot_config::SnapshotConfig,
+    snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
     snapshot_utils::{
         self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
@@ -721,7 +721,7 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            last_full_snapshot_slot: Default::default(),
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -721,6 +721,7 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            last_full_snapshot_slot: Default::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1163,7 +1163,6 @@ fn load_frozen_forks(
                     // Must be called after `squash()`, so that AccountsDb knows what
                     // the roots are for the cache flushing in exhaustively_free_unused_resource().
                     // This could take few secs; so update last_free later
-                    // bprumo TODO: need to set correct last_full_snapshot_slot here
                     new_root_bank.exhaustively_free_unused_resource(None);
                     last_free = Instant::now();
                 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1163,6 +1163,7 @@ fn load_frozen_forks(
                     // Must be called after `squash()`, so that AccountsDb knows what
                     // the roots are for the cache flushing in exhaustively_free_unused_resource().
                     // This could take few secs; so update last_free later
+                    // bprumo TODO: need to set correct last_full_snapshot_slot here
                     new_root_bank.exhaustively_free_unused_resource(None);
                     last_free = Instant::now();
                 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3478,6 +3478,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        last_full_snapshot_slot: Default::default(),
     };
 
     // Create the account paths

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -43,7 +43,7 @@ use {
     },
     solana_runtime::{
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -3478,7 +3478,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        last_full_snapshot_slot: Default::default(),
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -263,6 +263,7 @@ impl ReplicaNode {
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
             maximum_snapshots_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            last_full_snapshot_slot: Default::default(),
         };
 
         let bank_info =

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -23,7 +23,7 @@ use {
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{clock::Slot, exit::Exit, genesis_config::GenesisConfig, hash::Hash},
@@ -263,7 +263,7 @@ impl ReplicaNode {
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
             maximum_snapshots_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            last_full_snapshot_slot: Default::default(),
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
 
         let bank_info =

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -17,7 +17,7 @@ use {
     solana_runtime::{
         accounts_index::AccountSecondaryIndexes,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -127,7 +127,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        last_full_snapshot_slot: Default::default(),
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -127,6 +127,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        last_full_snapshot_slot: Default::default(),
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -26,10 +26,8 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::{
-        bank_forks::BankForks,
-        commitment::BlockCommitmentCache,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        bank_forks::BankForks, commitment::BlockCommitmentCache,
+        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
         snapshot_utils,
     },
     solana_sdk::{
@@ -493,6 +491,7 @@ mod tests {
         },
         solana_runtime::{
             bank::Bank,
+            snapshot_config::LastFullSnapshotSlot,
             snapshot_utils::{
                 ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             },

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -608,6 +608,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: Default::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -26,8 +26,10 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::{
-        bank_forks::BankForks, commitment::BlockCommitmentCache,
-        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
+        bank_forks::BankForks,
+        commitment::BlockCommitmentCache,
+        snapshot_archive_info::SnapshotArchiveInfoGetter,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils,
     },
     solana_sdk::{
@@ -608,7 +610,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: Default::default(),
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -176,9 +176,7 @@ impl SnapshotRequestHandler {
                     status_cache_slot_deltas,
                     &self.accounts_package_sender,
                     &self.snapshot_config.snapshot_path,
-                    &self.snapshot_config.snapshot_package_output_path,
                     self.snapshot_config.snapshot_version,
-                    &self.snapshot_config.archive_format,
                     hash_for_testing,
                 );
                 if r.is_err() {

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -31,5 +31,7 @@ pub struct SnapshotConfig {
     pub maximum_snapshots_to_retain: usize,
 
     /// Runtime information of the last full snapshot slot
-    pub last_full_snapshot_slot: Arc<RwLock<Option<Slot>>>,
+    pub last_full_snapshot_slot: LastFullSnapshotSlot,
 }
+
+pub type LastFullSnapshotSlot = Arc<RwLock<Option<Slot>>>;

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,7 +1,10 @@
 use crate::snapshot_utils::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
 use solana_sdk::clock::Slot;
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 /// Snapshot configuration and runtime information
 #[derive(Clone, Debug)]
@@ -26,4 +29,7 @@ pub struct SnapshotConfig {
 
     /// Maximum number of full snapshot archives to retain
     pub maximum_snapshots_to_retain: usize,
+
+    /// Runtime information of the last full snapshot slot
+    pub last_full_snapshot_slot: Arc<RwLock<Option<Slot>>>,
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2617,6 +2617,7 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_snapshots_to_retain,
+        last_full_snapshot_slot: Default::default(),
     });
 
     validator_config.accounts_hash_interval_slots =

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,7 +49,7 @@ use {
         },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -2617,7 +2617,7 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_snapshots_to_retain,
-        last_full_snapshot_slot: Default::default(),
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
#### Problem

AccountsHashVerifier does not know to take Incremental Snapshots


#### Summary of Changes

AccountsHashVerifier now creates SnapshotPackages that are either Full or Incremental Snapshots depending on the SnapshotConfig's full/incremental snapshot interval.

Additionally:

- Move some fields to SnapshotPackage and remove from AccountsPackage
- Move snapshot storages filtering into SnapshotPackage, since the AccountsPackage doesn't know
- SnapshotPackage knows about full snapshots vs incremental snapshots, and AccountsPackage no longer does
- Remove the "processing" of AccountsPackage, as (1) it only conditional verifies the hash, and (2), the verification is only done in AccountsHashVerifier
- Refactor AccountsHashVerifier
- Update snapshots background services test to now take/expect incremental snapshots

Fixes #19167

_NOTE: This PR is on the large side, due to the renaming/refactoring. I'm happy to walk through/explain more anything/everything here! Thanks in advance!_ 