### PR TITLE
Increase gossip votes retention to 3000 pre-leader slot

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -389,7 +389,7 @@ impl ClusterInfoVoteListener {
             let would_be_leader = poh_recorder
                 .lock()
                 .unwrap()
-                .would_be_leader(20 * DEFAULT_TICKS_PER_SLOT);
+                .would_be_leader(3000 * DEFAULT_TICKS_PER_SLOT);
             if let Err(e) = verified_vote_packets.receive_and_process_vote_packets(
                 &verified_vote_label_packets_receiver,
                 &mut update_version,


### PR DESCRIPTION
#### Problem

With long-running forks, votes for the older fork could be purged before they can be applied to a bank.

#### Summary of Changes

Increase the retention slots to 3000 which should give around 20 minutes of forking.

Fixes #
