### PR TITLE
Use f64 for stake math in get_stake_percent_in_gossip

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1512,21 +1512,22 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         }
     }
 
+    let online_stake_percentage = (online_stake as f64 / total_activated_stake as f64) * 100.;
     if log {
         info!(
-            "{}% of active stake visible in gossip",
-            online_stake * 100 / total_activated_stake
+            "{:.3}% of active stake visible in gossip",
+            online_stake_percentage
         );
 
         if !wrong_shred_nodes.is_empty() {
             info!(
-                "{}% of active stake has the wrong shred version in gossip",
-                wrong_shred_stake * 100 / total_activated_stake,
+                "{:.3}% of active stake has the wrong shred version in gossip",
+                (wrong_shred_stake as f64 / total_activated_stake as f64) * 100.,
             );
             for (stake, identity) in wrong_shred_nodes {
                 info!(
-                    "    {}% - {}",
-                    stake * 100 / total_activated_stake,
+                    "    {:.3}% - {}",
+                    (stake as f64 / total_activated_stake as f64) * 100.,
                     identity
                 );
             }
@@ -1534,20 +1535,20 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
 
         if !offline_nodes.is_empty() {
             info!(
-                "{}% of active stake is not visible in gossip",
-                offline_stake * 100 / total_activated_stake
+                "{:.3}% of active stake is not visible in gossip",
+                (offline_stake as f64 / total_activated_stake as f64) * 100.
             );
             for (stake, identity) in offline_nodes {
                 info!(
-                    "    {}% - {}",
-                    stake * 100 / total_activated_stake,
+                    "    {:.3}% - {}",
+                    (stake as f64 / total_activated_stake as f64) * 100.,
                     identity
                 );
             }
         }
     }
 
-    online_stake * 100 / total_activated_stake
+    online_stake_percentage as u64
 }
 
 // Cleanup anything that looks like an accounts append-vec


### PR DESCRIPTION
#### Problem
Mainnet-beta has so much active_stake that active_stake * 100 overflows a u64.

#### Summary of Changes
Use floating points to divide first
Also pulls in the display changes from https://github.com/solana-labs/solana/pull/19886

Closes #19886 
