### PR TITLE
Use PubsubConfig limit instead of default

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -499,7 +499,7 @@ impl RpcSubscriptions {
             .unwrap();
 
         let control = SubscriptionControl::new(
-            PubSubConfig::default().max_active_subscriptions,
+            config.max_active_subscriptions,
             notification_sender.clone(),
             broadcast_sender,
         );


### PR DESCRIPTION
#### Problem
RPC nodes are not correctly limiting the number of pubsub subscriptions to the provided `--rpc-pubsub-max-active-subscriptions` value because the real `max_active_subscriptions` is not being passed to SubscriptionControl

#### Summary of Changes
Remove erroneous `default()`
