### PR TITLE
Reduce payer balance needed to deploy programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -31,7 +31,7 @@ use solana_sdk::{
     clock::Clock,
     entrypoint::{HEAP_LENGTH, SUCCESS},
     feature_set::{
-        add_missing_program_error_mappings, close_upgradeable_program_accounts,
+        add_missing_program_error_mappings, close_upgradeable_program_accounts, fix_write_privs,
         stop_verify_mul64_imm_nonzero,
     },
     ic_logger_msg, ic_msg,
@@ -390,6 +390,14 @@ fn process_loader_upgradeable_instruction(
                 return Err(InstructionError::InvalidArgument);
             }
 
+            if invoke_context.is_feature_active(&fix_write_privs::id()) {
+                // Drain the Buffer account to payer before paying for programdata account
+                payer
+                    .try_account_ref_mut()?
+                    .checked_add_lamports(buffer.lamports()?)?;
+                buffer.try_account_ref_mut()?.set_lamports(0);
+            }
+
             let instruction = system_instruction::create_account(
                 payer.unsigned_key(),
                 programdata.unsigned_key(),
@@ -434,11 +442,13 @@ fn process_loader_upgradeable_instruction(
             })?;
             program.try_account_ref_mut()?.set_executable(true);
 
-            // Drain the Buffer account back to the payer
-            payer
-                .try_account_ref_mut()?
-                .checked_add_lamports(buffer.lamports()?)?;
-            buffer.try_account_ref_mut()?.set_lamports(0);
+            if !invoke_context.is_feature_active(&fix_write_privs::id()) {
+                // Drain the Buffer account back to the payer
+                payer
+                    .try_account_ref_mut()?
+                    .checked_add_lamports(buffer.lamports()?)?;
+                buffer.try_account_ref_mut()?.set_lamports(0);
+            }
 
             ic_logger_msg!(logger, "Deployed program {:?}", new_program_id);
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1724,7 +1724,6 @@ mod tests {
         bank.store_account(&buffer_address, &buffer_account);
         bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
         bank.store_account(&programdata_address, &AccountSharedData::default());
-        let before = bank.get_balance(&payer_keypair.pubkey());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &payer_keypair.pubkey(),
@@ -1743,8 +1742,7 @@ mod tests {
                 message
             )
             .is_ok());
-        let balance = bank.get_balance(&payer_keypair.pubkey());
-        assert_eq!(bank.get_balance(&payer_address), 0);
+        assert_eq!(bank.get_balance(&payer_keypair.pubkey()), 0);
         assert_eq!(bank.get_balance(&buffer_address), 0);
         assert_eq!(None, bank.get_account(&buffer_address));
         let post_program_account = bank.get_account(&program_keypair.pubkey()).unwrap();


### PR DESCRIPTION
#### Problem
Program deploys require more SOL than necessary for a successful deploy.

The payer balance is used to pay for programdata account creation before the payer is credited for the deploy buffer account. The buffer account balance is about the same as the required programdata balance, so a payer basically has to cover twice the rent cost than they need to.

#### Summary of Changes
- Credit buffer balance before paying for programdata account creation

Fixes #
