### PR TITLE
adds unprefixed_malloc_on_supported_platforms to jemalloc

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -50,7 +50,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.8.0" }
 symlink = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = {package = "tikv-jemallocator", version = "0.4.1"}
+jemallocator = {package = "tikv-jemallocator", version = "0.4.1", feautres = ["unprefixed_malloc_on_supported_platforms"]}
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.103"


### PR DESCRIPTION
#### Problem
Without this feature jemalloc is used only for Rust code but not for
bundled C/C++ libraries (like rocksdb).
https://github.com/solana-labs/solana/issues/14366#issuecomment-930404992

#### Summary of Changes
added the feature