### PR TITLE
Call `Bank::update_accounts_hash()` before taking bank snapshot

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1192,8 +1192,14 @@ fn load_frozen_forks(
                         block_height,
                         snapshot_config.full_snapshot_archive_interval_slots,
                     ) {
+                        info!("Taking snapshot of new root bank that has crossed the full snapshot interval! slot: {}", *root);
                         *last_full_snapshot_slot = Some(*root);
                         new_root_bank.clean_accounts(true, true, *last_full_snapshot_slot);
+                        new_root_bank.update_accounts_hash_with_index_option(
+                            snapshot_config.accounts_hash_use_index,
+                            snapshot_config.accounts_hash_debug_verify,
+                            Some(new_root_bank.epoch_schedule().slots_per_epoch),
+                        );
                         snapshot_utils::snapshot_bank(
                             new_root_bank,
                             new_root_bank.src.slot_deltas(&new_root_bank.src.roots()),

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -29,6 +29,12 @@ pub struct SnapshotConfig {
     /// Maximum number of incremental snapshot archives to retain
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
     pub maximum_incremental_snapshot_archives_to_retain: usize,
+
+    /// This is the `use_index` parameter to use when calling `update_accounts_hash()`
+    pub accounts_hash_use_index: bool,
+
+    /// This is the `debug_verify` parameter to use when calling `update_accounts_hash()`
+    pub accounts_hash_debug_verify: bool,
 }
 
 impl Default for SnapshotConfig {
@@ -46,6 +52,8 @@ impl Default for SnapshotConfig {
                 snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             maximum_incremental_snapshot_archives_to_retain:
                 snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            accounts_hash_use_index: false,
+            accounts_hash_debug_verify: false,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2751,6 +2751,8 @@ pub fn main() {
         snapshot_version,
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
+        accounts_hash_use_index: validator_config.accounts_db_use_index_hash_calculation,
+        accounts_hash_debug_verify: validator_config.accounts_db_test_hash_calculation,
     });
 
     validator_config.accounts_hash_interval_slots =


### PR DESCRIPTION
This is a bugfix.

When `load_frozen_forks()` called `snapshot_bank()`, the accounts hash
was not computed.  So then when a snapshot archive was eventually
created, its hash would be all 1s, which is clearly wrong.  The fix is
to update the bank's accounts hash before taking the bank snapshot.

Related to PR #19600 
