### PR TITLE
Add RpcClient::get_multiple_accounts_with_config()

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -2966,10 +2966,24 @@ impl RpcClient {
         pubkeys: &[Pubkey],
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
+        self.get_multiple_accounts_with_config(
+            pubkeys,
+            RpcAccountInfoConfig {
+                encoding: Some(UiAccountEncoding::Base64Zstd),
+                commitment: Some(self.maybe_map_commitment(commitment_config)?),
+                data_slice: None,
+            },
+        )
+    }
+
+    pub fn get_multiple_accounts_with_config(
+        &self,
+        pubkeys: &[Pubkey],
+        config: RpcAccountInfoConfig,
+    ) -> RpcResult<Vec<Option<Account>>> {
         let config = RpcAccountInfoConfig {
-            encoding: Some(UiAccountEncoding::Base64Zstd),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
-            data_slice: None,
+            commitment: config.commitment.or_else(|| Some(self.commitment())),
+            ..config
         };
         let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
         let response = self.send(RpcRequest::GetMultipleAccounts, json!([pubkeys, config]))?;


### PR DESCRIPTION
The `dataSlice` input to [getMultipleAccounts](https://docs.solana.com/developing/clients/jsonrpc-api#getmultipleaccounts) isn't exposed in RpcClient