### PR TITLE
add synchronization comment to handle_new_root

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2703,6 +2703,8 @@ impl ReplayStage {
             accounts_background_request_sender,
             highest_confirmed_root,
         );
+        // Dropping the bank_forks write lock and reacquiring as a read lock is
+        // safe because updates to bank_forks are only made by a single thread.
         let r_bank_forks = bank_forks.read().unwrap();
         let new_root_bank = &r_bank_forks[new_root];
         if !*has_new_vote_been_rooted {


### PR DESCRIPTION
#### Problem
handle_new_root() acquires a write lock on bank_forks, drops the lock, acquires a read lock, and looks up the new_root added under the write lock. Because bank_forks is only updated by a single thread this is safe. See: fix race in handle_new_root #18984

#### Summary of Changes
Add a comment to describe why this is safe.
