### PR TITLE
Remove nodejs install

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -805,7 +805,6 @@ $(
     install-earlyoom.sh \
     install-iftop.sh \
     install-libssl-compatability.sh \
-    install-nodejs.sh \
     install-redis.sh \
     install-rsync.sh \
     localtime.sh \


### PR DESCRIPTION
#### Problem

nodejs version 10 not installing

```
Oct  4 02:24:10 gce-perf-cpu-only-bootstrap-validator startup-script: INFO startup-script: Reading package lists...
Oct  4 02:24:10 gce-perf-cpu-only-bootstrap-validator startup-script: INFO startup-script: E: The repository 'https://deb.nodesource.com/node_10.x focal Release' does not have a Release file.
Oct  4 02:24:10 gce-perf-cpu-only-bootstrap-validator startup-script: INFO startup-script: Error executing command, exiting
Oct  4 02:24:10 gce-perf-cpu-only-bootstrap-validator startup-script: INFO startup-script: Return code 1.
```

#### Summary of Changes

Remove nodejs install

Fixes #
