### PR TITLE
Use a constant for unlocked header uid

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -36,15 +36,18 @@ struct Header {
     lock: AtomicU64,
 }
 
+/// A Header UID of 0 indicates that the header is unlocked
+pub(crate) const UID_UNLOCKED: u64 = 0;
+
 impl Header {
     fn try_lock(&self, uid: u64) -> bool {
-        Ok(0)
+        Ok(UID_UNLOCKED)
             == self
                 .lock
-                .compare_exchange(0, uid, Ordering::Acquire, Ordering::Relaxed)
+                .compare_exchange(UID_UNLOCKED, uid, Ordering::Acquire, Ordering::Relaxed)
     }
     fn unlock(&self) -> u64 {
-        self.lock.swap(0, Ordering::Release)
+        self.lock.swap(UID_UNLOCKED, Ordering::Release)
     }
     fn uid(&self) -> u64 {
         self.lock.load(Ordering::Relaxed)
@@ -133,7 +136,7 @@ impl BucketStorage {
         if ix >= self.num_cells() {
             panic!("allocate: bad index size");
         }
-        if 0 == uid {
+        if UID_UNLOCKED == uid {
             panic!("allocate: bad uid");
         }
         let mut e = Err(BucketStorageError::AlreadyAllocated);
@@ -154,7 +157,7 @@ impl BucketStorage {
         if ix >= self.num_cells() {
             panic!("free: bad index size");
         }
-        if 0 == uid {
+        if UID_UNLOCKED == uid {
             panic!("free: bad uid");
         }
         let ix = (ix * self.cell_size) as usize;


### PR DESCRIPTION
Instead of just a literal `0` for UID when the header is unlocked, make a constant to give additional context.
