### PR TITLE
Reduce budget request instruction length

### DIFF
--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -11,7 +11,7 @@ use {
 
 crate::declare_id!("ComputeBudget111111111111111111111111111111");
 
-const MAX_UNITS: u64 = 1_000_000;
+const MAX_UNITS: u32 = 1_000_000;
 
 /// Compute Budget Instructions
 #[derive(
@@ -29,11 +29,11 @@ const MAX_UNITS: u64 = 1_000_000;
 pub enum ComputeBudgetInstruction {
     /// Request a specific maximum number of compute units the transaction is
     /// allowed to consume.
-    RequestUnits(u64),
+    RequestUnits(u32),
 }
 impl ComputeBudgetInstruction {
     /// Create a `ComputeBudgetInstruction::RequestUnits` `Instruction`
-    pub fn request_units(units: u64) -> Instruction {
+    pub fn request_units(units: u32) -> Instruction {
         Instruction::new_with_borsh(id(), &ComputeBudgetInstruction::RequestUnits(units), vec![])
     }
 }
@@ -115,7 +115,7 @@ impl ComputeBudget {
                 if units > MAX_UNITS {
                     return Err(error);
                 }
-                self.max_units = units;
+                self.max_units = units as u64;
             }
         }
         Ok(())
@@ -203,7 +203,7 @@ mod tests {
         assert_eq!(
             compute_budget,
             ComputeBudget {
-                max_units: MAX_UNITS,
+                max_units: MAX_UNITS as u64,
                 ..ComputeBudget::default()
             }
         );


### PR DESCRIPTION
#### Problem

Budget request length longer than it needs to be

#### Summary of Changes

Reduce each by ~half

Fixes #
