### PR TITLE
Simplify return_data accessors in InvokeContext

### DIFF
--- a/program-runtime/src/instruction_processor.rs
+++ b/program-runtime/src/instruction_processor.rs
@@ -595,7 +595,7 @@ impl InstructionProcessor {
         invoke_context.verify_and_update(instruction, account_indices, caller_write_privileges)?;
 
         // clear the return data
-        invoke_context.set_return_data(None);
+        invoke_context.set_return_data(Vec::new())?;
 
         // Invoke callee
         invoke_context.push(

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -230,7 +230,7 @@ fn run_program(
     for i in 0..2 {
         let mut parameter_bytes = parameter_bytes.clone();
         {
-            invoke_context.set_return_data(None);
+            invoke_context.set_return_data(Vec::new()).unwrap();
 
             let mut vm = create_vm(
                 &loader_id,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -945,9 +945,9 @@ impl Executor for BpfExecutor {
                 trace!("BPF Program Instruction Trace:\n{}", trace_string);
             }
             drop(vm);
-            let return_data = invoke_context.get_return_data();
-            if let Some((program_id, return_data)) = return_data {
-                stable_log::program_return(&logger, program_id, return_data);
+            let (program_id, return_data) = invoke_context.get_return_data();
+            if !return_data.is_empty() {
+                stable_log::program_return(&logger, &program_id, return_data);
             }
             match result {
                 Ok(status) => {
@@ -960,7 +960,7 @@ impl Executor for BpfExecutor {
                         } else {
                             status.into()
                         };
-                        stable_log::program_failure(&logger, program_id, &error);
+                        stable_log::program_failure(&logger, &program_id, &error);
                         return Err(error);
                     }
                 }
@@ -974,7 +974,7 @@ impl Executor for BpfExecutor {
                             InstructionError::ProgramFailedToComplete
                         }
                     };
-                    stable_log::program_failure(&logger, program_id, &error);
+                    stable_log::program_failure(&logger, &program_id, &error);
                     return Err(error);
                 }
             }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -43,7 +43,6 @@ use solana_sdk::{
 use std::{
     alloc::Layout,
     cell::{Ref, RefCell, RefMut},
-    cmp::min,
     mem::{align_of, size_of},
     rc::Rc,
     slice::from_raw_parts_mut,
@@ -2322,23 +2321,21 @@ impl<'a> SyscallObject<BpfError> for SyscallSetReturnData<'a> {
             return;
         }
 
-        if len == 0 {
-            invoke_context.set_return_data(None);
+        let return_data = if len == 0 {
+            Vec::new()
         } else {
-            let return_data = question_mark!(
+            question_mark!(
                 translate_slice::<u8>(memory_mapping, addr, len, self.loader_id),
                 result
-            );
-
-            let program_id = *question_mark!(
-                invoke_context
-                    .get_caller()
-                    .map_err(SyscallError::InstructionError),
-                result
-            );
-
-            invoke_context.set_return_data(Some((program_id, return_data.to_vec())));
-        }
+            )
+            .to_vec()
+        };
+        question_mark!(
+            invoke_context
+                .set_return_data(return_data)
+                .map_err(SyscallError::InstructionError),
+            result
+        );
 
         *result = Ok(0);
     }
@@ -2352,7 +2349,7 @@ impl<'a> SyscallObject<BpfError> for SyscallGetReturnData<'a> {
     fn call(
         &mut self,
         return_data_addr: u64,
-        len: u64,
+        mut length: u64,
         program_id_addr: u64,
         _arg4: u64,
         _arg5: u64,
@@ -2375,47 +2372,33 @@ impl<'a> SyscallObject<BpfError> for SyscallGetReturnData<'a> {
             result
         );
 
-        if let Some((program_id, return_data)) = invoke_context.get_return_data() {
-            if len != 0 {
-                let length = min(return_data.len() as u64, len);
+        let (program_id, return_data) = invoke_context.get_return_data();
+        length = length.min(return_data.len() as u64);
+        if length != 0 {
+            question_mark!(
+                invoke_context
+                    .get_compute_meter()
+                    .consume((length + size_of::<Pubkey>() as u64) / budget.cpi_bytes_per_unit),
+                result
+            );
 
-                question_mark!(
-                    invoke_context
-                        .get_compute_meter()
-                        .consume((length + size_of::<Pubkey>() as u64) / budget.cpi_bytes_per_unit),
-                    result
-                );
+            let return_data_result = question_mark!(
+                translate_slice_mut::<u8>(memory_mapping, return_data_addr, length, self.loader_id,),
+                result
+            );
 
-                let return_data_result = question_mark!(
-                    translate_slice_mut::<u8>(
-                        memory_mapping,
-                        return_data_addr,
-                        length,
-                        self.loader_id,
-                    ),
-                    result
-                );
+            return_data_result.copy_from_slice(&return_data[..length as usize]);
 
-                return_data_result.copy_from_slice(&return_data[..length as usize]);
+            let program_id_result = question_mark!(
+                translate_slice_mut::<Pubkey>(memory_mapping, program_id_addr, 1, self.loader_id,),
+                result
+            );
 
-                let program_id_result = question_mark!(
-                    translate_slice_mut::<Pubkey>(
-                        memory_mapping,
-                        program_id_addr,
-                        1,
-                        self.loader_id,
-                    ),
-                    result
-                );
-
-                program_id_result[0] = *program_id;
-            }
-
-            // Return the actual length, rather the length returned
-            *result = Ok(return_data.len() as u64);
-        } else {
-            *result = Ok(0);
+            program_id_result[0] = program_id;
         }
+
+        // Return the actual length, rather the length returned
+        *result = Ok(return_data.len() as u64);
     }
 }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -68,8 +68,7 @@ pub struct ThisInvokeContext<'a> {
     sysvars: RefCell<Vec<(Pubkey, Option<Rc<Vec<u8>>>)>>,
     blockhash: &'a Hash,
     fee_calculator: &'a FeeCalculator,
-    // return data and program_id that set it
-    return_data: Option<(Pubkey, Vec<u8>)>,
+    return_data: (Pubkey, Vec<u8>),
 }
 impl<'a> ThisInvokeContext<'a> {
     #[allow(clippy::too_many_arguments)]
@@ -115,7 +114,7 @@ impl<'a> ThisInvokeContext<'a> {
             sysvars: RefCell::new(vec![]),
             blockhash,
             fee_calculator,
-            return_data: None,
+            return_data: (Pubkey::default(), Vec::new()),
         }
     }
 }
@@ -429,11 +428,12 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     fn get_fee_calculator(&self) -> &FeeCalculator {
         self.fee_calculator
     }
-    fn set_return_data(&mut self, return_data: Option<(Pubkey, Vec<u8>)>) {
-        self.return_data = return_data;
+    fn set_return_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
+        self.return_data = (*self.get_caller()?, data);
+        Ok(())
     }
-    fn get_return_data(&self) -> &Option<(Pubkey, Vec<u8>)> {
-        &self.return_data
+    fn get_return_data(&self) -> (Pubkey, &[u8]) {
+        (self.return_data.0, &self.return_data.1)
     }
 }
 pub struct ThisLogger {


### PR DESCRIPTION
#### Problem
Internally the handling of `return_data` in `InvokeContext` is more complex than it needs to be and it hinders integration in ABI v2.

#### Summary of Changes
* Automatically retrieves `program_id` from `invocation_stack`
* Removes the `Option::None` and instead use an empty data `Vec` for that
* Syscall interfaces remain the same

Fixes #
