### PR TITLE
AcctIdx: move background() to bucket holder

### DIFF
--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -1,8 +1,7 @@
 use crate::accounts_index::{AccountsIndexConfig, IndexValue};
-use crate::bucket_map_holder::{BucketMapHolder, AGE_MS};
+use crate::bucket_map_holder::BucketMapHolder;
 use crate::in_mem_accounts_index::InMemAccountsIndex;
 use std::fmt::Debug;
-use std::time::Duration;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -71,7 +70,7 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
                     Builder::new()
                         .name("solana-idx-flusher".to_string())
                         .spawn(move || {
-                            Self::background(storage_, exit_, in_mem_);
+                            storage_.background(exit_, in_mem_);
                         })
                         .unwrap()
                 })
@@ -83,40 +82,6 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
             handles,
             storage,
             in_mem,
-        }
-    }
-
-    pub fn storage(&self) -> &Arc<BucketMapHolder<T>> {
-        &self.storage
-    }
-
-    // intended to execute in a bg thread
-    pub fn background(
-        storage: Arc<BucketMapHolder<T>>,
-        exit: Arc<AtomicBool>,
-        in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
-    ) {
-        let bins = in_mem.len();
-        let flush = storage.disk.is_some();
-        loop {
-            // this will transition to thread throttling
-            storage
-                .wait_dirty_or_aged
-                .wait_timeout(Duration::from_millis(AGE_MS));
-            if exit.load(Ordering::Relaxed) {
-                break;
-            }
-
-            storage.maybe_advance_age();
-            storage.stats.active_threads.fetch_add(1, Ordering::Relaxed);
-            for _ in 0..bins {
-                if flush {
-                    let index = storage.next_bucket_to_flush();
-                    in_mem[index].flush();
-                }
-                storage.stats.report_stats(&storage);
-            }
-            storage.stats.active_threads.fetch_sub(1, Ordering::Relaxed);
         }
     }
 }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -3,7 +3,6 @@ use crate::bucket_map_holder::BucketMapHolder;
 use solana_sdk::timing::{timestamp, AtomicInterval};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
-use std::sync::Arc;
 
 #[derive(Debug, Default)]
 pub struct BucketMapHolderStats {
@@ -59,7 +58,7 @@ impl BucketMapHolderStats {
         now.saturating_sub(last) // could saturate to 0. That is ok.
     }
 
-    fn ms_per_age<T: IndexValue>(&self, storage: &Arc<BucketMapHolder<T>>) -> u64 {
+    fn ms_per_age<T: IndexValue>(&self, storage: &BucketMapHolder<T>) -> u64 {
         let elapsed_ms = self.get_elapsed_ms_and_reset();
         let mut age_now = storage.current_age();
         let last_age = self.last_age.swap(age_now, Ordering::Relaxed);
@@ -75,7 +74,7 @@ impl BucketMapHolderStats {
         }
     }
 
-    pub fn report_stats<T: IndexValue>(&self, storage: &Arc<BucketMapHolder<T>>) {
+    pub fn report_stats<T: IndexValue>(&self, storage: &BucketMapHolder<T>) {
         // account index stats every 10 s
         if !self.last_time.should_update(10_000) {
             return;


### PR DESCRIPTION
#### Problem
this function makes more sense in the bucket holder. Most of the state is stored in bucket holder.
#### Summary of Changes

Fixes #
