### PR TITLE
Fixes MockInvokeContext::get_compute_meter()

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -25,11 +25,11 @@ use solana_sdk::{
     entrypoint::SUCCESS,
     instruction::{AccountMeta, Instruction},
     message::Message,
-    process_instruction::{InvokeContext, MockInvokeContext},
+    process_instruction::{InvokeContext, MockComputeMeter, MockInvokeContext},
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
-use std::{cell::RefCell, env, fs::File, io::Read, mem, path::PathBuf, sync::Arc};
+use std::{cell::RefCell, env, fs::File, io::Read, mem, path::PathBuf, rc::Rc, sync::Arc};
 use test::Bencher;
 
 /// BPF program file extension
@@ -237,7 +237,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
     let instruction_data = vec![0u8];
 
     let mut invoke_context = MockInvokeContext::new(&loader_id, keyed_accounts);
-    invoke_context.compute_meter.remaining = BUDGET;
+    invoke_context.compute_meter = Rc::new(RefCell::new(MockComputeMeter { remaining: BUDGET }));
 
     // Serialize account data
     let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
@@ -296,7 +296,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .collect();
     let instruction_data = vec![0u8];
     let mut invoke_context = MockInvokeContext::new(&program_id, keyed_accounts);
-    invoke_context.compute_meter.remaining = BUDGET;
+    invoke_context.compute_meter = Rc::new(RefCell::new(MockComputeMeter { remaining: BUDGET }));
 
     // Serialize account data
     let (mut serialized, account_lengths) = serialize_parameters(

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1365,39 +1365,39 @@ fn assert_instruction_count() {
     #[cfg(feature = "bpf_c")]
     {
         programs.extend_from_slice(&[
-            ("alloc", 1137),
-            ("bpf_to_bpf", 13),
-            ("multiple_static", 8),
+            ("alloc", 1237),
+            ("bpf_to_bpf", 96),
+            ("multiple_static", 52),
             ("noop", 5),
             ("noop++", 5),
-            ("relative_call", 10),
-            ("return_data", 480),
-            ("sanity", 169),
-            ("sanity++", 168),
-            ("secp256k1_recover", 359),
-            ("sha", 1040),
-            ("struct_pass", 8),
-            ("struct_ret", 22),
+            ("relative_call", 26),
+            ("return_data", 980),
+            ("sanity", 1246),
+            ("sanity++", 1250),
+            ("secp256k1_recover", 25357),
+            ("sha", 1328),
+            ("struct_pass", 108),
+            ("struct_ret", 28),
         ]);
     }
     #[cfg(feature = "bpf_rust")]
     {
         programs.extend_from_slice(&[
             ("solana_bpf_rust_128bit", 584),
-            ("solana_bpf_rust_alloc", 7143),
-            ("solana_bpf_rust_custom_heap", 522),
+            ("solana_bpf_rust_alloc", 7388),
+            ("solana_bpf_rust_custom_heap", 512),
             ("solana_bpf_rust_dep_crate", 47),
-            ("solana_bpf_rust_external_spend", 504),
-            ("solana_bpf_rust_iter", 724),
-            ("solana_bpf_rust_many_args", 233),
-            ("solana_bpf_rust_mem", 3119),
-            ("solana_bpf_rust_membuiltins", 4065),
-            ("solana_bpf_rust_noop", 478),
-            ("solana_bpf_rust_param_passing", 46),
-            ("solana_bpf_rust_rand", 481),
-            ("solana_bpf_rust_sanity", 922),
-            ("solana_bpf_rust_secp256k1_recover", 301),
-            ("solana_bpf_rust_sha", 32337),
+            ("solana_bpf_rust_external_spend", 483),
+            ("solana_bpf_rust_iter", 824),
+            ("solana_bpf_rust_many_args", 941),
+            ("solana_bpf_rust_mem", 3083),
+            ("solana_bpf_rust_membuiltins", 3976),
+            ("solana_bpf_rust_noop", 457),
+            ("solana_bpf_rust_param_passing", 146),
+            ("solana_bpf_rust_rand", 464),
+            ("solana_bpf_rust_sanity", 1714),
+            ("solana_bpf_rust_secp256k1_recover", 25216),
+            ("solana_bpf_rust_sha", 30704),
         ]);
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1328,7 +1328,7 @@ mod tests {
         keyed_accounts.insert(0, (false, false, &program_key, &processor_account));
         let mut invoke_context =
             MockInvokeContext::new(&program_key, create_keyed_accounts_unified(&keyed_accounts));
-        invoke_context.compute_meter = MockComputeMeter::default();
+        invoke_context.compute_meter = Rc::new(RefCell::new(MockComputeMeter::default()));
         assert_eq!(
             Err(InstructionError::ProgramFailedToComplete),
             super::process_instruction(1, &[], &mut invoke_context)

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -354,7 +354,7 @@ pub struct MockInvokeContext<'a> {
     pub invoke_stack: Vec<InvokeContextStackFrame<'a>>,
     pub logger: MockLogger,
     pub compute_budget: ComputeBudget,
-    pub compute_meter: MockComputeMeter,
+    pub compute_meter: Rc<RefCell<dyn ComputeMeter>>,
     pub programs: Vec<(Pubkey, ProcessInstructionWithContext)>,
     pub accounts: Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>,
     #[allow(clippy::type_complexity)]
@@ -372,9 +372,9 @@ impl<'a> MockInvokeContext<'a> {
             invoke_stack: Vec::with_capacity(compute_budget.max_invoke_depth),
             logger: MockLogger::default(),
             compute_budget,
-            compute_meter: MockComputeMeter {
+            compute_meter: Rc::new(RefCell::new(MockComputeMeter {
                 remaining: std::i64::MAX as u64,
-            },
+            })),
             programs: vec![],
             accounts: vec![],
             sysvars: RefCell::new(Vec::new()),
@@ -464,7 +464,7 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
-        Rc::new(RefCell::new(self.compute_meter.clone()))
+        self.compute_meter.clone()
     }
     fn add_executor(&self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
     fn get_executor(&self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {


### PR DESCRIPTION
#### Problem
`MockInvokeContext::get_compute_meter()` created a reference to a clone instead of cloning the reference.

#### Summary of Changes
 Fixes the bug and adjusts the test `assert_instruction_count` accordingly.

Fixes #
