### PR TITLE
cli: show upgradeable program accounts

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -442,6 +442,8 @@ fn test_cli_program_deploy_with_authority() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(program_pubkey),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });
@@ -533,6 +535,8 @@ fn test_cli_program_deploy_with_authority() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(program_pubkey),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });
@@ -748,6 +752,8 @@ fn test_cli_program_write_buffer() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(buffer_keypair.pubkey()),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });
@@ -841,6 +847,8 @@ fn test_cli_program_write_buffer() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(buffer_pubkey),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });
@@ -1177,6 +1185,8 @@ fn test_cli_program_show() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(buffer_keypair.pubkey()),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });
@@ -1237,6 +1247,8 @@ fn test_cli_program_show() {
     config.command = CliCommand::Program(ProgramCliCommand::Show {
         account_pubkey: Some(program_keypair.pubkey()),
         authority_pubkey: keypair.pubkey(),
+        get_programs: false,
+        get_buffers: false,
         all: false,
         use_lamports_unit: false,
     });


### PR DESCRIPTION
#### Problem

The command-line interface does not support showing upgradeable program accounts.  One reason developers may want to show program accounts is to clean up and reclaim lamports from any programs they may have been using for development and forgotten about.

#### Summary of Changes

Add the ability to show program accounts in the command-line interface.

Fixes #
