### PR TITLE
accounts index iterator uses copy of pubkey and account map entry

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -629,22 +629,22 @@ pub struct AccountsIndexIterator<'a, T: IsCached> {
 }
 
 impl<'a, T: IsCached> AccountsIndexIterator<'a, T> {
-    fn range<'b, R>(
-        map: &'b AccountMapsReadLock<'b, T>,
+    fn range<R>(
+        map: &AccountMapsReadLock<T>,
         range: R,
         collect_all_unsorted: bool,
-    ) -> Vec<(&'b Pubkey, &'b AccountMapEntry<T>)>
+    ) -> Vec<(Pubkey, AccountMapEntry<T>)>
     where
         R: RangeBounds<Pubkey>,
     {
         let mut result = Vec::with_capacity(map.len());
         for (k, v) in map.iter() {
             if range.contains(k) {
-                result.push((k, v));
+                result.push((*k, v.clone()));
             }
         }
         if !collect_all_unsorted {
-            result.sort_unstable_by(|a, b| a.0.cmp(b.0));
+            result.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         }
         result
     }
@@ -734,7 +734,7 @@ impl<'a, T: IsCached> Iterator for AccountsIndexIterator<'a, T> {
                 if chunk.len() >= ITER_BATCH_SIZE && !self.collect_all_unsorted {
                     break 'outer;
                 }
-                let item = (*pubkey, account_map_entry.clone());
+                let item = (pubkey, account_map_entry);
                 chunk.push(item);
             }
         }


### PR DESCRIPTION
#### Problem
Minor refactoring making accounts iteration return owned copies earlier in the call chain. This maps better to disk buckets later.
#### Summary of Changes

Fixes #
