### PR TITLE
AcctIdx: allocate threads for accounts idx based on cpus

### DIFF
--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -44,11 +44,11 @@ impl<T: IndexValue> Drop for AccountsIndexStorage<T> {
 
 impl<T: IndexValue> AccountsIndexStorage<T> {
     pub fn new(bins: usize, config: &Option<AccountsIndexConfig>) -> AccountsIndexStorage<T> {
-        const DEFAULT_THREADS: usize = 1; // soon, this will be a cpu calculation
+        let num_threads = std::cmp::max(2, num_cpus::get() / 4);
         let threads = config
             .as_ref()
             .and_then(|config| config.flush_threads)
-            .unwrap_or(DEFAULT_THREADS);
+            .unwrap_or(num_threads);
 
         let storage = Arc::new(BucketMapHolder::new(bins, config, threads));
 


### PR DESCRIPTION
#### Problem
We may have to adjust this ratio, but the # of threads by default should be something proportional to the cpus. Caller can pass a specific # of threads. This code only runs with optional validator args to enable disk based index right now.
#### Summary of Changes

Fixes #
