### PR TITLE
Correct rent exempt check

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -428,7 +428,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         if let StakeState::Uninitialized = self.state()? {
             let rent_exempt_reserve = rent.minimum_balance(self.data_len()?);
 
-            if rent_exempt_reserve < self.lamports()? {
+            if rent_exempt_reserve <= self.lamports()? {
                 self.set_state(&StakeState::Initialized(Meta {
                     rent_exempt_reserve,
                     authorized: *authorized,


### PR DESCRIPTION
#### Problem
The `Initialize` instruction in the `Stake` program was erroring out with `Insufficient Funds` even though the Stake account had exactly the amount required to be rent exempt.

#### Summary of Changes
This PR allows the Stake account to be Initialized if it has the exact amount required to be rent exempt, in addition to having more than the required amount.

This is my expectation as a user. I am not sure if this is the correct behavior or the behavior happening earlier was correct. Maybe I am missing something, please feel free to shed some light.