### PR TITLE
Remove encode in JSON parser

### DIFF
--- a/system-test/testnet-automation-json-parser.py
+++ b/system-test/testnet-automation-json-parser.py
@@ -6,7 +6,7 @@ data=json.load(sys.stdin)
 if 'results' in data:
    for result in data['results']:
       if 'series' in result:
-         print(result['series'][0]['columns'][1].encode() + ': ' + str(result['series'][0]['values'][0][1]))
+         print(result['series'][0]['columns'][1] + ': ' + str(result['series'][0]['values'][0][1]))
       else:
          print("An expected result from CURL request is missing")
 else:


### PR DESCRIPTION
#### Problem
Encoding the results string as bytes when uploading to slack caused problems

#### Summary of Changes
Remove the encode

Fixes #
