### PR TITLE
feat(web3.js): provide subscribe error notifications for websocket rpc

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3905,7 +3905,6 @@ export class Connection {
   /**
    * Register a callback to be invoked when there is a subscribe error
    *
-   *
    * @param callback Function to invoke when a subscribe error occurs
    * @returns subscription id
    */

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3727,11 +3727,11 @@ export class Connection {
           sub.subscriptionId = null;
         }
 
-        Object.values(this._subscribeErrorCallbacks).forEach(callback =>
-          callback(rpcMethod, rpcArgs, error),
-        );
-
-        if (this._subscribeErrorCallbackCounter === 0) {
+        if (Object.values(this._subscribeErrorCallbacks).length) {
+          Object.values(this._subscribeErrorCallbacks).forEach(callback =>
+            callback(rpcMethod, rpcArgs, error),
+          );
+        } else {
           console.error(
             `${rpcMethod} error for argument`,
             rpcArgs,

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1725,7 +1725,7 @@ export type KeyedAccountInfo = {
  */
 export type SubscribeErrorCallback = (
   rpcMethod: string,
-  rpcArgs: IWSRequestParams,
+  rpcArgs: any,
   error: any,
 ) => void;
 

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3055,6 +3055,34 @@ describe('Connection', () => {
       );
     });
 
+    it('subscribes and unsubscribes to subscription error notifications', done => {
+      const connection = new Connection(url);
+      const programAccount = Keypair.generate();
+
+      stubRpcWebSocket(connection, () => {
+        throw new Error('Subscribe error');
+      });
+
+      const subscriptionId = connection.onSubscribeError(
+        (rpcMethod, rpcArgs, error) => {
+          connection.removeSubscribeErrorListener(subscriptionId);
+          expect(rpcMethod).to.equal('accountSubscribe');
+          expect(rpcArgs).lengthOf(2);
+          expect(error.message).to.equal('Subscribe error');
+          expect(Object.values(connection._subscribeErrorCallbacks)).lengthOf(
+            0,
+          );
+          done();
+        },
+      );
+
+      connection.onAccountChange(
+        programAccount.publicKey,
+        () => {},
+        'confirmed',
+      );
+    });
+
     // it('account change notification', async () => {
     //   if (mockServer) {
     //     console.log('non-live test skipped');

--- a/web3.js/test/mocks/rpc-websockets.ts
+++ b/web3.js/test/mocks/rpc-websockets.ts
@@ -37,7 +37,10 @@ export const mockRpcMessage = ({
   ]);
 };
 
-export const stubRpcWebSocket = (connection: Connection) => {
+export const stubRpcWebSocket = (
+  connection: Connection,
+  callCallback?: () => Promise<void>,
+) => {
   const rpcWebSocket = connection._rpcWebSocket;
   const mockClient = new MockClient(rpcWebSocket);
   sandbox.stub(rpcWebSocket, 'connect').callsFake(() => {
@@ -49,6 +52,10 @@ export const stubRpcWebSocket = (connection: Connection) => {
   sandbox
     .stub(rpcWebSocket, 'call')
     .callsFake((method: string, params: any) => {
+      if (callCallback) {
+        return callCallback();
+      }
+
       return mockClient.call(method, params);
     });
 };


### PR DESCRIPTION
#### Problem
If a RPC request fails to subscribe an account, the failure is only logged. There is no onError callback or error propagation. Without the propagation users' and the Dapps cannot report these errors.

#### Summary of Changes
- add support for subscribing to websocket rpc subscribe errors

Fixes https://github.com/solana-labs/solana/issues/19072
