### PR TITLE
Enable booting testnet validators without tower required

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -20,6 +20,7 @@ else
 fi
 
 no_restart=0
+maybeRequireTower=true
 
 args=()
 while [[ -n $1 ]]; do
@@ -84,6 +85,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --accounts-db-skip-shrink ]]; then
       args+=("$1")
       shift
+    elif [[ $1 == --skip-require-tower ]]; then
+      maybeRequireTower=false
+      shift
     else
       echo "Unknown argument: $1"
       $program --help
@@ -108,8 +112,11 @@ ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-validator
   exit 1
 }
 
+if [[ $maybeRequireTower = true ]]; then
+  args+=(--require-tower)
+fi
+
 args+=(
-  --require-tower
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 200

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -46,6 +46,8 @@ EOF
   exit 1
 }
 
+maybeRequireTower=true
+
 positional_args=()
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -163,6 +165,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --accounts-db-skip-shrink ]]; then
       args+=("$1")
       shift
+    elif [[ $1 == --skip-require-tower ]]; then
+      maybeRequireTower=false
+      shift
     elif [[ $1 = -h ]]; then
       usage "$@"
     else
@@ -235,7 +240,10 @@ default_arg --identity "$identity"
 default_arg --vote-account "$vote_account"
 default_arg --ledger "$ledger_dir"
 default_arg --log -
-default_arg --require-tower
+
+if [[ $maybeRequireTower = true ]]; then
+  default_arg --require-tower
+fi
 
 if [[ -n $SOLANA_CUDA ]]; then
   program=$solana_validator_cuda

--- a/net/net.sh
+++ b/net/net.sh
@@ -307,7 +307,7 @@ startBootstrapLeader() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -378,7 +378,7 @@ startNode() {
          $nodeIndex \
          ${#clientIpList[@]} \"$benchTpsExtraArgs\" \
          \"$genesisOptions\" \
-         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink\" \
+         \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
@@ -777,6 +777,7 @@ maybeDisableAirdrops=""
 maybeWaitForSupermajority=""
 maybeAllowPrivateAddr=""
 maybeAccountsDbSkipShrink=""
+maybeSkipRequireTower=""
 debugBuild=false
 doBuild=true
 gpuMode=auto
@@ -908,6 +909,9 @@ while [[ -n $1 ]]; do
       shift 1
     elif [[ $1 = --accounts-db-skip-shrink ]]; then
       maybeAccountsDbSkipShrink="$1"
+      shift 1
+    elif [[ $1 = --skip-require-tower ]]; then
+      maybeSkipRequireTower="$1"
       shift 1
     else
       usage "Unknown long option: $1"


### PR DESCRIPTION
#### Problem
When rebooting a testnet from a previous snapshot -- eg. in the case of cluster failure, or to test new code against many existing accounts -- the previous tower file may no longer be relevant. Currently the only way to allow the boot to proceed is to manually remove the `--require-tower` arg from the multinode-demo scripts.

#### Summary of Changes
Add a `--skip-require-tower` option to skip the `--require-tower` arg.

This is foundational work to enable complete automation of rebooting testnet from previous snap.
Needs rebase on #19290
