### PR TITLE
Log supermajority achieved status

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1472,6 +1472,10 @@ fn wait_for_supermajority(
         let gossip_stake_percent = get_stake_percent_in_gossip(bank, cluster_info, i % 10 == 0);
 
         if gossip_stake_percent >= WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT {
+            info!(
+                "Supermajority reached, {}% active stake detected, starting up now.",
+                gossip_stake_percent,
+            );
             break;
         }
         // The normal RPC health checks don't apply as the node is waiting, so feign health to


### PR DESCRIPTION
#### Problem
During a cluster restart the validator waits for the WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT to be achieved, periodically printing the current cluster stats to the log. Once the threshold is met the node starts with no log to indicate this change of state, making it difficult to ascertain the time the node started voting or that the state has even changed without digging further.

Additionally if the node starts with the --wait-for-supermajority flag but the cluster has already met the threshold there is no indication from the log what has happened.

#### Summary of Changes
Just added an info log in the conditional that succeeds once the threshold is met in wait_for_supermajority() in validator.rs


Fixes #
