### PR TITLE
Add recent-items metrics

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -207,6 +207,12 @@ impl RecentItems {
                 .checked_sub(item.len())
                 .expect("total bytes underflow");
         }
+
+        datapoint_info!(
+            "rpc_subscriptions_recent_items",
+            ("num", self.queue.len(), i64),
+            ("total_bytes", self.total_bytes, i64),
+        );
     }
 }
 


### PR DESCRIPTION
#### Problem
New pubsub validator params cap RecentItems, but no visibility into those queues.

#### Summary of Changes
Add metrics
