### PR TITLE
fix(docs): getInflationRate epoch type from f64 => u64

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1277,7 +1277,7 @@ The result field will be a JSON object with the following fields:
 - `total: <f64>`, total inflation
 - `validator: <f64>`, inflation allocated to validators
 - `foundation: <f64>`, inflation allocated to the foundation
-- `epoch: <f64>`, epoch for which these values are valid
+- `epoch: <u64>`, epoch for which these values are valid
 
 #### Example:
 


### PR DESCRIPTION
#### Problem

According to https://github.com/solana-labs/solana/blob/master/client/src/rpc_response.rs#L116
I think the type of epoch which responsed by `getInflationRate` is u64 not f64.

#### Summary of Changes

only `docs/src/developing/clients/jsonrpc-api.md `
