### PR TITLE
Use crossbeam channels for packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,7 @@ name = "solana-bench-streamer"
 version = "1.8.0"
 dependencies = [
  "clap 2.33.3",
+ "crossbeam-channel",
  "solana-clap-utils",
  "solana-logger 1.8.0",
  "solana-net-utils",
@@ -4759,6 +4760,7 @@ dependencies = [
  "bincode",
  "bv",
  "clap 2.33.3",
+ "crossbeam-channel",
  "flate2",
  "indexmap",
  "itertools 0.10.1",
@@ -5631,6 +5633,7 @@ dependencies = [
 name = "solana-streamer"
 version = "1.8.0"
 dependencies = [
+ "crossbeam-channel",
  "itertools 0.10.1",
  "libc",
  "log 0.4.14",

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 clap = "2.33.1"
+crossbeam-channel = "0.5"
 solana-clap-utils = { path = "../clap-utils", version = "=1.8.0" }
 solana-streamer = { path = "../streamer", version = "=1.8.0" }
 solana-logger = { path = "../logger", version = "=1.8.0" }

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, App, Arg};
+use crossbeam_channel::unbounded;
 use solana_streamer::packet::{Packet, Packets, PacketsRecycler, PACKET_DATA_SIZE};
 use solana_streamer::streamer::{receiver, PacketReceiver};
 use std::cmp::max;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::thread::{spawn, JoinHandle, Result};
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
         addr = read.local_addr().unwrap();
         port = addr.port();
 
-        let (s_reader, r_reader) = channel();
+        let (s_reader, r_reader) = unbounded();
         read_channels.push(r_reader);
         read_threads.push(receiver(
             Arc::new(read),

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -14,14 +14,13 @@ use solana_sdk::hash::Hash;
 use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::system_transaction;
 use solana_sdk::timing::duration_as_ms;
-use std::sync::mpsc::channel;
 use std::time::{Duration, Instant};
 use test::Bencher;
 
 #[bench]
 fn bench_sigverify_stage(bencher: &mut Bencher) {
     solana_logger::setup();
-    let (packet_s, packet_r) = channel();
+    let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = unbounded();
     let verifier = TransactionSigVerifier::default();
     let stage = SigVerifyStage::new(packet_r, verified_s, verifier);

--- a/core/src/serve_repair_service.rs
+++ b/core/src/serve_repair_service.rs
@@ -1,10 +1,10 @@
 use crate::serve_repair::ServeRepair;
+use crossbeam_channel::unbounded;
 use solana_ledger::blockstore::Blockstore;
 use solana_perf::recycler::Recycler;
 use solana_streamer::{socket::SocketAddrSpace, streamer};
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
 use std::thread::{self, JoinHandle};
 
@@ -20,7 +20,7 @@ impl ServeRepairService {
         socket_addr_space: SocketAddrSpace,
         exit: &Arc<AtomicBool>,
     ) -> Self {
-        let (request_sender, request_receiver) = channel();
+        let (request_sender, request_receiver) = unbounded();
         let serve_repair_socket = Arc::new(serve_repair_socket);
         trace!(
             "ServeRepairService: id: {}, listening on: {:?}",
@@ -36,7 +36,7 @@ impl ServeRepairService {
             1,
             false,
         );
-        let (response_sender, response_receiver) = channel();
+        let (response_sender, response_receiver) = unbounded();
         let t_responder = streamer::responder(
             "serve-repairs",
             serve_repair_socket,

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -1,6 +1,7 @@
 //! The `shred_fetch_stage` pulls shreds from UDP sockets and sends it to a channel.
 
 use crate::packet_hasher::PacketHasher;
+use crossbeam_channel::unbounded;
 use lru::LruCache;
 use solana_ledger::shred::{get_shred_slot_index_type, ShredFetchStats};
 use solana_perf::cuda_runtime::PinnedVec;
@@ -11,7 +12,6 @@ use solana_sdk::clock::{Slot, DEFAULT_MS_PER_SLOT};
 use solana_streamer::streamer::{self, PacketReceiver, PacketSender};
 use std::net::UdpSocket;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::thread::{self, Builder, JoinHandle};
@@ -139,7 +139,7 @@ impl ShredFetchStage {
     where
         F: Fn(&mut Packet) + Send + 'static,
     {
-        let (packet_sender, packet_receiver) = channel();
+        let (packet_sender, packet_receiver) = unbounded();
         let streamers = sockets
             .into_iter()
             .map(|s| {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -28,11 +28,7 @@ use solana_runtime::{
 };
 use std::{
     net::UdpSocket,
-    sync::{
-        atomic::AtomicBool,
-        mpsc::{channel, Receiver},
-        Arc, Mutex, RwLock,
-    },
+    sync::{atomic::AtomicBool, mpsc::Receiver, Arc, Mutex, RwLock},
     thread,
 };
 
@@ -73,7 +69,7 @@ impl Tpu {
         cluster_confirmed_slot_sender: GossipDuplicateConfirmedSlotsSender,
         cost_model: &Arc<RwLock<CostModel>>,
     ) -> Self {
-        let (packet_sender, packet_receiver) = channel();
+        let (packet_sender, packet_receiver) = unbounded();
         let fetch_stage = FetchStage::new_with_sender(
             transactions_sockets,
             tpu_forwards_sockets,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -145,7 +145,7 @@ impl Tvu {
             forwards: tvu_forward_sockets,
         } = sockets;
 
-        let (fetch_sender, fetch_receiver) = channel();
+        let (fetch_sender, fetch_receiver) = unbounded();
 
         let repair_socket = Arc::new(repair_socket);
         let fetch_sockets: Vec<Arc<UdpSocket>> = fetch_sockets.into_iter().map(Arc::new).collect();

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/solana-gossip"
 bincode = "1.3.3"
 bv = { version = "0.11.1", features = ["serde"] }
 clap = "2.33.1"
+crossbeam-channel = "0.5"
 flate2 = "1.0"
 indexmap = { version = "1.7", features = ["rayon"] }
 itertools = "0.10.1"

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -33,6 +33,7 @@ use {
         weighted_shuffle::WeightedShuffle,
     },
     bincode::{serialize, serialized_size},
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     itertools::Itertools,
     rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng},
     rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
@@ -83,7 +84,6 @@ use {
         result::Result,
         sync::{
             atomic::{AtomicBool, Ordering},
-            mpsc::{Receiver, RecvTimeoutError, Sender},
             {Arc, Mutex, RwLock, RwLockReadGuard},
         },
         thread::{sleep, Builder, JoinHandle},

--- a/gossip/src/gossip_error.rs
+++ b/gossip/src/gossip_error.rs
@@ -1,5 +1,6 @@
 use {
     crate::duplicate_shred,
+    crossbeam_channel::{RecvTimeoutError, SendError},
     std::{io, sync},
     thiserror::Error,
 };
@@ -13,11 +14,17 @@ pub enum GossipError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
-    RecvTimeoutError(#[from] sync::mpsc::RecvTimeoutError),
+    RecvTimeoutError(#[from] RecvTimeoutError),
     #[error("send error")]
     SendError,
     #[error("serialization error")]
     Serialize(#[from] Box<bincode::ErrorKind>),
+}
+
+impl<T> std::convert::From<SendError<T>> for GossipError {
+    fn from(_e: SendError<T>) -> GossipError {
+        GossipError::SendError
+    }
 }
 
 impl<T> std::convert::From<sync::mpsc::SendError<T>> for GossipError {

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/solana-streamer"
 edition = "2018"
 
 [dependencies]
+crossbeam-channel = "0.5"
 itertools = "0.10.1"
 log = "0.4.14"
 solana-metrics = { path = "../metrics", version = "=1.8.0" }


### PR DESCRIPTION
#### Problem
The standard library `mpsc` channel implementation is known to be slow and has the added risk of the notorious `recv_timeout` panic bug.

#### Summary of Changes
- Switch packet channels from mspc channels to crossbeam channels for improved perf

Fixes #
