### PR TITLE
Allow closing upgradeable program accounts

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1956,6 +1956,29 @@ impl fmt::Display for CliUpgradeableProgram {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CliUpgradeableProgramClosed {
+    pub program_id: String,
+    pub lamports: u64,
+    #[serde(skip_serializing)]
+    pub use_lamports_unit: bool,
+}
+impl QuietDisplay for CliUpgradeableProgramClosed {}
+impl VerboseDisplay for CliUpgradeableProgramClosed {}
+impl fmt::Display for CliUpgradeableProgramClosed {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln!(
+            f,
+            "Closed Program Id {}, {} reclaimed",
+            &self.program_id,
+            &build_balance_message(self.lamports, self.use_lamports_unit, true)
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CliUpgradeableBuffer {
     pub address: String,
     pub authority: String,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -525,7 +525,7 @@ fn test_cli_program_deploy_with_authority() {
     {
         assert_eq!(upgrade_authority_address, None);
     } else {
-        panic!("not a buffer account");
+        panic!("not a ProgramData account");
     }
 
     // Get buffer authority
@@ -546,6 +546,88 @@ fn test_cli_program_deploy_with_authority() {
         .as_str()
         .unwrap();
     assert_eq!("none", authority_pubkey_str);
+}
+
+#[test]
+fn test_cli_program_close_program() {
+    solana_logger::setup();
+
+    let mut pathbuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    pathbuf.push("tests");
+    pathbuf.push("fixtures");
+    pathbuf.push("noop");
+    pathbuf.set_extension("so");
+
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let faucet_addr = run_local_faucet(mint_keypair, None);
+    let test_validator =
+        TestValidator::with_no_fees(mint_pubkey, Some(faucet_addr), SocketAddrSpace::Unspecified);
+
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+
+    let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
+    let mut program_data = Vec::new();
+    file.read_to_end(&mut program_data).unwrap();
+    let max_len = program_data.len();
+    let minimum_balance_for_programdata = rpc_client
+        .get_minimum_balance_for_rent_exemption(
+            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
+        )
+        .unwrap();
+    let minimum_balance_for_program = rpc_client
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::program_len().unwrap())
+        .unwrap();
+    let upgrade_authority = Keypair::new();
+
+    let mut config = CliConfig::recent_for_tests();
+    let keypair = Keypair::new();
+    config.json_rpc_url = test_validator.rpc_url();
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Airdrop {
+        pubkey: None,
+        lamports: 100 * minimum_balance_for_programdata + minimum_balance_for_program,
+    };
+    process_command(&config).unwrap();
+
+    // Deploy the upgradeable program
+    let program_keypair = Keypair::new();
+    config.signers = vec![&keypair, &upgrade_authority, &program_keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(pathbuf.to_str().unwrap().to_string()),
+        program_signer_index: Some(2),
+        program_pubkey: Some(program_keypair.pubkey()),
+        buffer_signer_index: None,
+        buffer_pubkey: None,
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: false,
+        max_len: Some(max_len),
+    });
+    config.output_format = OutputFormat::JsonCompact;
+    process_command(&config).unwrap();
+
+    let (programdata_pubkey, _) = Pubkey::find_program_address(
+        &[program_keypair.pubkey().as_ref()],
+        &bpf_loader_upgradeable::id(),
+    );
+
+    // Close program
+    let close_account = rpc_client.get_account(&programdata_pubkey).unwrap();
+    let programdata_lamports = close_account.lamports;
+    let recipient_pubkey = Pubkey::new_unique();
+    config.signers = vec![&keypair, &upgrade_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::Close {
+        account_pubkey: Some(program_keypair.pubkey()),
+        recipient_pubkey,
+        authority_index: 1,
+        use_lamports_unit: false,
+    });
+    process_command(&config).unwrap();
+    rpc_client.get_account(&programdata_pubkey).unwrap_err();
+    let recipient_account = rpc_client.get_account(&recipient_pubkey).unwrap();
+    assert_eq!(programdata_lamports, recipient_account.lamports);
 }
 
 #[test]

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -587,10 +587,10 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         check_undefined_symbols(config, &program_so);
 
         println!();
-        println!("Deploying this program will use the following generated keypair by default for the program's address:");
-        println!("  {}", program_keypair.display());
         println!("To deploy this program:");
         println!("  $ solana program deploy {}", program_so.display());
+        println!("The program address will default to this keypair (override with --program-id):");
+        println!("  {}", program_keypair.display());
     } else if config.dump {
         println!("Note: --dump is only available for crates with a cdylib target");
     }

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -587,6 +587,8 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         check_undefined_symbols(config, &program_so);
 
         println!();
+        println!("Deploying this program will use the following generated keypair by default for the program's address:");
+        println!("  {}", program_keypair.display());
         println!("To deploy this program:");
         println!("  $ solana program deploy {}", program_so.display());
     } else if config.dump {

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -196,6 +196,10 @@ pub fn is_set_authority_instruction(instruction_data: &[u8]) -> bool {
     !instruction_data.is_empty() && 4 == instruction_data[0]
 }
 
+pub fn is_close_instruction(instruction_data: &[u8]) -> bool {
+    !instruction_data.is_empty() && 5 == instruction_data[0]
+}
+
 /// Returns the instructions required to set a buffers's authority.
 pub fn set_buffer_authority(
     buffer_address: &Pubkey,
@@ -231,17 +235,37 @@ pub fn set_upgrade_authority(
     Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
 }
 
-/// Returns the instructions required to close an account
+/// Returns the instructions required to close a buffer account
 pub fn close(
     close_address: &Pubkey,
     recipient_address: &Pubkey,
     authority_address: &Pubkey,
 ) -> Instruction {
-    let metas = vec![
+    close_any(
+        close_address,
+        recipient_address,
+        Some(authority_address),
+        None,
+    )
+}
+
+/// Returns the instructions required to close program, buffer, or uninitialized account
+pub fn close_any(
+    close_address: &Pubkey,
+    recipient_address: &Pubkey,
+    authority_address: Option<&Pubkey>,
+    program_address: Option<&Pubkey>,
+) -> Instruction {
+    let mut metas = vec![
         AccountMeta::new(*close_address, false),
         AccountMeta::new(*recipient_address, false),
-        AccountMeta::new_readonly(*authority_address, true),
     ];
+    if let Some(authority_address) = authority_address {
+        metas.push(AccountMeta::new(*authority_address, true));
+    }
+    if let Some(program_address) = program_address {
+        metas.push(AccountMeta::new(*program_address, false));
+    }
     Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::Close, metas)
 }
 

--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -117,8 +117,12 @@ pub enum UpgradeableLoaderInstruction {
     /// withdraws all the lamports
     ///
     /// # Account references
-    ///   0. `[writable]` The account to close.
+    ///   0. `[writable]` The account to close, if closing a program must be the
+    ///      ProgramData account.
     ///   1. `[writable]` The account to deposit the closed account's lamports.
-    ///   2. `[signer]` The account's authority.
+    ///   2. `[signer]` The account's authority, Optional, required for
+    ///      initialized accounts.
+    ///   3. `[writable]` The associated Program account if the account to close
+    ///      is a ProgramData account.
     Close,
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -199,6 +199,10 @@ pub mod libsecp256k1_fail_on_bad_count {
     solana_sdk::declare_id!("8aXvSuopd1PUj7UhehfXJRg6619RHp8ZvwTyyJHdUYsj");
 }
 
+pub mod close_upgradeable_program_accounts {
+    solana_sdk::declare_id!("EQMtCuSAkMVF9ZdhGuABtgvyXJLtSRF5AQKv1RNsrhj7");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -241,7 +245,8 @@ lazy_static! {
         (gate_large_block::id(), "validator checks block cost against max limit in realtime, reject if exceeds."),
         (mem_overlap_fix::id(), "memory overlap fix"),
         (versioned_tx_message_enabled::id(), "enable versioned transaction message processing"),
-        (libsecp256k1_fail_on_bad_count::id(), "Fail libsec256k1_verify if count appears wrong")
+        (libsecp256k1_fail_on_bad_count::id(), "Fail libsec256k1_verify if count appears wrong"),
+        (close_upgradeable_program_accounts::id(), "enable closing upgradeable program accounts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

- Developers can never reclaim the lamports from an upgradeable program account
- If someone transfers ownership of an account that holds lamports to the upgradeable loader they can never reclaim those lamports

#### Summary of Changes

- Allow upgradeable program accounts to be closed.  The actual executable "Program" account is not closed or drained, but the "ProgramData" account is.  The "Program" account holds very few lamports and is executable so is immutable so will be left forever.  When the ProgramData account is closed its lamports are drained and it is set to the `Uninitialized` state.  This means that any invoke, upgrade, etc.. of that program in the future will fail.
- Allow loader accounts in the `Uninitialized` state to be drained.  This does not require an authority so there is a chance that someone else could drain it first but this should be rare because `Uninitialized` accounts owned by the loader should never carry any lamports.

Fixes #
