### PR TITLE
AcctIdx: avoid crazy #s on ms_per_age stat

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -77,19 +77,20 @@ impl BucketMapHolderStats {
     }
 
     fn ms_per_age<T: IndexValue>(&self, storage: &BucketMapHolder<T>) -> u64 {
-        let elapsed_ms = self.get_elapsed_ms_and_reset();
-        let mut age_now = storage.current_age();
-        let last_age = self.last_age.swap(age_now, Ordering::Relaxed);
-        if last_age > age_now {
-            // age may have wrapped
-            age_now += u8::MAX;
+        if !storage.get_startup() {
+            let elapsed_ms = self.get_elapsed_ms_and_reset();
+            let mut age_now = storage.current_age();
+            let last_age = self.last_age.swap(age_now, Ordering::Relaxed);
+            if last_age > age_now {
+                // age may have wrapped
+                age_now += u8::MAX;
+            }
+            let age_delta = age_now.saturating_sub(last_age) as u64;
+            if age_delta > 0 {
+                return elapsed_ms / age_delta;
+            }
         }
-        let age_delta = age_now.saturating_sub(last_age) as u64;
-        if age_delta > 0 {
-            elapsed_ms / age_delta
-        } else {
-            0
-        }
+        0 // avoid crazy numbers
     }
 
     pub fn report_stats<T: IndexValue>(&self, storage: &BucketMapHolder<T>) {


### PR DESCRIPTION
#### Problem
at startup, many items can be sent to the index at once. This can cause a wide range of stat values for this measurement.
#### Summary of Changes

Fixes #
