### PR TITLE
fix syntax error in bash_profile

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -436,7 +436,7 @@ fn add_to_path(new_path: &str) -> bool {
 
 #[cfg(unix)]
 fn add_to_path(new_path: &str) -> bool {
-    let shell_export_string = format!(r#"export PATH="{}:$PATH""#, new_path);
+    let shell_export_string = format!("\nexport PATH=\"{}:$PATH\"", new_path);
     let mut modified_rcfiles = false;
 
     // Look for sh, bash, and zsh rc files


### PR DESCRIPTION
if there is no newline at the end of the file, this export is glued to the rest of the code and generates a syntax error like this

```bash
if [ -f ~/.git-completion.bash ]; then
  . ~/.git-completion.bash
fiexport PATH="/Users/user/.local/share/solana/install/active_release/bin:$PATH"
```

#### Problem

#### Summary of Changes

Fixes #
