### PR TITLE
Docsimprv: Improve Documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,11 +1083,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+checksum = "61579ada4ec0c6031cfac3f86fdba0d195a7ebeb5e36693bd53cb5999a25beeb"
 dependencies = [
- "console",
+ "console 0.15.0",
  "lazy_static",
  "tempfile",
  "zeroize",
@@ -2016,7 +2031,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console",
+ "console 0.14.1",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -4471,7 +4486,7 @@ dependencies = [
  "bincode",
  "bs58 0.4.0",
  "clap 2.33.3",
- "console",
+ "console 0.14.1",
  "const_format",
  "criterion-stats",
  "ctrlc",
@@ -4526,7 +4541,7 @@ dependencies = [
  "base64 0.13.0",
  "chrono",
  "clap 2.33.3",
- "console",
+ "console 0.14.1",
  "humantime",
  "indicatif",
  "serde",
@@ -4707,7 +4722,7 @@ dependencies = [
 name = "solana-download-utils"
 version = "1.9.0"
 dependencies = [
- "console",
+ "console 0.14.1",
  "indicatif",
  "log 0.4.14",
  "reqwest",
@@ -4899,7 +4914,7 @@ dependencies = [
  "bzip2",
  "chrono",
  "clap 2.33.3",
- "console",
+ "console 0.14.1",
  "ctrlc",
  "dirs-next",
  "indicatif",
@@ -5356,7 +5371,7 @@ name = "solana-remote-wallet"
 version = "1.9.0"
 dependencies = [
  "base32",
- "console",
+ "console 0.14.1",
  "dialoguer",
  "hidapi",
  "log 0.4.14",
@@ -5725,7 +5740,7 @@ dependencies = [
  "bincode",
  "chrono",
  "clap 2.33.3",
- "console",
+ "console 0.14.1",
  "csv",
  "ctrlc",
  "indexmap",
@@ -5788,7 +5803,7 @@ version = "1.9.0"
 dependencies = [
  "chrono",
  "clap 2.33.3",
- "console",
+ "console 0.14.1",
  "core_affinity",
  "fd-lock",
  "indicatif",

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -291,6 +291,7 @@ solana-validator \
   --vote-account ~/vote-account-keypair.json \
   --rpc-port 8899 \
   --entrypoint entrypoint.devnet.solana.com:8001 \
+  --ledger ~/ledger \
   --limit-ledger-size \
   --log ~/solana-validator.log
 ```

--- a/docs/src/wallet-guide/paper-wallet.md
+++ b/docs/src/wallet-guide/paper-wallet.md
@@ -46,20 +46,20 @@ access your account.
 
 ### Seed Phrase Generation
 
-Generating a new keypair can be done using the `solana-keygen new` command. The
+Generating a new keypair can be done using the `solana-keygen new` command. To generate a keypair for the paper wallet, use the "--no-outfile" flag along with the "solana-keygen new" command. The
 command will generate a random seed phrase, ask you to enter an optional
 passphrase, and then will display the derived public key and the generated seed
-phrase for your paper wallet.
+phrase for your paper wallet. Please copy or write your seeds somewhere safe.
 
-After copying down your seed phrase, you can use the
-[public key derivation](#public-key-derivation) instructions to verify that you
-have not made any errors.
 
 ```bash
 solana-keygen new --no-outfile
 ```
 
 > If the `--no-outfile` flag is **omitted**, the default behavior is to write the keypair to `~/.config/solana/id.json`, resulting in a [file system wallet](file-system-wallet.md).
+
+After copying down your seed phrase, you can use the
+[public key derivation](#public-key-derivation) instructions to verify that you have not made any errors.
 
 The output of this command will display a line like this:
 

--- a/docs/src/wallet-guide/paper-wallet.md
+++ b/docs/src/wallet-guide/paper-wallet.md
@@ -46,10 +46,12 @@ access your account.
 
 ### Seed Phrase Generation
 
-Generating a new keypair can be done using the `solana-keygen new` command. To generate a keypair for the paper wallet, use the "--no-outfile" flag along with the "solana-keygen new" command. The
-command will generate a random seed phrase, ask you to enter an optional
-passphrase, and then will display the derived public key and the generated seed
-phrase for your paper wallet. Please copy or write your seeds somewhere safe.
+Generating a new keypair can be done using the `solana-keygen new` command. To
+generate a keypair for the paper wallet, use the "--no-outfile" flag along 
+with the "solana-keygen new" command. The command will generate a random seed 
+phrase, ask you to enter an optional passphrase, and then will display the 
+derived public key and the generated seedphrase for your paper wallet. Please 
+copy or write your seeds somewhere safe.
 
 
 ```bash

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -451,6 +451,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,11 +637,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+checksum = "61579ada4ec0c6031cfac3f86fdba0d195a7ebeb5e36693bd53cb5999a25beeb"
 dependencies = [
- "console",
+ "console 0.15.0",
  "lazy_static",
  "tempfile",
  "zeroize",
@@ -1264,7 +1279,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
- "console",
+ "console 0.14.1",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -2870,7 +2885,7 @@ dependencies = [
  "base64 0.13.0",
  "chrono",
  "clap",
- "console",
+ "console 0.14.1",
  "humantime",
  "indicatif",
  "serde",
@@ -3220,7 +3235,7 @@ name = "solana-remote-wallet"
 version = "1.9.0"
 dependencies = [
  "base32",
- "console",
+ "console 0.14.1",
  "dialoguer",
  "hidapi",
  "log",

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/solana-remote-wallet"
 [dependencies]
 base32 = "0.4.0"
 console = "0.14.1"
-dialoguer = "0.8.0"
+dialoguer = "0.9.0"
 hidapi = { version = "1.2.6", default-features = false }
 log = "0.4.14"
 num-derive = { version = "0.3" }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1432,9 +1432,13 @@ impl ShrinkStats {
     }
 }
 
+fn quarter_thread_count() -> usize {
+    std::cmp::max(2, num_cpus::get() / 4)
+}
+
 pub fn make_min_priority_thread_pool() -> ThreadPool {
     // Use lower thread count to reduce priority.
-    let num_threads = std::cmp::max(2, num_cpus::get() / 4);
+    let num_threads = quarter_thread_count();
     rayon::ThreadPoolBuilder::new()
         .thread_name(|i| format!("solana-cleanup-accounts-{}", i))
         .num_threads(num_threads)
@@ -5799,28 +5803,38 @@ impl AccountsDb {
 
     // previous_slot_entry_was_cached = true means we just need to assert that after this update is complete
     //  that there are no items we would have put in reclaims that are not cached
-    fn update_index(
+    fn update_index<T: ReadableAccount + Sync>(
         &self,
         slot: Slot,
         infos: Vec<AccountInfo>,
-        accounts: &[(&Pubkey, &impl ReadableAccount)],
+        accounts: &[(&Pubkey, &T)],
         previous_slot_entry_was_cached: bool,
     ) -> SlotList<AccountInfo> {
-        let mut reclaims = SlotList::<AccountInfo>::with_capacity(infos.len() * 2);
-        for (info, pubkey_account) in infos.into_iter().zip(accounts.iter()) {
-            let pubkey = pubkey_account.0;
-            self.accounts_index.upsert(
-                slot,
-                pubkey,
-                pubkey_account.1.owner(),
-                pubkey_account.1.data(),
-                &self.account_indexes,
-                info,
-                &mut reclaims,
-                previous_slot_entry_was_cached,
-            );
-        }
-        reclaims
+        // using a thread pool here results in deadlock panics from bank_hashes.write()
+        // so, instead we limit how many threads will be created to the same size as the bg thread pool
+        let chunk_size = std::cmp::max(1, accounts.len() / quarter_thread_count()); // # pubkeys/thread
+        infos
+            .par_chunks(chunk_size)
+            .zip(accounts.par_chunks(chunk_size))
+            .map(|(infos_chunk, accounts_chunk)| {
+                let mut reclaims = Vec::with_capacity(infos_chunk.len() / 2);
+                for (info, pubkey_account) in infos_chunk.iter().zip(accounts_chunk.iter()) {
+                    let pubkey = pubkey_account.0;
+                    self.accounts_index.upsert(
+                        slot,
+                        pubkey,
+                        pubkey_account.1.owner(),
+                        pubkey_account.1.data(),
+                        &self.account_indexes,
+                        *info,
+                        &mut reclaims,
+                        previous_slot_entry_was_cached,
+                    );
+                }
+                reclaims
+            })
+            .flatten()
+            .collect::<Vec<_>>()
     }
 
     fn should_not_shrink(aligned_bytes: u64, total_bytes: u64, num_stores: usize) -> bool {
@@ -6167,6 +6181,7 @@ impl AccountsDb {
     }
 
     /// Store the account update.
+    /// only called by tests
     pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         self.store(slot, accounts, false);
     }
@@ -6190,11 +6205,14 @@ impl AccountsDb {
             .store_total_data
             .fetch_add(total_data as u64, Ordering::Relaxed);
 
-        let mut bank_hashes = self.bank_hashes.write().unwrap();
-        let slot_info = bank_hashes
-            .entry(slot)
-            .or_insert_with(BankHashInfo::default);
-        slot_info.stats.merge(&stats);
+        {
+            // we need to drop bank_hashes to prevent deadlocks
+            let mut bank_hashes = self.bank_hashes.write().unwrap();
+            let slot_info = bank_hashes
+                .entry(slot)
+                .or_insert_with(BankHashInfo::default);
+            slot_info.stats.merge(&stats);
+        }
 
         // we use default hashes for now since the same account may be stored to the cache multiple times
         self.store_accounts_unfrozen(slot, accounts, None, is_cached_store);
@@ -6338,10 +6356,10 @@ impl AccountsDb {
         );
     }
 
-    fn store_accounts_frozen<'a>(
+    fn store_accounts_frozen<'a, T: ReadableAccount + Sync>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &impl ReadableAccount)],
+        accounts: &[(&Pubkey, &T)],
         hashes: Option<&[impl Borrow<Hash>]>,
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = StoredMetaWriteVersion>>>,
@@ -6362,10 +6380,10 @@ impl AccountsDb {
         )
     }
 
-    fn store_accounts_custom<'a>(
+    fn store_accounts_custom<'a, T: ReadableAccount + Sync>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &impl ReadableAccount)],
+        accounts: &[(&Pubkey, &T)],
         hashes: Option<&[impl Borrow<Hash>]>,
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2471,7 +2471,7 @@ impl AccountsDb {
         unrefed_pubkeys: &mut Vec<&'a Pubkey>,
     ) -> usize
     where
-        I: Iterator<Item = (&'a Pubkey, &'a FoundStoredAccount<'a>)>,
+        I: Iterator<Item = &'a (Pubkey, FoundStoredAccount<'a>)>,
     {
         let mut alive_total = 0;
 
@@ -2543,6 +2543,10 @@ impl AccountsDb {
             }
             num_stores += 1;
         }
+
+        // sort by pubkey to keep account index lookups close
+        let mut stored_accounts = stored_accounts.into_iter().collect::<Vec<_>>();
+        stored_accounts.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
         let mut index_read_elapsed = Measure::start("index_read_elapsed");
         let alive_total_collect = AtomicUsize::new(0);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3076,7 +3076,7 @@ impl Bank {
     }
 
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64 {
-        self.rent_collector.rent.minimum_balance(data_len)
+        self.rent_collector.rent.minimum_balance(data_len).max(1)
     }
 
     #[deprecated(


### PR DESCRIPTION
#### Problem
I got stuck at  paper wallet and using system service section when I tried to install a validator.
I used validator as system service without specified ledger path, the validator cannot find the ledger. I suggest to use --ledger flag in start-validator section.
As for paper wallet section, the document is correct. However, with a slight adjustment, it may be easier to understand.

#### Summary of Changes
1. assign ledger path when running solana-validator command
2. reorganize words in keygen process of paper wallet
Fixes #
N.A
