### PR TITLE
adds metrics tracking gossip crds writes and votes

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -523,6 +523,7 @@ mod tests {
         super::*,
         rand::{seq::SliceRandom, Rng},
         solana_gossip::{
+            crds::GossipRoute,
             crds_value::{CrdsData, CrdsValue},
             deprecated::{
                 shuffle_peers_and_index, sorted_retransmit_peers_and_stakes,
@@ -589,7 +590,10 @@ mod tests {
             for node in nodes.iter().skip(1) {
                 let node = CrdsData::ContactInfo(node.clone());
                 let node = CrdsValue::new_unsigned(node);
-                assert_eq!(gossip_crds.insert(node, now), Ok(()));
+                assert_eq!(
+                    gossip_crds.insert(node, now, GossipRoute::LocalMessage),
+                    Ok(())
+                );
             }
         }
         (nodes, stakes, cluster_info)

--- a/gossip/benches/crds.rs
+++ b/gossip/benches/crds.rs
@@ -6,7 +6,9 @@ use {
     rand::{thread_rng, Rng},
     rayon::ThreadPoolBuilder,
     solana_gossip::{
-        crds::Crds, crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, crds_value::CrdsValue,
+        crds::{Crds, GossipRoute},
+        crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS,
+        crds_value::CrdsValue,
     },
     solana_sdk::pubkey::Pubkey,
     std::collections::HashMap,
@@ -21,7 +23,7 @@ fn bench_find_old_labels(bencher: &mut Bencher) {
     let now = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS + CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 1000;
     std::iter::repeat_with(|| (CrdsValue::new_rand(&mut rng, None), rng.gen_range(0, now)))
         .take(50_000)
-        .for_each(|(v, ts)| assert!(crds.insert(v, ts).is_ok()));
+        .for_each(|(v, ts)| assert!(crds.insert(v, ts, GossipRoute::LocalMessage).is_ok()));
     let mut timeouts = HashMap::new();
     timeouts.insert(Pubkey::default(), CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS);
     bencher.iter(|| {

--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -7,7 +7,7 @@ use {
     rayon::ThreadPoolBuilder,
     solana_gossip::{
         cluster_info::MAX_BLOOM_SIZE,
-        crds::Crds,
+        crds::{Crds, GossipRoute},
         crds_gossip_pull::{CrdsFilter, CrdsGossipPull},
         crds_value::CrdsValue,
     },
@@ -39,7 +39,11 @@ fn bench_build_crds_filters(bencher: &mut Bencher) {
     let mut num_inserts = 0;
     for _ in 0..90_000 {
         if crds
-            .insert(CrdsValue::new_rand(&mut rng, None), rng.gen())
+            .insert(
+                CrdsValue::new_rand(&mut rng, None),
+                rng.gen(),
+                GossipRoute::LocalMessage,
+            )
             .is_ok()
         {
             num_inserts += 1;

--- a/gossip/benches/crds_shards.rs
+++ b/gossip/benches/crds_shards.rs
@@ -5,7 +5,7 @@ extern crate test;
 use {
     rand::{thread_rng, Rng},
     solana_gossip::{
-        crds::{Crds, VersionedCrdsValue},
+        crds::{Crds, GossipRoute, VersionedCrdsValue},
         crds_shards::CrdsShards,
         crds_value::CrdsValue,
     },
@@ -20,7 +20,8 @@ fn new_test_crds_value<R: Rng>(rng: &mut R) -> VersionedCrdsValue {
     let value = CrdsValue::new_rand(rng, None);
     let label = value.label();
     let mut crds = Crds::default();
-    crds.insert(value, timestamp()).unwrap();
+    crds.insert(value, timestamp(), GossipRoute::LocalMessage)
+        .unwrap();
     crds.get::<&VersionedCrdsValue>(&label).cloned().unwrap()
 }
 

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -78,7 +78,10 @@ impl<'a, 'b> CrdsEntry<'a, 'b> for &'a SnapshotHashes {
 mod tests {
     use {
         super::*,
-        crate::{crds::Crds, crds_value::new_rand_timestamp},
+        crate::{
+            crds::{Crds, GossipRoute},
+            crds_value::new_rand_timestamp,
+        },
         rand::seq::SliceRandom,
         solana_sdk::signature::Keypair,
         std::collections::HashMap,
@@ -94,7 +97,11 @@ mod tests {
             let keypair = keypairs.choose(&mut rng).unwrap();
             let value = CrdsValue::new_rand(&mut rng, Some(keypair));
             let key = value.label();
-            if let Ok(()) = crds.insert(value.clone(), new_rand_timestamp(&mut rng)) {
+            if let Ok(()) = crds.insert(
+                value.clone(),
+                new_rand_timestamp(&mut rng),
+                GossipRoute::LocalMessage,
+            ) {
                 entries.insert(key, value);
             }
         }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -15,7 +15,7 @@ use {
     crate::{
         cluster_info::{Ping, CRDS_UNIQUE_PUBKEY_CAPACITY},
         contact_info::ContactInfo,
-        crds::{Crds, VersionedCrdsValue},
+        crds::{Crds, GossipRoute, VersionedCrdsValue},
         crds_gossip::{get_stake, get_weight},
         crds_gossip_error::CrdsGossipError,
         crds_value::CrdsValue,
@@ -348,7 +348,7 @@ impl CrdsGossipPull {
         let mut crds = crds.write().unwrap();
         for caller in callers {
             let key = caller.pubkey();
-            let _ = crds.insert(caller, now);
+            let _ = crds.insert(caller, now, GossipRoute::PullRequest);
             crds.update_record_timestamp(&key, now);
         }
     }
@@ -430,12 +430,12 @@ impl CrdsGossipPull {
         let mut owners = HashSet::new();
         let mut crds = crds.write().unwrap();
         for response in responses_expired_timeout {
-            let _ = crds.insert(response, now);
+            let _ = crds.insert(response, now, GossipRoute::PullResponse);
         }
         let mut num_inserts = 0;
         for response in responses {
             let owner = response.pubkey();
-            if let Ok(()) = crds.insert(response, now) {
+            if let Ok(()) = crds.insert(response, now, GossipRoute::PullResponse) {
                 num_inserts += 1;
                 owners.insert(owner);
             }
@@ -731,14 +731,16 @@ pub(crate) mod tests {
             &solana_sdk::pubkey::new_rand(),
             0,
         )));
-        crds.insert(me.clone(), 0).unwrap();
+        crds.insert(me.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         for i in 1..=30 {
             let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = entry.label().pubkey();
-            crds.insert(entry.clone(), 0).unwrap();
+            crds.insert(entry.clone(), 0, GossipRoute::LocalMessage)
+                .unwrap();
             stakes.insert(id, i * 100);
         }
         let now = 1024;
@@ -792,10 +794,14 @@ pub(crate) mod tests {
             ..ContactInfo::default()
         }));
 
-        crds.insert(me.clone(), 0).unwrap();
-        crds.insert(spy.clone(), 0).unwrap();
-        crds.insert(node_123.clone(), 0).unwrap();
-        crds.insert(node_456.clone(), 0).unwrap();
+        crds.insert(me.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(spy.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_123.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_456.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         let crds = RwLock::new(crds);
 
         // shred version 123 should ignore nodes with versions 0 and 456
@@ -854,8 +860,10 @@ pub(crate) mod tests {
             ..ContactInfo::default()
         }));
 
-        crds.insert(me.clone(), 0).unwrap();
-        crds.insert(node_123.clone(), 0).unwrap();
+        crds.insert(me.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_123.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         let crds = RwLock::new(crds);
 
         // Empty gossip_validators -- will pull from nobody
@@ -958,7 +966,10 @@ pub(crate) mod tests {
         for _ in 0..40_000 {
             let keypair = keypairs.choose(&mut rng).unwrap();
             let value = CrdsValue::new_rand(&mut rng, Some(keypair));
-            if crds.insert(value, rng.gen()).is_ok() {
+            if crds
+                .insert(value, rng.gen(), GossipRoute::LocalMessage)
+                .is_ok()
+            {
                 num_inserts += 1;
             }
         }
@@ -1019,7 +1030,10 @@ pub(crate) mod tests {
             Err(CrdsGossipError::NoPeers)
         );
 
-        crds.write().unwrap().insert(entry, 0).unwrap();
+        crds.write()
+            .unwrap()
+            .insert(entry, 0, GossipRoute::LocalMessage)
+            .unwrap();
         assert_eq!(
             node.new_pull_request(
                 &thread_pool,
@@ -1043,7 +1057,10 @@ pub(crate) mod tests {
             .unwrap()
             .mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        crds.write().unwrap().insert(new.clone(), now).unwrap();
+        crds.write()
+            .unwrap()
+            .insert(new.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
         let req = node.new_pull_request(
             &thread_pool,
             &crds,
@@ -1063,7 +1080,10 @@ pub(crate) mod tests {
         node.mark_pull_request_creation_time(new.contact_info().unwrap().id, now);
         let offline = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), now);
         let offline = CrdsValue::new_unsigned(CrdsData::ContactInfo(offline));
-        crds.write().unwrap().insert(offline, now).unwrap();
+        crds.write()
+            .unwrap()
+            .insert(offline, now, GossipRoute::LocalMessage)
+            .unwrap();
         let req = node.new_pull_request(
             &thread_pool,
             &crds,
@@ -1098,15 +1118,17 @@ pub(crate) mod tests {
             0,
         )));
         let node = CrdsGossipPull::default();
-        crds.insert(entry, now).unwrap();
+        crds.insert(entry, now, GossipRoute::LocalMessage).unwrap();
         let old = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ping_cache.mock_pong(old.id, old.gossip, Instant::now());
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(old));
-        crds.insert(old.clone(), now).unwrap();
+        crds.insert(old.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ping_cache.mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        crds.insert(new.clone(), now).unwrap();
+        crds.insert(new.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
         let crds = RwLock::new(crds);
 
         // set request creation time to now.
@@ -1193,11 +1215,13 @@ pub(crate) mod tests {
         )));
         let caller = entry.clone();
         let node = CrdsGossipPull::default();
-        node_crds.insert(entry, 0).unwrap();
+        node_crds
+            .insert(entry, 0, GossipRoute::LocalMessage)
+            .unwrap();
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ping_cache.mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        node_crds.insert(new, 0).unwrap();
+        node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
         let node_crds = RwLock::new(node_crds);
         let mut pings = Vec::new();
         let req = node.new_pull_request(
@@ -1234,7 +1258,11 @@ pub(crate) mod tests {
         dest_crds
             .write()
             .unwrap()
-            .insert(new, CRDS_GOSSIP_PULL_MSG_TIMEOUT_MS)
+            .insert(
+                new,
+                CRDS_GOSSIP_PULL_MSG_TIMEOUT_MS,
+                GossipRoute::LocalMessage,
+            )
             .unwrap();
 
         //should skip new value since caller is to old
@@ -1283,7 +1311,9 @@ pub(crate) mod tests {
         )));
         let caller = entry.clone();
         let node = CrdsGossipPull::default();
-        node_crds.insert(entry, 0).unwrap();
+        node_crds
+            .insert(entry, 0, GossipRoute::LocalMessage)
+            .unwrap();
         let mut ping_cache = PingCache::new(
             Duration::from_secs(20 * 60), // ttl
             128,                          // capacity
@@ -1291,7 +1321,7 @@ pub(crate) mod tests {
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ping_cache.mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        node_crds.insert(new, 0).unwrap();
+        node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
         let node_crds = RwLock::new(node_crds);
         let mut pings = Vec::new();
         let req = node.new_pull_request(
@@ -1340,7 +1370,9 @@ pub(crate) mod tests {
         let caller = entry.clone();
         let node_pubkey = entry.label().pubkey();
         let node = CrdsGossipPull::default();
-        node_crds.insert(entry, 0).unwrap();
+        node_crds
+            .insert(entry, 0, GossipRoute::LocalMessage)
+            .unwrap();
         let mut ping_cache = PingCache::new(
             Duration::from_secs(20 * 60), // ttl
             128,                          // capacity
@@ -1348,14 +1380,16 @@ pub(crate) mod tests {
         let new = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 1);
         ping_cache.mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        node_crds.insert(new, 0).unwrap();
+        node_crds.insert(new, 0, GossipRoute::LocalMessage).unwrap();
 
         let mut dest_crds = Crds::default();
         let new_id = solana_sdk::pubkey::new_rand();
         let new = ContactInfo::new_localhost(&new_id, 1);
         ping_cache.mock_pong(new.id, new.gossip, Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(new));
-        dest_crds.insert(new.clone(), 0).unwrap();
+        dest_crds
+            .insert(new.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         let dest_crds = RwLock::new(dest_crds);
 
         // node contains a key from the dest node, but at an older local timestamp
@@ -1364,7 +1398,9 @@ pub(crate) mod tests {
         let same_key = CrdsValue::new_unsigned(CrdsData::ContactInfo(same_key));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());
-        node_crds.insert(same_key.clone(), 0).unwrap();
+        node_crds
+            .insert(same_key.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         assert_eq!(0, {
             let entry: &VersionedCrdsValue = node_crds.get(&same_key.label()).unwrap();
             entry.local_timestamp
@@ -1449,12 +1485,16 @@ pub(crate) mod tests {
         let node_label = entry.label();
         let node_pubkey = node_label.pubkey();
         let node = CrdsGossipPull::default();
-        node_crds.insert(entry, 0).unwrap();
+        node_crds
+            .insert(entry, 0, GossipRoute::LocalMessage)
+            .unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &solana_sdk::pubkey::new_rand(),
             0,
         )));
-        node_crds.insert(old.clone(), 0).unwrap();
+        node_crds
+            .insert(old.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
         let value_hash = {
             let entry: &VersionedCrdsValue = node_crds.get(&old.label()).unwrap();
             entry.value_hash

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -15,7 +15,7 @@ use {
     crate::{
         cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY,
         contact_info::ContactInfo,
-        crds::{Crds, Cursor},
+        crds::{Crds, Cursor, GossipRoute},
         crds_gossip::{get_stake, get_weight},
         crds_gossip_error::CrdsGossipError,
         crds_value::CrdsValue,
@@ -240,7 +240,7 @@ impl CrdsGossipPush {
             .map(|value| {
                 let value = value?;
                 let origin = value.pubkey();
-                match crds.insert(value, now) {
+                match crds.insert(value, now, GossipRoute::PushMessage) {
                     Ok(()) => Ok(origin),
                     Err(_) => {
                         self.num_old.fetch_add(1, Ordering::Relaxed);
@@ -665,7 +665,10 @@ mod test {
             0,
         )));
 
-        assert_eq!(crds.insert(value1.clone(), now), Ok(()));
+        assert_eq!(
+            crds.insert(value1.clone(), now, GossipRoute::LocalMessage),
+            Ok(())
+        );
         let crds = RwLock::new(crds);
         push.refresh_push_active_set(
             &crds,
@@ -686,7 +689,12 @@ mod test {
         )));
         assert!(active_set.get(&value2.label().pubkey()).is_none());
         drop(active_set);
-        assert_eq!(crds.write().unwrap().insert(value2.clone(), now), Ok(()));
+        assert_eq!(
+            crds.write()
+                .unwrap()
+                .insert(value2.clone(), now, GossipRoute::LocalMessage),
+            Ok(())
+        );
         for _ in 0..30 {
             push.refresh_push_active_set(
                 &crds,
@@ -711,7 +719,12 @@ mod test {
             let value2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(
                 ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0),
             ));
-            assert_eq!(crds.write().unwrap().insert(value2.clone(), now), Ok(()));
+            assert_eq!(
+                crds.write()
+                    .unwrap()
+                    .insert(value2.clone(), now, GossipRoute::LocalMessage),
+                Ok(())
+            );
         }
         push.refresh_push_active_set(
             &crds,
@@ -738,7 +751,8 @@ mod test {
                 time,
             )));
             let id = peer.label().pubkey();
-            crds.insert(peer.clone(), time).unwrap();
+            crds.insert(peer.clone(), time, GossipRoute::LocalMessage)
+                .unwrap();
             stakes.insert(id, i * 100);
             push.last_pushed_to.write().unwrap().put(id, time);
         }
@@ -791,10 +805,14 @@ mod test {
             ..ContactInfo::default()
         }));
 
-        crds.insert(me.clone(), now).unwrap();
-        crds.insert(spy.clone(), now).unwrap();
-        crds.insert(node_123.clone(), now).unwrap();
-        crds.insert(node_456, now).unwrap();
+        crds.insert(me.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(spy.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_123.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_456, now, GossipRoute::LocalMessage)
+            .unwrap();
         let crds = RwLock::new(crds);
 
         // shred version 123 should ignore nodes with versions 0 and 456
@@ -845,8 +863,10 @@ mod test {
             ..ContactInfo::default()
         }));
 
-        crds.insert(me.clone(), 0).unwrap();
-        crds.insert(node_123.clone(), now).unwrap();
+        crds.insert(me.clone(), 0, GossipRoute::LocalMessage)
+            .unwrap();
+        crds.insert(node_123.clone(), now, GossipRoute::LocalMessage)
+            .unwrap();
         let crds = RwLock::new(crds);
 
         // Unknown pubkey in gossip_validators -- will push to nobody
@@ -898,7 +918,10 @@ mod test {
             &solana_sdk::pubkey::new_rand(),
             0,
         )));
-        assert_eq!(crds.insert(peer.clone(), now), Ok(()));
+        assert_eq!(
+            crds.insert(peer.clone(), now, GossipRoute::LocalMessage),
+            Ok(())
+        );
         let crds = RwLock::new(crds);
         push.refresh_push_active_set(
             &crds,
@@ -940,8 +963,14 @@ mod test {
             })
             .collect();
         let origin: Vec<_> = peers.iter().map(|node| node.pubkey()).collect();
-        assert_eq!(crds.insert(peers[0].clone(), now), Ok(()));
-        assert_eq!(crds.insert(peers[1].clone(), now), Ok(()));
+        assert_eq!(
+            crds.insert(peers[0].clone(), now, GossipRoute::LocalMessage),
+            Ok(())
+        );
+        assert_eq!(
+            crds.insert(peers[1].clone(), now, GossipRoute::LocalMessage),
+            Ok(())
+        );
         let crds = RwLock::new(crds);
         assert_eq!(
             push.process_push_message(&crds, &Pubkey::default(), vec![peers[2].clone()], now),
@@ -977,7 +1006,10 @@ mod test {
             &solana_sdk::pubkey::new_rand(),
             0,
         )));
-        assert_eq!(crds.insert(peer.clone(), 0), Ok(()));
+        assert_eq!(
+            crds.insert(peer.clone(), 0, GossipRoute::LocalMessage),
+            Ok(())
+        );
         let crds = RwLock::new(crds);
         push.refresh_push_active_set(
             &crds,
@@ -1015,7 +1047,7 @@ mod test {
             &solana_sdk::pubkey::new_rand(),
             0,
         )));
-        assert_eq!(crds.insert(peer, 0), Ok(()));
+        assert_eq!(crds.insert(peer, 0, GossipRoute::LocalMessage), Ok(()));
         let crds = RwLock::new(crds);
         push.refresh_push_active_set(
             &crds,

--- a/gossip/src/crds_shards.rs
+++ b/gossip/src/crds_shards.rs
@@ -134,7 +134,10 @@ where
 mod test {
     use {
         super::*,
-        crate::{crds::Crds, crds_value::CrdsValue},
+        crate::{
+            crds::{Crds, GossipRoute},
+            crds_value::CrdsValue,
+        },
         rand::{thread_rng, Rng},
         solana_sdk::timing::timestamp,
         std::{collections::HashSet, iter::repeat_with, ops::Index},
@@ -144,7 +147,8 @@ mod test {
         let value = CrdsValue::new_rand(rng, None);
         let label = value.label();
         let mut crds = Crds::default();
-        crds.insert(value, timestamp()).unwrap();
+        crds.insert(value, timestamp(), GossipRoute::LocalMessage)
+            .unwrap();
         crds.get::<&VersionedCrdsValue>(&label).cloned().unwrap()
     }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -494,6 +494,7 @@ mod tests {
         crate::rpc::create_validator_exit,
         solana_gossip::{
             contact_info::ContactInfo,
+            crds::GossipRoute,
             crds_value::{CrdsData, CrdsValue, SnapshotHashes},
         },
         solana_ledger::{
@@ -794,6 +795,7 @@ mod tests {
                     ],
                 ))),
                 1,
+                GossipRoute::LocalMessage,
             )
             .unwrap();
         assert_eq!(rm.health_check(), "ok");
@@ -810,6 +812,7 @@ mod tests {
                     vec![(1000 + health_check_slot_distance - 1, Hash::default())],
                 ))),
                 1,
+                GossipRoute::LocalMessage,
             )
             .unwrap();
         assert_eq!(rm.health_check(), "ok");
@@ -826,6 +829,7 @@ mod tests {
                     vec![(1000 + health_check_slot_distance, Hash::default())],
                 ))),
                 1,
+                GossipRoute::LocalMessage,
             )
             .unwrap();
         assert_eq!(rm.health_check(), "behind");


### PR DESCRIPTION
#### Problem
Need to track crds propagation through gossip, traffic composition, and votes propagation.

#### Summary of Changes
* Collect metrics at `crds.insert` point if the value is successfully added to the table and its respective kind.
* For votes, count votes inserted for each slot.
