### PR TITLE
sort pubkeys for clean

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1993,11 +1993,20 @@ impl AccountsDb {
         self.report_store_stats();
 
         let mut key_timings = CleanKeyTimings::default();
-        let pubkeys = self.construct_candidate_clean_keys(
+        let mut pubkeys = self.construct_candidate_clean_keys(
             max_clean_root,
             last_full_snapshot_slot,
             &mut key_timings,
         );
+
+        let mut sort = Measure::start("sort");
+        if is_startup {
+            pubkeys.par_sort_unstable();
+        } else {
+            self.thread_pool_clean
+                .install(|| pubkeys.par_sort_unstable());
+        }
+        sort.stop();
 
         let total_keys_count = pubkeys.len();
         let mut accounts_scan = Measure::start("accounts_scan");
@@ -2216,6 +2225,7 @@ impl AccountsDb {
             ("delta_insert_us", key_timings.delta_insert_us, i64),
             ("delta_key_count", key_timings.delta_key_count, i64),
             ("dirty_pubkeys_count", key_timings.dirty_pubkeys_count, i64),
+            ("sort_us", sort.as_us(), i64),
             ("total_keys_count", total_keys_count, i64),
             (
                 "scan_found_not_zero",


### PR DESCRIPTION
#### Problem
idea is that acct idx is binned by pubkey high bits. Result is that looking up items in the index in sorted order will result in locality of the index and data files, reusing the cache more.
With more accounts, # accounts being cleaned grows to large numbers. With the pubkeys sorted, further optimizations are possible.
#### Summary of Changes

Fixes #
