### PR TITLE
Add LastFullSnapshotSlot to SnapshotConfig

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -224,6 +224,7 @@ mod tests {
     use super::*;
     use solana_gossip::{cluster_info::make_accounts_hashes_message, contact_info::ContactInfo};
     use solana_runtime::{
+        snapshot_config::LastFullSnapshotSlot,
         snapshot_package::SnapshotType,
         snapshot_utils::{ArchiveFormat, SnapshotVersion},
     };
@@ -297,6 +298,7 @@ mod tests {
             archive_format: ArchiveFormat::Tar,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: usize::MAX,
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let slot = full_snapshot_archive_interval_slots + i as u64;

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -15,7 +15,7 @@ use {
     solana_runtime::{
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{
             ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -528,6 +528,7 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -65,7 +65,7 @@ mod tests {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         snapshot_archive_info::FullSnapshotArchiveInfo,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_package::{AccountsPackage, PendingSnapshotPackage},
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -146,6 +146,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -31,7 +31,7 @@ use solana_runtime::{
     bank_forks::BankForks,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_archive_info::SnapshotArchiveInfoGetter,
-    snapshot_config::SnapshotConfig,
+    snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
     snapshot_utils::{
         self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
@@ -719,6 +719,7 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -43,7 +43,7 @@ use {
     },
     solana_runtime::{
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -3478,6 +3478,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -23,7 +23,7 @@ use {
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{clock::Slot, exit::Exit, genesis_config::GenesisConfig, hash::Hash},
@@ -263,6 +263,7 @@ impl ReplicaNode {
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
             maximum_snapshots_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
 
         let bank_info =

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -17,7 +17,7 @@ use {
     solana_runtime::{
         accounts_index::AccountSecondaryIndexes,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -127,6 +127,7 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -491,6 +491,7 @@ mod tests {
         },
         solana_runtime::{
             bank::Bank,
+            snapshot_config::LastFullSnapshotSlot,
             snapshot_utils::{
                 ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             },
@@ -608,6 +609,7 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,7 +1,10 @@
 use crate::snapshot_utils::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
 use solana_sdk::clock::Slot;
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 /// Snapshot configuration and runtime information
 #[derive(Clone, Debug)]
@@ -26,4 +29,9 @@ pub struct SnapshotConfig {
 
     /// Maximum number of full snapshot archives to retain
     pub maximum_snapshots_to_retain: usize,
+
+    /// Runtime information of the last full snapshot slot
+    pub last_full_snapshot_slot: LastFullSnapshotSlot,
 }
+
+pub type LastFullSnapshotSlot = Arc<RwLock<Option<Slot>>>;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,7 +49,7 @@ use {
         },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
+        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -2621,6 +2621,7 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_snapshots_to_retain,
+        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
#### Problem

There is not a way to communicate what the last full snapshot slot is.

#### Summary of Changes

Add `last_full_snapshot_slot` to `SnapshotConfig` to enable passing runtime information between threads about the last full snapshot slot.

Related to #17088 

_(To see how LastFullSnapshotSlot will be used, see this next PR #19342)_