### PR TITLE
clap-utils: trim single-quotes from signer uris on windows

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -258,6 +258,15 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(
     let source = {
         #[cfg(target_family = "windows")]
         {
+            // trim matched single-quotes since cmd.exe won't
+            let mut source = source;
+            while let Some(trimmed) = source.strip_prefix('\'') {
+                source = if let Some(trimmed) = trimmed.strip_suffix('\'') {
+                    trimmed
+                } else {
+                    break;
+                }
+            }
             source.replace("\\", "/")
         }
         #[cfg(not(target_family = "windows"))]


### PR DESCRIPTION
#### Problem

cmd.exe leaves single-quote-wrapped args unmodified, leading to signer URI parse failures

#### Summary of Changes

eat matched single-quotes wrapping signer URIs
