### PR TITLE
Preserve pre-existing vote/stake keypairs for bootstrap validator

### DIFF
--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -21,9 +21,16 @@ if [[ -f $BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR ]]; then
 else
   $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
 fi
-
-$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
-$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
+if [[ -f $BOOTSTRAP_VALIDATOR_STAKE_KEYPAIR ]]; then
+  cp -f "$BOOTSTRAP_VALIDATOR_STAKE_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
+else
+  $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
+fi
+if [[ -f $BOOTSTRAP_VALIDATOR_VOTE_KEYPAIR ]]; then
+  cp -f "$BOOTSTRAP_VALIDATOR_VOTE_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
+else
+  $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
+fi
 
 args=(
   "$@"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -217,6 +217,12 @@ EOF
       if [[ -f net/keypairs/bootstrap-validator-identity.json ]]; then
         export BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR=net/keypairs/bootstrap-validator-identity.json
       fi
+      if [[ -f net/keypairs/bootstrap-validator-stake.json ]]; then
+        export BOOTSTRAP_VALIDATOR_STAKE_KEYPAIR=net/keypairs/bootstrap-validator-stake.json
+      fi
+      if [[ -f net/keypairs/bootstrap-validator-vote.json ]]; then
+        export BOOTSTRAP_VALIDATOR_VOTE_KEYPAIR=net/keypairs/bootstrap-validator-vote.json
+      fi
       echo "remote-node.sh: Primordial stakes: $extraPrimordialStakes"
       if [[ "$extraPrimordialStakes" -gt 0 ]]; then
         if [[ "$extraPrimordialStakes" -gt "$numNodes" ]]; then


### PR DESCRIPTION
#### Problem
When rebooting a test cluster from a snapshot, the validators need to use the same vote accounts, and it is possible to provide these static keypairs via a `/keypairs` directory. This works well for non-bootstrap validators, but `remote-node.sh` creates a new vote account for the bootstrap-validator on every run, causing that node's stake to be always delinquent.

#### Summary of Changes
Add handling to look for bootstrap stake- and vote-account keypairs in `/keypairs`
