### PR TITLE
Send request from ReplayStage to repair for dumped slots

### DIFF
--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -1368,6 +1368,8 @@ mod test {
         // Simulate Replay dumping this slot
         let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
         duplicate_slots_to_repair.insert(dead_slot, Hash::new_unique());
+        let (duplicate_slot_repair_request_sender, _duplicate_slot_repair_request_receiver) =
+            unbounded();
         ReplayStage::dump_then_repair_correct_slots(
             &mut duplicate_slots_to_repair,
             &mut bank_forks.read().unwrap().ancestors(),
@@ -1376,6 +1378,7 @@ mod test {
             &bank_forks,
             &requester_blockstore,
             None,
+            &duplicate_slot_repair_request_sender,
         );
 
         // Simulate making a request

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -10,7 +10,9 @@ use {
         cluster_slots_service::{ClusterSlotsService, ClusterSlotsUpdateReceiver},
         completed_data_sets_service::CompletedDataSetsSender,
         packet_hasher::PacketHasher,
-        repair_service::{DuplicateSlotsResetSender, RepairInfo},
+        repair_service::{
+            DuplicateSlotRepairRequestReceiver, DuplicateSlotsResetSender, RepairInfo,
+        },
         window_service::{should_retransmit_and_persist, WindowService},
     },
     crossbeam_channel::{Receiver, Sender},
@@ -394,6 +396,7 @@ impl RetransmitStage {
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         duplicate_slots_sender: Sender<Slot>,
         ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
+        duplicate_slot_repair_request_receiver: DuplicateSlotRepairRequestReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
         // https://github.com/rust-lang/rust/issues/39364#issuecomment-634545136
@@ -454,6 +457,7 @@ impl RetransmitStage {
             completed_data_sets_sender,
             duplicate_slots_sender,
             ancestor_hashes_replay_update_receiver,
+            duplicate_slot_repair_request_receiver,
         );
 
         Self {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -172,6 +172,8 @@ impl Tvu {
         let compaction_interval = tvu_config.rocksdb_compaction_interval;
         let max_compaction_jitter = tvu_config.rocksdb_max_compaction_jitter;
         let (duplicate_slots_sender, duplicate_slots_receiver) = unbounded();
+        let (duplicate_slot_repair_request_sender, duplicate_slot_repair_request_receiver) =
+            unbounded();
         let (cluster_slots_update_sender, cluster_slots_update_receiver) = unbounded();
         let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
             unbounded();
@@ -197,6 +199,7 @@ impl Tvu {
             Some(rpc_subscriptions.clone()),
             duplicate_slots_sender,
             ancestor_hashes_replay_update_receiver,
+            duplicate_slot_repair_request_receiver,
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();
@@ -322,6 +325,7 @@ impl Tvu {
             cluster_slots_update_sender,
             cost_update_sender,
             voting_sender,
+            duplicate_slot_repair_request_sender,
         );
 
         let ledger_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -7,7 +7,9 @@ use {
         cluster_info_vote_listener::VerifiedVoteReceiver,
         completed_data_sets_service::CompletedDataSetsSender,
         repair_response,
-        repair_service::{OutstandingShredRepairs, RepairInfo, RepairService},
+        repair_service::{
+            DuplicateSlotRepairRequestReceiver, OutstandingShredRepairs, RepairInfo, RepairService,
+        },
         result::{Error, Result},
     },
     crossbeam_channel::{
@@ -428,6 +430,7 @@ impl WindowService {
         completed_data_sets_sender: CompletedDataSetsSender,
         duplicate_slots_sender: DuplicateSlotSender,
         ancestor_hashes_replay_update_receiver: AncestorHashesReplayUpdateReceiver,
+        duplicate_slot_repair_request_receiver: DuplicateSlotRepairRequestReceiver,
     ) -> WindowService
     where
         F: 'static
@@ -449,6 +452,7 @@ impl WindowService {
             verified_vote_receiver,
             outstanding_requests.clone(),
             ancestor_hashes_replay_update_receiver,
+            duplicate_slot_repair_request_receiver,
         );
 
         let (insert_sender, insert_receiver) = unbounded();


### PR DESCRIPTION
#### Problem
Replay doesn't send a request to repair a dumped slot

#### Summary of Changes
Add request from replay -> repair to fetch dumped slot from a peer who has it.

Fixes #
