### PR TITLE
[Explorer] Added improved MetaplexNFTHeader support for Mobile

### DIFF
--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -16,22 +16,21 @@ export function NFTHeader({
 }) {
   const metadata = nftData.metadata;
   return (
-    <div className="row align-items-begin">
+    <div className="row">
       <div className="col-auto ml-2 d-flex align-items-center">
         <ArtContent metadata={metadata} pubkey={address} />
       </div>
-
-      <div className="col mb-3 ml-n3 ml-md-n2 mt-3">
+      <div className="col mb-3 ml-0.5 mt-3">
         {<h6 className="header-pretitle ml-1">Metaplex NFT</h6>}
         <div className="d-flex align-items-center">
-          <h2 className="header-title ml-1 align-items-center">
+          <h2 className="header-title ml-1 align-items-center no-overflow-with-ellipsis">
             {metadata.data.name !== ""
               ? metadata.data.name
               : "No NFT name was found"}
           </h2>
           {getEditionPill(nftData.editionData)}
         </div>
-        <h4 className="header-pretitle ml-1 mt-1">
+        <h4 className="header-pretitle ml-1 mt-1 no-overflow-with-ellipsis">
           {metadata.data.symbol !== ""
             ? metadata.data.symbol
             : "No Symbol was found"}

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -428,3 +428,9 @@ p.updated-time {
   justify-content: center;
   width: 150px;
 }
+
+.no-overflow-with-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
#### Problem

`MetaplexNFTHeader` content sometimes looks awkward on mobile devices.

#### Summary of Changes

- Added overflow control and made sure NFT content is displayed in a reasonable manner on narrow screens.

**With Change (Image)**

![mobile-fixed](https://user-images.githubusercontent.com/3758645/137387395-27275d09-d4c0-4385-a30a-a52a28f99f23.png)

**With Change (HTML/Video)**

![video-animation](https://user-images.githubusercontent.com/3758645/137387639-0a892ac3-4b1f-4c06-bdcd-5bcb0d4be621.png)

**Before Change**

![mobile-broken](https://user-images.githubusercontent.com/3758645/137387402-1bfeef2f-c262-4603-8905-cf97aef20243.png)
