### PR TITLE
Remove feature switch handling for `check_init_vote_data`

### DIFF
--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -338,7 +338,6 @@ pub fn process_instruction(
                     keyed_accounts,
                     first_instruction_account + 2,
                 )?)?,
-                invoke_context.is_feature_active(&feature_set::check_init_vote_data::id()),
             )
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => vote_state::authorize(

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -710,9 +710,8 @@ pub fn initialize_account<S: std::hash::BuildHasher>(
     vote_init: &VoteInit,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
-    check_data_size: bool,
 ) -> Result<(), InstructionError> {
-    if check_data_size && vote_account.data_len()? != VoteState::size_of() {
+    if vote_account.data_len()? != VoteState::size_of() {
         return Err(InstructionError::InvalidAccountData);
     }
     let versioned = State::<VoteStateVersions>::state(vote_account)?;
@@ -842,7 +841,6 @@ mod tests {
             },
             &signers,
             &Clock::default(),
-            true,
         );
         assert_eq!(res, Err(InstructionError::MissingRequiredSignature));
 
@@ -860,7 +858,6 @@ mod tests {
             },
             &signers,
             &Clock::default(),
-            true,
         );
         assert_eq!(res, Ok(()));
 
@@ -875,7 +872,6 @@ mod tests {
             },
             &signers,
             &Clock::default(),
-            true,
         );
         assert_eq!(res, Err(InstructionError::AccountAlreadyInitialized));
 
@@ -893,7 +889,6 @@ mod tests {
             },
             &signers,
             &Clock::default(),
-            true,
         );
         assert_eq!(res, Err(InstructionError::InvalidAccountData));
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4914,7 +4914,6 @@ impl Bank {
             self.stakes.write().unwrap().store(
                 pubkey,
                 account,
-                self.check_init_vote_data_enabled(),
                 self.stakes_remove_delegation_if_inactive_enabled(),
             );
         }
@@ -5669,7 +5668,6 @@ impl Bank {
                 if let Some(old_vote_account) = self.stakes.write().unwrap().store(
                     pubkey,
                     account,
-                    self.check_init_vote_data_enabled(),
                     self.stakes_remove_delegation_if_inactive_enabled(),
                 ) {
                     // TODO: one of the indices is redundant.
@@ -5898,11 +5896,6 @@ impl Bank {
     pub fn no_overflow_rent_distribution_enabled(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::no_overflow_rent_distribution::id())
-    }
-
-    pub fn check_init_vote_data_enabled(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::check_init_vote_data::id())
     }
 
     pub fn verify_tx_signatures_len_enabled(&self) -> bool {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -195,7 +195,6 @@ impl Stakes {
         &mut self,
         pubkey: &Pubkey,
         account: &AccountSharedData,
-        check_vote_init: bool,
         remove_delegation_on_inactive: bool,
     ) -> Option<VoteAccount> {
         if solana_vote_program::check_id(account.owner()) {
@@ -205,9 +204,7 @@ impl Stakes {
             let old = self.vote_accounts.remove(pubkey);
             // when account is removed (lamports == 0 or data uninitialized), don't read so that
             // given `pubkey` can be used for any owner in the future, while not affecting Stakes.
-            if account.lamports() != 0
-                && !(check_vote_init && VoteState::is_uninitialized_no_deser(account.data()))
-            {
+            if account.lamports() != 0 && !VoteState::is_uninitialized_no_deser(account.data()) {
                 let stake = old.as_ref().map_or_else(
                     || self.calculate_stake(pubkey, self.epoch, Some(&self.stake_history)),
                     |v| v.0,
@@ -378,8 +375,8 @@ pub mod tests {
             let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
                 create_staked_node_accounts(10);
 
-            stakes.store(&vote_pubkey, &vote_account, true, true);
-            stakes.store(&stake_pubkey, &stake_account, true, true);
+            stakes.store(&vote_pubkey, &vote_account, true);
+            stakes.store(&stake_pubkey, &stake_account, true);
             let stake = stake_state::stake_from(&stake_account).unwrap();
             {
                 let vote_accounts = stakes.vote_accounts();
@@ -391,7 +388,7 @@ pub mod tests {
             }
 
             stake_account.set_lamports(42);
-            stakes.store(&stake_pubkey, &stake_account, true, true);
+            stakes.store(&stake_pubkey, &stake_account, true);
             {
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
@@ -403,7 +400,7 @@ pub mod tests {
 
             // activate more
             let (_stake_pubkey, mut stake_account) = create_stake_account(42, &vote_pubkey);
-            stakes.store(&stake_pubkey, &stake_account, true, true);
+            stakes.store(&stake_pubkey, &stake_account, true);
             let stake = stake_state::stake_from(&stake_account).unwrap();
             {
                 let vote_accounts = stakes.vote_accounts();
@@ -415,7 +412,7 @@ pub mod tests {
             }
 
             stake_account.set_lamports(0);
-            stakes.store(&stake_pubkey, &stake_account, true, true);
+            stakes.store(&stake_pubkey, &stake_account, true);
             {
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
@@ -433,14 +430,14 @@ pub mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
 
         let ((vote11_pubkey, vote11_account), (stake11_pubkey, stake11_account)) =
             create_staked_node_accounts(20);
 
-        stakes.store(&vote11_pubkey, &vote11_account, true, true);
-        stakes.store(&stake11_pubkey, &stake11_account, true, true);
+        stakes.store(&vote11_pubkey, &vote11_account, true);
+        stakes.store(&stake11_pubkey, &stake11_account, true);
 
         let vote11_node_pubkey = VoteState::from(&vote11_account).unwrap().node_pubkey;
 
@@ -457,8 +454,8 @@ pub mod tests {
         let ((vote_pubkey, mut vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -467,7 +464,7 @@ pub mod tests {
         }
 
         vote_account.set_lamports(0);
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -475,7 +472,7 @@ pub mod tests {
         }
 
         vote_account.set_lamports(1);
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -488,7 +485,7 @@ pub mod tests {
         let mut pushed = vote_account.data().to_vec();
         pushed.push(0);
         vote_account.set_data(pushed);
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -499,7 +496,7 @@ pub mod tests {
         let default_vote_state = VoteState::default();
         let versioned = VoteStateVersions::new_current(default_vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -507,7 +504,7 @@ pub mod tests {
         }
 
         vote_account.set_data(cache_data);
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -529,11 +526,11 @@ pub mod tests {
         let ((vote_pubkey2, vote_account2), (_stake_pubkey2, stake_account2)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&vote_pubkey2, &vote_account2, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&vote_pubkey2, &vote_account2, true);
 
         // delegates to vote_pubkey
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
 
         let stake = stake_state::stake_from(&stake_account).unwrap();
 
@@ -549,7 +546,7 @@ pub mod tests {
         }
 
         // delegates to vote_pubkey2
-        stakes.store(&stake_pubkey, &stake_account2, true, true);
+        stakes.store(&stake_pubkey, &stake_account2, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -574,11 +571,11 @@ pub mod tests {
 
         let (stake_pubkey2, stake_account2) = create_stake_account(10, &vote_pubkey);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
 
         // delegates to vote_pubkey
-        stakes.store(&stake_pubkey, &stake_account, true, true);
-        stakes.store(&stake_pubkey2, &stake_account2, true, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
+        stakes.store(&stake_pubkey2, &stake_account2, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -594,8 +591,8 @@ pub mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
         let stake = stake_state::stake_from(&stake_account).unwrap();
 
         {
@@ -623,8 +620,8 @@ pub mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
         let stake = stake_state::stake_from(&stake_account).unwrap();
 
         {
@@ -655,8 +652,8 @@ pub mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10);
 
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
 
         {
             let vote_accounts = stakes.vote_accounts();
@@ -668,7 +665,6 @@ pub mod tests {
         stakes.store(
             &stake_pubkey,
             &AccountSharedData::new(1, 0, &stake::program::id()),
-            true,
             true,
         );
         {
@@ -699,8 +695,8 @@ pub mod tests {
         let genesis_epoch = 0;
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_warming_staked_node_accounts(10, genesis_epoch);
-        stakes.store(&vote_pubkey, &vote_account, true, true);
-        stakes.store(&stake_pubkey, &stake_account, true, true);
+        stakes.store(&vote_pubkey, &vote_account, true);
+        stakes.store(&stake_pubkey, &stake_account, true);
 
         assert_eq!(stakes.vote_balance_and_staked(), 11);
         assert_eq!(stakes.vote_balance_and_warmed_staked(), 1);


### PR DESCRIPTION
#### Problem
The `check_init_vote_data` feature switch has been enabled for a long time and doesn't need to be checked anymore

#### Summary of Changes
- Remove feature switch handling for `check_init_vote_data`

Fixes #
