### PR TITLE
call set_startup and add metrics on generate_index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -219,6 +219,7 @@ struct GenerateIndexTimings {
     pub storage_size_accounts_map_us: u64,
     pub storage_size_storages_us: u64,
     pub storage_size_accounts_map_flatten_us: u64,
+    pub index_flush_us: u64,
 }
 
 #[derive(Default, Debug, PartialEq)]
@@ -253,6 +254,7 @@ impl GenerateIndexTimings {
                 self.storage_size_accounts_map_flatten_us as i64,
                 i64
             ),
+            ("index_flush_us", self.index_flush_us as i64, i64),
         );
     }
 }
@@ -6408,6 +6410,9 @@ impl AccountsDb {
         // verify checks that all the expected items are in the accounts index and measures how long it takes to look them all up
         let passes = if verify { 2 } else { 1 };
         for pass in 0..passes {
+            if pass == 0 {
+                self.accounts_index.set_startup(true);
+            }
             let storage_info = StorageSizeAndCountMap::default();
             let total_processed_slots_across_all_threads = AtomicU64::new(0);
             let outer_slots_len = slots.len();
@@ -6496,7 +6501,17 @@ impl AccountsDb {
 
             let storage_info_timings = storage_info_timings.into_inner().unwrap();
 
+            let mut index_flush_us = 0;
+            if pass == 0 {
+                // tell accounts index we are done adding the initial accounts at startup
+                let mut m = Measure::start("accounts_index_idle_us");
+                self.accounts_index.set_startup(false);
+                m.stop();
+                index_flush_us = m.as_us();
+            }
+
             let mut timings = GenerateIndexTimings {
+                index_flush_us,
                 scan_time,
                 index_time: index_time.as_us(),
                 insertion_time_us: insertion_time_us.load(Ordering::Relaxed),

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1376,6 +1376,11 @@ impl<T: IndexValue> AccountsIndex<T> {
         let iter = self.iter(Some(range), true);
         iter.hold_range_in_memory(range, start_holding);
     }
+
+    pub fn set_startup(&self, value: bool) {
+        self.storage.storage.set_startup(value);
+    }
+
     /// Get an account
     /// The latest account that appears in `ancestors` or `roots` is returned.
     pub(crate) fn get(

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -23,7 +23,7 @@ pub struct AccountsIndexStorage<T: IndexValue> {
     handles: Option<Vec<JoinHandle<()>>>,
 
     // eventually the backing storage
-    storage: Arc<BucketMapHolder<T>>,
+    pub storage: Arc<BucketMapHolder<T>>,
     pub in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
 }
 

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -48,7 +48,14 @@ impl<T: IndexValue> BucketMapHolder<T> {
     }
 
     pub fn set_startup(&self, value: bool) {
+        if !value {
+            self.wait_for_idle();
+        }
         self.startup.store(value, Ordering::Relaxed)
+    }
+
+    pub(crate) fn wait_for_idle(&self) {
+        assert!(self.get_startup());
     }
 
     pub fn current_age(&self) -> Age {


### PR DESCRIPTION
#### Problem
Startup of the accounts index requires special handling. During startup, we want to write inserted items to disk as quickly as possible. Otherwise, we could run out of memory with large account counts. Also, there are no (or fewer) thread limits during this time since account index flushing will not interfere with validator tx processing.

#### Summary of Changes
during generate_index, set startup to true and then false so the accounts index understands operating parameters. Flush and thread throttling will respond to this later.
Fixes #
