### PR TITLE
fix hash calc # storages, # slots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5538,7 +5538,8 @@ impl AccountsDb {
         let bin_calculator = PubkeyBinCalculator24::new(bins);
         assert!(bin_range.start < bins && bin_range.end <= bins && bin_range.start < bin_range.end);
         let mut time = Measure::start("scan all accounts");
-        stats.num_snapshot_storage = storage.slot_count();
+        stats.num_snapshot_storage = storage.storage_count();
+        stats.num_slots = storage.slot_count();
         let mismatch_found = AtomicU64::new(0);
         let range = bin_range.end - bin_range.start;
         let sort_time = AtomicU64::new(0);

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -27,6 +27,7 @@ pub struct HashStats {
     pub hash_total: usize,
     pub unreduced_entries: usize,
     pub num_snapshot_storage: usize,
+    pub num_slots: usize,
     pub collect_snapshots_us: u64,
     pub storage_sort_us: u64,
     pub min_bin_size: usize,
@@ -59,6 +60,7 @@ impl HashStats {
                 self.num_snapshot_storage as i64,
                 i64
             ),
+            ("num_slots", self.num_slots as i64, i64),
             ("min_bin_size", self.min_bin_size as i64, i64),
             ("max_bin_size", self.max_bin_size as i64, i64),
             ("total", total_time_us as i64, i64),

--- a/runtime/src/sorted_storages.rs
+++ b/runtime/src/sorted_storages.rs
@@ -8,6 +8,7 @@ pub struct SortedStorages<'a> {
     range: Range<Slot>,
     storages: Vec<Option<&'a SnapshotStorage>>,
     slot_count: usize,
+    storage_count: usize,
 }
 
 impl<'a> SortedStorages<'a> {
@@ -30,6 +31,10 @@ impl<'a> SortedStorages<'a> {
 
     pub fn slot_count(&self) -> usize {
         self.slot_count
+    }
+
+    pub fn storage_count(&self) -> usize {
+        self.storage_count
     }
 
     // assumptions:
@@ -79,7 +84,9 @@ impl<'a> SortedStorages<'a> {
         let mut slot_count = 0;
         let mut time = Measure::start("get slot");
         let source_ = source.clone();
-        source_.for_each(|(_, slot)| {
+        let mut storage_count = 0;
+        source_.for_each(|(storages, slot)| {
+            storage_count += storages.len();
             slot_count += 1;
             adjust_min_max(*slot);
         });
@@ -109,6 +116,7 @@ impl<'a> SortedStorages<'a> {
             range,
             storages,
             slot_count,
+            storage_count,
         }
     }
 }
@@ -132,6 +140,7 @@ pub mod tests {
                 range,
                 storages,
                 slot_count,
+                storage_count: 0,
             }
         }
     }


### PR DESCRIPTION
#### Problem
Metrics for hash calc were reporting # slots for # storages. With filler accounts (or multiple storages per slot), this is no longer accurate.
#### Summary of Changes

Fixes #
