### PR TITLE
enable ipv6 for docker

### DIFF
--- a/net/scripts/install-docker.sh
+++ b/net/scripts/install-docker.sh
@@ -68,6 +68,13 @@ KillMode=process
 WantedBy=multi-user.target
 EOF
 
+cat > /etc/docker/daemon.json <<EOF
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "2001:db8:1::/64"
+}
+EOF
+
 systemctl daemon-reload
 systemctl enable --now /lib/systemd/system/docker.service
 


### PR DESCRIPTION
#### Problem
ipv6 testing fails from buildkite

#### Summary of Changes
enable docker ipv6 networking
