### PR TITLE
Handle duplicate AppendVec IDs

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8669,11 +8669,6 @@ pub mod tests {
             accounts.write_version.load(Ordering::Relaxed)
         );
 
-        assert_eq!(
-            daccounts.next_id.load(Ordering::Relaxed),
-            accounts.next_id.load(Ordering::Relaxed)
-        );
-
         // Get the hash for the latest slot, which should be the only hash in the
         // bank_hashes map on the deserialized AccountsDb
         assert_eq!(daccounts.bank_hashes.read().unwrap().len(), 2);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -433,8 +433,8 @@ where
     }
 
     // Remap the deserialized AppendVec paths to point to correct local paths
-    let num_collisions = AtomicUsize::default();
-    let next_append_vec_id = AtomicUsize::default();
+    let num_collisions = AtomicUsize::new(0);
+    let next_append_vec_id = AtomicUsize::new(0);
     let mut measure_remap = Measure::start("remap");
     let mut storage = (0..snapshot_storages.len())
         .into_par_iter()

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -472,7 +472,8 @@ where
                         break (new_append_vec_id, new_append_vec_path);
                     }
 
-                    // A file exists at the new path.  Try again.
+                    // If we made it this far, a file exists at the new path.  Record the collision
+                    // and try again.
                     num_collisions.fetch_add(1, Ordering::Relaxed);
                 };
                 // Only rename the file if the new ID is actually different from the original.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -520,7 +520,7 @@ where
         .fetch_add(snapshot_version, Ordering::Relaxed);
     accounts_db.generate_index(limit_load_slot_count_from_snapshot, verify_index);
 
-    datapoint_debug!(
+    datapoint_info!(
         "reconstruct_accountsdb_from_fields()",
         ("remap-time-us", measure_remap.as_us(), i64),
         (

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -459,9 +459,6 @@ where
                     let new_append_vec_path =
                         append_vec_path.parent().unwrap().join(&new_file_name);
 
-                    // If the new ID is the same as the original ID, then
-                    // Break out early and do not rename file.
-                    //
                     // Break out of the loop in the following situations:
                     // 1. The new ID is the same as the original ID.  This means we do not need to
                     //    rename the file, since the ID is the "correct" one already.

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -467,12 +467,10 @@ where
                     //    rename the file, since the ID is the "correct" one already.
                     // 2. There is not a file already at the new path.  This means it is safe to
                     //    rename the file to this new path.
-                    //    **DEVELOPER NOTE:** `fs::metadata()` can error for multiple reasons, so
-                    //    we cannot check for `fs::metadata().is_err()` instead of
-                    //    `!fs::metadata().is_ok()` here.  Additionally, keep this check last so
-                    //    that it can short-circuit if possible.
+                    //    **DEVELOPER NOTE:**  Keep this check last so that it can short-circuit if
+                    //    possible.
                     if storage_entry.id() == new_append_vec_id
-                        || !std::fs::metadata(&new_append_vec_path).is_ok()
+                        || std::fs::metadata(&new_append_vec_path).is_err()
                     {
                         break (new_append_vec_id, new_append_vec_path);
                     }


### PR DESCRIPTION
When reconstructing the AccountsDb, if the storages came from full and
incremental snapshots generated on different nodes, it's possible that
the AppendVec IDs could overlap/have duplicates, which would cause the
reconstruction to fail.

This commit handles this issue by unconditionally remapping the
AppendVec ID for every AppendVec.

Fixes #18641