### PR TITLE
Correctly constrain BucketStorage Header's memory ordering

### DIFF
--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -46,7 +46,7 @@ impl Header {
         Ok(UID_UNLOCKED)
             == self
                 .lock
-                .compare_exchange(UID_UNLOCKED, uid, Ordering::AcqRel, Ordering::Acquire)
+                .compare_exchange(UID_UNLOCKED, uid, Ordering::AcqRel, Ordering::Relaxed)
     }
     fn unlock(&self) -> Uid {
         self.lock.swap(UID_UNLOCKED, Ordering::Release)


### PR DESCRIPTION
#### Problem

Uid is used to get if something is unlocked/available, so it needs to have an ordering relationship with _all_ stores to the Uid. So loading Uid needs `Acquire`, and all the stores need `Release`. `unlock()` was already good, but `try_lock()` didn't. `try_lock()` does do a store, so it needs to have `Release` on its store, hence `AcqRel` now. 

#### Summary of Changes

- uid load needs `Acquire`
- try_lock cxchg needs `AcqRel`