### PR TITLE
Update block max cost limit to fix performance regession

### DIFF
--- a/ledger/src/block_cost_limits.rs
+++ b/ledger/src/block_cost_limits.rs
@@ -15,7 +15,7 @@ pub const fn max_instructions_per_block() -> u64 {
 }
 
 pub const fn block_cost_max() -> u64 {
-    MAX_INSTRUCTION_COST * max_instructions_per_block()
+    MAX_INSTRUCTION_COST * max_instructions_per_block() * 10
 }
 
 pub const fn account_cost_max() -> u64 {
@@ -23,7 +23,7 @@ pub const fn account_cost_max() -> u64 {
 }
 
 pub const fn compute_unit_to_us_ratio() -> u64 {
-    block_cost_max() / MAX_BLOCK_TIME_US
+     (MAX_INSTRUCTION_COST / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM;
 }
 
 pub const fn signature_cost() -> u64 {

--- a/ledger/src/block_cost_limits.rs
+++ b/ledger/src/block_cost_limits.rs
@@ -23,7 +23,7 @@ pub const fn account_cost_max() -> u64 {
 }
 
 pub const fn compute_unit_to_us_ratio() -> u64 {
-     (MAX_INSTRUCTION_COST / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM;
+    (MAX_INSTRUCTION_COST / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM
 }
 
 pub const fn signature_cost() -> u64 {


### PR DESCRIPTION
#### Problem
During performance test, `bench-tps` generated transfer transactions started to hit block max limit, therefore being rejected and retried by `banking_stage`. 

This is the result of block max limit was set too low for now, partly due to increasing account read/write cost. Created issue #19275 to resync cost limit

#### Summary of Changes
increase block_cost_max by 10 times to accommodate updated account read and write costs; 

Fixes #
