### PR TITLE
ClusterInfoVoteListener send only missing votes to BankingStage

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -243,7 +243,7 @@ EOF
 
   command_step "local-cluster" \
     ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-local-cluster.sh" \
-    45
+    50
 }
 
 pull_or_push_steps() {

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -570,8 +570,10 @@ impl ClusterInfoVoteListener {
                         .add_new_optimistic_confirmed_slots(confirmed_slots.clone());
                 }
                 Err(e) => match e {
-                    Error::CrossbeamRecvTimeout(RecvTimeoutError::Disconnected)
-                    | Error::ReadyTimeout => (),
+                    Error::CrossbeamRecvTimeout(RecvTimeoutError::Disconnected) => {
+                        return Ok(());
+                    }
+                    Error::ReadyTimeout => (),
                     _ => {
                         error!("thread {:?} error {:?}", thread::current().name(), e);
                     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5642,7 +5642,7 @@ pub mod tests {
         );
 
         let mut cursor = Cursor::default();
-        let (_, votes) = cluster_info.get_votes(&mut cursor);
+        let votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
         let vote_tx = &votes[0];
         assert_eq!(vote_tx.message.recent_blockhash, bank0.last_blockhash());
@@ -5671,7 +5671,7 @@ pub mod tests {
             );
 
             // No new votes have been submitted to gossip
-            let (_, votes) = cluster_info.get_votes(&mut cursor);
+            let votes = cluster_info.get_votes(&mut cursor);
             assert!(votes.is_empty());
             // Tower's latest vote tx blockhash hasn't changed either
             assert_eq!(tower.last_vote_tx_blockhash(), bank0.last_blockhash());
@@ -5704,7 +5704,7 @@ pub mod tests {
             vote_info,
             false,
         );
-        let (_, votes) = cluster_info.get_votes(&mut cursor);
+        let votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
         let vote_tx = &votes[0];
         assert_eq!(vote_tx.message.recent_blockhash, bank1.last_blockhash());
@@ -5727,7 +5727,7 @@ pub mod tests {
         );
 
         // No new votes have been submitted to gossip
-        let (_, votes) = cluster_info.get_votes(&mut cursor);
+        let votes = cluster_info.get_votes(&mut cursor);
         assert!(votes.is_empty());
         assert_eq!(tower.last_vote_tx_blockhash(), bank1.last_blockhash());
         assert_eq!(tower.last_voted_slot().unwrap(), 1);
@@ -5774,7 +5774,7 @@ pub mod tests {
         );
 
         assert!(last_vote_refresh_time.last_refresh_time > clone_refresh_time);
-        let (_, votes) = cluster_info.get_votes(&mut cursor);
+        let votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes.len(), 1);
         let vote_tx = &votes[0];
         assert_eq!(
@@ -5830,7 +5830,7 @@ pub mod tests {
             &voting_sender,
         );
 
-        let (_, votes) = cluster_info.get_votes(&mut cursor);
+        let votes = cluster_info.get_votes(&mut cursor);
         assert!(votes.is_empty());
         assert_eq!(
             vote_tx.message.recent_blockhash,

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -1,14 +1,92 @@
 use crate::{cluster_info_vote_listener::VerifiedLabelVotePacketsReceiver, result::Result};
-use solana_gossip::crds_value::CrdsValueLabel;
+use crossbeam_channel::Select;
 use solana_perf::packet::Packets;
-use solana_sdk::clock::Slot;
+use solana_runtime::bank::Bank;
+use solana_sdk::{
+    account::from_account, clock::Slot, hash::Hash, pubkey::Pubkey, slot_hashes::SlotHashes, sysvar,
+};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, BTreeMap, HashMap},
+    sync::Arc,
     time::Duration,
 };
 
+const MAX_VOTES_PER_VALIDATOR: usize = 1000;
+
+pub struct ValidatorGossipVotesIterator<'a> {
+    my_leader_bank: Arc<Bank>,
+    slot_hashes: SlotHashes,
+    verified_vote_packets: &'a VerifiedVotePackets,
+    vote_account_keys: Vec<Pubkey>,
+}
+
+impl<'a> ValidatorGossipVotesIterator<'a> {
+    pub fn new(my_leader_bank: Arc<Bank>, verified_vote_packets: &'a VerifiedVotePackets) -> Self {
+        let slot_hashes_account = my_leader_bank
+            .get_account(&sysvar::slot_hashes::id())
+            .expect("Slot hashes sysvar must exist");
+        let slot_hashes = from_account::<SlotHashes, _>(&slot_hashes_account).unwrap();
+        // TODO: my_leader_bank.vote_accounts() may not contain zero-staked validators
+        // in this epoch, but those validators may have stake warming up in the next epoch
+        let vote_account_keys: Vec<Pubkey> =
+            my_leader_bank.vote_accounts().keys().copied().collect();
+        Self {
+            my_leader_bank,
+            slot_hashes,
+            verified_vote_packets,
+            vote_account_keys,
+        }
+    }
+}
+
+/// Each iteration returns all of the missing votes for a single validator, the votes
+/// ordered from smallest to largest.
+///
+/// Iterator is done after iterating through all vote accounts
+impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
+    type Item = Vec<Packets>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: Maybe prioritize by stake weight
+        self.vote_account_keys.pop().and_then(|vote_account_key| {
+            // Get all the gossip votes we've queued up for this validator
+            self.verified_vote_packets
+                .0
+                .get(&vote_account_key)
+                .and_then(|validator_gossip_votes| {
+                    // Fetch the validator's vote state from the bank
+                    self.my_leader_bank
+                        .vote_accounts()
+                        .get(&vote_account_key)
+                        .and_then(|(_stake, vote_account)| {
+                            vote_account.vote_state().as_ref().ok().map(|vote_state| {
+                                let latest_vote = vote_state.last_voted_slot().unwrap_or(0);
+                                // Filter out the votes that are outdated or on wrong fork
+                                validator_gossip_votes
+                                    .range((latest_vote + 1, Hash::default())..)
+                                    .filter_map(|((slot, hash), packet)| {
+                                        // Check the hash is actually on this fork
+                                        if self
+                                            .slot_hashes
+                                            .get(slot)
+                                            .map(|found_hash| found_hash == hash)
+                                            .unwrap_or(false)
+                                        {
+                                            Some(packet.clone())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<Packets>>()
+                            })
+                        })
+                })
+        })
+    }
+}
+
 #[derive(Default)]
-pub struct VerifiedVotePackets(HashMap<CrdsValueLabel, (u64, Slot, Packets)>);
+pub struct VerifiedVotePackets(HashMap<Pubkey, BTreeMap<(Slot, Hash), Packets>>);
 
 impl VerifiedVotePackets {
     pub fn receive_and_process_vote_packets(
@@ -17,21 +95,29 @@ impl VerifiedVotePackets {
         last_update_version: &mut u64,
         would_be_leader: bool,
     ) -> Result<()> {
-        let timer = Duration::from_millis(200);
-        let vote_packets = vote_packets_receiver.recv_timeout(timer)?;
-        *last_update_version += 1;
-        if would_be_leader {
-            for (label, slot, packet) in vote_packets {
-                self.0.insert(label, (*last_update_version, slot, packet));
-            }
-        } else {
-            self.0.clear();
-            self.0.shrink_to_fit();
-        }
-        while let Ok(vote_packets) = vote_packets_receiver.try_recv() {
+        let mut sel = Select::new();
+        sel.recv(vote_packets_receiver);
+        let _ = sel.ready_timeout(Duration::from_millis(200))?;
+
+        for gossip_votes in vote_packets_receiver.try_iter() {
             if would_be_leader {
-                for (label, slot, packet) in vote_packets {
-                    self.0.insert(label, (*last_update_version, slot, packet));
+                for (label, vote, packet) in gossip_votes {
+                    let validator_key = label.pubkey();
+                    if vote.slots.is_empty() {
+                        error!("Empty votes should have been filtered out earlier in the pipeline");
+                        continue;
+                    }
+                    let slot = vote.slots.last().unwrap();
+                    let hash = vote.hash;
+
+                    let validator_votes = self.0.entry(validator_key).or_default();
+
+                    validator_votes.insert((*slot, hash), packet);
+
+                    if validator_votes.len() > MAX_VOTES_PER_VALIDATOR {
+                        let smallest_key = validator_votes.keys().next().cloned().unwrap();
+                        validator_votes.remove(&smallest_key).unwrap();
+                    }
                 }
             }
         }
@@ -43,7 +129,7 @@ impl VerifiedVotePackets {
         self.0.get(key)
     }
 
-    pub fn get_latest_votes(&self, last_update_version: u64) -> (u64, Packets) {
+    /*pub fn get_latest_votes(&self, last_update_version: u64) -> (u64, Packets) {
         let mut new_update_version = last_update_version;
         let mut votes = HashMap::new();
         for (label, (version, slot, packets)) in &self.0 {
@@ -69,7 +155,7 @@ impl VerifiedVotePackets {
             .cloned()
             .collect();
         (new_update_version, Packets::new(packets))
-    }
+    }*/
 }
 
 #[cfg(test)]

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -1,27 +1,42 @@
 use crate::{cluster_info_vote_listener::VerifiedLabelVotePacketsReceiver, result::Result};
 use crossbeam_channel::Select;
+use solana_gossip::crds_value::CrdsValueLabel;
 use solana_perf::packet::Packets;
 use solana_runtime::bank::Bank;
 use solana_sdk::{
-    account::from_account, clock::Slot, hash::Hash, pubkey::Pubkey, slot_hashes::SlotHashes, sysvar,
+    account::from_account, clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signature,
+    slot_hashes::SlotHashes, sysvar,
 };
+use solana_vote_program::vote_state::Vote;
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::Duration,
 };
 
 const MAX_VOTES_PER_VALIDATOR: usize = 1000;
 
+pub struct VerifiedVoteMetadata {
+    pub label: CrdsValueLabel,
+    pub vote: Vote,
+    pub packet: Packets,
+    pub signature: Signature,
+}
+
 pub struct ValidatorGossipVotesIterator<'a> {
     my_leader_bank: Arc<Bank>,
     slot_hashes: SlotHashes,
     verified_vote_packets: &'a VerifiedVotePackets,
     vote_account_keys: Vec<Pubkey>,
+    previously_sent_to_bank_votes: &'a mut HashSet<Signature>,
 }
 
 impl<'a> ValidatorGossipVotesIterator<'a> {
-    pub fn new(my_leader_bank: Arc<Bank>, verified_vote_packets: &'a VerifiedVotePackets) -> Self {
+    pub fn new(
+        my_leader_bank: Arc<Bank>,
+        verified_vote_packets: &'a VerifiedVotePackets,
+        previously_sent_to_bank_votes: &'a mut HashSet<Signature>,
+    ) -> Self {
         let slot_hashes_account = my_leader_bank
             .get_account(&sysvar::slot_hashes::id())
             .expect("Slot hashes sysvar must exist");
@@ -35,6 +50,7 @@ impl<'a> ValidatorGossipVotesIterator<'a> {
             slot_hashes,
             verified_vote_packets,
             vote_account_keys,
+            previously_sent_to_bank_votes,
         }
     }
 }
@@ -61,11 +77,18 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
                         .and_then(|(_stake, vote_account)| {
                             vote_account.vote_state().as_ref().ok().map(|vote_state| {
                                 let latest_vote = vote_state.last_voted_slot().unwrap_or(0);
-                                // Filter out the votes that are outdated or on wrong fork
+                                // Filter out the votes that are outdated
                                 validator_gossip_votes
                                     .range((latest_vote + 1, Hash::default())..)
-                                    .filter_map(|((slot, hash), packet)| {
-                                        // Check the hash is actually on this fork
+                                    .filter_map(|((slot, hash), (packet, tx_signature))| {
+                                        if self.previously_sent_to_bank_votes.contains(tx_signature)
+                                        {
+                                            return None;
+                                        }
+                                        // Don't send the same vote to the same bank multiple times
+                                        self.previously_sent_to_bank_votes.insert(*tx_signature);
+                                        // Filter out votes on the wrong fork (or too old to be)
+                                        // on this fork
                                         if self
                                             .slot_hashes
                                             .get(slot)
@@ -85,23 +108,29 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
     }
 }
 
+pub type SingleValidatorVotes = BTreeMap<(Slot, Hash), (Packets, Signature)>;
+
 #[derive(Default)]
-pub struct VerifiedVotePackets(HashMap<Pubkey, BTreeMap<(Slot, Hash), Packets>>);
+pub struct VerifiedVotePackets(HashMap<Pubkey, SingleValidatorVotes>);
 
 impl VerifiedVotePackets {
     pub fn receive_and_process_vote_packets(
         &mut self,
         vote_packets_receiver: &VerifiedLabelVotePacketsReceiver,
-        last_update_version: &mut u64,
         would_be_leader: bool,
     ) -> Result<()> {
         let mut sel = Select::new();
         sel.recv(vote_packets_receiver);
         let _ = sel.ready_timeout(Duration::from_millis(200))?;
-
         for gossip_votes in vote_packets_receiver.try_iter() {
             if would_be_leader {
-                for (label, vote, packet) in gossip_votes {
+                for verfied_vote_metadata in gossip_votes {
+                    let VerifiedVoteMetadata {
+                        label,
+                        vote,
+                        packet,
+                        signature,
+                    } = verfied_vote_metadata;
                     let validator_key = label.pubkey();
                     if vote.slots.is_empty() {
                         error!("Empty votes should have been filtered out earlier in the pipeline");
@@ -112,7 +141,7 @@ impl VerifiedVotePackets {
 
                     let validator_votes = self.0.entry(validator_key).or_default();
 
-                    validator_votes.insert((*slot, hash), packet);
+                    validator_votes.insert((*slot, hash), (packet, signature));
 
                     if validator_votes.len() > MAX_VOTES_PER_VALIDATOR {
                         let smallest_key = validator_votes.keys().next().cloned().unwrap();
@@ -123,159 +152,217 @@ impl VerifiedVotePackets {
         }
         Ok(())
     }
-
-    #[cfg(test)]
-    fn get_vote_packets(&self, key: &CrdsValueLabel) -> Option<&(u64, Slot, Packets)> {
-        self.0.get(key)
-    }
-
-    /*pub fn get_latest_votes(&self, last_update_version: u64) -> (u64, Packets) {
-        let mut new_update_version = last_update_version;
-        let mut votes = HashMap::new();
-        for (label, (version, slot, packets)) in &self.0 {
-            new_update_version = std::cmp::max(*version, new_update_version);
-            if *version <= last_update_version {
-                continue;
-            }
-            match votes.entry(label.pubkey()) {
-                Entry::Vacant(entry) => {
-                    entry.insert((slot, packets));
-                }
-                Entry::Occupied(mut entry) => {
-                    let (entry_slot, _) = entry.get();
-                    if *entry_slot < slot {
-                        *entry.get_mut() = (slot, packets);
-                    }
-                }
-            }
-        }
-        let packets = votes
-            .into_iter()
-            .flat_map(|(_, (_, packets))| &packets.packets)
-            .cloned()
-            .collect();
-        (new_update_version, Packets::new(packets))
-    }*/
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::result::Error;
-    use crossbeam_channel::{unbounded, RecvTimeoutError};
-    use solana_perf::packet::{Meta, Packet};
+    use crossbeam_channel::unbounded;
+    use solana_perf::packet::Packet;
 
     #[test]
-    fn test_get_latest_votes() {
+    fn test_verified_vote_packets_receive_and_process_vote_packets() {
+        let (s, r) = unbounded();
         let pubkey = solana_sdk::pubkey::new_rand();
-        let label1 = CrdsValueLabel::Vote(0, pubkey);
-        let label2 = CrdsValueLabel::Vote(1, pubkey);
+
+        // Construct the buffer
         let mut verified_vote_packets = VerifiedVotePackets(HashMap::new());
 
-        let data = Packet {
-            meta: Meta {
-                repair: true,
-                ..Meta::default()
-            },
-            ..Packet::default()
-        };
-
-        let none_empty_packets = Packets::new(vec![data, Packet::default()]);
-
+        // Send a vote from `pubkey`, check that it was inserted
+        let vote_slot = 0;
+        let vote_hash = Hash::new_unique();
+        let vote_index = 0;
+        let label = CrdsValueLabel::Vote(vote_index, pubkey);
+        let vote = Vote::new(vec![vote_slot], vote_hash);
+        s.send(vec![VerifiedVoteMetadata {
+            label: label.clone(),
+            vote: vote.clone(),
+            packet: Packets::default(),
+            signature: Signature::new(&[1u8; 64]),
+        }])
+        .unwrap();
         verified_vote_packets
-            .0
-            .insert(label1, (2, 42, none_empty_packets));
+            .receive_and_process_vote_packets(&r, true)
+            .unwrap();
+        assert_eq!(verified_vote_packets.0.get(&pubkey).unwrap().len(), 1);
+
+        // Same slot, same hash, should not be inserted
+        s.send(vec![VerifiedVoteMetadata {
+            label: label.clone(),
+            vote: vote.clone(),
+            packet: Packets::default(),
+            signature: Signature::new(&[1u8; 64]),
+        }])
+        .unwrap();
         verified_vote_packets
-            .0
-            .insert(label2, (1, 23, Packets::default()));
+            .receive_and_process_vote_packets(&r, true)
+            .unwrap();
+        assert_eq!(verified_vote_packets.0.get(&pubkey).unwrap().len(), 1);
 
-        // Both updates have timestamps greater than 0, so both should be returned
-        let (new_update_version, updates) = verified_vote_packets.get_latest_votes(0);
-        assert_eq!(new_update_version, 2);
-        assert_eq!(updates.packets.len(), 2);
+        // Same slot, different hash, should still be inserted
+        let new_vote_hash = Hash::new_unique();
+        let vote = Vote::new(vec![vote_slot], new_vote_hash);
+        s.send(vec![VerifiedVoteMetadata {
+            label,
+            vote,
+            packet: Packets::default(),
+            signature: Signature::new(&[1u8; 64]),
+        }])
+        .unwrap();
+        verified_vote_packets
+            .receive_and_process_vote_packets(&r, true)
+            .unwrap();
+        assert_eq!(verified_vote_packets.0.get(&pubkey).unwrap().len(), 2);
 
-        // Only the nonempty packet had a timestamp greater than 1
-        let (new_update_version, updates) = verified_vote_packets.get_latest_votes(1);
-        assert_eq!(new_update_version, 2);
-        assert!(!updates.packets.is_empty());
+        // Different vote slot, should be inserted
+        let vote_slot = 1;
+        let vote_hash = Hash::new_unique();
+        let vote_index = 0;
+        let label = CrdsValueLabel::Vote(vote_index, pubkey);
+        let vote = Vote::new(vec![vote_slot], vote_hash);
+        s.send(vec![VerifiedVoteMetadata {
+            label,
+            vote,
+            packet: Packets::default(),
+            signature: Signature::new(&[2u8; 64]),
+        }])
+        .unwrap();
+        verified_vote_packets
+            .receive_and_process_vote_packets(&r, true)
+            .unwrap();
+        assert_eq!(verified_vote_packets.0.get(&pubkey).unwrap().len(), 3);
 
-        // If the given timestamp is greater than all timestamps in any update,
-        // returned timestamp should be the same as the given timestamp, and
-        // no updates should be returned
-        let (new_update_version, updates) = verified_vote_packets.get_latest_votes(3);
-        assert_eq!(new_update_version, 3);
-        assert!(updates.is_empty());
+        // No new messages, should time out
+        assert_matches!(
+            verified_vote_packets.receive_and_process_vote_packets(&r, true),
+            Err(Error::ReadyTimeout)
+        );
     }
 
     #[test]
-    fn test_get_and_process_vote_packets() {
+    fn test_verified_vote_packets_receive_and_process_vote_packets_max_len() {
         let (s, r) = unbounded();
         let pubkey = solana_sdk::pubkey::new_rand();
-        let label1 = CrdsValueLabel::Vote(0, pubkey);
-        let label2 = CrdsValueLabel::Vote(1, pubkey);
-        let mut update_version = 0;
-        s.send(vec![(label1.clone(), 17, Packets::default())])
-            .unwrap();
-        s.send(vec![(label2.clone(), 23, Packets::default())])
-            .unwrap();
 
-        let data = Packet {
-            meta: Meta {
-                repair: true,
-                ..Meta::default()
-            },
-            ..Packet::default()
-        };
-
-        let later_packets = Packets::new(vec![data, Packet::default()]);
-        s.send(vec![(label1.clone(), 42, later_packets)]).unwrap();
+        // Construct the buffer
         let mut verified_vote_packets = VerifiedVotePackets(HashMap::new());
+
+        // Send many more votes than the upper limit per validator
+        for _ in 0..2 * MAX_VOTES_PER_VALIDATOR {
+            let vote_slot = 0;
+            let vote_hash = Hash::new_unique();
+            let vote_index = 0;
+            let label = CrdsValueLabel::Vote(vote_index, pubkey);
+            let vote = Vote::new(vec![vote_slot], vote_hash);
+            s.send(vec![VerifiedVoteMetadata {
+                label,
+                vote,
+                packet: Packets::default(),
+                signature: Signature::new(&[1u8; 64]),
+            }])
+            .unwrap();
+        }
+
+        // At most `MAX_VOTES_PER_VALIDATOR` should be stored per validator
         verified_vote_packets
-            .receive_and_process_vote_packets(&r, &mut update_version, true)
+            .receive_and_process_vote_packets(&r, true)
             .unwrap();
-
-        // Test timestamps for same batch are the same
-        let update_version1 = verified_vote_packets.get_vote_packets(&label1).unwrap().0;
         assert_eq!(
-            update_version1,
-            verified_vote_packets.get_vote_packets(&label2).unwrap().0
+            verified_vote_packets.0.get(&pubkey).unwrap().len(),
+            MAX_VOTES_PER_VALIDATOR
         );
+    }
 
-        // Test the later value overwrote the earlier one for this label
-        assert!(
-            verified_vote_packets
-                .get_vote_packets(&label1)
-                .unwrap()
-                .2
-                .packets
-                .len()
-                > 1
-        );
-        assert_eq!(
-            verified_vote_packets
-                .get_vote_packets(&label2)
-                .unwrap()
-                .2
-                .packets
-                .len(),
-            0
-        );
+    #[test]
+    fn test_verified_vote_packets_validator_gossip_votes_iterator() {
+        let (s, r) = unbounded();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
-        // Test timestamp for next batch overwrites the original
-        s.send(vec![(label2.clone(), 51, Packets::default())])
+        // Construct the buffer
+        let mut verified_vote_packets = VerifiedVotePackets(HashMap::new());
+
+        // Create two validators with `MAX_VOTES_PER_VALIDATOR` each
+        let mut pubkey = Pubkey::new_unique();
+        let mut num_packets = 1;
+        for i in 0..2 * MAX_VOTES_PER_VALIDATOR {
+            if i % MAX_VOTES_PER_VALIDATOR == 0 {
+                pubkey = Pubkey::new_unique();
+                num_packets += 1;
+            }
+            let vote_slot = 0;
+            let vote_hash = Hash::new_unique();
+            let vote_index = 0;
+            let label = CrdsValueLabel::Vote(vote_index, pubkey);
+            let vote = Vote::new(vec![vote_slot], vote_hash);
+            s.send(vec![VerifiedVoteMetadata {
+                label: label.clone(),
+                vote,
+                packet: Packets::new(vec![Packet::default(); num_packets]),
+                signature: Signature::new_unique(),
+            }])
             .unwrap();
+        }
+
+        // Ingest the votes into the buffer
         verified_vote_packets
-            .receive_and_process_vote_packets(&r, &mut update_version, true)
+            .receive_and_process_vote_packets(&r, true)
             .unwrap();
-        let update_version2 = verified_vote_packets.get_vote_packets(&label2).unwrap().0;
-        assert!(update_version2 > update_version1);
 
-        // Test empty doesn't bump the version
-        let before = update_version;
-        assert_matches!(
-            verified_vote_packets.receive_and_process_vote_packets(&r, &mut update_version, true),
-            Err(Error::CrossbeamRecvTimeout(RecvTimeoutError::Timeout))
+        // Create tracker for previously sent bank votes
+        let mut previously_sent_to_bank_votes = HashSet::new();
+        let my_leader_bank = Arc::new(Bank::default_for_tests());
+        let mut gossip_votes_iterator = ValidatorGossipVotesIterator::new(
+            my_leader_bank.clone(),
+            &verified_vote_packets,
+            &mut previously_sent_to_bank_votes,
         );
-        assert_eq!(before, update_version);
+
+        // Check we get two batches, one for each validator. Each batch
+        // should only contain a packets structure with the specific number
+        // of packets associated with that batch
+        let first_validator_batch: Vec<Packets> = gossip_votes_iterator.next().unwrap();
+        assert_eq!(first_validator_batch.len(), MAX_VOTES_PER_VALIDATOR);
+        assert!(first_validator_batch.iter().all(|p| p.packets.len() == 1));
+
+        let second_validator_batch: Vec<Packets> = gossip_votes_iterator.next().unwrap();
+        assert_eq!(second_validator_batch.len(), MAX_VOTES_PER_VALIDATOR);
+        assert!(gossip_votes_iterator
+            .next()
+            .unwrap()
+            .iter()
+            .all(|p| p.packets.len() == 2));
+
+        assert!(gossip_votes_iterator.next().is_none());
+
+        // If we construct another iterator, should return nothing because `previously_sent_to_bank_votes`
+        // should filter out everything
+        let mut gossip_votes_iterator = ValidatorGossipVotesIterator::new(
+            my_leader_bank,
+            &verified_vote_packets,
+            &mut previously_sent_to_bank_votes,
+        );
+        assert!(gossip_votes_iterator.next().is_none());
+
+        // If we add some new votes, we should return those
+        let vote_slot = 1;
+        let vote_hash = Hash::new_unique();
+        let vote_index = 0;
+        let label = CrdsValueLabel::Vote(vote_index, pubkey);
+        let vote = Vote::new(vec![vote_slot], vote_hash);
+        s.send(vec![VerifiedVoteMetadata {
+            label: label.clone(),
+            vote,
+            packet: Packets::new(vec![Packet::default(); num_packets]),
+            signature: Signature::new_unique(),
+        }])
+        .unwrap();
+        let mut gossip_votes_iterator = ValidatorGossipVotesIterator::new(
+            my_leader_bank,
+            &verified_vote_packets,
+            &mut previously_sent_to_bank_votes,
+        );
+        assert!(gossip_votes_iterator.next().is_some());
+        assert!(gossip_votes_iterator.next().is_none());
     }
 }

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -332,7 +332,6 @@ pub fn cluster_info_scale() {
                 //if node.0.get_votes(0).1.len() != (num_nodes * num_votes) {
                 let has_tx = node
                     .get_votes(&mut Cursor::default())
-                    .1
                     .iter()
                     .filter(|v| v.message.account_keys == tx.message.account_keys)
                     .count();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2680,7 +2680,7 @@ fn test_duplicate_shreds_broadcast_leader() {
                     return;
                 }
 
-                let (labels, votes) = cluster_info.get_votes(&mut cursor);
+                let (labels, votes) = cluster_info.get_votes_with_labels(&mut cursor);
                 let mut parsed_vote_iter: Vec<_> = labels
                     .into_iter()
                     .zip(votes.into_iter())

--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -34,6 +34,9 @@ impl SlotHashes {
         slot_hashes.sort_by(|(a, _), (b, _)| b.cmp(a));
         Self(slot_hashes)
     }
+    pub fn slot_hashes(&self) -> &[SlotHash] {
+        &self.0
+    }
 }
 
 impl FromIterator<(Slot, Hash)> for SlotHashes {

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -32,6 +32,11 @@ impl Signature {
         Self(GenericArray::clone_from_slice(signature_slice))
     }
 
+    pub fn new_unique() -> Self {
+        let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+        Self::new(&random_bytes)
+    }
+
     pub(self) fn verify_verbose(
         &self,
         pubkey_bytes: &[u8],


### PR DESCRIPTION
#### Problem
1. ClusterInfoVoteListener has too short of a window (20 slots) for sending votes to BankingStage
2. ClusterInfoVoteListener sends all votes to BankingStage, even outdated/ones on wrong fork
3. ClusterInfoVoteListener may send votes out of order

#### Summary of Changes
Only send newer votes on the same fork, in the right order to BankingStage

Fixes #
