### PR TITLE
Add snapshot_hash module

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -11,6 +11,7 @@ use solana_runtime::{
     accounts_db::{self, AccountsDb},
     accounts_hash::HashStats,
     snapshot_config::SnapshotConfig,
+    snapshot_hash::SnapshotHash,
     snapshot_package::{
         AccountsPackage, AccountsPackageReceiver, PendingSnapshotPackage, SnapshotPackage,
         SnapshotType,
@@ -97,7 +98,7 @@ impl AccountsHashVerifier {
         trusted_validators: Option<&HashSet<Pubkey>>,
         halt_on_trusted_validator_accounts_hash_mismatch: bool,
         pending_snapshot_package: Option<&PendingSnapshotPackage>,
-        hashes: &mut Vec<(Slot, Hash)>,
+        hashes: &mut Vec<SnapshotHash>,
         exit: &Arc<AtomicBool>,
         fault_injection_rate_slots: u64,
         snapshot_config: Option<&SnapshotConfig>,
@@ -152,7 +153,7 @@ impl AccountsHashVerifier {
         cluster_info: &ClusterInfo,
         trusted_validators: Option<&HashSet<Pubkey>>,
         halt_on_trusted_validator_accounts_hash_mismatch: bool,
-        hashes: &mut Vec<(Slot, Hash)>,
+        hashes: &mut Vec<SnapshotHash>,
         exit: &Arc<AtomicBool>,
         fault_injection_rate_slots: u64,
     ) {

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -2,10 +2,10 @@ use solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
 use solana_runtime::{
     snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
+    snapshot_hash::SnapshotHash,
     snapshot_package::{PendingSnapshotPackage, SnapshotType},
     snapshot_utils,
 };
-use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -22,7 +22,7 @@ pub struct SnapshotPackagerService {
 impl SnapshotPackagerService {
     pub fn new(
         pending_snapshot_package: PendingSnapshotPackage,
-        starting_snapshot_hash: Option<(Slot, Hash)>,
+        starting_snapshot_hash: Option<SnapshotHash>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
         snapshot_config: SnapshotConfig,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -71,6 +71,7 @@ use {
         hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
+        snapshot_hash::SnapshotHash,
         snapshot_package::{AccountsPackageSender, PendingSnapshotPackage},
         snapshot_utils,
     },
@@ -1145,7 +1146,7 @@ fn new_banks_from_ledger(
     CompletedSlotsReceiver,
     LeaderScheduleCache,
     Option<Slot>,
-    Option<(Slot, Hash)>,
+    Option<SnapshotHash>,
     TransactionHistoryServices,
     Tower,
 ) {

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -3,10 +3,11 @@ use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use solana_runtime::{
+    snapshot_hash::SnapshotHash,
     snapshot_package::SnapshotType,
     snapshot_utils::{self, ArchiveFormat},
 };
-use solana_sdk::{clock::Slot, genesis_config::DEFAULT_GENESIS_ARCHIVE, hash::Hash};
+use solana_sdk::genesis_config::DEFAULT_GENESIS_ARCHIVE;
 use std::fs::{self, File};
 use std::io;
 use std::io::Read;
@@ -252,7 +253,7 @@ pub fn download_genesis_if_missing(
 pub fn download_snapshot_archive<'a, 'b>(
     rpc_addr: &SocketAddr,
     snapshot_archives_dir: &Path,
-    desired_snapshot_hash: (Slot, Hash),
+    desired_snapshot_hash: SnapshotHash,
     snapshot_type: SnapshotType,
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -9,11 +9,11 @@ use {
     bincode::{serialize, serialized_size},
     rand::{CryptoRng, Rng},
     serde::de::{Deserialize, Deserializer},
+    solana_runtime::snapshot_hash::SnapshotHash,
     solana_sdk::sanitize::{Sanitize, SanitizeError},
     solana_sdk::timing::timestamp,
     solana_sdk::{
         clock::Slot,
-        hash::Hash,
         pubkey::{self, Pubkey},
         signature::{Keypair, Signable, Signature, Signer},
         transaction::Transaction,
@@ -164,7 +164,7 @@ impl CrdsData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, AbiExample)]
 pub struct SnapshotHashes {
     pub from: Pubkey,
-    pub hashes: Vec<(Slot, Hash)>,
+    pub hashes: Vec<SnapshotHash>,
     pub wallclock: u64,
 }
 
@@ -181,7 +181,7 @@ impl Sanitize for SnapshotHashes {
 }
 
 impl SnapshotHashes {
-    pub fn new(from: Pubkey, hashes: Vec<(Slot, Hash)>) -> Self {
+    pub fn new(from: Pubkey, hashes: Vec<SnapshotHash>) -> Self {
         Self {
             from,
             hashes,
@@ -210,8 +210,8 @@ impl SnapshotHashes {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, AbiExample)]
 pub struct IncrementalSnapshotHashes {
     from: Pubkey,
-    base: (Slot, Hash),
-    hashes: Vec<(Slot, Hash)>,
+    base: SnapshotHash,
+    hashes: Vec<SnapshotHash>,
     wallclock: u64,
 }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -12,9 +12,9 @@ use solana_entry::entry::VerifyRecyclers;
 use solana_runtime::{
     accounts_update_notifier_interface::AccountsUpdateNotifier, bank_forks::BankForks,
     snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
-    snapshot_package::AccountsPackageSender, snapshot_utils,
+    snapshot_hash::SnapshotHash, snapshot_package::AccountsPackageSender, snapshot_utils,
 };
-use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash};
+use solana_sdk::{clock::Slot, genesis_config::GenesisConfig};
 use std::{fs, path::PathBuf, process, result};
 
 pub type LoadResult = result::Result<
@@ -22,14 +22,14 @@ pub type LoadResult = result::Result<
         BankForks,
         LeaderScheduleCache,
         Option<Slot>,
-        Option<(Slot, Hash)>,
+        Option<SnapshotHash>,
     ),
     BlockstoreProcessorError,
 >;
 
 fn to_loadresult(
     bpr: BlockstoreProcessorResult,
-    snapshot_slot_and_hash: Option<(Slot, Hash)>,
+    snapshot_hash: Option<SnapshotHash>,
 ) -> LoadResult {
     bpr.map(
         |(bank_forks, leader_schedule_cache, last_full_snapshot_slot)| {
@@ -37,7 +37,7 @@ fn to_loadresult(
                 bank_forks,
                 leader_schedule_cache,
                 last_full_snapshot_slot,
-                snapshot_slot_and_hash,
+                snapshot_hash,
             )
         },
     )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -42,6 +42,7 @@ pub mod serde_snapshot;
 mod shared_buffer_reader;
 pub mod snapshot_archive_info;
 pub mod snapshot_config;
+pub mod snapshot_hash;
 pub mod snapshot_package;
 pub mod snapshot_utils;
 pub mod sorted_storages;

--- a/runtime/src/snapshot_hash.rs
+++ b/runtime/src/snapshot_hash.rs
@@ -1,0 +1,5 @@
+//! Helper types and functions for handling and dealing with snapshot hashes.
+use solana_sdk::{clock::Slot, hash::Hash};
+
+type SlotHash = (Slot, Hash);
+pub type SnapshotHash = SlotHash;

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -13,6 +13,7 @@ use {
     solana_runtime::{
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
+        snapshot_hash::SnapshotHash,
         snapshot_package::SnapshotType,
         snapshot_utils::{
             self, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -22,7 +23,6 @@ use {
     solana_sdk::{
         clock::Slot,
         commitment_config::CommitmentConfig,
-        hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
@@ -52,7 +52,7 @@ fn is_trusted_validator(id: &Pubkey, trusted_validators: &Option<HashSet<Pubkey>
 fn get_trusted_snapshot_hashes(
     cluster_info: &ClusterInfo,
     trusted_validators: &Option<HashSet<Pubkey>>,
-) -> Option<HashSet<(Slot, Hash)>> {
+) -> Option<HashSet<SnapshotHash>> {
     if let Some(trusted_validators) = trusted_validators {
         let mut trusted_snapshot_hashes = HashSet::new();
         for trusted_validator in trusted_validators {
@@ -109,7 +109,7 @@ fn get_rpc_node(
     snapshot_not_required: bool,
     no_untrusted_rpc: bool,
     snapshot_archives_dir: &Path,
-) -> Option<(ContactInfo, Option<(Slot, Hash)>)> {
+) -> Option<(ContactInfo, Option<SnapshotHash>)> {
     let mut blacklist_timeout = Instant::now();
     let mut newer_cluster_snapshot_timeout = None;
     let mut retry_reason = None;
@@ -688,11 +688,11 @@ pub fn rpc_bootstrap(
     }
 }
 
-/// Get the Slot and Hash of the local snapshot with the highest slot.  Can be either a full
+/// Get the SnapshotHash of the local snapshot with the highest slot.  Can be either a full
 /// snapshot or an incremental snapshot.
 fn get_highest_local_snapshot_hash(
     snapshot_archives_dir: impl AsRef<Path>,
-) -> Option<(Slot, Hash)> {
+) -> Option<SnapshotHash> {
     if let Some(full_snapshot_info) =
         snapshot_utils::get_highest_full_snapshot_archive_info(&snapshot_archives_dir)
     {


### PR DESCRIPTION
### Overview

I'm adding a module for snapshot hashes. This commit basically just adds the type alias for `SnapshotHash` to `(Slot, Hash)`.

Going forward, I need to get snapshot hashes during startup (from `bank_forks_utils::load()`), then pass that through to `SnapshotPackagerService` for the starting snapshot hashes (see issue #20423 for more info).

Additionally, normal operation of `SnapshotPackagerService` will push snapshot hashes to gossip, and will need to handle both full and incremental snapshot hashes.

I'll be putting those shared types into this snapshot_hash module.


### Miscellaneous

In addition to adding the snapshot_hash module, I've used it in a number of files that correspond to the files mentioned above. So the diff may seem like a lot has been touched, but hopefully it's actually quite minimal, since it's basically the same change everywhere: `s/(Slot, Hash)/SnapshotHash/` and then also fixing up the `use` calls.