### PR TITLE
pass AcctIdxConfig to BucketMapHolder

### DIFF
--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -47,7 +47,7 @@ impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
 
 impl<T: IndexValue> AccountsIndexStorage<T> {
     pub fn new(bins: usize, config: &Option<AccountsIndexConfig>) -> AccountsIndexStorage<T> {
-        let storage = Arc::new(BucketMapHolder::new(bins));
+        let storage = Arc::new(BucketMapHolder::new(bins, config));
 
         let in_mem = (0..bins)
             .into_iter()

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -1,4 +1,4 @@
-use crate::accounts_index::IndexValue;
+use crate::accounts_index::{AccountsIndexConfig, IndexValue};
 use crate::bucket_map_holder_stats::BucketMapHolderStats;
 use crate::waitable_condvar::WaitableCondvar;
 use std::fmt::Debug;
@@ -49,7 +49,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
         self.count_ages_flushed.load(Ordering::Relaxed) >= self.bins
     }
 
-    pub fn new(bins: usize) -> Self {
+    pub fn new(bins: usize, _config: &Option<AccountsIndexConfig>) -> Self {
         Self {
             count_ages_flushed: AtomicUsize::default(),
             age: AtomicU8::default(),
@@ -83,7 +83,7 @@ pub mod tests {
     fn test_next_bucket_to_flush() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins);
+        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()));
         let visited = (0..bins)
             .into_iter()
             .map(|_| AtomicUsize::default())
@@ -107,7 +107,7 @@ pub mod tests {
     fn test_age_increment() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins);
+        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()));
         for age in 0..513 {
             assert_eq!(test.current_age(), (age % 256) as Age);
 
@@ -125,7 +125,7 @@ pub mod tests {
     fn test_age_broad() {
         solana_logger::setup();
         let bins = 4;
-        let test = BucketMapHolder::<u64>::new(bins);
+        let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()));
         assert_eq!(test.current_age(), 0);
         assert!(!test.all_buckets_flushed_at_current_age());
         // inc all but 1

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -378,10 +378,13 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::accounts_index::BINS_FOR_TESTING;
+    use crate::accounts_index::{AccountsIndexConfig, BINS_FOR_TESTING};
 
     fn new_for_test<T: IndexValue>() -> InMemAccountsIndex<T> {
-        let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING));
+        let holder = Arc::new(BucketMapHolder::new(
+            BINS_FOR_TESTING,
+            &Some(AccountsIndexConfig::default()),
+        ));
         InMemAccountsIndex::new(&holder, BINS_FOR_TESTING)
     }
 


### PR DESCRIPTION
#### Problem
Allow access to acct idx config options (which could be specified on validator cli) where we create the disk buckets instance.
#### Summary of Changes

Fixes #
