### PR TITLE
Add logging of incremental snapshots to purge_old_snapshot_archives()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1233,9 +1233,10 @@ pub fn purge_old_snapshot_archives<P>(
     P: AsRef<Path>,
 {
     info!(
-        "Purging old snapshot archives in {}, retaining {} full snapshots",
+        "Purging old snapshot archives in {}, retaining {} full snapshots and {} incremental snapshots",
         snapshot_archives_dir.as_ref().display(),
-        maximum_full_snapshot_archives_to_retain
+        maximum_full_snapshot_archives_to_retain,
+        maximum_incremental_snapshot_archives_to_retain
     );
     let mut snapshot_archives = get_full_snapshot_archives(&snapshot_archives_dir);
     snapshot_archives.sort_unstable();


### PR DESCRIPTION
#### Problem

`snapshot_utils::purge_old_snapshot_archives()` does not log info about the maximum incremental snapshot archives to retain.

#### Summary of Changes

Log it. 