### PR TITLE
Make bigtable delete-slots actually usable

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -439,7 +439,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
         }
         ("delete-slots", Some(arg_matches)) => {
             let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-            let dry_run = !value_t_or_exit!(arg_matches, "force", bool);
+            let dry_run = !arg_matches.is_present("force");
             runtime.block_on(delete_slots(slots, dry_run))
         }
         ("first-available-block", Some(_arg_matches)) => runtime.block_on(first_available_block()),


### PR DESCRIPTION
#### Problem

seems last-minute review adjustments made `solana-ledger-tool bigtable delete-slots` not workable at all (with/without `--force`)

#### Summary of Changes

context: https://github.com/solana-labs/solana/pull/19931