### PR TITLE
AcctIdx: configurable flush threads

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -34,11 +34,14 @@ pub const ITER_BATCH_SIZE: usize = 1000;
 pub const BINS_DEFAULT: usize = 8192;
 pub const BINS_FOR_TESTING: usize = BINS_DEFAULT;
 pub const BINS_FOR_BENCHMARKS: usize = BINS_DEFAULT;
+pub const FLUSH_THREADS_TESTING: usize = 1;
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_TESTING),
+    flush_threads: Some(FLUSH_THREADS_TESTING),
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
+    flush_threads: Some(FLUSH_THREADS_TESTING),
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
@@ -93,6 +96,7 @@ pub struct AccountSecondaryIndexesIncludeExclude {
 #[derive(Debug, Default, Clone)]
 pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
+    pub flush_threads: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -46,7 +46,7 @@ impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
 }
 
 impl<T: IndexValue> AccountsIndexStorage<T> {
-    pub fn new(bins: usize, _config: &Option<AccountsIndexConfig>) -> AccountsIndexStorage<T> {
+    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>) -> AccountsIndexStorage<T> {
         let storage = Arc::new(BucketMapHolder::new(bins));
 
         let in_mem = (0..bins)
@@ -55,7 +55,11 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
             .collect();
 
         const DEFAULT_THREADS: usize = 1; // soon, this will be a cpu calculation
-        let threads = DEFAULT_THREADS;
+        let threads = config
+            .as_ref()
+            .and_then(|config| config.flush_threads)
+            .unwrap_or(DEFAULT_THREADS);
+
         let exit = Arc::new(AtomicBool::default());
         let wait = Arc::new(WaitableCondvar::default());
         let handles = Some(


### PR DESCRIPTION
#### Problem
We will eventually possibly have options at the validator level. For the moment, it is necessary to allow tests to specify the # of threads to use for bg flushing.
#### Summary of Changes

Fixes #
