### PR TITLE
Report consumed_buffered_packets_count stat to metrics

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -164,6 +164,12 @@ impl BankingStageStats {
                     i64
                 ),
                 (
+                    "consumed_buffered_packets_count",
+                    self.consumed_buffered_packets_count
+                        .swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
                     "consume_buffered_packets_elapsed",
                     self.consume_buffered_packets_elapsed
                         .swap(0, Ordering::Relaxed) as i64,


### PR DESCRIPTION
#### Problem
Can't see how many buffered packets we are consuming in metrics

#### Summary of Changes

Fixes #
