### PR TITLE
Add Vote instruction to update on chain vote state

### DIFF
--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -61,6 +61,9 @@ pub enum VoteError {
     #[error("Zero confirmations")]
     ZeroConfirmations,
 
+    #[error("Confirmation exceeds limit")]
+    ConfirmationTooLarge,
+
     #[error("Root rolled back")]
     RootRollBack,
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -10,7 +10,6 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use serde_derive::{Deserialize, Serialize};
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::{
-    clock::Slot,
     decode_error::DecodeError,
     feature_set,
     hash::Hash,
@@ -47,17 +46,17 @@ pub enum VoteError {
     TooSoonToReauthorize,
 
     // TODO: figure out how to migrate these new errors
-    #[error("Old state had slot {0}, with confirmation {1}, which should not have been popped off by {2}")]
-    LockoutConflict(Slot, u32, Slot),
+    #[error("Old state had vote which should not have been popped off by vote in new state")]
+    LockoutConflict,
 
-    #[error("Proposed state had slot {0}, with confirmation {1}, which should have been popped off by {2}")]
-    NewVoteStateLockoutMismatch(Slot, u32, Slot),
+    #[error("Proposed state had earlier slot which should have been popped off by later vote")]
+    NewVoteStateLockoutMismatch,
 
-    #[error("Slots are not ordered")]
+    #[error("Vote slots are not ordered")]
     SlotsNotOrdered,
 
-    #[error("Lockouts are not ordered")]
-    LockoutsNotOrdered,
+    #[error("Confirmations are not ordered")]
+    ConfirmationsNotOrdered,
 
     #[error("Zero confirmations")]
     ZeroConfirmations,
@@ -65,11 +64,11 @@ pub enum VoteError {
     #[error("Root rolled back")]
     RootRollBack,
 
-    #[error("Confirmations for slot {0} rolled back from {1} to {2}")]
-    LockoutRollBack(Slot, u32, u32),
+    #[error("Confirmations for same vote were smaller in new proposed state")]
+    ConfirmationRollBack,
 
-    #[error("Vote slot {0} was smaller than root {1}")]
-    SlotSmallerThanRoot(Slot, Slot),
+    #[error("New state contained a vote slot smaller than the root")]
+    SlotSmallerThanRoot,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -72,6 +72,9 @@ pub enum VoteError {
 
     #[error("New state contained a vote slot smaller than the root")]
     SlotSmallerThanRoot,
+
+    #[error("New state contained too many votes")]
+    TooManyVotes,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -10,6 +10,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use serde_derive::{Deserialize, Serialize};
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::{
+    clock::Slot,
     decode_error::DecodeError,
     feature_set,
     hash::Hash,
@@ -44,6 +45,28 @@ pub enum VoteError {
 
     #[error("authorized voter has already been changed this epoch")]
     TooSoonToReauthorize,
+
+    // TODO: figure out how to migrate these new errors
+    #[error("Old state had slot {0}, with confirmation {1}, which should not have been popped off by {2}")]
+    LockoutConflict(Slot, u32, Slot),
+
+    #[error("Proposed state had slot {0}, with confirmation {1}, which should have been popped off by {2}")]
+    NewVoteStateLockoutMismatch(Slot, u32, Slot),
+
+    #[error("Slots are not ordered")]
+    SlotsNotOrdered,
+
+    #[error("Lockouts are not ordered")]
+    LockoutsNotOrdered,
+
+    #[error("Zero confirmations")]
+    ZeroConfirmations,
+
+    #[error("Root rolled back")]
+    RootRollBack,
+
+    #[error("Vote slot {0} was smaller than root {1}")]
+    SlotSmallerThanRoot(Slot, Slot),
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -65,6 +65,9 @@ pub enum VoteError {
     #[error("Root rolled back")]
     RootRollBack,
 
+    #[error("Confirmations for slot {0} rolled back from {1} to {2}")]
+    LockoutRollBack(Slot, u32, u32),
+
     #[error("Vote slot {0} was smaller than root {1}")]
     SlotSmallerThanRoot(Slot, Slot),
 }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -384,7 +384,7 @@ impl VoteState {
     // and the confirmations sorted from largest to smallest.
     // 2) Confirmations `c` on any vote slot satisfy `0 < c <= MAX_LOCKOUT_HISTORY`
     // 3) Lockouts are not expired by consecutive votes, i.e. for every consecutive
-    // `v_i`, `v_{i + 1}` satisfy `v_i.last_locked_out_slot() <= v_{i + 1}`.
+    // `v_i`, `v_{i + 1}` satisfy `v_i.last_locked_out_slot() >= v_{i + 1}`.
 
     // We also guarantee that compared to the current vote state, `new_state`
     // introduces no rollback. This means:

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -41,6 +41,10 @@ pub trait VoteTransaction {
     fn slot(&self, i: usize) -> Slot;
     fn len(&self) -> usize;
     fn hash(&self) -> Hash;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 #[frozen_abi(digest = "Ch2vVEwos2EjAVqSHCyJjnN2MNX1yrpapZTGhMSCjWUH")]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -312,7 +312,7 @@ impl VoteState {
         // Note:
         //
         // 1) `vote.slots` is sorted from oldest/smallest vote to newest/largest
-        // vote, due to the way votes are applied to the vote state (newest vots
+        // vote, due to the way votes are applied to the vote state (newest votes
         // pushed to the back), but `slot_hashes` is sorted smallest to largest.
         //
         // 2) Conversely, `slot_hashes` is sorted from newest/largest vote to

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -68,6 +68,25 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::UpdateVoteState(vote_state_update) => {
+            check_num_vote_accounts(&instruction.accounts, 4)?;
+            let vote_state_update = json!({
+                "lockouts": vote_state_update.lockouts,
+                "root": vote_state_update.root,
+                "hash": vote_state_update.hash.to_string(),
+                "timestamp": vote_state_update.timestamp,
+            });
+            Ok(ParsedInstructionEnum {
+                instruction_type: "updatevotestate".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "slotHashesSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "clockSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "voteAuthority": account_keys[instruction.accounts[3] as usize].to_string(),
+                    "voteStateUpdate": vote_state_update,
+                }),
+            })
+        }
         VoteInstruction::Withdraw(lamports) => {
             check_num_vote_accounts(&instruction.accounts, 3)?;
             Ok(ParsedInstructionEnum {


### PR DESCRIPTION
#### Problem
To avoid out of order voting issues, we allow validators to update the on chain vote state directly through this new instruction. 

#### Summary of Changes
Plumbing for #20014 in the vote program

Fixes #
