### PR TITLE
Add maximum_incremental_snapshot_archives_to_retain to SnapshotConfig

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -343,6 +343,7 @@ mod tests {
             archive_format: ArchiveFormat::Tar,
             snapshot_version: SnapshotVersion::default(),
             maximum_full_snapshot_archives_to_retain: usize::MAX,
+            maximum_incremental_snapshot_archives_to_retain: usize::MAX,
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -18,6 +18,7 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_utils::{
             ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
     },
     solana_sdk::{
@@ -529,6 +530,8 @@ impl TestValidator {
                 snapshot_version: SnapshotVersion::default(),
                 maximum_full_snapshot_archives_to_retain:
                     DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_incremental_snapshot_archives_to_retain:
+                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -71,6 +71,7 @@ mod tests {
         },
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
         status_cache::MAX_CACHE_ENTRIES,
     };
@@ -149,6 +150,8 @@ mod tests {
                 snapshot_version,
                 maximum_full_snapshot_archives_to_retain:
                     DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_incremental_snapshot_archives_to_retain:
+                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -34,6 +34,7 @@ use solana_runtime::{
     snapshot_config::SnapshotConfig,
     snapshot_utils::{
         self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
 };
 use solana_sdk::{
@@ -719,6 +720,8 @@ fn load_bank_forks(
             archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
             maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            maximum_incremental_snapshot_archives_to_retain:
+                DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3536,6 +3536,8 @@ fn setup_snapshot_validator_config(
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_full_snapshot_archives_to_retain:
             snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        maximum_incremental_snapshot_archives_to_retain:
+            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -270,6 +270,8 @@ impl ReplicaNode {
             snapshot_version: snapshot_utils::SnapshotVersion::default(),
             maximum_full_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            maximum_incremental_snapshot_archives_to_retain:
+                snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         };
 
         let bank_info =

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -129,6 +129,8 @@ fn setup_snapshot_validator_config(
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
         maximum_full_snapshot_archives_to_retain:
             snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        maximum_incremental_snapshot_archives_to_retain:
+            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -506,6 +506,7 @@ mod tests {
             bank::Bank,
             snapshot_utils::{
                 ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             },
         },
         solana_sdk::{
@@ -623,6 +624,8 @@ mod tests {
                 snapshot_version: SnapshotVersion::default(),
                 maximum_full_snapshot_archives_to_retain:
                     DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                maximum_incremental_snapshot_archives_to_retain:
+                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -26,4 +26,8 @@ pub struct SnapshotConfig {
 
     /// Maximum number of full snapshot archives to retain
     pub maximum_full_snapshot_archives_to_retain: usize,
+
+    /// Maximum number of incremental snapshot archives to retain
+    /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
+    pub maximum_incremental_snapshot_archives_to_retain: usize,
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -52,6 +52,7 @@ const DEFAULT_SNAPSHOT_VERSION: SnapshotVersion = SnapshotVersion::V1_2_0;
 pub(crate) const TMP_BANK_SNAPSHOT_PREFIX: &str = "tmp-bank-snapshot-";
 pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 2;
+pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 100;
 pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$";
 pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$";
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -53,6 +53,7 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         },
     },
     solana_sdk::{
@@ -2691,6 +2692,8 @@ pub fn main() {
         archive_format,
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
+        maximum_incremental_snapshot_archives_to_retain:
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
Adding `maximum_incremental_snapshot_archives_to_retain` into `SnapshotConfig` has a good bit of plumbing noise, so pulled it out into its own PR.

The `maximum_incremental_snapshot_archives_to_retain` will be used by many functions in snapshot_utils.