### PR TITLE
Silence vercel github comments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
#### Problem
Vercel bot comments on changes for any PR regardless of ignored build config. 

#### Summary of Changes
Use the [github.silent](https://vercel.com/docs/cli#git-configuration/github-silent
) config to disable noisy vercel comments

Fixes #
