### PR TITLE
uses nanos precision for timestamp when submitting metrics to influxdb

### DIFF
--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -1,8 +1,13 @@
-use crate::metrics::submit_counter;
-use log::*;
-use solana_sdk::timing;
-use std::env;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use {
+    crate::metrics::submit_counter,
+    log::*,
+    solana_sdk::timing,
+    std::{
+        env,
+        sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+        time::SystemTime,
+    },
+};
 
 const DEFAULT_LOG_RATE: usize = 1000;
 // Submit a datapoint every second by default
@@ -23,7 +28,7 @@ pub struct Counter {
 pub struct CounterPoint {
     pub name: &'static str,
     pub count: i64,
-    pub timestamp: u64,
+    pub timestamp: SystemTime,
 }
 
 impl CounterPoint {
@@ -32,7 +37,7 @@ impl CounterPoint {
         CounterPoint {
             name,
             count: 0,
-            timestamp: 0,
+            timestamp: std::time::UNIX_EPOCH,
         }
     }
 }
@@ -198,7 +203,7 @@ impl Counter {
             let counter = CounterPoint {
                 name: self.name,
                 count: counts as i64 - lastlog as i64,
-                timestamp: now,
+                timestamp: SystemTime::now(),
             };
             submit_counter(counter, level, bucket);
         }

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -1,9 +1,9 @@
-use std::fmt;
+use std::{fmt, time::SystemTime};
 
 #[derive(Clone, Debug)]
 pub struct DataPoint {
     pub name: &'static str,
-    pub timestamp: u64,
+    pub timestamp: SystemTime,
     pub fields: Vec<(&'static str, String)>,
 }
 
@@ -11,7 +11,7 @@ impl DataPoint {
     pub fn new(name: &'static str) -> Self {
         DataPoint {
             name,
-            timestamp: solana_sdk::timing::timestamp(),
+            timestamp: SystemTime::now(),
             fields: vec![],
         }
     }


### PR DESCRIPTION

#### Problem
Current datapoint_info! is apparently overwriting itself when run inside
a loop. For example in
https://github.com/solana-labs/solana/blob/005d6863f/core/src/window_service.rs#L101-L107
only one of the slots will show up in influxdb.

This is apparently because of metrics code using milliseconds as the
timestamp, as mentioned here:
https://github.com/solana-labs/solana/issues/19789#issuecomment-922482013

#### Summary of Changes
* use nanos precision for timestamp when submitting metrics to influxdb

Fixes #19789