### PR TITLE
implements copy-on-write for vote-accounts

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -29,7 +29,6 @@ use solana_runtime::{
     bank_forks::BankForks,
     commitment::VOTE_THRESHOLD_SIZE,
     epoch_stakes::{EpochAuthorizedVoters, EpochStakes},
-    stakes::Stakes,
     vote_sender_types::{ReplayVoteReceiver, ReplayedVote},
 };
 use solana_sdk::{
@@ -601,7 +600,7 @@ impl ClusterInfoVoteListener {
             // The last vote slot, which is the greatest slot in the stack
             // of votes in a vote transaction, qualifies for optimistic confirmation.
             if slot == last_vote_slot {
-                let vote_accounts = Stakes::vote_accounts(epoch_stakes.stakes());
+                let vote_accounts = epoch_stakes.stakes().vote_accounts();
                 let stake = vote_accounts
                     .get(vote_pubkey)
                     .map(|(stake, _)| *stake)

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -183,8 +183,8 @@ impl AggregateCommitmentService {
 
         let mut commitment = HashMap::new();
         let mut rooted_stake: Vec<(Slot, u64)> = Vec::new();
-        for (_, (lamports, account)) in bank.vote_accounts().into_iter() {
-            if lamports == 0 {
+        for (lamports, account) in bank.vote_accounts().values() {
+            if *lamports == 0 {
                 continue;
             }
             if let Ok(vote_state) = account.vote_state().as_ref() {
@@ -193,7 +193,7 @@ impl AggregateCommitmentService {
                     &mut rooted_stake,
                     vote_state,
                     ancestors,
-                    lamports,
+                    *lamports,
                 );
             }
         }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -198,17 +198,14 @@ impl Tower {
         Self::new(node_pubkey, vote_account, root, &heaviest_bank)
     }
 
-    pub(crate) fn collect_vote_lockouts<F>(
+    pub(crate) fn collect_vote_lockouts(
         vote_account_pubkey: &Pubkey,
         bank_slot: Slot,
-        vote_accounts: F,
+        vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
         ancestors: &HashMap<Slot, HashSet<Slot>>,
         get_frozen_hash: impl Fn(Slot) -> Option<Hash>,
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
-    ) -> ComputedBankState
-    where
-        F: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
-    {
+    ) -> ComputedBankState {
         let mut vote_slots = HashSet::new();
         let mut voted_stakes = HashMap::new();
         let mut total_stake = 0;
@@ -217,7 +214,8 @@ impl Tower {
         // keyed by end of the range
         let mut lockout_intervals = LockoutIntervals::new();
         let mut my_latest_landed_vote = None;
-        for (key, (voted_stake, account)) in vote_accounts {
+        for (&key, (voted_stake, account)) in vote_accounts.iter() {
+            let voted_stake = *voted_stake;
             if voted_stake == 0 {
                 continue;
             }
@@ -1270,56 +1268,60 @@ pub fn reconcile_blockstore_roots_with_tower(
 
 #[cfg(test)]
 pub mod test {
-    use super::*;
-    use crate::{
-        fork_choice::ForkChoice, heaviest_subtree_fork_choice::SlotHashKey,
-        replay_stage::HeaviestForkFailures, tower_storage::FileTowerStorage,
-        vote_simulator::VoteSimulator,
+    use {
+        super::*,
+        crate::{
+            fork_choice::ForkChoice, heaviest_subtree_fork_choice::SlotHashKey,
+            replay_stage::HeaviestForkFailures, tower_storage::FileTowerStorage,
+            vote_simulator::VoteSimulator,
+        },
+        itertools::Itertools,
+        solana_ledger::{blockstore::make_slot_entries, get_tmp_ledger_path},
+        solana_runtime::bank::Bank,
+        solana_sdk::{
+            account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
+            clock::Slot,
+            hash::Hash,
+            pubkey::Pubkey,
+            signature::Signer,
+            slot_history::SlotHistory,
+        },
+        solana_vote_program::vote_state::{Vote, VoteStateVersions, MAX_LOCKOUT_HISTORY},
+        std::{
+            collections::HashMap,
+            fs::{remove_file, OpenOptions},
+            io::{Read, Seek, SeekFrom, Write},
+            path::PathBuf,
+            sync::Arc,
+        },
+        tempfile::TempDir,
+        trees::tr,
     };
-    use solana_ledger::{blockstore::make_slot_entries, get_tmp_ledger_path};
-    use solana_runtime::bank::Bank;
-    use solana_sdk::{
-        account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
-        clock::Slot,
-        hash::Hash,
-        pubkey::Pubkey,
-        signature::Signer,
-        slot_history::SlotHistory,
-    };
-    use solana_vote_program::vote_state::{Vote, VoteStateVersions, MAX_LOCKOUT_HISTORY};
-    use std::{
-        collections::HashMap,
-        fs::{remove_file, OpenOptions},
-        io::{Read, Seek, SeekFrom, Write},
-        path::PathBuf,
-        sync::Arc,
-    };
-    use tempfile::TempDir;
-    use trees::tr;
 
-    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, VoteAccount))> {
-        let mut stakes = vec![];
-        for (lamports, votes) in stake_votes {
-            let mut account = AccountSharedData::from(Account {
-                data: vec![0; VoteState::size_of()],
-                lamports: *lamports,
-                ..Account::default()
-            });
-            let mut vote_state = VoteState::default();
-            for slot in *votes {
-                vote_state.process_slot_vote_unchecked(*slot);
-            }
-            VoteState::serialize(
-                &VoteStateVersions::new_current(vote_state),
-                &mut account.data_as_mut_slice(),
-            )
-            .expect("serialize state");
-            stakes.push((
-                solana_sdk::pubkey::new_rand(),
-                (*lamports, VoteAccount::from(account)),
-            ));
-        }
-        stakes
+    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> HashMap<Pubkey, (u64, VoteAccount)> {
+        stake_votes
+            .iter()
+            .map(|(lamports, votes)| {
+                let mut account = AccountSharedData::from(Account {
+                    data: vec![0; VoteState::size_of()],
+                    lamports: *lamports,
+                    ..Account::default()
+                });
+                let mut vote_state = VoteState::default();
+                for slot in *votes {
+                    vote_state.process_slot_vote_unchecked(*slot);
+                }
+                VoteState::serialize(
+                    &VoteStateVersions::new_current(vote_state),
+                    &mut account.data_as_mut_slice(),
+                )
+                .expect("serialize state");
+                (
+                    solana_sdk::pubkey::new_rand(),
+                    (*lamports, VoteAccount::from(account)),
+                )
+            })
+            .collect()
     }
 
     #[test]
@@ -1964,10 +1966,10 @@ pub mod test {
     #[test]
     fn test_collect_vote_lockouts_sums() {
         //two accounts voting for slot 0 with 1 token staked
-        let mut accounts = gen_stakes(&[(1, &[0]), (1, &[0])]);
-        accounts.sort_by_key(|(pk, _)| *pk);
+        let accounts = gen_stakes(&[(1, &[0]), (1, &[0])]);
         let account_latest_votes: Vec<(Pubkey, SlotHashKey)> = accounts
             .iter()
+            .sorted_by_key(|(pk, _)| *pk)
             .map(|(pubkey, _)| (*pubkey, (0, Hash::default())))
             .collect();
 
@@ -1984,7 +1986,7 @@ pub mod test {
         } = Tower::collect_vote_lockouts(
             &Pubkey::default(),
             1,
-            accounts.into_iter(),
+            &accounts,
             &ancestors,
             |_| Some(Hash::default()),
             &mut latest_validator_votes_for_frozen_banks,
@@ -2004,10 +2006,10 @@ pub mod test {
     fn test_collect_vote_lockouts_root() {
         let votes: Vec<u64> = (0..MAX_LOCKOUT_HISTORY as u64).collect();
         //two accounts voting for slots 0..MAX_LOCKOUT_HISTORY with 1 token staked
-        let mut accounts = gen_stakes(&[(1, &votes), (1, &votes)]);
-        accounts.sort_by_key(|(pk, _)| *pk);
+        let accounts = gen_stakes(&[(1, &votes), (1, &votes)]);
         let account_latest_votes: Vec<(Pubkey, SlotHashKey)> = accounts
             .iter()
+            .sorted_by_key(|(pk, _)| *pk)
             .map(|(pubkey, _)| {
                 (
                     *pubkey,
@@ -2044,7 +2046,7 @@ pub mod test {
         } = Tower::collect_vote_lockouts(
             &Pubkey::default(),
             MAX_LOCKOUT_HISTORY as u64,
-            accounts.into_iter(),
+            &accounts,
             &ancestors,
             |_| Some(Hash::default()),
             &mut latest_validator_votes_for_frozen_banks,
@@ -2340,7 +2342,7 @@ pub mod test {
         } = Tower::collect_vote_lockouts(
             &Pubkey::default(),
             vote_to_evaluate,
-            accounts.clone().into_iter(),
+            &accounts,
             &ancestors,
             |_| None,
             &mut LatestValidatorVotesForFrozenBanks::default(),
@@ -2358,7 +2360,7 @@ pub mod test {
         } = Tower::collect_vote_lockouts(
             &Pubkey::default(),
             vote_to_evaluate,
-            accounts.into_iter(),
+            &accounts,
             &ancestors,
             |_| None,
             &mut LatestValidatorVotesForFrozenBanks::default(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2169,7 +2169,7 @@ impl ReplayStage {
                     let computed_bank_state = Tower::collect_vote_lockouts(
                         my_vote_pubkey,
                         bank_slot,
-                        bank.vote_accounts().into_iter(),
+                        &bank.vote_accounts(),
                         ancestors,
                         |slot| progress.get_hash(slot),
                         latest_validator_votes_for_frozen_banks,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1544,7 +1544,8 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     let my_shred_version = cluster_info.my_shred_version();
     let my_id = cluster_info.id();
 
-    for (_, (activated_stake, vote_account)) in bank.vote_accounts() {
+    for (activated_stake, vote_account) in bank.vote_accounts().values() {
+        let activated_stake = *activated_stake;
         total_activated_stake += activated_stake;
 
         if activated_stake == 0 {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -353,18 +353,18 @@ fn graph_forks(bank_forks: &BankForks, include_all_votes: bool) -> String {
             .iter()
             .map(|(_, (stake, _))| stake)
             .sum();
-        for (_, (stake, vote_account)) in bank.vote_accounts() {
+        for (stake, vote_account) in bank.vote_accounts().values() {
             let vote_state = vote_account.vote_state();
             let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
             if let Some(last_vote) = vote_state.votes.iter().last() {
                 let entry = last_votes.entry(vote_state.node_pubkey).or_insert((
                     last_vote.slot,
                     vote_state.clone(),
-                    stake,
+                    *stake,
                     total_stake,
                 ));
                 if entry.0 < last_vote.slot {
-                    *entry = (last_vote.slot, vote_state.clone(), stake, total_stake);
+                    *entry = (last_vote.slot, vote_state.clone(), *stake, total_stake);
                 }
             }
         }
@@ -394,7 +394,7 @@ fn graph_forks(bank_forks: &BankForks, include_all_votes: bool) -> String {
 
         let mut first = true;
         loop {
-            for (_, (_, vote_account)) in bank.vote_accounts() {
+            for (_, vote_account) in bank.vote_accounts().values() {
                 let vote_state = vote_account.vote_state();
                 let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
                 if let Some(last_vote) = vote_state.votes.iter().last() {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1112,7 +1112,7 @@ fn load_frozen_forks(
                     supermajority_root_from_vote_accounts(
                         bank.slot(),
                         bank.total_epoch_stake(),
-                        bank.vote_accounts(),
+                        &bank.vote_accounts(),
                     ).and_then(|supermajority_root| {
                         if supermajority_root > *root {
                             // If there's a cluster confirmed root greater than our last
@@ -1221,18 +1221,15 @@ fn supermajority_root(roots: &[(Slot, u64)], total_epoch_stake: u64) -> Option<S
     None
 }
 
-fn supermajority_root_from_vote_accounts<I>(
+fn supermajority_root_from_vote_accounts(
     bank_slot: Slot,
     total_epoch_stake: u64,
-    vote_accounts: I,
-) -> Option<Slot>
-where
-    I: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
-{
+    vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
+) -> Option<Slot> {
     let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts
-        .into_iter()
+        .iter()
         .filter_map(|(key, (stake, account))| {
-            if stake == 0 {
+            if *stake == 0 {
                 return None;
             }
 
@@ -1244,7 +1241,7 @@ where
                     );
                     None
                 }
-                Ok(vote_state) => vote_state.root_slot.map(|root_slot| (root_slot, stake)),
+                Ok(vote_state) => Some((vote_state.root_slot?, *stake)),
             }
         })
         .collect();
@@ -3581,7 +3578,7 @@ pub mod tests {
     #[allow(clippy::field_reassign_with_default)]
     fn test_supermajority_root_from_vote_accounts() {
         let convert_to_vote_accounts =
-            |roots_stakes: Vec<(Slot, u64)>| -> Vec<(Pubkey, (u64, VoteAccount))> {
+            |roots_stakes: Vec<(Slot, u64)>| -> HashMap<Pubkey, (u64, VoteAccount)> {
                 roots_stakes
                     .into_iter()
                     .map(|(root, stake)| {
@@ -3599,7 +3596,7 @@ pub mod tests {
                             (stake, VoteAccount::from(vote_account)),
                         )
                     })
-                    .collect_vec()
+                    .collect()
             };
 
         let total_stake = 10;
@@ -3607,22 +3604,19 @@ pub mod tests {
 
         // Supermajority root should be None
         assert!(
-            supermajority_root_from_vote_accounts(slot, total_stake, std::iter::empty()).is_none()
+            supermajority_root_from_vote_accounts(slot, total_stake, &HashMap::default()).is_none()
         );
 
         // Supermajority root should be None
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 1)];
         let accounts = convert_to_vote_accounts(roots_stakes);
-        assert!(
-            supermajority_root_from_vote_accounts(slot, total_stake, accounts.into_iter())
-                .is_none()
-        );
+        assert!(supermajority_root_from_vote_accounts(slot, total_stake, &accounts).is_none());
 
         // Supermajority root should be 4, has 7/10 of the stake
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 5)];
         let accounts = convert_to_vote_accounts(roots_stakes);
         assert_eq!(
-            supermajority_root_from_vote_accounts(slot, total_stake, accounts.into_iter()).unwrap(),
+            supermajority_root_from_vote_accounts(slot, total_stake, &accounts).unwrap(),
             4
         );
 
@@ -3630,7 +3624,7 @@ pub mod tests {
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 6)];
         let accounts = convert_to_vote_accounts(roots_stakes);
         assert_eq!(
-            supermajority_root_from_vote_accounts(slot, total_stake, accounts.into_iter()).unwrap(),
+            supermajority_root_from_vote_accounts(slot, total_stake, &accounts).unwrap(),
             8
         );
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2251,25 +2251,21 @@ impl Bank {
     ) -> Option<UnixTimestamp> {
         let mut get_timestamp_estimate_time = Measure::start("get_timestamp_estimate");
         let slots_per_epoch = self.epoch_schedule().slots_per_epoch;
-        let recent_timestamps =
-            self.vote_accounts()
-                .into_iter()
-                .filter_map(|(pubkey, (_, account))| {
-                    let vote_state = account.vote_state();
-                    let vote_state = vote_state.as_ref().ok()?;
-                    let slot_delta = self.slot().checked_sub(vote_state.last_timestamp.slot)?;
-                    if slot_delta <= slots_per_epoch {
-                        Some((
-                            pubkey,
-                            (
-                                vote_state.last_timestamp.slot,
-                                vote_state.last_timestamp.timestamp,
-                            ),
-                        ))
-                    } else {
-                        None
-                    }
-                });
+        let vote_accounts = self.vote_accounts();
+        let recent_timestamps = vote_accounts.iter().filter_map(|(pubkey, (_, account))| {
+            let vote_state = account.vote_state();
+            let vote_state = vote_state.as_ref().ok()?;
+            let slot_delta = self.slot().checked_sub(vote_state.last_timestamp.slot)?;
+            (slot_delta <= slots_per_epoch).then(|| {
+                (
+                    *pubkey,
+                    (
+                        vote_state.last_timestamp.slot,
+                        vote_state.last_timestamp.timestamp,
+                    ),
+                )
+            })
+        });
         let slot_duration = Duration::from_nanos(self.ns_per_slot as u64);
         let epoch = self.epoch_schedule().get_epoch(self.slot());
         let stakes = self.epoch_vote_accounts(epoch)?;
@@ -3715,24 +3711,25 @@ impl Bank {
     //
     // Ref: collect_fees
     #[allow(clippy::needless_collect)]
-    fn distribute_rent_to_validators<I>(&self, vote_accounts: I, rent_to_be_distributed: u64)
-    where
-        I: IntoIterator<Item = (Pubkey, (u64, VoteAccount))>,
-    {
+    fn distribute_rent_to_validators(
+        &self,
+        vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
+        rent_to_be_distributed: u64,
+    ) {
         let mut total_staked = 0;
 
         // Collect the stake associated with each validator.
         // Note that a validator may be present in this vector multiple times if it happens to have
         // more than one staked vote account somehow
         let mut validator_stakes = vote_accounts
-            .into_iter()
+            .iter()
             .filter_map(|(_vote_pubkey, (staked, account))| {
-                if staked == 0 {
+                if *staked == 0 {
                     None
                 } else {
-                    total_staked += staked;
+                    total_staked += *staked;
                     let node_pubkey = account.vote_state().as_ref().ok()?.node_pubkey;
-                    Some((node_pubkey, staked))
+                    Some((node_pubkey, *staked))
                 }
             })
             .collect::<Vec<(Pubkey, u64)>>();
@@ -3847,7 +3844,7 @@ impl Bank {
             return;
         }
 
-        self.distribute_rent_to_validators(self.vote_accounts(), rent_to_be_distributed);
+        self.distribute_rent_to_validators(&self.vote_accounts(), rent_to_be_distributed);
     }
 
     fn collect_rent(
@@ -5187,26 +5184,15 @@ impl Bank {
 
     /// current vote accounts for this bank along with the stake
     ///   attributed to each account
-    /// Note: This clones the entire vote-accounts hashmap. For a single
-    /// account lookup use get_vote_account instead.
-    pub fn vote_accounts(&self) -> Vec<(Pubkey, (/*stake:*/ u64, VoteAccount))> {
-        self.stakes
-            .read()
-            .unwrap()
-            .vote_accounts()
-            .iter()
-            .map(|(k, v)| (*k, v.clone()))
-            .collect()
+    pub fn vote_accounts(&self) -> Arc<HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>> {
+        let stakes = self.stakes.read().unwrap();
+        Arc::from(stakes.vote_accounts())
     }
 
     /// Vote account for the given vote account pubkey along with the stake.
     pub fn get_vote_account(&self, vote_account: &Pubkey) -> Option<(/*stake:*/ u64, VoteAccount)> {
-        self.stakes
-            .read()
-            .unwrap()
-            .vote_accounts()
-            .get(vote_account)
-            .cloned()
+        let stakes = self.stakes.read().unwrap();
+        stakes.vote_accounts().get(vote_account).cloned()
     }
 
     /// Get the EpochStakes for a given epoch
@@ -5228,9 +5214,8 @@ impl Bank {
         &self,
         epoch: Epoch,
     ) -> Option<&HashMap<Pubkey, (u64, VoteAccount)>> {
-        self.epoch_stakes
-            .get(&epoch)
-            .map(|epoch_stakes| Stakes::vote_accounts(epoch_stakes.stakes()))
+        let epoch_stakes = self.epoch_stakes.get(&epoch)?.stakes();
+        Some(epoch_stakes.vote_accounts().as_ref())
     }
 
     /// Get the fixed authorized voter for the given vote account for the
@@ -6668,7 +6653,7 @@ pub(crate) mod tests {
 
         let bank = Bank::new_for_tests(&genesis_config);
         let old_validator_lamports = bank.get_balance(&validator_pubkey);
-        bank.distribute_rent_to_validators(bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
+        bank.distribute_rent_to_validators(&bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
         let new_validator_lamports = bank.get_balance(&validator_pubkey);
         assert_eq!(
             new_validator_lamports,
@@ -6682,7 +6667,7 @@ pub(crate) mod tests {
         let bank = std::panic::AssertUnwindSafe(Bank::new_for_tests(&genesis_config));
         let old_validator_lamports = bank.get_balance(&validator_pubkey);
         let new_validator_lamports = std::panic::catch_unwind(|| {
-            bank.distribute_rent_to_validators(bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
+            bank.distribute_rent_to_validators(&bank.vote_accounts(), RENT_TO_BE_DISTRIBUTED);
             bank.get_balance(&validator_pubkey)
         });
 
@@ -9520,7 +9505,7 @@ pub(crate) mod tests {
 
         bank.process_transaction(&transaction).unwrap();
 
-        let vote_accounts = bank.vote_accounts().into_iter().collect::<HashMap<_, _>>();
+        let vote_accounts = bank.vote_accounts();
 
         assert_eq!(vote_accounts.len(), 2);
 
@@ -9895,7 +9880,10 @@ pub(crate) mod tests {
         }
 
         // Non-native loader accounts can not be used for instruction processing
-        assert!(bank.stakes.read().unwrap().vote_accounts().is_empty());
+        {
+            let stakes = bank.stakes.read().unwrap();
+            assert!(stakes.vote_accounts().as_ref().is_empty());
+        }
         assert!(bank.stakes.read().unwrap().stake_delegations().is_empty());
         assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
 
@@ -9905,13 +9893,19 @@ pub(crate) mod tests {
             .fetch_add(vote_account.lamports() + stake_account.lamports(), Relaxed);
         bank.store_account(&vote_id, &vote_account);
         bank.store_account(&stake_id, &stake_account);
-        assert!(!bank.stakes.read().unwrap().vote_accounts().is_empty());
+        {
+            let stakes = bank.stakes.read().unwrap();
+            assert!(!stakes.vote_accounts().as_ref().is_empty());
+        }
         assert!(!bank.stakes.read().unwrap().stake_delegations().is_empty());
         assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
 
         bank.add_builtin("mock_program1", vote_id, mock_ix_processor);
         bank.add_builtin("mock_program2", stake_id, mock_ix_processor);
-        assert!(bank.stakes.read().unwrap().vote_accounts().is_empty());
+        {
+            let stakes = bank.stakes.read().unwrap();
+            assert!(stakes.vote_accounts().as_ref().is_empty());
+        }
         assert!(bank.stakes.read().unwrap().stake_delegations().is_empty());
         assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
         assert_eq!(
@@ -9931,7 +9925,10 @@ pub(crate) mod tests {
         bank.update_accounts_hash();
         let new_hash = bank.get_accounts_hash();
         assert_eq!(old_hash, new_hash);
-        assert!(bank.stakes.read().unwrap().vote_accounts().is_empty());
+        {
+            let stakes = bank.stakes.read().unwrap();
+            assert!(stakes.vote_accounts().as_ref().is_empty());
+        }
         assert!(bank.stakes.read().unwrap().stake_delegations().is_empty());
         assert_eq!(bank.calculate_capitalization(true), bank.capitalization());
         assert_eq!(

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -24,9 +24,9 @@ pub struct EpochStakes {
 
 impl EpochStakes {
     pub fn new(stakes: &Stakes, leader_schedule_epoch: Epoch) -> Self {
-        let epoch_vote_accounts = Stakes::vote_accounts(stakes);
+        let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
-            Self::parse_epoch_vote_accounts(epoch_vote_accounts, leader_schedule_epoch);
+            Self::parse_epoch_vote_accounts(epoch_vote_accounts.as_ref(), leader_schedule_epoch);
         Self {
             stakes: Arc::new(stakes.clone()),
             total_stake,
@@ -52,7 +52,8 @@ impl EpochStakes {
     }
 
     pub fn vote_account_stake(&self, vote_account: &Pubkey) -> u64 {
-        Stakes::vote_accounts(&self.stakes)
+        self.stakes
+            .vote_accounts()
             .get(vote_account)
             .map(|(stake, _)| *stake)
             .unwrap_or(0)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -196,8 +196,8 @@ impl Stakes {
         }
     }
 
-    pub fn vote_accounts(&self) -> &HashMap<Pubkey, (u64, VoteAccount)> {
-        self.vote_accounts.as_ref()
+    pub fn vote_accounts(&self) -> &VoteAccounts {
+        &self.vote_accounts
     }
 
     pub fn stake_delegations(&self) -> &HashMap<Pubkey, Delegation> {


### PR DESCRIPTION

#### Problem
`Bank::vote_accounts` redundantly clones vote-accounts HashMap even though
an immutable reference will suffice:
https://github.com/solana-labs/solana/blob/95c998a19/runtime/src/bank.rs#L5174-L5186


#### Summary of Changes
This commit implements copy-on-write semantics for vote-accounts by
wrapping the underlying HashMap in `Arc<...>`.
