### PR TITLE
complete_partial_program_init: remove redundant conditional

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2040,9 +2040,7 @@ fn complete_partial_program_init(
             elf_pubkey,
             account_data_len as u64,
         ));
-        if account.owner != *loader_id {
-            instructions.push(system_instruction::assign(elf_pubkey, loader_id));
-        }
+        instructions.push(system_instruction::assign(elf_pubkey, loader_id));
         if account.lamports < minimum_balance {
             let balance = minimum_balance - account.lamports;
             instructions.push(system_instruction::transfer(


### PR DESCRIPTION
#### Problem
complete_partial_program_init does generate the correct instructions when:
- Account data is not empty, but the owner is not the loader yet
- The loader is the owner, but there are no sufficient funds yet
#### Summary of Changes
Restructure conditionals to cover the mentioned cases