### PR TITLE
Add `delete` subcommand to `ledger-tool bigtable`

### DIFF
--- a/ledger/src/bigtable_delete.rs
+++ b/ledger/src/bigtable_delete.rs
@@ -1,7 +1,4 @@
-use log::*;
-use solana_measure::measure::Measure;
-use solana_sdk::clock::Slot;
-use std::result::Result;
+use {log::*, solana_measure::measure::Measure, solana_sdk::clock::Slot, std::result::Result};
 
 // Attempt to delete this many blocks in parallel
 const NUM_BLOCKS_TO_DELETE_IN_PARALLEL: usize = 32;

--- a/ledger/src/bigtable_delete.rs
+++ b/ledger/src/bigtable_delete.rs
@@ -1,0 +1,56 @@
+use log::*;
+use solana_measure::measure::Measure;
+use solana_sdk::clock::Slot;
+use std::result::Result;
+
+// Attempt to delete this many blocks in parallel
+const NUM_BLOCKS_TO_DELETE_IN_PARALLEL: usize = 32;
+
+pub async fn delete_confirmed_blocks(
+    bigtable: solana_storage_bigtable::LedgerStorage,
+    blocks_to_delete: Vec<Slot>,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut measure = Measure::start("entire delete");
+
+    if blocks_to_delete.is_empty() {
+        info!("No blocks to be deleted");
+        return Ok(());
+    }
+    info!("{} blocks to be deleted", blocks_to_delete.len());
+
+    let mut failures = 0;
+    for blocks in blocks_to_delete.chunks(NUM_BLOCKS_TO_DELETE_IN_PARALLEL) {
+        let mut measure_delete = Measure::start("Delete");
+        info!("Preparing the next {} blocks for deletion", blocks.len());
+
+        let deletion_futures = blocks
+            .iter()
+            .map(|block| bigtable.delete_confirmed_block(*block, dry_run));
+
+        for (block, result) in blocks
+            .iter()
+            .zip(futures::future::join_all(deletion_futures).await)
+        {
+            if result.is_err() {
+                error!(
+                    "delete_confirmed_block({}) failed: {:?}",
+                    block,
+                    result.err()
+                );
+                failures += 1;
+            }
+        }
+
+        measure_delete.stop();
+        info!("{} for {} blocks", measure_delete, blocks.len());
+    }
+
+    measure.stop();
+    info!("{}", measure);
+    if failures > 0 {
+        Err(format!("Incomplete deletion, {} operations failed", failures).into())
+    } else {
+        Ok(())
+    }
+}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate solana_bpf_loader_program;
 
 pub mod bank_forks_utils;
+pub mod bigtable_delete;
 pub mod bigtable_upload;
 pub mod bigtable_upload_service;
 pub mod block_error;

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -66,6 +66,9 @@ pub enum Error {
     #[error("Row write failed")]
     RowWriteFailed,
 
+    #[error("Row delete failed")]
+    RowDeleteFailed,
+
     #[error("Object not found: {0}")]
     ObjectNotFound(String),
 
@@ -222,6 +225,31 @@ impl BigTableConnection {
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.put_bincode_cells(table, cells).await?)
+        })
+        .await
+    }
+
+    pub async fn delete_rows_with_retry(&self, table: &str, row_keys: &[RowKey]) -> Result<()> {
+        use backoff::{future::retry, ExponentialBackoff};
+        retry(ExponentialBackoff::default(), || async {
+            let mut client = self.client();
+            Ok(client.delete_rows(table, row_keys).await?)
+        })
+        .await
+    }
+
+    pub async fn get_bincode_cells_with_retry<T>(
+        &self,
+        table: &str,
+        row_keys: &[RowKey],
+    ) -> Result<Vec<(RowKey, Result<T>)>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        use backoff::{future::retry, ExponentialBackoff};
+        retry(ExponentialBackoff::default(), || async {
+            let mut client = self.client();
+            Ok(client.get_bincode_cells(table, row_keys).await?)
         })
         .await
     }
@@ -444,6 +472,38 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         self.decode_read_rows_response(response).await
     }
 
+    /// Get latest data from multiple rows of `table`, if those rows exist.
+    pub async fn get_multi_row_data(
+        &mut self,
+        table_name: &str,
+        row_keys: &[RowKey],
+    ) -> Result<Vec<(RowKey, RowData)>> {
+        self.refresh_access_token().await;
+
+        let response = self
+            .client
+            .read_rows(ReadRowsRequest {
+                table_name: format!("{}{}", self.table_prefix, table_name),
+                rows_limit: 0, // return all keys
+                rows: Some(RowSet {
+                    row_keys: row_keys
+                        .iter()
+                        .map(|k| k.as_bytes().to_vec())
+                        .collect::<Vec<_>>(),
+                    row_ranges: vec![],
+                }),
+                filter: Some(RowFilter {
+                    // Only return the latest version of each cell
+                    filter: Some(row_filter::Filter::CellsPerColumnLimitFilter(1)),
+                }),
+                ..ReadRowsRequest::default()
+            })
+            .await?
+            .into_inner();
+
+        self.decode_read_rows_response(response).await
+    }
+
     /// Get latest data from a single row of `table`, if that row exists. Returns an error if that
     /// row does not exist.
     ///
@@ -479,6 +539,47 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
             .next()
             .map(|r| r.1)
             .ok_or(Error::RowNotFound)
+    }
+
+    /// Delete one or more `table` rows
+    async fn delete_rows(&mut self, table_name: &str, row_keys: &[RowKey]) -> Result<()> {
+        self.refresh_access_token().await;
+
+        let mut entries = vec![];
+        for row_key in row_keys {
+            entries.push(mutate_rows_request::Entry {
+                row_key: row_key.as_bytes().to_vec(),
+                mutations: vec![Mutation {
+                    mutation: Some(mutation::Mutation::DeleteFromRow(
+                        mutation::DeleteFromRow {},
+                    )),
+                }],
+            });
+        }
+
+        let mut response = self
+            .client
+            .mutate_rows(MutateRowsRequest {
+                table_name: format!("{}{}", self.table_prefix, table_name),
+                entries,
+                ..MutateRowsRequest::default()
+            })
+            .await?
+            .into_inner();
+
+        while let Some(res) = response.message().await? {
+            for entry in res.entries {
+                if let Some(status) = entry.status {
+                    if status.code != 0 {
+                        eprintln!("delete_rows error {}: {}", status.code, status.message);
+                        warn!("delete_rows error {}: {}", status.code, status.message);
+                        return Err(Error::RowDeleteFailed);
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Store data for one or more `table` rows in the `family_name` Column family
@@ -541,6 +642,28 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
     {
         let row_data = self.get_single_row_data(table, key.clone()).await?;
         deserialize_bincode_cell_data(&row_data, table, key.to_string())
+    }
+
+    pub async fn get_bincode_cells<T>(
+        &mut self,
+        table: &str,
+        keys: &[RowKey],
+    ) -> Result<Vec<(RowKey, Result<T>)>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        Ok(self
+            .get_multi_row_data(table, keys)
+            .await?
+            .into_iter()
+            .map(|(key, row_data)| {
+                let key_str = key.to_string();
+                (
+                    key,
+                    deserialize_bincode_cell_data(&row_data, table, key_str),
+                )
+            })
+            .collect())
     }
 
     pub async fn get_protobuf_or_bincode_cell<B, P>(

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -6,6 +6,7 @@ use {
         compression::{compress_best, decompress},
         root_ca_certificate,
     },
+    backoff::{future::retry, ExponentialBackoff},
     log::*,
     std::time::{Duration, Instant},
     thiserror::Error,
@@ -221,7 +222,6 @@ impl BigTableConnection {
     where
         T: serde::ser::Serialize,
     {
-        use backoff::{future::retry, ExponentialBackoff};
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.put_bincode_cells(table, cells).await?)
@@ -230,7 +230,6 @@ impl BigTableConnection {
     }
 
     pub async fn delete_rows_with_retry(&self, table: &str, row_keys: &[RowKey]) -> Result<()> {
-        use backoff::{future::retry, ExponentialBackoff};
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.delete_rows(table, row_keys).await?)
@@ -246,7 +245,6 @@ impl BigTableConnection {
     where
         T: serde::de::DeserializeOwned,
     {
-        use backoff::{future::retry, ExponentialBackoff};
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.get_bincode_cells(table, row_keys).await?)
@@ -262,7 +260,6 @@ impl BigTableConnection {
     where
         T: prost::Message,
     {
-        use backoff::{future::retry, ExponentialBackoff};
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.put_protobuf_cells(table, cells).await?)


### PR DESCRIPTION
#### Problem
When corrupted blocks are uploaded to bigtable, there should be a way to remove them easily

#### Summary of Changes
Added a `delete` subcommand to `ledger-tool bigtable` which accepts a list of slots for deletion and for each slot:
1. Fetch the confirmed block from bigtable
2. Fetch the bigtable tx info for each tx in the block
3. Check if the expected tx info (based on confirmed block) matches the tx info row
4. If the tx info matches (includes a slot check), delete the tx info
5. Delete address slot rows
6. Delete block

Also included a `--dry-run` arg which is enabled by default for safety

Fixes https://github.com/solana-labs/solana/issues/19914
