### PR TITLE
Fix docs CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
       if: type IN (push, pull_request) OR tag IS present
       language: node_js
       node_js:
-        - "node"
+        - "lts/*"
 
       services:
         - docker


### PR DESCRIPTION
#### Problem

CI docs build fails:
```
[info] [webpackbar] Compiling Client
[info] [webpackbar] Compiling Server
node:internal/crypto/hash:67
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:130:10)
    at module.exports (/home/travis/build/solana-labs/solana/docs/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/travis/build/solana-labs/solana/docs/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/home/travis/build/solana-labs/solana/docs/node_modules/webpack/lib/NormalModule.js:471:10)
    at /home/travis/build/solana-labs/solana/docs/node_modules/webpack/lib/NormalModule.js:503:5
    at /home/travis/build/solana-labs/solana/docs/node_modules/webpack/lib/NormalModule.js:358:12
    at /home/travis/build/solana-labs/solana/docs/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/home/travis/build/solana-labs/solana/docs/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/home/travis/build/solana-labs/solana/docs/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /home/travis/build/solana-labs/solana/docs/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/home/travis/build/solana-labs/solana/docs/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/travis/build/solana-labs/solana/docs/node_modules/babel-loader/lib/index.js:59:71 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

#### Summary of Changes

Install LTS nodejs, like the other TravisCI builds
