### PR TITLE
make test pass with 1 bin to remove noisy failure during testing

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -12415,14 +12415,15 @@ pub mod tests {
         ];
         // make sure accounts are in 2 different bins
         assert!(
-            accounts
-                .accounts_index
-                .bin_calculator
-                .bin_from_pubkey(&keys[0])
-                != accounts
+            (accounts.accounts_index.bins() == 1)
+                ^ (accounts
                     .accounts_index
                     .bin_calculator
-                    .bin_from_pubkey(&keys[1])
+                    .bin_from_pubkey(&keys[0])
+                    != accounts
+                        .accounts_index
+                        .bin_calculator
+                        .bin_from_pubkey(&keys[1]))
         );
         let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
         let account_big = AccountSharedData::new(1, 1000, AccountSharedData::default().owner());


### PR DESCRIPTION
#### Problem
While tuning or debugging changes, sometimes you use 1 bin. This currently fails a test needlessly.
#### Summary of Changes
make the test pass if there is only 1 bin.
Fixes #
