### PR TITLE
program-test: Fix getting new blockhash post-warp

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -240,10 +240,7 @@ impl Banks for BanksServer {
 
         let blockhash = &transaction.message.recent_blockhash;
         let last_valid_block_height = self
-            .bank_forks
-            .read()
-            .unwrap()
-            .root_bank()
+            .bank(commitment)
             .get_blockhash_last_valid_block_height(blockhash)
             .unwrap();
         let signature = transaction.signatures.get(0).cloned().unwrap_or_default();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1038,7 +1038,7 @@ impl ProgramTestContext {
         bank_forks.set_root(
             pre_warp_slot,
             &solana_runtime::accounts_background_service::AbsRequestSender::default(),
-            Some(warp_slot),
+            Some(pre_warp_slot),
         );
 
         // warp bank is frozen, so go forward one slot from it
@@ -1051,7 +1051,11 @@ impl ProgramTestContext {
         // Update block commitment cache, otherwise banks server will poll at
         // the wrong slot
         let mut w_block_commitment_cache = self.block_commitment_cache.write().unwrap();
-        w_block_commitment_cache.set_all_slots(pre_warp_slot, warp_slot);
+        // HACK: The root set here should be `pre_warp_slot`, but since we're
+        // in a testing environment, the root bank never updates after a warp.
+        // The ticking thread only updates the working bank, and never the root
+        // bank.
+        w_block_commitment_cache.set_all_slots(warp_slot, warp_slot);
 
         let bank = bank_forks.working_bank();
         self.last_blockhash = bank.last_blockhash();


### PR DESCRIPTION
#### Problem

There's a longstanding issue with blockhashes not properly refreshing post-warp, and while debugging CI issues from  #20508 I realized we finally needed this fix.  The issue is really confusing, so please bear me as I try to explain it.

ProgramTest is in a fake environment that tries its best to mimic normal chain operation.  If you never warp, everything turns out fine, since the bank always stays at slot 1, which is also the root at the same time.  As the ticking thread advances `working_bank`, that's actually the same as `root_bank`, so you can get new blockhashes on the root bank no problem.  You never actually add a new bank to your bank forks.

Once you warp though, everything changes. ProgramTest creates a new bank for you, warps it forward, sets it as root, and then creates one more new bank, which is now your working bank.  Unfortunately, operations to get a new blockhash are only ever looking at the root bank, which will never change, since only the working bank is ticked / updated.  Even if you get a new blockhash from the working bank though, BanksServer will fail trying to find this blockhash on the rooted bank (which again, is never changing).

#### Summary of Changes

It's a very small changeset:

* hack the block commitment cache to think that the bank at the working slot is actually the root, which allows us to get new blockhashes from the working bank instead of the root bank
* make BanksServer check the blockhash from the bank requested by the `commitment` during transaction processing, which is how RPC is doing things.

The alternative is to have ProgramTest move slots forward and root banks as normal operation, which seems like overkill, and more a job for `SolanaTestValidator`.

Thanks to @ruuda for noticing this and for providing a great test.

Fixes #18201 