### PR TITLE
Fix duplicate broadcast test

### DIFF
--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -38,8 +38,8 @@ pub(super) struct BroadcastDuplicatesRun {
     prev_entry_hash: Option<Hash>,
     num_slots_broadcasted: usize,
     cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
-    original_last_data_shreds: HashSet<Signature>,
-    partition_last_data_shreds: HashSet<Signature>,
+    original_last_data_shreds: Arc<Mutex<HashSet<Signature>>>,
+    partition_last_data_shreds: Arc<Mutex<HashSet<Signature>>>,
 }
 
 impl BroadcastDuplicatesRun {
@@ -60,8 +60,8 @@ impl BroadcastDuplicatesRun {
             prev_entry_hash: None,
             num_slots_broadcasted: 0,
             cluster_nodes_cache,
-            original_last_data_shreds: HashSet::default(),
-            partition_last_data_shreds: HashSet::default(),
+            original_last_data_shreds: Arc::new(Mutex::new(HashSet::default())),
+            partition_last_data_shreds: Arc::new(Mutex::new(HashSet::default())),
         }
     }
 }
@@ -205,16 +205,19 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         // Special handling of last shred to cause partition
         if let Some((original_last_data_shred, partition_last_data_shred)) = last_shreds {
             let pubkey = keypair.pubkey();
-            self.original_last_data_shreds
-                .extend(original_last_data_shred.iter().map(|shred| {
+            self.original_last_data_shreds.lock().unwrap().extend(
+                original_last_data_shred.iter().map(|shred| {
                     assert!(shred.verify(&pubkey));
                     shred.signature()
-                }));
-            self.partition_last_data_shreds
-                .extend(partition_last_data_shred.iter().map(|shred| {
+                }),
+            );
+            self.partition_last_data_shreds.lock().unwrap().extend(
+                partition_last_data_shred.iter().map(|shred| {
+                    info!("adding {} to partition set", shred.signature());
                     assert!(shred.verify(&pubkey));
                     shred.signature()
-                }));
+                }),
+            );
             let original_last_data_shred = Arc::new(original_last_data_shred);
             let partition_last_data_shred = Arc::new(partition_last_data_shred);
 
@@ -252,6 +255,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             (bank_forks.root_bank(), bank_forks.working_bank())
         };
         let self_pubkey = cluster_info.id();
+
         // Creat cluster partition.
         let cluster_partition: HashSet<Pubkey> = {
             let mut cumilative_stake = 0;
@@ -269,6 +273,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 .map(|(pubkey, _)| *pubkey)
                 .collect()
         };
+
         // Broadcast data
         let cluster_nodes =
             self.cluster_nodes_cache
@@ -276,14 +281,22 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         let socket_addr_space = cluster_info.socket_addr_space();
         let packets: Vec<_> = shreds
             .iter()
-            .filter_map(|shred| {
+            .flat_map(|shred| {
                 let seed = shred.seed(Some(self_pubkey), &root_bank);
-                let node = cluster_nodes.get_broadcast_peer(seed)?;
-                if !socket_addr_space.check(&node.tvu) {
-                    return None;
+                let node = cluster_nodes.get_broadcast_peer(seed);
+                if node.is_none() {
+                    return vec![];
                 }
-                if self.original_last_data_shreds.contains(&shred.signature()) {
-                    // If the node is within the partitin skip the shred.
+                let node = node.unwrap();
+                if !socket_addr_space.check(&node.tvu) {
+                    return vec![];
+                }
+                if self
+                    .original_last_data_shreds
+                    .lock()
+                    .unwrap()
+                    .remove(&shred.signature())
+                {
                     if cluster_partition.contains(&node.id) {
                         info!(
                             "skipping node {} for original shred index {}, slot {}",
@@ -291,22 +304,27 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                             shred.index(),
                             shred.slot()
                         );
-                        return None;
+                        return vec![];
                     }
+                } else if self
+                    .partition_last_data_shreds
+                    .lock()
+                    .unwrap()
+                    .remove(&shred.signature())
+                {
+                    // If the shred is part of the partition, broadcast it directly to
+                    // the partition node
+                    return cluster_partition
+                        .iter()
+                        .filter_map(|pubkey| {
+                            let tvu = cluster_info
+                                .lookup_contact_info(pubkey, |contact_info| contact_info.tvu)?;
+                            Some((&shred.payload, tvu))
+                        })
+                        .collect();
                 }
-                if self.partition_last_data_shreds.contains(&shred.signature()) {
-                    // If the node is not within the partitin skip the shred.
-                    if !cluster_partition.contains(&node.id) {
-                        info!(
-                            "skipping node {} for partition shred index {}, slot {}",
-                            node.id,
-                            shred.index(),
-                            shred.slot()
-                        );
-                        return None;
-                    }
-                }
-                Some((&shred.payload, node.tvu))
+
+                vec![(&shred.payload, node.tvu)]
             })
             .collect();
         if let Err(SendPktsError::IoError(ioerr, _)) = batch_send(sock, &packets) {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -148,6 +148,11 @@ impl LocalCluster {
                 .iter()
                 .zip(&config.node_stakes)
                 .filter_map(|((node_keypair, in_genesis), stake)| {
+                    info!(
+                        "STARTING LOCAL CLUSTER: key {} has {} stake",
+                        node_keypair.pubkey(),
+                        stake
+                    );
                     if *in_genesis {
                         Some((
                             ValidatorVoteKeypairs {


### PR DESCRIPTION
#### Problem
1.  `partition_last_data_shreds` isn't shared between the run() and transmit() shreds
2. `partition_last_data_shreds` is currently only transmitted if the selected broadcast node via `get_broadcast_peer()` is in the partition. However, when the partition stake is small such as in `test_duplicate_shreds_broadcast_leader()`, then the partition node is never selected by `get_broadcast_peer()`

#### Summary of Changes
1. Share `partition_last_data_shreds` via a `Mutex`
2. Always broadcast `partition_last_data_shreds` to the partition nodes, even if they are not selected via `get_broadcast_peer()`

Fixes #
