### PR TITLE
docs: Amend RPC Transaction History proposal

### DIFF
--- a/docs/src/implemented-proposals/rpc-transaction-history.md
+++ b/docs/src/implemented-proposals/rpc-transaction-history.md
@@ -16,10 +16,7 @@ The affected RPC endpoints are:
 - [getConfirmedSignaturesForAddress](developing/clients/jsonrpc-api.md#getconfirmedsignaturesforaddress)
 - [getConfirmedTransaction](developing/clients/jsonrpc-api.md#getconfirmedtransaction)
 - [getSignatureStatuses](developing/clients/jsonrpc-api.md#getsignaturestatuses)
-
-Note that [getBlockTime](developing/clients/jsonrpc-api.md#getblocktime)
-is not supported, as once https://github.com/solana-labs/solana/issues/10089 is
-fixed then `getBlockTime` can be removed.
+- [getBlockTime](developing/clients/jsonrpc-api.md#getblocktime)
 
 Some system design constraints:
 


### PR DESCRIPTION
#### Problem

The initial proposal ruled out implementing BigTable queries for
the `getBlockTime` RPC, but then it was implemented a couple months
later. Indicating that the functionality was never implemented in
the "implemented-proposals" document is a little confusing, so let's
bring the document in line with what actually happened. 🦾

#### Summary of Changes

Remove the blurb about how `getBlockTime` was going to be deprecated
and add it to the list of calls that didn't yet support BigTable
queries at the time the proposal was written.
