### PR TITLE
Add docs to solana_clap_utils::keypair

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1124,9 +1124,13 @@ fn sanitize_seed_phrase(seed_phrase: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::offline::OfflineArgs;
+    use clap::{value_t_or_exit, App, Arg};
     use solana_remote_wallet::locator::Manufacturer;
+    use solana_remote_wallet::remote_wallet::initialize_wallet_manager;
+    use solana_sdk::signer::keypair::write_keypair_file;
     use solana_sdk::system_instruction;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     #[test]
     fn test_sanitize_seed_phrase() {
@@ -1288,14 +1292,6 @@ mod tests {
 
     #[test]
     fn signer_from_path_with_file() -> Result<(), Box<dyn std::error::Error>> {
-        use crate::keypair::signer_from_path;
-        use crate::offline::OfflineArgs;
-        use clap::{value_t_or_exit, App, Arg};
-        use solana_remote_wallet::remote_wallet::initialize_wallet_manager;
-        use solana_sdk::signature::Keypair;
-        use solana_sdk::signer::keypair::write_keypair_file;
-        use tempfile::TempDir;
-
         let dir = TempDir::new()?;
         let dir = dir.path();
         let keypair_path = dir.join("id.json");


### PR DESCRIPTION
#### Problem

solana_clap_utils::keypair needs docs

#### Summary of Changes

This adds documentation and examples to the important `signer_from_path` function and related and derived functions.

In the process I added one test, but only for the file loading case. Other cases are interactive or otherwise complex to test. As a result I have mostly written the docs by reading the code, and may have gotten some details wrong. Please read the signer_from_path docs most carefully; other docs are mostly copy-pasted from that function or defer to it.