### PR TITLE
Cli: check current authorities before attempting to change them

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1973,17 +1973,36 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
+        let vote_account_info_response = json!(Response {
+            context: RpcResponseContext { slot: 1 },
+            value: json!({
+                "data": ["KLUv/QBYNQIAtAIBAAAAbnoc3Smwt4/ROvTFWY/v9O8qlxZuPKby5Pv8zYBQW/EFAAEAAB8ACQD6gx92zAiAAecDP4B2XeEBSIx7MQeung==", "base64+zstd"],
+                "lamports": 42,
+                "owner": "Vote111111111111111111111111111111111111111",
+                "executable": false,
+                "rentEpoch": 1,
+            }),
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, vote_account_info_response);
+        let rpc_client = RpcClient::new_mock_with_mocks("".to_string(), mocks);
+        let mut vote_config = CliConfig {
+            rpc_client: Some(Arc::new(rpc_client)),
+            json_rpc_url: "http://127.0.0.1:8899".to_string(),
+            ..CliConfig::default()
+        };
+        let current_authority = keypair_from_seed(&[5; 32]).unwrap();
         let new_authorized_pubkey = solana_sdk::pubkey::new_rand();
-        config.signers = vec![&bob_keypair];
-        config.command = CliCommand::VoteAuthorize {
+        vote_config.signers = vec![&current_authority];
+        vote_config.command = CliCommand::VoteAuthorize {
             vote_account_pubkey: bob_pubkey,
             new_authorized_pubkey,
-            vote_authorize: VoteAuthorize::Voter,
+            vote_authorize: VoteAuthorize::Withdrawer,
             memo: None,
             authorized: 0,
             new_authorized: None,
         };
-        let result = process_command(&config);
+        let result = process_command(&vote_config);
         assert!(result.is_ok());
 
         let new_identity_keypair = Keypair::new();

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -32,6 +32,7 @@ use solana_sdk::{
     account::from_account,
     account_utils::StateMut,
     clock::{Clock, UnixTimestamp, SECONDS_PER_DAY},
+    commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     message::Message,
     pubkey::Pubkey,
@@ -1353,6 +1354,15 @@ pub fn process_stake_authorize(
 ) -> ProcessResult {
     let mut ixs = Vec::new();
     let custodian = custodian.map(|index| config.signers[index]);
+    let current_stake_account = if !sign_only {
+        Some(get_stake_account_state(
+            rpc_client,
+            stake_account_pubkey,
+            config.commitment,
+        )?)
+    } else {
+        None
+    };
     for StakeAuthorizationIndexed {
         authorization_type,
         new_authority_pubkey,
@@ -1365,6 +1375,29 @@ pub fn process_stake_authorize(
             (new_authority_pubkey, "new_authorized_pubkey".to_string()),
         )?;
         let authority = config.signers[*authority];
+        if let Some(current_stake_account) = current_stake_account {
+            let authorized = match current_stake_account {
+                StakeState::Stake(Meta { authorized, .. }, ..) => Some(authorized),
+                StakeState::Initialized(Meta { authorized, .. }) => Some(authorized),
+                _ => None,
+            };
+            if let Some(authorized) = authorized {
+                match authorization_type {
+                    StakeAuthorize::Staker => {
+                        check_stake_current_authority(&authorized.staker, &authority.pubkey())?;
+                    }
+                    StakeAuthorize::Withdrawer => {
+                        check_stake_current_authority(&authorized.withdrawer, &authority.pubkey())?;
+                    }
+                }
+            } else {
+                return Err(CliError::RpcRequestError(format!(
+                    "{:?} is not an Initialized or Delegated stake account",
+                    stake_account_pubkey,
+                ))
+                .into());
+            }
+        }
         if new_authority_signer.is_some() {
             ixs.push(stake_instruction::authorize_checked(
                 stake_account_pubkey, // stake account to update
@@ -2031,6 +2064,47 @@ pub fn build_stake_state(
                 ..CliStakeState::default()
             }
         }
+    }
+}
+
+fn get_stake_account_state(
+    rpc_client: &RpcClient,
+    stake_account_pubkey: &Pubkey,
+    commitment_config: CommitmentConfig,
+) -> Result<StakeState, Box<dyn std::error::Error>> {
+    let stake_account = rpc_client
+        .get_account_with_commitment(stake_account_pubkey, commitment_config)?
+        .value
+        .ok_or_else(|| {
+            CliError::RpcRequestError(format!("{:?} account does not exist", stake_account_pubkey))
+        })?;
+    if stake_account.owner != stake::program::id() {
+        return Err(CliError::RpcRequestError(format!(
+            "{:?} is not a stake account",
+            stake_account_pubkey,
+        ))
+        .into());
+    }
+    stake_account.state().map_err(|err| {
+        CliError::RpcRequestError(format!(
+            "Account data could not be deserialized to stake state: {}",
+            err
+        ))
+        .into()
+    })
+}
+
+fn check_stake_current_authority(
+    stake_account_current_authority: &Pubkey,
+    provided_current_authority: &Pubkey,
+) -> Result<(), CliError> {
+    if stake_account_current_authority != provided_current_authority {
+        Err(CliError::RpcRequestError(format!(
+            "Invalid current authority provided: {:?}, expected {:?}",
+            provided_current_authority, stake_account_current_authority
+        )))
+    } else {
+        Ok(())
     }
 }
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1384,10 +1384,10 @@ pub fn process_stake_authorize(
             if let Some(authorized) = authorized {
                 match authorization_type {
                     StakeAuthorize::Staker => {
-                        check_stake_current_authority(&authorized.staker, &authority.pubkey())?;
+                        check_current_authority(&authorized.staker, &authority.pubkey())?;
                     }
                     StakeAuthorize::Withdrawer => {
-                        check_stake_current_authority(&authorized.withdrawer, &authority.pubkey())?;
+                        check_current_authority(&authorized.withdrawer, &authority.pubkey())?;
                     }
                 }
             } else {
@@ -1934,7 +1934,7 @@ pub fn process_stake_set_lockup(
         };
         if let Some(lockup) = lockup {
             if lockup.custodian != Pubkey::default() {
-                check_stake_current_authority(&lockup.custodian, &custodian.pubkey())?;
+                check_current_authority(&lockup.custodian, &custodian.pubkey())?;
             }
         } else {
             return Err(CliError::RpcRequestError(format!(
@@ -2114,14 +2114,14 @@ fn get_stake_account_state(
     })
 }
 
-fn check_stake_current_authority(
-    stake_account_current_authority: &Pubkey,
+pub(crate) fn check_current_authority(
+    account_current_authority: &Pubkey,
     provided_current_authority: &Pubkey,
 ) -> Result<(), CliError> {
-    if stake_account_current_authority != provided_current_authority {
+    if account_current_authority != provided_current_authority {
         Err(CliError::RpcRequestError(format!(
             "Invalid current authority provided: {:?}, expected {:?}",
-            provided_current_authority, stake_account_current_authority
+            provided_current_authority, account_current_authority
         )))
     } else {
         Ok(())


### PR DESCRIPTION
#### Problem
Submitting the same solana-cli checked commands repeatedly succeeds unexpectedly. For example:
```
$ solana stake-authorize-checked ~/stake.json --withdraw-authority ~/current_authority.json --new-withdraw-authority ~/new_authority.json
```
will succeed indefinitely. This is because the stake program checks that the current authority according to the program and the new authority according to the instruction are both signers, and they are -- the same `~/new_authority.json`.

`solana stake-set-lockup-checked`, `solana vote-authorize-voter-checked` and `solana-authorize-withdrawer-checked` evidence the same behavior.

#### Summary of Changes
When not in offline mode, check the stake or vote account ahead of time to ensure the provided current authority is consistent with the account
