### PR TITLE
Add RpcClient::get_transport_stats()

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -12,7 +12,7 @@ use {
             RpcStakeActivation, RpcSupply, RpcVersionInfo, RpcVoteAccountInfo,
             RpcVoteAccountStatus, StakeActivationState,
         },
-        rpc_sender::RpcSender,
+        rpc_sender::*,
     },
     serde_json::{json, Number, Value},
     solana_sdk::{
@@ -84,6 +84,10 @@ impl MockSender {
 }
 
 impl RpcSender for MockSender {
+    fn get_transport_stats(&self) -> RpcTransportStats {
+        RpcTransportStats::default()
+    }
+
     fn send(&self, request: RpcRequest, params: serde_json::Value) -> Result<serde_json::Value> {
         if let Some(value) = self.mocks.write().unwrap().remove(&request) {
             return Ok(value);

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -20,7 +20,7 @@ use {
         rpc_config::*,
         rpc_request::{RpcError, RpcRequest, RpcResponseErrorData, TokenAccountsFilter},
         rpc_response::*,
-        rpc_sender::RpcSender,
+        rpc_sender::*,
     },
     bincode::serialize,
     indicatif::{ProgressBar, ProgressStyle},
@@ -3970,6 +3970,10 @@ impl RpcClient {
             .map_err(|err| err.into_with_request(request))?;
         serde_json::from_value(response)
             .map_err(|err| ClientError::new_with_request(err.into(), request))
+    }
+
+    pub fn get_transport_stats(&self) -> RpcTransportStats {
+        self.sender.get_transport_stats()
     }
 }
 

--- a/client/src/rpc_sender.rs
+++ b/client/src/rpc_sender.rs
@@ -1,6 +1,22 @@
 //! A transport for RPC calls.
 
-use crate::{client_error::Result, rpc_request::RpcRequest};
+use {
+    crate::{client_error::Result, rpc_request::RpcRequest},
+    std::time::Duration,
+};
+
+#[derive(Default, Clone)]
+pub struct RpcTransportStats {
+    /// Number of RPC requests issued
+    pub request_count: usize,
+
+    /// Total amount of time spent transacting with the RPC server
+    pub elapsed_time: Duration,
+
+    /// Total amount of waiting time due to RPC server rate limiting
+    /// (a subset of `elapsed_time`)
+    pub rate_limited_time: Duration,
+}
 
 /// A transport for RPC calls.
 ///
@@ -15,4 +31,5 @@ use crate::{client_error::Result, rpc_request::RpcRequest};
 /// [`MockSender`]: crate::mock_sender::MockSender
 pub trait RpcSender {
     fn send(&self, request: RpcRequest, params: serde_json::Value) -> Result<serde_json::Value>;
+    fn get_transport_stats(&self) -> RpcTransportStats;
 }


### PR DESCRIPTION
Provides the RpcClient user insight into:
1. Number of RPC requests issued
2. Total amount of time spent transacting with the RPC server
3. Total amount of time paused due to server-side rate limiting