### PR TITLE
build downstream spl bpf programs for tests

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -68,6 +68,7 @@ spl() {
 
     $cargo build
     $cargo test
+    $cargo_build_bpf
     $cargo_test_bpf
   )
 }


### PR DESCRIPTION
#### Problem

Downstream CI tests are failing because not all the dependent bpf programs are being built

#### Summary of Changes

Build them.

Should these be built implicitly, maybe missing dep?

Fixes #
