### PR TITLE
TpuClient now uses the processed slot to seed its leader schedule cache

### DIFF
--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -5,7 +5,9 @@ use crate::{
 };
 use bincode::serialize;
 use log::*;
-use solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::Transaction};
+use solana_sdk::{
+    clock::Slot, commitment_config::CommitmentConfig, pubkey::Pubkey, transaction::Transaction,
+};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     net::{SocketAddr, UdpSocket},
@@ -242,7 +244,7 @@ struct LeaderTpuService {
 
 impl LeaderTpuService {
     fn new(rpc_client: Arc<RpcClient>, websocket_url: &str, exit: Arc<AtomicBool>) -> Result<Self> {
-        let start_slot = rpc_client.get_max_shred_insert_slot()?;
+        let start_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::processed())?;
 
         let recent_slots = RecentLeaderSlots::new(start_slot);
         let leader_tpu_cache = Arc::new(RwLock::new(LeaderTpuCache::new(&rpc_client, start_slot)));


### PR DESCRIPTION
Backport of https://github.com/solana-labs/solana/pull/19717 to v1.7