### PR TITLE
Add logging after taking a bank snapshot

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -217,6 +217,12 @@ impl SnapshotRequestHandler {
                     }
                 }
                 snapshot_time.stop();
+                info!("Took bank snapshot. snapshot type: {:?}, slot: {}, accounts hash: {}, bank hash: {}",
+                      snapshot_type,
+                      snapshot_root_bank.slot(),
+                      snapshot_root_bank.get_accounts_hash(),
+                      snapshot_root_bank.hash(),
+                  );
 
                 // Cleanup outdated snapshots
                 let mut purge_old_snapshots_time = Measure::start("purge_old_snapshots_time");


### PR DESCRIPTION
#### Problem

From @CriesofCarrots 
> When I boot test clusters from intermediate snapshots, I need to know the expected bank hash to pass to each validator in order to sync/wait-for-supermajority on the snapshot slot. To this point, I've just been using a dummy hash on the first boot attempt, and letting the validator process the snapshot to get the right hash. But this takes a long time with the huge snapshots Jeff and I are using for our simulations.
Is there a better method?

#### Summary of Changes

As a simple first step, log the bank hash when AccountsBackgroundService takes a bank snapshot. Later, using the snapshot slot (or snapshot/accounts hash), you'll be able to go back through the log to get the bank hash for that snapshot.