### PR TITLE
Only encode data with <128 bytes in base58

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -28,6 +28,7 @@ use {
 
 pub type StringAmount = String;
 pub type StringDecimals = String;
+pub const MAX_BS58_BYTES: usize = 128;
 
 /// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -64,7 +65,6 @@ impl UiAccount {
         account: &T,
         data_slice_config: Option<UiDataSliceConfig>,
     ) -> String {
-        const MAX_BS58_BYTES: usize = 128;
         if account.data().len() <= MAX_BS58_BYTES {
             bs58::encode(slice_data(account.data(), data_slice_config)).into_string()
         } else {

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -28,7 +28,7 @@ use {
 
 pub type StringAmount = String;
 pub type StringDecimals = String;
-pub const MAX_BS58_BYTES: usize = 128;
+pub const MAX_BASE58_BYTES: usize = 128;
 
 /// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -65,7 +65,7 @@ impl UiAccount {
         account: &T,
         data_slice_config: Option<UiDataSliceConfig>,
     ) -> String {
-        if account.data().len() <= MAX_BS58_BYTES {
+        if account.data().len() <= MAX_BASE58_BYTES {
             bs58::encode(slice_data(account.data(), data_slice_config)).into_string()
         } else {
             "error: data too large for bs58 encoding".to_string()

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -60,6 +60,18 @@ pub enum UiAccountEncoding {
 }
 
 impl UiAccount {
+    fn encode_bs58<T: ReadableAccount>(
+        account: &T,
+        data_slice_config: Option<UiDataSliceConfig>,
+    ) -> String {
+        const MAX_BS58_BYTES: usize = 128;
+        if account.data().len() <= MAX_BS58_BYTES {
+            bs58::encode(slice_data(account.data(), data_slice_config)).into_string()
+        } else {
+            "error: data too large for bs58 encoding".to_string()
+        }
+    }
+
     pub fn encode<T: ReadableAccount>(
         pubkey: &Pubkey,
         account: &T,
@@ -68,13 +80,14 @@ impl UiAccount {
         data_slice_config: Option<UiDataSliceConfig>,
     ) -> Self {
         let data = match encoding {
-            UiAccountEncoding::Binary => UiAccountData::LegacyBinary(
-                bs58::encode(slice_data(account.data(), data_slice_config)).into_string(),
-            ),
-            UiAccountEncoding::Base58 => UiAccountData::Binary(
-                bs58::encode(slice_data(account.data(), data_slice_config)).into_string(),
-                encoding,
-            ),
+            UiAccountEncoding::Binary => {
+                let data = Self::encode_bs58(account, data_slice_config);
+                UiAccountData::LegacyBinary(data)
+            }
+            UiAccountEncoding::Base58 => {
+                let data = Self::encode_bs58(account, data_slice_config);
+                UiAccountData::Binary(data, encoding)
+            }
             UiAccountEncoding::Base64 => UiAccountData::Binary(
                 base64::encode(slice_data(account.data(), data_slice_config)),
                 encoding,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -14,7 +14,7 @@ use {
     serde::{Deserialize, Serialize},
     solana_account_decoder::{
         parse_token::{spl_token_id_v2_0, token_amount_to_ui_amount, UiTokenAmount},
-        UiAccount, UiAccountEncoding, UiDataSliceConfig, MAX_BS58_BYTES,
+        UiAccount, UiAccountEncoding, UiDataSliceConfig, MAX_BASE58_BYTES,
     },
     solana_client::{
         rpc_cache::LargestAccountsCache,
@@ -2102,9 +2102,9 @@ fn encode_account<T: ReadableAccount>(
     data_slice: Option<UiDataSliceConfig>,
 ) -> Result<UiAccount> {
     if (encoding == UiAccountEncoding::Binary || encoding == UiAccountEncoding::Base58)
-        && account.data().len() > MAX_BS58_BYTES
+        && account.data().len() > MAX_BASE58_BYTES
     {
-        let message = format!("Encoded binary (base 58) data should be less than {} bytes, please use Base64 encoding.", MAX_BS58_BYTES);
+        let message = format!("Encoded binary (base 58) data should be less than {} bytes, please use Base64 encoding.", MAX_BASE58_BYTES);
         Err(error::Error {
             code: error::ErrorCode::InvalidRequest,
             message,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -14,7 +14,7 @@ use {
     serde::{Deserialize, Serialize},
     solana_account_decoder::{
         parse_token::{spl_token_id_v2_0, token_amount_to_ui_amount, UiTokenAmount},
-        UiAccount, UiAccountEncoding, UiDataSliceConfig,
+        UiAccount, UiAccountEncoding, UiDataSliceConfig, MAX_BS58_BYTES,
     },
     solana_client::{
         rpc_cache::LargestAccountsCache,
@@ -2102,9 +2102,9 @@ fn encode_account<T: ReadableAccount>(
     data_slice: Option<UiDataSliceConfig>,
 ) -> Result<UiAccount> {
     if (encoding == UiAccountEncoding::Binary || encoding == UiAccountEncoding::Base58)
-        && account.data().len() > 128
+        && account.data().len() > MAX_BS58_BYTES
     {
-        let message = "Encoded binary (base 58) data should be less than 128 bytes, please use Base64 encoding.".to_string();
+        let message = format!("Encoded binary (base 58) data should be less than {} bytes, please use Base64 encoding.", MAX_BS58_BYTES);
         Err(error::Error {
             code: error::ErrorCode::InvalidRequest,
             message,

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -827,6 +827,7 @@ mod tests {
             max_active_subscriptions: MAX_ACTIVE_SUBSCRIPTIONS,
         };
         let session = create_session();
+        let encoding = UiAccountEncoding::Base64;
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("accountNotification");
         rpc.account_subscribe(
             session,
@@ -834,7 +835,7 @@ mod tests {
             stake_account.pubkey().to_string(),
             Some(RpcAccountInfoConfig {
                 commitment: Some(CommitmentConfig::processed()),
-                encoding: None,
+                encoding: Some(encoding),
                 data_slice: None,
             }),
         );
@@ -873,7 +874,7 @@ mod tests {
                    "value": {
                        "owner": stake_program_id.to_string(),
                        "lamports": 51,
-                       "data": bs58::encode(expected_data).into_string(),
+                       "data": [base64::encode(expected_data), encoding],
                        "executable": false,
                        "rentEpoch": 0,
                    },


### PR DESCRIPTION
#### Problem

base58 encoding is slow

#### Summary of Changes

Only encode with account data 128 bytes or less. This means that account and program subscriptions that would return large base58-encoded account data will now return an error string for that field.

Fixes #18929 
