### PR TITLE
[Explorer] Video NFT Assets are TOO BIG

### DIFF
--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -17,7 +17,7 @@ export function NFTHeader({
   const metadata = nftData.metadata;
   return (
     <div className="row align-items-begin">
-      <div className="col-auto ml-2">
+      <div className="col-auto ml-2 d-flex align-items-center">
         <ArtContent metadata={metadata} pubkey={address} />
       </div>
 

--- a/explorer/src/metaplex/Art/Art.tsx
+++ b/explorer/src/metaplex/Art/Art.tsx
@@ -127,13 +127,13 @@ const VideoArtContent = ({
           streamRef={(e: any) => playerRef(e)}
           src={likelyVideo.replace("https://watch.videodelivery.net/", "")}
           loop={true}
-          height={150}
-          width={150}
+          height={180}
+          width={320}
           controls={false}
           style={{ borderRadius: 12 }}
           videoDimensions={{
-            videoHeight: 150,
-            videoWidth: 150,
+            videoWidth: 320,
+            videoHeight: 180,
           }}
           autoplay={true}
           muted={true}
@@ -146,7 +146,7 @@ const VideoArtContent = ({
         muted={true}
         controls={true}
         controlsList="nodownload"
-        style={{ borderRadius: 12 }}
+        style={{ borderRadius: 12, width: 320, height: 180 }}
         loop={true}
         poster={uri}
       >
@@ -186,7 +186,7 @@ const HTMLContent = ({
         frameBorder="0"
         src={htmlURL}
         className={`${loaded ? "d-block" : "d-none"}`}
-        style={{ width: 150, borderRadius: 12 }}
+        style={{ width: 320, height: 180, borderRadius: 12 }}
         onLoad={() => {
           setLoaded(true);
         }}

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -427,5 +427,4 @@ p.updated-time {
   align-items: center;
   justify-content: center;
   width: 150px;
-  margin-top: 20px;
 }


### PR DESCRIPTION
#### Problem

Metaplex NFTs that use video assets are too big in the Explorer. This is because of a lack of dimension limits.

#### Summary of Changes

- Added dimension limits to ALL video assets (320x180)
- Added the same dimension limits as video to HTML animations (320x180)
- Vertically centered all NFTArt in their `<div>`

**Video Dimension Fix**

![video-good](https://user-images.githubusercontent.com/3758645/137186409-d4e59b10-3a17-4774-844c-5d6ab1d2e6e8.png)

**Vertically centered NFT Art**

![after-image-center](https://user-images.githubusercontent.com/3758645/137186283-56b6c150-2b86-4279-b07d-55cb82e7bfc0.png)

**Not vertically centered**
![before-image-center](https://user-images.githubusercontent.com/3758645/137186315-1d18a3db-2f77-4187-b4a6-7184d93bb7a4.png)

**Video TOO BIG!!!**

![video-too-big](https://user-images.githubusercontent.com/3758645/137186454-113d3364-5202-4b6a-b9dd-008c191e9293.png)