### PR TITLE
AcctIdx: pass bins to BucketMapHolder

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -742,7 +742,7 @@ impl<T: IndexValue> AccountsIndex<T> {
             .unwrap_or(BINS_DEFAULT);
         // create bin_calculator early to verify # bins is reasonable
         let bin_calculator = PubkeyBinCalculator16::new(bins);
-        let storage = AccountsIndexStorage::new();
+        let storage = AccountsIndexStorage::new(bins);
         let account_maps = (0..bins)
             .into_iter()
             .map(|bin| RwLock::new(AccountMap::new(&storage, bin)))

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -14,8 +14,6 @@ use std::{
 // Also manages the lifetime of the background processing threads.
 //  When this instance is dropped, it will drop the bucket map and cleanup
 //  and it will stop all the background threads and join them.
-
-#[derive(Default)]
 pub struct AccountsIndexStorage<T: IndexValue> {
     // for managing the bg threads
     exit: Arc<AtomicBool>,
@@ -43,8 +41,8 @@ impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
 }
 
 impl<T: IndexValue> AccountsIndexStorage<T> {
-    pub fn new() -> AccountsIndexStorage<T> {
-        let storage = Arc::new(BucketMapHolder::new());
+    pub fn new(bins: usize) -> AccountsIndexStorage<T> {
+        let storage = Arc::new(BucketMapHolder::new(bins));
         let storage_ = storage.clone();
         let exit = Arc::new(AtomicBool::default());
         let exit_ = exit.clone();

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 // will eventually hold the bucket map
-#[derive(Default)]
 pub struct BucketMapHolder<T: IndexValue> {
     pub stats: BucketMapHolderStats,
     _phantom: std::marker::PhantomData<T>,
@@ -20,8 +19,11 @@ impl<T: IndexValue> Debug for BucketMapHolder<T> {
 }
 
 impl<T: IndexValue> BucketMapHolder<T> {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(_bins: usize) -> Self {
+        Self {
+            stats: BucketMapHolderStats::default(),
+            _phantom: std::marker::PhantomData::<T>::default(),
+        }
     }
 
     // intended to execute in a bg thread

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -41,10 +41,6 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         &self.map_internal
     }
 
-    pub fn new_bucket_map_holder() -> Arc<BucketMapHolder<T>> {
-        Arc::new(BucketMapHolder::new())
-    }
-
     pub fn items<R>(&self, range: &Option<&R>) -> Vec<(K, AccountMapEntry<T>)>
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,


### PR DESCRIPTION
#### Problem
We will need to pass bins through. This gets rid of the noise, removes the clippy required default, etc.
#### Summary of Changes

Fixes #
