### PR TITLE
AcctIdx: first pass at aging buckets

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -88,12 +88,16 @@ impl<T: IndexValue> BucketMapHolder<T> {
     }
 
     pub fn bucket_flushed_at_current_age(&self) {
-        self.count_ages_flushed.fetch_add(1, Ordering::Relaxed);
+        self.count_ages_flushed.fetch_add(1, Ordering::Acquire);
     }
 
     // have all buckets been flushed at the current age?
     pub fn all_buckets_flushed_at_current_age(&self) -> bool {
-        self.count_ages_flushed.load(Ordering::Relaxed) >= self.bins
+        self.count_ages_flushed() >= self.bins
+    }
+
+    pub fn count_ages_flushed(&self) -> usize {
+        self.count_ages_flushed.load(Ordering::Relaxed)
     }
 
     pub fn maybe_advance_age(&self) -> bool {


### PR DESCRIPTION
#### Problem
Implement aging mechanism for lru of account index items in cache. Individual items will have an age in the future at which they are set to be thrown out.
#### Summary of Changes

Fixes #
