### PR TITLE
Update deprecated snapshot/fees/blockhash api docs

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1153,8 +1153,8 @@ Unhealthy Result (if additional information is available)
 
 ### getHighestSnapshotSlot
 
-**NEW: This method is only available in solana-core v1.8 or newer. Please use
-[getSnapshotSlot](jsonrpc-api.md#getsnapshotslot) for solana-core v1.7**
+**NEW: This method is only available in solana-core v1.9 or newer. Please use
+[getSnapshotSlot](jsonrpc-api.md#getsnapshotslot) for solana-core v1.7/v1.8**
 
 Returns the highest slot information that the node has snapshots for.
 


### PR DESCRIPTION
#### Problem
We cut v1.8 as a short-lived testnet release, making some master rpc deprecations inaccurate.

#### Summary of Changes
Fixup, and move deprecated method docs all together
