### PR TITLE
Add note about ASK keyword to paper wallet doc

### DIFF
--- a/docs/src/wallet-guide/paper-wallet.md
+++ b/docs/src/wallet-guide/paper-wallet.md
@@ -113,7 +113,7 @@ associated with your seed phrase.
 
 > Copy the derived address to a USB stick for easy usage on networked computers
 
-If needed, you can access your root pubkey using the `ASK` keyword:
+If needed, you can access the legacy, raw keypair's pubkey by instead passing the `ASK` keyword:
 
 ```bash
 solana-keygen pubkey ASK

--- a/docs/src/wallet-guide/paper-wallet.md
+++ b/docs/src/wallet-guide/paper-wallet.md
@@ -82,6 +82,7 @@ For full usage details run:
 solana-keygen new --help
 ```
 
+
 ### Public Key Derivation
 
 Public keys can be derived from a seed phrase and a passphrase if you choose to
@@ -107,10 +108,16 @@ solana-keygen pubkey prompt:// --skip-seed-phrase-validation
 ```
 
 After entering your seed phrase with `solana-keygen pubkey prompt://` the console
-will display a string of base-58 character. This is the base _wallet address_
+will display a string of base-58 character. This is the [derived](#hierarchical-derivation) solana BIP44 _wallet address_
 associated with your seed phrase.
 
 > Copy the derived address to a USB stick for easy usage on networked computers
+
+If needed, you can access your root pubkey using the `ASK` keyword:
+
+```bash
+solana-keygen pubkey ASK
+```
 
 > A common next step is to [check the balance](#checking-account-balance) of the account associated with a public key
 


### PR DESCRIPTION
#### Problem

Confusing documentation on paper wallet pubkey derivation via `pubkey prompt://`

#### Summary of Changes

Per https://github.com/solana-labs/solana/issues/17325#issuecomment-844434585, this change adds a note to the paper wallet docs mentioning the use of the `ASK` keyword. 

Also specifes that the `solana-keygen pubkey prompt://` command returns a derived bip44 base address.

(I'm new to Solana development and this was a point of confusion for me, only resolved by finding this issue)