### PR TITLE
AcctIdx: when no disk index, always wait for stats

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -158,7 +158,11 @@ impl<T: IndexValue> BucketMapHolder<T> {
         let bins = in_mem.len();
         let flush = self.disk.is_some();
         loop {
-            if self.all_buckets_flushed_at_current_age() {
+            if !flush {
+                self.wait_dirty_or_aged.wait_timeout(Duration::from_millis(
+                    self.stats.remaining_until_next_interval(),
+                ));
+            } else if self.all_buckets_flushed_at_current_age() {
                 let wait = std::cmp::min(
                     self.age_timer.remaining_until_next_interval(AGE_MS),
                     self.stats.remaining_until_next_interval(),


### PR DESCRIPTION
#### Problem
The current logic causes the threads to not wait if we aren't using disk buckets. This will cause those threads to run at 100%.
#### Summary of Changes
Without disk buckets, those threads wait until next stats timeout.
Fixes #
