### PR TITLE
Populate memo in bigtable transaction structs

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -12,9 +12,10 @@ use {
     },
     solana_storage_proto::convert::{generated, tx_by_addr},
     solana_transaction_status::{
-        ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Reward,
-        TransactionByAddrInfo, TransactionConfirmationStatus, TransactionStatus,
-        TransactionStatusMeta, TransactionWithStatusMeta,
+        extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransaction,
+        ConfirmedTransactionStatusWithSignature, Reward, TransactionByAddrInfo,
+        TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
+        TransactionWithStatusMeta,
     },
     std::{collections::HashMap, convert::TryInto},
     thiserror::Error,
@@ -559,6 +560,7 @@ impl LedgerStorage {
             let err = meta.as_ref().and_then(|meta| meta.status.clone().err());
             let index = index as u32;
             let signature = transaction.signatures[0];
+            let memo = extract_and_fmt_memos(&transaction.message);
 
             for address in &transaction.message.account_keys {
                 if !is_sysvar_id(address) {
@@ -569,7 +571,7 @@ impl LedgerStorage {
                             signature,
                             err: err.clone(),
                             index,
-                            memo: None, // TODO
+                            memo: memo.clone(),
                             block_time: confirmed_block.block_time,
                         });
                 }
@@ -581,7 +583,7 @@ impl LedgerStorage {
                     slot,
                     index,
                     err,
-                    memo: None, // TODO
+                    memo,
                 },
             ));
         }

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -32,7 +32,10 @@ fn extract_memos(message: &Message) -> Vec<String> {
         for instruction in &message.instructions {
             let program_id = message.account_keys[instruction.program_id_index as usize];
             if program_id == spl_memo_id_v1() || program_id == spl_memo_id_v3() {
-                memos.push(parse_memo_data(&instruction.data).unwrap_or_default());
+                let memo_len = instruction.data.len();
+                let parsed_memo = parse_memo_data(&instruction.data)
+                    .unwrap_or_else(|_| "(unparseable)".to_string());
+                memos.push(format!("[{}] {}", memo_len, parsed_memo));
             }
         }
     }

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -1,0 +1,40 @@
+use {
+    crate::parse_instruction::parse_memo_data,
+    solana_sdk::{message::Message, pubkey::Pubkey},
+};
+
+// A helper function to convert spl_memo::v1::id() as spl_sdk::pubkey::Pubkey to
+// solana_sdk::pubkey::Pubkey
+pub fn spl_memo_id_v1() -> Pubkey {
+    Pubkey::new_from_array(spl_memo::v1::id().to_bytes())
+}
+
+// A helper function to convert spl_memo::id() as spl_sdk::pubkey::Pubkey to
+// solana_sdk::pubkey::Pubkey
+pub fn spl_memo_id_v3() -> Pubkey {
+    Pubkey::new_from_array(spl_memo::id().to_bytes())
+}
+
+pub fn extract_and_fmt_memos(message: &Message) -> Option<String> {
+    let memos = extract_memos(message);
+    if memos.is_empty() {
+        None
+    } else {
+        Some(memos.join("; "))
+    }
+}
+
+fn extract_memos(message: &Message) -> Vec<String> {
+    let mut memos = vec![];
+    if message.account_keys.contains(&spl_memo_id_v1())
+        || message.account_keys.contains(&spl_memo_id_v3())
+    {
+        for instruction in &message.instructions {
+            let program_id = message.account_keys[instruction.program_id_index as usize];
+            if program_id == spl_memo_id_v1() || program_id == spl_memo_id_v3() {
+                memos.push(parse_memo_data(&instruction.data).unwrap_or_default());
+            }
+        }
+    }
+    memos
+}

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
 
+pub mod extract_memos;
 pub mod parse_accounts;
 pub mod parse_associated_token;
 pub mod parse_bpf_loader;
@@ -14,6 +15,7 @@ pub mod parse_token;
 pub mod parse_vote;
 pub mod token_balances;
 
+pub use crate::extract_memos::extract_and_fmt_memos;
 use crate::{
     parse_accounts::{parse_accounts, ParsedAccount},
     parse_instruction::{parse, ParsedInstruction},


### PR DESCRIPTION
#### Problem
Payment providers would like to use memos to annotate transactions, but wallets can't easily display these memos in the tx-history list. `ConfirmedTransactionStatusWithSignature` and `RpcConfirmedTransactionStatusWithSignature` contain memo fields for this purpose, but these are not being populated. 

#### Summary of Changes
Populate memo field in bigtable structs `TransactionInfo` and `TransactionByAddrInfo`, which will by turn populate the memo field for `getSignaturesForAddress` response objects that are queried from bigtable.

Transactions will multiple memos will return them in one semicolon-separated String. I thought of other potential ways to handle/disambiguate multiple memo ixs in the same tx, but this seemed sufficient, especially since most use-cases will only have one memo/tx.

```
$ solana transaction-history F8vKjn13shKnef6pGfoHuWfpWP6DqmWT3xZK7oahnGuw -v

RPC URL: http://localhost:8899
Default Signer Path: id.json
Commitment: confirmed
3HtfiPUR67EFvkJia4u3TUYGQTVCva1jGpNpaT44UCKbcnSmUd6RFw5HNRtRd8Rxfz1mEe79u56JKhB6HZJGAT2i [slot=47 timestamp=2021-08-31T00:18:38Z status=Finalized] Test; This is a test second memo
5gESbb4gP15oy3U3RvHE9StEMzv55Qq67dVDqwcmV5AGvUTRiiEgc8HmtcYw2QXSV7SWp6T2WMmcqZsSfHx5kruC [slot=30 timestamp=2021-08-31T00:18:30Z status=Finalized]
52zpvpGSVGN58VfhXkf4duy67a3FpMcT9YC5QUTDEDCg7jbwsUFST2ByppWMdVGM84jKZHZMeDPLPjneruFdfPLj [slot=18 timestamp=2021-08-31T00:18:24Z status=Finalized] Beep beep boop boop; This is a test second memo
3 transactions found
```

Support for blockstore-queried transactions will require db changes to store the memo; separate PR.
