### PR TITLE
AcctIdx: refactor get to use more refs

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1176,12 +1176,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         let read_lock = self.account_maps[self.bin_calculator.bin_from_pubkey(pubkey)]
             .read()
             .unwrap();
-        let get = read_lock.get(pubkey);
-        get.map(|entry| {
-            let result = user(&mut entry.slot_list.write().unwrap());
-            entry.set_dirty(true);
-            result
-        })
+        read_lock.slot_list_mut(pubkey, user)
     }
 
     pub fn handle_dead_keys(


### PR DESCRIPTION
#### Problem
Use refs in 'get' code paths and push slot_list_mut deeper to use refs.
Note to reviewers: ignore whitespace for the diff.
#### Summary of Changes

Fixes #
