### PR TITLE
bucket_map: rename num_cells() to capacity()

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -58,7 +58,7 @@ impl<T: Clone + Copy> Bucket<T> {
 
     pub fn keys(&self) -> Vec<Pubkey> {
         let mut rv = vec![];
-        for i in 0..self.index.num_cells() {
+        for i in 0..self.index.capacity() {
             if self.index.uid(i) == UID_UNLOCKED {
                 continue;
             }
@@ -73,8 +73,8 @@ impl<T: Clone + Copy> Bucket<T> {
         R: RangeBounds<Pubkey>,
     {
         let mut result = Vec::with_capacity(self.index.used.load(Ordering::Relaxed) as usize);
-        for i in 0..self.index.num_cells() {
-            let ii = i % self.index.num_cells();
+        for i in 0..self.index.capacity() {
+            let ii = i % self.index.capacity();
             if self.index.uid(ii) == UID_UNLOCKED {
                 continue;
             }
@@ -107,7 +107,7 @@ impl<T: Clone + Copy> Bucket<T> {
     ) -> Option<(&'a mut IndexEntry, u64)> {
         let ix = Self::bucket_index_ix(index, key, random);
         for i in ix..ix + index.max_search() {
-            let ii = i % index.num_cells();
+            let ii = i % index.capacity();
             if index.uid(ii) == UID_UNLOCKED {
                 continue;
             }
@@ -126,7 +126,7 @@ impl<T: Clone + Copy> Bucket<T> {
     ) -> Option<(&'a IndexEntry, u64)> {
         let ix = Self::bucket_index_ix(index, key, random);
         for i in ix..ix + index.max_search() {
-            let ii = i % index.num_cells();
+            let ii = i % index.capacity();
             if index.uid(ii) == UID_UNLOCKED {
                 continue;
             }
@@ -147,7 +147,7 @@ impl<T: Clone + Copy> Bucket<T> {
     ) -> Result<u64, BucketMapError> {
         let ix = Self::bucket_index_ix(index, key, random);
         for i in ix..ix + index.max_search() {
-            let ii = i as u64 % index.num_cells();
+            let ii = i as u64 % index.capacity();
             if index.uid(ii) != UID_UNLOCKED {
                 continue;
             }
@@ -233,7 +233,7 @@ impl<T: Clone + Copy> Bucket<T> {
             //need to move the allocation to a best fit spot
             let best_bucket = &self.data[best_fit_bucket as usize];
             let cap_power = best_bucket.capacity_pow2;
-            let cap = best_bucket.num_cells();
+            let cap = best_bucket.capacity();
             let pos = thread_rng().gen_range(0, cap);
             for i in pos..pos + self.index.max_search() {
                 let ix = i % cap;
@@ -292,7 +292,7 @@ impl<T: Clone + Copy> Bucket<T> {
                 );
                 let random = thread_rng().gen();
                 let mut valid = true;
-                for ix in 0..self.index.num_cells() {
+                for ix in 0..self.index.capacity() {
                     let uid = self.index.uid(ix);
                     if UID_UNLOCKED != uid {
                         let elem: &IndexEntry = self.index.get(ix);
@@ -362,8 +362,8 @@ impl<T: Clone + Copy> Bucket<T> {
         //location in any bucket on all validators
         random.hash(&mut s);
         let ix = s.finish();
-        ix % index.num_cells()
-        //debug!(            "INDEX_IX: {:?} uid:{} loc: {} cap:{}",            key,            uid,            location,            index.num_cells()        );
+        ix % index.capacity()
+        //debug!(            "INDEX_IX: {:?} uid:{} loc: {} cap:{}",            key,            uid,            location,            index.capacity()        );
     }
 
     pub fn insert(&mut self, key: &Pubkey, value: (&[T], RefCount)) {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -123,7 +123,7 @@ impl BucketStorage {
     }
 
     pub fn uid(&self, ix: u64) -> Uid {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("bad index size");
         }
         let ix = (ix * self.cell_size) as usize;
@@ -135,7 +135,7 @@ impl BucketStorage {
     }
 
     pub fn allocate(&self, ix: u64, uid: Uid) -> Result<(), BucketStorageError> {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("allocate: bad index size");
         }
         if UID_UNLOCKED == uid {
@@ -156,7 +156,7 @@ impl BucketStorage {
     }
 
     pub fn free(&self, ix: u64, uid: Uid) {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("free: bad index size");
         }
         if UID_UNLOCKED == uid {
@@ -179,7 +179,7 @@ impl BucketStorage {
     }
 
     pub fn get<T: Sized>(&self, ix: u64) -> &T {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("bad index size");
         }
         let start = (ix * self.cell_size) as usize + std::mem::size_of::<Header>();
@@ -201,7 +201,7 @@ impl BucketStorage {
     }
 
     pub fn get_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &[T] {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("bad index size");
         }
         let ix = self.cell_size * ix;
@@ -217,7 +217,7 @@ impl BucketStorage {
 
     #[allow(clippy::mut_from_ref)]
     pub fn get_mut<T: Sized>(&self, ix: u64) -> &mut T {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("bad index size");
         }
         let start = (ix * self.cell_size) as usize + std::mem::size_of::<Header>();
@@ -231,7 +231,7 @@ impl BucketStorage {
 
     #[allow(clippy::mut_from_ref)]
     pub fn get_mut_cell_slice<T: Sized>(&self, ix: u64, len: u64) -> &mut [T] {
-        if ix >= self.num_cells() {
+        if ix >= self.capacity() {
             panic!("bad index size");
         }
         let ix = self.cell_size * ix;
@@ -295,7 +295,7 @@ impl BucketStorage {
 
     pub fn grow(&mut self) {
         let mut m = Measure::start("grow");
-        let old_cap = self.num_cells();
+        let old_cap = self.capacity();
         let old_map = &self.mmap;
         let old_file = self.path.clone();
 
@@ -332,7 +332,9 @@ impl BucketStorage {
         self.stats.resizes.fetch_add(1, Ordering::Relaxed);
         self.stats.resize_us.fetch_add(m.as_us(), Ordering::Relaxed);
     }
-    pub fn num_cells(&self) -> u64 {
+
+    /// Return the number of cells currently allocated
+    pub fn capacity(&self) -> u64 {
         1 << self.capacity_pow2
     }
 }


### PR DESCRIPTION
I'm reading through bucket_map to make sure I understand it all. While doing that, I've been updating/renaming/documenting bits and pieces that has helped me.

**_No behavior changes_**