### PR TITLE
Remove tar-rs audit ignore

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -46,11 +46,5 @@ cargo_audit_ignores=(
   # https://github.com/paritytech/jsonrpc/issues/605
   --ignore RUSTSEC-2021-0079
 
-  # tar: Links in archive can create arbitrary directories
-  #
-  # Blocked on `tar` releasing safe upgrade
-  # https://github.com/alexcrichton/tar-rs/issues/238
-  --ignore RUSTSEC-2021-0080
-
 )
 scripts/cargo-for-all-lock-files.sh stable audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem
We are ignoring a security advisory that no longer applies to our codebase, fix at #19216 

#### Summary of Changes
Remove ignore
