### PR TITLE
fix: use stable endpoints for getBlocks

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3119,7 +3119,7 @@ export class Connection {
       endSlot !== undefined ? [startSlot, endSlot] : [startSlot],
       commitment,
     );
-    const unsafeRes = await this._rpcRequest('getBlocks', args);
+    const unsafeRes = await this._rpcRequest('getConfirmedBlocks', args);
     const res = create(unsafeRes, jsonRpcResult(array(number())));
     if ('error' in res) {
       throw new Error('failed to get blocks: ' + res.error.message);

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -2080,7 +2080,7 @@ describe('Connection', () => {
 
   it('get blocks between two slots', async () => {
     await mockRpcResponse({
-      method: 'getBlocks',
+      method: 'getConfirmedBlocks',
       params: [0, 10],
       value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     });
@@ -2100,7 +2100,7 @@ describe('Connection', () => {
 
   it('get blocks from starting slot', async () => {
     await mockRpcResponse({
-      method: 'getBlocks',
+      method: 'getConfirmedBlocks',
       params: [0],
       value: [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,


### PR DESCRIPTION
#### Problem
`getBlocks` isn't stable yet (not on v1.6 so not supported on mainnet-beta) so the web3 method should call `getConfirmedBlocks` for now.

#### Summary of Changes
- Switch underlying RPC method from `getBlocks` to `getConfirmedBlocks` for `Connection.getBlocks`

Fixes #
