### PR TITLE
Restore windows release binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,12 @@ jobs:
     - <<: *release-artifacts
       name: "Windows release artifacts"
       os: windows
+      install:
+        - choco install openssl
+        - export OPENSSL_DIR="C:\Program Files\OpenSSL-Win64"
+        - source ci/rust-version.sh
+        - PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+        - readlink -f .
     #  Linux release artifacts are still built by ci/buildkite-secondary.yml
     #- <<: *release-artifacts
     #  name: "Linux release artifacts"


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/20099 broke windows binary builds because the Travis CI windows image doesn't ship with openssl.

#### Summary of Changes
Install openssl and set OPENSSL_DIR appropriately for rust-openssl to pick it up.
This is currently more brittle than I would like, but there were complications with all the various approaches. This one is the fastest to execute, at least. Perhaps we can fix this up when transitioning to github actions.

Fixes #20382 
