### PR TITLE
Clean up explorer deploy and stop mirroring the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ jobs:
         depth: false
       script:
         - .travis/export-github-repo.sh web3.js/ solana-web3.js
-        - .travis/export-github-repo.sh explorer/ explorer
 
     - &release-artifacts
       if: type IN (api, cron) OR tag IS present

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -262,7 +262,7 @@ pull_or_push_steps() {
     all_test_steps
   fi
 
-  # web3.js, explorer and docs changes run on Travis...
+  # web3.js, explorer and docs changes run on Travis or Github actions...
 }
 
 

--- a/explorer/.github/PULL_REQUEST_TEMPLATE.md
+++ b/explorer/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,0 @@
-# This repo is a mirror of https://github.com/solana-labs/solana/tree/master/explorer
-
-Please make changes directly to the main Solana repo: https://github.com/solana-labs/solana

--- a/explorer/.slugignore
+++ b/explorer/.slugignore
@@ -1,1 +1,0 @@
-node_modules

--- a/explorer/app.json
+++ b/explorer/app.json
@@ -1,7 +1,0 @@
-{
-  "buildpacks": [
-    {
-      "url": "https://github.com/solana-labs/create-react-app-buildpack.git"
-    }
-  ]
-}

--- a/explorer/static.json
+++ b/explorer/static.json
@@ -1,7 +1,0 @@
-{
-  "https_only": true,
-  "root": "build/",
-  "routes": {
-    "/**": "index.html"
-  }
-}


### PR DESCRIPTION
#### Problem
The explorer mirror confuses everyone but only existed for heroku deploys I believe but we have just migrated the explorer from heroku over to vercel.

#### Summary of Changes
- Stop exporting explorer changes to the mirror repo (will archive it after this)
- Remove pull request template that's not needed anymore
- Remove heroku config

Fixes #
