### PR TITLE
Derive Pod/Zeroable for Pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5271,6 +5271,7 @@ dependencies = [
  "borsh-derive",
  "bs58 0.4.0",
  "bv",
+ "bytemuck",
  "curve25519-dalek 3.2.0",
  "hex",
  "itertools 0.10.1",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3135,6 +3135,7 @@ dependencies = [
  "borsh-derive",
  "bs58 0.4.0",
  "bv",
+ "bytemuck",
  "curve25519-dalek 3.2.0",
  "hex",
  "itertools 0.10.1",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -16,6 +16,7 @@ blake3 = { version = "1.0.0", features = ["traits-preview"] }
 borsh = "0.9.1"
 borsh-derive = "0.9.1"
 bs58 = "0.4.0"
+bytemuck = { version = "1.7.2", features = ["derive"] }
 bv = { version = "0.11.1", features = ["serde"] }
 hex = "0.4.2"
 itertools =  "0.10.1"

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -1,14 +1,16 @@
 #![allow(clippy::integer_arithmetic)]
-use crate::{decode_error::DecodeError, hash::hashv};
-
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use num_derive::{FromPrimitive, ToPrimitive};
-use std::{
-    convert::{Infallible, TryFrom},
-    fmt, mem,
-    str::FromStr,
+use {
+    crate::{decode_error::DecodeError, hash::hashv},
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    bytemuck::{Pod, Zeroable},
+    num_derive::{FromPrimitive, ToPrimitive},
+    std::{
+        convert::{Infallible, TryFrom},
+        fmt, mem,
+        str::FromStr,
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Number of bytes in a pubkey
 pub const PUBKEY_BYTES: usize = 32;
@@ -48,20 +50,22 @@ impl From<u64> for PubkeyError {
 
 #[repr(transparent)]
 #[derive(
-    Serialize,
-    Deserialize,
-    BorshSerialize,
+    AbiExample,
     BorshDeserialize,
     BorshSchema,
+    BorshSerialize,
     Clone,
     Copy,
     Default,
+    Deserialize,
     Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
     Hash,
-    AbiExample,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Pod,
+    Serialize,
+    Zeroable,
 )]
 pub struct Pubkey([u8; 32]);
 


### PR DESCRIPTION
This'll allow me to delete the following code from a downstream dependency:
```rust
/// Placeholder until/if `Pod` is derived for `Pubkey`
#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
#[repr(transparent)]
pub struct PodPubkey([u8; 32]);
impl From<Pubkey> for PodPubkey {
    fn from(pubkey: Pubkey) -> Self {
        Self(pubkey.to_bytes())
    }
}
impl PodPubkey {
    /// Check for equality with a normal `Pubkey`
    pub fn equals(&self, pubkey: &Pubkey) -> bool {
        self.0 == pubkey.as_ref()
    }
}
```