### PR TITLE
Add `--destake-vote-account <VOTE_ADDRESS>...` argument to `create-snapshot` command

### DIFF
--- a/docs/src/running-validator/restart-cluster.md
+++ b/docs/src/running-validator/restart-cluster.md
@@ -96,7 +96,7 @@ If less than 80% of the stake join the restart after a reasonable amount of
 time, it will be necessary to retry the restart attempt with the stake from the
 non-responsive validators removed.
 
-The community should identity and come to social consensus on the set of
+The community should identify and come to social consensus on the set of
 non-responsive validators. Then all participating validators return to Step 4
 and create a new snapshot with additional `--destake-vote-account <PUBKEY>`
 arguments for each of the non-responsive validator's vote account address

--- a/docs/src/running-validator/restart-cluster.md
+++ b/docs/src/running-validator/restart-cluster.md
@@ -88,3 +88,28 @@ Post something like the following to #announcements (adjusting the text as appro
 ### Step 7. Wait and listen
 
 Monitor the validators as they restart. Answer questions, help folks,
+
+## Troubleshooting
+
+### 80% of the stake didn't participate in the restart, now what?
+If less than 80% of the stake join the restart after a reasonable amount of
+time, it will be necessary to retry the restart attempt with the stake from the
+non-responsive validators removed.
+
+The community should identity and come to social consensus on the set of
+non-responsive validators. Then all participating validators return to Step 4
+and create a new snapshot with additional `--destake-vote-account <PUBKEY>`
+arguments for each of the non-responsive validator's vote account address
+
+```bash
+$ solana-ledger-tool -l ledger create-snapshot SLOT_X ledger --hard-fork SLOT_X \
+    --destake-vote-account <VOTE_ACCOUNT_1> \
+    --destake-vote-account <VOTE_ACCOUNT_2> \
+    .
+    .
+    --destake-vote-account <VOTE_ACCOUNT_N> \
+```
+
+This will cause all stake associated with the non-responsive validators to be
+immediately deactivated. All their stakers will need to re-delegate their stake
+once the cluster restart is successful.


### PR DESCRIPTION
On a failed restart due to lack of participation, the responsive validators may decide to exclude the absent validators from the next restart.   The `--destake-vote-account` introduced here makes this possible by clearing all stake delegations from the specified vote account
