### PR TITLE
Plumb accounts-db-skip-shrink through testnet scripts

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -81,6 +81,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --allow-private-addr ]]; then
       args+=("$1")
       shift
+    elif [[ $1 == --accounts-db-skip-shrink ]]; then
+      args+=("$1")
+      shift
     else
       echo "Unknown argument: $1"
       $program --help

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -160,6 +160,9 @@ while [[ -n $1 ]]; do
       args+=("$1")
       maybe_allow_private_addr=$1
       shift
+    elif [[ $1 == --accounts-db-skip-shrink ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = -h ]]; then
       usage "$@"
     else

--- a/net/net.sh
+++ b/net/net.sh
@@ -307,7 +307,7 @@ startBootstrapLeader() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -378,7 +378,7 @@ startNode() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -776,6 +776,7 @@ maybeSkipLedgerVerify=""
 maybeDisableAirdrops=""
 maybeWaitForSupermajority=""
 maybeAllowPrivateAddr=""
+maybeAccountsDbSkipShrink=""
 debugBuild=false
 doBuild=true
 gpuMode=auto
@@ -904,6 +905,9 @@ while [[ -n $1 ]]; do
       # May also be added by loadConfigFile if 'gce.sh create' was invoked
       # without -P.
       maybeAllowPrivateAddr="$1"
+      shift 1
+    elif [[ $1 = --accounts-db-skip-shrink ]]; then
+      maybeAccountsDbSkipShrink="$1"
       shift 1
     else
       usage "Unknown long option: $1"


### PR DESCRIPTION
#### Problem
Booting simulations from snapshots with millions of accounts, initial shrink can take hours. Currently the only way to take advantage of #19028 is by manually editing the multinode-demo bash.

#### Summary of Changes
Plumb args to allow testnet boots to easily skip shrink
