### PR TITLE
Fix bug in node json with string more than 500mb

### DIFF
--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@discoveryjs/json-ext": "^0.5.3",
         "@solana/buffer-layout": "^3.0.0",
         "bn.js": "^5.0.0",
         "borsh": "^0.4.0",
@@ -2448,6 +2449,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
+      "integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -21731,6 +21740,11 @@
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
+    },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
+      "integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@discoveryjs/json-ext": "^0.5.3",
     "@solana/buffer-layout": "^3.0.0",
     "bn.js": "^5.0.0",
     "borsh": "^0.4.0",


### PR DESCRIPTION
#### Problem
For big response It can happen error `Error: Cannot create a string longer than 0x1fffffe8 characters`

#### Summary of Changes

Add library `@discoveryjs/json-ext` for parsing response from `arrayBuffer`. 
It works right now, but I've made a PR https://github.com/discoveryjs/json-ext/pull/7 for supporting typings for typescript.

Fixes #
