### PR TITLE
AcctIdx: set startup around clean and shrink at startup to flush cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5551,6 +5551,11 @@ impl Bank {
         }
         clean_time.stop();
 
+        self.rc
+            .accounts
+            .accounts_db
+            .accounts_index
+            .set_startup(true);
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("shrinking..");
@@ -5562,6 +5567,11 @@ impl Bank {
         let mut verify_time = Measure::start("verify_bank_hash");
         let mut verify = self.verify_bank_hash(test_hash_calculation);
         verify_time.stop();
+        self.rc
+            .accounts
+            .accounts_db
+            .accounts_index
+            .set_startup(false);
 
         info!("verify_hash..");
         let mut verify2_time = Measure::start("verify_hash");


### PR DESCRIPTION
#### Problem
startup causes the in mem index to immediately remove everything it can from memory. This is in contrast to 'non-startup', when we keep things around in an LRU manner.
#### Summary of Changes

Fixes #
