### PR TITLE
removes Slot from TransmitShreds

### DIFF
--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -40,7 +40,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         keypair: &Keypair,
         blockstore: &Arc<Blockstore>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<(TransmitShreds, Option<BroadcastShredBatchInfo>)>,
+        socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
@@ -107,7 +107,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         let data_shreds = Arc::new(data_shreds);
         blockstore_sender.send((data_shreds.clone(), None))?;
         // 4) Start broadcast step
-        socket_sender.send(((bank.slot(), data_shreds), None))?;
+        socket_sender.send((data_shreds, None))?;
         if let Some((good_last_data_shred, bad_last_data_shred)) = last_shreds {
             // Stash away the good shred so we can rewrite them later
             self.good_shreds.extend(good_last_data_shred.clone());
@@ -126,7 +126,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             // Store the bad shred so we serve bad repairs to validators catching up
             blockstore_sender.send((bad_last_data_shred.clone(), None))?;
             // Send bad shreds to rest of network
-            socket_sender.send(((bank.slot(), bad_last_data_shred), None))?;
+            socket_sender.send((bad_last_data_shred, None))?;
         }
         Ok(())
     }
@@ -137,27 +137,17 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         sock: &UdpSocket,
         bank_forks: &Arc<RwLock<BankForks>>,
     ) -> Result<()> {
-        let ((slot, shreds), _) = receiver.lock().unwrap().recv()?;
-        let (root_bank, working_bank) = {
-            let bank_forks = bank_forks.read().unwrap();
-            (bank_forks.root_bank(), bank_forks.working_bank())
-        };
-        // Broadcast data
-        let cluster_nodes =
-            self.cluster_nodes_cache
-                .get(slot, &root_bank, &working_bank, cluster_info);
+        let (shreds, _) = receiver.lock().unwrap().recv()?;
         broadcast_shreds(
             sock,
             &shreds,
-            &cluster_nodes,
+            &self.cluster_nodes_cache,
             &Arc::new(AtomicInterval::default()),
             &mut TransmitShredsStats::default(),
-            cluster_info.id(),
+            cluster_info,
             bank_forks,
             cluster_info.socket_addr_space(),
-        )?;
-
-        Ok(())
+        )
     }
     fn record(
         &mut self,

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -50,7 +50,7 @@ pub struct ClusterNodes<T> {
 
 type CacheEntry<T> = Option<(/*as of:*/ Instant, Arc<ClusterNodes<T>>)>;
 
-pub(crate) struct ClusterNodesCache<T> {
+pub struct ClusterNodesCache<T> {
     // Cache entries are wrapped in Arc<Mutex<...>>, so that, when needed, only
     // one thread does the computations to update the entry for the epoch.
     cache: Mutex<LruCache<Epoch, Arc<Mutex<CacheEntry<T>>>>>,
@@ -230,7 +230,7 @@ fn get_nodes(cluster_info: &ClusterInfo, stakes: &HashMap<Pubkey, u64>) -> Vec<N
 }
 
 impl<T> ClusterNodesCache<T> {
-    pub(crate) fn new(
+    pub fn new(
         // Capacity of underlying LRU-cache in terms of number of epochs.
         cap: usize,
         // A time-to-live eviction policy is enforced to refresh entries in


### PR DESCRIPTION

#### Problem
An earlier version of the code was funneling through stakes along with
shreds to broadcast:
https://github.com/solana-labs/solana/blob/b67ffab37/core/src/broadcast_stage.rs#L127

This was changed to only slots as stakes computation was pushed further
down the pipeline in:
https://github.com/solana-labs/solana/pull/18971

However shreds themselves embody which slot they belong to. So pairing
them with slot is redundant and adds rooms for bugs should they become
inconsistent.

#### Summary of Changes
* Removed `Slot` from `TransmitShreds`.
* Look up slot directly from the shreds.