### PR TITLE
Add debug guard to catch invalid  params

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -507,6 +507,8 @@ impl MessageProcessor {
             &fee_calculator,
         );
         let compute_meter = invoke_context.get_compute_meter();
+
+        debug_assert_eq!(program_indices.len(), message.instructions.len());
         for (instruction_index, (instruction, program_indices)) in message
             .instructions
             .iter()


### PR DESCRIPTION
#### Problem

`MessageProcessor::process_message` can return a false positive if the `program_indices` length does not match the number of instructions in the message.   This could happen as the runtime evolves or when new tests are added that call `process_message` directly.

#### Summary of Changes

Add a guard to ensure an evolving runtime doesn't pass silently pass tests for the wrong reason

Fixes #
