### PR TITLE
Add CLI args for no-incremental-snapshot-fetch

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -40,6 +40,12 @@ use {
     },
 };
 
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum ConfigState {
+    Disabled,
+    Enabled,
+}
+
 #[derive(Debug)]
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
@@ -47,6 +53,8 @@ pub struct RpcBootstrapConfig {
     pub no_untrusted_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
     pub no_check_vote_account: bool,
+    pub incremental_snapshots: ConfigState,
+    pub incremental_snapshot_fetch: ConfigState,
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -522,6 +522,13 @@ pub fn main() {
                       start from a local snapshot if present"),
         )
         .arg(
+            Arg::with_name("no_incremental_snapshot_fetch")
+                .long("no-incremental-snapshot-fetch")
+                .takes_value(false)
+                .help("Do not attempt to fetch incremental snapshots from the cluster, only fetch \
+                      full snapshots"),
+        )
+        .arg(
             Arg::with_name("no_genesis_fetch")
                 .long("no-genesis-fetch")
                 .takes_value(false)
@@ -1788,6 +1795,16 @@ pub fn main() {
             "max_genesis_archive_unpacked_size",
             u64
         ),
+        incremental_snapshots: if matches.is_present("incremental_snapshots") {
+            bootstrap::ConfigState::Enabled
+        } else {
+            bootstrap::ConfigState::Disabled
+        },
+        incremental_snapshot_fetch: if matches.is_present("no_incremental_snapshot_fetch") {
+            bootstrap::ConfigState::Disabled
+        } else {
+            bootstrap::ConfigState::Enabled
+        },
     };
 
     let private_rpc = matches.is_present("private_rpc");


### PR DESCRIPTION
Refactor some logic from the larger PR #20696.

This PR adds the `no-incremental-snapshot-fetch` CLI arg, and passes it to bootstrap via RpcBootstrapConfig.