### PR TITLE
Fix tests that make assumptions about tx fee rate

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10349,7 +10349,14 @@ pub(crate) mod tests {
         assert_eq!(bank.process_transaction(&durable_tx), Ok(()));
 
         /* Check balances */
-        assert_eq!(bank.get_balance(&custodian_pubkey), 4_640_000);
+        let mut expected_balance = 4_650_000
+            - bank
+                .get_fee_for_message(
+                    &bank.last_blockhash(),
+                    &durable_tx.message.try_into().unwrap(),
+                )
+                .unwrap();
+        assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
         assert_eq!(bank.get_balance(&nonce_pubkey), 250_000);
         assert_eq!(bank.get_balance(&alice_pubkey), 100_000);
 
@@ -10372,7 +10379,7 @@ pub(crate) mod tests {
             Err(TransactionError::BlockhashNotFound)
         );
         /* Check fee not charged and nonce not advanced */
-        assert_eq!(bank.get_balance(&custodian_pubkey), 4_640_000);
+        assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
         assert_eq!(new_nonce, get_nonce_account(&bank, &nonce_pubkey).unwrap());
 
         let nonce_hash = new_nonce;
@@ -10400,7 +10407,13 @@ pub(crate) mod tests {
             ))
         );
         /* Check fee charged and nonce has advanced */
-        assert_eq!(bank.get_balance(&custodian_pubkey), 4_630_000);
+        expected_balance -= bank
+            .get_fee_for_message(
+                &bank.last_blockhash(),
+                &SanitizedMessage::try_from(durable_tx.message.clone()).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
         assert_ne!(nonce_hash, get_nonce_account(&bank, &nonce_pubkey).unwrap());
         /* Confirm replaying a TX that failed with InstructionError::* now
          * fails with TransactionError::BlockhashNotFound
@@ -10460,7 +10473,13 @@ pub(crate) mod tests {
         /* Check fee charged and nonce has *not* advanced */
         assert_eq!(
             bank.get_balance(&custodian_pubkey),
-            initial_custodian_balance - 10_000
+            initial_custodian_balance
+                - bank
+                    .get_fee_for_message(
+                        &bank.last_blockhash(),
+                        &durable_tx.message.try_into().unwrap()
+                    )
+                    .unwrap()
         );
         assert_eq!(nonce_hash, get_nonce_account(&bank, &nonce_pubkey).unwrap());
     }
@@ -10468,8 +10487,10 @@ pub(crate) mod tests {
     #[test]
     fn test_nonce_payer() {
         solana_logger::setup();
+        let nonce_starting_balance = 250_000;
         let (mut bank, _mint_keypair, custodian_keypair, nonce_keypair) =
-            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, nonce_starting_balance, None)
+                .unwrap();
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
         let custodian_pubkey = custodian_keypair.pubkey();
@@ -10505,7 +10526,16 @@ pub(crate) mod tests {
             ))
         );
         /* Check fee charged and nonce has advanced */
-        assert_eq!(bank.get_balance(&nonce_pubkey), 240_000);
+        assert_eq!(
+            bank.get_balance(&nonce_pubkey),
+            nonce_starting_balance
+                - bank
+                    .get_fee_for_message(
+                        &bank.last_blockhash(),
+                        &durable_tx.message.try_into().unwrap()
+                    )
+                    .unwrap()
+        );
         assert_ne!(nonce_hash, get_nonce_account(&bank, &nonce_pubkey).unwrap());
     }
 


### PR DESCRIPTION
#### Problem
Some tests have hard-coded numbers that assume the current default fee rate. These will break in the future as transaction-cost-model work is completed, and even if the default `lamports_per_signature` is changed now.

#### Summary of Changes
Use Bank method to determine balance changes.