### PR TITLE
Hide  deploy from cli subcommands

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -387,6 +387,7 @@ impl ProgramSubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("deploy")
                 .about("Deploy a program")
+                .setting(AppSettings::Hidden)
                 .arg(
                     Arg::with_name("program_location")
                         .index(1)
@@ -2190,9 +2191,8 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
         words
     );
     eprintln!("{}\n{}\n{}", divider, phrase, divider);
-    eprintln!("To resume a deploy, pass the recovered keypair as");
-    eprintln!("the [PROGRAM_ADDRESS_SIGNER] argument to `solana deploy` or");
-    eprintln!("as the [BUFFER_SIGNER] to `solana program deploy` or `solana write-buffer'.");
+    eprintln!("To resume a deploy, pass the recovered keypair as the");
+    eprintln!("[BUFFER_SIGNER] to `solana program deploy` or `solana write-buffer'.");
     eprintln!("Or to recover the account's lamports, pass it as the");
     eprintln!(
         "[BUFFER_ACCOUNT_ADDRESS] argument to `solana program close`.\n{}",

--- a/docs/src/cli/deploy-a-program.md
+++ b/docs/src/cli/deploy-a-program.md
@@ -132,8 +132,7 @@ Recover the intermediate account's ephemeral keypair file with
 valley flat great hockey share token excess clever benefit traffic avocado athlete
 ==================================================================================
 To resume a deploy, pass the recovered keypair as
-the [PROGRAM_ADDRESS_SIGNER] argument to `solana deploy` or
-as the [BUFFER_SIGNER] to `solana program deploy` or `solana write-buffer'.
+the [BUFFER_SIGNER] to `solana program deploy` or `solana write-buffer'.
 Or to recover the account's lamports, pass it as the
 [BUFFER_ACCOUNT_ADDRESS] argument to `solana program drain`.
 ==================================================================================
@@ -242,16 +241,6 @@ Or anytime after:
 ```bash
 solana program set-upgrade-authority <PROGRAM_ADDRESS> --final
 ```
-
-`solana program deploy ...` utilizes Solana's upgradeable loader, but there is
-another way to deploy immutable programs using the original on-chain loader:
-
-```bash
-solana deploy <PROGRAM_FILEPATH>
-```
-
-Programs deployed with `solana deploy ...` are not redeployable and are not
-compatible with the `solana program ...` commands.
 
 ### Dumping a program to a file
 


### PR DESCRIPTION
#### Problem

`solana deploy` uses the older, non-upgradeable loader and is not the preferred method of program deployment but developers may land there first when looking at the cli help

#### Summary of Changes

Hide the `deploy` subcommand

Fixes #20872
