### PR TITLE
lift store.slot() from loop

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5857,9 +5857,10 @@ impl AccountsDb {
                     .into_par_iter()
                     .map(|store| {
                         let accounts = store.all_accounts();
+                        let slot = store.slot();
                         accounts
                             .into_iter()
-                            .map(|account| (store.slot(), account.meta.pubkey))
+                            .map(|account| (slot, account.meta.pubkey))
                             .collect::<HashSet<(Slot, Pubkey)>>()
                     })
                     .reduce(HashSet::new, |mut reduced, store_pubkeys| {


### PR DESCRIPTION
#### Problem
I have measured this call as relatively expensive in previous profiling. This code path is getting very expensive at 600M+ accounts in kin sim.
#### Summary of Changes
Since it is unnecessary to call for each item, lift it from the loop.
Fixes #
