### PR TITLE
clean_accounts calls AcctIdx: get_many

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2034,7 +2034,7 @@ impl AccountsDb {
                         let mut not_found_on_fork = 0;
                         let mut missing = 0;
                         let mut useful = 0;
-                        self.accounts_index.get_many(
+                        self.accounts_index.scan(
                             pubkeys,
                             max_clean_root,
                             // return true if we want this item to remain in the cache

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1402,7 +1402,7 @@ impl<T: IndexValue> AccountsIndex<T> {
 
     /// For each pubkey, find the latest account that appears in `roots` and <= `max_root`
     ///   call `callback`
-    pub(crate) fn get_many<F>(&self, pubkeys: &[Pubkey], max_root: Option<Slot>, mut callback: F)
+    pub(crate) fn scan<F>(&self, pubkeys: &[Pubkey], max_root: Option<Slot>, mut callback: F)
     where
         // return true if accounts index entry should be put in in_mem cache
         // params:


### PR DESCRIPTION
#### Problem
clean is very slow on large acct #s. Many items (65%?) that clean_accounts loads from the acct idx are not useful - they aren't zero lamports, they don't have multiple entries, they aren't in uncleaned roots. These changes allow us to not add useless items to the in-mem acct idx. This improves performance of clean. There are further optimizations that could be done with sorted pubkeys and asking about vectors of accounts.
#### Summary of Changes

Fixes #
