### PR TITLE
Add parameter to allow setting max-retries for SendTransaction rpc

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -167,6 +167,7 @@ impl Banks for BanksServer {
             serialize(&transaction).unwrap(),
             last_valid_block_height,
             None,
+            None,
         );
         self.transaction_sender.send(info).unwrap();
     }
@@ -256,6 +257,7 @@ impl Banks for BanksServer {
             signature,
             serialize(&transaction).unwrap(),
             last_valid_block_height,
+            None,
             None,
         );
         self.transaction_sender.send(info).unwrap();

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -21,6 +21,7 @@ pub struct RpcSendTransactionConfig {
     pub skip_preflight: bool,
     pub preflight_commitment: Option<CommitmentLevel>,
     pub encoding: Option<UiTransactionEncoding>,
+    pub max_retries: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3246,6 +3246,8 @@ submission.
   - `skipPreflight: <bool>` - if true, skip the preflight transaction checks (default: false)
   - `preflightCommitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to use for preflight (default: `"finalized"`).
   - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
+  - `maxRetries: <usize>` - (optional) Maximum number of times for the RPC node to retry sending the transaction to the leader.
+  If this parameter not provided, the RPC node will retry the transaction until it is finalized or until the blockhash expires.
 
 #### Results:
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2216,12 +2216,14 @@ fn _send_transaction(
     wire_transaction: Vec<u8>,
     last_valid_block_height: u64,
     durable_nonce_info: Option<(Pubkey, Hash)>,
+    max_retries: Option<usize>,
 ) -> Result<String> {
     let transaction_info = TransactionInfo::new(
         signature,
         wire_transaction,
         last_valid_block_height,
         durable_nonce_info,
+        max_retries,
     );
     meta.transaction_sender
         .lock()
@@ -3291,6 +3293,7 @@ pub mod rpc_full {
                 wire_transaction,
                 last_valid_block_height,
                 None,
+                None,
             )
         }
 
@@ -3390,6 +3393,7 @@ pub mod rpc_full {
                 wire_transaction,
                 last_valid_block_height,
                 durable_nonce_info,
+                config.max_retries,
             )
         }
 


### PR DESCRIPTION
#### Problem
Some transactions are only relevant if they execute promptly, but an rpc node will retry every transaction it receives until the recent blockhash expires, potentially wasting rpc and validator banking-stage cycles.

#### Summary of Changes
Add parameter to allow setting max-retries for SendTransaction rpc
Add tracking in SendTransactionService for transactions dropped due to reaching max-retries

Fixes #19347 
