### PR TITLE
Ignore delinquent stake on exit

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2351,6 +2351,8 @@ pub fn main() {
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let identity = pubkey_of(subcommand_matches, "identity");
+            let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
+            
             wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquency).unwrap_or_else(|err| {
                 println!("{}", err);
                 exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2300,9 +2300,7 @@ pub fn main() {
                 .unwrap_or(DEFAULT_MAX_DELINQUENT_STAKE_PERCENT);
 
             if max_delinquent_stake > 100 {
-                println!(
-                    "Maximum permitted delinquency can't exceed 100"
-                );
+                println!("Maximum permitted delinquency can't exceed 100");
                 exit(1);
             }
 
@@ -2373,9 +2371,7 @@ pub fn main() {
                 .unwrap_or(DEFAULT_MAX_DELINQUENT_STAKE_PERCENT);
 
             if max_delinquent_stake > 100 {
-                println!(
-                    "Maximum permitted delinquency can't exceed 100"
-                );
+                println!("Maximum permitted delinquency can't exceed 100");
                 exit(1);
             }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -154,7 +154,6 @@ fn wait_for_restart_window(
         "Maximum permitted delinquency: {}%",
         max_delinquency_percentage
     );
-    
 
     let mut current_epoch = None;
     let mut leader_schedule = VecDeque::new();
@@ -2295,8 +2294,8 @@ pub fn main() {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let force = subcommand_matches.is_present("force");
             let monitor = subcommand_matches.is_present("monitor");
-            let max_delinquent_stake = value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
-
+            let max_delinquent_stake =
+                value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
 
             if !force {
                 wait_for_restart_window(&ledger_path, None, min_idle_time, max_delinquent_stake)
@@ -2361,7 +2360,8 @@ pub fn main() {
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let identity = pubkey_of(subcommand_matches, "identity");
-            let max_delinquent_stake = value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
+            let max_delinquent_stake =
+                value_t_or_exit!(subcommand_matches, "max_delinquent_stake", u8);
 
             wait_for_restart_window(&ledger_path, identity, min_idle_time, max_delinquent_stake)
                 .unwrap_or_else(|err| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -122,7 +122,7 @@ fn wait_for_restart_window(
     ledger_path: &Path,
     identity: Option<Pubkey>,
     min_idle_time_in_minutes: usize,
-    ignore_delinquency: bool,
+    ignore_delinquent_stake: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sleep_interval = Duration::from_secs(5);
     let min_delinquency_percentage = 0.05;
@@ -150,7 +150,7 @@ fn wait_for_restart_window(
             min_idle_slots, min_idle_time_in_minutes
         ),
     );
-    if ignore_delinquency {
+    if ignore_delinquent_stake {
         println!("{}", style("Ignoring delinquent stake").yellow());
     }
 
@@ -304,7 +304,7 @@ fn wait_for_restart_window(
                         if restart_snapshot == snapshot_slot && !monitoring_another_validator {
                             "Waiting for a new snapshot".to_string()
                         } else if delinquent_stake_percentage >= min_delinquency_percentage
-                            && !ignore_delinquency
+                            && !ignore_delinquent_stake
                         {
                             style("Delinquency too high").red().to_string()
                         } else {
@@ -2126,11 +2126,11 @@ pub fn main() {
                     .help("Minimum time that the validator should not be leader before restarting")
             )
             .arg(
-                Arg::with_name("ignore_delinquency")
+                Arg::with_name("ignore_delinquent-stake")
                     .short("i")
-                    .long("ignore-delinquency")
+                    .long("ignore-delinquent-stake")
                     .takes_value(false)
-                    .help("Ignore delinquency threshold when exiting")
+                    .help("Ignore delinquent stake threshold when exiting")
             )
         )
         .subcommand(
@@ -2217,11 +2217,11 @@ pub fn main() {
                     .help("Validator identity to monitor [default: your validator]")
             )
             .arg(
-                Arg::with_name("ignore_delinquency")
+                Arg::with_name("ignore_delinquent-stake")
                     .short("i")
-                    .long("ignore-delinquency")
+                    .long("ignore-delinquent-stake")
                     .takes_value(false)
-                    .help("Ignore delinquency threshold when exiting")
+                    .help("Ignore delinquent stake threshold when exiting")
             )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")
@@ -2289,10 +2289,10 @@ pub fn main() {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let force = subcommand_matches.is_present("force");
             let monitor = subcommand_matches.is_present("monitor");
-            let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
+            let ignore_delinquent_stake = subcommand_matches.is_present("ignore_delinquent_stake");
 
             if !force {
-                wait_for_restart_window(&ledger_path, None, min_idle_time, ignore_delinquency)
+                wait_for_restart_window(&ledger_path, None, min_idle_time, ignore_delinquent_stake)
                     .unwrap_or_else(|err| {
                         println!("{}", err);
                         exit(1);
@@ -2354,8 +2354,8 @@ pub fn main() {
         ("wait-for-restart-window", Some(subcommand_matches)) => {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let identity = pubkey_of(subcommand_matches, "identity");
-            let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
-            wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquency)
+            let ignore_delinquent_stake = subcommand_matches.is_present("ignore_delinquent_stake");
+            wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquent_stake)
                 .unwrap_or_else(|err| {
                     println!("{}", err);
                     exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -11,7 +11,7 @@ use {
         input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
         input_validators::{
             is_bin, is_keypair, is_keypair_or_ask_keyword, is_parsable, is_pubkey,
-            is_pubkey_or_keypair, is_slot, is_valid_percentage
+            is_pubkey_or_keypair, is_slot, is_valid_percentage,
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2207,20 +2207,19 @@ pub fn main() {
                     .help("Minimum time that the validator should not be leader before restarting")
             )
             .arg(
-<<<<<<< HEAD
                 Arg::with_name("identity")
                     .long("identity")
                     .value_name("ADDRESS")
                     .takes_value(true)
                     .validator(is_pubkey_or_keypair)
                     .help("Validator identity to monitor [default: your validator]")
-=======
+            )
+            .arg(
                 Arg::with_name("ignore_delinquency")
                     .short("i")
                     .long("ignore-delinquency")
                     .takes_value(false)
                     .help("Ignore delinquency threshold when exiting")
->>>>>>> a07b61339... Add --ignore-delinquency flag to exit and wait-for-restart-window subcommands of solana-validator
             )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2352,7 +2352,6 @@ pub fn main() {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let identity = pubkey_of(subcommand_matches, "identity");
             let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
-            
             wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquency).unwrap_or_else(|err| {
                 println!("{}", err);
                 exit(1);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -122,7 +122,7 @@ fn wait_for_restart_window(
     ledger_path: &Path,
     identity: Option<Pubkey>,
     min_idle_time_in_minutes: usize,
-    ignore_delinquency: bool
+    ignore_delinquency: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sleep_interval = Duration::from_secs(5);
     let min_delinquency_percentage = 0.05;
@@ -303,7 +303,9 @@ fn wait_for_restart_window(
                         }
                         if restart_snapshot == snapshot_slot && !monitoring_another_validator {
                             "Waiting for a new snapshot".to_string()
-                        } else if delinquent_stake_percentage >= min_delinquency_percentage && !ignore_delinquency {
+                        } else if delinquent_stake_percentage >= min_delinquency_percentage
+                            && !ignore_delinquency
+                        {
                             style("Delinquency too high").red().to_string()
                         } else {
                             break; // Restart!
@@ -2290,10 +2292,11 @@ pub fn main() {
             let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
 
             if !force {
-                wait_for_restart_window(&ledger_path, None, min_idle_time, ignore_delinquency).unwrap_or_else(|err| {
-                    println!("{}", err);
-                    exit(1);
-                });
+                wait_for_restart_window(&ledger_path, None, min_idle_time, ignore_delinquency)
+                    .unwrap_or_else(|err| {
+                        println!("{}", err);
+                        exit(1);
+                    });
             }
 
             let admin_client = admin_rpc_service::connect(&ledger_path);
@@ -2352,10 +2355,11 @@ pub fn main() {
             let min_idle_time = value_t_or_exit!(subcommand_matches, "min_idle_time", usize);
             let identity = pubkey_of(subcommand_matches, "identity");
             let ignore_delinquency = subcommand_matches.is_present("ignore_delinquency");
-            wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquency).unwrap_or_else(|err| {
-                println!("{}", err);
-                exit(1);
-            });
+            wait_for_restart_window(&ledger_path, identity, min_idle_time, ignore_delinquency)
+                .unwrap_or_else(|err| {
+                    println!("{}", err);
+                    exit(1);
+                });
             return;
         }
         _ => unreachable!(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -11,7 +11,7 @@ use {
         input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
         input_validators::{
             is_bin, is_keypair, is_keypair_or_ask_keyword, is_parsable, is_pubkey,
-            is_pubkey_or_keypair, is_slot,
+            is_pubkey_or_keypair, is_slot, is_valid_percentage
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
@@ -2130,10 +2130,10 @@ pub fn main() {
                 Arg::with_name("max_delinquent_stake")
                     .long("max-delinquent-stake")
                     .takes_value(true)
-                    .validator(solana_clap_utils:: input_validators::is_valid_percentage)
+                    .validator(is_valid_percentage)
                     .default_value("5")
                     .value_name("PERCENT")
-                    .help("The maximum delinquent stake % permitted for an exit [default: 5]")
+                    .help("The maximum delinquent stake % permitted for an exit")
             )
         )
         .subcommand(
@@ -2223,10 +2223,10 @@ pub fn main() {
                 Arg::with_name("max_delinquent_stake")
                     .long("max-delinquent-stake")
                     .takes_value(true)
-                    .validator(solana_clap_utils:: input_validators::is_valid_percentage)
+                    .validator(is_valid_percentage)
                     .default_value("5")
                     .value_name("PERCENT")
-                    .help("The maximum delinquent stake % permitted for a restart [default: 5]")
+                    .help("The maximum delinquent stake % permitted for a restart")
             )
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/18863 mentions some issues with the exit command, this PR addresses one of these issues only: ability to ignore delinquency when exiting

#### Summary of Changes
Add an --ignore delinquent-stake (-i) flag to the solana-validator exit and wait-for-restart-window sub commands which if passed will cause the wait_for_restart_window function to ignore delinquent stake when in a leader schedule hole.


