### PR TITLE
Shrink mmap leakage

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2500,7 +2500,7 @@ impl AccountsDb {
         let mut total_alive_bytes: u64 = 0;
         let mut candidates_count: usize = 0;
         let mut total_bytes: u64 = 0;
-        let mut total_candidate_stores: i64 = 0;
+        let mut total_candidate_stores: usize = 0;
         for (slot, slot_shrink_candidates) in shrink_slots {
             candidates_count += slot_shrink_candidates.len();
             for store in slot_shrink_candidates.values() {
@@ -2563,24 +2563,8 @@ impl AccountsDb {
             measure.as_ms() as usize
         );
         inc_new_counter_info!("select_top_sparse_storage_entries-seeds", candidates_count);
-        datapoint_info!(
-            "shrink-candidates",
-            (
-                "total_preliminary_candidate_stores",
-                total_candidate_stores,
-                i64
-            ),
-            (
-                "select_top_sparse_storage_entries-ms",
-                measure.as_ms() as u64,
-                i64
-            ),
-            (
-                "select_top_sparse_storage_entries-seeds",
-                candidates_count,
-                i64
-            ),
-        );
+        inc_new_counter_info!("total_preliminary_candidate_stores", total_candidate_stores);
+
         (shrink_slots, shrink_slots_next_batch)
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2559,11 +2559,11 @@ impl AccountsDb {
         }
         measure.stop();
         inc_new_counter_info!(
-            "select_top_sparse_storage_entries-ms",
+            "shrink_select_top_sparse_storage_entries-ms",
             measure.as_ms() as usize
         );
-        inc_new_counter_info!("select_top_sparse_storage_entries-seeds", candidates_count);
-        inc_new_counter_info!("total_preliminary_candidate_stores", total_candidate_stores);
+        inc_new_counter_info!("shrink_select_top_sparse_storage_entries-seeds", candidates_count);
+        inc_new_counter_info!("shrink_total_preliminary_candidate_stores", total_candidate_stores);
 
         (shrink_slots, shrink_slots_next_batch)
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2483,7 +2483,8 @@ impl AccountsDb {
     /// Given the input `ShrinkCandidates`, this function sorts the stores by their alive ratio
     /// in increasing order with the most sparse entries in the front. It will then simulate the
     /// shrinking by working on the most sparse entries first and if the overall alive ratio is
-    /// achieved, it will stop and return the filtered-down candidates.
+    /// achieved, it will stop and return the filtered-down candidates and the candidates which
+    /// are skipped in this round and might be eligible for the future shrink.
     fn select_candidates_by_total_usage(
         &self,
         shrink_slots: &ShrinkCandidates,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2593,12 +2593,16 @@ impl AccountsDb {
             measure_shrink_all_candidates.as_ms() as usize
         );
         inc_new_counter_info!("shrink_all_candidate_slots-count", shrink_candidates_count);
+        let mut pended_counts: usize = 0;
         if let Some(shrink_slots_next_batch) = shrink_slots_next_batch {
             let mut shrink_slots = self.shrink_candidate_slots.lock().unwrap();
             for (slot, stores) in shrink_slots_next_batch {
+                pended_counts += stores.len();
                 shrink_slots.entry(slot).or_default().extend(stores);
             }
         }
+        inc_new_counter_info!("shrink_pended_stores-count", pended_counts);
+
         num_candidates
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10014,7 +10014,7 @@ pub mod tests {
         ));
 
         // The store2's alive_ratio is 0.5: as its page aligned alive size is 1 page.
-        let store2_alive_bytes = 1024;
+        let store2_alive_bytes = (PAGE_SIZE - 1) as usize;
         store2
             .alive_bytes
             .store(store2_alive_bytes, Ordering::Relaxed);
@@ -10032,7 +10032,7 @@ pub mod tests {
         ));
 
         // The store3's alive ratio is 1.0 as its page-aligned alive size is 2 pages
-        let store3_alive_bytes = 1024 * 7;
+        let store3_alive_bytes = (PAGE_SIZE + 1) as usize;
         entry3
             .alive_bytes
             .store(store3_alive_bytes, Ordering::Relaxed);
@@ -10042,7 +10042,7 @@ pub mod tests {
             .or_default()
             .insert(entry3.append_vec_id(), entry3.clone());
 
-        // Set the target alive ratio to 0.6 so that we can just get rid of store1, the remaing two stores
+        // Set the target alive ratio to 0.6 so that we can just get rid of store1, the remaining two stores
         // alive ratio can be > the target ratio: the actual ratio is 0.75 because of 3 alive pages / 4 total pages.
         // The target ratio is also set to larger than store2's alive ratio: 0.5 so that it would be added
         // to the candidates list for next round.
@@ -10090,7 +10090,7 @@ pub mod tests {
         ));
 
         // The store2's alive_ratio is 0.5: as its page aligned alive size is 1 page.
-        let store2_alive_bytes = 1024;
+        let store2_alive_bytes = (PAGE_SIZE - 1) as usize;
         store2
             .alive_bytes
             .store(store2_alive_bytes, Ordering::Relaxed);
@@ -10108,7 +10108,7 @@ pub mod tests {
         ));
 
         // The store3's alive ratio is 1.0 as its page-aligned alive size is 2 pages
-        let store3_alive_bytes = 1024 * 7;
+        let store3_alive_bytes = (PAGE_SIZE + 1) as usize;
         entry3
             .alive_bytes
             .store(store3_alive_bytes, Ordering::Relaxed);
@@ -10149,7 +10149,7 @@ pub mod tests {
         ));
 
         // store1 has 1 page-aligned alive bytes, its alive ratio is 1/4: 0.25
-        let store1_alive_bytes = 3 * 1024;
+        let store1_alive_bytes = (PAGE_SIZE - 1) as usize;
         store1
             .alive_bytes
             .store(store1_alive_bytes, Ordering::Relaxed);
@@ -10169,7 +10169,7 @@ pub mod tests {
         ));
 
         // store2 has 2 page-aligned bytes, its alive ratio is 2/4: 0.5
-        let store2_alive_bytes = 5 * 1024;
+        let store2_alive_bytes = (PAGE_SIZE + 1) as usize;
         store2
             .alive_bytes
             .store(store2_alive_bytes, Ordering::Relaxed);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2500,6 +2500,7 @@ impl AccountsDb {
         let mut total_alive_bytes: u64 = 0;
         let mut candidates_count: usize = 0;
         let mut total_bytes: u64 = 0;
+        let mut total_candidate_stores: i64 = 0;
         for (slot, slot_shrink_candidates) in shrink_slots {
             candidates_count += slot_shrink_candidates.len();
             for store in slot_shrink_candidates.values() {
@@ -2512,6 +2513,7 @@ impl AccountsDb {
                     alive_ratio,
                     store: store.clone(),
                 });
+                total_candidate_stores += 1;
             }
         }
         store_usage.sort_by(|a, b| {
@@ -2561,6 +2563,24 @@ impl AccountsDb {
             measure.as_ms() as usize
         );
         inc_new_counter_info!("select_top_sparse_storage_entries-seeds", candidates_count);
+        datapoint_info!(
+            "shrink-candidates",
+            (
+                "total_preliminary_candidate_stores",
+                total_candidate_stores,
+                i64
+            ),
+            (
+                "select_top_sparse_storage_entries-ms",
+                measure.as_ms() as u64,
+                i64
+            ),
+            (
+                "select_top_sparse_storage_entries-seeds",
+                candidates_count,
+                i64
+            ),
+        );
         (shrink_slots, shrink_slots_next_batch)
     }
 


### PR DESCRIPTION
#### Problem
The shrink by total usage may skip shrink candidates in the next round.

#### Summary of Changes
If the candidate's own alive ratio is lower than the threshold add it back to the candidate so that it can be processed next time.

Fixes #
