### PR TITLE
Add system test to measure recovery after partition

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -121,7 +121,7 @@ function get_validator_confirmation_time {
       curl -G "${INFLUX_HOST}/query?u=ro&p=topsecret" \
         --data-urlencode "db=${TESTNET_TAG}" \
         --data-urlencode "q=$q_mean_confirmation" |
-      python3 "${REPO_ROOT}"/system-test/testnet-automation-json-parser.py |
+      python3 "${REPO_ROOT}"/system-test/testnet-automation-json-parser.py --empty_error |
       cut -d' ' -f2)
 }
 

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -110,6 +110,21 @@ function get_current_stake {
     '$HOME/.cargo/bin/solana --url http://127.0.0.1:8899 validators --output=json | grep -o "totalCurrentStake\": [0-9]*" | cut -d: -f2'
 }
 
+function get_validator_confirmation_time {
+  SINCE=$1
+  declare q_mean_confirmation='
+    SELECT ROUND(MEAN("duration_ms")) as "mean_confirmation_ms"
+      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
+      WHERE time > now() - '"$SINCE"'s'
+
+  mean_confirmation_ms=$( \
+      curl -G "${INFLUX_HOST}/query?u=ro&p=topsecret" \
+        --data-urlencode "db=${TESTNET_TAG}" \
+        --data-urlencode "q=$q_mean_confirmation" |
+      python3 "${REPO_ROOT}"/system-test/testnet-automation-json-parser.py |
+      cut -d' ' -f2)
+}
+
 function collect_performance_statistics {
   execution_step "Collect performance statistics about run"
   declare q_mean_tps='

--- a/system-test/partition-testcases/gce-partition-recovery.yml
+++ b/system-test/partition-testcases/gce-partition-recovery.yml
@@ -1,0 +1,22 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "Partition recovery on GCE"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "false"
+      CLOUD_PROVIDER: "gce"
+      ENABLE_GPU: "false"
+      NUMBER_OF_VALIDATOR_NODES: 4
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      NUMBER_OF_CLIENT_NODES: 1
+      ADDITIONAL_FLAGS: "--dedicated"
+      SKIP_PERF_RESULTS: "true"
+      EXTRA_PRIMORDIAL_STAKES: 4
+      WAIT_FOR_EQUAL_STAKE: "true"
+      TEST_TYPE: "script"
+      WARMUP_SLOTS_BEFORE_TEST: 400
+      PRE_PARTITION_DURATION: 120
+      PARTITION_DURATION: 120
+      NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"
+      CUSTOM_SCRIPT: "system-test/partition-testcases/measure-partition-recovery.sh"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/partition-testcases/gce-partition-recovery.yml
+++ b/system-test/partition-testcases/gce-partition-recovery.yml
@@ -15,7 +15,8 @@ steps:
       TEST_TYPE: "script"
       WARMUP_SLOTS_BEFORE_TEST: 400
       PRE_PARTITION_DURATION: 120
-      PARTITION_DURATION: 120
+      PARTITION_DURATION: 600
+      PARTITION_INCREMENT: 120
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"
       CUSTOM_SCRIPT: "system-test/partition-testcases/measure-partition-recovery.sh"
     agents:

--- a/system-test/partition-testcases/gce-partition-recovery.yml
+++ b/system-test/partition-testcases/gce-partition-recovery.yml
@@ -2,21 +2,20 @@ steps:
   - command: "system-test/testnet-automation.sh"
     label: "Partition recovery on GCE"
     env:
-      UPLOAD_RESULTS_TO_SLACK: "false"
+      UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
       ENABLE_GPU: "false"
-      NUMBER_OF_VALIDATOR_NODES: 4
+      NUMBER_OF_VALIDATOR_NODES: 9
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
       ADDITIONAL_FLAGS: "--dedicated"
       SKIP_PERF_RESULTS: "true"
       EXTRA_PRIMORDIAL_STAKES: 4
-      WAIT_FOR_EQUAL_STAKE: "true"
       TEST_TYPE: "script"
       WARMUP_SLOTS_BEFORE_TEST: 400
       PRE_PARTITION_DURATION: 120
-      PARTITION_DURATION: 600
-      PARTITION_INCREMENT: 120
+      PARTITION_DURATION: 360
+      PARTITION_INCREMENT: 60
       NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"
       CUSTOM_SCRIPT: "system-test/partition-testcases/measure-partition-recovery.sh"
     agents:

--- a/system-test/partition-testcases/measure-partition-recovery.sh
+++ b/system-test/partition-testcases/measure-partition-recovery.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+source "$(dirname "$0")"/../automation_utils.sh
+
+RESULT_FILE="$1"
+
+[[ -n $TESTNET_TAG ]] || TESTNET_TAG=${CLOUD_PROVIDER}-testnet-automation
+
+if [[ -z $NETEM_CONFIG_FILE  ]]; then
+  echo "Error: For this test NETEM_CONFIG_FILE must be specified"
+  exit 1
+fi
+
+if [[ -z $PRE_PARTITION_DURATION ]]; then
+  PRE_PARTITION_DURATION=60
+fi
+
+if [[ -z $PARTITION_DURATION ]]; then
+  PARTITION_DURATION=300
+fi
+
+num_online_nodes=$(( NUMBER_OF_VALIDATOR_NODES + 1 ))
+if [[ -n "$NUMBER_OF_OFFLINE_NODES" ]]; then
+  num_online_nodes=$(( num_online_nodes - NUMBER_OF_OFFLINE_NODES ))
+fi
+
+execution_step "Measuring validator confirmation time for $PRE_PARTITION_DURATION seconds"
+sleep "$PRE_PARTITION_DURATION"
+get_validator_confirmation_time "$PRE_PARTITION_DURATION"
+execution_step "Pre partition validator confirmation time is $mean_confirmation_ms ms"
+echo "Pre partition validator confirmation time: $mean_confirmation_ms ms" >> "$RESULT_FILE"
+
+execution_step "Applying partition config $NETEM_CONFIG_FILE for $PARTITION_DURATION seconds"
+"${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE" -n $num_online_nodes
+sleep "$PARTITION_DURATION"
+
+execution_step "Resolving partition"
+"${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE" --netem-cmd cleanup -n $num_online_nodes
+
+target=$mean_confirmation_ms
+get_validator_confirmation_time 10
+time=0
+echo "Validator confirmation is $mean_confirmation_ms ms immediately after the partition" >> "$RESULT_FILE"
+
+while [[ $mean_confirmation_ms == "expected" || $mean_confirmation_ms -gt $target ]]; do
+  sleep 1
+  time=$(( time + 1 ))
+  get_validator_confirmation_time 10
+done
+
+echo "$time seconds after resolving the partition, validator confirmation time fell to $mean_confirmation_ms" >> "$RESULT_FILE"

--- a/system-test/partition-testcases/measure-partition-recovery.sh
+++ b/system-test/partition-testcases/measure-partition-recovery.sh
@@ -23,6 +23,10 @@ if [[ -z $PARTITION_DURATION ]]; then
   PARTITION_DURATION=300
 fi
 
+if [[ -z $PARTITION_INCREMENT ]]; then
+  PARTITION_INCREMENT=60
+fi
+
 num_online_nodes=$(( NUMBER_OF_VALIDATOR_NODES + 1 ))
 if [[ -n "$NUMBER_OF_OFFLINE_NODES" ]]; then
   num_online_nodes=$(( num_online_nodes - NUMBER_OF_OFFLINE_NODES ))
@@ -46,21 +50,20 @@ while true; do
 
   get_validator_confirmation_time 10
   time=0
-  echo "Validator confirmation is $mean_confirmation_ms ms immediately after resolving the partition" >> "$RESULT_FILE"
+  echo "Validator confirmation is $mean_confirmation_ms ms immediately after resolving the partition"
 
   while [[ $mean_confirmation_ms == "expected" || $mean_confirmation_ms -gt $target ]]; do
     sleep 1
     time=$(( time + 1 ))
 
     if [[ $time -gt $PARTITION_DURATION ]]; then
-      echo "Unable to make progress after $time seconds. confirmation time is still $mean_confirmation_ms ms" >> "$RESULT_FILE"
+      echo "Partition Duration: $PARTITION_DURATION: Unable to make progress after $time seconds. Confirmation time did not fall below pre partition confirmation time" >> "$RESULT_FILE"
       exit 0
     fi
     get_validator_confirmation_time 10
   done
 
-  echo "$time seconds after resolving the partition, validator confirmation time fell to $mean_confirmation_ms ms" >> "$RESULT_FILE"
-  printf "\n" >> "$RESULT_FILE"
+  echo "Partition Duration: $PARTITION: $time seconds for validator confirmation to fall to $mean_confirmation_ms ms" >> "$RESULT_FILE"
 
-  PARTITION_DURATION=$(( PARTITION_DURATION + 60 ))
+  PARTITION_DURATION=$(( PARTITION_DURATION + PARTITION_INCREMENT ))
 done

--- a/system-test/partition-testcases/measure-partition-recovery.sh
+++ b/system-test/partition-testcases/measure-partition-recovery.sh
@@ -31,6 +31,7 @@ fi
 execution_step "Measuring validator confirmation time for $PRE_PARTITION_DURATION seconds"
 sleep "$PRE_PARTITION_DURATION"
 get_validator_confirmation_time "$PRE_PARTITION_DURATION"
+# shellcheck disable=SC2154
 execution_step "Pre partition validator confirmation time is $mean_confirmation_ms ms"
 echo "Pre partition validator confirmation time: $mean_confirmation_ms ms" >> "$RESULT_FILE"
 

--- a/system-test/testnet-automation-json-parser.py
+++ b/system-test/testnet-automation-json-parser.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-import sys, json
+import sys, json, argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--empty_error", action="store_true", help="If present, do not print error message")
+args = parser.parse_args()
 
 data=json.load(sys.stdin)
 
@@ -7,7 +11,7 @@ if 'results' in data:
    for result in data['results']:
       if 'series' in result:
          print(result['series'][0]['columns'][1] + ': ' + str(result['series'][0]['values'][0][1]))
-      else:
+      elif not args.empty_error:
          print("An expected result from CURL request is missing")
-else:
+elif not args.empty_error:
    print("No results returned from CURL request")


### PR DESCRIPTION
#### Problem
We wish to test how long the cluster takes to recover after a partition.

#### Summary of Changes
Sets up a buildkite test that partitions the network for a specified time. Then by measuring validator confirmation times, we can measure the time needed for the cluster to recover.

Here's an example run of 5 nodes with 2 partitions that warmed up for 120 seconds, partitioned for 300 seconds and then took 42 seconds to recover after resolving the partition.

```
Pre partition validator confirmation time: 1167 ms
Validator confirmation is 123229 ms immediately after the partition
42 seconds after resolving the partition, validator confirmation time fell to 779
```

Fixes #
