### PR TITLE
Invoke cost tracker from its bank

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -16,7 +16,7 @@ use solana_perf::packet::to_packets_chunked;
 use solana_poh::poh_recorder::{create_test_recorder, PohRecorder, WorkingBankEntry};
 use solana_runtime::{
     accounts_background_service::AbsRequestSender, bank::Bank, bank_forks::BankForks,
-    cost_model::CostModel, cost_tracker::CostTracker,
+    cost_model::CostModel,
 };
 use solana_sdk::{
     hash::Hash,
@@ -233,9 +233,7 @@ fn main() {
             vote_receiver,
             None,
             replay_vote_sender,
-            Arc::new(RwLock::new(CostTracker::new(Arc::new(RwLock::new(
-                CostModel::default(),
-            ))))),
+            Arc::new(RwLock::new(CostModel::default())),
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -19,7 +19,6 @@ use solana_perf::test_tx::test_tx;
 use solana_poh::poh_recorder::{create_test_recorder, WorkingBankEntry};
 use solana_runtime::bank::Bank;
 use solana_runtime::cost_model::CostModel;
-use solana_runtime::cost_tracker::CostTracker;
 use solana_runtime::cost_tracker_stats::CostTrackerStats;
 use solana_sdk::genesis_config::GenesisConfig;
 use solana_sdk::hash::Hash;
@@ -95,9 +94,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
-                &Arc::new(RwLock::new(CostTracker::new(Arc::new(RwLock::new(
-                    CostModel::new(std::u64::MAX, std::u64::MAX),
-                ))))),
+                &Arc::new(RwLock::new(CostModel::default())),
                 &mut CostTrackerStats::default(),
             );
         });
@@ -172,6 +169,11 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     bank.ns_per_slot = std::u128::MAX;
     let bank = Arc::new(Bank::new_for_benches(&genesis_config));
 
+    // set cost tracker limits to MAX so it will not filter out TXs
+    bank.write_cost_tracker()
+        .unwrap()
+        .set_limits(std::u64::MAX, std::u64::MAX);
+
     debug!("threads: {} txs: {}", num_threads, txes);
 
     let transactions = match tx_type {
@@ -225,9 +227,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             vote_receiver,
             None,
             s,
-            Arc::new(RwLock::new(CostTracker::new(Arc::new(RwLock::new(
-                CostModel::new(std::u64::MAX, std::u64::MAX),
-            ))))),
+            Arc::new(RwLock::new(CostModel::default())),
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -23,7 +23,6 @@ use solana_rpc::{
 use solana_runtime::{
     bank_forks::BankForks,
     cost_model::CostModel,
-    cost_tracker::CostTracker,
     vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
 };
 use std::{
@@ -123,7 +122,6 @@ impl Tpu {
             cluster_confirmed_slot_sender,
         );
 
-        let cost_tracker = Arc::new(RwLock::new(CostTracker::new(cost_model.clone())));
         let banking_stage = BankingStage::new(
             cluster_info,
             poh_recorder,
@@ -132,7 +130,7 @@ impl Tpu {
             verified_gossip_vote_packets_receiver,
             transaction_status_sender,
             replay_vote_sender,
-            cost_tracker,
+            cost_model.clone(),
         );
 
         let broadcast_stage = broadcast_type.new_broadcast_stage(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -775,13 +775,11 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
     let mut program_ids = HashMap::new();
     let mut cost_model = CostModel::default();
     cost_model.initialize_cost_table(&blockstore.read_program_costs().unwrap());
-    let cost_model = Arc::new(RwLock::new(cost_model));
-    let mut cost_tracker = CostTracker::new(cost_model.clone());
+    let mut cost_tracker = CostTracker::default();
     let mut cost_tracker_stats = CostTrackerStats::default();
 
     for entry in entries {
         num_transactions += entry.transactions.len();
-        let mut cost_model = cost_model.write().unwrap();
         entry
             .transactions
             .into_iter()
@@ -802,7 +800,7 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
                     true, // demote_program_write_locks
                 );
                 if cost_tracker
-                    .try_add(tx_cost, &mut cost_tracker_stats)
+                    .try_add(&transaction, &tx_cost, &mut cost_tracker_stats)
                     .is_err()
                 {
                     println!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -44,6 +44,7 @@ use crate::{
     ancestors::{Ancestors, AncestorsForSerialization},
     blockhash_queue::BlockhashQueue,
     builtins::{self, ActivationType, Builtin, Builtins},
+    cost_tracker::CostTracker,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     inline_spl_token_v2_0,
     instruction_recorder::InstructionRecorder,
@@ -994,6 +995,8 @@ pub struct Bank {
     pub freeze_started: AtomicBool,
 
     vote_only_bank: bool,
+
+    pub cost_tracker: RwLock<CostTracker>,
 }
 
 impl Default for BlockhashQueue {
@@ -1132,6 +1135,7 @@ impl Bank {
             drop_callback: RwLock::<OptionalDropCallback>::default(),
             freeze_started: AtomicBool::default(),
             vote_only_bank: false,
+            cost_tracker: RwLock::<CostTracker>::default(),
         }
     }
 
@@ -1382,6 +1386,7 @@ impl Bank {
                     .map(|drop_callback| drop_callback.clone_box()),
             )),
             freeze_started: AtomicBool::new(false),
+            cost_tracker: RwLock::new(CostTracker::default()),
         };
 
         datapoint_info!(
@@ -1568,6 +1573,7 @@ impl Bank {
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
             vote_only_bank: false,
+            cost_tracker: RwLock::new(CostTracker::default()),
         };
         bank.finish_init(
             genesis_config,
@@ -5943,6 +5949,14 @@ impl Bank {
     pub fn send_to_tpu_vote_port_enabled(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::send_to_tpu_vote_port::id())
+    }
+
+    pub fn read_cost_tracker(&self) -> LockResult<RwLockReadGuard<CostTracker>> {
+        self.cost_tracker.read()
+    }
+
+    pub fn write_cost_tracker(&self) -> LockResult<RwLockWriteGuard<CostTracker>> {
+        self.cost_tracker.write()
     }
 
     // Check if the wallclock time from bank creation to now has exceeded the allotted


### PR DESCRIPTION
#### Problem
Sharing cost_tracker between banks has risk of race condition.

#### Summary of Changes
- aggregate cost_tracker into bank, replacing shared obj;
- decouple cost_model from cost_tracker, allowing one cost_model per validator;
- updated cost_model.calculate_cost() api to return tx_cost, without need of mutable ref 
- 
Fixes #
