### PR TITLE
fixup! test-validator: start logging asap

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -323,7 +323,7 @@ fn main() {
 
     let validator_log_symlink = ledger_path.join("validator.log");
 
-    let logfile = if output != Output::Log {
+    let logfile = if output == Output::Log {
         let validator_log_with_timestamp = format!(
             "validator-{}.log",
             SystemTime::now()


### PR DESCRIPTION
#### Problem
I think the logic for when we make a logfile is inverted (from https://github.com/solana-labs/solana/commit/ee65ffb3c8); the current behavior is:
`./solana-test-validator` ==> logfile generated in `ledger_path` directory
`/solana-test-validator --log` ==> No logfile + output to console