### PR TITLE
Refactor: Remove program_id from process_instruction()

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1993,7 +1993,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut invoke_context = MockInvokeContext::new(vec![]);
+    let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
     // Verify the program
     <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -14,7 +14,6 @@ use solana_sdk::{
     keyed_account::keyed_account_at_index,
     native_loader,
     process_instruction::{InvokeContext, LoaderEntrypoint},
-    pubkey::Pubkey,
 };
 use std::{
     collections::HashMap,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -100,7 +100,6 @@ fn get_invoke_context<'a>() -> &'a mut dyn InvokeContext {
 
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
-    _program_id: &Pubkey,
     _first_instruction_account: usize,
     input: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -185,13 +184,11 @@ pub fn builtin_process_instruction(
 macro_rules! processor {
     ($process_instruction:expr) => {
         Some(
-            |_program_id: &Pubkey,
-             first_instruction_account: usize,
+            |first_instruction_account: usize,
              input: &[u8],
              invoke_context: &mut dyn solana_sdk::process_instruction::InvokeContext| {
                 $crate::builtin_process_instruction(
                     $process_instruction,
-                    _program_id,
                     first_instruction_account,
                     input,
                     invoke_context,

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -95,7 +95,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
         .unwrap();
     inner_iter.write_u64::<LittleEndian>(0).unwrap();
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::new(vec![]);
+    let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
     let elf = load_elf("bench_alu").unwrap();
     let mut executable = <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
@@ -216,13 +216,13 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .collect();
     let instruction_data = vec![0u8];
 
-    let mut invoke_context = MockInvokeContext::new(keyed_accounts);
+    let mut invoke_context = MockInvokeContext::new(&loader_id, keyed_accounts);
     invoke_context.compute_meter.remaining = BUDGET;
 
     // Serialize account data
     let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
     let (mut serialized, account_lengths) = serialize_parameters(
-        &bpf_loader::id(),
+        &loader_id,
         &solana_sdk::pubkey::new_rand(),
         keyed_accounts,
         &instruction_data,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -203,13 +203,13 @@ fn run_program(
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
     let (parameter_bytes, account_lengths) = serialize_parameters(
-        &bpf_loader::id(),
+        &loader_id,
         program_id,
         &parameter_accounts,
         &instruction_data,
     )
     .unwrap();
-    let mut invoke_context = MockInvokeContext::new(parameter_accounts);
+    let mut invoke_context = MockInvokeContext::new(&loader_id, parameter_accounts);
     let compute_meter = invoke_context.get_compute_meter();
     let mut instruction_meter = ThisInstructionMeter { compute_meter };
 
@@ -284,7 +284,7 @@ fn run_program(
         }
         let parameter_accounts = invoke_context.get_keyed_accounts().unwrap();
         deserialize_parameters(
-            &bpf_loader::id(),
+            &loader_id,
             parameter_accounts,
             parameter_bytes.as_slice(),
             &account_lengths,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -167,13 +167,11 @@ pub fn create_vm<'a>(
 }
 
 pub fn process_instruction(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
-        _program_id,
         first_instruction_account,
         instruction_data,
         invoke_context,
@@ -182,13 +180,11 @@ pub fn process_instruction(
 }
 
 pub fn process_instruction_jit(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
-        _program_id,
         first_instruction_account,
         instruction_data,
         invoke_context,
@@ -197,7 +193,6 @@ pub fn process_instruction_jit(
 }
 
 fn process_instruction_common(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -1124,10 +1119,9 @@ mod tests {
         let mut keyed_accounts = keyed_accounts.to_vec();
         keyed_accounts.insert(0, (false, false, owner, &processor_account));
         super::process_instruction(
-            owner,
             1,
             instruction_data,
-            &mut MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts)),
+            &mut MockInvokeContext::new(owner, create_keyed_accounts_unified(&keyed_accounts)),
         )
     }
 
@@ -1318,11 +1312,11 @@ mod tests {
         let mut keyed_accounts = keyed_accounts.clone();
         keyed_accounts.insert(0, (false, false, &program_key, &processor_account));
         let mut invoke_context =
-            MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts));
+            MockInvokeContext::new(&program_key, create_keyed_accounts_unified(&keyed_accounts));
         invoke_context.compute_meter = MockComputeMeter::default();
         assert_eq!(
             Err(InstructionError::ProgramFailedToComplete),
-            super::process_instruction(&program_key, 1, &[], &mut invoke_context)
+            super::process_instruction(1, &[], &mut invoke_context)
         );
     }
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3331,7 +3331,7 @@ mod tests {
                 leader_schedule_epoch: 4,
                 unix_timestamp: 5,
             };
-            let mut invoke_context = MockInvokeContext::new(vec![]);
+            let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_clock).unwrap();
             invoke_context
@@ -3376,7 +3376,7 @@ mod tests {
                 first_normal_epoch: 3,
                 first_normal_slot: 4,
             };
-            let mut invoke_context = MockInvokeContext::new(vec![]);
+            let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
             invoke_context
@@ -3428,7 +3428,7 @@ mod tests {
                     lamports_per_signature: 1,
                 },
             };
-            let mut invoke_context = MockInvokeContext::new(vec![]);
+            let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_fees).unwrap();
             invoke_context
@@ -3471,7 +3471,7 @@ mod tests {
                 exemption_threshold: 2.0,
                 burn_percent: 3,
             };
-            let mut invoke_context = MockInvokeContext::new(vec![]);
+            let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_rent).unwrap();
             invoke_context

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -1,9 +1,6 @@
-use solana_sdk::{
-    instruction::InstructionError, process_instruction::InvokeContext, pubkey::Pubkey,
-};
+use solana_sdk::{instruction::InstructionError, process_instruction::InvokeContext};
 
 pub fn process_instruction(
-    _program_id: &Pubkey,
     _first_instruction_account: usize,
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -14,7 +14,6 @@ use solana_sdk::{
 use std::collections::BTreeSet;
 
 pub fn process_instruction(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -144,6 +143,7 @@ mod tests {
         account::{Account, AccountSharedData},
         keyed_account::create_keyed_accounts_unified,
         process_instruction::MockInvokeContext,
+        pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_instruction::SystemInstruction,
     };
@@ -158,10 +158,9 @@ mod tests {
         let mut keyed_accounts = keyed_accounts.to_vec();
         keyed_accounts.insert(0, (false, false, owner, &processor_account));
         super::process_instruction(
-            owner,
             1,
             instruction_data,
-            &mut MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts)),
+            &mut MockInvokeContext::new(owner, create_keyed_accounts_unified(&keyed_accounts)),
         )
     }
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -7,7 +7,6 @@ use {
         keyed_account::{from_keyed_account, get_signers, keyed_account_at_index},
         process_instruction::{get_sysvar, InvokeContext},
         program_utils::limited_deserialize,
-        pubkey::Pubkey,
         stake::{
             instruction::StakeInstruction,
             program::id,
@@ -24,7 +23,6 @@ use {
 pub use solana_sdk::stake::instruction::*;
 
 pub fn process_instruction(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -333,6 +331,7 @@ mod tests {
         instruction::{AccountMeta, Instruction},
         keyed_account::create_keyed_accounts_unified,
         process_instruction::{mock_set_sysvar, MockInvokeContext},
+        pubkey::Pubkey,
         rent::Rent,
         stake::{
             config as stake_config,
@@ -379,10 +378,9 @@ mod tests {
         let mut keyed_accounts = keyed_accounts.to_vec();
         keyed_accounts.insert(0, (false, false, owner, &processor_account));
         super::process_instruction(
-            owner,
             1,
             instruction_data,
-            &mut MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts)),
+            &mut MockInvokeContext::new(owner, create_keyed_accounts_unified(&keyed_accounts)),
         )
     }
 
@@ -440,20 +438,17 @@ mod tests {
                 .collect();
             let processor_id = id();
             keyed_accounts.insert(0, (false, false, &processor_id, &processor_account));
-            let mut invoke_context =
-                MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts));
+            let mut invoke_context = MockInvokeContext::new(
+                &processor_id,
+                create_keyed_accounts_unified(&keyed_accounts),
+            );
             mock_set_sysvar(
                 &mut invoke_context,
                 sysvar::clock::id(),
                 sysvar::clock::Clock::default(),
             )
             .unwrap();
-            super::process_instruction(
-                &Pubkey::default(),
-                1,
-                &instruction.data,
-                &mut invoke_context,
-            )
+            super::process_instruction(1, &instruction.data, &mut invoke_context)
         }
     }
 
@@ -1104,7 +1099,7 @@ mod tests {
             (true, false, &custodian, &custodian_account),
         ];
         let mut invoke_context =
-            MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts));
+            MockInvokeContext::new(&id(), create_keyed_accounts_unified(&keyed_accounts));
         let clock = Clock::default();
         let mut data = vec![];
         bincode::serialize_into(&mut data, &clock).unwrap();
@@ -1114,7 +1109,6 @@ mod tests {
 
         assert_eq!(
             super::process_instruction(
-                &Pubkey::default(),
                 1,
                 &serialize(&StakeInstruction::SetLockupChecked(LockupCheckedArgs {
                     unix_timestamp: None,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -5075,7 +5075,7 @@ mod tests {
         let stake_lamports = 42;
 
         let signers = vec![authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5179,7 +5179,7 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
         let signers = HashSet::from_iter(vec![authority_pubkey]);
@@ -5232,7 +5232,7 @@ mod tests {
 
         let signers = vec![authorized_pubkey].into_iter().collect();
         let wrong_signers = vec![wrong_authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5298,7 +5298,7 @@ mod tests {
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let signers = vec![authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         for state in &[
             StakeState::Uninitialized,
@@ -5368,7 +5368,7 @@ mod tests {
         .expect("source_stake_account");
         let source_stake_keyed_account =
             KeyedAccount::new(&source_stake_pubkey, true, &source_stake_account);
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         assert_eq!(
             stake_keyed_account.merge(
@@ -5438,7 +5438,7 @@ mod tests {
 
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         clock.epoch = 0;
         let mut effective = base_lamports;
@@ -6016,7 +6016,7 @@ mod tests {
                 ..Delegation::default()
             },
         };
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         let identical = good_stake;
         assert!(
@@ -6105,7 +6105,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_pre_v4() {
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6191,7 +6191,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_v4() {
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6357,7 +6357,7 @@ mod tests {
         let stake_keyed_account = KeyedAccount::new(&authority_pubkey, true, &stake_account);
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         // Uninitialized state fails
         assert_eq!(
@@ -6584,7 +6584,7 @@ mod tests {
         let inactive = MergeKind::Inactive(Meta::default(), lamports);
         let activation_epoch = MergeKind::ActivationEpoch(meta, stake);
         let fully_active = MergeKind::FullyActive(meta, stake);
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         assert_eq!(
             inactive
@@ -6670,7 +6670,7 @@ mod tests {
             credits_observed: credits_a,
         };
 
-        let invoke_context = MockInvokeContext::new(vec![]);
+        let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
 
         // activating stake merge, match credits observed
         let activation_epoch_a = MergeKind::ActivationEpoch(meta, stake_a);

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -308,7 +308,6 @@ fn verify_rent_exemption(
 }
 
 pub fn process_instruction(
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -428,10 +427,9 @@ mod tests {
         let mut keyed_accounts = keyed_accounts.to_vec();
         keyed_accounts.insert(0, (false, false, owner, &processor_account));
         super::process_instruction(
-            owner,
             1,
             instruction_data,
-            &mut MockInvokeContext::new(create_keyed_accounts_unified(&keyed_accounts)),
+            &mut MockInvokeContext::new(owner, create_keyed_accounts_unified(&keyed_accounts)),
         )
     }
 

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -175,7 +175,7 @@ native machine code before execting it in the virtual machine.",
             (Vec::from(bytes.as_slice_mut()), account_lengths)
         }
     };
-    let mut invoke_context = MockInvokeContext::new(accounts);
+    let mut invoke_context = MockInvokeContext::new(&bpf_loader::id(), accounts);
     let logger = invoke_context.logger.clone();
     let compute_meter = invoke_context.get_compute_meter();
     let mut instruction_meter = ThisInstructionMeter { compute_meter };

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -32,7 +32,6 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
-    _program_id: &Pubkey,
     _first_instruction_account: usize,
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6685,7 +6685,6 @@ pub(crate) mod tests {
     }
 
     fn mock_process_instruction(
-        _program_id: &Pubkey,
         first_instruction_account: usize,
         data: &[u8],
         invoke_context: &mut dyn InvokeContext,
@@ -10333,7 +10332,6 @@ pub(crate) mod tests {
             Pubkey::new(&[42u8; 32])
         }
         fn mock_vote_processor(
-            _program_id: &Pubkey,
             _first_instruction_account: usize,
             _instruction_data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -10392,7 +10390,6 @@ pub(crate) mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_vote_processor(
-            _pubkey: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
@@ -10443,7 +10440,6 @@ pub(crate) mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
-            _pubkey: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
@@ -11285,7 +11281,6 @@ pub(crate) mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_process_instruction(
-            _program_id: &Pubkey,
             first_instruction_account: usize,
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -11346,7 +11341,6 @@ pub(crate) mod tests {
 
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
-            _program_id: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
@@ -11533,7 +11527,6 @@ pub(crate) mod tests {
 
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ok_vote_processor(
-        _pubkey: &Pubkey,
         _first_instruction_account: usize,
         _data: &[u8],
         _invoke_context: &mut dyn InvokeContext,
@@ -11784,7 +11777,6 @@ pub(crate) mod tests {
     #[test]
     fn test_same_program_id_uses_unqiue_executable_accounts() {
         fn nested_processor(
-            _program_id: &Pubkey,
             first_instruction_account: usize,
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -12156,7 +12148,6 @@ pub(crate) mod tests {
 
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
-            _pubkey: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
@@ -12206,7 +12197,6 @@ pub(crate) mod tests {
 
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
-            _pubkey: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _context: &mut dyn InvokeContext,
@@ -13097,7 +13087,6 @@ pub(crate) mod tests {
         // intentionally create bogus native programs
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
-            _program_id: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
@@ -14595,7 +14584,6 @@ pub(crate) mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
-            _pubkey: &Pubkey,
             first_instruction_account: usize,
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -14805,7 +14793,6 @@ pub(crate) mod tests {
         let mut bank = Bank::new_for_tests(&genesis_config);
 
         fn mock_ix_processor(
-            _pubkey: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -13,7 +13,6 @@ use solana_frozen_abi::abi_example::AbiExample;
 
 fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
-    _program_id: &Pubkey,
     first_instruction_account: usize,
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
@@ -24,12 +23,7 @@ fn process_instruction_with_program_logging(
     let program_id = invoke_context.get_caller()?;
     stable_log::program_invoke(&logger, program_id, invoke_context.invoke_depth());
 
-    let result = process_instruction(
-        _program_id,
-        first_instruction_account,
-        instruction_data,
-        invoke_context,
-    );
+    let result = process_instruction(first_instruction_account, instruction_data, invoke_context);
 
     let program_id = invoke_context.get_caller()?;
     match &result {
@@ -41,13 +35,11 @@ fn process_instruction_with_program_logging(
 
 macro_rules! with_program_logging {
     ($process_instruction:expr) => {
-        |_program_id: &Pubkey,
-         first_instruction_account: usize,
+        |first_instruction_account: usize,
          instruction_data: &[u8],
          invoke_context: &mut dyn InvokeContext| {
             process_instruction_with_program_logging(
                 $process_instruction,
-                _program_id,
                 first_instruction_account,
                 instruction_data,
                 invoke_context,
@@ -96,7 +88,7 @@ impl AbiExample for Builtin {
         Self {
             name: String::default(),
             id: Pubkey::default(),
-            process_instruction_with_context: |_, _, _, _| Ok(()),
+            process_instruction_with_context: |_, _, _| Ok(()),
         }
     }
 }
@@ -143,7 +135,6 @@ fn genesis_builtins() -> Vec<Builtin> {
 
 /// place holder for secp256k1, remove when the precompile program is deactivated via feature activation
 fn dummy_process_instruction(
-    _program_id: &Pubkey,
     _first_instruction_account: usize,
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -550,11 +550,8 @@ impl MessageProcessor {
             let result = invoke_context
                 .push(program_id, message, instruction, program_indices, None)
                 .and_then(|_| {
-                    instruction_processor.process_instruction(
-                        program_id,
-                        &instruction.data,
-                        &mut invoke_context,
-                    )?;
+                    instruction_processor
+                        .process_instruction(&instruction.data, &mut invoke_context)?;
                     invoke_context.verify(message, instruction, program_indices)?;
                     timings.accumulate(&invoke_context.timings);
                     Ok(())
@@ -598,7 +595,6 @@ mod tests {
     }
 
     fn mock_process_instruction(
-        _program_id: &Pubkey,
         first_instruction_account: usize,
         data: &[u8],
         invoke_context: &mut dyn InvokeContext,
@@ -822,7 +818,6 @@ mod tests {
         }
 
         fn mock_system_process_instruction(
-            _program_id: &Pubkey,
             first_instruction_account: usize,
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -996,7 +991,6 @@ mod tests {
         }
 
         fn mock_system_process_instruction(
-            _program_id: &Pubkey,
             first_instruction_account: usize,
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
@@ -1524,7 +1518,6 @@ mod tests {
     fn test_precompile() {
         let mock_program_id = Pubkey::new_unique();
         fn mock_process_instruction(
-            _program_id: &Pubkey,
             _first_instruction_account: usize,
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,

--- a/sdk/src/builtins.rs
+++ b/sdk/src/builtins.rs
@@ -79,7 +79,6 @@ macro_rules! declare_builtin_name {
 /// use solana_sdk::declare_builtin;
 ///
 /// fn my_process_instruction(
-///     program_id: &Pubkey,
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],
@@ -111,7 +110,6 @@ macro_rules! declare_builtin_name {
 /// use solana_sdk::declare_builtin;
 ///
 /// fn my_process_instruction(
-///     program_id: &Pubkey,
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -94,7 +94,6 @@ macro_rules! declare_name {
 /// };
 ///
 /// fn my_process_instruction(
-///     program_id: &Pubkey,
 ///     first_instruction_account: usize,
 ///     instruction_data: &[u8],
 ///     invoke_context: &mut dyn InvokeContext,
@@ -128,7 +127,6 @@ macro_rules! declare_name {
 /// };
 ///
 /// fn my_process_instruction(
-///     program_id: &Pubkey,
 ///     first_instruction_account: usize,
 ///     instruction_data: &[u8],
 ///     invoke_context: &mut dyn InvokeContext,
@@ -155,12 +153,11 @@ macro_rules! declare_program(
 
         #[no_mangle]
         pub extern "C" fn $name(
-            program_id: &$crate::pubkey::Pubkey,
             first_instruction_account: usize,
             instruction_data: &[u8],
             invoke_context: &mut dyn $crate::process_instruction::InvokeContext,
         ) -> Result<(), $crate::instruction::InstructionError> {
-            $entrypoint(program_id, first_instruction_account, instruction_data, invoke_context)
+            $entrypoint(first_instruction_account, instruction_data, invoke_context)
         }
     )
 );

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -289,7 +289,7 @@ mod test {
     }
 
     fn create_invoke_context_with_blockhash<'a>(seed: usize) -> MockInvokeContext<'a> {
-        let mut invoke_context = MockInvokeContext::new(vec![]);
+        let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
         let (blockhash, fee_calculator) = create_test_blockhash(seed);
         invoke_context.blockhash = blockhash;
         invoke_context.fee_calculator = fee_calculator;
@@ -979,7 +979,7 @@ mod test {
         let min_lamports = rent.minimum_balance(State::size());
         with_test_keyed_account(min_lamports + 42, true, |nonce_account| {
             let mut signers = HashSet::new();
-            let invoke_context = MockInvokeContext::new(vec![]);
+            let invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             signers.insert(*nonce_account.signer_key().unwrap());
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -28,7 +28,7 @@ pub type LoaderEntrypoint = unsafe extern "C" fn(
 ) -> Result<(), InstructionError>;
 
 pub type ProcessInstructionWithContext =
-    fn(&Pubkey, usize, &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
+    fn(usize, &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
 
 pub struct InvokeContextStackFrame<'a> {
     pub key: Pubkey,
@@ -455,7 +455,7 @@ pub struct MockInvokeContext<'a> {
 }
 
 impl<'a> MockInvokeContext<'a> {
-    pub fn new(keyed_accounts: Vec<KeyedAccount<'a>>) -> Self {
+    pub fn new(program_id: &Pubkey, keyed_accounts: Vec<KeyedAccount<'a>>) -> Self {
         let compute_budget = ComputeBudget::default();
         let mut invoke_context = MockInvokeContext {
             invoke_stack: Vec::with_capacity(compute_budget.max_invoke_depth),
@@ -475,10 +475,7 @@ impl<'a> MockInvokeContext<'a> {
         };
         invoke_context
             .invoke_stack
-            .push(InvokeContextStackFrame::new(
-                Pubkey::default(),
-                keyed_accounts,
-            ));
+            .push(InvokeContextStackFrame::new(*program_id, keyed_accounts));
         invoke_context
     }
 }


### PR DESCRIPTION
#### Problem
The parameter `program_id: &Pubkey` is redundant as it is stored in `InvokeContext::invoke_stack` anyway.

#### Summary of Changes
Removes the parameter `program_id: &Pubkey` from `process_instruction()`.

Fixes #
