### PR TITLE
cli: Don't top up program deploy buffer balance if it already exists

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2037,24 +2037,24 @@ fn complete_partial_program_init(
         if account.owner != *loader_id {
             instructions.push(system_instruction::assign(elf_pubkey, loader_id));
         }
-    }
-    if account.lamports < minimum_balance {
-        let balance = minimum_balance - account.lamports;
-        instructions.push(system_instruction::transfer(
-            payer_pubkey,
-            elf_pubkey,
-            balance,
-        ));
-        balance_needed = balance;
-    } else if account.lamports > minimum_balance
-        && system_program::check_id(&account.owner)
-        && !allow_excessive_balance
-    {
-        return Err(format!(
-            "Buffer account has a balance: {:?}; it may already be in use",
-            Sol(account.lamports)
-        )
-        .into());
+        if account.lamports < minimum_balance {
+            let balance = minimum_balance - account.lamports;
+            instructions.push(system_instruction::transfer(
+                payer_pubkey,
+                elf_pubkey,
+                balance,
+            ));
+            balance_needed = balance;
+        } else if account.lamports > minimum_balance
+            && system_program::check_id(&account.owner)
+            && !allow_excessive_balance
+        {
+            return Err(format!(
+                "Buffer account has a balance: {:?}; it may already be in use",
+                Sol(account.lamports)
+            )
+            .into());
+        }
     }
     Ok((instructions, balance_needed))
 }


### PR DESCRIPTION
#### Problem
If a program buffer account is not rent exempt, the cli tries to top it up before proceeding with a deploy. This isn't necessary and it fails now that there are stricter rules around write locks for accounts owned by the bpf loader.

#### Summary of Changes
- Disable buffer balance check if the buffer already exists

Fixes #
