### PR TITLE
Rpc: remove not required clone

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -125,46 +125,42 @@ impl RpcSender for HttpSender {
                         .body(request_json)
                         .send()
                 })
-            };
+            }?;
 
-            match response {
-                Ok(response) => {
-                    if !response.status().is_success() {
-                        if response.status() == StatusCode::TOO_MANY_REQUESTS
-                            && too_many_requests_retries > 0
-                        {
-                            let mut duration = Duration::from_millis(500);
-                            if let Some(retry_after) = response.headers().get(RETRY_AFTER) {
-                                if let Ok(retry_after) = retry_after.to_str() {
-                                    if let Ok(retry_after) = retry_after.parse::<u64>() {
-                                        if retry_after < 120 {
-                                            duration = Duration::from_secs(retry_after);
-                                        }
-                                    }
+            if !response.status().is_success() {
+                if response.status() == StatusCode::TOO_MANY_REQUESTS
+                    && too_many_requests_retries > 0
+                {
+                    let mut duration = Duration::from_millis(500);
+                    if let Some(retry_after) = response.headers().get(RETRY_AFTER) {
+                        if let Ok(retry_after) = retry_after.to_str() {
+                            if let Ok(retry_after) = retry_after.parse::<u64>() {
+                                if retry_after < 120 {
+                                    duration = Duration::from_secs(retry_after);
                                 }
                             }
+                        }
+                    }
 
-                            too_many_requests_retries -= 1;
-                            debug!(
+                    too_many_requests_retries -= 1;
+                    debug!(
                                 "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
                                 response, too_many_requests_retries, duration
                             );
 
-                            sleep(duration);
-                            stats_updater.add_rate_limited_time(duration);
-                            continue;
-                        }
-                        return Err(response.error_for_status().unwrap_err().into());
-                    }
+                    sleep(duration);
+                    stats_updater.add_rate_limited_time(duration);
+                    continue;
+                }
+                return Err(response.error_for_status().unwrap_err().into());
+            }
 
-                    let response_text = tokio::task::block_in_place(move || response.text())?;
-
-                    let json: serde_json::Value = serde_json::from_str(&response_text)?;
-                    if json["error"].is_object() {
-                        return match serde_json::from_value::<RpcErrorObject>(json["error"].clone())
-                        {
-                            Ok(rpc_error_object) => {
-                                let data = match rpc_error_object.code {
+            let mut json =
+                tokio::task::block_in_place(move || response.json::<serde_json::Value>())?;
+            if json["error"].is_object() {
+                return match serde_json::from_value::<RpcErrorObject>(json["error"].clone()) {
+                    Ok(rpc_error_object) => {
+                        let data = match rpc_error_object.code {
                                     rpc_custom_error::JSON_RPC_SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE => {
                                         match serde_json::from_value::<RpcSimulateTransactionResult>(json["error"]["data"].clone()) {
                                             Ok(data) => RpcResponseErrorData::SendTransactionPreflightFailure(data),
@@ -185,27 +181,22 @@ impl RpcSender for HttpSender {
                                     _ => RpcResponseErrorData::Empty
                                 };
 
-                                Err(RpcError::RpcResponseError {
-                                    code: rpc_error_object.code,
-                                    message: rpc_error_object.message,
-                                    data,
-                                }
-                                .into())
-                            }
-                            Err(err) => Err(RpcError::RpcRequestError(format!(
-                                "Failed to deserialize RPC error response: {} [{}]",
-                                serde_json::to_string(&json["error"]).unwrap(),
-                                err
-                            ))
-                            .into()),
-                        };
+                        Err(RpcError::RpcResponseError {
+                            code: rpc_error_object.code,
+                            message: rpc_error_object.message,
+                            data,
+                        }
+                        .into())
                     }
-                    return Ok(json["result"].clone());
-                }
-                Err(err) => {
-                    return Err(err.into());
-                }
+                    Err(err) => Err(RpcError::RpcRequestError(format!(
+                        "Failed to deserialize RPC error response: {} [{}]",
+                        serde_json::to_string(&json["error"]).unwrap(),
+                        err
+                    ))
+                    .into()),
+                };
             }
+            return Ok(json["result"].take());
         }
     }
 }


### PR DESCRIPTION
#### Problem

For extract value from `serde_json::Value` `clone` call is not required, `take` method can be used.

#### Summary of Changes

`clone` replaced by `take`. In addition, I added `?` operator instead of `match`.

```rust
return Ok(json["result"].clone());
```
changed to
```rust
return Ok(json["result"].take());
```
