### PR TITLE
web3.js: allow confirm transaction timeout to be configurable

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1948,6 +1948,8 @@ export type ConnectionConfig = {
   fetchMiddleware?: FetchMiddleware;
   /** Optional Disable retring calls when server responds with HTTP 429 (Too Many Requests) */
   disableRetryOnRateLimit?: boolean;
+  /** time to allow for the server to initially process a transaction (in milliseconds) */
+  confirmTransactionInitialTimeout?: number;
 };
 
 /**
@@ -1955,6 +1957,7 @@ export type ConnectionConfig = {
  */
 export class Connection {
   /** @internal */ _commitment?: Commitment;
+  /** @internal */ _confirmTransactionInitialTimeout?: number;
   /** @internal */ _rpcEndpoint: string;
   /** @internal */ _rpcWsEndpoint: string;
   /** @internal */ _rpcClient: RpcClient;
@@ -2039,6 +2042,8 @@ export class Connection {
       this._commitment = commitmentOrConfig;
     } else if (commitmentOrConfig) {
       this._commitment = commitmentOrConfig.commitment;
+      this._confirmTransactionInitialTimeout =
+        commitmentOrConfig.confirmTransactionInitialTimeout;
       wsEndpoint = commitmentOrConfig.wsEndpoint;
       httpHeaders = commitmentOrConfig.httpHeaders;
       fetchMiddleware = commitmentOrConfig.fetchMiddleware;
@@ -2598,14 +2603,14 @@ export class Connection {
       }
     });
 
-    let timeoutMs = 60 * 1000;
+    let timeoutMs = this._confirmTransactionInitialTimeout || 60 * 1000;
     switch (subscriptionCommitment) {
       case 'processed':
       case 'recent':
       case 'single':
       case 'confirmed':
       case 'singleGossip': {
-        timeoutMs = 30 * 1000;
+        timeoutMs = this._confirmTransactionInitialTimeout || 30 * 1000;
         break;
       }
       // exhaust enums to ensure full coverage


### PR DESCRIPTION
#### Problem
ConfirmedTransation timeout is currently hardcoded and some developers have suggested this be configurable. 

#### Summary of Changes
Add optional configuration option to Connection 

Fixes #
