### PR TITLE
AcctIdx: remove auto Debug trait

### DIFF
--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -1,6 +1,7 @@
 use crate::accounts_index::IndexValue;
 use crate::bucket_map_holder::BucketMapHolder;
 use crate::waitable_condvar::WaitableCondvar;
+use std::fmt::Debug;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -14,7 +15,7 @@ use std::{
 //  When this instance is dropped, it will drop the bucket map and cleanup
 //  and it will stop all the background threads and join them.
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct AccountsIndexStorage<T: IndexValue> {
     // for managing the bg threads
     exit: Arc<AtomicBool>,
@@ -23,6 +24,12 @@ pub struct AccountsIndexStorage<T: IndexValue> {
 
     // eventually the backing storage
     storage: Arc<BucketMapHolder<T>>,
+}
+
+impl<T: IndexValue> Debug for AccountsIndexStorage<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
 }
 
 impl<T: IndexValue> Drop for AccountsIndexStorage<T> {

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -7,10 +7,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 // will eventually hold the bucket map
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct BucketMapHolder<T: IndexValue> {
     pub stats: BucketMapHolderStats,
     _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: IndexValue> Debug for BucketMapHolder<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
 }
 
 impl<T: IndexValue> BucketMapHolder<T> {

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -15,12 +15,17 @@ use std::ops::RangeBounds;
 type K = Pubkey;
 
 // one instance of this represents one bin of the accounts index.
-#[derive(Debug)]
 pub struct InMemAccountsIndex<T: IndexValue> {
     // backing store
     map_internal: RwLock<HashMap<Pubkey, AccountMapEntry<T>>>,
     storage: Arc<BucketMapHolder<T>>,
     bin: usize,
+}
+
+impl<T: IndexValue> Debug for InMemAccountsIndex<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
 }
 
 impl<T: IndexValue> InMemAccountsIndex<T> {


### PR DESCRIPTION
#### Problem
Of all things, there is a test that tests that we can debug print a bank and it succeeds. It turns out with 8k rwlocks of various hierarchies of objects, this test can take a long time to run. Debug is required from AccountsIndex trait, so do a default impl of all these types so that we satisfy the requirements. But, we don't need to be able to debug print anything atm.
#### Summary of Changes

Fixes #
