### PR TITLE
Remove @brief annotations from Rust API docs

### DIFF
--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
 use solana_program::{custom_panic_default, entrypoint::SUCCESS};

--- a/programs/bpf/rust/128bit_dep/src/lib.rs
+++ b/programs/bpf/rust/128bit_dep/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF program utility functions and types
+//! Solana Rust-based BPF program utility functions and types
 
 extern crate solana_program;
 

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that test dynamic memory allocation
+//! Example Rust-based BPF program that test dynamic memory allocation
 
 #[macro_use]
 extern crate alloc;

--- a/programs/bpf/rust/call_depth/src/lib.rs
+++ b/programs/bpf/rust/call_depth/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that tests call depth and stack usage
+//! Example Rust-based BPF program that tests call depth and stack usage
 
 use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
 

--- a/programs/bpf/rust/custom_heap/src/lib.rs
+++ b/programs/bpf/rust/custom_heap/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF that tests out using a custom heap
+//! Example Rust-based BPF that tests out using a custom heap
 
 use solana_program::{
     account_info::AccountInfo,

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests dependent crates
+//! Example Rust-based BPF program tests dependent crates
 
 extern crate solana_program;
 use byteorder::{ByteOrder, LittleEndian};

--- a/programs/bpf/rust/deprecated_loader/src/lib.rs
+++ b/programs/bpf/rust/deprecated_loader/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that supports the deprecated loader
+//! Example Rust-based BPF program that supports the deprecated loader
 
 #![allow(unreachable_code)]
 

--- a/programs/bpf/rust/dup_accounts/src/lib.rs
+++ b/programs/bpf/rust/dup_accounts/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that tests duplicate accounts passed via accounts
+//! Example Rust-based BPF program that tests duplicate accounts passed via accounts
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/bpf/rust/error_handling/src/lib.rs
+++ b/programs/bpf/rust/error_handling/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that exercises error handling
+//! Example Rust-based BPF program that exercises error handling
 
 extern crate solana_program;
 use num_derive::FromPrimitive;

--- a/programs/bpf/rust/external_spend/src/lib.rs
+++ b/programs/bpf/rust/external_spend/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that moves a lamport from one account to another
+//! Example Rust-based BPF program that moves a lamport from one account to another
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/bpf/rust/finalize/src/lib.rs
+++ b/programs/bpf/rust/finalize/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF sanity program that finalizes a BPF program
+//! Example Rust-based BPF sanity program that finalizes a BPF program
 
 #![allow(unreachable_code)]
 

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that exercises instruction introspection
+//! Example Rust-based BPF program that exercises instruction introspection
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/bpf/rust/invoke/src/instructions.rs
+++ b/programs/bpf/rust/invoke/src/instructions.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 pub const TEST_SUCCESS: u8 = 1;
 pub const TEST_PRIVILEGE_ESCALATION_SIGNER: u8 = 2;

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 pub mod instructions;
 pub mod processor;

--- a/programs/bpf/rust/invoke/src/processor.rs
+++ b/programs/bpf/rust/invoke/src/processor.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 #![cfg(feature = "program")]
 #![allow(unreachable_code)]

--- a/programs/bpf/rust/invoke_and_error/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_error/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! Invokes an instruction and returns an error, the instruction invoked
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{

--- a/programs/bpf/rust/invoke_and_ok/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_ok/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! Invokes an instruction and returns an error, the instruction invoked
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{

--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! Invokes an instruction and returns an error, the instruction invoked
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{

--- a/programs/bpf/rust/invoked/src/instructions.rs
+++ b/programs/bpf/rust/invoked/src/instructions.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 use solana_program::{
     instruction::{AccountMeta, Instruction},

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 pub mod instructions;
 pub mod processor;

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that issues a cross-program-invocation
+//! Example Rust-based BPF program that issues a cross-program-invocation
 
 #![cfg(feature = "program")]
 

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
 use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};

--- a/programs/bpf/rust/log_data/src/lib.rs
+++ b/programs/bpf/rust/log_data/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that uses sol_log_data syscall
+//! Example Rust-based BPF program that uses sol_log_data syscall
 
 #![cfg(feature = "program")]
 

--- a/programs/bpf/rust/many_args/src/helper.rs
+++ b/programs/bpf/rust/many_args/src/helper.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
 use solana_program::log::*;

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 mod helper;
 extern crate solana_program;

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF program utility functions and types
+//! Solana Rust-based BPF program utility functions and types
 
 extern crate solana_program;
 use solana_program::msg;

--- a/programs/bpf/rust/mem/src/entrypoint.rs
+++ b/programs/bpf/rust/mem/src/entrypoint.rs
@@ -1,4 +1,4 @@
-//! @brief Test mem functions
+//! Test mem functions
 
 use crate::{run_mem_tests, MemOps};
 use solana_program::{

--- a/programs/bpf/rust/mem/src/lib.rs
+++ b/programs/bpf/rust/mem/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Test mem functions
+//! Test mem functions
 
 #[cfg(not(feature = "no-entrypoint"))]
 pub mod entrypoint;

--- a/programs/bpf/rust/membuiltins/src/lib.rs
+++ b/programs/bpf/rust/membuiltins/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Test builtin mem functions
+//! Test builtin mem functions
 
 #![cfg(target_arch = "bpf")]
 #![feature(rustc_private)]

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF noop program
+//! Example Rust-based BPF noop program
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that panics
+//! Example Rust-based BPF program that panics
 
 #[cfg(all(feature = "custom-panic", target_arch = "bpf"))]
 #[no_mangle]

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
 use solana_bpf_rust_param_passing_dep::{Data, TestDep};

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program tests loop iteration
+//! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
 

--- a/programs/bpf/rust/rand/src/lib.rs
+++ b/programs/bpf/rust/rand/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that tests rand behavior
+//! Example Rust-based BPF program that tests rand behavior
 
 #![allow(unreachable_code)]
 

--- a/programs/bpf/rust/realloc/src/instructions.rs
+++ b/programs/bpf/rust/realloc/src/instructions.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 use solana_program::{
     instruction::{AccountMeta, Instruction},

--- a/programs/bpf/rust/realloc/src/lib.rs
+++ b/programs/bpf/rust/realloc/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 pub mod instructions;
 pub mod processor;

--- a/programs/bpf/rust/realloc/src/processor.rs
+++ b/programs/bpf/rust/realloc/src/processor.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 #![cfg(feature = "program")]
 

--- a/programs/bpf/rust/realloc_invoke/src/instructions.rs
+++ b/programs/bpf/rust/realloc_invoke/src/instructions.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 pub const INVOKE_REALLOC_ZERO_RO: u8 = 0;
 pub const INVOKE_REALLOC_ZERO: u8 = 1;

--- a/programs/bpf/rust/realloc_invoke/src/lib.rs
+++ b/programs/bpf/rust/realloc_invoke/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 pub mod instructions;
 pub mod processor;

--- a/programs/bpf/rust/realloc_invoke/src/processor.rs
+++ b/programs/bpf/rust/realloc_invoke/src/processor.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF realloc test program
+//! Example Rust-based BPF realloc test program
 
 #![cfg(feature = "program")]
 

--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF sanity program that prints out the parameters passed to it
+//! Example Rust-based BPF sanity program that prints out the parameters passed to it
 
 #![allow(unreachable_code)]
 

--- a/programs/bpf/rust/secp256k1_recover/src/lib.rs
+++ b/programs/bpf/rust/secp256k1_recover/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Secp256k1Recover Syscall test
+//! Secp256k1Recover Syscall test
 
 extern crate solana_program;
 use solana_program::{custom_panic_default, msg};

--- a/programs/bpf/rust/sha/src/lib.rs
+++ b/programs/bpf/rust/sha/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief SHA Syscall test
+//! SHA Syscall test
 
 extern crate solana_program;
 use solana_program::{custom_panic_default, msg};

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that tests sysvar use
+//! Example Rust-based BPF program that tests sysvar use
 
 extern crate solana_program;
 #[allow(deprecated)]

--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF upgradeable program
+//! Example Rust-based BPF upgradeable program
 
 extern crate solana_program;
 use solana_program::{

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF upgraded program
+//! Example Rust-based BPF upgraded program
 
 extern crate solana_program;
 use solana_program::{

--- a/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF noop program
+//! Example Rust-based BPF noop program
 
 extern crate solana_program;
 use solana_program::{

--- a/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF noop program
+//! Example Rust-based BPF noop program
 
 extern crate solana_program;
 use solana_program::{

--- a/sdk/program/src/bpf_loader.rs
+++ b/sdk/program/src/bpf_loader.rs
@@ -1,4 +1,4 @@
-//! @brief The latest Solana BPF loader.
+//! The latest Solana BPF loader.
 //!
 //! The BPF loader is responsible for loading, finalizing, and executing BPF
 //! programs.  Not all networks may support the latest loader.  You can use the

--- a/sdk/program/src/bpf_loader_deprecated.rs
+++ b/sdk/program/src/bpf_loader_deprecated.rs
@@ -1,4 +1,4 @@
-//! @brief The original and now deprecated Solana BPF loader.
+//! The original and now deprecated Solana BPF loader.
 //!
 //! The BPF loader is responsible for loading, finalizing, and executing BPF
 //! programs.

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -1,4 +1,4 @@
-//! @brief An Upgradeable Solana BPF loader.
+//! An Upgradeable Solana BPF loader.
 //!
 //! The upgradeable BPF loader is responsible for deploying, upgrading, and
 //! executing BPF programs.  The upgradeable loader allows a program's authority

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF program entry point supported by the latest
+//! Solana Rust-based BPF program entry point supported by the latest
 //! BPFLoader.  For more information see './bpf_loader.rs'
 
 extern crate alloc;

--- a/sdk/program/src/entrypoint_deprecated.rs
+++ b/sdk/program/src/entrypoint_deprecated.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
-//! @brief Solana Rust-based BPF program entry point supported by the original
+//! Solana Rust-based BPF program entry point supported by the original
 //!  and now deprecated BPFLoader.  For more information see
 //!  './bpf_loader_deprecated.rs'
 

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF program logging
+//! Solana Rust-based BPF program logging
 
 use crate::account_info::AccountInfo;
 

--- a/sdk/program/src/program_memory.rs
+++ b/sdk/program/src/program_memory.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Rust-based BPF memory operations
+//! Solana Rust-based BPF memory operations
 
 /// Memcpy
 ///

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -1,4 +1,4 @@
-//! @brief Syscall stubs when building for programs for non-BPF targets
+//! Syscall stubs when building for programs for non-BPF targets
 
 #![cfg(not(target_arch = "bpf"))]
 

--- a/sdk/src/builtins.rs
+++ b/sdk/src/builtins.rs
@@ -1,4 +1,4 @@
-//! @brief Solana builtin helper macros
+//! Solana builtin helper macros
 
 #[rustversion::since(1.46.0)]
 #[macro_export]

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -1,4 +1,4 @@
-//! @brief Solana Native program entry point
+//! Solana Native program entry point
 
 use crate::{instruction::InstructionError, keyed_account::KeyedAccount, pubkey::Pubkey};
 

--- a/sdk/src/precompiles.rs
+++ b/sdk/src/precompiles.rs
@@ -1,4 +1,4 @@
-//! @brief Solana precompiled programs
+//! Solana precompiled programs
 
 #![cfg(feature = "full")]
 

--- a/web3.js/test/fixtures/noop-program/src/lib.rs
+++ b/web3.js/test/fixtures/noop-program/src/lib.rs
@@ -1,4 +1,4 @@
-//! @brief Example Rust-based BPF program that prints out the parameters passed to it
+//! Example Rust-based BPF program that prints out the parameters passed to it
 
 
 use solana_program::{


### PR DESCRIPTION
#### Problem

The Rust APIs are filled with `@brief` annotations for their brief description, which is not valid rustdoc, and make a poor first impression.

#### Summary of Changes

Remove `@brief`.

I realize these come from the C API docs, and hope they are not auto-generated.
