### PR TITLE
Use LastFullSnapshotSlot

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,6 +1,8 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::PendingSnapshotPackage,
+    snapshot_archive_info::SnapshotArchiveInfoGetter,
+    snapshot_config::SnapshotConfig,
+    snapshot_package::{PendingSnapshotPackage, SnapshotType},
     snapshot_utils,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
@@ -23,7 +25,7 @@ impl SnapshotPackagerService {
         starting_snapshot_hash: Option<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
-        maximum_snapshots_to_retain: usize,
+        snapshot_config: SnapshotConfig,
     ) -> Self {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
@@ -45,9 +47,13 @@ impl SnapshotPackagerService {
                     if let Some(snapshot_package) = snapshot_package {
                         match snapshot_utils::archive_snapshot_package(
                             &snapshot_package,
-                            maximum_snapshots_to_retain,
+                            snapshot_config.maximum_snapshots_to_retain,
                         ) {
                             Ok(_) => {
+                                if snapshot_package.snapshot_type == SnapshotType::FullSnapshot {
+                                    *snapshot_config.last_full_snapshot_slot.write().unwrap() =
+                                        Some(snapshot_package.slot());
+                                }
                                 hashes.push((snapshot_package.slot(), *snapshot_package.hash()));
                                 while hashes.len() > MAX_SNAPSHOT_HASHES {
                                     hashes.remove(0);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -634,7 +634,7 @@ impl Validator {
                     snapshot_hash,
                     &exit,
                     &cluster_info,
-                    snapshot_config.maximum_snapshots_to_retain,
+                    snapshot_config.clone(),
                 );
                 (
                     Some(snapshot_packager_service),
@@ -1219,6 +1219,8 @@ fn new_banks_from_ledger(
             error!("Unable to create snapshot: {}", err);
             abort();
         });
+        *snapshot_config.last_full_snapshot_slot.write().unwrap() =
+            Some(full_snapshot_archive_info.slot());
         info!(
             "created snapshot: {}",
             full_snapshot_archive_info.path().display()

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -501,7 +501,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            snapshot_test_config.snapshot_config.clone(),
         );
 
         let thread_pool = accounts_db::make_min_priority_thread_pool();
@@ -921,9 +921,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            snapshot_test_config
-                .snapshot_config
-                .maximum_snapshots_to_retain,
+            snapshot_test_config.snapshot_config.clone(),
         );
 
         let accounts_hash_verifier = AccountsHashVerifier::new(

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -160,7 +160,9 @@ impl SnapshotRequestHandler {
                 // accounts that were included in the bank delta hash when the bank was frozen,
                 // and if we clean them here, the newly created snapshot's hash may not match
                 // the frozen hash.
-                snapshot_root_bank.clean_accounts(true, false, None);
+                let last_full_snapshot_slot =
+                    *self.snapshot_config.last_full_snapshot_slot.read().unwrap();
+                snapshot_root_bank.clean_accounts(true, false, last_full_snapshot_slot);
                 clean_time.stop();
 
                 if accounts_db_caching_enabled {
@@ -399,7 +401,18 @@ impl AccountsBackgroundService {
                                 // slots >= bank.slot()
                                 bank.force_flush_accounts_cache();
                             }
-                            bank.clean_accounts(true, false, None);
+                            let last_full_snapshot_slot = request_handler
+                                .snapshot_request_handler
+                                .as_ref()
+                                .map(|snapshot_request_handler| {
+                                    *snapshot_request_handler
+                                        .snapshot_config
+                                        .last_full_snapshot_slot
+                                        .read()
+                                        .unwrap()
+                                })
+                                .flatten();
+                            bank.clean_accounts(true, false, last_full_snapshot_slot);
                             last_cleaned_block_height = bank.block_height();
                         }
                     }


### PR DESCRIPTION
#### Problem

Threads/background services do not communicate the last full snapshot slot, and therefore do not call `clean_accounts()` correctly once adding Incremental Snapshots.

#### Summary of Changes

- SnapshotPackagerService now gets a SnapshotConfig
- SnapshotPackagerService writes/updates last_full_snapshot_slot after successfully taking a full snapshot
- AccountsBackgroundService reads last_full_snapshot_slot and passes that value when it calls `clean_accounts()`
- Validator also writes last_full_snapshot_slot after it calls `bank_to_full_snapshot_archive()`.

Related to #17088 