### PR TITLE
Only allow votes when root distance gets too high

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1453,12 +1453,22 @@ impl ReplayStage {
                 poh_slot, parent_slot, root_slot
             );
 
+            let root_distance = poh_slot - root_slot;
+            const MAX_ROOT_DISTANCE_FOR_VOTE_ONLY: Slot = 500;
+            let vote_only_bank = if root_distance > MAX_ROOT_DISTANCE_FOR_VOTE_ONLY {
+                datapoint_info!("vote-only-bank", ("slot", poh_slot, i64));
+                true
+            } else {
+                false
+            };
+
             let tpu_bank = Self::new_bank_from_parent_with_notify(
                 &parent,
                 poh_slot,
                 root_slot,
                 my_pubkey,
                 rpc_subscriptions,
+                vote_only_bank,
             );
 
             let tpu_bank = bank_forks.write().unwrap().insert(tpu_bank);
@@ -2784,6 +2794,7 @@ impl ReplayStage {
                     forks.root(),
                     &leader,
                     rpc_subscriptions,
+                    false,
                 );
                 let empty: Vec<Pubkey> = vec![];
                 Self::update_fork_propagated_threshold_from_votes(
@@ -2810,9 +2821,10 @@ impl ReplayStage {
         root_slot: u64,
         leader: &Pubkey,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
+        vote_only_bank: bool,
     ) -> Bank {
         rpc_subscriptions.notify_slot(slot, parent.slot(), root_slot);
-        Bank::new_from_parent(parent, leader, slot)
+        Bank::new_from_parent_with_vote_only(parent, leader, slot, vote_only_bank)
     }
 
     fn record_rewards(bank: &Bank, rewards_recorder_sender: &Option<RewardsRecorderSender>) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -984,6 +984,8 @@ pub struct Bank {
     pub drop_callback: RwLock<OptionalDropCallback>,
 
     pub freeze_started: AtomicBool,
+
+    vote_only_bank: bool,
 }
 
 impl Default for BlockhashQueue {
@@ -1109,6 +1111,7 @@ impl Bank {
             feature_set: Arc::<FeatureSet>::default(),
             drop_callback: RwLock::<OptionalDropCallback>::default(),
             freeze_started: AtomicBool::default(),
+            vote_only_bank: false,
         }
     }
 
@@ -1219,7 +1222,22 @@ impl Bank {
 
     /// Create a new bank that points to an immutable checkpoint of another bank.
     pub fn new_from_parent(parent: &Arc<Bank>, collector_id: &Pubkey, slot: Slot) -> Self {
-        Self::_new_from_parent(parent, collector_id, slot, &mut null_tracer())
+        Self::_new_from_parent(parent, collector_id, slot, &mut null_tracer(), false)
+    }
+
+    pub fn new_from_parent_with_vote_only(
+        parent: &Arc<Bank>,
+        collector_id: &Pubkey,
+        slot: Slot,
+        vote_only_bank: bool,
+    ) -> Self {
+        Self::_new_from_parent(
+            parent,
+            collector_id,
+            slot,
+            &mut null_tracer(),
+            vote_only_bank,
+        )
     }
 
     pub fn new_from_parent_with_tracer(
@@ -1228,7 +1246,13 @@ impl Bank {
         slot: Slot,
         reward_calc_tracer: impl FnMut(&RewardCalculationEvent),
     ) -> Self {
-        Self::_new_from_parent(parent, collector_id, slot, &mut Some(reward_calc_tracer))
+        Self::_new_from_parent(
+            parent,
+            collector_id,
+            slot,
+            &mut Some(reward_calc_tracer),
+            false,
+        )
     }
 
     fn _new_from_parent(
@@ -1236,6 +1260,7 @@ impl Bank {
         collector_id: &Pubkey,
         slot: Slot,
         reward_calc_tracer: &mut Option<impl FnMut(&RewardCalculationEvent)>,
+        vote_only_bank: bool,
     ) -> Self {
         parent.freeze();
         assert_ne!(slot, parent.slot());
@@ -1284,6 +1309,7 @@ impl Bank {
             fee_calculator: fee_rate_governor.create_fee_calculator(),
             fee_rate_governor,
             capitalization: AtomicU64::new(parent.capitalization()),
+            vote_only_bank,
             inflation: parent.inflation.clone(),
             transaction_count: AtomicU64::new(parent.transaction_count()),
             transaction_error_count: AtomicU64::new(0),
@@ -1372,6 +1398,10 @@ impl Bank {
 
     pub fn set_callback(&self, callback: Option<Box<dyn DropCallback + Send + Sync>>) {
         *self.drop_callback.write().unwrap() = OptionalDropCallback(callback);
+    }
+
+    pub fn vote_only_bank(&self) -> bool {
+        self.vote_only_bank
     }
 
     /// Like `new_from_parent` but additionally:
@@ -1469,6 +1499,7 @@ impl Bank {
             feature_set: new(),
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
+            vote_only_bank: false,
         };
         bank.finish_init(
             genesis_config,
@@ -5698,7 +5729,7 @@ pub fn goto_end_of_slot(bank: &mut Bank) {
     }
 }
 
-fn is_simple_vote_transaction(transaction: &SanitizedTransaction) -> bool {
+pub fn is_simple_vote_transaction(transaction: &SanitizedTransaction) -> bool {
     if transaction.message().instructions().len() == 1 {
         let (program_pubkey, instruction) = transaction
             .message()


### PR DESCRIPTION
#### Problem

When root distance is too high, problems are created

#### Summary of Changes

Block non-vote transactions once the root distance is too high to recover

Fixes #
