### PR TITLE
fix typo in calling-between-programs developing documentation

### DIFF
--- a/docs/src/developing/programming-model/calling-between-programs.md
+++ b/docs/src/developing/programming-model/calling-between-programs.md
@@ -124,7 +124,7 @@ point that it gets called back.
 
 ## Program Derived Addresses
 
-Program derived addresses allow programmaticly generated signature to be used
+Program derived addresses allow programmatically generated signatures to be used
 when [calling between programs](#cross-program-invocations).
 
 Using a program derived address, a program may be given the authority over an


### PR DESCRIPTION
#### Problem

Typo in the `docs/src/developing/programming-model/calling-between-programs.md` documentation file.

#### Summary of Changes

Fixes the two discovered typos.
