### PR TITLE
v1.7: remove original write-lock gating

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -247,8 +247,7 @@ impl Accounts {
                             .unwrap_or_default();
 
                         if bpf_loader_upgradeable::check_id(account.owner()) {
-                            if demote_program_write_locks
-                                && message.is_writable(i, demote_program_write_locks)
+                            if message.is_writable(i, demote_program_write_locks)
                                 && !message.is_upgradeable_loader_present()
                             {
                                 error_counters.invalid_writable_account += 1;
@@ -277,7 +276,6 @@ impl Accounts {
                                 }
                             }
                         } else if account.executable()
-                            && demote_program_write_locks
                             && message.is_writable(i, demote_program_write_locks)
                         {
                             error_counters.invalid_writable_account += 1;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6445,10 +6445,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             bank.process_transaction(&tx),
-            Err(TransactionError::InstructionError(
-                0,
-                InstructionError::ExecutableLamportChange
-            ))
+            Err(TransactionError::InvalidWritableAccount)
         );
         assert_eq!(bank.get_balance(&account_pubkey), account_balance);
     }

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -402,9 +402,6 @@ impl Message {
     }
 
     pub fn is_writable(&self, i: usize, demote_program_write_locks: bool) -> bool {
-        let demote_program_id = demote_program_write_locks
-            && self.is_key_called_as_program(i)
-            && !self.is_upgradeable_loader_present();
         (i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize
             || (i >= self.header.num_required_signatures as usize
@@ -414,7 +411,8 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && !demote_program_id
+            && (!self.is_key_called_as_program(i)
+                || (demote_program_write_locks && self.is_upgradeable_loader_present()))
     }
 
     pub fn is_signer(&self, i: usize) -> bool {


### PR DESCRIPTION
#### Problem
v1.7 is incompatible with v1.6 until the `demote_program_write_locks` feature is activated. But we want to test v1.7 on mainnet-beta sooner.

#### Summary of Changes
Remove original feature gating to restore compatibility

- [x] Needs rebase on #20332 
