### PR TITLE
Update feature switch for reduced required deploy balance

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -207,6 +207,10 @@ pub mod fix_write_privs {
     solana_sdk::declare_id!("7Tr5C1tdcCeBVD8jxtHYnvjL1DGdFboYBHCJkEFdenBb");
 }
 
+pub mod reduce_required_deploy_balance {
+    solana_sdk::declare_id!("EBeznQDjcPG8491sFsKZYBi5S5jTVXMpAKNDJMQPS2kq");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -254,6 +258,7 @@ lazy_static! {
         (check_seed_length::id(), "Check program address seed lengths"),
         (return_data_syscall_enabled::id(), "enable sol_{set,get}_return_data syscall"),
         (fix_write_privs::id(), "fix native invoke write privileges"),
+        (reduce_required_deploy_balance::id(), "reduce required payer balance for program deploys"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The feature switch for reduced required deploy balance piggy backed off of the native invoke write privileges feature switch but didn't make it into the same v1.7 release.

#### Summary of Changes
Introduce a new feature switch and require both feature switches to predrain the buffer balance to the payer

Fixes #
