### PR TITLE
Revert "Add LastFullSnapshotSlot to SnapshotConfig (#19341)"

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -271,10 +271,7 @@ impl AccountsHashVerifier {
 mod tests {
     use super::*;
     use solana_gossip::{cluster_info::make_accounts_hashes_message, contact_info::ContactInfo};
-    use solana_runtime::{
-        snapshot_config::LastFullSnapshotSlot,
-        snapshot_utils::{ArchiveFormat, SnapshotVersion},
-    };
+    use solana_runtime::snapshot_utils::{ArchiveFormat, SnapshotVersion};
     use solana_sdk::{
         genesis_config::ClusterType,
         hash::hash,
@@ -346,7 +343,6 @@ mod tests {
             archive_format: ArchiveFormat::Tar,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: usize::MAX,
-            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -15,7 +15,7 @@ use {
     solana_runtime::{
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_utils::{
             ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -528,7 +528,6 @@ impl TestValidator {
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -65,7 +65,7 @@ mod tests {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         snapshot_archive_info::FullSnapshotArchiveInfo,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_package::{
             AccountsPackage, PendingSnapshotPackage, SnapshotPackage, SnapshotType,
         },
@@ -148,7 +148,6 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -31,7 +31,7 @@ use solana_runtime::{
     bank_forks::BankForks,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_archive_info::SnapshotArchiveInfoGetter,
-    snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+    snapshot_config::SnapshotConfig,
     snapshot_utils::{
         self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
@@ -719,7 +719,6 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -43,7 +43,7 @@ use {
     },
     solana_runtime::{
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -3535,7 +3535,6 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -23,7 +23,7 @@ use {
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{clock::Slot, exit::Exit, genesis_config::GenesisConfig, hash::Hash},
@@ -265,7 +265,6 @@ impl ReplicaNode {
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
             maximum_snapshots_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            last_full_snapshot_slot: LastFullSnapshotSlot::default(),
         };
 
         let bank_info =

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -17,7 +17,7 @@ use {
     solana_runtime::{
         accounts_index::AccountSecondaryIndexes,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_utils::{self, ArchiveFormat},
     },
     solana_sdk::{
@@ -127,7 +127,6 @@ fn setup_snapshot_validator_config(
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -492,7 +492,6 @@ mod tests {
         },
         solana_runtime::{
             bank::Bank,
-            snapshot_config::LastFullSnapshotSlot,
             snapshot_utils::{
                 ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             },
@@ -610,7 +609,6 @@ mod tests {
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
                 maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                last_full_snapshot_slot: LastFullSnapshotSlot::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,10 +1,7 @@
 use crate::snapshot_utils::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
 use solana_sdk::clock::Slot;
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+use std::path::PathBuf;
 
 /// Snapshot configuration and runtime information
 #[derive(Clone, Debug)]
@@ -29,9 +26,4 @@ pub struct SnapshotConfig {
 
     /// Maximum number of full snapshot archives to retain
     pub maximum_snapshots_to_retain: usize,
-
-    /// Runtime information of the last full snapshot slot
-    pub last_full_snapshot_slot: LastFullSnapshotSlot,
 }
-
-pub type LastFullSnapshotSlot = Arc<RwLock<Option<Slot>>>;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -49,7 +49,7 @@ use {
         },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::{LastFullSnapshotSlot, SnapshotConfig},
+        snapshot_config::SnapshotConfig,
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
@@ -2621,7 +2621,6 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_snapshots_to_retain,
-        last_full_snapshot_slot: LastFullSnapshotSlot::default(),
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
#### Problem

LastFullSnapshotSlot is no longer used.

This was the meant to be the second version of how incremental snapshot support would be added to the background services, but a different implementation has been used instead (see PR #19401 if interested).

#### Summary of Changes

This reverts commit 4d361af976af79125271dd8c08cbea97711c3eb3, which removes LastFullSnapshotSlot.
