### PR TITLE
feat(web3): pass fetch result to middleware

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -768,7 +768,7 @@ function createRpcClient(
         fetchMiddleware(url, options, async (url: string, options: any) => {
           try {
             const result = await fetch(url, options);
-            resolve(result);
+            resolve(result.clone());
             return result; // Pass result to middleware promise
           } catch (error) {
             reject(error);

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -767,9 +767,12 @@ function createRpcClient(
       return new Promise<Response>((resolve, reject) => {
         fetchMiddleware(url, options, async (url: string, options: any) => {
           try {
-            resolve(await fetch(url, options));
+            const result = await fetch(url, options);
+            resolve(result);
+            return result; // Pass result to middleware promise
           } catch (error) {
             reject(error);
+            throw error; // Pass error to middleware promise
           }
         });
       });

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -116,7 +116,7 @@ describe('Connection', () => {
           options.headers = Object.assign(options.headers, {
             Authorization: 'Bearer 123',
           });
-          fetch(url, options);
+          return fetch(url, options);
         },
       });
 

--- a/web3.js/test/mocks/rpc-http.ts
+++ b/web3.js/test/mocks/rpc-http.ts
@@ -65,6 +65,7 @@ export const mockRpcResponse = async ({
   error,
   withContext,
   withHeaders,
+  statusCode,
 }: {
   method: string;
   params: Array<any>;
@@ -72,6 +73,7 @@ export const mockRpcResponse = async ({
   error?: any;
   withContext?: boolean;
   withHeaders?: HttpHeaders;
+  statusCode?: number;
 }) => {
   if (!mockServer) return;
 
@@ -94,7 +96,7 @@ export const mockRpcResponse = async ({
     })
     .withHeaders(withHeaders || {})
     .thenReply(
-      200,
+      statusCode || 200,
       JSON.stringify({
         jsonrpc: '2.0',
         id: '',


### PR DESCRIPTION
Problem

I want to pass result of http request to middleware - it makes possible to collect statistics (i.e. response time) and errors.

Summary of Changes

Add changes in connection.ts, fix test