### PR TITLE
factor out InMemAccountsIndex to prepare for disk index

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1,6 +1,7 @@
 use crate::{
     ancestors::Ancestors,
     contains::Contains,
+    in_mem_accounts_index::InMemAccountsIndex,
     inline_spl_token_v2_0::{self, SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
     pubkey_bins::PubkeyBinCalculator16,
     secondary_index::*,
@@ -14,7 +15,7 @@ use solana_sdk::{
     pubkey::{Pubkey, PUBKEY_BYTES},
 };
 use std::{
-    collections::{btree_map::BTreeMap, hash_map::Entry, HashMap, HashSet},
+    collections::{btree_map::BTreeMap, hash_map::Entry, HashSet},
     fmt::Debug,
     ops::{
         Bound,
@@ -42,7 +43,7 @@ pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
 pub type SlotSlice<'s, T> = &'s [(Slot, T)];
 pub type RefCount = u64;
-pub type AccountMap<V> = HashMap<Pubkey, V>;
+pub type AccountMap<V> = InMemAccountsIndex<V>;
 
 type AccountMapEntry<T> = Arc<AccountMapEntryInner<T>>;
 

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1,0 +1,51 @@
+use solana_sdk::pubkey::Pubkey;
+use std::collections::{
+    hash_map::{Entry, Iter, Keys},
+    HashMap,
+};
+use std::fmt::Debug;
+
+type K = Pubkey;
+
+// one instance of this represents one bin of the accounts index.
+#[derive(Debug, Default)]
+pub struct InMemAccountsIndex<V> {
+    // backing store
+    map: HashMap<Pubkey, V>,
+}
+
+impl<V> InMemAccountsIndex<V> {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn entry(&mut self, pubkey: Pubkey) -> Entry<K, V> {
+        self.map.entry(pubkey)
+    }
+
+    pub fn iter(&self) -> Iter<K, V> {
+        self.map.iter()
+    }
+
+    pub fn keys(&self) -> Keys<K, V> {
+        self.map.keys()
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    pub fn remove(&mut self, key: &K) {
+        self.map.remove(key);
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,6 +20,7 @@ pub mod contains;
 pub mod epoch_stakes;
 pub mod genesis_utils;
 pub mod hardened_unpack;
+pub mod in_mem_accounts_index;
 pub mod inline_spl_token_v2_0;
 pub mod instruction_recorder;
 pub mod loader_utils;


### PR DESCRIPTION
#### Problem
Factor out one disk index bin so we can begin adding metrics and refactoring towards disk buckets. Previously, this was a hashmap directly used by AccountsIndex.
#### Summary of Changes

Fixes #
