### PR TITLE
Rename maximum_full_snapshot_archives_to_retain

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -342,7 +342,7 @@ mod tests {
             bank_snapshots_dir: PathBuf::default(),
             archive_format: ArchiveFormat::Tar,
             snapshot_version: SnapshotVersion::default(),
-            maximum_snapshots_to_retain: usize::MAX,
+            maximum_full_snapshot_archives_to_retain: usize::MAX,
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -527,7 +527,8 @@ impl TestValidator {
                 snapshot_archives_dir: ledger_path.to_path_buf(),
                 archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
-                maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_full_snapshot_archives_to_retain:
+                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -651,7 +651,7 @@ impl Validator {
                     snapshot_hash,
                     &exit,
                     &cluster_info,
-                    snapshot_config.maximum_snapshots_to_retain,
+                    snapshot_config.maximum_full_snapshot_archives_to_retain,
                 );
                 (
                     Some(snapshot_packager_service),
@@ -1237,7 +1237,7 @@ fn new_banks_from_ledger(
             None,
             &snapshot_config.snapshot_archives_dir,
             snapshot_config.archive_format,
-            snapshot_config.maximum_snapshots_to_retain,
+            snapshot_config.maximum_full_snapshot_archives_to_retain,
         )
         .unwrap_or_else(|err| {
             error!("Unable to create snapshot: {}", err);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -147,7 +147,8 @@ mod tests {
                 bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
-                maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_full_snapshot_archives_to_retain:
+                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {
@@ -771,7 +772,7 @@ mod tests {
             bank.get_snapshot_storages(None),
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
-            snapshot_config.maximum_snapshots_to_retain,
+            snapshot_config.maximum_full_snapshot_archives_to_retain,
         )?;
 
         Ok(())
@@ -807,7 +808,7 @@ mod tests {
             storages,
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
-            snapshot_config.maximum_snapshots_to_retain,
+            snapshot_config.maximum_full_snapshot_archives_to_retain,
         )?;
 
         Ok(())
@@ -924,7 +925,7 @@ mod tests {
             &cluster_info,
             snapshot_test_config
                 .snapshot_config
-                .maximum_snapshots_to_retain,
+                .maximum_full_snapshot_archives_to_retain,
         );
 
         let accounts_hash_verifier = AccountsHashVerifier::new(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -718,7 +718,7 @@ fn load_bank_forks(
             bank_snapshots_dir,
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
-            maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3534,7 +3534,8 @@ fn setup_snapshot_validator_config(
         bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
-        maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        maximum_full_snapshot_archives_to_retain:
+            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -94,7 +94,7 @@ fn initialize_from_snapshot(
         &replica_config.snapshot_archives_dir,
         replica_config.snapshot_info,
         false,
-        snapshot_config.maximum_snapshots_to_retain,
+        snapshot_config.maximum_full_snapshot_archives_to_retain,
         &mut None,
     )
     .unwrap();
@@ -268,7 +268,7 @@ impl ReplicaNode {
             bank_snapshots_dir: replica_config.bank_snapshots_dir.clone(),
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
-            maximum_snapshots_to_retain:
+            maximum_full_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         };
 

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -127,7 +127,8 @@ fn setup_snapshot_validator_config(
         bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
         archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
-        maximum_snapshots_to_retain: snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        maximum_full_snapshot_archives_to_retain:
+            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -621,7 +621,8 @@ mod tests {
                 bank_snapshots_dir: PathBuf::from("/"),
                 archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
-                maximum_snapshots_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_full_snapshot_archives_to_retain:
+                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -25,5 +25,5 @@ pub struct SnapshotConfig {
     pub snapshot_version: SnapshotVersion,
 
     /// Maximum number of full snapshot archives to retain
-    pub maximum_snapshots_to_retain: usize,
+    pub maximum_full_snapshot_archives_to_retain: usize,
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -916,7 +916,7 @@ fn rpc_bootstrap(
                             let maximum_snapshots_to_retain = if let Some(snapshot_config) =
                                 validator_config.snapshot_config.as_ref()
                             {
-                                snapshot_config.maximum_snapshots_to_retain
+                                snapshot_config.maximum_full_snapshot_archives_to_retain
                             } else {
                                 DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
                             };
@@ -2627,7 +2627,7 @@ pub fn main() {
 
     let snapshot_interval_slots = value_t_or_exit!(matches, "snapshot_interval_slots", u64);
     let maximum_local_snapshot_age = value_t_or_exit!(matches, "maximum_local_snapshot_age", u64);
-    let maximum_snapshots_to_retain =
+    let maximum_full_snapshot_archives_to_retain =
         value_t_or_exit!(matches, "maximum_snapshots_to_retain", usize);
     let minimal_snapshot_download_speed =
         value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
@@ -2679,7 +2679,7 @@ pub fn main() {
         snapshot_archives_dir: snapshot_archives_dir.clone(),
         archive_format,
         snapshot_version,
-        maximum_snapshots_to_retain,
+        maximum_full_snapshot_archives_to_retain,
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
To prepare for adding maximum_incremental_snapshot_archives_to_retain,
rename the current field in SnapshotConfig.
