### PR TITLE
Return error if Transaction contains writable executable or ProgramData accounts

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1865,9 +1865,9 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
         invoke_and_return,
         &[0],
         vec![
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(clock::id(), false),
+            AccountMeta::new_readonly(program_id, false),
+            AccountMeta::new_readonly(program_id, false),
+            AccountMeta::new_readonly(clock::id(), false),
         ],
     );
 
@@ -2054,9 +2054,9 @@ fn test_program_bpf_upgrade_via_cpi() {
         invoke_and_return,
         &[0],
         vec![
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(clock::id(), false),
+            AccountMeta::new_readonly(program_id, false),
+            AccountMeta::new_readonly(program_id, false),
+            AccountMeta::new_readonly(clock::id(), false),
         ],
     );
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -281,8 +281,8 @@ impl Accounts {
                             && message.is_writable(i, demote_program_write_locks)
                             && !is_upgradeable_loader_present
                         {
-                            error_counters.invalid_account_index += 1;
-                            return Err(TransactionError::InvalidAccountIndex);
+                            error_counters.invalid_writable_account += 1;
+                            return Err(TransactionError::InvalidWritableAccount);
                         }
 
                         if bpf_loader_upgradeable::check_id(account.owner()) {
@@ -315,8 +315,8 @@ impl Accounts {
                                 if let Ok(UpgradeableLoaderState::ProgramData { .. }) =
                                     account.state()
                                 {
-                                    error_counters.invalid_account_index += 1;
-                                    return Err(TransactionError::InvalidAccountIndex);
+                                    error_counters.invalid_writable_account += 1;
+                                    return Err(TransactionError::InvalidWritableAccount);
                                 }
                             }
                         }
@@ -1744,11 +1744,11 @@ mod tests {
         let tx = Transaction::new(&[&keypair], message.clone(), Hash::default());
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::InvalidAccountIndex), None)
+            (Err(TransactionError::InvalidWritableAccount), None)
         );
 
         // Solution 1: include bpf_loader_upgradeable account
@@ -1765,7 +1765,7 @@ mod tests {
         let loaded_accounts =
             load_accounts(tx, &accounts_with_upgradeable_loader, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts_with_upgradeable_loader[..2]);
@@ -1780,7 +1780,7 @@ mod tests {
         let tx = Transaction::new(&[&keypair], message, Hash::default());
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);
@@ -1827,11 +1827,11 @@ mod tests {
         let tx = Transaction::new(&[&keypair], message.clone(), Hash::default());
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
-            (Err(TransactionError::InvalidAccountIndex), None)
+            (Err(TransactionError::InvalidWritableAccount), None)
         );
 
         // Solution 1: include bpf_loader_upgradeable account
@@ -1848,7 +1848,7 @@ mod tests {
         let loaded_accounts =
             load_accounts(tx, &accounts_with_upgradeable_loader, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts_with_upgradeable_loader[..2]);
@@ -1863,7 +1863,7 @@ mod tests {
         let tx = Transaction::new(&[&keypair], message, Hash::default());
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(error_counters.invalid_writable_account, 1);
         assert_eq!(loaded_accounts.len(), 1);
         let result = loaded_accounts[0].0.as_ref().unwrap();
         assert_eq!(result.accounts[..2], accounts[..2]);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -251,9 +251,6 @@ impl Accounts {
                     }
 
                     if solana_sdk::sysvar::instructions::check_id(key) {
-                        if message.is_writable(i, demote_program_write_locks) {
-                            return Err(TransactionError::InvalidAccountIndex);
-                        }
                         Self::construct_instructions_account(
                             message,
                             feature_set

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -287,26 +287,40 @@ impl Accounts {
                             return Err(TransactionError::InvalidAccountIndex);
                         }
 
-                        if account.executable() && bpf_loader_upgradeable::check_id(account.owner())
-                        {
-                            // The upgradeable loader requires the derived ProgramData account
-                            if let Ok(UpgradeableLoaderState::Program {
-                                programdata_address,
-                            }) = account.state()
-                            {
-                                if let Some(account) = self
-                                    .accounts_db
-                                    .load_with_fixed_root(ancestors, &programdata_address)
-                                    .map(|(account, _)| account)
+                        if bpf_loader_upgradeable::check_id(account.owner()) {
+                            if account.executable() {
+                                // The upgradeable loader requires the derived ProgramData account
+                                if let Ok(UpgradeableLoaderState::Program {
+                                    programdata_address,
+                                }) = account.state()
                                 {
-                                    account_deps.push((programdata_address, account));
+                                    if let Some(account) = self
+                                        .accounts_db
+                                        .load_with_fixed_root(ancestors, &programdata_address)
+                                        .map(|(account, _)| account)
+                                    {
+                                        account_deps.push((programdata_address, account));
+                                    } else {
+                                        error_counters.account_not_found += 1;
+                                        return Err(TransactionError::ProgramAccountNotFound);
+                                    }
                                 } else {
-                                    error_counters.account_not_found += 1;
-                                    return Err(TransactionError::ProgramAccountNotFound);
+                                    error_counters.invalid_program_for_execution += 1;
+                                    return Err(TransactionError::InvalidProgramForExecution);
                                 }
-                            } else {
-                                error_counters.invalid_program_for_execution += 1;
-                                return Err(TransactionError::InvalidProgramForExecution);
+                            }
+
+                            // If a ProgramData account is present, it should only be writable
+                            // if the bpf_loader_upgradeable account is also present
+                            if let Ok(UpgradeableLoaderState::ProgramData { .. }) = account.state()
+                            {
+                                if demote_program_write_locks
+                                    && message.is_writable(i, demote_program_write_locks)
+                                    && !is_upgradeable_loader_present(message)
+                                {
+                                    error_counters.invalid_account_index += 1;
+                                    return Err(TransactionError::InvalidAccountIndex);
+                                }
                             }
                         }
 
@@ -1766,6 +1780,89 @@ mod tests {
         // Solution 2: mark programdata as readonly
         message.account_keys = vec![key0, key1, key2]; // revert key change
         message.header.num_readonly_unsigned_accounts = 2; // ark both executables as readonly
+        let tx = Transaction::new(&[&keypair], message, Hash::default());
+        let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
+
+        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(loaded_accounts.len(), 1);
+        let result = loaded_accounts[0].0.as_ref().unwrap();
+        assert_eq!(result.accounts[..2], accounts[..2]);
+        assert_eq!(result.loaders[0], vec![accounts[2].clone()]);
+    }
+
+    #[test]
+    fn test_load_accounts_programdata_with_write_lock() {
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
+        let mut error_counters = ErrorCounters::default();
+
+        let keypair = Keypair::new();
+        let key0 = keypair.pubkey();
+        let key1 = Pubkey::new(&[5u8; 32]);
+        let key2 = Pubkey::new(&[6u8; 32]);
+
+        let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
+        account.set_rent_epoch(1);
+        accounts.push((key0, account));
+
+        let program_data = UpgradeableLoaderState::ProgramData {
+            slot: 42,
+            upgrade_authority_address: None,
+        };
+        let mut account =
+            AccountSharedData::new_data(40, &program_data, &bpf_loader_upgradeable::id()).unwrap();
+        account.set_rent_epoch(1);
+        accounts.push((key1, account));
+
+        let mut account = AccountSharedData::new(40, 1, &native_loader::id());
+        account.set_executable(true);
+        account.set_rent_epoch(1);
+        accounts.push((key2, account));
+
+        let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
+        let mut message = Message::new_with_compiled_instructions(
+            1,
+            0,
+            1, // only the program marked as readonly
+            vec![key0, key1, key2],
+            Hash::default(),
+            instructions,
+        );
+        let tx = Transaction::new(&[&keypair], message.clone(), Hash::default());
+        let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
+
+        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(loaded_accounts.len(), 1);
+        assert_eq!(
+            loaded_accounts[0],
+            (Err(TransactionError::InvalidAccountIndex), None)
+        );
+
+        // Solution 1: include bpf_loader_upgradeable account
+        let mut account = AccountSharedData::new(40, 1, &native_loader::id()); // create mock bpf_loader_upgradeable
+        account.set_executable(true);
+        account.set_rent_epoch(1);
+        let accounts_with_upgradeable_loader = vec![
+            accounts[0].clone(),
+            accounts[1].clone(),
+            (bpf_loader_upgradeable::id(), account),
+        ];
+        message.account_keys = vec![key0, key1, bpf_loader_upgradeable::id()];
+        let tx = Transaction::new(&[&keypair], message.clone(), Hash::default());
+        let loaded_accounts =
+            load_accounts(tx, &accounts_with_upgradeable_loader, &mut error_counters);
+
+        assert_eq!(error_counters.invalid_account_index, 1);
+        assert_eq!(loaded_accounts.len(), 1);
+        let result = loaded_accounts[0].0.as_ref().unwrap();
+        assert_eq!(result.accounts[..2], accounts_with_upgradeable_loader[..2]);
+        assert_eq!(
+            result.loaders[0],
+            vec![accounts_with_upgradeable_loader[2].clone()]
+        );
+
+        // Solution 2: mark programdata as readonly
+        message.account_keys = vec![key0, key1, key2]; // revert key change
+        message.header.num_readonly_unsigned_accounts = 2; // extend readonly set to include programdata
         let tx = Transaction::new(&[&keypair], message, Hash::default());
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -175,6 +175,7 @@ pub struct ErrorCounters {
     pub invalid_account_index: usize,
     pub invalid_program_for_execution: usize,
     pub not_allowed_during_cluster_maintenance: usize,
+    pub invalid_writable_account: usize,
 }
 
 #[derive(Default, Debug)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -189,7 +189,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "GT81Hdwrh73i55ScQvFqmzeHfUL42yxuavZods8VyzGc")]
+#[frozen_abi(digest = "5Br3PNyyX1L7XoS4jYLt5JTeMXowLSsu7v9LhokC8vnq")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>;
 type TransactionLoaderRefCells = Vec<Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>>;
@@ -3117,6 +3117,12 @@ impl Bank {
             inc_new_counter_info!(
                 "bank-process_transactions-error-cluster-maintenance",
                 error_counters.not_allowed_during_cluster_maintenance
+            );
+        }
+        if 0 != error_counters.invalid_writable_account {
+            inc_new_counter_info!(
+                "bank-process_transactions-error-invalid_writable_account",
+                error_counters.invalid_writable_account
             );
         }
     }

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -116,6 +116,10 @@ pub enum TransactionError {
     /// Transaction version is unsupported
     #[error("Transaction version is unsupported")]
     UnsupportedVersion,
+
+    /// Transaction loads a writable account that cannot be written
+    #[error("Transaction loads a writable account that cannot be written")]
+    InvalidWritableAccount,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -43,6 +43,7 @@ enum TransactionErrorType {
     ACCOUNT_BORROW_OUTSTANDING_TX = 16;
     WOULD_EXCEED_MAX_BLOCK_COST_LIMIT = 17;
     UNSUPPORTED_VERSION = 18;
+    INVALID_WRITABLE_ACCOUNT = 19;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -550,6 +550,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             16 => TransactionError::AccountBorrowOutstanding,
             17 => TransactionError::WouldExceedMaxBlockCostLimit,
             18 => TransactionError::UnsupportedVersion,
+            19 => TransactionError::InvalidWritableAccount,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -613,6 +614,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::UnsupportedVersion => {
                     tx_by_addr::TransactionErrorType::UnsupportedVersion
+                }
+                TransactionError::InvalidWritableAccount => {
+                    tx_by_addr::TransactionErrorType::InvalidWritableAccount
                 }
             } as i32,
             instruction_error: match transaction_error {


### PR DESCRIPTION
#### Problem
Accounts marked executable can only be written to if being upgraded (ie. if the UpgradeableLoader is present in the transaction). As of #19593, we're demoting top-level program ids incorrectly marked as writable, but we can't detect other executables until the accounts are loaded.
Similarly, ProgramData accounts can only be written if the UpgradeableLoader is present in the transaction, but we can't identify these accounts until they are loaded.

#### Summary of Changes
Return `InvalidAccountIndex` error to fail these types of Transactions and release the write lock quickly. Open to creating a new error type, if this seems significant enough.

Needs rebase on #19593 
@jackcmay  @jstarry , the last 3 commits are ready for review
