### PR TITLE
fix build break from 20099

### DIFF
--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(not(target_family = "windows"))]
 use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
 use log::*;
 


### PR DESCRIPTION
#### Problem

567f30aa1a5803047bad568c7d45f6b58baa16f1 broke osx builds

#### Summary of Changes

change target_family check

Fixes #
