### PR TITLE
acct idx tests use 2 bins instead of 8k

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -32,8 +32,8 @@ use thiserror::Error;
 
 pub const ITER_BATCH_SIZE: usize = 1000;
 pub const BINS_DEFAULT: usize = 8192;
-pub const BINS_FOR_TESTING: usize = BINS_DEFAULT;
-pub const BINS_FOR_BENCHMARKS: usize = BINS_DEFAULT;
+pub const BINS_FOR_TESTING: usize = 2; // we want > 1, but each bin is a few disk files with a disk based index, so fewer is better
+pub const BINS_FOR_BENCHMARKS: usize = 2;
 pub const FLUSH_THREADS_TESTING: usize = 1;
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_TESTING),


### PR DESCRIPTION
#### Problem
We want > 1 bins, but each bin is a few disk files with a disk based index, so fewer is better

#### Summary of Changes

Fixes #
