### PR TITLE
clean:clone uncleaned_roots for loop

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2001,6 +2001,7 @@ impl AccountsDb {
 
         let total_keys_count = pubkeys.len();
         let mut accounts_scan = Measure::start("accounts_scan");
+        let uncleaned_roots = self.accounts_index.clone_uncleaned_roots();
         let uncleaned_roots_len = self.accounts_index.uncleaned_roots_len();
         let found_not_zero_accum = AtomicU64::new(0);
         let not_found_on_fork_accum = AtomicU64::new(0);
@@ -2035,7 +2036,7 @@ impl AccountsDb {
                                     let slot = *slot;
                                     drop(locked_entry);
 
-                                    if self.accounts_index.is_uncleaned_root(slot) {
+                                    if uncleaned_roots.contains(&slot) {
                                         // Assertion enforced by `accounts_index.get()`, the latest slot
                                         // will not be greater than the given `max_clean_root`
                                         if let Some(max_clean_root) = max_clean_root {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1865,6 +1865,10 @@ impl<T: IndexValue> AccountsIndex<T> {
         self.roots_tracker.write().unwrap().roots.clear()
     }
 
+    pub fn clone_uncleaned_roots(&self) -> HashSet<Slot> {
+        self.roots_tracker.read().unwrap().uncleaned_roots.clone()
+    }
+
     pub fn uncleaned_roots_len(&self) -> usize {
         self.roots_tracker.read().unwrap().uncleaned_roots.len()
     }


### PR DESCRIPTION
#### Problem
clean is slow. Especially with many accounts. Removing things from the per-pubkey loop that are invariant. This hashset is either invariant (<= max_slot_to_clean) or it is a race condition. Faster and seems safer to move it to being read only once instead of once per pubkey in parallel processing.
#### Summary of Changes

Fixes #
