### PR TITLE
Properly enable unprefixed_malloc_on_supported_platforms in tikv-jemallocator

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -50,7 +50,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.8.0" }
 symlink = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = {package = "tikv-jemallocator", version = "0.4.1", feautres = ["unprefixed_malloc_on_supported_platforms"]}
+jemallocator = {package = "tikv-jemallocator", version = "0.4.1", features = ["unprefixed_malloc_on_supported_platforms"]}
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.103"


### PR DESCRIPTION
Trivial typo fix.

#### Problem

Feature was added with typo in 4bf6d0c4d7f9 ("adds unprefixed_malloc_on_supported_platforms to jemalloc (#20317)").

#### Summary of Changes

Typo fix. Should be backported to v1.7.