### PR TITLE
validator: Default --rpc-bind-address to 127.0.0.1 when --private-rpc is provided and --bind-address is not

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1059,7 +1059,7 @@ pub fn main() {
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .help("IP address to bind the RPC port [default: use --bind-address]"),
+                .help("IP address to bind the RPC port [default: 127.0.0.1 if --private-rpc is present, otherwise use --bind-address]"),
         )
         .arg(
             Arg::with_name("rpc_threads")
@@ -1828,6 +1828,8 @@ pub fn main() {
     let rpc_bind_address = if matches.is_present("rpc_bind_address") {
         solana_net_utils::parse_host(matches.value_of("rpc_bind_address").unwrap())
             .expect("invalid rpc_bind_address")
+    } else if private_rpc {
+        solana_net_utils::parse_host("127.0.0.1").unwrap()
     } else {
         bind_address
     };


### PR DESCRIPTION
It's reasonable for people to assume that `--private-rpc` that cause the RPC to not be accessible from the Internet, but that's not the case.

`--private-rpc` causes the RPC port to not be advertised in gossip, but it remains open.  So if you don't either firewall the port or use `--rpc-bind-address 127.0.0.1` then RPC remains accessible to the Internet.

As a more sane (and slightly breaky) default, set `--rpc-bind-address` to 127.0.0.1 when `--private-rpc` is provided and `--bind-address` is not