### PR TITLE
Plumb `maximum_incremental_snapshot_archives_to_retain`

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -54,6 +54,7 @@ impl SnapshotPackagerService {
                     snapshot_utils::archive_snapshot_package(
                         &snapshot_package,
                         snapshot_config.maximum_full_snapshot_archives_to_retain,
+                        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
                     )
                     .expect("failed to archive snapshot package");
 
@@ -190,6 +191,7 @@ mod tests {
         snapshot_utils::archive_snapshot_package(
             &snapshot_package,
             snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         )
         .unwrap();
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1238,6 +1238,7 @@ fn new_banks_from_ledger(
             &snapshot_config.snapshot_archives_dir,
             snapshot_config.archive_format,
             snapshot_config.maximum_full_snapshot_archives_to_retain,
+            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         )
         .unwrap_or_else(|err| {
             error!("Unable to create snapshot: {}", err);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -299,7 +299,8 @@ mod tests {
         let snapshot_package = SnapshotPackage::from(accounts_package);
         snapshot_utils::archive_snapshot_package(
             &snapshot_package,
-            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            snapshot_config.maximum_full_snapshot_archives_to_retain,
+            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         )
         .unwrap();
 
@@ -387,7 +388,7 @@ mod tests {
         let saved_slot = 4;
         let mut saved_archive_path = None;
 
-        for forks in 0..snapshot_utils::MAX_BANK_SNAPSHOTS + 2 {
+        for forks in 0..snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN + 2 {
             let bank = Bank::new_from_parent(
                 &bank_forks[forks as u64],
                 &Pubkey::default(),
@@ -483,7 +484,7 @@ mod tests {
         assert!(bank_snapshots
             .into_iter()
             .map(|path| path.slot)
-            .eq(3..=snapshot_utils::MAX_BANK_SNAPSHOTS as u64 + 2));
+            .eq(3..=snapshot_utils::MAX_BANK_SNAPSHOTS_TO_RETAIN as u64 + 2));
 
         // Create a SnapshotPackagerService to create tarballs from all the pending
         // SnapshotPackage's on the channel. By the time this service starts, we have already
@@ -776,6 +777,7 @@ mod tests {
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
             snapshot_config.maximum_full_snapshot_archives_to_retain,
+            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         )?;
 
         Ok(())
@@ -812,6 +814,7 @@ mod tests {
             snapshot_config.archive_format,
             snapshot_config.snapshot_version,
             snapshot_config.maximum_full_snapshot_archives_to_retain,
+            snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         )?;
 
         Ok(())

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -249,13 +249,14 @@ pub fn download_snapshot<'a, 'b>(
     snapshot_archives_dir: &Path,
     desired_snapshot_hash: (Slot, Hash),
     use_progress_bar: bool,
-    maximum_snapshots_to_retain: usize,
+    maximum_full_snapshot_archives_to_retain: usize,
+    maximum_incremental_snapshot_archives_to_retain: usize,
     progress_notify_callback: &'a mut DownloadProgressCallbackOption<'b>,
 ) -> Result<(), String> {
     snapshot_utils::purge_old_snapshot_archives(
         snapshot_archives_dir,
-        maximum_snapshots_to_retain,
-        snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        maximum_full_snapshot_archives_to_retain,
+        maximum_incremental_snapshot_archives_to_retain,
     );
 
     for compression in &[

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2018,8 +2018,10 @@ fn main() {
                         })
                     });
 
-            let maximum_snapshots_to_retain =
+            let maximum_full_snapshot_archives_to_retain =
                 value_t_or_exit!(arg_matches, "maximum_snapshots_to_retain", usize);
+            let maximum_incremental_snapshot_archives_to_retain =
+                snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN;
             let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
             let blockstore = open_blockstore(
                 &ledger_path,
@@ -2235,7 +2237,8 @@ fn main() {
                         Some(snapshot_version),
                         output_directory,
                         ArchiveFormat::TarZstd,
-                        maximum_snapshots_to_retain,
+                        maximum_full_snapshot_archives_to_retain,
+                        maximum_incremental_snapshot_archives_to_retain,
                     )
                     .unwrap_or_else(|err| {
                         eprintln!("Unable to create snapshot: {}", err);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1708,6 +1708,7 @@ fn test_snapshot_download() {
         archive_snapshot_hash,
         false,
         snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
         &mut None,
     )
     .unwrap();

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -95,6 +95,7 @@ fn initialize_from_snapshot(
         replica_config.snapshot_info,
         false,
         snapshot_config.maximum_full_snapshot_archives_to_retain,
+        snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         &mut None,
     )
     .unwrap();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -925,19 +925,20 @@ fn rpc_bootstrap(
                                 gossip.take().unwrap();
                             cluster_info.save_contact_info();
                             gossip_exit_flag.store(true, Ordering::Relaxed);
-                            let maximum_snapshots_to_retain = if let Some(snapshot_config) =
+                            let (maximum_full_snapshot_archives_to_retain, maximum_incremental_snapshot_archives_to_retain) = if let Some(snapshot_config) =
                                 validator_config.snapshot_config.as_ref()
                             {
-                                snapshot_config.maximum_full_snapshot_archives_to_retain
+                                (snapshot_config.maximum_full_snapshot_archives_to_retain, snapshot_config.maximum_incremental_snapshot_archives_to_retain)
                             } else {
-                                DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN
+                                (DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN, DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN)
                             };
                             let ret = download_snapshot(
                                 &rpc_contact_info.rpc,
                                 snapshot_archives_dir,
                                 snapshot_hash,
                                 use_progress_bar,
-                                maximum_snapshots_to_retain,
+                                maximum_full_snapshot_archives_to_retain,
+                                maximum_incremental_snapshot_archives_to_retain,
                                 &mut Some(Box::new(|download_progress: &DownloadProgressRecord| {
                                     debug!("Download progress: {:?}", download_progress);
 


### PR DESCRIPTION
#### Problem

`purge_old_snapshot_archives()` could accept a `maximum_incremental_snapshot_archives_to_retain` parameter, but no functions could set that parameter with anything other than the default, since it was not plumbed through.

#### Summary of Changes

Plumb through `maximum_incremental_snapshot_archives_to_retain`

This is the final PR for this work. See also:

PR #19612 
PR #19615
PR #19616 

And the main issue: #18639 