### PR TITLE
ITER_BATCH_SIZE from 1k -> 10k

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -31,7 +31,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub const ITER_BATCH_SIZE: usize = 1000;
+pub const ITER_BATCH_SIZE: usize = 10_000;
 pub const BINS_DEFAULT: usize = 16;
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_DEFAULT),


### PR DESCRIPTION
#### Problem
AccountsIndex is changing. We are likely to move to a non-sorted map structure. We already bin into 16 bins in master. We will likely set the # bins to 32k(#19286) or more. 80M accounts across 32k bins is 2.4k pubkeys per bin.
When iterating through the accounts in the index, we currently start at the beginning and iterate, stopping at ITER_BATCH_SIZE. We then remember the pubkey of the last element. The next time we continue the iteration, we start after the last pubkey. This mechanism works fine for a sorted map.
For an unsorted map, if we arbitrarily stop in the middle of a bin iter (because we hit ITER_BATCH_SIZE), one easy method is to sort all the items in the bin to figure out how to reliably continue next time without repeating or skipping keys.
Sorts are expensive.
So, one option is to keep the bin sizes to a manageable size over time, as # accounts grow, and set ITER_BATCH_SIZE to generally higher than that bin size.
I can imagine other ways to accomplish this.
My question here is what problems do you see with ITER_BATCH_SIZE being 10k, for example.
We may be loading 10k accounts during an rpc scan perhaps.
#### Summary of Changes
This is a step in the direction of more items being returned per scan. Soon, I want to return all items in a bin (#19299). I'm hoping this simple PR will help us figure out if there are any concerns I'm not thinking of.

We are currently [tracking max items in a bin (currently ~5M with 16 bins in mnb)](https://metrics.solana.com:8888/sources/23/chronograf/data-explorer?query=SELECT%20mean%28%22max_bin_size%22%29%20AS%20%22mean_max_bin_size%22%2C%20mean%28%22min_bin_size%22%29%20AS%20%22mean_min_bin_size%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22generate_index%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29).

Fixes #
