### PR TITLE
CPI without Account Refs

### DIFF
--- a/program-runtime/src/instruction_processor.rs
+++ b/program-runtime/src/instruction_processor.rs
@@ -5,10 +5,10 @@ use solana_sdk::{
     account_utils::StateMut,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     feature_set::{demote_program_write_locks, fix_write_privs},
-    ic_logger_msg, ic_msg,
-    instruction::{CompiledInstruction, Instruction, InstructionError},
+    ic_msg,
+    instruction::{Instruction, InstructionError},
     message::Message,
-    process_instruction::{Executor, InvokeContext, Logger, ProcessInstructionWithContext},
+    process_instruction::{Executor, InvokeContext, ProcessInstructionWithContext},
     pubkey::Pubkey,
     rent::Rent,
     system_program,
@@ -516,30 +516,16 @@ impl InstructionProcessor {
                 caller_write_privileges.push(caller_keyed_accounts[*index].is_writable());
             }
         };
-        let account_indices = message
-            .account_keys
-            .iter()
-            .map(|account_key| {
-                invoke_context
-                    .get_account(account_key)
-                    .ok_or(InstructionError::MissingAccount)
-                    .map(|(account_index, _account)| account_index)
-            })
-            .collect::<Result<Vec<_>, InstructionError>>()?;
-        let accounts = message
-            .account_keys
-            .iter()
-            .map(|account_key| {
-                invoke_context
-                    .get_account(account_key)
-                    .ok_or(InstructionError::MissingAccount)
-                    .map(|(_account_index, account)| (*account_key, account))
-            })
-            .collect::<Result<Vec<_>, InstructionError>>()?;
-        let account_sizes = accounts
-            .iter()
-            .map(|(_key, account)| account.borrow().data().len())
-            .collect::<Vec<_>>();
+        let mut account_indices = Vec::with_capacity(message.account_keys.len());
+        let mut accounts = Vec::with_capacity(message.account_keys.len());
+        for account_key in message.account_keys.iter() {
+            let (account_index, account) = invoke_context
+                .get_account(account_key)
+                .ok_or(InstructionError::MissingAccount)?;
+            let account_length = account.borrow().data().len();
+            account_indices.push(account_index);
+            accounts.push((account, account_length));
+        }
 
         // Record the instruction
         invoke_context.record_instruction(&instruction);
@@ -549,13 +535,12 @@ impl InstructionProcessor {
             &message,
             &program_indices,
             &account_indices,
-            &accounts,
             &caller_write_privileges,
             *invoke_context,
         )?;
 
         // Verify the called program has not misbehaved
-        for ((_key, account), prev_size) in accounts.iter().zip(account_sizes.iter()) {
+        for (account, prev_size) in accounts.iter() {
             if *prev_size != account.borrow().data().len() && *prev_size != 0 {
                 // Only support for `CreateAccount` at this time.
                 // Need a way to limit total realloc size across multiple CPI calls
@@ -576,7 +561,6 @@ impl InstructionProcessor {
         message: &Message,
         program_indices: &[usize],
         account_indices: &[usize],
-        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
         caller_write_privileges: &[bool],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
@@ -589,7 +573,7 @@ impl InstructionProcessor {
         let program_id = instruction.program_id(&message.account_keys);
 
         // Verify the calling program hasn't misbehaved
-        invoke_context.verify_and_update(instruction, accounts, caller_write_privileges)?;
+        invoke_context.verify_and_update(instruction, account_indices, caller_write_privileges)?;
 
         // clear the return data
         invoke_context.set_return_data(None);
@@ -620,66 +604,13 @@ impl InstructionProcessor {
             let write_privileges: Vec<bool> = (0..message.account_keys.len())
                 .map(|i| message.is_writable(i, demote_program_write_locks))
                 .collect();
-            result = invoke_context.verify_and_update(instruction, accounts, &write_privileges);
+            result =
+                invoke_context.verify_and_update(instruction, account_indices, &write_privileges);
         }
 
         // Restore previous state
         invoke_context.pop();
         result
-    }
-
-    /// Verify the results of a cross-program instruction
-    #[allow(clippy::too_many_arguments)]
-    pub fn verify_and_update(
-        instruction: &CompiledInstruction,
-        pre_accounts: &mut [PreAccount],
-        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
-        program_id: &Pubkey,
-        rent: &Rent,
-        write_privileges: &[bool],
-        timings: &mut ExecuteDetailsTimings,
-        logger: Rc<RefCell<dyn Logger>>,
-    ) -> Result<(), InstructionError> {
-        // Verify the per-account instruction results
-        let (mut pre_sum, mut post_sum) = (0_u128, 0_u128);
-        let mut work = |_unique_index: usize, account_index: usize| {
-            if account_index < write_privileges.len() && account_index < accounts.len() {
-                let (key, account) = &accounts[account_index];
-                let is_writable = write_privileges[account_index];
-                // Find the matching PreAccount
-                for pre_account in pre_accounts.iter_mut() {
-                    if key == pre_account.key() {
-                        {
-                            // Verify account has no outstanding references
-                            let _ = account
-                                .try_borrow_mut()
-                                .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
-                        }
-                        let account = account.borrow();
-                        pre_account
-                            .verify(program_id, is_writable, rent, &account, timings, false)
-                            .map_err(|err| {
-                                ic_logger_msg!(logger, "failed to verify account {}: {}", key, err);
-                                err
-                            })?;
-                        pre_sum += u128::from(pre_account.lamports());
-                        post_sum += u128::from(account.lamports());
-                        if is_writable && !pre_account.executable() {
-                            pre_account.update(&account);
-                        }
-                        return Ok(());
-                    }
-                }
-            }
-            Err(InstructionError::MissingAccount)
-        };
-        instruction.visit_each_account(&mut work)?;
-
-        // Verify that the total sum of all the lamports did not change
-        if pre_sum != post_sum {
-            return Err(InstructionError::UnbalancedInstruction);
-        }
-        Ok(())
     }
 }
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -267,30 +267,35 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         stable_log::program_invoke(&logger, &program_id, invoke_context.invoke_depth());
 
         // Convert AccountInfos into Accounts
-        fn ai_to_a(ai: &AccountInfo) -> AccountSharedData {
-            AccountSharedData::from(Account {
-                lamports: ai.lamports(),
-                data: ai.try_borrow_data().unwrap().to_vec(),
-                owner: *ai.owner,
-                executable: ai.executable,
-                rent_epoch: ai.rent_epoch,
-            })
-        }
-        let mut accounts = vec![];
-        'outer: for key in &message.account_keys {
-            for account_info in account_infos {
-                if account_info.unsigned_key() == key {
-                    accounts.push((*key, Rc::new(RefCell::new(ai_to_a(account_info)))));
-                    continue 'outer;
-                }
+        let mut account_indices = Vec::with_capacity(message.account_keys.len());
+        let mut accounts = Vec::with_capacity(message.account_keys.len());
+        let mut account_refs = Vec::with_capacity(message.account_keys.len());
+        for (i, account_key) in message.account_keys.iter().enumerate() {
+            let ((account_index, account), account_info) = invoke_context
+                .get_account(account_key)
+                .zip(
+                    account_infos
+                        .iter()
+                        .find(|account_info| account_info.unsigned_key() == account_key),
+                )
+                .ok_or(InstructionError::MissingAccount)
+                .unwrap();
+            {
+                let mut account = account.borrow_mut();
+                account.copy_into_owner_from_slice(account_info.owner.as_ref());
+                account.set_data_from_slice(&account_info.try_borrow_data().unwrap());
+                account.set_lamports(account_info.lamports());
+                account.set_executable(account_info.executable);
+                account.set_rent_epoch(account_info.rent_epoch);
             }
-            panic!("Account {} wasn't found in account_infos", key);
+            account_indices.push(account_index);
+            accounts.push((*account_key, account));
+            account_refs.push(if message.is_writable(i, demote_program_write_locks) {
+                Some(account_info)
+            } else {
+                None
+            });
         }
-        assert_eq!(
-            accounts.len(),
-            message.account_keys.len(),
-            "Missing or not enough accounts passed to invoke"
-        );
         let (program_account_index, _program_account) =
             invoke_context.get_account(&program_id).unwrap();
         let program_indices = vec![program_account_index];
@@ -322,6 +327,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         InstructionProcessor::process_cross_program_instruction(
             &message,
             &program_indices,
+            &account_indices,
             &accounts,
             &caller_privileges,
             invoke_context,
@@ -329,36 +335,30 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos
-        for (i, (pubkey, account)) in accounts.iter().enumerate().take(message.account_keys.len()) {
-            if !message.is_writable(i, demote_program_write_locks) {
-                continue;
-            }
-            for account_info in account_infos {
-                if account_info.unsigned_key() == pubkey {
-                    **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports();
-
-                    let mut data = account_info.try_borrow_mut_data()?;
-                    let account_borrow = account.borrow();
-                    let new_data = account_borrow.data();
-                    if account_info.owner != account.borrow().owner() {
-                        // TODO Figure out a better way to allow the System Program to set the account owner
-                        #[allow(clippy::transmute_ptr_to_ptr)]
-                        #[allow(mutable_transmutes)]
-                        let account_info_mut =
-                            unsafe { transmute::<&Pubkey, &mut Pubkey>(account_info.owner) };
-                        *account_info_mut = *account.borrow().owner();
-                    }
-                    if data.len() != new_data.len() {
-                        // TODO: Figure out how to allow the System Program to resize the account data
-                        panic!(
-                            "Account data resizing not supported yet: {} -> {}. \
-                            Consider making this test conditional on `#[cfg(feature = \"test-bpf\")]`",
-                            data.len(),
-                            new_data.len()
-                        );
-                    }
-                    data.clone_from_slice(new_data);
+        for ((_account_key, account), account_info) in accounts.iter().zip(account_refs.iter()) {
+            if let Some(account_info) = account_info {
+                **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports();
+                let mut data = account_info.try_borrow_mut_data()?;
+                let account_borrow = account.borrow();
+                let new_data = account_borrow.data();
+                if account_info.owner != account.borrow().owner() {
+                    // TODO Figure out a better way to allow the System Program to set the account owner
+                    #[allow(clippy::transmute_ptr_to_ptr)]
+                    #[allow(mutable_transmutes)]
+                    let account_info_mut =
+                        unsafe { transmute::<&Pubkey, &mut Pubkey>(account_info.owner) };
+                    *account_info_mut = *account.borrow().owner();
                 }
+                if data.len() != new_data.len() {
+                    // TODO: Figure out how to allow the System Program to resize the account data
+                    panic!(
+                        "Account data resizing not supported yet: {} -> {}. \
+                        Consider making this test conditional on `#[cfg(feature = \"test-bpf\")]`",
+                        data.len(),
+                        new_data.len()
+                    );
+                }
+                data.clone_from_slice(new_data);
             }
         }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -212,7 +212,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         let (mut pre_sum, mut post_sum) = (0_u128, 0_u128);
         let mut work = |_unique_index: usize, index_in_instruction: usize| {
             if index_in_instruction < write_privileges.len()
-                && index_in_instruction < accounts.len()
+                && index_in_instruction < account_indices.len()
             {
                 let account_index = account_indices[index_in_instruction];
                 let (key, account) = &accounts[account_index];

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -59,7 +59,7 @@ pub trait InvokeContext {
         message: &Message,
         instruction: &CompiledInstruction,
         program_indices: &[usize],
-        instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        account_indices: &[usize],
     ) -> Result<(), InstructionError>;
     /// Pop a stack frame from the invocation stack
     ///
@@ -478,7 +478,7 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
         _message: &Message,
         _instruction: &CompiledInstruction,
         _program_indices: &[usize],
-        _instruction_accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        _account_indices: &[usize],
     ) -> Result<(), InstructionError> {
         self.invoke_stack.push(InvokeContextStackFrame::new(
             *_key,

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -51,8 +51,6 @@ impl<'a> InvokeContextStackFrame<'a> {
 /// Invocation context passed to loaders
 pub trait InvokeContext {
     /// Push a stack frame onto the invocation stack
-    ///
-    /// Used in MessageProcessor::process_cross_program_instruction
     fn push(
         &mut self,
         key: &Pubkey,
@@ -62,8 +60,6 @@ pub trait InvokeContext {
         account_indices: &[usize],
     ) -> Result<(), InstructionError>;
     /// Pop a stack frame from the invocation stack
-    ///
-    /// Used in MessageProcessor::process_cross_program_instruction
     fn pop(&mut self);
     /// Current depth of the invocation stake
     fn invoke_depth(&self) -> usize;
@@ -71,7 +67,7 @@ pub trait InvokeContext {
     fn verify_and_update(
         &mut self,
         instruction: &CompiledInstruction,
-        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        account_indices: &[usize],
         write_privileges: &[bool],
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
@@ -495,7 +491,7 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
     fn verify_and_update(
         &mut self,
         _instruction: &CompiledInstruction,
-        _accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        _account_indices: &[usize],
         _write_pivileges: &[bool],
     ) -> Result<(), InstructionError> {
         Ok(())


### PR DESCRIPTION
#### Problem
#15410 introduced [this](https://github.com/solana-labs/solana/blob/7a785e067ac109bb065ea1170af4bd9f896adfc2/runtime/src/message_processor.rs#L178) `unsafe` expression.

#### Summary of Changes
* Removes search for accounts and `unsafe` lifetime transmute in `InvokeContext::push()`.
* Replaces account parameters of all CPI methods by indices, as they are easier to verify and compatible with ABIv2 (see #19191).

Fixes #
