### PR TITLE
Ignore RUSTSEC-2020-0159

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -46,5 +46,11 @@ cargo_audit_ignores=(
   # https://github.com/paritytech/jsonrpc/issues/605
   --ignore RUSTSEC-2021-0079
 
+  # chrono: Potential segfault in `localtime_r` invocations
+  #
+  # Blocked due to no safe upgrade
+  # https://github.com/chronotope/chrono/issues/499
+  --ignore RUSTSEC-2020-0159
+
 )
 scripts/cargo-for-all-lock-files.sh stable audit "${cargo_audit_ignores[@]}"


### PR DESCRIPTION
#### Problem

CI `checks` is failing due to new vulnerability in chrono. See [this buildkite log](https://buildkite.com/solana-labs/solana/builds/58018#fe116293-ca90-4a81-841d-c5ddb1026c4b) for more info.

#### Summary of Changes

Ignore the new vulnerability.