### PR TITLE
Support port number in postgres connection (#20662)

### DIFF
--- a/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
+++ b/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
@@ -39,6 +39,7 @@ pub struct AccountsDbPluginPostgresConfig {
     pub host: String,
     pub user: String,
     pub threads: Option<usize>,
+    pub port: Option<u16>,
 }
 
 #[derive(Error, Debug)]

--- a/accountsdb-plugin-postgres/src/postgres_client.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client.rs
@@ -25,6 +25,7 @@ use {
 /// The maximum asynchronous requests allowed in the channel to avoid excessive
 /// memory usage. The downside -- calls after this threshold is reached can get blocked.
 const MAX_ASYNC_REQUESTS: usize = 10240;
+const DEFAULT_POSTGRES_PORT: u16 = 5432;
 
 struct PostgresSqlClientWrapper {
     client: Client,
@@ -147,7 +148,10 @@ pub trait PostgresClient {
 
 impl SimplePostgresClient {
     pub fn new(config: &AccountsDbPluginPostgresConfig) -> Result<Self, AccountsDbPluginError> {
-        let connection_str = format!("host={} user={}", config.host, config.user);
+        let port = config.port.unwrap_or(DEFAULT_POSTGRES_PORT);
+
+        let connection_str = format!("host={} user={} port={}", config.host, config.user, port);
+
         match Client::connect(&connection_str, NoTls) {
             Err(err) => {
                 return Err(AccountsDbPluginError::Custom(Box::new(AccountsDbPluginPostgresError::DataStoreConnectionError {


### PR DESCRIPTION
Merge Support port number in postgres connection (#20662) to v1.8
