### PR TITLE
Fix solana docker image

### DIFF
--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 # RPC JSON
 EXPOSE 8899/tcp


### PR DESCRIPTION
Running the image fails with:

solana-validator: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by solana-validator)

#### Problem

#### Summary of Changes

Fixes #
