### PR TITLE
Extend TestBroadcastReceiver::recv timeout

### DIFF
--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -178,6 +178,10 @@ impl TestBroadcastReceiver {
         loop {
             match self.inner.try_recv() {
                 Ok(notification) => {
+                    debug!(
+                        "TestBroadcastReceiver: {:?}ms elapsed",
+                        started.elapsed().as_millis()
+                    );
                     if let Some(json) = self.handler.handle(notification).expect("handler failed") {
                         return json.to_string();
                     }


### PR DESCRIPTION
#### Problem
`test_check_account_subscribe` is flaky. It appears that TestBroadcastReceiver::recv is timing out.

#### Summary of Changes
Extend the recv timeout; also add elapsed log for success case to enable better tuning.
