### PR TITLE
Bump fee-api check version conditional

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4801,7 +4801,7 @@ impl RpcClient {
 
     #[allow(deprecated)]
     pub fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
-        if self.get_node_version()? < semver::Version::new(1, 8, 0) {
+        if self.get_node_version()? < semver::Version::new(1, 9, 0) {
             let Fees { fee_calculator, .. } = self.get_fees()?;
             Ok(fee_calculator
                 .lamports_per_signature


### PR DESCRIPTION
#### Problem
Various master clients (eg bench-tps) are currently incompatible with testnet. This is because they are attempting to call the non-existent `getFeeForMessage` RPC endpoint because the cluster satisfies the `get_node_version` conditional due to v1.8 jumping the normal release process.

#### Summary of Changes
Bump checked version to be in sync for master
