### PR TITLE
Limit message encoding to base-64

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -3892,7 +3892,7 @@ impl RpcClient {
                 serialize_and_encode::<Message>(message, UiTransactionEncoding::Base64)?;
             let result = self.send::<Response<Option<u64>>>(
                 RpcRequest::GetFeeForMessage,
-                json!([blockhash.to_string(), serialized_encoded, self.commitment(),]),
+                json!([blockhash.to_string(), serialized_encoded, self.commitment()]),
             )?;
             result
                 .value

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -3892,12 +3892,7 @@ impl RpcClient {
                 serialize_and_encode::<Message>(message, UiTransactionEncoding::Base64)?;
             let result = self.send::<Response<Option<u64>>>(
                 RpcRequest::GetFeeForMessage,
-                json!([
-                    blockhash.to_string(),
-                    serialized_encoded,
-                    UiTransactionEncoding::Base64,
-                    self.commitment(),
-                ]),
+                json!([blockhash.to_string(), serialized_encoded, self.commitment(),]),
             )?;
             result
                 .value

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1149,8 +1149,7 @@ Get the fee the network will charge for a particular Message
 #### Parameters:
 
 - `blockhash: <string>` - The blockhash of this block, as base-58 encoded string
-- `message: <string>` - Encoded Message
-  - `encoding: <string>` - (optional) Encoding used for the message data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
+- `message: <string>` - Base-64 encoded Message
 - `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
 
 #### Results:
@@ -1168,7 +1167,6 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
   "method":"getFeeForMessage",
   "params":[
     "FxVKTksYShgKjnFG3RQUEo2AEesDb4ZHGY3NGJ7KHd7F","AQABAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAA",
-    "base64",
     {
       "commitment":"processed"
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3111,7 +3111,6 @@ pub mod rpc_full {
             meta: Self::Metadata,
             blockhash: String,
             data: String,
-            encoding: UiTransactionEncoding,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<Option<u64>>>;
     }
@@ -3636,13 +3635,13 @@ pub mod rpc_full {
             meta: Self::Metadata,
             blockhash: String,
             data: String,
-            encoding: UiTransactionEncoding,
             commitment: Option<CommitmentConfig>,
         ) -> Result<RpcResponse<Option<u64>>> {
             debug!("get_fee_for_message rpc request received");
             let blockhash = Hash::from_str(&blockhash)
                 .map_err(|e| Error::invalid_params(format!("{:?}", e)))?;
-            let (_, message) = decode_and_deserialize::<Message>(data, encoding)?;
+            let (_, message) =
+                decode_and_deserialize::<Message>(data, UiTransactionEncoding::Base64)?;
             SanitizedMessage::try_from(message)
                 .map_err(|err| {
                     Error::invalid_params(format!("invalid transaction message: {}", err))


### PR DESCRIPTION
#### Problem

base-58 encoded messages are lame

#### Summary of Changes

Don't allow it!

Fixes #
