### PR TITLE
Staking docs: link to overview

### DIFF
--- a/docs/src/cli/delegate-stake.md
+++ b/docs/src/cli/delegate-stake.md
@@ -1,6 +1,10 @@
 ---
-title: Delegate Stake
+title: Staking
 ---
+For an overview of staking, read first the
+[Staking and Inflation FAQ](https://solana.com/staking).
+
+------
 
 After you have [received SOL](transfer-tokens.md), you might consider putting
 it to use by delegating _stake_ to a validator. Stake is what we call tokens


### PR DESCRIPTION
#### Problem

[Fragmented info on staking](https://github.com/solana-labs/solana/issues/20400#issuecomment-933710307)

#### Summary of Changes

Link to https://solana.com/staking, at least as a stop-gap measure until the docs are unified somehow.
