### PR TITLE
Add backwards compatibility support to get_highest_snapshot_slot()

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1043,8 +1043,8 @@ impl RpcClient {
     pub fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
         if self.get_node_version()? < semver::Version::new(1, 8, 0) {
             #[allow(deprecated)]
-            Ok(RpcSnapshotSlotInfo {
-                full: self.get_snapshot_slot()?,
+            self.get_snapshot_slot().map(|full| RpcSnapshotSlotInfo {
+                full,
                 incremental: None,
             })
         } else {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1043,9 +1043,8 @@ impl RpcClient {
     pub fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
         if self.get_node_version()? < semver::Version::new(1, 8, 0) {
             #[allow(deprecated)]
-            let full_snapshot_slot = self.get_snapshot_slot()?;
             Ok(RpcSnapshotSlotInfo {
-                full: full_snapshot_slot,
+                full: self.get_snapshot_slot()?,
                 incremental: None,
             })
         } else {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1041,7 +1041,16 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
-        self.send(RpcRequest::GetHighestSnapshotSlot, Value::Null)
+        if self.get_node_version()? < semver::Version::new(1, 8, 0) {
+            #[allow(deprecated)]
+            let full_snapshot_slot = self.get_snapshot_slot()?;
+            Ok(RpcSnapshotSlotInfo {
+                full: full_snapshot_slot,
+                incremental: None,
+            })
+        } else {
+            self.send(RpcRequest::GetHighestSnapshotSlot, Value::Null)
+        }
     }
 
     #[deprecated(


### PR DESCRIPTION
As per this comment from @mvines (https://github.com/solana-labs/solana/pull/19587#issuecomment-912036981), adding backwards compatibility for the `get_highest_snapshot_slot()` RPC call.
