### PR TITLE
Add RPC get_highest_incremental_snapshot_info()

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -2,18 +2,8 @@
 
 use {
     crate::{
-        client_error::Result,
-        rpc_config::RpcBlockProductionConfig,
-        rpc_request::RpcRequest,
-        rpc_response::{
-            Response, RpcAccountBalance, RpcBlockProduction, RpcBlockProductionRange, RpcBlockhash,
-            RpcConfirmedTransactionStatusWithSignature, RpcContactInfo, RpcFees, RpcIdentity,
-            RpcInflationGovernor, RpcInflationRate, RpcInflationReward, RpcKeyedAccount,
-            RpcPerfSample, RpcResponseContext, RpcSimulateTransactionResult, RpcSnapshotSlotInfo,
-            RpcStakeActivation, RpcSupply, RpcVersionInfo, RpcVoteAccountInfo,
-            RpcVoteAccountStatus, StakeActivationState,
-        },
-        rpc_sender::*,
+        client_error::Result, rpc_config::RpcBlockProductionConfig, rpc_request::RpcRequest,
+        rpc_response::*, rpc_sender::*,
     },
     serde_json::{json, Number, Value},
     solana_account_decoder::{UiAccount, UiAccountEncoding},
@@ -22,6 +12,7 @@ use {
         clock::{Slot, UnixTimestamp},
         epoch_info::EpochInfo,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
+        hash::Hash,
         instruction::InstructionError,
         message::MessageHeader,
         pubkey::Pubkey,
@@ -231,6 +222,10 @@ impl RpcSender for MockSender {
             "getMaxShredInsertSlot" => json![0],
             "requestAirdrop" => Value::String(Signature::new(&[8; 64]).to_string()),
             "getSnapshotSlot" => Value::Number(Number::from(0)),
+            "getHighestIncrementalSnapshotInfo" => json!(RpcSnapshotInfo {
+                slot: 8_200,
+                hash: Hash::new_unique().to_string(),
+            }),
             "getHighestSnapshotSlot" => json!(RpcSnapshotSlotInfo {
                 full: 100,
                 incremental: Some(110),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1052,6 +1052,38 @@ impl RpcClient {
         )
     }
 
+    /// Returns the information for the highest incremental snapshot this node has, _based on_
+    /// `base_slot`.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getHighestIncrementalSnapshotInfo`] RPC method.
+    ///
+    /// [`getHighestIncrementalSnapshotInfo`]: https://docs.solana.com/developing/clients/jsonrpc-api#gethighestincrementalsnapshotinfo
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_client::{
+    /// #     rpc_client::RpcClient,
+    /// #     client_error::ClientError,
+    /// # };
+    /// # use solana_sdk::clock::Slot;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// # let full_snapshot_slot = Slot::default();
+    /// let incremental_snapshot_info = rpc_client.get_highest_incremental_snapshot_info(full_snapshot_slot)?;
+    /// # Ok::<(), ClientError>(())
+    /// ```
+    pub fn get_highest_incremental_snapshot_info(
+        &self,
+        base_slot: Slot,
+    ) -> ClientResult<RpcSnapshotInfo> {
+        self.send(
+            RpcRequest::GetHighestIncrementalSnapshotInfo,
+            json!([base_slot]),
+        )
+    }
+
     /// Returns the highest slot information that the node has snapshots for.
     ///
     /// This will find the highest full snapshot slot, and the highest incremental snapshot slot

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -79,6 +79,7 @@ pub enum RpcRequest {
     )]
     GetRecentBlockhash,
     GetRecentPerformanceSamples,
+    GetHighestIncrementalSnapshotInfo,
     GetHighestSnapshotSlot,
     #[deprecated(
         since = "1.8.0",
@@ -156,6 +157,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetProgramAccounts => "getProgramAccounts",
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetRecentPerformanceSamples => "getRecentPerformanceSamples",
+            RpcRequest::GetHighestIncrementalSnapshotInfo => "getHighestIncrementalSnapshotInfo",
             RpcRequest::GetHighestSnapshotSlot => "getHighestSnapshotSlot",
             RpcRequest::GetSnapshotSlot => "getSnapshotSlot",
             RpcRequest::GetSignaturesForAddress => "getSignaturesForAddress",

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -437,7 +437,15 @@ impl From<ConfirmedTransactionStatusWithSignature> for RpcConfirmedTransactionSt
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcSnapshotSlotInfo {
     pub full: Slot,
     pub incremental: Option<Slot>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcSnapshotInfo {
+    pub slot: Slot,
+    pub hash: String,
 }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -34,6 +34,7 @@ gives a convenient interface for the RPC methods.
 - [getFirstAvailableBlock](jsonrpc-api.md#getfirstavailableblock)
 - [getGenesisHash](jsonrpc-api.md#getgenesishash)
 - [getHealth](jsonrpc-api.md#gethealth)
+- [getHighestIncrementalSnapshotInfo](jsonrpc-api.md#gethighestincrementalsnapshotinfo)
 - [getHighestSnapshotSlot](jsonrpc-api.md#gethighestsnapshotslot)
 - [getIdentity](jsonrpc-api.md#getidentity)
 - [getInflationGovernor](jsonrpc-api.md#getinflationgovernor)
@@ -1292,6 +1293,56 @@ Unhealthy Result (if additional information is available)
     "data": {
       "numSlotsBehind": 42
     }
+  },
+  "id": 1
+}
+```
+
+### getHighestIncrementalSnapshotInfo
+
+**NEW: This method is only available in solana-core v1.8 or newer.**
+
+Returns the information for the highest incremental snapshot this node has,
+_based on_ `base_slot`.
+
+#### Parameters:
+
+- `base_slot: <u64>` - Base slot for the incremental snapshot, i.e. a full snapshot slot
+
+#### Results:
+
+- `<object>` - Highest incremental snapshot info _based on_ the full snapshot at slot `base_slot`
+    - `slot: <u64>` - Highest incremental snapshot slot
+    - `hash: <string>` - Highest incremental snapshot hash as a base-58 encoded string
+
+#### Example:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1,"method":"getHighestSnapshotInfo","params":[8000]}
+'
+```
+
+Result:
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "slot": 8200,
+    "hash": "8opHzTAnfzRpPEx21XtnrVTX28YQuCpAjcn1PczScKh"
+  },
+  "id": 1
+}
+```
+
+Result when the node has no snapshot:
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32008,
+    "message": "No snapshot"
   },
   "id": 1
 }


### PR DESCRIPTION
#### Problem

During bootstrap, a node gets snapshot hashes from CRDS. These snapshot hashes are for full snapshots only. After downloading a full snapshot (or if the node already has one), it needs to download an incremental snapshot. However, at the moment there's no way to discover information about incremental snapshots on other nodes.

#### Summary of Changes

Add an RPC fn for getting the highest incremental snapshot information.

For more information on the algorithm to be used during bootstrap—and how this new RPC fn will be used—see #19885 

Fixes #20357