### PR TITLE
add --accounts-index-path to be used by disk accounts index

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -891,6 +891,12 @@ fn main() {
         .value_name("PATHS")
         .takes_value(true)
         .help("Comma separated persistent accounts location");
+    let accounts_index_path_arg = Arg::with_name("accounts_index_path")
+        .long("accounts-index-path")
+        .value_name("PATH")
+        .takes_value(true)
+        .multiple(true)
+        .help("Persistent accounts-index location");
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")
         .help("Enable hash calculation test");
@@ -1195,6 +1201,7 @@ fn main() {
             .about("Verify the ledger")
             .arg(&no_snapshot_arg)
             .arg(&account_paths_arg)
+            .arg(&accounts_index_path_arg)
             .arg(&halt_at_slot_arg)
             .arg(&limit_load_slot_count_from_snapshot_arg)
             .arg(&accounts_index_bins)
@@ -1925,7 +1932,11 @@ fn main() {
             }
 
             {
-                let mut accounts_index_paths = vec![]; // will be option
+                let mut accounts_index_paths: Vec<PathBuf> =
+                    values_t_or_exit!(arg_matches, "accounts_index_path", String)
+                        .into_iter()
+                        .map(PathBuf::from)
+                        .collect();
                 if accounts_index_paths.is_empty() {
                     accounts_index_paths = vec![ledger_path.join("accounts_index")];
                 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -896,7 +896,11 @@ fn main() {
         .value_name("PATH")
         .takes_value(true)
         .multiple(true)
-        .help("Persistent accounts-index location");
+        .help(
+            "Persistent accounts-index location. \
+             May be specified multiple times. \
+             [default: [ledger]/accounts_index]",
+        );
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")
         .help("Enable hash calculation test");
@@ -1933,10 +1937,14 @@ fn main() {
 
             {
                 let mut accounts_index_paths: Vec<PathBuf> =
-                    values_t_or_exit!(arg_matches, "accounts_index_path", String)
-                        .into_iter()
-                        .map(PathBuf::from)
-                        .collect();
+                    if arg_matches.is_present("accounts_index_path") {
+                        values_t_or_exit!(arg_matches, "accounts_index_path", String)
+                            .into_iter()
+                            .map(PathBuf::from)
+                            .collect()
+                    } else {
+                        vec![]
+                    };
                 if accounts_index_paths.is_empty() {
                     accounts_index_paths = vec![ledger_path.join("accounts_index")];
                 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2012,6 +2012,14 @@ pub fn main() {
                 .help("Number of bins to divide the accounts index into"),
         )
         .arg(
+            Arg::with_name("accounts_index_path")
+                .long("accounts-index-path")
+                .value_name("PATH")
+                .takes_value(true)
+                .multiple(true)
+                .help("Persistent accounts-index location"),
+        )
+        .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
                 .help("Enables testing of hash calculation using stores in \
@@ -2530,7 +2538,11 @@ pub fn main() {
     }
 
     {
-        let mut accounts_index_paths = vec![]; // will be option soon
+        let mut accounts_index_paths: Vec<PathBuf> =
+            values_t_or_exit!(matches, "accounts_index_path", String)
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
         if accounts_index_paths.is_empty() {
             accounts_index_paths = vec![ledger_path.join("accounts_index")];
         }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2017,8 +2017,10 @@ pub fn main() {
                 .value_name("PATH")
                 .takes_value(true)
                 .multiple(true)
-                .help("Persistent accounts-index location"),
-        )
+                .help("Persistent accounts-index location. \
+                       May be specified multiple times. \
+                       [default: [ledger]/accounts_index]"),
+ )
         .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
@@ -2538,11 +2540,14 @@ pub fn main() {
     }
 
     {
-        let mut accounts_index_paths: Vec<PathBuf> =
+        let mut accounts_index_paths: Vec<PathBuf> = if matches.is_present("accounts_index_path") {
             values_t_or_exit!(matches, "accounts_index_path", String)
                 .into_iter()
                 .map(PathBuf::from)
-                .collect();
+                .collect()
+        } else {
+            vec![]
+        };
         if accounts_index_paths.is_empty() {
             accounts_index_paths = vec![ledger_path.join("accounts_index")];
         }


### PR DESCRIPTION
#### Problem
Disk-based accounts index is stored on disk. This is an argument to allow a validator to specify 0-n disks/folders/drives/nvmes to be used for the backing store. With no argument, the result is <ledger>/accounts_index

This will be connected to the disk index.
#### Summary of Changes
--accounts-index-path /dev1/accounts_index --accounts-index-path /dev1/accounts_index
Fixes #
