### PR TITLE
Remove filter_snapshot_storages_for_incremental_snapshot()

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -799,14 +799,7 @@ mod tests {
                         "did not find bank snapshot with this path",
                     )
                 })?;
-        let storages = {
-            let mut storages = bank.get_snapshot_storages(Some(incremental_snapshot_base_slot));
-            snapshot_utils::filter_snapshot_storages_for_incremental_snapshot(
-                &mut storages,
-                incremental_snapshot_base_slot,
-            );
-            storages
-        };
+        let storages = bank.get_snapshot_storages(Some(incremental_snapshot_base_slot));
         snapshot_utils::package_process_and_archive_incremental_snapshot(
             bank,
             incremental_snapshot_base_slot,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1635,11 +1635,7 @@ pub fn bank_to_incremental_snapshot_archive(
     bank.rehash(); // Bank accounts may have been manually modified by the caller
 
     let temp_dir = tempfile::tempdir_in(bank_snapshots_dir)?;
-    let storages = {
-        let mut storages = bank.get_snapshot_storages(Some(full_snapshot_slot));
-        filter_snapshot_storages_for_incremental_snapshot(&mut storages, full_snapshot_slot);
-        storages
-    };
+    let storages = bank.get_snapshot_storages(Some(full_snapshot_slot));
     let bank_snapshot_info = add_bank_snapshot(&temp_dir, bank, &storages, snapshot_version)?;
 
     package_process_and_archive_incremental_snapshot(
@@ -1813,19 +1809,6 @@ pub fn process_accounts_package(
         accounts_package.snapshot_version,
         snapshot_type,
     )
-}
-
-/// Filter snapshot storages and retain only the ones with slots _higher than_
-/// `incremental_snapshot_base_slot`.
-pub fn filter_snapshot_storages_for_incremental_snapshot(
-    snapshot_storages: &mut SnapshotStorages,
-    incremental_snapshot_base_slot: Slot,
-) {
-    snapshot_storages.retain(|storage| {
-        storage
-            .first()
-            .map_or(false, |entry| entry.slot() > incremental_snapshot_base_slot)
-    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Now that we can get just the subset of snapshot storages we want, the extra filtering afterwards is redundant.

#### Summary of Changes

Remove calls to `filter_snapshot_storages_for_incremental_snapshot()`, and the function itself.

Related to #17088 