### PR TITLE
Bump mango client used by explorer, previous version was breaking explorer builds

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@blockworks-foundation/mango-client": "^3.0.12",
+        "@blockworks-foundation/mango-client": "^3.0.14",
         "@bonfida/bot": "^0.5.3",
         "@metamask/jazzicon": "^2.0.0",
         "@project-serum/serum": "^0.13.58",
@@ -1309,18 +1309,18 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@blockworks-foundation/mango-client": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@blockworks-foundation/mango-client/-/mango-client-3.0.12.tgz",
-      "integrity": "sha512-gDwn2feXPMuyxb+mQXXJfAlyVLojnCifPbvxfRNikV4nswHQmPVQ1GhLzqAYXxqxANBiRlDB3uHISnnQp0Xqcw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@blockworks-foundation/mango-client/-/mango-client-3.0.14.tgz",
+      "integrity": "sha512-t6W4yYFtoEVdG8d4ItspVbSOvNK/8o8iy9y/Fy2dhEFBf++pzIIMaaDPvN8H8zDZmzhCYuDnqL4GUhTO9qTGKg==",
       "dependencies": {
         "@project-serum/serum": "0.13.55",
         "@project-serum/sol-wallet-adapter": "^0.2.0",
         "@solana/spl-token": "^0.1.6",
         "@solana/web3.js": "1.21.0",
+        "axios": "^0.21.1",
         "big.js": "^6.1.1",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.1.0",
-        "borsh": "git+https://github.com/defactojob/borsh-js.git#field-mapper",
         "buffer-layout": "^1.2.1",
         "yargs": "^17.0.1"
       },
@@ -1472,17 +1472,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bigjs"
-      }
-    },
-    "node_modules/@blockworks-foundation/mango-client/node_modules/borsh": {
-      "version": "0.3.1",
-      "resolved": "git+ssh://git@github.com/defactojob/borsh-js.git#33a0d24af281112c0a48efb3fa503f3212443de9",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/bn.js": "^4.11.5",
-        "bn.js": "^5.0.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "node_modules/@blockworks-foundation/mango-client/node_modules/cliui": {
@@ -5545,6 +5534,14 @@
       "integrity": "sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -10390,11 +10387,22 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-in": {
@@ -26347,18 +26355,18 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@blockworks-foundation/mango-client": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@blockworks-foundation/mango-client/-/mango-client-3.0.12.tgz",
-      "integrity": "sha512-gDwn2feXPMuyxb+mQXXJfAlyVLojnCifPbvxfRNikV4nswHQmPVQ1GhLzqAYXxqxANBiRlDB3uHISnnQp0Xqcw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@blockworks-foundation/mango-client/-/mango-client-3.0.14.tgz",
+      "integrity": "sha512-t6W4yYFtoEVdG8d4ItspVbSOvNK/8o8iy9y/Fy2dhEFBf++pzIIMaaDPvN8H8zDZmzhCYuDnqL4GUhTO9qTGKg==",
       "requires": {
         "@project-serum/serum": "0.13.55",
         "@project-serum/sol-wallet-adapter": "^0.2.0",
         "@solana/spl-token": "^0.1.6",
         "@solana/web3.js": "1.21.0",
+        "axios": "^0.21.1",
         "big.js": "^6.1.1",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.1.0",
-        "borsh": "git+https://github.com/defactojob/borsh-js.git#field-mapper",
         "buffer-layout": "^1.2.1",
         "yargs": "^17.0.1"
       },
@@ -26470,16 +26478,6 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
           "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg=="
-        },
-        "borsh": {
-          "version": "git+ssh://git@github.com/defactojob/borsh-js.git#33a0d24af281112c0a48efb3fa503f3212443de9",
-          "from": "borsh@git+https://github.com/defactojob/borsh-js.git#field-mapper",
-          "requires": {
-            "@types/bn.js": "^4.11.5",
-            "bn.js": "^5.0.0",
-            "bs58": "^4.0.0",
-            "text-encoding-utf-8": "^1.0.2"
-          }
         },
         "cliui": {
           "version": "7.0.4",
@@ -29827,6 +29825,14 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.2.tgz",
       "integrity": "sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg=="
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -33883,9 +33889,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+      "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@blockworks-foundation/mango-client": "^3.0.12",
+    "@blockworks-foundation/mango-client": "^3.0.14",
     "@bonfida/bot": "^0.5.3",
     "@metamask/jazzicon": "^2.0.0",
     "@project-serum/serum": "^0.13.58",

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -51,7 +51,10 @@ import { useQuery } from "utils/url";
 import { TokenInfoMap } from "@solana/spl-token-registry";
 import { useTokenRegistry } from "providers/mints/token-registry";
 import { getTokenProgramInstructionName } from "utils/instruction";
-import { isMangoInstruction, parseMangoInstructionTitle } from "components/instruction/mango/types";
+import {
+  isMangoInstruction,
+  parseMangoInstructionTitle,
+} from "components/instruction/mango/types";
 
 const TRUNCATE_TOKEN_LENGTH = 10;
 const ALL_TOKENS = "";


### PR DESCRIPTION
Previous version of mango client in explorer used to break builds so

```
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/defactojob/borsh-js.git
0.01s$ .travis/affects.sh explorer/ .travis || travis_terminate 0
before_install.2
2200.00s$ cd explorer
22169.29s$ npm ci 
222npm ERR! Error while executing:
223npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/defactojob/borsh-js.git
224npm ERR! 
225npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.112.4' to the list of known hosts.
226npm ERR! git@github.com: Permission denied (publickey).
227npm ERR! fatal: Could not read from remote repository.
228npm ERR! 
229npm ERR! Please make sure you have the correct access rights
230npm ERR! and the repository exists.
231npm ERR! 
232npm ERR! exited with error code: 128
233
234npm ERR! A complete log of this run can be found in:
235npm ERR!     /home/travis/.npm/_logs/2021-09-04T05_04_42_074Z-debug.log
```

The problematic dependency has been now removed from latest mango client i.e. 3.0.14 
