### PR TITLE
Add missing owner check to bpf loader close ix

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -692,6 +692,10 @@ fn process_loader_upgradeable_instruction(
                         ic_logger_msg!(logger, "Program account is not writable");
                         return Err(InstructionError::InvalidArgument);
                     }
+                    if &program_account.owner()? != program_id {
+                        ic_logger_msg!(logger, "Program account not owned by loader");
+                        return Err(InstructionError::IncorrectProgramId);
+                    }
 
                     match program_account.state()? {
                         UpgradeableLoaderState::Program {


### PR DESCRIPTION
#### Problem
When closing a programdata account, the corresponding program account must have a write lock to ensure that the program is not invoked in parallel with the transaction that closes the program. Currently, the write lock is checked, but a bogus program account could be supplied since the owner is not checked.

#### Summary of Changes
- Add owner check for program account when closing a programdata account

Fixes #
