### PR TITLE
hash calc: sort time is redundantly counted as part of 'total time'

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -37,7 +37,6 @@ impl HashStats {
         let total_time_us = self.scan_time_total_us
             + self.zeros_time_total_us
             + self.hash_time_total_us
-            + self.sort_time_total_us
             + self.collect_snapshots_us
             + self.storage_sort_us;
         datapoint_info!(


### PR DESCRIPTION
#### Problem
The hash calc algorithm has changed over time. In the latest state, scan time is wall clock time. It includes 'sort' time. Sort time is also thread time, which can greatly exceed wall clock time. Whatever the case, sort time should no longer be added to get a 'total'.

```
datapoint: calculate_accounts_hash_without_index
accounts_scan=4,519,886
eliminate_zeros=1,182,664
hash=100,058
sort=7,056,544 ** should not be included, is included in accounts_scan
storage_sort_us=5,284
collect_snapshots_us=126,359
total=12,990,795 ** this is too high by 7s
```
#### Summary of Changes

Fixes #
