### PR TITLE
Add get_snapshot_info() RPC function

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -2,23 +2,15 @@
 
 use {
     crate::{
-        client_error::Result,
-        rpc_config::RpcBlockProductionConfig,
-        rpc_request::RpcRequest,
-        rpc_response::{
-            Response, RpcAccountBalance, RpcBlockProduction, RpcBlockProductionRange, RpcBlockhash,
-            RpcConfirmedTransactionStatusWithSignature, RpcContactInfo, RpcFees, RpcPerfSample,
-            RpcResponseContext, RpcSimulateTransactionResult, RpcSnapshotSlotInfo,
-            RpcStakeActivation, RpcSupply, RpcVersionInfo, RpcVoteAccountInfo,
-            RpcVoteAccountStatus, StakeActivationState,
-        },
-        rpc_sender::*,
+        client_error::Result, rpc_config::RpcBlockProductionConfig, rpc_request::RpcRequest,
+        rpc_response::*, rpc_sender::*,
     },
     serde_json::{json, Number, Value},
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         epoch_info::EpochInfo,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
+        hash::Hash,
         instruction::InstructionError,
         message::MessageHeader,
         signature::Signature,
@@ -231,6 +223,18 @@ impl RpcSender for MockSender {
                 full: 100,
                 incremental: Some(110),
             }),
+            "getSnapshotInfo" => {
+                json!(RpcSnapshotInfo::IncrementalSnapshot {
+                    full: SnapshotInfo {
+                        slot: 8_000,
+                        hash: Hash::new_unique().to_string(),
+                    },
+                    incremental: SnapshotInfo {
+                        slot: 8_200,
+                        hash: Hash::new_unique().to_string(),
+                    },
+                })
+            },
             "getBlockHeight" => Value::Number(Number::from(1234)),
             "getSlotLeaders" => json!([PUBKEY]),
             "getBlockProduction" => {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1061,6 +1061,38 @@ impl RpcClient {
         self.send(RpcRequest::GetSnapshotSlot, Value::Null)
     }
 
+    /// Returns the snapshot information for the given snapshot slot and hash
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getSnapshotInfo`] RPC method.
+    ///
+    /// [`getSnapshotInfo`]: https://docs.solana.com/developing/clients/jsonrpc-api#getsnapshotinfo
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_client::{
+    /// #     rpc_client::RpcClient,
+    /// #     client_error::ClientError,
+    /// # };
+    /// # use solana_sdk::clock::Slot;
+    /// # use solana_sdk::hash::Hash;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// # let snapshot_slot_hash = (Slot::default(), Hash::default());
+    /// let snapshot_info = rpc_client.get_snapshot_info(snapshot_slot_hash)?;
+    /// # Ok::<(), ClientError>(())
+    /// ```
+    pub fn get_snapshot_info(
+        &self,
+        snapshot_slot_hash: (Slot, Hash),
+    ) -> ClientResult<RpcSnapshotInfo> {
+        self.send(
+            RpcRequest::GetSnapshotInfo,
+            json!([(snapshot_slot_hash.0, snapshot_slot_hash.1.to_string())]),
+        )
+    }
+
     /// Check if a transaction has been processed with the default commitment level.
     ///
     /// If the transaction has been processed with the default commitment level,

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -85,6 +85,7 @@ pub enum RpcRequest {
         note = "Please use RpcRequest::GetHighestSnapshotSlot instead"
     )]
     GetSnapshotSlot,
+    GetSnapshotInfo,
     GetSignaturesForAddress,
     GetSignatureStatuses,
     GetSlot,
@@ -158,6 +159,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetRecentPerformanceSamples => "getRecentPerformanceSamples",
             RpcRequest::GetHighestSnapshotSlot => "getHighestSnapshotSlot",
             RpcRequest::GetSnapshotSlot => "getSnapshotSlot",
+            RpcRequest::GetSnapshotInfo => "getSnapshotInfo",
             RpcRequest::GetSignaturesForAddress => "getSignaturesForAddress",
             RpcRequest::GetSignatureStatuses => "getSignatureStatuses",
             RpcRequest::GetSlot => "getSlot",

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -437,7 +437,25 @@ impl From<ConfirmedTransactionStatusWithSignature> for RpcConfirmedTransactionSt
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcSnapshotSlotInfo {
     pub full: Slot,
     pub incremental: Option<Slot>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum RpcSnapshotInfo {
+    FullSnapshot(SnapshotInfo),
+    IncrementalSnapshot {
+        full: SnapshotInfo,
+        incremental: SnapshotInfo,
+    },
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotInfo {
+    pub slot: Slot,
+    pub hash: String,
 }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -53,6 +53,7 @@ gives a convenient interface for the RPC methods.
 - [getSlot](jsonrpc-api.md#getslot)
 - [getSlotLeader](jsonrpc-api.md#getslotleader)
 - [getSlotLeaders](jsonrpc-api.md#getslotleaders)
+- [getSnapshotInfo](jsonrpc-api.md#getsnapshotinfo)
 - [getStakeActivation](jsonrpc-api.md#getstakeactivation)
 - [getSupply](jsonrpc-api.md#getsupply)
 - [getTokenAccountBalance](jsonrpc-api.md#gettokenaccountbalance)
@@ -2440,6 +2441,96 @@ The first leader returned is the leader for slot #100:
     "DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP",
     "DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP"
   ],
+  "id": 1
+}
+```
+
+### getSnapshotInfo
+
+**NEW: This method is only available in solana-core v1.8 or newer.**
+
+Returns the snapshot information for the given snapshot slot and hash.
+
+If the node has a snapshot with the given slot and hash, it will return the
+associated information about it.  For full snapshots, this is the slot and has.
+For incremental snapshots, this is the slot and hash _plus_ the slot and hash
+for its associated full snapshot.
+
+#### Parameters:
+
+- `<object>`
+  - `slot: <u64>` - The slot for the snapshot being queried
+  - `hash: <string>` - A base-58 encoded hash for the snapshot being queried
+
+#### Results:
+
+Result when the node has a full snapshot for this slot and hash:
+- `<object>`
+  - `fullSnapshot: <object>` - This object indicates the result is for a full snapshot
+    - `slot: <u64>` - The slot of the snapshot
+    - `hash: <string>` - The base-58 encoded hash of the snapshot
+
+Result when the node has an incremental snapshot for this slot and hash:
+- `<object>`
+  - `incrementalSnapshot: <object>` - This object indicates the result is for an incremental snapshot
+    - `full: <object>` - The information for the associated full snapshot
+      - `slot: <u64>` - The slot of the full snapshot
+      - `hash: <string>` - The base-58 encoded hash of the full snapshot
+    - `incremental: <object>` - The information for the incremental snapshot
+      - `slot: <u64>` - The slot of the incremental snapshot
+      - `hash: <string>` - The base-58 encoded hash of the incremental snapshot
+
+#### Example:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1,"method":"getSnapshotInfo","params":[{"slot":123,"hash":"CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3"}]}
+'
+```
+
+Result when the node has a full snapshot for this slot and hash:
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "fullSnapshot": {
+      "slot": 123,
+      "hash": "CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3"
+    }
+  },
+  "id": 1
+}
+```
+
+Result when the node has an incremental snapshot for this slot and hash:
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "incrementalSnapshot": {
+      "full": {
+        "slot": 8000,
+        "hash": "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"
+      },
+      "incremental": {
+        "slot": 8200,
+        "hash": "8opHzTAnfzRpPEx21XtnrVTX28YQuCpAjcn1PczScKh"
+      }
+    }
+  },
+  "id": 1
+}
+```
+
+Result when the node does not have a snapshot for this slot and hash:
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32008,
+    "message": "No snapshot"
+  },
   "id": 1
 }
 ```

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2452,7 +2452,7 @@ The first leader returned is the leader for slot #100:
 Returns the snapshot information for the given snapshot slot and hash.
 
 If the node has a snapshot with the given slot and hash, it will return the
-associated information about it.  For full snapshots, this is the slot and has.
+associated information about it.  For full snapshots, this is the slot and hash.
 For incremental snapshots, this is the slot and hash _plus_ the slot and hash
 for its associated full snapshot.
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1146,7 +1146,7 @@ where
 }
 
 /// Get a list of the incremental snapshot archives in a directory
-fn get_incremental_snapshot_archives<P>(
+pub fn get_incremental_snapshot_archives<P>(
     snapshot_archives_dir: P,
 ) -> Vec<IncrementalSnapshotArchiveInfo>
 where


### PR DESCRIPTION
#### Problem

During bootstrap, the node gets a list of snapshot hashes to download a snapshot. The node assumes all these hashes correspond to full snapshots, which is not the case anymore. So (1) the node needs to query if the hash is a full or incremental snapshot in order to construct the download file path correctly, and (2), if the hash is an incremental snapshot, the node must then also download the full snapshot afterwards (or rather, it'll check if it has it locally already).

The changes to the download logic in bootstrap will happen in a subsequent PR (see issue #20225). This PR addresses the problem of not being able to query a snapshot hash for its type and associated information.

#### Summary of Changes

Add an RPC fn for querying a snapshot's information.

Fixes #20173