### PR TITLE
Adds test coverage for #20669

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1772,6 +1772,21 @@ mod tests {
             assert_eq!(elf[i], *byte);
         }
 
+        // Invoke deployed program
+        {
+            let programdata_account = RefCell::new(post_programdata_account);
+            let program_account = RefCell::new(post_program_account);
+            let program_address = program_keypair.pubkey();
+            let keyed_accounts: Vec<KeyedAccountTuple> = vec![
+                (false, false, &programdata_address, &programdata_account),
+                (false, false, &program_address, &program_account),
+            ];
+            assert_eq!(
+                Ok(()),
+                process_instruction(&program_address, &[], &keyed_accounts),
+            );
+        }
+
         // Test initialized program account
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
@@ -3386,7 +3401,7 @@ mod tests {
         ];
         assert_eq!(
             Err(InstructionError::InvalidAccountData),
-            process_instruction(&program_address, &instruction, &keyed_accounts),
+            process_instruction(&program_address, &[], &keyed_accounts),
         );
     }
 


### PR DESCRIPTION
#### Problem
#20669 unveiled a gap in the tests:
Upgradeable loader BPF programs were invoked but the executor was already cached.
So the situation in which the executor needs to be created [here](https://github.com/solana-labs/solana/blob/ad0a88f1f2102bab8bc2cb61a3e0aa5e6a70ed8a/programs/bpf_loader/src/lib.rs#L262) never occurred.

#### Summary of Changes
Invoke the deployed program in `test_bpf_loader_upgradeable_deploy_with_max_len`.

Fixes #
