### PR TITLE
web3.js: add accounts support to simulateTransaction

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3517,8 +3517,8 @@ export class Connection {
         Array.isArray(includeAccounts)
           ? includeAccounts
           : message.accountKeys.filter(
-              (_, index) => !message.isProgramId(index),
-            )
+            (_, index) => !message.isProgramId(index),
+          )
       ).map(key => key.toBase58());
 
       config['accounts'] = {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -441,15 +441,42 @@ const VersionResult = pick({
   'feature-set': optional(number()),
 });
 
+export type SimulatedTransactionAccountInfo = {
+  /** `true` if this account's data contains a loaded program */
+  executable: boolean;
+  /** Identifier of the program that owns the account */
+  owner: string;
+  /** Number of lamports assigned to the account */
+  lamports: number;
+  /** Optional data assigned to the account */
+  data: string[];
+  /** Optional rent epoch info for account */
+  rentEpoch?: number;
+};
+
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
+  accounts?: SimulatedTransactionAccountInfo[];
+  unitsConsumed?: number;
 };
 
 const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
   pick({
     err: nullable(union([pick({}), string()])),
     logs: nullable(array(string())),
+    accounts: optional(
+      array(
+        pick({
+          executable: boolean(),
+          owner: string(),
+          lamports: number(),
+          data: array(string()),
+          rentEpoch: optional(number()),
+        }),
+      ),
+    ),
+    unitsConsumed: optional(number()),
   }),
 );
 
@@ -1681,6 +1708,8 @@ export type AccountInfo<T> = {
   lamports: number;
   /** Optional data assigned to the account */
   data: T;
+  /** Optional rent epoch infor for account */
+  rentEpoch?: number;
 };
 
 /**

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3469,12 +3469,7 @@ export class Connection {
     if (transactionOrMessage instanceof Transaction) {
       transaction = transactionOrMessage;
     } else {
-      transaction = Transaction.populate(
-        transactionOrMessage,
-        new Array(transactionOrMessage.header.numRequiredSignatures).fill(
-          DEFAULT_SIGNATURE,
-        ),
-      );
+      transaction = Transaction.populate(transactionOrMessage);
     }
 
     if (transaction.nonceInfo && signers) {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3516,9 +3516,7 @@ export class Connection {
       const addresses = (
         Array.isArray(includeAccounts)
           ? includeAccounts
-          : message.accountKeys.filter(
-            (_, index) => !message.isProgramId(index),
-          )
+          : message.nonProgramIds()
       ).map(key => key.toBase58());
 
       config['accounts'] = {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -44,8 +44,6 @@ import type {FeeCalculator} from './fee-calculator';
 import type {TransactionSignature} from './transaction';
 import type {CompiledInstruction} from './message';
 
-const DEFAULT_SIGNATURE = bs58.encode(Buffer.alloc(64).fill(0));
-
 const PublicKeyFromString = coerce(
   instance(PublicKey),
   string(),

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -455,7 +455,7 @@ export type SimulatedTransactionAccountInfo = {
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
-  accounts?: SimulatedTransactionAccountInfo[];
+  accounts?: SimulatedTransactionAccountInfo[] | null;
   unitsConsumed?: number;
 };
 
@@ -464,14 +464,16 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
     err: nullable(union([pick({}), string()])),
     logs: nullable(array(string())),
     accounts: optional(
-      array(
-        pick({
-          executable: boolean(),
-          owner: string(),
-          lamports: number(),
-          data: array(string()),
-          rentEpoch: optional(number()),
-        }),
+      nullable(
+        array(
+          pick({
+            executable: boolean(),
+            owner: string(),
+            lamports: number(),
+            data: array(string()),
+            rentEpoch: optional(number()),
+          }),
+        ),
       ),
     ),
     unitsConsumed: optional(number()),

--- a/web3.js/src/message.ts
+++ b/web3.js/src/message.ts
@@ -65,11 +65,22 @@ export class Message {
   recentBlockhash: Blockhash;
   instructions: CompiledInstruction[];
 
+  private indexToProgramIds: Map<number, PublicKey> = new Map<
+    number,
+    PublicKey
+  >();
+
   constructor(args: MessageArgs) {
     this.header = args.header;
     this.accountKeys = args.accountKeys.map(account => new PublicKey(account));
     this.recentBlockhash = args.recentBlockhash;
     this.instructions = args.instructions;
+    this.instructions.forEach(ix =>
+      this.indexToProgramIds.set(
+        ix.programIdIndex,
+        this.accountKeys[ix.programIdIndex],
+      ),
+    );
   }
 
   isAccountWritable(index: number): boolean {
@@ -81,6 +92,14 @@ export class Message {
         index <
           this.accountKeys.length - this.header.numReadonlyUnsignedAccounts)
     );
+  }
+
+  isProgramId(index: number): boolean {
+    return this.indexToProgramIds.has(index);
+  }
+
+  programIds(): PublicKey[] {
+    return [...this.indexToProgramIds.values()];
   }
 
   serialize(): Buffer {

--- a/web3.js/src/message.ts
+++ b/web3.js/src/message.ts
@@ -83,6 +83,10 @@ export class Message {
     );
   }
 
+  isAccountSigner(index: number): boolean {
+    return index < this.header.numRequiredSignatures;
+  }
+
   isAccountWritable(index: number): boolean {
     return (
       index <

--- a/web3.js/src/message.ts
+++ b/web3.js/src/message.ts
@@ -106,6 +106,10 @@ export class Message {
     return [...this.indexToProgramIds.values()];
   }
 
+  nonProgramIds(): PublicKey[] {
+    return this.accountKeys.filter((_, index) => !this.isProgramId(index));
+  }
+
   serialize(): Buffer {
     const numKeys = this.accountKeys.length;
 

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -666,7 +666,10 @@ export class Transaction {
   /**
    * Populate Transaction object from message and signatures
    */
-  static populate(message: Message, signatures: Array<string>): Transaction {
+  static populate(
+    message: Message,
+    signatures: Array<string> = [],
+  ): Transaction {
     const transaction = new Transaction();
     transaction.recentBlockhash = message.recentBlockhash;
     if (message.header.numRequiredSignatures > 0) {
@@ -688,9 +691,10 @@ export class Transaction {
         const pubkey = message.accountKeys[account];
         return {
           pubkey,
-          isSigner: transaction.signatures.some(
-            keyObj => keyObj.publicKey.toString() === pubkey.toString(),
-          ),
+          isSigner:
+            transaction.signatures.some(
+              keyObj => keyObj.publicKey.toString() === pubkey.toString(),
+            ) || message.isAccountSigner(account),
           isWritable: message.isAccountWritable(account),
         };
       });

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -17,6 +17,7 @@ import {
   StakeProgram,
   sendAndConfirmTransaction,
   Keypair,
+  Message,
 } from '../src';
 import invariant from '../src/util/assert';
 import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../src/timing';
@@ -2818,6 +2819,65 @@ describe('Connection', () => {
   });
 
   if (process.env.TEST_LIVE) {
+    it('simulate transaction with message', async () => {
+      connection._commitment = 'confirmed';
+
+      const account1 = Keypair.generate();
+      const account2 = Keypair.generate();
+
+      await helpers.airdrop({
+        connection,
+        address: account1.publicKey,
+        amount: LAMPORTS_PER_SOL,
+      });
+
+      await helpers.airdrop({
+        connection,
+        address: account2.publicKey,
+        amount: LAMPORTS_PER_SOL,
+      });
+
+      const recentBlockhash = await (
+        await helpers.recentBlockhash({connection})
+      ).blockhash;
+      const message = new Message({
+        accountKeys: [
+          account1.publicKey.toString(),
+          account2.publicKey.toString(),
+          'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo',
+        ],
+        header: {
+          numReadonlySignedAccounts: 1,
+          numReadonlyUnsignedAccounts: 1,
+          numRequiredSignatures: 1,
+        },
+        instructions: [
+          {
+            accounts: [1],
+            data: bs58.encode(Buffer.alloc(5).fill(9)),
+            programIdIndex: 2,
+          },
+        ],
+        recentBlockhash,
+      });
+
+      const results1 = await connection.simulateTransaction(
+        message,
+        [account1],
+        true,
+      );
+
+      expect(results1.value.accounts).lengthOf(2);
+
+      const results2 = await connection.simulateTransaction(
+        message,
+        [account1],
+        [account1.publicKey],
+      );
+
+      expect(results2.value.accounts).lengthOf(1);
+    }).timeout(10000);
+
     it('transaction', async () => {
       connection._commitment = 'confirmed';
 

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -2848,12 +2848,12 @@ describe('Connection', () => {
         ],
         header: {
           numReadonlySignedAccounts: 1,
-          numReadonlyUnsignedAccounts: 1,
+          numReadonlyUnsignedAccounts: 2,
           numRequiredSignatures: 1,
         },
         instructions: [
           {
-            accounts: [1],
+            accounts: [0, 1],
             data: bs58.encode(Buffer.alloc(5).fill(9)),
             programIdIndex: 2,
           },


### PR DESCRIPTION
#### Problem
`Connection.simulateTransaction` doesn't support the `accounts` parameter exposed in RPC.
Also, it's difficult to use when starting with a serialized Message.

#### Summary of Changes

- Add support for Message
- include non-program accounts when includeAccounts is true or use specified PublicKey[]
- add helper functions to Message
- support default signatures when populating transaction from Message

Fixes https://github.com/solana-labs/solana/issues/19568, https://github.com/solana-labs/solana/issues/19569