### PR TITLE
docs: prefer `solana gossip` to `solana-gossip spy`

### DIFF
--- a/docs/src/running-validator/validator-monitor.md
+++ b/docs/src/running-validator/validator-monitor.md
@@ -8,7 +8,7 @@ Confirm the IP address and **identity pubkey** of your validator is visible in
 the gossip network by running:
 
 ```bash
-solana-gossip spy --entrypoint devnet.solana.com:8001
+solana gossip
 ```
 
 ## Check Your Balance

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -26,16 +26,6 @@ solana transaction-count
 View the [metrics dashboard](https://metrics.solana.com:3000/d/monitor/cluster-telemetry) for more
 detail on cluster activity.
 
-## Confirm your Installation
-
-Try running following command to join the gossip network and view all the other
-nodes in the cluster:
-
-```bash
-solana-gossip spy --entrypoint entrypoint.devnet.solana.com:8001
-# Press ^C to exit
-```
-
 ## Enabling CUDA
 
 If your machine has a GPU with CUDA installed \(Linux-only currently\), include
@@ -318,11 +308,11 @@ The ledger will be placed in the `ledger/` directory by default, use the
 > `solana-validator --identity ASK ... --authorized-voter ASK ...`
 > and you will be prompted to enter your seed phrases and optional passphrase.
 
-Confirm your validator connected to the network by opening a new terminal and
+Confirm your validator is connected to the network by opening a new terminal and
 running:
 
 ```bash
-solana-gossip spy --entrypoint entrypoint.devnet.solana.com:8001
+solana gossip
 ```
 
 If your validator is connected, its public key and IP address will appear in the list.


### PR DESCRIPTION
#### Problem

Validator startup instructions suggest using `solana-gossip spy` in various ways, despite it being heavy and its output unintuitive to interpret

#### Summary of Changes

Prefer `solana gossip` instead