### PR TITLE
fix: Use ethers for ios compatibility instead crypto-hash

### DIFF
--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -69,7 +69,7 @@
     "bs58": "^4.0.1",
     "buffer": "6.0.1",
     "cross-fetch": "^3.1.4",
-    "crypto-hash": "^1.2.2",
+    "ethers": "^5.5.1",
     "jayson": "^3.4.4",
     "js-sha3": "^0.8.0",
     "rpc-websockets": "^7.4.2",

--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 import nacl from 'tweetnacl';
-import {sha256} from 'crypto-hash';
+import {ethers} from 'ethers';
 
 import {Struct, SOLANA_SCHEMA} from './util/borsh-schema';
 import {toBuffer} from './util/to-buffer';
@@ -120,6 +120,7 @@ export class PublicKey extends Struct {
    * The program ID will also serve as the owner of the public key, giving
    * it permission to write data to the account.
    */
+  /* eslint-disable require-await */
   static async createWithSeed(
     fromPublicKey: PublicKey,
     seed: string,
@@ -130,13 +131,14 @@ export class PublicKey extends Struct {
       Buffer.from(seed),
       programId.toBuffer(),
     ]);
-    const hash = await sha256(new Uint8Array(buffer));
+    const hash = ethers.utils.sha256(new Uint8Array(buffer)).slice(2);
     return new PublicKey(Buffer.from(hash, 'hex'));
   }
 
   /**
    * Derive a program address from seeds and a program ID.
    */
+  /* eslint-disable require-await */
   static async createProgramAddress(
     seeds: Array<Buffer | Uint8Array>,
     programId: PublicKey,
@@ -153,7 +155,7 @@ export class PublicKey extends Struct {
       programId.toBuffer(),
       Buffer.from('ProgramDerivedAddress'),
     ]);
-    let hash = await sha256(new Uint8Array(buffer));
+    let hash = ethers.utils.sha256(new Uint8Array(buffer)).slice(2);
     let publicKeyBytes = new BN(hash, 16).toArray(undefined, 32);
     if (is_on_curve(publicKeyBytes)) {
       throw new Error(`Invalid seeds, address must fall off the curve`);


### PR DESCRIPTION
#### Problem

`crypto-hash` does not work with react native (for iOS target) instead we can use `ethers`

#### Summary of Changes

Use `ethers` instead of `crypto-hash`

Fixes #
