### PR TITLE
Populate memo in blockstore signatures-for-address

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -140,6 +140,7 @@ pub struct Blockstore {
     code_shred_cf: LedgerColumn<cf::ShredCode>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
     address_signatures_cf: LedgerColumn<cf::AddressSignatures>,
+    _transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
@@ -342,6 +343,7 @@ impl Blockstore {
         let code_shred_cf = db.column();
         let transaction_status_cf = db.column();
         let address_signatures_cf = db.column();
+        let transaction_memos_cf = db.column();
         let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
         let blocktime_cf = db.column();
@@ -391,6 +393,7 @@ impl Blockstore {
             code_shred_cf,
             transaction_status_cf,
             address_signatures_cf,
+            _transaction_memos_cf: transaction_memos_cf,
             transaction_status_index_cf,
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2623,12 +2623,13 @@ impl Blockstore {
             let transaction_status =
                 self.get_transaction_status(signature, &confirmed_unrooted_slots)?;
             let err = transaction_status.and_then(|(_slot, status)| status.status.err());
+            let memo = self.read_transaction_memos(signature)?;
             let block_time = self.get_block_time(slot)?;
             infos.push(ConfirmedTransactionStatusWithSignature {
                 signature,
                 slot,
                 err,
-                memo: None,
+                memo,
                 block_time,
             });
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -140,7 +140,7 @@ pub struct Blockstore {
     code_shred_cf: LedgerColumn<cf::ShredCode>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
     address_signatures_cf: LedgerColumn<cf::AddressSignatures>,
-    _transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
+    transaction_memos_cf: LedgerColumn<cf::TransactionMemos>,
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
@@ -393,7 +393,7 @@ impl Blockstore {
             code_shred_cf,
             transaction_status_cf,
             address_signatures_cf,
-            _transaction_memos_cf: transaction_memos_cf,
+            transaction_memos_cf,
             transaction_status_index_cf,
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,
@@ -2113,6 +2113,14 @@ impl Blockstore {
             )?;
         }
         Ok(())
+    }
+
+    pub fn read_transaction_memos(&self, signature: Signature) -> Result<Option<String>> {
+        self.transaction_memos_cf.get(signature)
+    }
+
+    pub fn write_transaction_memos(&self, signature: &Signature, memos: String) -> Result<()> {
+        self.transaction_memos_cf.put(*signature, &memos)
     }
 
     fn check_lowest_cleanup_slot(&self, slot: Slot) -> Result<std::sync::RwLockReadGuard<Slot>> {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -8,7 +8,9 @@ use {
     solana_runtime::bank::{
         Bank, InnerInstructionsList, NonceRollbackInfo, TransactionLogMessages,
     },
-    solana_transaction_status::{InnerInstructions, Reward, TransactionStatusMeta},
+    solana_transaction_status::{
+        extract_and_fmt_memos, InnerInstructions, Reward, TransactionStatusMeta,
+    },
     std::{
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -141,6 +143,12 @@ impl TransactionStatusService {
                                 .collect(),
                         );
 
+                        if let Some(memos) = extract_and_fmt_memos(transaction.message()) {
+                            blockstore
+                                .write_transaction_memos(transaction.signature(), memos)
+                                .expect("Expect database write to succeed: TransactionMemos");
+                        }
+
                         blockstore
                             .write_transaction_status(
                                 slot,
@@ -159,7 +167,7 @@ impl TransactionStatusService {
                                     rewards,
                                 },
                             )
-                            .expect("Expect database write to succeed");
+                            .expect("Expect database write to succeed: TransactionStatus");
                     }
                 }
             }

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -27,6 +27,14 @@ pub fn extract_and_fmt_memos<T: ExtractMemos>(message: &T) -> Option<String> {
     }
 }
 
+fn maybe_push_parsed_memo(memos: &mut Vec<String>, program_id: Pubkey, data: &[u8]) {
+    if program_id == spl_memo_id_v1() || program_id == spl_memo_id_v3() {
+        let memo_len = data.len();
+        let parsed_memo = parse_memo_data(data).unwrap_or_else(|_| "(unparseable)".to_string());
+        memos.push(format!("[{}] {}", memo_len, parsed_memo));
+    }
+}
+
 pub trait ExtractMemos {
     fn extract_memos(&self) -> Vec<String>;
 }
@@ -39,12 +47,7 @@ impl ExtractMemos for Message {
         {
             for instruction in &self.instructions {
                 let program_id = self.account_keys[instruction.program_id_index as usize];
-                if program_id == spl_memo_id_v1() || program_id == spl_memo_id_v3() {
-                    let memo_len = instruction.data.len();
-                    let parsed_memo = parse_memo_data(&instruction.data)
-                        .unwrap_or_else(|_| "(unparseable)".to_string());
-                    memos.push(format!("[{}] {}", memo_len, parsed_memo));
-                }
+                maybe_push_parsed_memo(&mut memos, program_id, &instruction.data);
             }
         }
         memos
@@ -59,14 +62,86 @@ impl ExtractMemos for SanitizedMessage {
             .any(|&pubkey| pubkey == spl_memo_id_v1() || pubkey == spl_memo_id_v3())
         {
             for (program_id, instruction) in self.program_instructions_iter() {
-                if *program_id == spl_memo_id_v1() || *program_id == spl_memo_id_v3() {
-                    let memo_len = instruction.data.len();
-                    let parsed_memo = parse_memo_data(&instruction.data)
-                        .unwrap_or_else(|_| "(unparseable)".to_string());
-                    memos.push(format!("[{}] {}", memo_len, parsed_memo));
-                }
+                maybe_push_parsed_memo(&mut memos, *program_id, &instruction.data);
             }
         }
         memos
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        solana_sdk::{
+            hash::Hash,
+            instruction::CompiledInstruction,
+            message::{v0, MappedAddresses, MappedMessage, MessageHeader},
+        },
+    };
+
+    #[test]
+    fn test_extract_memos() {
+        let fee_payer = Pubkey::new_unique();
+        let another_program_id = Pubkey::new_unique();
+        let memo0 = "Test memo";
+        let memo1 = "🦖";
+        let expected_memos = vec![
+            format!("[{}] {}", memo0.len(), memo0),
+            format!("[{}] {}", memo1.len(), memo1),
+        ];
+        let memo_instructions = vec![
+            CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![],
+                data: memo0.as_bytes().to_vec(),
+            },
+            CompiledInstruction {
+                program_id_index: 2,
+                accounts: vec![],
+                data: memo1.as_bytes().to_vec(),
+            },
+            CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![],
+                data: memo1.as_bytes().to_vec(),
+            },
+        ];
+        let message = Message::new_with_compiled_instructions(
+            1,
+            0,
+            3,
+            vec![
+                fee_payer,
+                spl_memo_id_v1(),
+                another_program_id,
+                spl_memo_id_v3(),
+            ],
+            Hash::default(),
+            memo_instructions.clone(),
+        );
+        assert_eq!(message.extract_memos(), expected_memos);
+
+        let sanitized_message = SanitizedMessage::Legacy(message);
+        assert_eq!(sanitized_message.extract_memos(), expected_memos);
+
+        let mapped_message = MappedMessage {
+            message: v0::Message {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 3,
+                },
+                account_keys: vec![fee_payer],
+                instructions: memo_instructions,
+                ..v0::Message::default()
+            },
+            mapped_addresses: MappedAddresses {
+                writable: vec![],
+                readonly: vec![spl_memo_id_v1(), another_program_id, spl_memo_id_v3()],
+            },
+        };
+        let sanitized_mapped_message = SanitizedMessage::V0(mapped_message);
+        assert_eq!(sanitized_mapped_message.extract_memos(), expected_memos);
     }
 }


### PR DESCRIPTION
#### Problem
cc #19512  Payment providers would like to use memos to annotate transactions, but wallets can't easily display these memos in the tx-history list. `ConfirmedTransactionStatusWithSignature` and `RpcConfirmedTransactionStatusWithSignature` contain memo fields for this purpose, but these are not being populated. 

#### Summary of Changes
Store memos in new blockstore TransactionMemos column via the TransactionStatusService, and use it to populate the memo field for `getSignaturesForAddress` response objects that are queried from blockstore.

This will require a stubbed TransactionMemos column in v1.6, or backporting both memo-population PRs to v1.6. Preference?

I also considered the alternate solution of a new AddressSignatures column to store the memo alongside each address, similar to the schema in bigtable, but ultimately decided that the very small perf savings in `Blockstore::get_confirmed_signatures_for_address2()` are not worth the additional disk to duplicate memos for every address. (However, it may still be worth plumbing a new AddressSignatures column sometime in the future to fix the column key to return signatures in proper execution order.)
