### PR TITLE
Enable easy full-rpc services on /net nodes

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -105,6 +105,8 @@ Operate a configured testnet
                                       - Override the number of slots in an epoch
    --warp-slot WARP_SLOT
                                       - Boot from a snapshot that has warped ahead to WARP_SLOT rather than a slot 0 genesis.
+   --full-rpc
+                                      - Support full RPC services on all nodes
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -310,6 +312,7 @@ startBootstrapLeader() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
+         \"$maybeFullRpc\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
          \"$TMPFS_ACCOUNTS\" \
@@ -381,6 +384,7 @@ startNode() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority $maybeAllowPrivateAddr $maybeAccountsDbSkipShrink $maybeSkipRequireTower\" \
          \"$gpuMode\" \
          \"$maybeWarpSlot\" \
+         \"$maybeFullRpc\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
          \"$TMPFS_ACCOUNTS\" \
@@ -788,6 +792,7 @@ netemCommand="add"
 clientDelayStart=0
 netLogDir=
 maybeWarpSlot=
+maybeFullRpc=false
 waitForNodeInit=true
 extraPrimordialStakes=0
 
@@ -896,6 +901,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --warp-slot ]]; then
       maybeWarpSlot="$1 $2"
       shift 2
+    elif [[ $1 == --full-rpc ]]; then
+      maybeFullRpc=true
+      shift 1
     elif [[ $1 == --async-node-init ]]; then
       waitForNodeInit=false
       shift 1

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -24,9 +24,10 @@ genesisOptions="${15}"
 extraNodeArgs="${16}"
 gpuMode="${17:-auto}"
 maybeWarpSlot="${18}"
-waitForNodeInit="${19}"
-extraPrimordialStakes="${20:=0}"
-tmpfsAccounts="${21:false}"
+maybeFullRpc="${19}"
+waitForNodeInit="${20}"
+extraPrimordialStakes="${21:=0}"
+tmpfsAccounts="${22:false}"
 set +x
 
 missing() {
@@ -277,6 +278,11 @@ EOF
       args+=(--accounts /mnt/solana-accounts)
     fi
 
+    if $maybeFullRpc; then
+      args+=(--enable-rpc-transaction-history)
+      args+=(--enable-cpi-and-log-storage)
+    fi
+
     if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
       ./multinode-demo/faucet.sh > faucet.log 2>&1 &
@@ -398,6 +404,11 @@ EOF
 
     if [[ "$tmpfsAccounts" = "true" ]]; then
       args+=(--accounts /mnt/solana-accounts)
+    fi
+
+    if $maybeFullRpc; then
+      args+=(--enable-rpc-transaction-history)
+      args+=(--enable-cpi-and-log-storage)
     fi
 
 cat >> ~/solana/on-reboot <<EOF


### PR DESCRIPTION
#### Problem
I don't know how many times I've thought something was broken with my client because I couldn't confirm a tx or see tx logs on my testnet.

#### Summary of Changes
Enable easy full-rpc services on nodes when booting with `net.sh`
