### PR TITLE
AcctIdx: Fix bad test

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -609,7 +609,8 @@ mod tests {
             BINS_FOR_TESTING,
             &Some(AccountsIndexConfig::default()),
         ));
-        InMemAccountsIndex::new(&holder, BINS_FOR_TESTING)
+        let bin = 0;
+        InMemAccountsIndex::new(&holder, bin)
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
test construction was passing # bins for bin#. bins are 0..#bins. This results in indexing at [bins] which will fail.
#### Summary of Changes

Fixes #
