### PR TITLE
CalculateHashIntermediate::new_without_slot -> new

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4969,11 +4969,8 @@ impl AccountsDb {
                     raw_lamports
                 };
 
-                let source_item = CalculateHashIntermediate::new_without_slot(
-                    loaded_account.loaded_hash(),
-                    balance,
-                    *pubkey,
-                );
+                let source_item =
+                    CalculateHashIntermediate::new(loaded_account.loaded_hash(), balance, *pubkey);
 
                 if check_hash {
                     let computed_hash = loaded_account.compute_hash(slot, pubkey);
@@ -6601,10 +6598,10 @@ pub mod tests {
         let pubkey255 = Pubkey::new(&[0xffu8; 32]);
 
         let mut raw_expected = vec![
-            CalculateHashIntermediate::new_without_slot(Hash::default(), 1, pubkey0),
-            CalculateHashIntermediate::new_without_slot(Hash::default(), 128, pubkey127),
-            CalculateHashIntermediate::new_without_slot(Hash::default(), 129, pubkey128),
-            CalculateHashIntermediate::new_without_slot(Hash::default(), 256, pubkey255),
+            CalculateHashIntermediate::new(Hash::default(), 1, pubkey0),
+            CalculateHashIntermediate::new(Hash::default(), 128, pubkey127),
+            CalculateHashIntermediate::new(Hash::default(), 129, pubkey128),
+            CalculateHashIntermediate::new(Hash::default(), 256, pubkey255),
         ];
 
         let expected_hashes = vec![

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -75,7 +75,7 @@ pub struct CalculateHashIntermediate {
 }
 
 impl CalculateHashIntermediate {
-    pub fn new_without_slot(hash: Hash, lamports: u64, pubkey: Pubkey) -> Self {
+    pub fn new(hash: Hash, lamports: u64, pubkey: Pubkey) -> Self {
         Self {
             hash,
             lamports,
@@ -814,14 +814,13 @@ pub mod tests {
 
         let key = Pubkey::new(&[11u8; 32]);
         let hash = Hash::new(&[1u8; 32]);
-        let val = CalculateHashIntermediate::new_without_slot(hash, 88, key);
+        let val = CalculateHashIntermediate::new(hash, 88, key);
         account_maps.push(val);
 
         // 2nd key - zero lamports, so will be removed
         let key = Pubkey::new(&[12u8; 32]);
         let hash = Hash::new(&[2u8; 32]);
-        let val =
-            CalculateHashIntermediate::new_without_slot(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+        let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
         account_maps.push(val);
 
         let result = AccountsHash::rest_of_hash_calculation(
@@ -837,7 +836,7 @@ pub mod tests {
         // 3rd key - with pubkey value before 1st key so it will be sorted first
         let key = Pubkey::new(&[10u8; 32]);
         let hash = Hash::new(&[2u8; 32]);
-        let val = CalculateHashIntermediate::new_without_slot(hash, 20, key);
+        let val = CalculateHashIntermediate::new(hash, 20, key);
         account_maps.insert(0, val);
 
         let result = AccountsHash::rest_of_hash_calculation(
@@ -853,7 +852,7 @@ pub mod tests {
         // 3rd key - with later slot
         let key = Pubkey::new(&[10u8; 32]);
         let hash = Hash::new(&[99u8; 32]);
-        let val = CalculateHashIntermediate::new_without_slot(hash, 30, key);
+        let val = CalculateHashIntermediate::new(hash, 30, key);
         account_maps.insert(1, val);
 
         let result = AccountsHash::rest_of_hash_calculation(
@@ -888,14 +887,13 @@ pub mod tests {
 
             let key = Pubkey::new(&[11u8; 32]);
             let hash = Hash::new(&[1u8; 32]);
-            let val = CalculateHashIntermediate::new_without_slot(hash, 88, key);
+            let val = CalculateHashIntermediate::new(hash, 88, key);
             account_maps.push(val);
 
             // 2nd key - zero lamports, so will be removed
             let key = Pubkey::new(&[12u8; 32]);
             let hash = Hash::new(&[2u8; 32]);
-            let val =
-                CalculateHashIntermediate::new_without_slot(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+            let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
             account_maps.push(val);
 
             let mut previous_pass = PreviousPass::default();
@@ -974,12 +972,12 @@ pub mod tests {
 
         let key = Pubkey::new(&[11u8; 32]);
         let hash = Hash::new(&[1u8; 32]);
-        let val = CalculateHashIntermediate::new_without_slot(hash, 88, key);
+        let val = CalculateHashIntermediate::new(hash, 88, key);
         account_maps.push(val);
 
         let key = Pubkey::new(&[12u8; 32]);
         let hash = Hash::new(&[2u8; 32]);
-        let val = CalculateHashIntermediate::new_without_slot(hash, 20, key);
+        let val = CalculateHashIntermediate::new(hash, 20, key);
         account_maps.push(val);
 
         let result = AccountsHash::rest_of_hash_calculation(
@@ -1058,7 +1056,7 @@ pub mod tests {
             total_lamports_expected += lamports;
             let key = Pubkey::new_unique();
             let hash = Hash::new_unique();
-            let val = CalculateHashIntermediate::new_without_slot(hash, lamports, key);
+            let val = CalculateHashIntermediate::new(hash, lamports, key);
             account_maps.push(val);
         }
 
@@ -1228,9 +1226,7 @@ pub mod tests {
         let accounts: Vec<_> = hashes
             .zip(keys.iter())
             .enumerate()
-            .map(|(i, (hash, key))| {
-                CalculateHashIntermediate::new_without_slot(hash, (i + 1) as u64, *key)
-            })
+            .map(|(i, (hash, key))| CalculateHashIntermediate::new(hash, (i + 1) as u64, *key))
             .collect();
 
         type ExpectedType = (String, bool, u64, String);
@@ -1379,11 +1375,11 @@ pub mod tests {
         solana_logger::setup();
         let key = Pubkey::new_unique();
         let hash = Hash::new_unique();
-        let val = CalculateHashIntermediate::new_without_slot(hash, 1, key);
+        let val = CalculateHashIntermediate::new(hash, 1, key);
 
         // slot same, version <
         let hash2 = Hash::new_unique();
-        let val2 = CalculateHashIntermediate::new_without_slot(hash2, 4, key);
+        let val2 = CalculateHashIntermediate::new(hash2, 4, key);
         assert_eq!(
             std::cmp::Ordering::Equal, // no longer comparing slots or versions
             AccountsHash::compare_two_hash_entries(&val, &val2)
@@ -1391,7 +1387,7 @@ pub mod tests {
 
         // slot same, vers =
         let hash3 = Hash::new_unique();
-        let val3 = CalculateHashIntermediate::new_without_slot(hash3, 2, key);
+        let val3 = CalculateHashIntermediate::new(hash3, 2, key);
         assert_eq!(
             std::cmp::Ordering::Equal,
             AccountsHash::compare_two_hash_entries(&val, &val3)
@@ -1399,7 +1395,7 @@ pub mod tests {
 
         // slot same, vers >
         let hash4 = Hash::new_unique();
-        let val4 = CalculateHashIntermediate::new_without_slot(hash4, 6, key);
+        let val4 = CalculateHashIntermediate::new(hash4, 6, key);
         assert_eq!(
             std::cmp::Ordering::Equal, // no longer comparing slots or versions
             AccountsHash::compare_two_hash_entries(&val, &val4)
@@ -1407,7 +1403,7 @@ pub mod tests {
 
         // slot >, version <
         let hash5 = Hash::new_unique();
-        let val5 = CalculateHashIntermediate::new_without_slot(hash5, 8, key);
+        let val5 = CalculateHashIntermediate::new(hash5, 8, key);
         assert_eq!(
             std::cmp::Ordering::Equal, // no longer comparing slots or versions
             AccountsHash::compare_two_hash_entries(&val, &val5)
@@ -1427,15 +1423,14 @@ pub mod tests {
         let key = Pubkey::new_unique();
         let hash = Hash::new_unique();
         let mut account_maps = Vec::new();
-        let val = CalculateHashIntermediate::new_without_slot(hash, 1, key);
+        let val = CalculateHashIntermediate::new(hash, 1, key);
         account_maps.push(val.clone());
 
         let result = test_de_dup_accounts_in_parallel(&account_maps[..]);
         assert_eq!(result, (vec![val.hash], val.lamports as u64, 1));
 
         // zero original lamports, higher version
-        let val =
-            CalculateHashIntermediate::new_without_slot(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
+        let val = CalculateHashIntermediate::new(hash, ZERO_RAW_LAMPORTS_SENTINEL, key);
         account_maps.push(val); // has to be after previous entry since account_maps are in slot order
 
         let result = test_de_dup_accounts_in_parallel(&account_maps[..]);
@@ -1801,16 +1796,12 @@ pub mod tests {
 
         let offset = 2;
         let input = vec![
-            CalculateHashIntermediate::new_without_slot(
+            CalculateHashIntermediate::new(
                 Hash::new(&[1u8; 32]),
                 u64::MAX - offset,
                 Pubkey::new_unique(),
             ),
-            CalculateHashIntermediate::new_without_slot(
-                Hash::new(&[2u8; 32]),
-                offset + 1,
-                Pubkey::new_unique(),
-            ),
+            CalculateHashIntermediate::new(Hash::new(&[2u8; 32]), offset + 1, Pubkey::new_unique()),
         ];
         AccountsHash::de_dup_accounts_in_parallel(&[vec![input]], 0);
     }
@@ -1822,12 +1813,12 @@ pub mod tests {
 
         let offset = 2;
         let input = vec![
-            vec![CalculateHashIntermediate::new_without_slot(
+            vec![CalculateHashIntermediate::new(
                 Hash::new(&[1u8; 32]),
                 u64::MAX - offset,
                 Pubkey::new_unique(),
             )],
-            vec![CalculateHashIntermediate::new_without_slot(
+            vec![CalculateHashIntermediate::new(
                 Hash::new(&[2u8; 32]),
                 offset + 1,
                 Pubkey::new_unique(),


### PR DESCRIPTION
#### Problem
follow up rename on earlier refactor
#### Summary of Changes
move the function name back to 'new'
Fixes #
