### PR TITLE
Fix flaky test test_fork_choice_refresh_old_votes

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1147,14 +1147,8 @@ fn test_fork_choice_refresh_old_votes() {
             .unwrap();
             let (heaviest_fork_latest_vote, _) =
                 last_vote_in_tower(&heaviest_ledger_path, &context.heaviest_validator_key).unwrap();
-            while lighter_fork_blockstore
-                .meta(lighter_fork_latest_vote)
-                .unwrap()
-                .is_none()
-                || heaviest_blockstore
-                    .meta(heaviest_fork_latest_vote)
-                    .unwrap()
-                    .is_none()
+            while !lighter_fork_blockstore.is_full(lighter_fork_latest_vote)
+                || !heaviest_blockstore.is_full(heaviest_fork_latest_vote)
             {
                 sleep(Duration::from_millis(100));
             }


### PR DESCRIPTION
#### Problem
During our leader slot we might enter a situation where we have voted for our slot but the slot has not yet reached blockstore through the broadcast thread. This causes the test to fail as we do not have the ancestor information for the fork in blockstore. 

#### Summary of Changes
Use the latest vote in tower that has also landed in blockstore.

Fixes #
