### PR TITLE
Fix null case in getMultipleAccountsInfo

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2415,13 +2415,13 @@ export class Connection {
   async getMultipleAccountsInfo(
     publicKeys: PublicKey[],
     commitment?: Commitment,
-  ): Promise<AccountInfo<Buffer>[] | null> {
+  ): Promise<(AccountInfo<Buffer> | null)[] | null> {
     const keys = publicKeys.map(key => key.toBase58());
     const args = this._buildArgs([keys], commitment, 'base64');
     const unsafeRes = await this._rpcRequest('getMultipleAccounts', args);
     const res = create(
       unsafeRes,
-      jsonRpcResultAndContext(nullable(array(AccountInfoResult))),
+      jsonRpcResultAndContext(nullable(array(nullable(AccountInfoResult)))),
     );
     if ('error' in res) {
       throw new Error(

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2415,13 +2415,13 @@ export class Connection {
   async getMultipleAccountsInfo(
     publicKeys: PublicKey[],
     commitment?: Commitment,
-  ): Promise<(AccountInfo<Buffer> | null)[] | null> {
+  ): Promise<(AccountInfo<Buffer> | null)[]> {
     const keys = publicKeys.map(key => key.toBase58());
     const args = this._buildArgs([keys], commitment, 'base64');
     const unsafeRes = await this._rpcRequest('getMultipleAccounts', args);
     const res = create(
       unsafeRes,
-      jsonRpcResultAndContext(nullable(array(nullable(AccountInfoResult)))),
+      jsonRpcResultAndContext(array(nullable(AccountInfoResult))),
     );
     if ('error' in res) {
       throw new Error(


### PR DESCRIPTION
#### Problem

#19301

#### Summary of Changes

Fixes #19301

Question:
In what case the response value is actually null? It seems like it 

https://docs.solana.com/developing/clients/jsonrpc-api#getmultipleaccounts
