### PR TITLE
tests which assert or panic in other threads now will report an error

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -12976,21 +12976,22 @@ pub(crate) mod tests {
         // Let threads run for a while, check the scans didn't see any mixed slots
         let min_expected_number_of_scans = 5;
         std::thread::sleep(Duration::new(5, 0));
-        let mut loops = 1000;
+        let mut remaining_loops = 1000;
         loop {
             if num_banks_scanned.load(Relaxed) > min_expected_number_of_scans {
                 break;
             } else {
                 std::thread::sleep(Duration::from_millis(100));
             }
-            loops -= 1;
-            if loops == 0 {
+            remaining_loops -= 1;
+            if remaining_loops == 0 {
                 break; // just quit and try to get the thread result (panic, etc.)
             }
         }
         exit.store(true, Relaxed);
         scan_thread.join().unwrap();
         update_thread.join().unwrap();
+        assert!(remaining_loops > 0, "test timed out");
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -12976,11 +12976,16 @@ pub(crate) mod tests {
         // Let threads run for a while, check the scans didn't see any mixed slots
         let min_expected_number_of_scans = 5;
         std::thread::sleep(Duration::new(5, 0));
+        let mut loops = 1000;
         loop {
             if num_banks_scanned.load(Relaxed) > min_expected_number_of_scans {
                 break;
             } else {
                 std::thread::sleep(Duration::from_millis(100));
+            }
+            loops -= 1;
+            if loops == 0 {
+                break; // just quit and try to get the thread result (panic, etc.)
             }
         }
         exit.store(true, Relaxed);


### PR DESCRIPTION
#### Problem
Tests calling this function have a tendency to fail in a thread. The result is the test hangs and we get no report of an error.
#### Summary of Changes
Only wait for the test to finish for 100s. If it takes longer than that, then join the other threads so we can get the failure message.
Fixes #
