### PR TITLE
disable gossip publish of snapshots when using filler accts

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -703,12 +703,22 @@ impl Validator {
                 // Start a snapshot packaging service
                 let pending_snapshot_package = PendingSnapshotPackage::default();
 
+                // filler accounts make snapshots invalid for use
+                // so, do not publish that we have snapshots
+                let enable_gossip_push = config
+                    .accounts_db_config
+                    .as_ref()
+                    .and_then(|config| config.filler_account_count)
+                    .map(|count| count == 0)
+                    .unwrap_or(true);
+
                 let snapshot_packager_service = SnapshotPackagerService::new(
                     pending_snapshot_package.clone(),
                     starting_snapshot_hashes,
                     &exit,
                     &cluster_info,
                     snapshot_config.clone(),
+                    enable_gossip_push,
                 );
                 (
                     Some(snapshot_packager_service),

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -501,6 +501,7 @@ mod tests {
             &exit,
             &cluster_info,
             snapshot_config.clone(),
+            true,
         );
 
         let _package_receiver = std::thread::Builder::new()
@@ -928,6 +929,7 @@ mod tests {
             &exit,
             &cluster_info,
             snapshot_test_config.snapshot_config.clone(),
+            true,
         );
 
         let tmpdir = TempDir::new().unwrap();


### PR DESCRIPTION
#### Problem
When creating filler accounts, generated snapshots become incorrect for use. But, we want the snapshots to be generated and managed in all the normal validator code paths. So, do not publish snapshots that we have available on gossip.
#### Summary of Changes

Fixes #
