### PR TITLE
AcctIdx: with multiple bg threads, only log stats once per time interval

### DIFF
--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -100,7 +100,8 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
         wait: Arc<WaitableCondvar>,
     ) {
         loop {
-            wait.wait_timeout(Duration::from_millis(10000)); // account index stats every 10 s
+            // this will transition to waits and thread throttling
+            wait.wait_timeout(Duration::from_millis(10000));
             if exit.load(Ordering::Relaxed) {
                 break;
             }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -1,3 +1,4 @@
+use solana_sdk::timing::AtomicInterval;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -19,6 +20,7 @@ pub struct BucketMapHolderStats {
     pub count_in_mem: AtomicU64,
     pub per_bucket_count: Vec<AtomicU64>,
     pub get_range_us: AtomicU64,
+    last_time: AtomicInterval,
 }
 
 impl BucketMapHolderStats {
@@ -46,6 +48,11 @@ impl BucketMapHolderStats {
     }
 
     pub fn report_stats(&self) {
+        // account index stats every 10 s
+        if !self.last_time.should_update(10_000) {
+            return;
+        }
+
         let mut ct = 0;
         let mut min = usize::MAX;
         let mut max = 0;


### PR DESCRIPTION
#### Problem
This will be refined, but when we have more than 1 bg thread, we want the metrics still to be dumped on the correct intervals.
#### Summary of Changes

Fixes #
