### PR TITLE
Add test for startup processing new roots past full snapshot interval

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2221,7 +2221,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     cluster.add_validator(
         &final_validator_snapshot_test_config.validator_config,
         stake,
-        final_validator_identity.clone(),
+        final_validator_identity,
         None,
         SocketAddrSpace::Unspecified,
     );


### PR DESCRIPTION
#### Problem

There's no test for the scenario that's in the title.

#### Summary of Changes

Here's the comment I added for the new test:

```
/// Test the scenario where a node starts up from a snapshot and its blockstore has enough new
/// roots that cross the full snapshot interval.  In this scenario, the node needs to take a full
/// snapshot while processing the blockstore so that once the background services start up, there
/// is the correct full snapshot available to take subsequent incremental snapshots.
```

Fixes #19856
