### PR TITLE
Add struct and convenience methods to track stake activation status

### DIFF
--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -301,7 +301,7 @@ async fn stake_rewards_from_warp() {
         stake
             .delegation
             .stake_activating_and_deactivating(clock.epoch, Some(&stake_history)),
-        StakeActivationStatus::fully_active(stake.delegation.stake),
+        StakeActivationStatus::with_effective(stake.delegation.stake),
     );
 }
 

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
 use {
-    assert_matches::assert_matches,
     bincode::deserialize,
     solana_banks_client::BanksClient,
     solana_program_test::{processor, ProgramTest, ProgramTestContext, ProgramTestError},
@@ -15,7 +14,7 @@ use {
         signature::{Keypair, Signer},
         stake::{
             instruction as stake_instruction,
-            state::{Authorized, Lockup, StakeState},
+            state::{Authorized, Lockup, StakeActivationStatus, StakeState},
         },
         system_instruction, system_program,
         sysvar::{
@@ -298,11 +297,11 @@ async fn stake_rewards_from_warp() {
     let stake_history: StakeHistory = deserialize(&stake_history_account.data).unwrap();
     let clock: Clock = deserialize(&clock_account.data).unwrap();
     let stake = stake_state.stake().unwrap();
-    assert_matches!(
+    assert_eq!(
         stake
             .delegation
             .stake_activating_and_deactivating(clock.epoch, Some(&stake_history)),
-        (_, 0, 0)
+        StakeActivationStatus::fully_active(stake.delegation.stake),
     );
 }
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1757,19 +1757,19 @@ mod tests {
         // assert that this stake follows step function if there's no history
         assert_eq!(
             stake.stake_activating_and_deactivating(stake.activation_epoch, Some(&stake_history),),
-            StakeActivationStatus::activating(0, stake.stake),
+            StakeActivationStatus::with_effective_and_activating(0, stake.stake),
         );
         for epoch in stake.activation_epoch + 1..stake.deactivation_epoch {
             assert_eq!(
                 stake.stake_activating_and_deactivating(epoch, Some(&stake_history)),
-                StakeActivationStatus::fully_active(stake.stake),
+                StakeActivationStatus::with_effective(stake.stake),
             );
         }
         // assert that this stake is full deactivating
         assert_eq!(
             stake
                 .stake_activating_and_deactivating(stake.deactivation_epoch, Some(&stake_history),),
-            StakeActivationStatus::deactivating(stake.stake),
+            StakeActivationStatus::with_deactivating(stake.stake),
         );
         // assert that this stake is fully deactivated if there's no history
         assert_eq!(
@@ -1790,7 +1790,7 @@ mod tests {
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
             stake.stake_activating_and_deactivating(1, Some(&stake_history)),
-            StakeActivationStatus::activating(0, stake.stake),
+            StakeActivationStatus::with_effective_and_activating(0, stake.stake),
         );
 
         stake_history.add(
@@ -1805,7 +1805,10 @@ mod tests {
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
             stake.stake_activating_and_deactivating(2, Some(&stake_history)),
-            StakeActivationStatus::activating(increment, stake.stake - increment),
+            StakeActivationStatus::with_effective_and_activating(
+                increment,
+                stake.stake - increment
+            ),
         );
 
         // start over, test deactivation edge cases
@@ -1824,7 +1827,7 @@ mod tests {
                 stake.deactivation_epoch + 1,
                 Some(&stake_history),
             ),
-            StakeActivationStatus::deactivating(stake.stake),
+            StakeActivationStatus::with_deactivating(stake.stake),
         );
 
         // put in my initial deactivating amount, but don't put in an entry for next
@@ -1843,7 +1846,7 @@ mod tests {
                 Some(&stake_history),
             ),
             // hung, should be lower
-            StakeActivationStatus::deactivating(stake.stake - increment),
+            StakeActivationStatus::with_deactivating(stake.stake - increment),
         );
     }
 
@@ -2051,21 +2054,21 @@ mod tests {
         };
 
         let expected_staking_status_transition = vec![
-            StakeActivationStatus::activating(0, 700),
-            StakeActivationStatus::activating(250, 450),
-            StakeActivationStatus::activating(562, 138),
-            StakeActivationStatus::fully_active(700),
-            StakeActivationStatus::deactivating(700),
-            StakeActivationStatus::deactivating(275),
+            StakeActivationStatus::with_effective_and_activating(0, 700),
+            StakeActivationStatus::with_effective_and_activating(250, 450),
+            StakeActivationStatus::with_effective_and_activating(562, 138),
+            StakeActivationStatus::with_effective(700),
+            StakeActivationStatus::with_deactivating(700),
+            StakeActivationStatus::with_deactivating(275),
             StakeActivationStatus::default(),
         ];
         let expected_staking_status_transition_base = vec![
-            StakeActivationStatus::activating(0, 700),
-            StakeActivationStatus::activating(250, 450),
-            StakeActivationStatus::activating(562, 138 + 1), // +1 is needed for rounding
-            StakeActivationStatus::fully_active(700),
-            StakeActivationStatus::deactivating(700),
-            StakeActivationStatus::deactivating(275 + 1), // +1 is needed for rounding
+            StakeActivationStatus::with_effective_and_activating(0, 700),
+            StakeActivationStatus::with_effective_and_activating(250, 450),
+            StakeActivationStatus::with_effective_and_activating(562, 138 + 1), // +1 is needed for rounding
+            StakeActivationStatus::with_effective(700),
+            StakeActivationStatus::with_deactivating(700),
+            StakeActivationStatus::with_deactivating(275 + 1), // +1 is needed for rounding
             StakeActivationStatus::default(),
         ];
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1824,7 +1824,6 @@ mod tests {
                 stake.deactivation_epoch + 1,
                 Some(&stake_history),
             ),
-            // says "I'm still waiting for deactivation"
             StakeActivationStatus::deactivating(stake.stake),
         );
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -875,12 +875,11 @@ impl MergeKind {
             StakeState::Stake(meta, stake) => {
                 // stake must not be in a transient state. Transient here meaning
                 // activating or deactivating with non-zero effective stake.
-                match stake
+                let status = stake
                     .delegation
-                    .stake_activating_and_deactivating(clock.epoch, Some(stake_history))
-                {
-                    /*
-                    (e, a, d): e - effective, a - activating, d - deactivating */
+                    .stake_activating_and_deactivating(clock.epoch, Some(stake_history));
+
+                match (status.effective, status.activating, status.deactivating) {
                     (0, 0, 0) => Ok(Self::Inactive(meta, stake_keyed_account.lamports()?)),
                     (0, _, _) => Ok(Self::ActivationEpoch(meta, stake)),
                     (_, 0, 0) => Ok(Self::FullyActive(meta, stake)),
@@ -1192,20 +1191,9 @@ pub fn new_stake_history_entry<'a, I>(
 where
     I: Iterator<Item = &'a Delegation>,
 {
-    // whatever the stake says they  had for the epoch
-    //  and whatever the were still waiting for
-    fn add(a: (u64, u64, u64), b: (u64, u64, u64)) -> (u64, u64, u64) {
-        (a.0 + b.0, a.1 + b.1, a.2 + b.2)
-    }
-    let (effective, activating, deactivating) = stakes.fold((0, 0, 0), |sum, stake| {
-        add(sum, stake.stake_activating_and_deactivating(epoch, history))
-    });
-
-    StakeHistoryEntry {
-        effective,
-        activating,
-        deactivating,
-    }
+    stakes.fold(StakeHistoryEntry::default(), |sum, stake| {
+        sum + stake.stake_activating_and_deactivating(epoch, history)
+    })
 }
 
 // genesis investor accounts
@@ -1769,19 +1757,19 @@ mod tests {
         // assert that this stake follows step function if there's no history
         assert_eq!(
             stake.stake_activating_and_deactivating(stake.activation_epoch, Some(&stake_history),),
-            (0, stake.stake, 0)
+            StakeActivationStatus::activating(0, stake.stake),
         );
         for epoch in stake.activation_epoch + 1..stake.deactivation_epoch {
             assert_eq!(
                 stake.stake_activating_and_deactivating(epoch, Some(&stake_history)),
-                (stake.stake, 0, 0)
+                StakeActivationStatus::fully_active(stake.stake),
             );
         }
         // assert that this stake is full deactivating
         assert_eq!(
             stake
                 .stake_activating_and_deactivating(stake.deactivation_epoch, Some(&stake_history),),
-            (stake.stake, 0, stake.stake)
+            StakeActivationStatus::deactivating(stake.stake),
         );
         // assert that this stake is fully deactivated if there's no history
         assert_eq!(
@@ -1789,21 +1777,20 @@ mod tests {
                 stake.deactivation_epoch + 1,
                 Some(&stake_history),
             ),
-            (0, 0, 0)
+            StakeActivationStatus::default(),
         );
 
         stake_history.add(
             0u64, // entry for zero doesn't have my activating amount
             StakeHistoryEntry {
                 effective: 1_000,
-                activating: 0,
                 ..StakeHistoryEntry::default()
             },
         );
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
             stake.stake_activating_and_deactivating(1, Some(&stake_history)),
-            (0, stake.stake, 0)
+            StakeActivationStatus::activating(0, stake.stake),
         );
 
         stake_history.add(
@@ -1818,7 +1805,7 @@ mod tests {
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
             stake.stake_activating_and_deactivating(2, Some(&stake_history)),
-            (increment, stake.stake - increment, 0)
+            StakeActivationStatus::activating(increment, stake.stake - increment),
         );
 
         // start over, test deactivation edge cases
@@ -1828,7 +1815,6 @@ mod tests {
             stake.deactivation_epoch, // entry for zero doesn't have my de-activating amount
             StakeHistoryEntry {
                 effective: 1_000,
-                activating: 0,
                 ..StakeHistoryEntry::default()
             },
         );
@@ -1838,7 +1824,8 @@ mod tests {
                 stake.deactivation_epoch + 1,
                 Some(&stake_history),
             ),
-            (stake.stake, 0, stake.stake) // says "I'm still waiting for deactivation"
+            // says "I'm still waiting for deactivation"
+            StakeActivationStatus::deactivating(stake.stake),
         );
 
         // put in my initial deactivating amount, but don't put in an entry for next
@@ -1856,7 +1843,8 @@ mod tests {
                 stake.deactivation_epoch + 2,
                 Some(&stake_history),
             ),
-            (stake.stake - increment, 0, stake.stake - increment) // hung, should be lower
+            // hung, should be lower
+            StakeActivationStatus::deactivating(stake.stake - increment),
         );
     }
 
@@ -1868,7 +1856,10 @@ mod tests {
             Slow,
         }
 
-        fn do_test(old_behavior: OldDeactivationBehavior, expected_stakes: &[(u64, u64, u64)]) {
+        fn do_test(
+            old_behavior: OldDeactivationBehavior,
+            expected_stakes: &[StakeActivationStatus],
+        ) {
             let cluster_stake = 1_000;
             let activating_stake = 10_000;
             let some_stake = 700;
@@ -1931,13 +1922,13 @@ mod tests {
             do_test(
                 OldDeactivationBehavior::Slow,
                 &[
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
                 ],
             );
         }
@@ -1950,13 +1941,13 @@ mod tests {
             do_test(
                 OldDeactivationBehavior::Stuck,
                 &[
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
-                    (0, 0, 0),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
+                    StakeActivationStatus::default(),
                 ],
             );
         }
@@ -2049,37 +2040,34 @@ mod tests {
                 })
                 .collect::<Vec<_>>()
         };
-        let adjust_staking_status = |rate: f64, status: &Vec<_>| {
+        let adjust_staking_status = |rate: f64, status: &[StakeActivationStatus]| {
             status
-                .clone()
-                .into_iter()
-                .map(|(a, b, c)| {
-                    (
-                        (a as f64 * rate) as u64,
-                        (b as f64 * rate) as u64,
-                        (c as f64 * rate) as u64,
-                    )
+                .iter()
+                .map(|entry| StakeActivationStatus {
+                    effective: (entry.effective as f64 * rate) as u64,
+                    activating: (entry.activating as f64 * rate) as u64,
+                    deactivating: (entry.deactivating as f64 * rate) as u64,
                 })
                 .collect::<Vec<_>>()
         };
 
         let expected_staking_status_transition = vec![
-            (0, 700, 0),
-            (250, 450, 0),
-            (562, 138, 0),
-            (700, 0, 0),
-            (700, 0, 700),
-            (275, 0, 275),
-            (0, 0, 0),
+            StakeActivationStatus::activating(0, 700),
+            StakeActivationStatus::activating(250, 450),
+            StakeActivationStatus::activating(562, 138),
+            StakeActivationStatus::fully_active(700),
+            StakeActivationStatus::deactivating(700),
+            StakeActivationStatus::deactivating(275),
+            StakeActivationStatus::default(),
         ];
         let expected_staking_status_transition_base = vec![
-            (0, 700, 0),
-            (250, 450, 0),
-            (562, 138 + 1, 0), // +1 is needed for rounding
-            (700, 0, 0),
-            (700, 0, 700),
-            (275 + 1, 0, 275 + 1), // +1 is needed for rounding
-            (0, 0, 0),
+            StakeActivationStatus::activating(0, 700),
+            StakeActivationStatus::activating(250, 450),
+            StakeActivationStatus::activating(562, 138 + 1), // +1 is needed for rounding
+            StakeActivationStatus::fully_active(700),
+            StakeActivationStatus::deactivating(700),
+            StakeActivationStatus::deactivating(275 + 1), // +1 is needed for rounding
+            StakeActivationStatus::default(),
         ];
 
         // normal stake activating and deactivating transition test, just in case
@@ -2170,7 +2158,11 @@ mod tests {
             };
             assert_eq!(
                 stake.stake_activating_and_deactivating(epoch, Some(&stake_history)),
-                (expected_stake, expected_activating, expected_deactivating)
+                StakeActivationStatus {
+                    effective: expected_stake,
+                    activating: expected_activating,
+                    deactivating: expected_deactivating,
+                },
             );
         }
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -61,7 +61,7 @@ use {
         message::{Message, SanitizedMessage},
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
-        stake::state::StakeState,
+        stake::state::{StakeActivationStatus, StakeState},
         stake_history::StakeHistory,
         system_instruction,
         sysvar::stake_history,
@@ -1573,13 +1573,16 @@ impl JsonRpcRequestProcessor {
             solana_sdk::account::from_account::<StakeHistory, _>(&stake_history_account)
                 .ok_or_else(Error::internal_error)?;
 
-        let (active, activating, deactivating) =
-            delegation.stake_activating_and_deactivating(epoch, Some(&stake_history));
+        let StakeActivationStatus {
+            effective,
+            activating,
+            deactivating,
+        } = delegation.stake_activating_and_deactivating(epoch, Some(&stake_history));
         let stake_activation_state = if deactivating > 0 {
             StakeActivationState::Deactivating
         } else if activating > 0 {
             StakeActivationState::Activating
-        } else if active > 0 {
+        } else if effective > 0 {
             StakeActivationState::Active
         } else {
             StakeActivationState::Inactive
@@ -1587,12 +1590,12 @@ impl JsonRpcRequestProcessor {
         let inactive_stake = match stake_activation_state {
             StakeActivationState::Activating => activating,
             StakeActivationState::Active => 0,
-            StakeActivationState::Deactivating => delegation.stake.saturating_sub(active),
+            StakeActivationState::Deactivating => delegation.stake.saturating_sub(effective),
             StakeActivationState::Inactive => delegation.stake,
         };
         Ok(RpcStakeActivation {
             state: stake_activation_state,
-            active,
+            active: effective,
             inactive: inactive_stake,
         })
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -10,7 +10,7 @@ use {
             self,
             state::{Delegation, StakeState},
         },
-        sysvar::stake_history::StakeHistory,
+        stake_history::StakeHistory,
     },
     solana_stake_program::stake_state,
     solana_vote_program::vote_state::VoteState,

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -361,13 +361,16 @@ impl Delegation {
         if target_epoch < self.deactivation_epoch {
             // not deactivated
             if activating_stake == 0 {
-                StakeActivationStatus::fully_active(effective_stake)
+                StakeActivationStatus::with_effective(effective_stake)
             } else {
-                StakeActivationStatus::activating(effective_stake, activating_stake)
+                StakeActivationStatus::with_effective_and_activating(
+                    effective_stake,
+                    activating_stake,
+                )
             }
         } else if target_epoch == self.deactivation_epoch {
             // can only deactivate what's activated
-            StakeActivationStatus::deactivating(effective_stake)
+            StakeActivationStatus::with_deactivating(effective_stake)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
@@ -424,7 +427,7 @@ impl Delegation {
             }
 
             // deactivating stake should equal to all of currently remaining effective stake
-            StakeActivationStatus::deactivating(current_effective_stake)
+            StakeActivationStatus::with_deactivating(current_effective_stake)
         } else {
             // no history or I've dropped out of history, so assume fully deactivated
             StakeActivationStatus::default()

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -9,11 +9,13 @@ use {
             config::Config,
             instruction::{LockupArgs, StakeError},
         },
-        stake_history::StakeHistory,
+        stake_history::{StakeHistory, StakeHistoryEntry},
     },
     borsh::{maybestd::io, BorshDeserialize, BorshSchema},
     std::collections::HashSet,
 };
+
+pub type StakeActivationStatus = StakeHistoryEntry;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
 #[allow(clippy::large_enum_variant)]
@@ -342,28 +344,26 @@ impl Delegation {
     }
 
     pub fn stake(&self, epoch: Epoch, history: Option<&StakeHistory>) -> u64 {
-        self.stake_activating_and_deactivating(epoch, history).0
+        self.stake_activating_and_deactivating(epoch, history)
+            .effective
     }
 
-    // returned tuple is (effective, activating, deactivating) stake
     #[allow(clippy::comparison_chain)]
     pub fn stake_activating_and_deactivating(
         &self,
         target_epoch: Epoch,
         history: Option<&StakeHistory>,
-    ) -> (u64, u64, u64) {
-        let delegated_stake = self.stake;
-
+    ) -> StakeActivationStatus {
         // first, calculate an effective and activating stake
         let (effective_stake, activating_stake) = self.stake_and_activating(target_epoch, history);
 
         // then de-activate some portion if necessary
         if target_epoch < self.deactivation_epoch {
             // not deactivated
-            (effective_stake, activating_stake, 0)
+            StakeActivationStatus::activating(effective_stake, activating_stake)
         } else if target_epoch == self.deactivation_epoch {
             // can only deactivate what's activated
-            (effective_stake, 0, effective_stake.min(delegated_stake))
+            StakeActivationStatus::deactivating(effective_stake)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
@@ -420,10 +420,10 @@ impl Delegation {
             }
 
             // deactivating stake should equal to all of currently remaining effective stake
-            (current_effective_stake, 0, current_effective_stake)
+            StakeActivationStatus::deactivating(current_effective_stake)
         } else {
             // no history or I've dropped out of history, so assume fully deactivated
-            (0, 0, 0)
+            StakeActivationStatus::default()
         }
     }
 

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -360,7 +360,11 @@ impl Delegation {
         // then de-activate some portion if necessary
         if target_epoch < self.deactivation_epoch {
             // not deactivated
-            StakeActivationStatus::activating(effective_stake, activating_stake)
+            if activating_stake == 0 {
+                StakeActivationStatus::fully_active(effective_stake)
+            } else {
+                StakeActivationStatus::activating(effective_stake, activating_stake)
+            }
         } else if target_epoch == self.deactivation_epoch {
             // can only deactivate what's activated
             StakeActivationStatus::deactivating(effective_stake)

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -16,14 +16,14 @@ pub struct StakeHistoryEntry {
 }
 
 impl StakeHistoryEntry {
-    pub fn fully_active(effective: u64) -> Self {
+    pub fn with_effective(effective: u64) -> Self {
         Self {
             effective,
             ..Self::default()
         }
     }
 
-    pub fn activating(effective: u64, activating: u64) -> Self {
+    pub fn with_effective_and_activating(effective: u64, activating: u64) -> Self {
         Self {
             effective,
             activating,
@@ -31,7 +31,7 @@ impl StakeHistoryEntry {
         }
     }
 
-    pub fn deactivating(deactivating: u64) -> Self {
+    pub fn with_deactivating(deactivating: u64) -> Self {
         Self {
             effective: deactivating,
             deactivating,

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -15,6 +15,42 @@ pub struct StakeHistoryEntry {
     pub deactivating: u64, // requested to be cooled down, not fully deactivated yet
 }
 
+impl StakeHistoryEntry {
+    pub fn fully_active(effective: u64) -> Self {
+        Self {
+            effective,
+            ..Self::default()
+        }
+    }
+
+    pub fn activating(effective: u64, activating: u64) -> Self {
+        Self {
+            effective,
+            activating,
+            ..Self::default()
+        }
+    }
+
+    pub fn deactivating(deactivating: u64) -> Self {
+        Self {
+            effective: deactivating,
+            deactivating,
+            ..Self::default()
+        }
+    }
+}
+
+impl std::ops::Add for StakeHistoryEntry {
+    type Output = StakeHistoryEntry;
+    fn add(self, rhs: StakeHistoryEntry) -> Self::Output {
+        Self {
+            effective: self.effective.saturating_add(rhs.effective),
+            activating: self.activating.saturating_add(rhs.activating),
+            deactivating: self.deactivating.saturating_add(rhs.deactivating),
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);


### PR DESCRIPTION
#### Problem
Tuples are not very dev-friendly

#### Summary of Changes
- Add `StakeActivationStatus` (type alias to StakeHistoryEntry) to represent `(effective, activating, deactivating)` tuple
- Implement `Add` operation for `StakeHistoryEntry` for easy summation
- Add some convenience constructors to `StakeHistoryEntry`

Fixes #
