### PR TITLE
Add some common subcommands and arguments to all solana CLIs (such as shell completion)

### DIFF
--- a/clap-utils/src/app.rs
+++ b/clap-utils/src/app.rs
@@ -1,0 +1,49 @@
+use clap::{App, Arg, Shell, SubCommand};
+use std::io::stdout;
+
+/// Trait that adds common solana arguments and subcommands to clap App.
+pub trait SolanaApp<'ab, 'v> {
+    /// Add common arguments and subcommands to provided App.
+    fn finalize(self) -> App<'ab, 'v>;
+    /// Process the common subcommands and arguments
+    fn process_common(&mut self, name: &str);
+}
+
+impl<'ab, 'v> SolanaApp<'ab, 'v> for App<'ab, 'v> {
+    fn finalize(self) -> App<'ab, 'v> {
+        self.subcommand(
+            SubCommand::with_name("completion")
+                .about("Generate completion scripts for various shells")
+                .arg(
+                    Arg::with_name("shell")
+                        .long("shell")
+                        .short("s")
+                        .takes_value(true)
+                        .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
+                        .default_value("bash"),
+                ),
+        )
+    }
+
+    fn process_common(&mut self, name: &str) {
+        let matches = self.clone().get_matches();
+        match matches.subcommand() {
+            // Autocompletion Command
+            ("completion", Some(matches)) => {
+                let shell_choice = match matches.value_of("shell") {
+                    Some("bash") => Shell::Bash,
+                    Some("fish") => Shell::Fish,
+                    Some("zsh") => Shell::Zsh,
+                    Some("powershell") => Shell::PowerShell,
+                    Some("elvish") => Shell::Elvish,
+                    // This is safe, since we assign default_value and possible_values
+                    // are restricted
+                    _ => unreachable!(),
+                };
+                self.gen_completions_to(name, shell_choice, &mut stdout());
+                std::process::exit(0);
+            }
+            (_, _) => {}
+        }
+    }
+}

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -23,6 +23,7 @@ impl std::fmt::Debug for DisplayError {
     }
 }
 
+pub mod app;
 pub mod fee_payer;
 pub mod input_parsers;
 pub mod input_validators;

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -187,16 +187,4 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                         ),
                 ),
         )
-        .subcommand(
-            SubCommand::with_name("completion")
-            .about("Generate completion scripts for various shells")
-            .arg(
-                Arg::with_name("shell")
-                .long("shell")
-                .short("s")
-                .takes_value(true)
-                .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
-                .default_value("bash")
-            )
-        )
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,8 +1,8 @@
 use crate::{
-    clap_app::*, cluster_query::*, feature::*, inflation::*, nonce::*, program::*, spend_utils::*,
-    stake::*, validator_info::*, vote::*, wallet::*,
+    cluster_query::*, feature::*, inflation::*, nonce::*, program::*, spend_utils::*, stake::*,
+    validator_info::*, vote::*, wallet::*,
 };
-use clap::{crate_description, crate_name, value_t_or_exit, ArgMatches, Shell};
+use clap::{value_t_or_exit, ArgMatches};
 use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, Value};
@@ -30,7 +30,7 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
 };
 use solana_vote_program::vote_state::VoteAuthorize;
-use std::{collections::HashMap, error, io::stdout, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashMap, error, str::FromStr, sync::Arc, time::Duration};
 use thiserror::Error;
 
 pub const DEFAULT_RPC_TIMEOUT_SECONDS: &str = "30";
@@ -591,26 +591,6 @@ pub fn parse_command(
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, Box<dyn error::Error>> {
     let response = match matches.subcommand() {
-        // Autocompletion Command
-        ("completion", Some(matches)) => {
-            let shell_choice = match matches.value_of("shell") {
-                Some("bash") => Shell::Bash,
-                Some("fish") => Shell::Fish,
-                Some("zsh") => Shell::Zsh,
-                Some("powershell") => Shell::PowerShell,
-                Some("elvish") => Shell::Elvish,
-                // This is safe, since we assign default_value and possible_values
-                // are restricted
-                _ => unreachable!(),
-            };
-            get_clap_app(
-                crate_name!(),
-                crate_description!(),
-                solana_version::version!(),
-            )
-            .gen_completions_to("solana", shell_choice, &mut stdout());
-            std::process::exit(0);
-        }
         // Cluster Query Commands
         ("block", Some(matches)) => parse_get_block(matches),
         ("block-height", Some(matches)) => parse_get_block_height(matches),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{crate_description, crate_name, value_t_or_exit, ArgMatches};
 use console::style;
 use solana_clap_utils::{
+    app::SolanaApp,
     input_validators::normalize_to_url_if_moniker,
     keypair::{CliSigners, DefaultSigner},
     DisplayError,
@@ -235,12 +236,10 @@ pub fn parse_args<'a>(
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     solana_logger::setup_with_default("off");
-    let matches = get_clap_app(
-        crate_name!(),
-        crate_description!(),
-        solana_version::version!(),
-    )
-    .get_matches();
+    let version = String::from(solana_version::version!());
+    let mut app = get_clap_app(crate_name!(), crate_description!(), &version).finalize();
+    app.process_common("solana");
+    let matches = app.get_matches();
 
     do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -5,6 +5,7 @@ use clap::{
     Arg, ArgMatches, SubCommand,
 };
 use solana_clap_utils::{
+    app::SolanaApp,
     input_parsers::STDOUT_OUTFILE_TOKEN,
     input_validators::{is_parsable, is_prompt_signer_source},
     keypair::{
@@ -329,9 +330,10 @@ fn grind_parse_args(
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let default_num_threads = num_cpus::get().to_string();
-    let matches = App::new(crate_name!())
+    let version = solana_version::version!();
+    let mut app = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_version::version!())
+        .version(version)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg({
             let arg = Arg::with_name("config_file")
@@ -518,7 +520,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 ),
 
         )
-        .get_matches();
+        .finalize();
+
+    app.process_common("solana-keygen");
+    let matches = app.get_matches();
 
     do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }


### PR DESCRIPTION
#### Problem
Add some common subcommands and arguments to all solana CLIs
(such as shell completion).

This problem for sure has multiple solutions, this is my take on it.

I introduced a trait that implements itself on clap App, adding method
for adding common commands (`finalize`) and processing added commands
(`process_common`).

All the end user has to do is import the trait in their program, call
`finalize` at the end of creation of clap App, and call `process_common`
later in the program whenever he wants to process common commands.

Personally, i just want the shell completion functionality, but this could be
extended to add some other common subcommands and arguments.
I also think this will add some generality to the implementations of CLI utilities,
as right now it's a mess.

I implemented this new design for solana-keygen CLI as a reference to show
how little change is needed in order to setup new API.