### PR TITLE
ci: Increase timeout duration for coverage step

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -137,7 +137,7 @@ all_test_steps() {
              ^ci/test-coverage.sh \
              ^scripts/coverage.sh \
       ; then
-    command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 30
+    command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 40
     wait_step
   else
     annotate --style info --context test-coverage \


### PR DESCRIPTION
#### Problem
The `coverage` step keeps timing out in buildkite. As a temporary fix, increase the timeout until we cut the fat.

#### Summary of Changes
- Bump timeout from 30min to 40min

Fixes #
