### PR TITLE
Rename to is_valid instead of is_invalid

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -636,7 +636,7 @@ impl Validator {
 
         let (snapshot_packager_service, snapshot_config_and_pending_package) =
             if let Some(snapshot_config) = config.snapshot_config.clone() {
-                if is_snapshot_config_invalid(
+                if !is_snapshot_config_valid(
                     snapshot_config.full_snapshot_archive_interval_slots,
                     config.accounts_hash_interval_slots,
                 ) {
@@ -1649,13 +1649,13 @@ fn cleanup_accounts_path(account_path: &std::path::Path) {
     }
 }
 
-pub fn is_snapshot_config_invalid(
+pub fn is_snapshot_config_valid(
     snapshot_interval_slots: u64,
     accounts_hash_interval_slots: u64,
 ) -> bool {
-    snapshot_interval_slots != 0
-        && (snapshot_interval_slots < accounts_hash_interval_slots
-            || snapshot_interval_slots % accounts_hash_interval_slots != 0)
+    snapshot_interval_slots == 0
+        || (snapshot_interval_slots >= accounts_hash_interval_slots
+            && snapshot_interval_slots % accounts_hash_interval_slots == 0)
 }
 
 #[cfg(test)]
@@ -1860,11 +1860,11 @@ mod tests {
 
     #[test]
     fn test_interval_check() {
-        assert!(!is_snapshot_config_invalid(0, 100));
-        assert!(is_snapshot_config_invalid(1, 100));
-        assert!(is_snapshot_config_invalid(230, 100));
-        assert!(!is_snapshot_config_invalid(500, 100));
-        assert!(!is_snapshot_config_invalid(5, 5));
+        assert!(is_snapshot_config_valid(0, 100));
+        assert!(!is_snapshot_config_valid(1, 100));
+        assert!(!is_snapshot_config_valid(230, 100));
+        assert!(is_snapshot_config_valid(500, 100));
+        assert!(is_snapshot_config_valid(5, 5));
     }
 
     #[test]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -23,9 +23,7 @@ use {
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
-        validator::{
-            is_snapshot_config_invalid, Validator, ValidatorConfig, ValidatorStartProgress,
-        },
+        validator::{is_snapshot_config_valid, Validator, ValidatorConfig, ValidatorStartProgress},
     },
     solana_download_utils::{download_snapshot, DownloadProgressRecord},
     solana_genesis_utils::download_then_check_genesis_hash,
@@ -2702,7 +2700,7 @@ pub fn main() {
         eprintln!("Accounts hash interval should not be 0.");
         exit(1);
     }
-    if is_snapshot_config_invalid(
+    if !is_snapshot_config_valid(
         snapshot_interval_slots,
         validator_config.accounts_hash_interval_slots,
     ) {


### PR DESCRIPTION
I'll be expanding snapshot configuration, and wanted to start with renaming this function to `is_snapshot_config_valid()` instead of _invalid_.