### PR TITLE
Fix Terminology.md public key section links

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -8,7 +8,7 @@ The following terms are used throughout the documentation.
 
 A record in the Solana ledger that either holds data or is an executable program.
 
-Like an account at a traditional bank, a Solana account may hold funds called [lamports](terminology.md#lamport). Like a file in Linux, it is addressable by a [key], often referred to as a [public key](terminology.md#public-key) or pubkey.
+Like an account at a traditional bank, a Solana account may hold funds called [lamports](terminology.md#lamport). Like a file in Linux, it is addressable by a [key], often referred to as a [public key](terminology.md#public-key-pubkey) or pubkey.
 
 The key may be one of:
 an ed25519 public key
@@ -147,7 +147,7 @@ The smallest contiguous unit of execution logic in a [program](terminology.md#pr
 
 ## keypair
 
-A [public key](terminology.md#public-key) and corresponding [private key](terminology.md#private-key) for accessing an account.
+A [public key](terminology.md#public-key-pubkey) and corresponding [private key](terminology.md#private-key) for accessing an account.
 
 ## lamport
 
@@ -159,7 +159,7 @@ The role of a [validator](terminology.md#validator) when it is appending [entrie
 
 ## leader schedule
 
-A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key) mapped to [slots](terminology.md#slot). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
+A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key-pubkey) mapped to [slots](terminology.md#slot). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
 
 ## ledger
 


### PR DESCRIPTION
#### Problem
Links in [Terminology](https://docs.solana.com/terminology) to Public Key term are broken.
<img width="461" alt="Screen Shot 2021-09-24 at 8 57 48 AM" src="https://user-images.githubusercontent.com/227422/134678094-b1fe1751-3eda-4894-88bd-872e25f075f1.png">
#### Summary of Changes
This change adds the correct link to the Public Key section.
