### PR TITLE
CI: fix mergify check for web3 ci status

### DIFF
--- a/.github/workflows/web3.yml
+++ b/.github/workflows/web3.yml
@@ -11,6 +11,14 @@ on:
       - "web3.js/**"
 
 jobs:
+  # needed for grouping check-web3 strategies into one check for mergify
+  all-web3-checks:
+    runs-on: ubuntu-latest
+    needs:
+      - check-web3
+    steps:
+      - run: echo "Done"
+
   check-web3:
     runs-on: ubuntu-latest
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,7 +33,7 @@ pull_request_rules:
           - -files~=^explorer/
         - or:
           # only require web3 checks if web3.js files changed
-          - status-success=check-web3
+          - status-success=all-web3-checks
           - -files~=^web3.js/
     actions:
       merge:
@@ -53,7 +53,7 @@ pull_request_rules:
           - -files~=^explorer/
         - or:
           # only require web3 checks if web3.js files changed
-          - status-success=check-web3
+          - status-success=all-web3-checks
           - -files~=^web3.js/
     actions:
       merge:


### PR DESCRIPTION
#### Problem
The github action job name changes when using strategies and Mergify wasn't updated to check all of them

#### Summary of Changes

Fixes #
