### PR TITLE
ProgramTest now rejects transactions that are too large

### DIFF
--- a/program-test/tests/toolarge.rs
+++ b/program-test/tests/toolarge.rs
@@ -1,0 +1,31 @@
+use {
+    solana_program_test::ProgramTest,
+    solana_sdk::{
+        instruction::Instruction, packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Signer,
+        transaction::Transaction,
+    },
+};
+
+#[tokio::test]
+async fn test_transaction_too_large() {
+    let (mut banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
+
+    let mut transaction = Transaction::new_with_payer(
+        &[Instruction {
+            program_id: Pubkey::default(),
+            accounts: vec![],
+            data: [42; PACKET_DATA_SIZE * 2].to_vec(),
+        }],
+        Some(&payer.pubkey()),
+    );
+    transaction.sign(&[&payer], recent_blockhash);
+
+    assert_eq!(
+        "transport transaction error: Transaction too large",
+        &banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .to_string(),
+    );
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -186,7 +186,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "5Br3PNyyX1L7XoS4jYLt5JTeMXowLSsu7v9LhokC8vnq")]
+#[frozen_abi(digest = "BwV8A4QVirumG226C5SsSo5BnYo8DLJGaoDx4fYqQ2Z9")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>;
 

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -122,6 +122,10 @@ pub enum TransactionError {
     /// Transaction loads a writable account that cannot be written
     #[error("Transaction loads a writable account that cannot be written")]
     InvalidWritableAccount,
+
+    /// Transaction is too large
+    #[error("Transaction too large")]
+    TooLarge,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -44,6 +44,7 @@ enum TransactionErrorType {
     WOULD_EXCEED_MAX_BLOCK_COST_LIMIT = 17;
     UNSUPPORTED_VERSION = 18;
     INVALID_WRITABLE_ACCOUNT = 19;
+    TOO_LARGE = 20;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -551,6 +551,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             17 => TransactionError::WouldExceedMaxBlockCostLimit,
             18 => TransactionError::UnsupportedVersion,
             19 => TransactionError::InvalidWritableAccount,
+            20 => TransactionError::TooLarge,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -618,6 +619,7 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 TransactionError::InvalidWritableAccount => {
                     tx_by_addr::TransactionErrorType::InvalidWritableAccount
                 }
+                TransactionError::TooLarge => tx_by_addr::TransactionErrorType::TooLarge,
             } as i32,
             instruction_error: match transaction_error {
                 TransactionError::InstructionError(index, ref instruction_error) => {


### PR DESCRIPTION
Make ProgramTest match RPC and reject transactions that are too large for a more realistic unit test environment