### PR TITLE
introduce CachedBucket in accounts index model

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -742,7 +742,7 @@ impl<T: IndexValue> AccountsIndex<T> {
             .unwrap_or(BINS_DEFAULT);
         // create bin_calculator early to verify # bins is reasonable
         let bin_calculator = PubkeyBinCalculator16::new(bins);
-        let storage = AccountsIndexStorage::new();
+        let storage = AccountsIndexStorage::new(bins);
         let account_maps = (0..bins)
             .into_iter()
             .map(|bin| RwLock::new(AccountMap::new(&storage, bin)))

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -1,6 +1,7 @@
 use crate::accounts_index::IndexValue;
 use crate::bucket_map_holder::BucketMapHolder;
 use crate::waitable_condvar::WaitableCondvar;
+use std::fmt::Debug;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -14,7 +15,7 @@ use std::{
 //  When this instance is dropped, it will drop the bucket map and cleanup
 //  and it will stop all the background threads and join them.
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct AccountsIndexStorage<T: IndexValue> {
     // for managing the bg threads
     exit: Arc<AtomicBool>,
@@ -23,6 +24,12 @@ pub struct AccountsIndexStorage<T: IndexValue> {
 
     // eventually the backing storage
     storage: Arc<BucketMapHolder<T>>,
+}
+
+impl<T: IndexValue> Debug for AccountsIndexStorage<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
 }
 
 impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
@@ -36,8 +43,8 @@ impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
 }
 
 impl<T: IndexValue> AccountsIndexStorage<T> {
-    pub fn new() -> AccountsIndexStorage<T> {
-        let storage = Arc::new(BucketMapHolder::new());
+    pub fn new(bins: usize) -> AccountsIndexStorage<T> {
+        let storage = Arc::new(BucketMapHolder::new(bins));
         let storage_ = storage.clone();
         let exit = Arc::new(AtomicBool::default());
         let exit_ = exit.clone();

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -1,21 +1,43 @@
 use crate::accounts_index::IndexValue;
 use crate::bucket_map_holder_stats::BucketMapHolderStats;
 use crate::waitable_condvar::WaitableCondvar;
-use std::fmt::Debug;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 // will eventually hold the bucket map
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct BucketMapHolder<T: IndexValue> {
-    pub stats: BucketMapHolderStats,
+    pub stats: Arc<BucketMapHolderStats>,
+    pub buckets: Vec<Arc<CachedBucket<T>>>,
+}
+
+#[derive(Default)]
+pub struct CachedBucket<T: IndexValue> {
+    // soon, this will hold the hashmap itself: pub map: RwLock<HashMap<Pubkey, AccountMapEntry<T>>>,
+    _bin: usize,
+    _stats: Arc<BucketMapHolderStats>,
     _phantom: std::marker::PhantomData<T>,
 }
 
+impl<T: IndexValue> CachedBucket<T> {
+    pub fn new(stats: Arc<BucketMapHolderStats>, bin: usize) -> Self {
+        Self {
+            _bin: bin,
+            _stats: stats,
+            ..Self::default()
+        }
+    }
+}
+
 impl<T: IndexValue> BucketMapHolder<T> {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(bins: usize) -> Self {
+        let stats = Arc::new(BucketMapHolderStats::default());
+        let buckets = (0..bins)
+            .into_iter()
+            .map(|bin| Arc::new(CachedBucket::new(stats.clone(), bin)))
+            .collect();
+        Self { stats, buckets }
     }
 
     // intended to execute in a bg thread


### PR DESCRIPTION
#### Problem
The hashmap itself will move to CachedBucket.
It will also be behind a RwLock.
This gets messy when combined.
The purpose of this change is to create the right struct hierarchy that matches the locking hierarchy and prepares the way for the right pieces of data to be owned in the right code cleanly.

#### Summary of Changes

Fixes #
