### PR TITLE
Don't gossip more shapshot hashes than what we retain

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -29,6 +29,10 @@ impl SnapshotPackagerService {
     ) -> Self {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
+        let max_snapshot_hashes = std::cmp::min(
+            MAX_SNAPSHOT_HASHES,
+            snapshot_config.maximum_full_snapshot_archives_to_retain,
+        );
 
         let t_snapshot_packager = Builder::new()
             .name("snapshot-packager".to_string())
@@ -64,7 +68,7 @@ impl SnapshotPackagerService {
                     // can have their hashes pushed out to the cluster.
                     if snapshot_package.snapshot_type == SnapshotType::FullSnapshot {
                         hashes.push((snapshot_package.slot(), *snapshot_package.hash()));
-                        while hashes.len() > MAX_SNAPSHOT_HASHES {
+                        while hashes.len() > max_snapshot_hashes {
                             hashes.remove(0);
                         }
                         cluster_info.push_snapshot_hashes(hashes.clone());


### PR DESCRIPTION
#### Problem

SnapshotPackagerService is responsible for pushing snapshot hashes to the cluster. It pushes at most `MAX_SNAPSHOT_HASHES`. But, the node may be configured to only retain `X` snapshots, where `X < MAX_SNAPSHOT_HASHES`. In that case, we should only push out a max of `X` snapshot hashes.

#### Summary of Changes

The maximum number of snapshot hashes to push should be `min(MAX_SNAPSHOT_HASHES, snapshots_to_retain)`.