### PR TITLE
Properly clean temp files in Blockstore::create_new_ledger()

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3737,7 +3737,7 @@ pub fn create_new_ledger(
         // unpack into a temp dir, while completely discarding the unpacked files
         let unpack_check = unpack_genesis_archive(
             &archive_path,
-            &temp_dir.into_path(),
+            temp_dir.path(),
             max_genesis_archive_unpacked_size,
         );
         if let Err(unpack_err) = unpack_check {


### PR DESCRIPTION
#### Problem
TempDir::into_path() returns the underlying PathBuf and voids the promise to delete the directory when the TempDir goes out of scope. As a result, this temporary directory doesn't get cleaned up (such as when running tests).
![image](https://user-images.githubusercontent.com/5400107/131916171-78094b2e-4523-4491-a260-d901e4a6c38a.png)

Given the comment above the line I changed (introdcued in https://github.com/solana-labs/solana/commit/a91236012d#diff-01b72272fd1033dcbb8fed13821a6232d35913119af6be20a7c2d1e9c772feb9R2680-R2689), I believe the intent was to have this location get cleaned up.

#### Summary of Changes
Use [TempDir::path()](https://docs.rs/tempdir/0.3.7/tempdir/struct.TempDir.html#method.path) instead of [TempDir::into_path()](https://docs.rs/tempdir/0.3.7/tempdir/struct.TempDir.html#method.into_path)
