### PR TITLE
explorer: Speed up cluster stats loading

### DIFF
--- a/explorer/src/providers/supply.tsx
+++ b/explorer/src/providers/supply.tsx
@@ -44,7 +44,9 @@ async function fetch(dispatch: Dispatch, cluster: Cluster, url: string) {
 
   try {
     const connection = new Connection(url, "finalized");
-    const supply = (await connection.getSupply()).value;
+    const supply = (
+      await connection.getSupply({ excludeNonCirculatingAccountsList: true })
+    ).value;
 
     // Update state if still connecting
     dispatch((state) => {


### PR DESCRIPTION
#### Problem
Cluster stats page blocks awhile on getting supply information. That request is slower than it should be because it enumerates non circulating accounts which the explorer doesn't make use of.

#### Summary of Changes
Exclude non circulating accounts from the supply request

Fixes #
