### PR TITLE
hash calc uses all threads during startup

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -123,6 +123,7 @@ fn main() {
                 None,
                 false,
                 None,
+                false,
             );
             time_store.stop();
             if results != results_store {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1204,6 +1204,7 @@ fn load_frozen_forks(
                             snapshot_config.accounts_hash_use_index,
                             snapshot_config.accounts_hash_debug_verify,
                             Some(new_root_bank.epoch_schedule().slots_per_epoch),
+                            false,
                         );
                         snapshot_utils::snapshot_bank(
                             new_root_bank,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -687,6 +687,7 @@ impl Accounts {
         debug_verify: bool,
     ) -> u64 {
         let use_index = false;
+        let is_startup = false; // there may be conditions where this is called at startup.
         self.accounts_db
             .update_accounts_hash_with_index_option(
                 use_index,
@@ -696,10 +697,12 @@ impl Accounts {
                 None,
                 can_cached_slot_be_unflushed,
                 None,
+                is_startup,
             )
             .1
     }
 
+    /// Only called from startup or test code.
     #[must_use]
     pub fn verify_bank_hash_and_lamports(
         &self,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -109,7 +109,7 @@ impl SnapshotRequestHandler {
                 let previous_hash = if test_hash_calculation {
                     // We have to use the index version here.
                     // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality.
-                    snapshot_root_bank.update_accounts_hash_with_index_option(true, false, None)
+                    snapshot_root_bank.update_accounts_hash_with_index_option(true, false, None, false)
                 } else {
                     Hash::default()
                 };
@@ -148,6 +148,7 @@ impl SnapshotRequestHandler {
                     use_index_hash_calculation,
                     test_hash_calculation,
                     Some(snapshot_root_bank.epoch_schedule().slots_per_epoch),
+                    false,
                 );
                 let hash_for_testing = if test_hash_calculation {
                     assert_eq!(previous_hash, this_hash);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5375,6 +5375,7 @@ impl Bank {
 
     /// Recalculate the hash_internal_state from the account stores. Would be used to verify a
     /// snapshot.
+    /// Only called from startup or test code.
     #[must_use]
     fn verify_bank_hash(&self, test_hash_calculation: bool) -> bool {
         self.rc.accounts.verify_bank_hash_and_lamports(
@@ -5492,6 +5493,7 @@ impl Bank {
         use_index: bool,
         mut debug_verify: bool,
         slots_per_epoch: Option<Slot>,
+        is_startup: bool,
     ) -> Hash {
         let (hash, total_lamports) = self
             .rc
@@ -5505,6 +5507,7 @@ impl Bank {
                 Some(self.capitalization()),
                 false,
                 slots_per_epoch,
+                is_startup,
             );
         if total_lamports != self.capitalization() {
             datapoint_info!(
@@ -5529,6 +5532,7 @@ impl Bank {
                         Some(self.capitalization()),
                         false,
                         slots_per_epoch,
+                        is_startup,
                     );
             }
 
@@ -5543,7 +5547,7 @@ impl Bank {
     }
 
     pub fn update_accounts_hash(&self) -> Hash {
-        self.update_accounts_hash_with_index_option(true, false, None)
+        self.update_accounts_hash_with_index_option(true, false, None, false)
     }
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash


### PR DESCRIPTION
#### Problem
this can take a long time at startup - especially since the first time requires creating the hash calc cache.
with 1B accounts, this currently took 9,017s with only the clean thread pool.
#### Summary of Changes
At startup, use no thread pool so all threads are available since this is all that is going on.
Fixes #
