### PR TITLE
Fix mergify automerge rule for explorer checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,24 +18,32 @@ pull_request_rules:
           - "@solana-labs/community-pr-subscribers"
   - name: automatic merge (squash) on CI success
     conditions:
-      - status-success=buildkite/solana
-      - status-success=Travis CI - Pull Request
-      - status-success=check-explorer
-      - status-success=ci-gate
-      - label=automerge
-      - author≠@dont-squash-my-commits
+      - and:
+        - status-success=buildkite/solana
+        - status-success=Travis CI - Pull Request
+        - status-success=ci-gate
+        - label=automerge
+        - author≠@dont-squash-my-commits
+        - or:
+          # only require explorer checks if explorer files changed
+          - status-success=check-explorer
+          - -files~=^explorer/
     actions:
       merge:
         method: squash
   # Join the dont-squash-my-commits group if you won't like your commits squashed
   - name: automatic merge (rebase) on CI success
     conditions:
-      - status-success=buildkite/solana
-      - status-success=Travis CI - Pull Request
-      - status-success=check-explorer
-      - status-success=ci-gate
-      - label=automerge
-      - author=@dont-squash-my-commits
+      - and:
+        - status-success=buildkite/solana
+        - status-success=Travis CI - Pull Request
+        - status-success=ci-gate
+        - label=automerge
+        - author=@dont-squash-my-commits
+        - or:
+          # only require explorer checks if explorer files changed
+          - status-success=check-explorer
+          - -files~=^explorer/
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
#### Problem
Mergify requires the check-explorer status check but that check isn't run if explorer files weren't changed

#### Summary of Changes

Fixes #
