### PR TITLE
Fix solana docker image

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,7 +8,13 @@
 set -e
 
 # Prefer possible `cargo build` binaries over PATH binaries
-cd "$(dirname "$0")/.."
+script_dir="$(readlink -f "$(dirname "$0")")"
+if [[ "$script_dir" =~ /scripts$ ]]; then
+  cd "$script_dir/.."
+else
+  cd "$script_dir"
+fi
+
 
 profile=debug
 if [[ -n $NDEBUG ]]; then


### PR DESCRIPTION
The docker image fails with:

/usr/bin/solana-run.sh: line 66: ./fetch-spl.sh: No such file or directory

In the solana docker image, scripts/run.sh is copied to
/usr/bin/solana-run.sh and fetch-spl.sh to /usr/bin/fetch-spl.sh. This
means that the line:

cd "$(dirname "$0")/.."

means we're doing a "cd /usr", which means we can't find fetch-spl.sh or
spl-genesis-args.sh (i.e., the error above).

#### Problem

#### Summary of Changes

Fixes #
