### PR TITLE
v1.6: Combine program write-lock features

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -140,7 +140,7 @@ fn format_account_mode(message: &Message, index: usize) -> String {
         } else {
             "-"
         },
-        if message.is_writable(index, /* restore_write_lock_when_upgradeable=*/ true) {
+        if message.is_writable(index, /* demote_program_write_locks=*/ true) {
             "w" // comment for consistent rust fmt (no joking; lol)
         } else {
             "-"

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -109,10 +109,9 @@ impl TransactionStatusService {
                             })
                             .expect("FeeCalculator must exist");
                         let fee = fee_calculator.calculate_fee(transaction.message());
-                        let (writable_keys, readonly_keys) =
-                            transaction.message.get_account_keys_by_lock_type(
-                                bank.restore_write_lock_when_upgradeable(),
-                            );
+                        let (writable_keys, readonly_keys) = transaction
+                            .message
+                            .get_account_keys_by_lock_type(bank.demote_program_write_locks());
 
                         let inner_instructions = inner_instructions.map(|inner_instructions| {
                             inner_instructions

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -19,7 +19,7 @@ use {
         clock::{Clock, Slot},
         entrypoint::{ProgramResult, SUCCESS},
         epoch_schedule::EpochSchedule,
-        feature_set::restore_write_lock_when_upgradeable,
+        feature_set::demote_program_write_locks,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         genesis_config::{ClusterType, GenesisConfig},
         hash::Hash,
@@ -256,14 +256,14 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             }
             panic!("Program id {} wasn't found in account_infos", program_id);
         };
-        let restore_write_lock_when_upgradeable =
-            invoke_context.is_feature_active(&restore_write_lock_when_upgradeable::id());
+        let demote_program_write_locks =
+            invoke_context.is_feature_active(&demote_program_write_locks::id());
         // TODO don't have the caller's keyed_accounts so can't validate writer or signer escalation or deescalation yet
         let caller_privileges = message
             .account_keys
             .iter()
             .enumerate()
-            .map(|(i, _)| message.is_writable(i, restore_write_lock_when_upgradeable))
+            .map(|(i, _)| message.is_writable(i, demote_program_write_locks))
             .collect::<Vec<bool>>();
 
         stable_log::program_invoke(&logger, &program_id, invoke_context.invoke_depth());
@@ -334,7 +334,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
         // Copy writeable account modifications back into the caller's AccountInfos
         for (i, account_pubkey) in message.account_keys.iter().enumerate() {
-            if !message.is_writable(i, restore_write_lock_when_upgradeable) {
+            if !message.is_writable(i, demote_program_write_locks) {
                 continue;
             }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -172,9 +172,9 @@ impl Accounts {
 
     fn construct_instructions_account(
         message: &Message,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) -> AccountSharedData {
-        let mut data = message.serialize_instructions(restore_write_lock_when_upgradeable);
+        let mut data = message.serialize_instructions(demote_program_write_locks);
         // add room for current instruction index.
         data.resize(data.len() + 2, 0);
         AccountSharedData::from(Account {
@@ -204,8 +204,8 @@ impl Accounts {
             let mut accounts = Vec::with_capacity(message.account_keys.len());
             let mut account_deps = Vec::with_capacity(message.account_keys.len());
             let mut rent_debits = RentDebits::default();
-            let restore_write_lock_when_upgradeable =
-                feature_set.is_active(&feature_set::restore_write_lock_when_upgradeable::id());
+            let demote_program_write_locks =
+                feature_set.is_active(&feature_set::demote_program_write_locks::id());
 
             for (i, key) in message.account_keys.iter().enumerate() {
                 let account = if message.is_non_loader_key(key, i) {
@@ -216,16 +216,13 @@ impl Accounts {
                     if solana_sdk::sysvar::instructions::check_id(key)
                         && feature_set.is_active(&feature_set::instructions_sysvar_enabled::id())
                     {
-                        Self::construct_instructions_account(
-                            message,
-                            restore_write_lock_when_upgradeable,
-                        )
+                        Self::construct_instructions_account(message, demote_program_write_locks)
                     } else {
                         let (account, rent) = self
                             .accounts_db
                             .load(ancestors, key)
                             .map(|(mut account, _)| {
-                                if message.is_writable(i, restore_write_lock_when_upgradeable) {
+                                if message.is_writable(i, demote_program_write_locks) {
                                     let rent_due = rent_collector
                                         .collect_from_existing_account(&key, &mut account);
                                     (account, rent_due)
@@ -236,7 +233,7 @@ impl Accounts {
                             .unwrap_or_default();
 
                         if bpf_loader_upgradeable::check_id(&account.owner) {
-                            if message.is_writable(i, restore_write_lock_when_upgradeable)
+                            if message.is_writable(i, demote_program_write_locks)
                                 && !message.is_upgradeable_loader_present()
                             {
                                 error_counters.invalid_writable_account += 1;
@@ -265,7 +262,7 @@ impl Accounts {
                                 }
                             }
                         } else if account.executable
-                            && message.is_writable(i, restore_write_lock_when_upgradeable)
+                            && message.is_writable(i, demote_program_write_locks)
                         {
                             error_counters.invalid_writable_account += 1;
                             return Err(TransactionError::InvalidWritableAccount);
@@ -790,7 +787,7 @@ impl Accounts {
         tx: &Transaction,
         result: &Result<()>,
         locks: &mut AccountLocks,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) {
         match result {
             Err(TransactionError::AccountInUse) => (),
@@ -799,7 +796,7 @@ impl Accounts {
             _ => {
                 let (writable_keys, readonly_keys) = &tx
                     .message()
-                    .get_account_keys_by_lock_type(restore_write_lock_when_upgradeable);
+                    .get_account_keys_by_lock_type(demote_program_write_locks);
                 for k in writable_keys {
                     locks.unlock_write(k);
                 }
@@ -831,7 +828,7 @@ impl Accounts {
     pub fn lock_accounts<'a>(
         &self,
         txs: impl Iterator<Item = &'a Transaction>,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) -> Vec<Result<()>> {
         use solana_sdk::sanitize::Sanitize;
         let keys: Vec<Result<_>> = txs
@@ -844,7 +841,7 @@ impl Accounts {
 
                 Ok(tx
                     .message()
-                    .get_account_keys_by_lock_type(restore_write_lock_when_upgradeable))
+                    .get_account_keys_by_lock_type(demote_program_write_locks))
             })
             .collect();
         let mut account_locks = &mut self.account_locks.lock().unwrap();
@@ -863,7 +860,7 @@ impl Accounts {
         &self,
         txs: impl Iterator<Item = &'a Transaction>,
         results: &[Result<()>],
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) {
         let mut account_locks = self.account_locks.lock().unwrap();
         debug!("bank unlock accounts");
@@ -872,7 +869,7 @@ impl Accounts {
                 tx,
                 lock_result,
                 &mut account_locks,
-                restore_write_lock_when_upgradeable,
+                demote_program_write_locks,
             );
         }
     }
@@ -890,7 +887,7 @@ impl Accounts {
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
         fix_recent_blockhashes_sysvar_delay: bool,
         merge_nonce_error_into_system_error: bool,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) {
         let accounts_to_store = self.collect_accounts_to_store(
             txs,
@@ -900,7 +897,7 @@ impl Accounts {
             last_blockhash_with_fee_calculator,
             fix_recent_blockhashes_sysvar_delay,
             merge_nonce_error_into_system_error,
-            restore_write_lock_when_upgradeable,
+            demote_program_write_locks,
         );
         self.accounts_db.store_cached(slot, &accounts_to_store);
     }
@@ -926,7 +923,7 @@ impl Accounts {
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
         fix_recent_blockhashes_sysvar_delay: bool,
         merge_nonce_error_into_system_error: bool,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) -> Vec<(&'a Pubkey, &'a AccountSharedData)> {
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _nonce_rollback), tx)) in loaded.iter_mut().zip(txs).enumerate() {
@@ -979,7 +976,7 @@ impl Accounts {
                     fee_payer_index = Some(i);
                 }
                 let is_fee_payer = Some(i) == fee_payer_index;
-                if message.is_writable(i, restore_write_lock_when_upgradeable)
+                if message.is_writable(i, demote_program_write_locks)
                     && (res.is_ok()
                         || (maybe_nonce_rollback.is_some() && (is_nonce_account || is_fee_payer)))
                 {
@@ -2015,7 +2012,7 @@ mod tests {
         accounts.store_slow_uncached(0, &keypair2.pubkey(), &account2);
         accounts.store_slow_uncached(0, &keypair3.pubkey(), &account3);
 
-        let restore_write_lock_when_upgradeable = true;
+        let demote_program_write_locks = true;
 
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
         let message = Message::new_with_compiled_instructions(
@@ -2027,8 +2024,7 @@ mod tests {
             instructions,
         );
         let tx = Transaction::new(&[&keypair0], message, Hash::default());
-        let results0 =
-            accounts.lock_accounts([tx.clone()].iter(), restore_write_lock_when_upgradeable);
+        let results0 = accounts.lock_accounts([tx.clone()].iter(), demote_program_write_locks);
 
         assert!(results0[0].is_ok());
         assert_eq!(
@@ -2063,7 +2059,7 @@ mod tests {
         );
         let tx1 = Transaction::new(&[&keypair1], message, Hash::default());
         let txs = vec![tx0, tx1];
-        let results1 = accounts.lock_accounts(txs.iter(), restore_write_lock_when_upgradeable);
+        let results1 = accounts.lock_accounts(txs.iter(), demote_program_write_locks);
 
         assert!(results1[0].is_ok()); // Read-only account (keypair1) can be referenced multiple times
         assert!(results1[1].is_err()); // Read-only account (keypair1) cannot also be locked as writable
@@ -2078,8 +2074,8 @@ mod tests {
             2
         );
 
-        accounts.unlock_accounts([tx].iter(), &results0, restore_write_lock_when_upgradeable);
-        accounts.unlock_accounts(txs.iter(), &results1, restore_write_lock_when_upgradeable);
+        accounts.unlock_accounts([tx].iter(), &results0, demote_program_write_locks);
+        accounts.unlock_accounts(txs.iter(), &results1, demote_program_write_locks);
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
         let message = Message::new_with_compiled_instructions(
             1,
@@ -2090,7 +2086,7 @@ mod tests {
             instructions,
         );
         let tx = Transaction::new(&[&keypair1], message, Hash::default());
-        let results2 = accounts.lock_accounts([tx].iter(), restore_write_lock_when_upgradeable);
+        let results2 = accounts.lock_accounts([tx].iter(), demote_program_write_locks);
         assert!(results2[0].is_ok()); // Now keypair1 account can be locked as writable
 
         // Check that read-only lock with zero references is deleted
@@ -2126,7 +2122,7 @@ mod tests {
         accounts.store_slow_uncached(0, &keypair1.pubkey(), &account1);
         accounts.store_slow_uncached(0, &keypair2.pubkey(), &account2);
 
-        let restore_write_lock_when_upgradeable = true;
+        let demote_program_write_locks = true;
 
         let accounts_arc = Arc::new(accounts);
 
@@ -2162,17 +2158,13 @@ mod tests {
                 let txs = vec![writable_tx.clone()];
                 let results = accounts_clone
                     .clone()
-                    .lock_accounts(txs.iter(), restore_write_lock_when_upgradeable);
+                    .lock_accounts(txs.iter(), demote_program_write_locks);
                 for result in results.iter() {
                     if result.is_ok() {
                         counter_clone.clone().fetch_add(1, Ordering::SeqCst);
                     }
                 }
-                accounts_clone.unlock_accounts(
-                    txs.iter(),
-                    &results,
-                    restore_write_lock_when_upgradeable,
-                );
+                accounts_clone.unlock_accounts(txs.iter(), &results, demote_program_write_locks);
                 if exit_clone.clone().load(Ordering::Relaxed) {
                     break;
                 }
@@ -2183,13 +2175,13 @@ mod tests {
             let txs = vec![readonly_tx.clone()];
             let results = accounts_arc
                 .clone()
-                .lock_accounts(txs.iter(), restore_write_lock_when_upgradeable);
+                .lock_accounts(txs.iter(), demote_program_write_locks);
             if results[0].is_ok() {
                 let counter_value = counter_clone.clone().load(Ordering::SeqCst);
                 thread::sleep(time::Duration::from_millis(50));
                 assert_eq!(counter_value, counter_clone.clone().load(Ordering::SeqCst));
             }
-            accounts_arc.unlock_accounts(txs.iter(), &results, restore_write_lock_when_upgradeable);
+            accounts_arc.unlock_accounts(txs.iter(), &results, demote_program_write_locks);
             thread::sleep(time::Duration::from_millis(50));
         }
         exit.store(true, Ordering::Relaxed);
@@ -2218,7 +2210,7 @@ mod tests {
         accounts.store_slow_uncached(0, &keypair2.pubkey(), &account2);
         accounts.store_slow_uncached(0, &keypair3.pubkey(), &account3);
 
-        let restore_write_lock_when_upgradeable = true;
+        let demote_program_write_locks = true;
 
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
         let message = Message::new_with_compiled_instructions(
@@ -2230,7 +2222,7 @@ mod tests {
             instructions,
         );
         let tx = Transaction::new(&[&keypair0], message, Hash::default());
-        let results0 = accounts.lock_accounts([tx].iter(), restore_write_lock_when_upgradeable);
+        let results0 = accounts.lock_accounts([tx].iter(), demote_program_write_locks);
 
         assert!(results0[0].is_ok());
         // Instruction program-id account demoted to readonly
@@ -2347,7 +2339,7 @@ mod tests {
             &(Hash::default(), FeeCalculator::default()),
             true,
             true, // merge_nonce_error_into_system_error
-            true, // restore_write_lock_when_upgradeable
+            true, // demote_program_write_locks
         );
         assert_eq!(collected_accounts.len(), 2);
         assert!(collected_accounts
@@ -2733,7 +2725,7 @@ mod tests {
             &(next_blockhash, FeeCalculator::default()),
             true,
             true, // merge_nonce_error_into_system_error
-            true, // restore_write_lock_when_upgradeable
+            true, // demote_program_write_locks
         );
         assert_eq!(collected_accounts.len(), 2);
         assert_eq!(
@@ -2850,7 +2842,7 @@ mod tests {
             &(next_blockhash, FeeCalculator::default()),
             true,
             true, // merge_nonce_error_into_system_error
-            true, // restore_write_lock_when_upgradeable
+            true, // demote_program_write_locks
         );
         assert_eq!(collected_accounts.len(), 1);
         let collected_nonce_account = collected_accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2505,7 +2505,7 @@ impl Bank {
         let hashed_txs: Vec<HashedTransaction> = txs.map(HashedTransaction::from).collect();
         let lock_results = self.rc.accounts.lock_accounts(
             hashed_txs.as_transactions_iter(),
-            self.restore_write_lock_when_upgradeable(),
+            self.demote_program_write_locks(),
         );
         TransactionBatch::new(lock_results, self, Cow::Owned(hashed_txs))
     }
@@ -2516,7 +2516,7 @@ impl Bank {
     ) -> TransactionBatch<'a, 'b> {
         let lock_results = self.rc.accounts.lock_accounts(
             hashed_txs.as_transactions_iter(),
-            self.restore_write_lock_when_upgradeable(),
+            self.demote_program_write_locks(),
         );
         TransactionBatch::new(lock_results, self, Cow::Borrowed(hashed_txs))
     }
@@ -2588,7 +2588,7 @@ impl Bank {
             self.rc.accounts.unlock_accounts(
                 batch.transactions_iter(),
                 batch.lock_results(),
-                self.restore_write_lock_when_upgradeable(),
+                self.demote_program_write_locks(),
             )
         }
     }
@@ -3335,7 +3335,7 @@ impl Bank {
             &self.last_blockhash_with_fee_calculator(),
             self.fix_recent_blockhashes_sysvar_delay(),
             self.merge_nonce_error_into_system_error(),
-            self.restore_write_lock_when_upgradeable(),
+            self.demote_program_write_locks(),
         );
         let rent_debits = self.collect_rent(executed, loaded_accounts);
 
@@ -4891,9 +4891,9 @@ impl Bank {
             .is_active(&feature_set::stakes_remove_delegation_if_inactive::id())
     }
 
-    pub fn restore_write_lock_when_upgradeable(&self) -> bool {
+    pub fn demote_program_write_locks(&self) -> bool {
         self.feature_set
-            .is_active(&feature_set::restore_write_lock_when_upgradeable::id())
+            .is_active(&feature_set::demote_program_write_locks::id())
     }
 
     // Check if the wallclock time from bank creation to now has exceeded the allotted

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -373,7 +373,7 @@ impl Message {
         self.program_position(i).is_some()
     }
 
-    pub fn is_writable(&self, i: usize, restore_write_lock_when_upgradeable: bool) -> bool {
+    pub fn is_writable(&self, i: usize, demote_program_write_locks: bool) -> bool {
         (i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize
             || (i >= self.header.num_required_signatures as usize
@@ -384,7 +384,7 @@ impl Message {
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
             && (!self.is_key_called_as_program(i)
-                || (restore_write_lock_when_upgradeable && self.is_upgradeable_loader_present()))
+                || (demote_program_write_locks && self.is_upgradeable_loader_present()))
     }
 
     pub fn is_signer(&self, i: usize) -> bool {
@@ -393,12 +393,12 @@ impl Message {
 
     pub fn get_account_keys_by_lock_type(
         &self,
-        restore_write_lock_when_upgradeable: bool,
+        demote_program_write_locks: bool,
     ) -> (Vec<&Pubkey>, Vec<&Pubkey>) {
         let mut writable_keys = vec![];
         let mut readonly_keys = vec![];
         for (i, key) in self.account_keys.iter().enumerate() {
-            if self.is_writable(i, restore_write_lock_when_upgradeable) {
+            if self.is_writable(i, demote_program_write_locks) {
                 writable_keys.push(key);
             } else {
                 readonly_keys.push(key);
@@ -420,7 +420,7 @@ impl Message {
     //   35..67 - program_id
     //   67..69 - data len - u16
     //   69..data_len - data
-    pub fn serialize_instructions(&self, restore_write_lock_when_upgradeable: bool) -> Vec<u8> {
+    pub fn serialize_instructions(&self, demote_program_write_locks: bool) -> Vec<u8> {
         // 64 bytes is a reasonable guess, calculating exactly is slower in benchmarks
         let mut data = Vec::with_capacity(self.instructions.len() * (32 * 2));
         append_u16(&mut data, self.instructions.len() as u16);
@@ -435,8 +435,7 @@ impl Message {
             for account_index in &instruction.accounts {
                 let account_index = *account_index as usize;
                 let is_signer = self.is_signer(account_index);
-                let is_writable =
-                    self.is_writable(account_index, restore_write_lock_when_upgradeable);
+                let is_writable = self.is_writable(account_index, demote_program_write_locks);
                 let mut meta_byte = 0;
                 if is_signer {
                     meta_byte |= 1 << Self::IS_SIGNER_BIT;
@@ -881,13 +880,13 @@ mod tests {
             recent_blockhash: Hash::default(),
             instructions: vec![],
         };
-        let restore_write_lock_when_upgradeable = true;
-        assert!(message.is_writable(0, restore_write_lock_when_upgradeable));
-        assert!(!message.is_writable(1, restore_write_lock_when_upgradeable));
-        assert!(!message.is_writable(2, restore_write_lock_when_upgradeable));
-        assert!(message.is_writable(3, restore_write_lock_when_upgradeable));
-        assert!(message.is_writable(4, restore_write_lock_when_upgradeable));
-        assert!(!message.is_writable(5, restore_write_lock_when_upgradeable));
+        let demote_program_write_locks = true;
+        assert!(message.is_writable(0, demote_program_write_locks));
+        assert!(!message.is_writable(1, demote_program_write_locks));
+        assert!(!message.is_writable(2, demote_program_write_locks));
+        assert!(message.is_writable(3, demote_program_write_locks));
+        assert!(message.is_writable(4, demote_program_write_locks));
+        assert!(!message.is_writable(5, demote_program_write_locks));
     }
 
     #[test]
@@ -915,7 +914,7 @@ mod tests {
             Some(&id1),
         );
         assert_eq!(
-            message.get_account_keys_by_lock_type(/*restore_write_lock_when_upgradeable=*/ true),
+            message.get_account_keys_by_lock_type(/*demote_program_write_locks=*/ true),
             (vec![&id1, &id0], vec![&id3, &id2, &program_id])
         );
     }
@@ -945,8 +944,7 @@ mod tests {
         ];
 
         let message = Message::new(&instructions, Some(&id1));
-        let serialized =
-            message.serialize_instructions(/*restore_write_lock_when_upgradeable=*/ true);
+        let serialized = message.serialize_instructions(/*demote_program_write_locks=*/ true);
         for (i, instruction) in instructions.iter().enumerate() {
             assert_eq!(
                 Message::deserialize_instruction(i, &serialized).unwrap(),
@@ -967,8 +965,7 @@ mod tests {
         ];
 
         let message = Message::new(&instructions, Some(&id1));
-        let serialized =
-            message.serialize_instructions(/*restore_write_lock_when_upgradeable=*/ true);
+        let serialized = message.serialize_instructions(/*demote_program_write_locks=*/ true);
         assert_eq!(
             Message::deserialize_instruction(instructions.len(), &serialized).unwrap_err(),
             SanitizeError::IndexOutOfBounds,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -174,10 +174,6 @@ pub mod stakes_remove_delegation_if_inactive {
     solana_sdk::declare_id!("HFpdDDNQjvcXnXKec697HDDsyk6tFoWS2o8fkxuhQZpL");
 }
 
-pub mod restore_write_lock_when_upgradeable {
-    solana_sdk::declare_id!("3Tye2iVqQTxprFSJNpyz5W6SjKNQVfRUDR2s3oVYS6h6");
-}
-
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -218,9 +214,8 @@ lazy_static! {
         (libsecp256k1_0_5_upgrade_enabled::id(), "upgrade libsecp256k1 to v0.5.0"),
         (merge_nonce_error_into_system_error::id(), "merge NonceError into SystemError"),
         (spl_token_v2_set_authority_fix::id(), "spl-token set_authority fix"),
-        (demote_program_write_locks::id(), "demote program write locks to readonly #19593"),
+        (demote_program_write_locks::id(), "demote program write locks to readonly, except when upgradeable loader present #19593 #20263"),
         (stakes_remove_delegation_if_inactive::id(), "remove delegations from stakes cache when inactive"),
-        (restore_write_lock_when_upgradeable::id(), "restore program-id write lock when upgradeable loader present"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -13,7 +13,7 @@ pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
     for (i, account_key) in message.account_keys.iter().enumerate() {
         accounts.push(ParsedAccount {
             pubkey: account_key.to_string(),
-            writable: message.is_writable(i, /*restore_write_lock_when_upgradeable=*/ true),
+            writable: message.is_writable(i, /*demote_program_write_locks=*/ true),
             signer: message.is_signer(i),
         });
     }


### PR DESCRIPTION
#### Problem
The dummy feature `demote_program_write_locks` is superfluous, since there is now a 2nd feature governing for program write-locks (`restore_write_lock_when_upgradeable`) and neither are activated on devnet/testnet.

#### Summary of Changes
Remove the new feature definition and repurpose `demote_program_write_locks` to wrap the #20263 behavior.
As described elsewhere, this feature needs to be activated before upgrading mainnet-beta to v1.7.
