### PR TITLE
Add decoded data section for accounts with a deployed Anchor IDL

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -12,6 +12,7 @@
         "@bonfida/bot": "^0.5.3",
         "@cloudflare/stream-react": "^1.2.0",
         "@metamask/jazzicon": "^2.0.0",
+        "@project-serum/anchor": "^0.17.1-beta.1",
         "@project-serum/serum": "^0.13.60",
         "@react-hook/debounce": "^4.0.0",
         "@sentry/react": "^6.13.3",
@@ -3623,9 +3624,9 @@
       }
     },
     "node_modules/@project-serum/anchor": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
-      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "version": "0.17.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.17.1-beta.1.tgz",
+      "integrity": "sha512-W23rI48nNm6sM+3L6jUh4kSWh5cLJWwJHiohB2AnnG+9jYs/NSgCcope8dP0g2DeHITCo5E/VpZpZc4Fulqqpg==",
       "dependencies": {
         "@project-serum/borsh": "^0.2.2",
         "@solana/web3.js": "^1.17.0",
@@ -3681,6 +3682,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/@project-serum/serum/node_modules/@project-serum/anchor": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
+      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "dependencies": {
+        "@project-serum/borsh": "^0.2.2",
+        "@solana/web3.js": "^1.17.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.0",
+        "camelcase": "^5.3.1",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "find": "^0.3.0",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
     "node_modules/@project-serum/serum/node_modules/@solana/spl-token": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.6.tgz",
@@ -3727,6 +3752,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@project-serum/serum/node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/@project-serum/sol-wallet-adapter": {
       "version": "0.1.8",
@@ -28970,9 +29000,9 @@
       }
     },
     "@project-serum/anchor": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
-      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "version": "0.17.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.17.1-beta.1.tgz",
+      "integrity": "sha512-W23rI48nNm6sM+3L6jUh4kSWh5cLJWwJHiohB2AnnG+9jYs/NSgCcope8dP0g2DeHITCo5E/VpZpZc4Fulqqpg==",
       "requires": {
         "@project-serum/borsh": "^0.2.2",
         "@solana/web3.js": "^1.17.0",
@@ -29018,6 +29048,27 @@
         "buffer-layout": "^1.2.0"
       },
       "dependencies": {
+        "@project-serum/anchor": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
+          "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+          "requires": {
+            "@project-serum/borsh": "^0.2.2",
+            "@solana/web3.js": "^1.17.0",
+            "base64-js": "^1.5.1",
+            "bn.js": "^5.1.2",
+            "bs58": "^4.0.1",
+            "buffer-layout": "^1.2.0",
+            "camelcase": "^5.3.1",
+            "crypto-hash": "^1.3.0",
+            "eventemitter3": "^4.0.7",
+            "find": "^0.3.0",
+            "js-sha256": "^0.9.0",
+            "pako": "^2.0.3",
+            "snake-case": "^3.0.4",
+            "toml": "^3.0.0"
+          }
+        },
         "@solana/spl-token": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.6.tgz",
@@ -29044,6 +29095,11 @@
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
           "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        },
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
         }
       }
     },

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -7,6 +7,7 @@
     "@bonfida/bot": "^0.5.3",
     "@cloudflare/stream-react": "^1.2.0",
     "@metamask/jazzicon": "^2.0.0",
+    "@project-serum/anchor": "^0.17.1-beta.1",
     "@project-serum/serum": "^0.13.60",
     "@react-hook/debounce": "^4.0.0",
     "@sentry/react": "^6.13.3",

--- a/explorer/src/components/account/AnchorAccountCard.tsx
+++ b/explorer/src/components/account/AnchorAccountCard.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+
+import {
+  Account,
+} from "providers/accounts";
+import { useCluster } from "providers/cluster";
+import { Address } from "components/common/Address";
+import { Program, Provider, Wallet, AccountsCoder} from "@project-serum/anchor";
+import { Connection, PublicKey, Keypair } from "@solana/web3.js";
+
+export function AnchorAccountCard({ account }: { account: Account }) {
+  const { url } = useCluster();
+  const [decodedAnchorAccountData, setDecodedAnchorAccountData] = React.useState<any>()
+  const [decodedAnchorAccountName, setDecodedAnchorAccountName] = React.useState<string>()
+
+  React.useEffect(()=>{
+    setDecodedAnchorAccountData(undefined);
+    (async()=>{
+      const connection = new Connection(url);
+      const provider = new Provider(connection, new Wallet(Keypair.generate()), {
+        skipPreflight: false,
+        commitment: 'confirmed',
+        preflightCommitment: 'confirmed'
+      })
+
+      if (!account.details) {
+        return
+      }
+
+      // TODO this should come from somewhere inside the client already? This lookup seems bad.
+      // Appears we don't cache data for accounts we don't know the type of?
+      const accountInfo = await connection.getAccountInfo(account.pubkey)
+      const discriminator = accountInfo?.data.slice(0, 8)
+      if (!discriminator){
+        return
+      }
+
+      await Program.at(account.details.owner, provider)
+      .then(program=>{
+        if (program && accountInfo && accountInfo.data){
+          // Iterate all the structs, see if any of the name-hashes match
+          Object.keys(program.account).forEach(accountType =>{
+            const layoutName = capitalizeFirstLetter(accountType)
+            const discriminatorToCheck = AccountsCoder.accountDiscriminator(layoutName)
+
+            if (equal(discriminatorToCheck, discriminator)) {
+              const decodedAnchorObject = program.account[accountType].coder.accounts.decode(layoutName, accountInfo.data)
+              setDecodedAnchorAccountName(layoutName)
+              setDecodedAnchorAccountData(decodedAnchorObject);
+            }
+          })
+        }
+      })
+      .catch(error=>{
+        console.log('No IDL found for address. Why did the tab load?',  error)
+      });
+    })()
+  },[account, url])
+
+  return (
+    <>
+      <div className="card">
+        <div className="card-header">
+          <div className="row align-items-center">
+            <div className="col">
+              <h3 className="card-header-title">{decodedAnchorAccountName}</h3>
+            </div>
+          </div>
+        </div>
+
+        <div className="table-responsive mb-0">
+          <table className="table table-sm table-nowrap card-table">
+            <thead>
+              <tr>
+                <th className="w-1 text-muted">Key</th>
+                <th className="text-muted">Value</th>
+              </tr>
+            </thead>
+            <tbody className="list">
+              {decodedAnchorAccountData && Object.keys(decodedAnchorAccountData).map((key)=>{
+                return renderAccountRow(key, decodedAnchorAccountData[key]);
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div className="card-footer">
+          <div className="text-muted text-center">
+            {decodedAnchorAccountData && Object.keys(decodedAnchorAccountData).length > 0
+            ?
+              `Decoded ${Object.keys(decodedAnchorAccountData).length} Items`
+            :
+              "No decoded data"}
+          </div>
+        </div>
+
+      </div>
+    </>
+  );
+}
+
+export const hasAnchorIDL = async (address: PublicKey, url: string): Promise<Boolean> =>{
+  const connection = new Connection(url);
+      const provider = new Provider(connection, new Wallet(Keypair.generate()), {
+        skipPreflight: false,
+        commitment: 'confirmed',
+        preflightCommitment: 'confirmed'
+      })
+
+      const program = await Program.at(address, provider)
+      .catch(()=>{})
+      return !!program
+}
+
+const renderAccountRow = (key: string, value: any) => {
+  console.log('Value', value)
+  let displayValue = value.toString()
+  if (value.constructor.name === "PublicKey"){
+    displayValue = <Address pubkey={value} link />
+  } else if (displayValue === {}.toString()){
+    if (Object.keys(value).length === 1){
+      displayValue =  Object.keys(value)[0]
+    } else {
+      displayValue = JSON.stringify(value)
+    }
+    //<Address pubkey={account.pubkey} alignRight raw />
+  }
+  return (
+    <tr key={key}>
+      <td className="w-1 text-monospace">
+        {camelToUnderscore(key)}
+      </td>
+      <td className="text-monospace">{displayValue}</td>
+    </tr>
+  );
+};
+
+
+
+function capitalizeFirstLetter(input: string) {
+  return input.charAt(0).toUpperCase() + input.slice(1);
+}
+
+function equal (buf1:Buffer, buf2:Buffer)
+{
+  if (buf1.byteLength !== buf2.byteLength) return false;
+  var dv1 = new Int8Array(buf1);
+  var dv2 = new Int8Array(buf2);
+  for (var i = 0 ; i !== buf1.byteLength ; i++)
+  {
+    if (dv1[i] !== dv2[i]) return false;
+  }
+  return true;
+}
+
+function camelToUnderscore(key:string) {
+  var result = key.replace( /([A-Z])/g, " $1" );
+  return result.split(' ').join('_').toLowerCase();
+}


### PR DESCRIPTION
### Feature idea:
If an Anchor program IDL is detected for the account's owner, decode the account data using that IDL and put it in a tab in the details section.

#### Problem
Sometimes you want to see the decoded account data for an account that has an Anchor IDL deployed. This would add a tab the account details page that shows the data.

#### Summary of Changes
- Add another tab type to `AccountDetailsPage`
- Add a dependency for `@project-serum/anchor`

#### Looking for feedback on:
- [ ] How to get the `accountInfo.data` since it's not cached for unknown accounts
- [ ] Where should it do the check to see if the account owner has a program IDL. Currently, this feels... not great.
- [ ] Since IDLs have very abstract formats, is there a better way to predict and format the output data.

#### Related Issue
 #16180

#### Visual preview
![screencapture-localhost-3000-address-CqPcKSVFiG3L4HNXDzGb6Wx9s387W8wbvz4CEkVqGvd2-anchor-2021-10-16-12_01_36 (1)](https://user-images.githubusercontent.com/374048/137605395-c46c0de8-4a74-40e6-8e8f-6834c7e8c1c6.png)