### PR TITLE
Make pub get_incremental_snapshot_archives()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1152,7 +1152,7 @@ where
 }
 
 /// Get a list of the incremental snapshot archives in a directory
-fn get_incremental_snapshot_archives<P>(
+pub fn get_incremental_snapshot_archives<P>(
     snapshot_archives_dir: P,
 ) -> Vec<IncrementalSnapshotArchiveInfo>
 where


### PR DESCRIPTION
`get_incremental_snapshot_archives()` will be called during bootstrap and needs to be public.

See PR #20696 for the context and changes to bootstrap that'll use this change.