### PR TITLE
Reduce visibility of `Hash` struct contents

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -740,7 +740,7 @@ mod tests {
         message.account_keys.push(pubkey1);
         message.account_keys.push(pubkey1);
         message.header.num_required_signatures = NUM_SIG as u8;
-        message.recent_blockhash = Hash(pubkey1.to_bytes());
+        message.recent_blockhash = Hash::new_from_array(pubkey1.to_bytes());
         let mut tx = Transaction::new_unsigned(message);
 
         info!("message: {:?}", tx.message_data());

--- a/replica-lib/src/replica_accounts_server.rs
+++ b/replica-lib/src/replica_accounts_server.rs
@@ -34,7 +34,7 @@ impl ReplicaAccountInfo {
         });
         ReplicaAccountInfo {
             account_meta,
-            hash: stored_account_meta.hash.0.to_vec(),
+            hash: stored_account_meta.hash.as_ref().to_vec(),
             data,
         }
     }
@@ -53,7 +53,7 @@ impl ReplicaAccountInfo {
         });
         ReplicaAccountInfo {
             account_meta,
-            hash: cached_account.hash().0.to_vec(),
+            hash: cached_account.hash().as_ref().to_vec(),
             data,
         }
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4300,7 +4300,9 @@ impl AccountsDb {
         hasher.update(owner.as_ref());
         hasher.update(pubkey.as_ref());
 
-        Hash(<[u8; solana_sdk::hash::HASH_BYTES]>::try_from(hasher.finalize().as_slice()).unwrap())
+        Hash::new_from_array(
+            <[u8; solana_sdk::hash::HASH_BYTES]>::try_from(hasher.finalize().as_slice()).unwrap(),
+        )
     }
 
     fn bulk_assign_write_version(&self, count: usize) -> StoredMetaWriteVersion {

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -26,7 +26,7 @@ const MAX_BASE58_LEN: usize = 44;
     AbiExample,
 )]
 #[repr(transparent)]
-pub struct Hash(pub [u8; HASH_BYTES]);
+pub struct Hash(pub(crate) [u8; HASH_BYTES]);
 
 #[derive(Clone, Default)]
 pub struct Hasher {

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -163,7 +163,7 @@ mod test {
         }
 
         let lamports = 55;
-        let hash = Hash([1; 32]);
+        let hash = Hash::new_from_array([1; 32]);
         let vote = Vote {
             slots: vec![1, 2, 4],
             hash,
@@ -289,7 +289,7 @@ mod test {
         );
         assert!(parse_vote(&message.instructions[0], &keys[0..1]).is_err());
 
-        let proof_hash = Hash([2; 32]);
+        let proof_hash = Hash::new_from_array([2; 32]);
         let instruction = vote_instruction::vote_switch(&keys[1], &keys[0], vote, proof_hash);
         let message = Message::new(&[instruction], None);
         assert_eq!(


### PR DESCRIPTION
`Pubkey` shows the way, no need for `Hash`'s inner array to be `pub`