### PR TITLE
chore: bump time from 0.3.1 to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,7 +3671,7 @@ dependencies = [
  "solana-logger 1.8.0",
  "solana-sdk",
  "solana_rbpf",
- "time 0.3.1",
+ "time 0.3.2",
 ]
 
 [[package]]
@@ -6418,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a776787d9c5d455bec3db044586ccdd8a9c74d5da5dc319fb80f3db08808fe6"
+checksum = "3e0a10c9a9fb3a5dce8c2239ed670f1a2569fcf42da035f5face1b19860d52b0"
 dependencies = [
  "libc",
 ]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -16,4 +16,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.8.0
 solana-logger = { path = "../logger", version = "=1.8.0" }
 solana-sdk = { path = "../sdk", version = "=1.8.0" }
 solana_rbpf = "=0.2.14"
-time = "0.3.1"
+time = "0.3.2"


### PR DESCRIPTION
#### Problem
`time` sub-dependencies scuttle dependabot build

#### Summary of Changes
Bump manually

Closes #19443