### PR TITLE
Correct JSON-RPC docs for getSlot

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2247,10 +2247,7 @@ Result:
 
 ### getSlot
 
-Returns the slot associated with the given commitment level
-
-If the commitment level is not provided, then this method returns the highest
-finalized slot.
+Returns the slot that has reached the [given or default commitment level](jsonrpc-api.md#configuring-state-commitment)
 
 #### Parameters:
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2247,7 +2247,10 @@ Result:
 
 ### getSlot
 
-Returns the current slot the node is processing
+Returns the slot associated with the given commitment level
+
+If the commitment level is not provided, then this method returns the highest
+finalized slot.
 
 #### Parameters:
 


### PR DESCRIPTION
#### Problem

From my reading and experiments, the description of the `getSlot` method is not quite correct. It says it returns the slot the node is processing, but what it really does is returns the slot that corresponds to a provided commitment level. That is not (ever?) the slot that is being processed, but a slot some number back.

#### Summary of Changes

Use more precise language.
