### PR TITLE
Fix native invoke writable privileges

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -68,6 +68,7 @@ spl() {
 
     $cargo build
     $cargo test
+    $cargo_build_bpf
     $cargo_test_bpf
   )
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -211,6 +211,10 @@ pub mod return_data_syscall_enabled {
     solana_sdk::declare_id!("BJVXq6NdLC7jCDGjfqJv7M1XHD4Y13VrpDqRF2U7UBcC");
 }
 
+pub mod fix_write_privs {
+    solana_sdk::declare_id!("7Tr5C1tdcCeBVD8jxtHYnvjL1DGdFboYBHCJkEFdenBb");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -258,7 +262,8 @@ lazy_static! {
         (ed25519_program_enabled::id(), "enable builtin ed25519 signature verify program"),
         (allow_native_ids::id(), "allow native program ids in program derived addresses"),
         (check_seed_length::id(), "Check program address seed lengths"),
-        (return_data_syscall_enabled::id(), "enable sol_{set,get}_return_data syscall")
+        (return_data_syscall_enabled::id(), "enable sol_{set,get}_return_data syscall"),
+        (fix_write_privs::id(), "fix native invoke write privileges"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Caller write privileges are not created correctly for native cpi. The `caller_write_privileges` vector should match up with `message.account_keys` because they will be indexed the same.

#### Summary of Changes
- Remove incorrect write privilege value insertion
- Match up write privileges vector with the `accounts` vector built from `message.account_keys`

Fix sourced from: https://github.com/solana-labs/solana/pull/18616, thanks @jstarry !

Fixes #18629
