### PR TITLE
Add note about older rust versions on release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ $ source $HOME/.cargo/env
 $ rustup component add rustfmt
 ```
 
-Please make sure you are always using the latest stable rust version by running:
+When building the master branch, please make sure you are using the latest stable rust version by running:
 
 ```bash
 $ rustup update
 ```
+
+When building a specific release branch, you should check the rust version in `ci/rust-version.sh` and if necessary, install that version by running:
+```bash
+$ rustup install VERSION
+```
+Note that if this is not the latest rust version on your machine, cargo commands may require an [override](https://rust-lang.github.io/rustup/overrides.html) in order to use the correct version.
 
 On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, etc.  On Ubuntu:
 


### PR DESCRIPTION
#### Problem
The README states to use the latest stable version of rust; this may not be correct when building a release branch.

#### Summary of Changes
Add note to check rust version when building a release branch;.

