### PR TITLE
v1.6: Optimize epoch boundary

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1523,7 +1523,6 @@ pub fn redeem_rewards(
     rewarded_epoch: Epoch,
     stake_state: StakeState,
     stake_account: &mut AccountSharedData,
-    vote_account: &mut AccountSharedData,
     vote_state: &VoteState,
     point_value: &PointValue,
     stake_history: Option<&StakeHistory>,
@@ -1555,8 +1554,6 @@ pub fn redeem_rewards(
             fix_stake_deactivate,
         ) {
             stake_account.lamports += stakers_reward;
-            vote_account.lamports += voters_reward;
-
             stake_account.set_state(&StakeState::Stake(meta, stake))?;
 
             Ok((stakers_reward, voters_reward))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1176,12 +1176,10 @@ impl Bank {
             new.apply_feature_activations(false);
         }
 
-        let cloned = new
-            .stakes
-            .read()
+        new.stakes
+            .write()
             .unwrap()
-            .clone_with_epoch(epoch, new.stake_program_v2_enabled());
-        *new.stakes.write().unwrap() = cloned;
+            .update_with_epoch(epoch, new.stake_program_v2_enabled());
 
         let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(slot);
         new.update_epoch_stakes(leader_schedule_epoch);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -29,9 +29,13 @@ use crate::{
     vote_account::ArcVoteAccount,
 };
 use byteorder::{ByteOrder, LittleEndian};
+use dashmap::DashMap;
 use itertools::Itertools;
 use log::*;
-use rayon::ThreadPool;
+use rayon::{
+    iter::{ParallelBridge, ParallelIterator},
+    ThreadPool, ThreadPoolBuilder,
+};
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_info};
 use solana_sdk::{
@@ -715,6 +719,10 @@ pub enum RewardCalculationEvent<'a, 'b> {
 
 fn null_tracer() -> Option<impl FnMut(&RewardCalculationEvent)> {
     None::<fn(&RewardCalculationEvent)>
+}
+
+fn null_inflation_tracer() -> Option<impl FnMut(&InflationPointCalculationEvent)> {
+    None::<fn(&InflationPointCalculationEvent)>
 }
 
 impl fmt::Display for RewardType {
@@ -1920,6 +1928,7 @@ impl Bank {
         reward_calc_tracer: &mut Option<impl FnMut(&RewardCalculationEvent)>,
         fix_stake_deactivate: bool,
     ) -> f64 {
+        let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let stake_history = self.stakes.read().unwrap().history().clone();
 
         let stake_delegation_accounts = self.load_stake_delegation_accounts(reward_calc_tracer);
@@ -1953,83 +1962,118 @@ impl Bank {
             return 0.0;
         }
 
-        let point_value = PointValue { rewards, points };
-
-        let mut rewards = vec![];
         // pay according to point value
-        for (
-            vote_pubkey,
-            StakeDelegationAccounts {
-                vote_state,
-                mut vote_account,
-                delegations,
+        let point_value = PointValue { rewards, points };
+        let vote_account_rewards: DashMap<Pubkey, (AccountSharedData, u8, u64, bool)> =
+            DashMap::with_capacity(stake_delegation_accounts.len());
+        let stake_delegation_iterator = stake_delegation_accounts.into_iter().flat_map(
+            |(
+                vote_pubkey,
+                StakeDelegationAccounts {
+                    vote_state,
+                    vote_account,
+                    delegations,
+                },
+            )| {
+                vote_account_rewards
+                    .insert(vote_pubkey, (vote_account, vote_state.commission, 0, false));
+                let vote_state = Arc::new(vote_state);
+                delegations
+                    .into_iter()
+                    .map(move |delegation| (vote_pubkey, Arc::clone(&vote_state), delegation))
             },
-        ) in stake_delegation_accounts.into_iter()
-        {
-            let mut vote_account_changed = false;
-            let voters_account_pre_balance = vote_account.lamports;
-            let commission = Some(vote_state.commission);
+        );
 
-            for (stake_pubkey, (stake_state, mut stake_account)) in delegations.into_iter() {
-                // curry closure to add the contextual stake_pubkey
-                let mut reward_calc_tracer = reward_calc_tracer.as_mut().map(|outer| {
-                    // inner
-                    move |inner_event: &_| {
-                        outer(&RewardCalculationEvent::Staking(&stake_pubkey, inner_event))
-                    }
-                });
-                let redeemed = stake_state::redeem_rewards(
-                    rewarded_epoch,
-                    stake_state,
-                    &mut stake_account,
-                    &mut vote_account,
-                    &vote_state,
-                    &point_value,
-                    Some(&stake_history),
-                    &mut reward_calc_tracer.as_mut(),
-                    fix_stake_deactivate,
-                );
-                if let Ok((stakers_reward, _voters_reward)) = redeemed {
-                    self.store_account(&stake_pubkey, &stake_account);
-                    vote_account_changed = true;
-
-                    if stakers_reward > 0 {
-                        rewards.push((
-                            stake_pubkey,
-                            RewardInfo {
-                                reward_type: RewardType::Staking,
-                                lamports: stakers_reward as i64,
-                                post_balance: stake_account.lamports,
-                                commission,
-                            },
-                        ));
-                    }
-                } else {
-                    debug!(
-                        "stake_state::redeem_rewards() failed for {}: {:?}",
-                        stake_pubkey, redeemed
-                    );
-                }
-            }
-
-            if vote_account_changed {
-                let post_balance = vote_account.lamports;
-                let lamports = (post_balance - voters_account_pre_balance) as i64;
-                if lamports != 0 {
-                    rewards.push((
+        let mut stake_rewards = thread_pool.install(|| {
+            stake_delegation_iterator
+                .par_bridge()
+                .filter_map(
+                    |(
                         vote_pubkey,
-                        RewardInfo {
-                            reward_type: RewardType::Voting,
-                            lamports,
-                            post_balance,
-                            commission,
-                        },
-                    ));
-                }
-                self.store_account(&vote_pubkey, &vote_account);
-            }
+                        vote_state,
+                        (stake_pubkey, (stake_state, mut stake_account)),
+                    )| {
+                        let redeemed = stake_state::redeem_rewards(
+                            rewarded_epoch,
+                            stake_state,
+                            &mut stake_account,
+                            &vote_state,
+                            &point_value,
+                            Some(&stake_history),
+                            &mut null_inflation_tracer(),
+                            fix_stake_deactivate,
+                        );
+                        if let Ok((stakers_reward, voters_reward)) = redeemed {
+                            // track voter rewards
+                            if let Some((
+                                _vote_account,
+                                _commission,
+                                vote_rewards_sum,
+                                vote_needs_store,
+                            )) = vote_account_rewards.get_mut(&vote_pubkey).as_deref_mut()
+                            {
+                                *vote_needs_store = true;
+                                *vote_rewards_sum += voters_reward;
+                            }
+
+                            // store stake account even if stakers_reward is 0
+                            // because credits observed has changed
+                            self.store_account(&stake_pubkey, &stake_account);
+
+                            if stakers_reward > 0 {
+                                return Some((
+                                    stake_pubkey,
+                                    RewardInfo {
+                                        reward_type: RewardType::Staking,
+                                        lamports: stakers_reward as i64,
+                                        post_balance: stake_account.lamports,
+                                        commission: Some(vote_state.commission),
+                                    },
+                                ));
+                            }
+                        } else {
+                            debug!(
+                                "stake_state::redeem_rewards() failed for {}: {:?}",
+                                stake_pubkey, redeemed
+                            );
+                        }
+                        None
+                    },
+                )
+                .collect()
+        });
+
+        let mut vote_rewards = vote_account_rewards
+            .into_iter()
+            .filter_map(
+                |(vote_pubkey, (mut vote_account, commission, vote_rewards, vote_needs_store))| {
+                    vote_account.lamports += vote_rewards;
+                    if vote_needs_store {
+                        self.store_account(&vote_pubkey, &vote_account);
+                    }
+
+                    if vote_rewards > 0 {
+                        Some((
+                            vote_pubkey,
+                            RewardInfo {
+                                reward_type: RewardType::Voting,
+                                lamports: vote_rewards as i64,
+                                post_balance: vote_account.lamports,
+                                commission: Some(commission),
+                            },
+                        ))
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect();
+
+        {
+            let mut rewards = self.rewards.write().unwrap();
+            rewards.append(&mut vote_rewards);
+            rewards.append(&mut stake_rewards);
         }
-        self.rewards.write().unwrap().append(&mut rewards);
 
         point_value.rewards as f64 / point_value.points as f64
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1,6 +1,7 @@
 //! Stakes serve as a cache of stake and vote accounts to derive
 //! node stakes
 use crate::vote_account::{ArcVoteAccount, VoteAccounts};
+use dashmap::DashMap;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount},
     clock::Epoch,
@@ -9,7 +10,14 @@ use solana_sdk::{
 };
 use solana_stake_program::stake_state::{new_stake_history_entry, Delegation, StakeState};
 use solana_vote_program::vote_state::VoteState;
-use std::{borrow::Borrow, collections::HashMap};
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 #[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]
 pub struct Stakes {
@@ -33,14 +41,33 @@ impl Stakes {
     pub fn history(&self) -> &StakeHistory {
         &self.stake_history
     }
-    pub fn clone_with_epoch(&self, next_epoch: Epoch, fix_stake_deactivate: bool) -> Self {
+
+    pub fn update_epoch_vote_account_stakes(
+        &mut self,
+        new_stakes: &DashMap<
+            Pubkey,
+            Option<(Arc<VoteState>, Arc<AccountSharedData>, Arc<AtomicU64>)>,
+        >,
+    ) {
+        for (pubkey, (stake, _account)) in self.vote_accounts.iter_mut() {
+            let new_stake = new_stakes
+                .get(pubkey)
+                .and_then(|state| {
+                    state
+                        .value()
+                        .as_ref()
+                        .map(|state| state.2.load(Ordering::Relaxed))
+                })
+                .unwrap_or(0);
+            *stake = new_stake;
+        }
+    }
+
+    pub fn update_with_epoch(&mut self, next_epoch: Epoch, fix_stake_deactivate: bool) {
         let prev_epoch = self.epoch;
-        if prev_epoch == next_epoch {
-            self.clone()
-        } else {
+        if prev_epoch != next_epoch {
             // wrap up the prev epoch by adding new stake history entry for the prev epoch
-            let mut stake_history_upto_prev_epoch = self.stake_history.clone();
-            stake_history_upto_prev_epoch.add(
+            self.stake_history.add(
                 prev_epoch,
                 new_stake_history_entry(
                     prev_epoch,
@@ -51,29 +78,7 @@ impl Stakes {
                     fix_stake_deactivate,
                 ),
             );
-
-            // refresh the stake distribution of vote accounts for the next epoch, using new stake history
-            let vote_accounts_for_next_epoch = self
-                .vote_accounts
-                .iter()
-                .map(|(pubkey, (_ /*stake*/, account))| {
-                    let stake = self.calculate_stake(
-                        pubkey,
-                        next_epoch,
-                        Some(&stake_history_upto_prev_epoch),
-                        fix_stake_deactivate,
-                    );
-                    (*pubkey, (stake, account.clone()))
-                })
-                .collect();
-
-            Stakes {
-                stake_delegations: self.stake_delegations.clone(),
-                unused: self.unused,
-                epoch: next_epoch,
-                stake_history: stake_history_upto_prev_epoch,
-                vote_accounts: vote_accounts_for_next_epoch,
-            }
+            self.epoch = next_epoch;
         }
     }
 

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -258,7 +258,7 @@ impl PartialEq<VoteAccounts> for VoteAccounts {
     }
 }
 
-type VoteAccountsHashMap = HashMap<Pubkey, (u64 /*stake*/, ArcVoteAccount)>;
+pub type VoteAccountsHashMap = HashMap<Pubkey, (u64 /*stake*/, ArcVoteAccount)>;
 
 impl From<VoteAccountsHashMap> for VoteAccounts {
     fn from(vote_accounts: VoteAccountsHashMap) -> Self {

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -41,6 +41,10 @@ pub struct VoteAccounts {
 }
 
 impl VoteAccount {
+    pub fn account(&self) -> &Account {
+        &self.account
+    }
+
     pub fn lamports(&self) -> u64 {
         self.account.lamports
     }
@@ -202,6 +206,12 @@ impl From<Account> for VoteAccount {
             vote_state: RwLock::new(INVALID_VOTE_STATE),
             vote_state_once: Once::new(),
         }
+    }
+}
+
+impl AsRef<VoteAccount> for ArcVoteAccount {
+    fn as_ref(&self) -> &VoteAccount {
+        &self.0
     }
 }
 


### PR DESCRIPTION
#### Problem
- `Bank::stake_delegation_accounts` loads vote accounts once for each delegated stake which is very inefficient
- Deserialized vote and stake states are not reused
- Stake activation and reward calculation on epoch boundaries is done serially

#### Summary of Changes
- Don't reload vote accounts more than once in `Bank::stake_delegation_accounts`
- Cache deserialized vote and stake state during rewards collection
- Add thread pool to load accounts, calculate rewards, and write changes in parallel

Fixes #
