### PR TITLE
Expand Rust API docs entry point

### DIFF
--- a/docs/src/developing/clients/rust-api.md
+++ b/docs/src/developing/clients/rust-api.md
@@ -2,7 +2,30 @@
 title: Rust API
 ---
 
-See [doc.rs](https://docs.rs/releases/search?query=solana-) for documentation of
-all crates published by Solana. In particular [solana-sdk](https://docs.rs/solana-sdk)
-for working with common data structures and [solana-client](https://docs.rs/solana-client)
-for querying the [JSON RPC API](jsonrpc-api).
+Solana's Rust crates are [published to crates.io][crates.io] and can be found
+[on docs.rs with the "solana-" prefix][docs.rs].
+
+[crates.io]: https://crates.io/search?q=solana-
+[docs.rs]: https://docs.rs/releases/search?query=solana-
+
+Some important crates:
+
+- [`solana-program`] &mdash; Imported by programs running on Solana, compiled
+  to BPF. This crate contains many fundamental data types and is re-exported from
+  [`solana-sdk`], which cannot be imported from a Solana program.
+
+- [`solana-sdk`] &mdash; The basic off-chain SDK, it re-exports
+  [`solana-program`] and adds more APIs on top of that. Most Solana programs
+  that do not run on-chain will import this.
+
+- [`solana-client`] &mdash; For interacting with a Solana node via the
+  [JSON RPC API](jsonrpc-api).
+
+- [`solana-clap-utils`] &mdash; Routines for setting up a CLI, using [`clap`],
+  as used by the main Solana CLI.
+
+[`solana-program`]: https://docs.rs/solana-program
+[`solana-sdk`]: https://docs.rs/solana-sdk
+[`solana-client`]: https://docs.rs/solana-client
+[`solana-clap-utils`]: https://docs.rs/solana-clap-utils
+[`clap`]: https://docs.rs/clap


### PR DESCRIPTION
#### Problem

The documentation page that introduces the Rust API doesn't give much guidance, and neither do the crate-level API docs.

#### Summary of Changes

This expands the description of a few key Rust crates in order to give users a better idea of where to look next.
