### PR TITLE
replace function with const var for better readability

### DIFF
--- a/core/src/cost_model.rs
+++ b/core/src/cost_model.rs
@@ -68,7 +68,7 @@ pub struct CostModel {
 
 impl Default for CostModel {
     fn default() -> Self {
-        CostModel::new(account_cost_max(), block_cost_max())
+        CostModel::new(ACCOUNT_COST_MAX, BLOCK_COST_MAX)
     }
 }
 
@@ -126,9 +126,9 @@ impl CostModel {
 
             if is_writable {
                 self.transaction_cost.writable_accounts.push(*k);
-                self.transaction_cost.account_access_cost += account_write_cost();
+                self.transaction_cost.account_access_cost += ACCOUNT_WRITE_COST;
             } else {
-                self.transaction_cost.account_access_cost += account_read_cost();
+                self.transaction_cost.account_access_cost += ACCOUNT_READ_COST;
             }
         });
         debug!(
@@ -388,8 +388,7 @@ mod tests {
                 .try_into()
                 .unwrap();
 
-        let expected_account_cost =
-            account_write_cost() + account_write_cost() + account_read_cost();
+        let expected_account_cost = ACCOUNT_WRITE_COST + ACCOUNT_WRITE_COST + ACCOUNT_READ_COST;
         let expected_execution_cost = 8;
 
         let mut cost_model = CostModel::default();
@@ -445,7 +444,7 @@ mod tests {
 
         let number_threads = 10;
         let expected_account_cost =
-            account_write_cost() + account_write_cost() * 2 + account_read_cost() * 2;
+            ACCOUNT_WRITE_COST + ACCOUNT_WRITE_COST * 2 + ACCOUNT_READ_COST * 2;
         let cost1 = 100;
         let cost2 = 200;
         // execution cost can be either 2 * Default (before write) or cost1+cost2 (after write)

--- a/ledger/src/block_cost_limits.rs
+++ b/ledger/src/block_cost_limits.rs
@@ -10,33 +10,25 @@ pub const SYSTEM_PARALLELISM: u64 = 10;
 pub const MAX_INSTRUCTION_COST: u64 = 200_000;
 pub const MAX_NUMBER_BPF_INSTRUCTIONS_PER_ACCOUNT: u64 = 200;
 
-pub const fn max_instructions_per_block() -> u64 {
-    (MAX_BLOCK_TIME_US / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM
-}
+// 4_000
+pub const MAX_INSTRUCTIONS_PER_BLOCK: u64 =
+    (MAX_BLOCK_TIME_US / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM;
 
-pub const fn block_cost_max() -> u64 {
-    MAX_INSTRUCTION_COST * max_instructions_per_block() * 10
-}
+// 8_000_000_000
+pub const BLOCK_COST_MAX: u64 = MAX_INSTRUCTION_COST * MAX_INSTRUCTIONS_PER_BLOCK * 10;
 
-pub const fn account_cost_max() -> u64 {
-    MAX_INSTRUCTION_COST * max_instructions_per_block()
-}
+// 800_000_000
+pub const ACCOUNT_COST_MAX: u64 = MAX_INSTRUCTION_COST * MAX_INSTRUCTIONS_PER_BLOCK;
 
-pub const fn compute_unit_to_us_ratio() -> u64 {
-    (MAX_INSTRUCTION_COST / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM
-}
+// 2_000
+pub const COMPUTE_UNIT_TO_US_RATIO: u64 =
+    (MAX_INSTRUCTION_COST / AVG_INSTRUCTION_TIME_US) * SYSTEM_PARALLELISM;
 
-pub const fn signature_cost() -> u64 {
-    // signature takes average 10us
-    compute_unit_to_us_ratio() * 10
-}
+// signature takes average 10us, or 20K CU
+pub const SIGNATURE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 
-pub const fn account_read_cost() -> u64 {
-    // read account averages 5us
-    compute_unit_to_us_ratio() * 5
-}
+// read account averages 5us, or 10K CU
+pub const ACCOUNT_READ_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 5;
 
-pub const fn account_write_cost() -> u64 {
-    // write account averages 25us
-    compute_unit_to_us_ratio() * 25
-}
+// write account averages 25us, or 50K CU
+pub const ACCOUNT_WRITE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 25;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -64,7 +64,7 @@ pub struct BlockCostCapacityMeter {
 
 impl Default for BlockCostCapacityMeter {
     fn default() -> Self {
-        BlockCostCapacityMeter::new(block_cost_max())
+        BlockCostCapacityMeter::new(BLOCK_COST_MAX)
     }
 }
 


### PR DESCRIPTION
#### Problem
`const fn foo()` isn't as readable as `const FOO`

#### Summary of Changes
To use `const VAR`, no functional change

Fixes #
