### PR TITLE
Add default() to SnapshotConfig

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -338,12 +338,7 @@ mod tests {
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots,
             incremental_snapshot_archive_interval_slots: Slot::MAX,
-            snapshot_archives_dir: PathBuf::default(),
-            bank_snapshots_dir: PathBuf::default(),
-            archive_format: ArchiveFormat::Tar,
-            snapshot_version: SnapshotVersion::default(),
-            maximum_full_snapshot_archives_to_retain: usize::MAX,
-            maximum_incremental_snapshot_archives_to_retain: usize::MAX,
+            ..SnapshotConfig::default()
         };
         for i in 0..MAX_SNAPSHOT_HASHES + 1 {
             let accounts_package = AccountsPackage {

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -14,12 +14,7 @@ use {
     solana_rpc::rpc::JsonRpcConfig,
     solana_runtime::{
         genesis_utils::create_genesis_config_with_leader_ex,
-        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
-        snapshot_utils::{
-            ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        },
+        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, snapshot_config::SnapshotConfig,
     },
     solana_sdk::{
         account::{Account, AccountSharedData},
@@ -526,12 +521,7 @@ impl TestValidator {
                 incremental_snapshot_archive_interval_slots: Slot::MAX,
                 bank_snapshots_dir: ledger_path.join("snapshot"),
                 snapshot_archives_dir: ledger_path.to_path_buf(),
-                archive_format: ArchiveFormat::Tar,
-                snapshot_version: SnapshotVersion::default(),
-                maximum_full_snapshot_archives_to_retain:
-                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                maximum_incremental_snapshot_archives_to_retain:
-                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                ..SnapshotConfig::default()
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -69,10 +69,7 @@ mod tests {
         snapshot_package::{
             AccountsPackage, PendingSnapshotPackage, SnapshotPackage, SnapshotType,
         },
-        snapshot_utils::{
-            self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        },
+        snapshot_utils::{self, ArchiveFormat, SnapshotVersion},
         status_cache::MAX_CACHE_ENTRIES,
     };
     use solana_sdk::{
@@ -146,12 +143,8 @@ mod tests {
                 incremental_snapshot_archive_interval_slots,
                 snapshot_archives_dir: snapshot_archives_dir.path().to_path_buf(),
                 bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
-                archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
-                maximum_full_snapshot_archives_to_retain:
-                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                maximum_incremental_snapshot_archives_to_retain:
-                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+                ..SnapshotConfig::default()
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
             SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -35,7 +35,6 @@ use solana_runtime::{
     snapshot_config::SnapshotConfig,
     snapshot_utils::{
         self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
     },
 };
 use solana_sdk::{
@@ -718,11 +717,7 @@ fn load_bank_forks(
             incremental_snapshot_archive_interval_slots: Slot::MAX,
             snapshot_archives_dir,
             bank_snapshots_dir,
-            archive_format: ArchiveFormat::TarBzip2,
-            snapshot_version: SnapshotVersion::default(),
-            maximum_full_snapshot_archives_to_retain: DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            maximum_incremental_snapshot_archives_to_retain:
-                DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            ..SnapshotConfig::default()
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1467,9 +1467,8 @@ pub mod tests {
     use matches::assert_matches;
     use rand::{thread_rng, Rng};
     use solana_entry::entry::{create_ticks, next_entry, next_entry_mut};
-    use solana_runtime::{
-        genesis_utils::{self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
-        snapshot_utils::{ArchiveFormat, SnapshotVersion},
+    use solana_runtime::genesis_utils::{
+        self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
     };
     use solana_sdk::{
         account::{AccountSharedData, WritableAccount},
@@ -3167,13 +3166,8 @@ pub mod tests {
         let bank_snapshots_tempdir = TempDir::new().unwrap();
         let snapshot_config = SnapshotConfig {
             full_snapshot_archive_interval_slots: FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
-            incremental_snapshot_archive_interval_slots: Slot::MAX, // value does not matter
-            snapshot_archives_dir: PathBuf::default(),              // value does not matter
             bank_snapshots_dir: bank_snapshots_tempdir.path().to_path_buf(),
-            archive_format: ArchiveFormat::TarZstd, // value does not matter
-            snapshot_version: SnapshotVersion::default(), // value does not matter
-            maximum_full_snapshot_archives_to_retain: usize::MAX, // value does not matter
-            maximum_incremental_snapshot_archives_to_retain: usize::MAX, // value does not matter
+            ..SnapshotConfig::default()
         };
 
         let (accounts_package_sender, accounts_package_receiver) = channel();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3533,12 +3533,7 @@ fn setup_snapshot_validator_config(
         incremental_snapshot_archive_interval_slots: Slot::MAX,
         snapshot_archives_dir: snapshot_archives_dir.path().to_path_buf(),
         bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
-        archive_format: ArchiveFormat::TarBzip2,
-        snapshot_version: snapshot_utils::SnapshotVersion::default(),
-        maximum_full_snapshot_archives_to_retain:
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        maximum_incremental_snapshot_archives_to_retain:
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        ..SnapshotConfig::default()
     };
 
     // Create the account paths

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -21,12 +21,9 @@ use {
         rpc_subscriptions::RpcSubscriptions,
     },
     solana_runtime::{
-        accounts_index::AccountSecondaryIndexes,
-        bank_forks::BankForks,
-        commitment::BlockCommitmentCache,
-        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-        snapshot_config::SnapshotConfig,
-        snapshot_utils::{self, ArchiveFormat},
+        accounts_index::AccountSecondaryIndexes, bank_forks::BankForks,
+        commitment::BlockCommitmentCache, hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+        snapshot_config::SnapshotConfig, snapshot_utils,
     },
     solana_sdk::{clock::Slot, exit::Exit, genesis_config::GenesisConfig, hash::Hash},
     solana_streamer::socket::SocketAddrSpace,
@@ -263,16 +260,11 @@ impl ReplicaNode {
         .unwrap();
 
         let snapshot_config = SnapshotConfig {
-            full_snapshot_archive_interval_slots: std::u64::MAX,
-            incremental_snapshot_archive_interval_slots: std::u64::MAX,
+            full_snapshot_archive_interval_slots: Slot::MAX,
+            incremental_snapshot_archive_interval_slots: Slot::MAX,
             snapshot_archives_dir: replica_config.snapshot_archives_dir.clone(),
             bank_snapshots_dir: replica_config.bank_snapshots_dir.clone(),
-            archive_format: ArchiveFormat::TarBzip2,
-            snapshot_version: snapshot_utils::SnapshotVersion::default(),
-            maximum_full_snapshot_archives_to_retain:
-                snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            maximum_incremental_snapshot_archives_to_retain:
-                snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            ..SnapshotConfig::default()
         };
 
         let bank_info =

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -16,10 +16,8 @@ use {
     },
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
-        accounts_index::AccountSecondaryIndexes,
-        snapshot_archive_info::SnapshotArchiveInfoGetter,
-        snapshot_config::SnapshotConfig,
-        snapshot_utils::{self, ArchiveFormat},
+        accounts_index::AccountSecondaryIndexes, snapshot_archive_info::SnapshotArchiveInfoGetter,
+        snapshot_config::SnapshotConfig, snapshot_utils,
     },
     solana_sdk::{
         client::SyncClient,
@@ -125,12 +123,7 @@ fn setup_snapshot_validator_config(
         incremental_snapshot_archive_interval_slots: Slot::MAX,
         snapshot_archives_dir: snapshot_archives_dir.path().to_path_buf(),
         bank_snapshots_dir: bank_snapshots_dir.path().to_path_buf(),
-        archive_format: ArchiveFormat::TarBzip2,
-        snapshot_version: snapshot_utils::SnapshotVersion::default(),
-        maximum_full_snapshot_archives_to_retain:
-            snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-        maximum_incremental_snapshot_archives_to_retain:
-            snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        ..SnapshotConfig::default()
     };
 
     // Create the account paths

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -502,15 +502,8 @@ mod tests {
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path,
         },
-        solana_runtime::{
-            bank::Bank,
-            snapshot_utils::{
-                ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            },
-        },
+        solana_runtime::bank::Bank,
         solana_sdk::{
-            clock::Slot,
             genesis_config::{ClusterType, DEFAULT_GENESIS_ARCHIVE},
             signature::Signer,
             signer::keypair::Keypair,
@@ -615,18 +608,7 @@ mod tests {
         );
         let rrm_with_snapshot_config = RpcRequestMiddleware::new(
             PathBuf::from("/"),
-            Some(SnapshotConfig {
-                full_snapshot_archive_interval_slots: Slot::MAX,
-                incremental_snapshot_archive_interval_slots: Slot::MAX,
-                snapshot_archives_dir: PathBuf::from("/"),
-                bank_snapshots_dir: PathBuf::from("/"),
-                archive_format: ArchiveFormat::TarBzip2,
-                snapshot_version: SnapshotVersion::default(),
-                maximum_full_snapshot_archives_to_retain:
-                    DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-                maximum_incremental_snapshot_archives_to_retain:
-                    DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            }),
+            Some(SnapshotConfig::default()),
             bank_forks,
             RpcHealth::stub(),
         );

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -1,5 +1,4 @@
-use crate::snapshot_utils::ArchiveFormat;
-use crate::snapshot_utils::SnapshotVersion;
+use crate::snapshot_utils::{self, ArchiveFormat, SnapshotVersion};
 use solana_sdk::clock::Slot;
 use std::path::PathBuf;
 
@@ -30,4 +29,23 @@ pub struct SnapshotConfig {
     /// Maximum number of incremental snapshot archives to retain
     /// NOTE: Incremental snapshots will only be kept for the latest full snapshot
     pub maximum_incremental_snapshot_archives_to_retain: usize,
+}
+
+impl Default for SnapshotConfig {
+    fn default() -> Self {
+        Self {
+            full_snapshot_archive_interval_slots:
+                snapshot_utils::DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            incremental_snapshot_archive_interval_slots:
+                snapshot_utils::DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            snapshot_archives_dir: PathBuf::default(),
+            bank_snapshots_dir: PathBuf::default(),
+            archive_format: ArchiveFormat::TarBzip2,
+            snapshot_version: SnapshotVersion::default(),
+            maximum_full_snapshot_archives_to_retain:
+                snapshot_utils::DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            maximum_incremental_snapshot_archives_to_retain:
+                snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

SnapshotConfig is about to get more parameters, and updating all its uses can be cumbersome. Adding default() simplifies future PRs.

#### Summary of Changes

Add default() to SnapshotConfig and then update all its uses.
