### PR TITLE
Set is_startup=true for exhaustively_free_unused_resource()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2339,6 +2339,7 @@ impl Bank {
     // Should not be called outside of startup, will race with
     // concurrent cleaning logic in AccountsBackgroundService
     pub fn exhaustively_free_unused_resource(&self, last_full_snapshot_slot: Option<Slot>) {
+        const IS_STARTUP: bool = true; // this is only called at startup, and we want to use more threads
         let mut flush = Measure::start("flush");
         // Flush all the rooted accounts. Must be called after `squash()`,
         // so that AccountsDb knows what the roots are.
@@ -2350,11 +2351,10 @@ impl Bank {
         // accounts that were included in the bank delta hash when the bank was frozen,
         // and if we clean them here, any newly created snapshot's hash for this bank
         // may not match the frozen hash.
-        self.clean_accounts(true, false, last_full_snapshot_slot);
+        self.clean_accounts(true, IS_STARTUP, last_full_snapshot_slot);
         clean.stop();
 
         let mut shrink = Measure::start("shrink");
-        const IS_STARTUP: bool = true; // this is only called at startup, and we want to use more threads
         self.shrink_all_slots(IS_STARTUP, last_full_snapshot_slot);
         shrink.stop();
 


### PR DESCRIPTION
#### Problem

`exhaustively_free_unused_resource()` is only called during startup, but it calls `clean_accounts()` with `is_startup` set to false.

#### Summary of Changes

Call `clean_accounts()` inside `exhaustively_free_unused_resource()` with `is_startup` set to true.