### PR TITLE
Recover from interrupted bpf sdk installs

### DIFF
--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -118,10 +118,10 @@ fn install_if_missing(
     package: &str,
     version: &str,
     url: &str,
-    file: &Path,
+    download_file_name: &str,
 ) -> Result<(), String> {
     // Check whether the package is already in ~/.cache/solana.
-    // Donwload it and place in the proper location if not found.
+    // Download it and place in the proper location if not found.
     let home_dir = PathBuf::from(env::var("HOME").unwrap_or_else(|err| {
         eprintln!("Can't get home directory path: {}", err);
         exit(1);
@@ -141,20 +141,24 @@ fn install_if_missing(
         if target_path.exists() {
             fs::remove_file(&target_path).map_err(|err| err.to_string())?;
         }
+        fs::create_dir_all(&target_path).map_err(|err| err.to_string())?;
         let mut url = String::from(url);
         url.push('/');
         url.push_str(version);
         url.push('/');
-        url.push_str(file.to_str().unwrap());
-        download_file(url.as_str(), file, true, &mut None)?;
-        fs::create_dir_all(&target_path).map_err(|err| err.to_string())?;
-        let zip = File::open(&file).map_err(|err| err.to_string())?;
+        url.push_str(download_file_name);
+        let download_file_path = target_path.join(download_file_name);
+        if download_file_path.exists() {
+            fs::remove_file(&download_file_path).map_err(|err| err.to_string())?;
+        }
+        download_file(url.as_str(), &download_file_path, true, &mut None)?;
+        let zip = File::open(&download_file_path).map_err(|err| err.to_string())?;
         let tar = BzDecoder::new(BufReader::new(zip));
         let mut archive = Archive::new(tar);
         archive
             .unpack(&target_path)
             .map_err(|err| err.to_string())?;
-        fs::remove_file(file).map_err(|err| err.to_string())?;
+        fs::remove_file(download_file_path).map_err(|err| err.to_string())?;
     }
     // Make a symbolic link source_path -> target_path in the
     // sdk/bpf/dependencies directory if no valid link found.
@@ -164,7 +168,17 @@ fn install_if_missing(
     }
     let source_path = source_base.join(package);
     // Check whether the correct symbolic link exists.
-    if source_path.read_link().is_err() {
+    let invalid_link = if let Ok(link_target) = source_path.read_link() {
+        if link_target != target_path {
+            fs::remove_file(&source_path).map_err(|err| err.to_string())?;
+            true
+        } else {
+            false
+        }
+    } else {
+        true
+    };
+    if invalid_link {
         #[cfg(unix)]
         std::os::unix::fs::symlink(target_path, source_path).map_err(|err| err.to_string())?;
         #[cfg(windows)]
@@ -444,7 +458,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     if legacy_program_feature_present {
         println!("Legacy program feature detected");
     }
-    let bpf_tools_filename = if cfg!(target_os = "macos") {
+    let bpf_tools_download_file_name = if cfg!(target_os = "macos") {
         "solana-bpf-tools-osx.tar.bz2"
     } else {
         "solana-bpf-tools-linux.tar.bz2"
@@ -454,7 +468,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         "bpf-tools",
         "v1.15",
         "https://github.com/solana-labs/bpf-tools/releases/download",
-        &PathBuf::from(bpf_tools_filename),
+        bpf_tools_download_file_name,
     )
     .expect("Failed to install bpf-tools");
     link_bpf_toolchain(config);


### PR DESCRIPTION
#### Problem
When installing the bpf-sdk, the tar file is downloaded to the user's program dir and then unpacked into `~/.cache/solana`. If the install is interrupted and re-run, the install will fail because the tar file already exists.

```
thread 'main' panicked at 'Failed to install bpf-tools: ""solana-bpf-tools-linux.tar.bz2" already exists"', sdk/cargo-build-bpf/src/main.rs:432:6
```

#### Summary of Changes
- Download the bpf sdk tar to the cache
- Delete the bpf sdk tar if it already exists (download may have been interrupted)
- Re-add the symlink check removed in https://github.com/solana-labs/solana/pull/19499 because otherwise bpf sdk installs will not properly update the `release/bin/sdk/bpf/dependencies/bpf-tools` symlink to the newly downloaded version

Fixes #
