### PR TITLE
allow vote to have up to 2 signatures 

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -265,7 +265,9 @@ fn check_for_simple_vote_transaction(
     packet_offsets: &PacketOffsets,
     current_offset: usize,
 ) -> Result<(), PacketError> {
-    if packet_offsets.sig_len != 1 {
+    // vote could have 1 or 2 sigs; zero sig has already been excluded at
+    // do_get_packet_offsets.
+    if packet_offsets.sig_len > 2 {
         return Err(PacketError::InvalidSignatureLen);
     }
 


### PR DESCRIPTION
#### Problem
Vote transactions can have up to 2 sigs. Example: https://explorer.solana.com/address/p2pUJruVeKTuZ41zbGWcxienmzRFnUa9fjBHigsR3QC

#### Summary of Changes
Adjust restriction to allow number of sigs <=2 

Fixes #
