### PR TITLE
Fix: #20598

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -261,7 +261,7 @@ fn process_instruction_common(
             Some(executor) => executor,
             None => {
                 let executor = create_executor(
-                    next_first_instruction_account,
+                    first_instruction_account,
                     program_data_offset,
                     invoke_context,
                     use_jit,


### PR DESCRIPTION
#### Problem

#20598 could not join MNB because of a wrong account index in the runtime.

#### Summary of Changes

Fixes the account index and renames the variables to avoid this kind of confusion in the future.

Fixes #
