### PR TITLE
Index loaders / executable accounts

### DIFF
--- a/program-runtime/src/instruction_processor.rs
+++ b/program-runtime/src/instruction_processor.rs
@@ -663,28 +663,6 @@ impl InstructionProcessor {
         }
     }
 
-    /// Record the initial state of the accounts so that they can be compared
-    /// after the instruction is processed
-    pub fn create_pre_accounts(
-        message: &Message,
-        instruction: &CompiledInstruction,
-        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
-    ) -> Vec<PreAccount> {
-        let mut pre_accounts = Vec::with_capacity(instruction.accounts.len());
-        {
-            let mut work = |_unique_index: usize, account_index: usize| {
-                if account_index < message.account_keys.len() && account_index < accounts.len() {
-                    let account = accounts[account_index].1.borrow();
-                    pre_accounts.push(PreAccount::new(&accounts[account_index].0, &account));
-                    return Ok(());
-                }
-                Err(InstructionError::MissingAccount)
-            };
-            let _ = instruction.visit_each_account(&mut work);
-        }
-        pre_accounts
-    }
-
     /// Verify the results of a cross-program instruction
     #[allow(clippy::too_many_arguments)]
     pub fn verify_and_update(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2229,14 +2229,15 @@ where
     let mut accounts = Vec::with_capacity(account_keys.len());
     let mut refs = Vec::with_capacity(account_keys.len());
     for (i, ref account_key) in account_keys.iter().enumerate() {
-        let account = invoke_context.get_account(account_key).ok_or_else(|| {
-            ic_msg!(
-                invoke_context,
-                "Instruction references an unknown account {}",
-                account_key
-            );
-            SyscallError::InstructionError(InstructionError::MissingAccount)
-        })?;
+        let (_account_index, account) =
+            invoke_context.get_account(account_key).ok_or_else(|| {
+                ic_msg!(
+                    invoke_context,
+                    "Instruction references an unknown account {}",
+                    account_key
+                );
+                SyscallError::InstructionError(InstructionError::MissingAccount)
+            })?;
 
         if i == program_account_index || account.borrow().executable() {
             // Use the known account
@@ -2321,14 +2322,20 @@ fn get_upgradeable_executable(
     callee_program_id: &Pubkey,
     program_account: &Rc<RefCell<AccountSharedData>>,
     invoke_context: &Ref<&mut dyn InvokeContext>,
-) -> Result<Option<(Pubkey, Rc<RefCell<AccountSharedData>>)>, EbpfError<BpfError>> {
+) -> Result<Option<(Pubkey, Rc<RefCell<AccountSharedData>>, usize)>, EbpfError<BpfError>> {
     if program_account.borrow().owner() == &bpf_loader_upgradeable::id() {
         match program_account.borrow().state() {
             Ok(UpgradeableLoaderState::Program {
                 programdata_address,
             }) => {
-                if let Some(account) = invoke_context.get_account(&programdata_address) {
-                    Ok(Some((programdata_address, account)))
+                if let Some((programdata_account_index, account)) =
+                    invoke_context.get_account(&programdata_address)
+                {
+                    Ok(Some((
+                        programdata_address,
+                        account,
+                        programdata_account_index,
+                    )))
                 } else {
                     ic_msg!(
                         invoke_context,
@@ -2442,16 +2449,22 @@ fn call<'a>(
         let program_account = accounts
             .get(callee_program_id_index)
             .ok_or_else(|| {
-                ic_msg!(invoke_context, "Unknown program {}", callee_program_id,);
+                ic_msg!(invoke_context, "Unknown program {}", callee_program_id);
                 SyscallError::InstructionError(InstructionError::MissingAccount)
             })?
             .1
             .clone();
+        let (program_account_index, found_program_account) =
+            invoke_context.get_account(&callee_program_id).ok_or(
+                SyscallError::InstructionError(InstructionError::MissingAccount),
+            )?;
+        assert_eq!(program_account, found_program_account);
+
         let programdata_executable =
             get_upgradeable_executable(&callee_program_id, &program_account, &invoke_context)?;
-        let mut executables = vec![(callee_program_id, program_account)];
-        if let Some(executable) = programdata_executable {
-            executables.push(executable);
+        let mut executables = vec![(callee_program_id, program_account, program_account_index)];
+        if let Some(programdata_executable) = programdata_executable {
+            executables.push(programdata_executable);
         }
 
         // Record the instruction

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -244,7 +244,10 @@ impl Accounts {
             let is_upgradeable_loader_present = is_upgradeable_loader_present(message);
 
             for (i, key) in message.account_keys_iter().enumerate() {
-                let account = if message.is_non_loader_key(i) {
+                let account = if !message.is_non_loader_key(i) {
+                    // Fill in an empty account for the program slots.
+                    AccountSharedData::default()
+                } else {
                     if payer_index.is_none() {
                         payer_index = Some(i);
                     }
@@ -289,12 +292,12 @@ impl Accounts {
                                     programdata_address,
                                 }) = account.state()
                                 {
-                                    if let Some(account) = self
+                                    if let Some((programdata_account, _)) = self
                                         .accounts_db
                                         .load_with_fixed_root(ancestors, &programdata_address)
-                                        .map(|(account, _)| account)
                                     {
-                                        account_deps.push((programdata_address, account));
+                                        account_deps
+                                            .push((programdata_address, programdata_account));
                                     } else {
                                         error_counters.account_not_found += 1;
                                         return Err(TransactionError::ProgramAccountNotFound);
@@ -317,9 +320,6 @@ impl Accounts {
 
                         account
                     }
-                } else {
-                    // Fill in an empty account for the program slots.
-                    AccountSharedData::default()
                 };
                 accounts.push((*key, account));
             }
@@ -338,50 +338,46 @@ impl Accounts {
                 let payer_account = &mut accounts[payer_index].1;
                 if payer_account.lamports() == 0 {
                     error_counters.account_not_found += 1;
-                    Err(TransactionError::AccountNotFound)
-                } else {
-                    let min_balance =
-                        match get_system_account_kind(payer_account).ok_or_else(|| {
-                            error_counters.invalid_account_for_fee += 1;
-                            TransactionError::InvalidAccountForFee
-                        })? {
-                            SystemAccountKind::System => 0,
-                            SystemAccountKind::Nonce => {
-                                // Should we ever allow a fees charge to zero a nonce account's
-                                // balance. The state MUST be set to uninitialized in that case
-                                rent_collector.rent.minimum_balance(nonce::State::size())
-                            }
-                        };
-
-                    if payer_account.lamports() < fee + min_balance {
-                        error_counters.insufficient_funds += 1;
-                        Err(TransactionError::InsufficientFundsForFee)
-                    } else {
-                        payer_account
-                            .checked_sub_lamports(fee)
-                            .map_err(|_| TransactionError::InsufficientFundsForFee)?;
-
-                        let message = tx.message();
-                        let program_indices = message
-                            .program_instructions_iter()
-                            .map(|(program_id, _ix)| {
-                                self.load_executable_accounts(ancestors, program_id, error_counters)
-                                    .map(|programs| {
-                                        let base_index = accounts.len();
-                                        accounts.append(&mut programs.clone());
-                                        (base_index..base_index + programs.len())
-                                            .collect::<Vec<_>>()
-                                    })
-                            })
-                            .collect::<Result<Vec<Vec<usize>>>>()?;
-                        Ok(LoadedTransaction {
-                            accounts,
-                            program_indices,
-                            rent: tx_rent,
-                            rent_debits,
-                        })
-                    }
+                    return Err(TransactionError::AccountNotFound);
                 }
+                let min_balance = match get_system_account_kind(payer_account).ok_or_else(|| {
+                    error_counters.invalid_account_for_fee += 1;
+                    TransactionError::InvalidAccountForFee
+                })? {
+                    SystemAccountKind::System => 0,
+                    SystemAccountKind::Nonce => {
+                        // Should we ever allow a fees charge to zero a nonce account's
+                        // balance. The state MUST be set to uninitialized in that case
+                        rent_collector.rent.minimum_balance(nonce::State::size())
+                    }
+                };
+
+                if payer_account.lamports() < fee + min_balance {
+                    error_counters.insufficient_funds += 1;
+                    return Err(TransactionError::InsufficientFundsForFee);
+                }
+                payer_account
+                    .checked_sub_lamports(fee)
+                    .map_err(|_| TransactionError::InsufficientFundsForFee)?;
+
+                let program_indices = message
+                    .instructions()
+                    .iter()
+                    .map(|instruction| {
+                        self.load_executable_accounts(
+                            ancestors,
+                            &mut accounts,
+                            instruction.program_id_index as usize,
+                            error_counters,
+                        )
+                    })
+                    .collect::<Result<Vec<Vec<usize>>>>()?;
+                Ok(LoadedTransaction {
+                    accounts,
+                    program_indices,
+                    rent: tx_rent,
+                    rent_debits,
+                })
             } else {
                 error_counters.account_not_found += 1;
                 Err(TransactionError::AccountNotFound)
@@ -392,35 +388,35 @@ impl Accounts {
     fn load_executable_accounts(
         &self,
         ancestors: &Ancestors,
-        program_id: &Pubkey,
+        accounts: &mut Vec<(Pubkey, AccountSharedData)>,
+        mut program_account_index: usize,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<(Pubkey, AccountSharedData)>> {
-        let mut accounts = Vec::new();
+    ) -> Result<Vec<usize>> {
+        let mut account_indices = Vec::new();
+        let mut program_id = accounts[program_account_index].0;
         let mut depth = 0;
-        let mut program_id = *program_id;
-        loop {
-            if native_loader::check_id(&program_id) {
-                // At the root of the chain, ready to dispatch
-                break;
-            }
-
+        while !native_loader::check_id(&program_id) {
             if depth >= 5 {
                 error_counters.call_chain_too_deep += 1;
                 return Err(TransactionError::CallChainTooDeep);
             }
             depth += 1;
 
-            let program = match self
+            program_account_index = match self
                 .accounts_db
                 .load_with_fixed_root(ancestors, &program_id)
-                .map(|(account, _)| account)
             {
-                Some(program) => program,
+                Some((program_account, _)) => {
+                    let account_index = accounts.len();
+                    accounts.push((program_id, program_account));
+                    account_index
+                }
                 None => {
                     error_counters.account_not_found += 1;
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
             };
+            let program = &accounts[program_account_index].1;
             if !program.executable() {
                 error_counters.invalid_program_for_execution += 1;
                 return Err(TransactionError::InvalidProgramForExecution);
@@ -435,26 +431,31 @@ impl Accounts {
                     programdata_address,
                 }) = program.state()
                 {
-                    if let Some(program) = self
+                    let programdata_account_index = match self
                         .accounts_db
                         .load_with_fixed_root(ancestors, &programdata_address)
-                        .map(|(account, _)| account)
                     {
-                        accounts.insert(0, (programdata_address, program));
-                    } else {
-                        error_counters.account_not_found += 1;
-                        return Err(TransactionError::ProgramAccountNotFound);
-                    }
+                        Some((programdata_account, _)) => {
+                            let account_index = accounts.len();
+                            accounts.push((programdata_address, programdata_account));
+                            account_index
+                        }
+                        None => {
+                            error_counters.account_not_found += 1;
+                            return Err(TransactionError::ProgramAccountNotFound);
+                        }
+                    };
+                    account_indices.insert(0, programdata_account_index);
                 } else {
                     error_counters.invalid_program_for_execution += 1;
                     return Err(TransactionError::InvalidProgramForExecution);
                 }
             }
 
-            accounts.insert(0, (program_id, program));
+            account_indices.insert(0, program_account_index);
             program_id = program_owner;
         }
-        Ok(accounts)
+        Ok(account_indices)
     }
 
     pub fn load_accounts(
@@ -1765,7 +1766,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);
-        assert_eq!(result.loaders[0], vec![accounts[2].clone()]);
+        assert_eq!(result.accounts[result.program_indices[0][0]], accounts[2]);
     }
 
     #[test]
@@ -1848,7 +1849,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);
-        assert_eq!(result.loaders[0], vec![accounts[5].clone()]);
+        assert_eq!(result.accounts[result.program_indices[0][0]], accounts[5]);
 
         // Solution 2: mark programdata as readonly
         message.account_keys = vec![key0, key1, key2]; // revert key change
@@ -1860,14 +1861,9 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);
-        assert_eq!(
-            result.loaders[0],
-            vec![
-                accounts[5].clone(),
-                accounts[3].clone(),
-                accounts[4].clone()
-            ]
-        );
+        assert_eq!(result.accounts[result.program_indices[0][0]], accounts[5]);
+        assert_eq!(result.accounts[result.program_indices[0][1]], accounts[3]);
+        assert_eq!(result.accounts[result.program_indices[0][2]], accounts[4]);
     }
 
     #[test]
@@ -1936,8 +1932,8 @@ mod tests {
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts_with_upgradeable_loader[..2]);
         assert_eq!(
-            result.loaders[0],
-            vec![accounts_with_upgradeable_loader[2].clone()]
+            result.accounts[result.program_indices[0][0]],
+            accounts_with_upgradeable_loader[2]
         );
 
         // Solution 2: mark programdata as readonly
@@ -1950,7 +1946,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);
-        assert_eq!(result.loaders[0], vec![accounts[2].clone()]);
+        assert_eq!(result.accounts[result.program_indices[0][0]], accounts[2]);
     }
 
     #[test]
@@ -1965,11 +1961,17 @@ mod tests {
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
 
+        let keypair = Keypair::new();
+        let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
+        account.set_executable(true);
+        accounts.store_slow_uncached(0, &keypair.pubkey(), &account);
+
         assert_eq!(
             accounts.load_executable_accounts(
                 &ancestors,
-                &solana_sdk::pubkey::new_rand(),
-                &mut error_counters
+                &mut vec![(keypair.pubkey(), account)],
+                0,
+                &mut error_counters,
             ),
             Err(TransactionError::ProgramAccountNotFound)
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -366,6 +366,10 @@ impl Accounts {
                             .program_instructions_iter()
                             .map(|(program_id, _ix)| {
                                 self.load_executable_accounts(ancestors, program_id, error_counters)
+                                    .map(|loaders| {
+                                        accounts.append(&mut loaders.clone());
+                                        loaders
+                                    })
                             })
                             .collect::<Result<TransactionLoaders>>()?;
                         Ok(LoadedTransaction {
@@ -1654,7 +1658,7 @@ mod tests {
         assert_eq!(loaded_accounts.len(), 1);
         match &loaded_accounts[0] {
             (Ok(loaded_transaction), _nonce_rollback) => {
-                assert_eq!(loaded_transaction.accounts.len(), 3);
+                assert_eq!(loaded_transaction.accounts.len(), 6);
                 assert_eq!(loaded_transaction.accounts[0].1, accounts[0].1);
                 assert_eq!(loaded_transaction.loaders.len(), 2);
                 assert_eq!(loaded_transaction.loaders[0].len(), 1);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2818,6 +2818,7 @@ impl Bank {
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
 
+        let number_of_accounts = transaction.message().account_keys_len();
         let batch = self.prepare_simulation_batch(transaction);
         let mut timings = ExecuteTimings::default();
 
@@ -2848,7 +2849,13 @@ impl Bank {
             .unwrap()
             .0
             .ok()
-            .map(|loaded_transaction| loaded_transaction.accounts.into_iter().collect::<Vec<_>>())
+            .map(|loaded_transaction| {
+                loaded_transaction
+                    .accounts
+                    .into_iter()
+                    .take(number_of_accounts)
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default();
 
         let units_consumed = timings

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -58,7 +58,7 @@ pub trait InvokeContext {
         key: &Pubkey,
         message: &Message,
         instruction: &CompiledInstruction,
-        executable_indices: &[(Pubkey, Rc<RefCell<AccountSharedData>>, usize)],
+        program_indices: &[usize],
         instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
     ) -> Result<(), InstructionError>;
     /// Pop a stack frame from the invocation stack
@@ -442,16 +442,14 @@ pub fn mock_set_sysvar<T: Sysvar>(
 }
 
 impl<'a> InvokeContext for MockInvokeContext<'a> {
-    #[allow(unreachable_code)] // TODO
     fn push(
         &mut self,
         _key: &Pubkey,
         _message: &Message,
         _instruction: &CompiledInstruction,
-        _executable_indices: &[(Pubkey, Rc<RefCell<AccountSharedData>>, usize)],
+        _program_indices: &[usize],
         _instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
     ) -> Result<(), InstructionError> {
-        panic!("unimplemented");
         self.invoke_stack.push(InvokeContextStackFrame::new(
             *_key,
             create_keyed_accounts_unified(&[]),

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -7,6 +7,7 @@ use solana_sdk::{
     hash::Hash,
     instruction::{CompiledInstruction, Instruction, InstructionError},
     keyed_account::{create_keyed_accounts_unified, KeyedAccount},
+    message::Message,
     pubkey::Pubkey,
     sysvar::Sysvar,
 };
@@ -55,7 +56,10 @@ pub trait InvokeContext {
     fn push(
         &mut self,
         key: &Pubkey,
-        keyed_accounts: &[(bool, bool, &Pubkey, &RefCell<AccountSharedData>)],
+        message: &Message,
+        instruction: &CompiledInstruction,
+        executable_indices: &[(Pubkey, Rc<RefCell<AccountSharedData>>, usize)],
+        instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
     ) -> Result<(), InstructionError>;
     /// Pop a stack frame from the invocation stack
     ///
@@ -438,17 +442,19 @@ pub fn mock_set_sysvar<T: Sysvar>(
 }
 
 impl<'a> InvokeContext for MockInvokeContext<'a> {
+    #[allow(unreachable_code)] // TODO
     fn push(
         &mut self,
-        key: &Pubkey,
-        keyed_accounts: &[(bool, bool, &Pubkey, &RefCell<AccountSharedData>)],
+        _key: &Pubkey,
+        _message: &Message,
+        _instruction: &CompiledInstruction,
+        _executable_indices: &[(Pubkey, Rc<RefCell<AccountSharedData>>, usize)],
+        _instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
     ) -> Result<(), InstructionError> {
-        fn transmute_lifetime<'a, 'b>(value: Vec<KeyedAccount<'a>>) -> Vec<KeyedAccount<'b>> {
-            unsafe { std::mem::transmute(value) }
-        }
+        panic!("unimplemented");
         self.invoke_stack.push(InvokeContextStackFrame::new(
-            *key,
-            transmute_lifetime(create_keyed_accounts_unified(keyed_accounts)),
+            *_key,
+            create_keyed_accounts_unified(&[]),
         ));
         Ok(())
     }

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -95,8 +95,8 @@ pub trait InvokeContext {
     fn record_instruction(&self, instruction: &Instruction);
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
-    /// Get an account by its key
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>>;
+    /// Find an account_index and account by its key
+    fn get_account(&self, pubkey: &Pubkey) -> Option<(usize, Rc<RefCell<AccountSharedData>>)>;
     /// Update timing
     fn update_timing(
         &mut self,
@@ -509,10 +509,10 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool {
         !self.disabled_features.contains(feature_id)
     }
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>> {
-        for (key, account) in self.accounts.iter() {
+    fn get_account(&self, pubkey: &Pubkey) -> Option<(usize, Rc<RefCell<AccountSharedData>>)> {
+        for (index, (key, account)) in self.accounts.iter().enumerate().rev() {
             if key == pubkey {
-                return Some(account.clone());
+                return Some((index, account.clone()));
             }
         }
         None


### PR DESCRIPTION
#### Problem
Loaders / executable accounts are still separate and need to be concatenated with the regular accounts in order to be indexed (transaction wide).
See #14523.

#### Summary of Changes
* Replaces `loaders` by `executable_indices`.
* Moves `MessageProcessor::create_keyed_accounts()` into `InvokeContext::push()`.
* WIP feature gate: Fill executable account gaps with the real deal directly (requires them to be read-only).