### PR TITLE
windows: Make solana-test-validator work

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -113,7 +113,7 @@ fn make_accounts_txs(txes: usize, mint_keypair: &Keypair, hash: Hash) -> Vec<Tra
         .into_par_iter()
         .map(|_| {
             let mut new = dummy.clone();
-            let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
+            let sig: Vec<_> = (0..64).map(|_| thread_rng().gen::<u8>()).collect();
             new.message.account_keys[0] = pubkey::new_rand();
             new.message.account_keys[1] = pubkey::new_rand();
             new.signatures = vec![Signature::new(&sig[0..64])];

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -362,7 +362,7 @@ fn get_windows_path_var() -> Result<Option<String>, String> {
                 Ok(Some(s))
             } else {
                 println!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. Not modifying the PATH variable");
-                return Ok(None);
+                Ok(None)
             }
         }
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(Some(String::new())),
@@ -391,7 +391,7 @@ fn add_to_path(new_path: &str) -> bool {
     if !old_path.contains(&new_path) {
         let mut new_path = new_path.to_string();
         if !old_path.is_empty() {
-            new_path.push_str(";");
+            new_path.push(';');
             new_path.push_str(&old_path);
         }
 
@@ -416,7 +416,7 @@ fn add_to_path(new_path: &str) -> bool {
             SendMessageTimeoutA(
                 HWND_BROADCAST,
                 WM_SETTINGCHANGE,
-                0 as WPARAM,
+                0_usize,
                 "Environment\0".as_ptr() as LPARAM,
                 SMTO_ABORTIFHUNG,
                 5000,

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -51,3 +51,21 @@ pub fn setup_with_default(filter: &str) {
 pub fn setup() {
     setup_with_default("error");
 }
+
+// Configures file logging with a default filter if RUST_LOG is not set
+//
+// NOTE: This does not work at the moment, pending the resolution of https://github.com/env-logger-rs/env_logger/issues/208
+pub fn setup_file_with_default(logfile: &str, filter: &str) {
+    use std::fs::OpenOptions;
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(true)
+        .open(logfile)
+        .unwrap();
+    let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
+        .format_timestamp_nanos()
+        .target(env_logger::Target::Pipe(Box::new(file)))
+        .build();
+    replace_logger(logger);
+}

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -374,7 +374,7 @@ pub fn is_host_port(string: String) -> Result<(), String> {
 
 #[cfg(windows)]
 fn udp_socket(_reuseaddr: bool) -> io::Result<Socket> {
-    let sock = Socket::new(Domain::ipv4(), Type::dgram(), None)?;
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
     Ok(sock)
 }
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -77,6 +77,7 @@ if [[ $CI_OS_NAME = windows ]]; then
     solana-install-init
     solana-keygen
     solana-stake-accounts
+    solana-test-validator
     solana-tokens
   )
 else

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
 use log::*;
 

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -3,8 +3,17 @@ pub use solana_core::test_validator;
 pub use solana_gossip::cluster_info::MINIMUM_VALIDATOR_PORT_RANGE_WIDTH;
 use {
     console::style,
+    fd_lock::{RwLock, RwLockWriteGuard},
     indicatif::{ProgressDrawTarget, ProgressStyle},
-    std::{borrow::Cow, env, fmt::Display, thread::JoinHandle},
+    std::{
+        borrow::Cow,
+        env,
+        fmt::Display,
+        fs::{File, OpenOptions},
+        path::Path,
+        process::exit,
+        thread::JoinHandle,
+    },
 };
 
 pub mod admin_rpc_service;
@@ -12,7 +21,7 @@ pub mod dashboard;
 
 #[cfg(unix)]
 fn redirect_stderr(filename: &str) {
-    use std::{fs::OpenOptions, os::unix::io::AsRawFd};
+    use std::os::unix::io::AsRawFd;
     match OpenOptions::new()
         .write(true)
         .create(true)
@@ -36,23 +45,22 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
     }
 
     let filter = "solana=info";
-    let logger_thread = match logfile {
+    match logfile {
         None => {
-            solana_logger::setup_with_default(&filter);
+            solana_logger::setup_with_default(filter);
             None
         }
         Some(logfile) => {
             #[cfg(unix)]
             {
                 use log::info;
-                use std::process::exit;
                 let signals = signal_hook::iterator::Signals::new(&[signal_hook::SIGUSR1])
                     .unwrap_or_else(|err| {
                         eprintln!("Unable to register SIGUSR1 handler: {:?}", err);
                         exit(1);
                     });
 
-                solana_logger::setup_with_default(&filter);
+                solana_logger::setup_with_default(filter);
                 redirect_stderr(&logfile);
                 Some(std::thread::spawn(move || {
                     for signal in signals.forever() {
@@ -67,13 +75,11 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
             #[cfg(not(unix))]
             {
                 println!("logrotate is not supported on this platform");
-                solana_logger::setup_file_with_default(&logfile, &filter);
+                solana_logger::setup_file_with_default(&logfile, filter);
                 None
             }
         }
-    };
-
-    logger_thread
+    }
 }
 
 pub fn port_validator(port: String) -> Result<(), String> {
@@ -138,4 +144,28 @@ impl ProgressBar {
             println!("{}", msg);
         }
     }
+}
+
+pub fn ledger_lockfile(ledger_path: &Path) -> RwLock<File> {
+    let lockfile = ledger_path.join("ledger.lock");
+    fd_lock::RwLock::new(
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&lockfile)
+            .unwrap(),
+    )
+}
+
+pub fn lock_ledger<'path, 'lock>(
+    ledger_path: &'path Path,
+    ledger_lockfile: &'lock mut RwLock<File>,
+) -> RwLockWriteGuard<'lock, File> {
+    ledger_lockfile.try_write().unwrap_or_else(|_| {
+        println!(
+            "Error: Unable to lock {} directory. Check if another validator is running",
+            ledger_path.display()
+        );
+        exit(1);
+    })
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -66,8 +66,8 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_validator::{
-        admin_rpc_service, dashboard::Dashboard, new_spinner_progress_bar, println_name_value,
-        redirect_stderr_to_file,
+        admin_rpc_service, dashboard::Dashboard, ledger_lockfile, lock_ledger,
+        new_spinner_progress_bar, println_name_value, redirect_stderr_to_file,
     },
     std::{
         collections::{HashSet, VecDeque},
@@ -2848,21 +2848,8 @@ pub fn main() {
         })
     });
 
-    let lockfile = ledger_path.join("ledger.lock");
-    let mut ledger_fd_lock = fd_lock::RwLock::new(
-        fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&lockfile)
-            .unwrap(),
-    );
-    let _ledger_lock = ledger_fd_lock.try_write().unwrap_or_else(|_| {
-        println!(
-            "Error: Unable to lock {} directory. Check if another validator is running",
-            ledger_path.display()
-        );
-        exit(1);
-    });
+    let mut ledger_lock = ledger_lockfile(&ledger_path);
+    let _ledger_write_guard = lock_ledger(&ledger_path, &mut ledger_lock);
 
     let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
     let admin_service_cluster_info = Arc::new(RwLock::new(None));

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2848,7 +2848,14 @@ pub fn main() {
         })
     });
 
-    let mut ledger_fd_lock = fd_lock::RwLock::new(fs::File::open(&ledger_path).unwrap());
+    let lockfile = ledger_path.join("ledger.lock");
+    let mut ledger_fd_lock = fd_lock::RwLock::new(
+        fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&lockfile)
+            .unwrap(),
+    );
     let _ledger_lock = ledger_fd_lock.try_write().unwrap_or_else(|_| {
         println!(
             "Error: Unable to lock {} directory. Check if another validator is running",


### PR DESCRIPTION
#### Problem

`solana-test-validator` doesn't work on Windows.

#### Summary of Changes

Let's get it working! Here are the important changes:

* ledger lock needs to be done on a file instead of the directory -- let me know if you prefer to have this gated on `cfg[windows]`
* IPC service needs to use the Windows pipe naming scheme (I couldn't believe this one, who comes up with this stuff?)
* always disable the JIT
* file logging not possible yet because we can't redirect stderr, but this will change once env_logger fixes the pipe output target!

I tested this by deploying a program, doing some transfers, making sure the lock works, and running the `program-test` tests.  Let me know if there are any other bits worth testing.

Since logging to file still isn't possible, it's a huge spew of logs when it's running, but at least it works!