### PR TITLE
Track reset bank in PohRecorder

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -312,11 +312,10 @@ fn main() {
                 tx_total_us += duration_as_us(&now.elapsed());
 
                 let mut poh_time = Measure::start("poh_time");
-                poh_recorder.lock().unwrap().reset(
-                    bank.last_blockhash(),
-                    bank.slot(),
-                    Some((bank.slot(), bank.slot() + 1)),
-                );
+                poh_recorder
+                    .lock()
+                    .unwrap()
+                    .reset(bank.clone(), Some((bank.slot(), bank.slot() + 1)));
                 poh_time.stop();
 
                 let mut new_bank_time = Measure::start("new_bank");

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1558,7 +1558,7 @@ mod tests {
     };
     use solana_perf::packet::to_packets_chunked;
     use solana_poh::{
-        poh_recorder::{create_test_recorder, Record, WorkingBank, WorkingBankEntry},
+        poh_recorder::{create_test_recorder, Record, WorkingBankEntry},
         poh_service::PohService,
     };
     use solana_rpc::transaction_status_service::TransactionStatusService;
@@ -1940,13 +1940,6 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
-        let start = Arc::new(Instant::now());
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            start,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: std::u64::MAX,
-        };
         let ledger_path = get_tmp_ledger_path!();
         {
             let blockstore = Blockstore::open(&ledger_path)
@@ -1969,7 +1962,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+            poh_recorder.lock().unwrap().set_bank(&bank);
             let pubkey = solana_sdk::pubkey::new_rand();
             let keypair2 = Keypair::new();
             let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -2011,8 +2004,9 @@ mod tests {
             // Once bank is set to a new bank (setting bank.slot() + 1 in record_transactions),
             // record_transactions should throw MaxHeightReached and return the set of retryable
             // txs
+            let next_slot = bank.slot() + 1;
             let (res, retryable) =
-                BankingStage::record_transactions(bank.slot() + 1, &txs, &results, &recorder);
+                BankingStage::record_transactions(next_slot, &txs, &results, &recorder);
             assert_matches!(res, Err(PohRecorderError::MaxHeightReached));
             // The first result was an error so it's filtered out. The second result was Ok(),
             // so it should be marked as retryable
@@ -2196,13 +2190,6 @@ mod tests {
                     .unwrap(),
             ];
 
-        let start = Arc::new(Instant::now());
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            start,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: bank.tick_height() + 1,
-        };
         let ledger_path = get_tmp_ledger_path!();
         {
             let blockstore = Blockstore::open(&ledger_path)
@@ -2224,7 +2211,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+            poh_recorder.lock().unwrap().set_bank(&bank);
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
 
             BankingStage::process_and_record_transactions(
@@ -2237,7 +2224,11 @@ mod tests {
             )
             .0
             .unwrap();
-            poh_recorder.lock().unwrap().tick();
+
+            // Tick up to max tick height
+            while poh_recorder.lock().unwrap().tick_height() != bank.max_tick_height() {
+                poh_recorder.lock().unwrap().tick();
+            }
 
             let mut done = false;
             // read entries until I find mine, might be ticks...
@@ -2332,13 +2323,6 @@ mod tests {
                 .unwrap(),
         ];
 
-        let start = Arc::new(Instant::now());
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            start,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: bank.tick_height() + 1,
-        };
         let ledger_path = get_tmp_ledger_path!();
         {
             let blockstore = Blockstore::open(&ledger_path)
@@ -2358,7 +2342,7 @@ mod tests {
             let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
-            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+            poh_recorder.lock().unwrap().set_bank(&bank);
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
@@ -2527,13 +2511,6 @@ mod tests {
         ];
         bank.transfer(4, &mint_keypair, &keypair1.pubkey()).unwrap();
 
-        let start = Arc::new(Instant::now());
-        let working_bank = WorkingBank {
-            bank: bank.clone(),
-            start,
-            min_tick_height: bank.tick_height(),
-            max_tick_height: bank.tick_height() + 1,
-        };
         let ledger_path = get_tmp_ledger_path!();
         {
             let blockstore = Blockstore::open(&ledger_path)
@@ -2556,7 +2533,7 @@ mod tests {
 
             let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
-            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+            poh_recorder.lock().unwrap().set_bank(&bank);
 
             let shreds = entries_to_test_shreds(entries, bank.slot(), 0, true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1955,7 +1955,7 @@ mod tests {
                 // TODO use record_receiver
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 None,
                 bank.ticks_per_slot(),
                 &Pubkey::default(),
@@ -2210,7 +2210,7 @@ mod tests {
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 Some((4, 4)),
                 bank.ticks_per_slot(),
                 &pubkey,
@@ -2346,7 +2346,7 @@ mod tests {
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 Some((4, 4)),
                 bank.ticks_per_slot(),
                 &pubkey,
@@ -2453,7 +2453,7 @@ mod tests {
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 Some((4, 4)),
                 bank.ticks_per_slot(),
                 &solana_sdk::pubkey::new_rand(),
@@ -2542,7 +2542,7 @@ mod tests {
             let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 Some((4, 4)),
                 bank.ticks_per_slot(),
                 &pubkey,
@@ -2643,7 +2643,7 @@ mod tests {
         let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
-            bank.slot(),
+            bank.clone(),
             Some((4, 4)),
             bank.ticks_per_slot(),
             &solana_sdk::pubkey::new_rand(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1930,7 +1930,7 @@ impl ReplayStage {
         poh_recorder
             .lock()
             .unwrap()
-            .reset(bank.last_blockhash(), bank.slot(), next_leader_slot);
+            .reset(bank.clone(), next_leader_slot);
 
         let next_leader_msg = if let Some(next_leader_slot) = next_leader_slot {
             format!("My next leader slot is {}", next_leader_slot.0)
@@ -2978,7 +2978,7 @@ pub mod tests {
             PohRecorder::new(
                 working_bank.tick_height(),
                 working_bank.last_blockhash(),
-                working_bank.slot(),
+                working_bank.clone(),
                 None,
                 working_bank.ticks_per_slot(),
                 &Pubkey::default(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5574,20 +5574,11 @@ pub mod tests {
         let my_vote_pubkey = my_vote_keypair[0].pubkey();
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
 
-        fn fill_bank_with_ticks(bank: &Bank) {
-            let parent_distance = bank.slot() - bank.parent_slot();
-            for _ in 0..parent_distance {
-                let last_blockhash = bank.last_blockhash();
-                while bank.last_blockhash() == last_blockhash {
-                    bank.register_tick(&Hash::new_unique())
-                }
-            }
-        }
         let (voting_sender, voting_receiver) = channel();
 
         // Simulate landing a vote for slot 0 landing in slot 1
         let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
-        fill_bank_with_ticks(&bank1);
+        bank1.fill_bank_with_ticks();
         tower.record_bank_vote(&bank0, &my_vote_pubkey);
         ReplayStage::push_vote(
             &bank0,
@@ -5625,7 +5616,7 @@ pub mod tests {
         // Trying to refresh the vote for bank 0 in bank 1 or bank 2 won't succeed because
         // the last vote has landed already
         let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), 2));
-        fill_bank_with_ticks(&bank2);
+        bank2.fill_bank_with_ticks();
         bank2.freeze();
         for refresh_bank in &[&bank1, &bank2] {
             ReplayStage::refresh_last_vote(
@@ -5708,7 +5699,7 @@ pub mod tests {
             &Pubkey::default(),
             bank2.slot() + MAX_PROCESSING_AGE as Slot,
         ));
-        fill_bank_with_ticks(&expired_bank);
+        expired_bank.fill_bank_with_ticks();
         expired_bank.freeze();
 
         // Now trying to refresh the vote for slot 1 will succeed because the recent blockhash
@@ -5770,7 +5761,7 @@ pub mod tests {
             vote_account.vote_state().as_ref().unwrap().tower(),
             vec![0, 1]
         );
-        fill_bank_with_ticks(&expired_bank_child);
+        expired_bank_child.fill_bank_with_ticks();
         expired_bank_child.freeze();
 
         // Trying to refresh the vote on a sibling bank where:
@@ -5782,7 +5773,7 @@ pub mod tests {
             &Pubkey::default(),
             expired_bank_child.slot() + 1,
         ));
-        fill_bank_with_ticks(&expired_bank_sibling);
+        expired_bank_sibling.fill_bank_with_ticks();
         expired_bank_sibling.freeze();
         // Set the last refresh to now, shouldn't refresh because the last refresh just happened.
         last_vote_refresh_time.last_refresh_time = Instant::now();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -504,7 +504,7 @@ impl Validator {
             PohRecorder::new_with_clear_signal(
                 bank.tick_height(),
                 bank.last_blockhash(),
-                bank.slot(),
+                bank.clone(),
                 leader_schedule_cache.next_leader_slot(
                     &id,
                     bank.slot(),

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -396,15 +396,18 @@ mod tests {
             });
             let exit = Arc::new(AtomicBool::new(false));
 
+            let ticks_per_slot = bank.ticks_per_slot();
+            let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+            let blockstore = Arc::new(blockstore);
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 prev_hash,
-                bank.slot(),
+                bank.clone(),
                 Some((4, 4)),
-                bank.ticks_per_slot(),
+                ticks_per_slot,
                 &Pubkey::default(),
-                &Arc::new(blockstore),
-                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &blockstore,
+                &leader_schedule_cache,
                 &poh_config,
                 exit.clone(),
             );

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -357,7 +357,6 @@ impl PohService {
 mod tests {
     use {
         super::*,
-        crate::poh_recorder::WorkingBank,
         rand::{thread_rng, Rng},
         solana_ledger::{
             blockstore::Blockstore,
@@ -412,14 +411,8 @@ mod tests {
                 exit.clone(),
             );
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
-            let start = Arc::new(Instant::now());
-            let working_bank = WorkingBank {
-                bank: bank.clone(),
-                start,
-                min_tick_height: bank.tick_height(),
-                max_tick_height: std::u64::MAX,
-            };
             let ticks_per_slot = bank.ticks_per_slot();
+            let bank_slot = bank.slot();
 
             // specify RUN_TIME to run in a benchmark-like mode
             // to calibrate batch size
@@ -444,7 +437,7 @@ mod tests {
                             // send some data
                             let mut time = Measure::start("record");
                             let _ = poh_recorder.lock().unwrap().record(
-                                bank.slot(),
+                                bank_slot,
                                 h1,
                                 vec![tx.clone()],
                             );
@@ -481,7 +474,7 @@ mod tests {
                 hashes_per_batch,
                 record_receiver,
             );
-            poh_recorder.lock().unwrap().set_working_bank(working_bank);
+            poh_recorder.lock().unwrap().set_bank(&bank);
 
             // get some events
             let mut hashes = 0;

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -105,7 +105,7 @@ mod test {
             let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
                 bank.last_blockhash(),
-                0,
+                bank.clone(),
                 Some((2, 2)),
                 bank.ticks_per_slot(),
                 &Pubkey::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5401,6 +5401,20 @@ impl Bank {
         self.feature_set = Arc::new(feature_set);
     }
 
+    pub fn fill_bank_with_ticks(&self) {
+        let parent_distance = if self.slot() == 0 {
+            1
+        } else {
+            self.slot() - self.parent_slot()
+        };
+        for _ in 0..parent_distance {
+            let last_blockhash = self.last_blockhash();
+            while self.last_blockhash() == last_blockhash {
+                self.register_tick(&Hash::new_unique())
+            }
+        }
+    }
+
     // This is called from snapshot restore AND for each epoch boundary
     // The entire code path herein must be idempotent
     fn apply_feature_activations(


### PR DESCRIPTION
#### Problem
BankingStage would like access to a bank to access validator stakes for QoS.

However, when the validator is not a leader, it PohRecorder does not currently have a bank.

This can be naturally solved if we always tracked in PohRecorder the last reset bank from startup/replay.

Extracted from https://github.com/solana-labs/solana/pull/19611.

#### Summary of Changes
Track a `start_bank` instead of a `start_slot` in `PohRecorder`

Most of the changes are just test changes, important bits are called out in comments.

Fixes #
