### PR TITLE
Removes deprecated BpfComputeBudget

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5086,15 +5086,6 @@ impl Bank {
         self.compute_budget = compute_budget;
     }
 
-    #[allow(deprecated)]
-    #[deprecated(since = "1.8.0", note = "please use `set_compute_budget` instead")]
-    pub fn set_bpf_compute_budget(
-        &mut self,
-        bpf_compute_budget: Option<solana_sdk::process_instruction::BpfComputeBudget>,
-    ) {
-        self.compute_budget = bpf_compute_budget.map(|budget| budget.into());
-    }
-
     pub fn hard_forks(&self) -> Arc<RwLock<HardForks>> {
         self.hard_forks.clone()
     }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -57,8 +57,6 @@ pub struct ThisInvokeContext<'a> {
     programs: &'a [(Pubkey, ProcessInstructionWithContext)],
     logger: Rc<RefCell<dyn Logger>>,
     compute_budget: ComputeBudget,
-    #[allow(deprecated)]
-    bpf_compute_budget: solana_sdk::process_instruction::BpfComputeBudget,
     compute_meter: Rc<RefCell<dyn ComputeMeter>>,
     executors: Rc<RefCell<Executors>>,
     instruction_recorders: Option<&'a [InstructionRecorder]>,
@@ -98,7 +96,6 @@ impl<'a> ThisInvokeContext<'a> {
             programs,
             logger: Rc::new(RefCell::new(ThisLogger { log_collector })),
             compute_budget,
-            bpf_compute_budget: compute_budget.into(),
             compute_meter,
             executors,
             instruction_recorders,
@@ -356,10 +353,6 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     }
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         self.logger.clone()
-    }
-    #[allow(deprecated)]
-    fn get_bpf_compute_budget(&self) -> &solana_sdk::process_instruction::BpfComputeBudget {
-        &self.bpf_compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         self.compute_meter.clone()


### PR DESCRIPTION
#### Problem
`BpfComputeBudget` is not used anywhere anymore.

#### Summary of Changes
Removes `BpfComputeBudget` and associated methods in `InvokeContext`.

Fixes #
