### PR TITLE
Flush accounts cache before calling clean_accounts()

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1194,6 +1194,7 @@ fn load_frozen_forks(
                     ) {
                         info!("Taking snapshot of new root bank that has crossed the full snapshot interval! slot: {}", *root);
                         *last_full_snapshot_slot = Some(*root);
+                        new_root_bank.force_flush_accounts_cache();
                         new_root_bank.clean_accounts(true, true, *last_full_snapshot_slot);
                         new_root_bank.update_accounts_hash_with_index_option(
                             snapshot_config.accounts_hash_use_index,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2009,6 +2009,12 @@ impl AccountsDb {
                 } else {
                     let mut key_set = HashSet::new();
                     key_set.insert(*key);
+                    assert!(
+                        !account_info.is_cached(),
+                        "The Accounts Cache must be flushed first for this account info. pubkey: {}, slot: {}",
+                        *key,
+                        *slot
+                    );
                     let count = self
                         .storage
                         .slot_store_count(*slot, account_info.store_id)


### PR DESCRIPTION
#### Problem

Jeff saw panics on his validator at boot when processing the blockstore that had roots that crossed a full snapshot interval. This was because the cache was not flushed before calling `clean_accounts()`.

```text
[2021-09-13T15:32:52.072465574Z INFO  solana_ledger::blockstore_processor] Taking snapshot of new root bank that has crossed the full snapshot interval! slot: 96387886
[2021-09-13T15:32:52.168348065Z INFO  solana_runtime::accounts_db] total_stores: 406391, newest_slot: 96387832, oldest_slot: 95955761, max_slot: 96064020 (num=1), min_slot: 96064020 (num=1)
[2021-09-13T15:32:52.168404416Z INFO  solana_metrics::metrics] datapoint: accounts_db-stores total_count=406391i recycle_count=1000i total_bytes=31089229824i total_alive_bytes=31089229824i total_alive_ratio=1
[2021-09-13T15:32:52.173525016Z INFO  solana_metrics::metrics] datapoint: accounts_db-perf-stats delta_hash_num=49i delta_hash_scan_us=54735i delta_hash_accumulate_us=116248i
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', runtime/src/accounts_db.rs:2015:26
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d2b04f075c0ce010758c4c8674152ff89d1d73f3/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/d2b04f075c0ce010758c4c8674152ff89d1d73f3/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/d2b04f075c0ce010758c4c8674152ff89d1d73f3/library/core/src/panicking.rs:50:5
   3: alloc::vec::Vec<T,A>::retain
   4: solana_runtime::accounts_db::AccountsDb::clean_accounts
   5: solana_ledger::blockstore_processor::do_process_blockstore_from_root
--
```

#### Summary of Changes

Flush the accounts cache before calling `clean_accounts()`.