### PR TITLE
Make rent balance be at least 1 for clusters where rent is 0

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3076,7 +3076,7 @@ impl Bank {
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
-        self.rent_collector.rent.minimum_balance(data_len)
+        self.rent_collector.rent.minimum_balance(data_len).max(1)
     }
 
     #[deprecated(


### PR DESCRIPTION
#### Problem

If rent is set to 0, then the minimum balance will return 0, but the account would be immediately deleted then.

#### Summary of Changes

Change the minimum to 1 lamport so that the account at least exists.

Fixes #
