### PR TITLE
AccountsIndexConfig -> AccountsDbConfig

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -61,8 +61,8 @@ use {
         transaction_status_service::TransactionStatusService,
     },
     solana_runtime::{
-        accounts_db::AccountShrinkThreshold,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
+        accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+        accounts_index::AccountSecondaryIndexes,
         bank::Bank,
         bank_forks::BankForks,
         commitment::BlockCommitmentCache,
@@ -149,7 +149,7 @@ pub struct ValidatorConfig {
     pub poh_hashes_per_batch: u64,
     pub account_indexes: AccountSecondaryIndexes,
     pub accounts_db_caching_enabled: bool,
-    pub accounts_index_config: Option<AccountsIndexConfig>,
+    pub accounts_db_config: Option<AccountsDbConfig>,
     pub warp_slot: Option<Slot>,
     pub accounts_db_test_hash_calculation: bool,
     pub accounts_db_skip_shrink: bool,
@@ -216,7 +216,7 @@ impl Default for ValidatorConfig {
             validator_exit: Arc::new(RwLock::new(Exit::default())),
             no_wait_for_vote_to_start_leader: true,
             accounts_shrink_ratio: AccountShrinkThreshold::default(),
-            accounts_index_config: None,
+            accounts_db_config: None,
         }
     }
 }
@@ -1171,7 +1171,7 @@ fn new_banks_from_ledger(
         debug_keys: config.debug_keys.clone(),
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,
-        accounts_index_config: config.accounts_index_config.clone(),
+        accounts_db_config: config.accounts_db_config.clone(),
         shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
         accounts_db_skip_shrink: config.accounts_db_skip_shrink,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -59,7 +59,7 @@ mod tests {
         accounts_background_service::{
             AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
         },
-        accounts_db,
+        accounts_db::{self, ACCOUNTS_DB_CONFIG_FOR_TESTING},
         accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta},
         bank_forks::BankForks,
@@ -209,7 +209,7 @@ mod tests {
             check_hash_calculation,
             false,
             false,
-            Some(solana_runtime::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 
@@ -844,7 +844,7 @@ mod tests {
             false,
             false,
             false,
-            Some(solana_runtime::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )?;
 
         assert_eq!(bank, &deserialized_bank);
@@ -1020,7 +1020,7 @@ mod tests {
             false,
             false,
             false,
-            Some(solana_runtime::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -26,6 +26,7 @@ use solana_ledger::{
     shred::Shred,
 };
 use solana_runtime::{
+    accounts_db::AccountsDbConfig,
     accounts_index::AccountsIndexConfig,
     bank::{Bank, RewardCalculationEvent},
     bank_forks::BankForks,
@@ -1886,6 +1887,9 @@ fn main() {
                 .ok()
                 .map(|bins| AccountsIndexConfig { bins: Some(bins) });
 
+            let accounts_db_config =
+                accounts_index_config.map(|x| AccountsDbConfig { index: Some(x) });
+
             let process_options = ProcessOptions {
                 dev_halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                 new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
@@ -1898,7 +1902,7 @@ fn main() {
                     usize
                 )
                 .ok(),
-                accounts_index_config,
+                accounts_db_config,
                 verify_index: arg_matches.is_present("verify_accounts_index"),
                 allow_dead_slots: arg_matches.is_present("allow_dead_slots"),
                 accounts_db_test_hash_calculation: arg_matches

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -157,7 +157,7 @@ fn load_from_snapshot(
             process_options.accounts_db_test_hash_calculation,
             process_options.accounts_db_skip_shrink,
             process_options.verify_index,
-            process_options.accounts_index_config.clone(),
+            process_options.accounts_db_config.clone(),
         )
         .expect("Load from snapshot failed");
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -16,8 +16,8 @@ use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
-    accounts_db::AccountShrinkThreshold,
-    accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
+    accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+    accounts_index::AccountSecondaryIndexes,
     bank::{
         Bank, ExecuteTimings, InnerInstructionsList, RentDebits, TransactionBalancesSet,
         TransactionExecutionResult, TransactionLogMessages, TransactionResults,
@@ -470,7 +470,7 @@ pub struct ProcessOptions {
     pub allow_dead_slots: bool,
     pub accounts_db_test_hash_calculation: bool,
     pub accounts_db_skip_shrink: bool,
-    pub accounts_index_config: Option<AccountsIndexConfig>,
+    pub accounts_db_config: Option<AccountsDbConfig>,
     pub verify_index: bool,
     pub shrink_ratio: AccountShrinkThreshold,
 }
@@ -504,7 +504,7 @@ pub fn process_blockstore(
         opts.accounts_db_caching_enabled,
         opts.shrink_ratio,
         false,
-        opts.accounts_index_config.clone(),
+        opts.accounts_db_config.clone(),
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -58,7 +58,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         poh_hashes_per_batch: config.poh_hashes_per_batch,
         no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
         accounts_shrink_ratio: config.accounts_shrink_ratio,
-        accounts_index_config: config.accounts_index_config.clone(),
+        accounts_db_config: config.accounts_db_config.clone(),
     }
 }
 

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -134,7 +134,7 @@ fn initialize_from_snapshot(
         process_options.accounts_db_test_hash_calculation,
         false,
         process_options.verify_index,
-        process_options.accounts_index_config,
+        process_options.accounts_db_config,
     )
     .unwrap();
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,12 +1,10 @@
 use crate::{
     accounts_db::{
-        AccountShrinkThreshold, AccountsDb, BankHashInfo, ErrorCounters, LoadHint, LoadedAccount,
-        ScanStorageResult,
+        AccountShrinkThreshold, AccountsDb, AccountsDbConfig, BankHashInfo, ErrorCounters,
+        LoadHint, LoadedAccount, ScanStorageResult, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
+        ACCOUNTS_DB_CONFIG_FOR_TESTING,
     },
-    accounts_index::{
-        AccountSecondaryIndexes, AccountsIndexConfig, IndexKey, ScanResult,
-        ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
-    },
+    accounts_index::{AccountSecondaryIndexes, IndexKey, ScanResult},
     ancestors::Ancestors,
     bank::{
         NonceRollbackFull, NonceRollbackInfo, RentDebits, TransactionCheckResult,
@@ -140,7 +138,7 @@ impl Accounts {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
     }
 
@@ -157,7 +155,7 @@ impl Accounts {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
+            Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
         )
     }
 
@@ -167,7 +165,7 @@ impl Accounts {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
-        accounts_index_config: Option<AccountsIndexConfig>,
+        accounts_db_config: Option<AccountsDbConfig>,
     ) -> Self {
         Self {
             accounts_db: Arc::new(AccountsDb::new_with_config(
@@ -176,7 +174,7 @@ impl Accounts {
                 account_indexes,
                 caching_enabled,
                 shrink_ratio,
-                accounts_index_config,
+                accounts_db_config,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -25,7 +25,7 @@ use crate::{
     accounts_index::{
         AccountIndexGetResult, AccountSecondaryIndexes, AccountsIndex, AccountsIndexConfig,
         AccountsIndexRootsStats, IndexKey, IsCached, RefCount, ScanResult, SlotList, SlotSlice,
-        ZeroLamport, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+        ZeroLamport, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
     },
     ancestors::Ancestors,
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion},
@@ -117,6 +117,18 @@ const CACHE_VIRTUAL_WRITE_VERSION: StoredMetaWriteVersion = 0;
 // that it doesn't actually map to an entry in an AppendVec.
 const CACHE_VIRTUAL_OFFSET: usize = 0;
 const CACHE_VIRTUAL_STORED_SIZE: usize = 0;
+
+pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
+    index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+};
+pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
+    index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct AccountsDbConfig {
+    pub index: Option<AccountsIndexConfig>,
+}
 
 struct FoundStoredAccount<'a> {
     pub account: StoredAccountMeta<'a>,
@@ -1458,7 +1470,7 @@ impl AccountsDb {
             AccountSecondaryIndexes::default(),
             false,
             AccountShrinkThreshold::default(),
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
     }
 
@@ -1468,9 +1480,9 @@ impl AccountsDb {
         account_indexes: AccountSecondaryIndexes,
         caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
-        accounts_index_config: Option<AccountsIndexConfig>,
+        accounts_db_config: Option<AccountsDbConfig>,
     ) -> Self {
-        let accounts_index = AccountsIndex::new(accounts_index_config);
+        let accounts_index = AccountsIndex::new(accounts_db_config.and_then(|x| x.index));
         let mut new = if !paths.is_empty() {
             Self {
                 paths,
@@ -6498,7 +6510,7 @@ impl AccountsDb {
             account_indexes,
             caching_enabled,
             shrink_ratio,
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,11 +38,11 @@ use crate::{
         AccountAddressFilter, Accounts, TransactionAccounts, TransactionLoadResult,
         TransactionLoaders,
     },
-    accounts_db::{AccountShrinkThreshold, ErrorCounters, SnapshotStorages},
-    accounts_index::{
-        AccountSecondaryIndexes, AccountsIndexConfig, IndexKey, ScanResult,
-        ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+    accounts_db::{
+        AccountShrinkThreshold, AccountsDbConfig, ErrorCounters, SnapshotStorages,
+        ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
     },
+    accounts_index::{AccountSecondaryIndexes, IndexKey, ScanResult},
     ancestors::{Ancestors, AncestorsForSerialization},
     blockhash_queue::BlockhashQueue,
     builtins::{self, ActivationType, Builtin, Builtins},
@@ -1140,7 +1140,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             debug_do_not_add_builtins,
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
     }
 
@@ -1165,7 +1165,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             debug_do_not_add_builtins,
-            Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
+            Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
         )
     }
 
@@ -1180,7 +1180,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
         debug_do_not_add_builtins: bool,
-        accounts_index_config: Option<AccountsIndexConfig>,
+        accounts_db_config: Option<AccountsDbConfig>,
     ) -> Self {
         let accounts = Accounts::new_with_config(
             paths,
@@ -1188,7 +1188,7 @@ impl Bank {
             account_indexes,
             accounts_db_caching_enabled,
             shrink_ratio,
-            accounts_index_config,
+            accounts_db_config,
         );
         let mut bank = Self::default_with_accounts(accounts);
         bank.ancestors = Ancestors::from(vec![bank.slot()]);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -2,9 +2,10 @@ use {
     crate::{
         accounts::Accounts,
         accounts_db::{
-            AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AppendVecId, BankHashInfo,
+            AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig, AppendVecId,
+            BankHashInfo,
         },
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
+        accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         append_vec::{AppendVec, StoredMetaWriteVersion},
         bank::{Bank, BankFieldsToDeserialize, BankRc},
@@ -198,7 +199,7 @@ pub(crate) fn bank_from_streams<R>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -236,7 +237,7 @@ where
                 limit_load_slot_count_from_snapshot,
                 shrink_ratio,
                 verify_index,
-                accounts_index_config,
+                accounts_db_config,
             )?;
             Ok(bank)
         }};
@@ -329,7 +330,7 @@ fn reconstruct_bank_from_fields<E>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> Result<Bank, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -344,7 +345,7 @@ where
         limit_load_slot_count_from_snapshot,
         shrink_ratio,
         verify_index,
-        accounts_index_config,
+        accounts_db_config,
     )?;
     accounts_db.freeze_accounts(
         &Ancestors::from(&bank_fields.ancestors),
@@ -396,7 +397,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> Result<AccountsDb, Error>
 where
     E: SerializableStorage + std::marker::Sync,
@@ -407,7 +408,7 @@ where
         account_secondary_indexes,
         caching_enabled,
         shrink_ratio,
-        accounts_index_config,
+        accounts_db_config,
     );
 
     let AccountsDbFields(

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -83,7 +83,7 @@ where
         None,
         AccountShrinkThreshold::default(),
         false,
-        Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+        Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
     )
 }
 
@@ -245,7 +245,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         None,
         AccountShrinkThreshold::default(),
         false,
-        Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+        Some(crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING),
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        accounts_db::AccountShrinkThreshold,
-        accounts_index::{AccountSecondaryIndexes, AccountsIndexConfig},
+        accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+        accounts_index::AccountSecondaryIndexes,
         bank::{Bank, BankSlotDelta},
         builtins::Builtins,
         hardened_unpack::{unpack_snapshot, ParallelSelector, UnpackError, UnpackedAppendVecMap},
@@ -732,7 +732,7 @@ pub fn bank_from_snapshot_archives(
     test_hash_calculation: bool,
     accounts_db_skip_shrink: bool,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> Result<(Bank, BankFromArchiveTimings)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
@@ -796,7 +796,7 @@ pub fn bank_from_snapshot_archives(
         limit_load_slot_count_from_snapshot,
         shrink_ratio,
         verify_index,
-        accounts_index_config,
+        accounts_db_config,
     )?;
     measure_rebuild.stop();
     info!("{}", measure_rebuild);
@@ -842,7 +842,7 @@ pub fn bank_from_latest_snapshot_archives(
     test_hash_calculation: bool,
     accounts_db_skip_shrink: bool,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> Result<(
     Bank,
     BankFromArchiveTimings,
@@ -885,7 +885,7 @@ pub fn bank_from_latest_snapshot_archives(
         test_hash_calculation,
         accounts_db_skip_shrink,
         verify_index,
-        accounts_index_config,
+        accounts_db_config,
     )?;
 
     verify_bank_against_expected_slot_hash(
@@ -1421,7 +1421,7 @@ fn rebuild_bank_from_snapshots(
     limit_load_slot_count_from_snapshot: Option<usize>,
     shrink_ratio: AccountShrinkThreshold,
     verify_index: bool,
-    accounts_index_config: Option<AccountsIndexConfig>,
+    accounts_db_config: Option<AccountsDbConfig>,
 ) -> Result<Bank> {
     let (full_snapshot_version, full_snapshot_root_paths) =
         verify_unpacked_snapshots_dir_and_version(
@@ -1469,7 +1469,7 @@ fn rebuild_bank_from_snapshots(
                     limit_load_slot_count_from_snapshot,
                     shrink_ratio,
                     verify_index,
-                    accounts_index_config,
+                    accounts_db_config,
                 ),
             }?,
         )
@@ -1814,6 +1814,7 @@ pub fn should_take_incremental_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING;
     use assert_matches::assert_matches;
     use bincode::{deserialize_from, serialize_into};
     use solana_sdk::{
@@ -2606,7 +2607,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 
@@ -2697,7 +2698,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 
@@ -2807,7 +2808,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 
@@ -2906,7 +2907,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
 
@@ -3047,7 +3048,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
         assert_eq!(
@@ -3109,7 +3110,7 @@ mod tests {
             false,
             false,
             false,
-            Some(crate::accounts_index::ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
+            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         )
         .unwrap();
         assert_eq!(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -39,7 +39,7 @@ use {
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
         accounts_db::{
-            AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
+            AccountShrinkThreshold, AccountsDbConfig, DEFAULT_ACCOUNTS_SHRINK_OPTIMIZE_TOTAL_SPACE,
             DEFAULT_ACCOUNTS_SHRINK_RATIO,
         },
         accounts_index::{
@@ -2444,6 +2444,7 @@ pub fn main() {
     let accounts_index_config = value_t!(matches, "accounts_index_bins", usize)
         .ok()
         .map(|bins| AccountsIndexConfig { bins: Some(bins) });
+    let accounts_db_config = accounts_index_config.map(|x| AccountsDbConfig { index: Some(x) });
 
     let accountsdb_repl_service_config = if matches.is_present("enable_accountsdb_repl") {
         let accountsdb_repl_bind_address = if matches.is_present("accountsdb_repl_bind_address") {
@@ -2563,7 +2564,7 @@ pub fn main() {
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
-        accounts_index_config,
+        accounts_db_config,
         accounts_db_skip_shrink: matches.is_present("accounts_db_skip_shrink"),
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,


### PR DESCRIPTION
#### Problem
There will be at least a few more parameters immediately. This is better than passing collections of parameters.
#### Summary of Changes
pass a hierarchy of accounts config
accounts db:
  accounts index
Fixes #
