### PR TITLE
add 'drives' to AccountsIndexConfig

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1912,6 +1912,15 @@ fn main() {
             if let Some(bins) = value_t!(matches, "accounts_index_bins", usize).ok() {
                 accounts_index_config.bins = Some(bins);
             }
+
+            {
+                let mut accounts_index_paths = vec![]; // will be option
+                if accounts_index_paths.is_empty() {
+                    accounts_index_paths = vec![ledger_path.join("accounts_index")];
+                }
+                accounts_index_config.drives = Some(accounts_index_paths);
+            }
+
             let accounts_db_config = Some(AccountsDbConfig {
                 index: Some(accounts_index_config),
                 accounts_hash_cache_path: Some(ledger_path.clone()),

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -23,6 +23,7 @@ use std::{
         Bound::{Excluded, Included, Unbounded},
         Range, RangeBounds,
     },
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard,
@@ -38,10 +39,12 @@ pub const FLUSH_THREADS_TESTING: usize = 1;
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_TESTING),
     flush_threads: Some(FLUSH_THREADS_TESTING),
+    drives: None,
 };
 pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_BENCHMARKS),
     flush_threads: Some(FLUSH_THREADS_TESTING),
+    drives: None,
 };
 pub type ScanResult<T> = Result<T, ScanError>;
 pub type SlotList<T> = Vec<(Slot, T)>;
@@ -97,6 +100,7 @@ pub struct AccountSecondaryIndexesIncludeExclude {
 pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub flush_threads: Option<usize>,
+    pub drives: Option<Vec<PathBuf>>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2512,6 +2512,14 @@ pub fn main() {
         accounts_index_config.bins = Some(bins);
     }
 
+    {
+        let mut accounts_index_paths = vec![]; // will be option soon
+        if accounts_index_paths.is_empty() {
+            accounts_index_paths = vec![ledger_path.join("accounts_index")];
+        }
+        accounts_index_config.drives = Some(accounts_index_paths);
+    }
+
     let accounts_db_config = Some(AccountsDbConfig {
         index: Some(accounts_index_config),
         accounts_hash_cache_path: Some(ledger_path.clone()),


### PR DESCRIPTION
#### Problem
this will be connected to validator options once everything is working. For now, I do not want to add a validator option which does nothing. But, we have to have the ledger path so we can know where to write the on-disk accounts index. This pr provides the config option to pass the path down to the right places so we have access to the path to use for the accounts index on disk.
#### Summary of Changes

Fixes #
