### PR TITLE
cargo-build-bpf: Add Windows support

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -3,11 +3,21 @@
 mkdir -p "$(dirname "$0")"/../dependencies
 cd "$(dirname "$0")"/../dependencies
 
-if [[ "$(uname)" = Darwin ]]; then
-  machine=osx
-else
-  machine=linux
-fi
+unameOut="$(uname -s)"
+case "${unameOut}" in
+  Linux*)
+    criterion_suffix=
+    machine=linux;;
+  Darwin*)
+    criterion_suffix=
+    machine=osx;;
+  MINGW*)
+    criterion_suffix=-mingw
+    machine=windows;;
+  *)
+    criterion_suffix=
+    machine=linux
+esac
 
 download() {
   declare url="$1/$2/$3"
@@ -80,7 +90,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
     job="download \
            https://github.com/Snaipe/Criterion/releases/download \
            $version \
-           criterion-$version-$machine-x86_64.tar.bz2 \
+           criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2 \
            criterion"
     get $version criterion "$job"
   )

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -634,8 +634,12 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
             let dump_script = config.bpf_sdk.join("scripts").join("dump.sh");
             #[cfg(windows)]
             {
-                println!("Dumping program is not supported from `build-bpf` on Windows, and must be done separately.");
-                println!("Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this command.", &dump_script.display(), &program_unstripped_so.display(), &program_dump.display());
+                eprintln!("Using Bash scripts from within a program is not supported on Windows, skipping `--dump`.");
+                eprintln!(
+                    "Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this command to see the processed program dump.",
+                    &dump_script.display(),
+                    &program_unstripped_so.display(),
+                    &program_dump.display());
             }
             #[cfg(not(windows))]
             {

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -463,7 +463,9 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     if legacy_program_feature_present {
         println!("Legacy program feature detected");
     }
-    let bpf_tools_download_file_name = if cfg!(target_os = "macos") {
+    let bpf_tools_download_file_name = if cfg!(target_os = "windows") {
+        "solana-bpf-tools-windows.tar.bz2"
+    } else if cfg!(target_os = "macos") {
         "solana-bpf-tools-osx.tar.bz2"
     } else {
         "solana-bpf-tools-linux.tar.bz2"
@@ -513,16 +515,21 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     env::set_var("AR", llvm_bin.join("llvm-ar"));
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
-    let rustflags = match env::var("RUSTFLAGS") {
+    const RF_LTO: &str = "-C lto=no";
+    let mut rustflags = match env::var("RUSTFLAGS") {
         Ok(rf) => {
-            if rf.contains("-C lto=no") {
+            if rf.contains(&RF_LTO) {
                 rf
             } else {
-                rf + &" -C lto=no".to_string()
+                format!("{} {}", rf, RF_LTO)
             }
         }
-        _ => "-C lto=no".to_string(),
+        _ => RF_LTO.to_string(),
     };
+    if cfg!(windows) && !rustflags.contains("-C linker=") {
+        let ld_path = llvm_bin.join("ld.lld");
+        rustflags = format!("{} -C linker={}", rustflags, ld_path.display());
+    }
     if config.verbose {
         println!("RUSTFLAGS={}", rustflags);
     }
@@ -602,6 +609,17 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         }
 
         if file_older_or_missing(&program_unstripped_so, &program_so) {
+            #[cfg(windows)]
+            let output = spawn(
+                &llvm_bin.join("llvm-objcopy"),
+                &[
+                    "--strip-all".as_ref(),
+                    program_unstripped_so.as_os_str(),
+                    program_so.as_os_str(),
+                ],
+                config.generate_child_script_on_failure,
+            );
+            #[cfg(not(windows))]
             let output = spawn(
                 &config.bpf_sdk.join("scripts").join("strip.sh"),
                 &[&program_unstripped_so, &program_so],
@@ -613,13 +631,22 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         }
 
         if config.dump && file_older_or_missing(&program_unstripped_so, &program_dump) {
-            let output = spawn(
-                &config.bpf_sdk.join("scripts").join("dump.sh"),
-                &[&program_unstripped_so, &program_dump],
-                config.generate_child_script_on_failure,
-            );
-            if config.verbose {
-                println!("{}", output);
+            let dump_script = config.bpf_sdk.join("scripts").join("dump.sh");
+            #[cfg(windows)]
+            {
+                println!("Dumping program is not supported from `build-bpf` on Windows, and must be done separately.");
+                println!("Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this command.", &dump_script.display(), &program_unstripped_so.display(), &program_dump.display());
+            }
+            #[cfg(not(windows))]
+            {
+                let output = spawn(
+                    &dump_script,
+                    &[&program_unstripped_so, &program_dump],
+                    config.generate_child_script_on_failure,
+                );
+                if config.verbose {
+                    println!("{}", output);
+                }
             }
             postprocess_dump(&program_dump);
         }
@@ -678,10 +705,6 @@ fn build_bpf(config: Config, manifest_path: Option<PathBuf>) {
 }
 
 fn main() {
-    if cfg!(windows) {
-        println!("Solana Rust BPF toolchain is not available on Windows");
-        exit(1);
-    }
     let default_config = Config::default();
     let default_bpf_sdk = format!("{}", default_config.bpf_sdk.display());
 


### PR DESCRIPTION
#### Problem

`cargo-build-bpf` doesn't support windows

#### Summary of Changes

Add support for it!

A few notes:
* `ld` doesn't ship by default with mingw, causing `linker not found` errors, so one of the changes is to force the usage of `ld.lld` from the sdk to link.  I have very little knowledge of different linker flavors, but this was the only one that worked.  If you think it should be another one, please let me know.
* it isn't possible to run bash scripts from the program, since they aren't natively executable by windows.  To get around that, this avoids calling `strip.sh` and just calls `llvm-objcopy` directly.
* for `dump.sh`, it's possible to run the script separately, and re-run `cargo build-bpf --dump` to do the postprocessing step.  it isn't elegant, but it actually works!

Fixes #
