### PR TITLE
Simplify calc_delete_dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5530,7 +5530,7 @@ dependencies = [
  "bincode",
  "chrono",
  "crossbeam-channel",
- "futures 0.3.16",
+ "futures 0.3.17",
  "futures-util",
  "log 0.4.14",
  "prost",
@@ -5541,7 +5541,7 @@ dependencies = [
  "solana-rpc",
  "solana-runtime",
  "solana-sdk",
- "tokio 1.10.1",
+ "tokio 1.11.0",
  "tonic",
  "tonic-build",
 ]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1594,21 +1594,8 @@ impl AccountsDb {
                 );
                 true
             } else {
-                let mut no_delete = false;
-                for (_slot, account_info) in account_infos {
-                    debug!(
-                        "calc_delete_dependencies()
-                        storage id: {},
-                        count len: {}",
-                        account_info.store_id,
-                        store_counts.get(&account_info.store_id).unwrap().0,
-                    );
-                    if store_counts.get(&account_info.store_id).unwrap().0 != 0 {
-                        no_delete = true;
-                        break;
-                    }
-                }
-                no_delete
+                assert_eq!(account_infos.len(), 1);
+                false
             };
             if no_delete {
                 let mut pending_store_ids: HashSet<usize> = HashSet::new();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8095,7 +8095,7 @@ pub mod tests {
 
         //Old state behind zero-lamport account is cleaned up
         assert_eq!(accounts.alive_account_count_in_slot(0), 0);
-        assert_eq!(accounts.alive_account_count_in_slot(1), 2);
+        assert_eq!(accounts.alive_account_count_in_slot(1), 1);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7998,7 +7998,7 @@ pub mod tests {
             slot1_store
         };
 
-        accounts.clean_accounts(None, false);
+        accounts.clean_accounts(None, false, None);
 
         // key2 should be cleaned, but slot1 should not be removed since key1 is
         // still keeping it alive
@@ -8015,7 +8015,7 @@ pub mod tests {
         // clean, but `key1` will not be added to the clean here.
         accounts.store_uncached(3, &[(&key0, &nonzero_lamport_account)]);
         accounts.add_root(3);
-        accounts.clean_accounts(None, false);
+        accounts.clean_accounts(None, false, None);
         assert!(accounts.storage.get_slot_storage_entries(0).is_none());
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&key1), 1);
         // Check key1 has not been shadowed
@@ -8023,7 +8023,7 @@ pub mod tests {
         assert_eq!(slot1_store.count(), 1);
 
         // This next clean will now fully clean up `key1`
-        accounts.clean_accounts(None, false);
+        accounts.clean_accounts(None, false, None);
         assert!(accounts.storage.get_slot_storage_entries(1).is_none());
         assert_eq!(accounts.accounts_index.ref_count_from_storage(&key1), 0);
     }
@@ -10333,8 +10333,6 @@ pub mod tests {
             accounts.all_account_count_in_append_vec(shrink_slot)
         );
     }
-
-    const UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE: bool = false;
 
     #[test]
     fn test_delete_dependencies() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -14063,7 +14063,7 @@ pub(crate) mod tests {
         //! 3. A key with zero lamports is _only_ in an unrooted bank (key4)
         //!     - In this case, key4 should be cleaned up
         //! 4. A key with zero lamports is in both an unrooted _and_ rooted bank (key5)
-        //!     - In this case, key5's ref-count should be decremented correctly
+        //!     - In this case, key5's ref-count should be cleaned up
 
         let (genesis_config, mint_keypair) = create_genesis_config(100);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -14102,7 +14102,6 @@ pub(crate) mod tests {
         bank2.clean_accounts(false, false, None);
 
         let expected_ref_count_for_cleaned_up_keys = 0;
-        let expected_ref_count_for_keys_in_both_slot1_and_slot2 = 1;
 
         assert_eq!(
             bank2
@@ -14138,7 +14137,7 @@ pub(crate) mod tests {
                 .accounts_db
                 .accounts_index
                 .ref_count_from_storage(&key5.pubkey()),
-            expected_ref_count_for_keys_in_both_slot1_and_slot2,
+            expected_ref_count_for_cleaned_up_keys,
         );
 
         assert_eq!(


### PR DESCRIPTION
#### Problem

As a refresher, we add keys to the candidate set on:
1. Dead slots, we add the storage entry to the candidate set
2. Shrinking slots, we add the storage entry to the candidate set
3. New roots, we add the storage entry to the candidate set
4.  Bank freeze we add the dirty pubkeys to the candidate set

So a zero lamport key will never be cleaned if there ever is ever a scenario where:
1) We add a zero lamport key to the candidate set
2) The zero lamport key is not removed via clean
3) We then never add the zero lamport key back to the candidate set

I think this can happen if:
1) We add the zero lamport key to the candidate set via one of the four options above
2) We don't clean the zero lamport key, *even though the ref count is 1*, due to this check: https://github.com/solana-labs/solana/blob/master/runtime/src/accounts_db.rs#L1594-L1597
3) The slot for the zero lamport key is never shrunk again because it never goes under 80% capacity (Maybe the zero lamport account data is large or there are a lot of zero lamport keys in this slot that can't be cleaned for the same reason as 2) above, *even if rent overwrites all the remaining non-zero pubkeys*.

#### Summary of Changes
1. Remove zero lamport keys if ref_count is 1, even if the storage entry is not empty
2. Remove recursive search in `calc_delete_dependencies` as this is no longer necessary

Fixes #
