### PR TITLE
Pass SnapshotConfig to SnapshotPackagerService

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,7 +1,7 @@
 use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
-    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_package::PendingSnapshotPackage,
-    snapshot_utils,
+    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
+    snapshot_package::PendingSnapshotPackage, snapshot_utils,
 };
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
@@ -23,7 +23,7 @@ impl SnapshotPackagerService {
         starting_snapshot_hash: Option<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
-        maximum_snapshots_to_retain: usize,
+        snapshot_config: SnapshotConfig,
     ) -> Self {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
@@ -53,7 +53,7 @@ impl SnapshotPackagerService {
                     // last_full_snapshot_slot that requires this archive call to succeed.
                     snapshot_utils::archive_snapshot_package(
                         &snapshot_package,
-                        maximum_snapshots_to_retain,
+                        snapshot_config.maximum_full_snapshot_archives_to_retain,
                     )
                     .expect("failed to archive snapshot package");
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -651,7 +651,7 @@ impl Validator {
                     snapshot_hash,
                     &exit,
                     &cluster_info,
-                    snapshot_config.maximum_full_snapshot_archives_to_retain,
+                    snapshot_config.clone(),
                 );
                 (
                     Some(snapshot_packager_service),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -502,7 +502,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            snapshot_config.clone(),
         );
 
         let _package_receiver = std::thread::Builder::new()
@@ -923,9 +923,7 @@ mod tests {
             None,
             &exit,
             &cluster_info,
-            snapshot_test_config
-                .snapshot_config
-                .maximum_full_snapshot_archives_to_retain,
+            snapshot_test_config.snapshot_config.clone(),
         );
 
         let accounts_hash_verifier = AccountsHashVerifier::new(


### PR DESCRIPTION
SnapshotPackagerService will need more values that are from SnapshotConfig for incremental snapshot support. Instead of just passing in each one-by-one everywhere, gimme the whole SnapshotConfig to make life easier.
