### PR TITLE
Bump bpf-tools to v1.18

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1377,7 +1377,7 @@ fn assert_instruction_count() {
             ("return_data", 980),
             ("sanity", 1246),
             ("sanity++", 1250),
-            ("secp256k1_recover", 25357),
+            ("secp256k1_recover", 25383),
             ("sha", 1328),
             ("struct_pass", 108),
             ("struct_ret", 28),

--- a/sdk/bpf/c/bpf.mk
+++ b/sdk/bpf/c/bpf.mk
@@ -17,6 +17,8 @@ OS := $(shell uname)
 LLVM_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/llvm
 LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/12.0.1/include
 COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/rust/lib/rustlib/bpfel-unknown-unknown/lib
+STD_INC_DIRS := $(LLVM_DIR)/include
+STD_LIB_DIRS := $(LLVM_DIR)/lib
 
 ifdef LLVM_DIR
 CC := $(LLVM_DIR)/bin/clang
@@ -36,7 +38,8 @@ C_FLAGS := \
   -fno-builtin \
   -std=c17 \
   $(addprefix -isystem,$(SYSTEM_INC_DIRS)) \
-  $(addprefix -I,$(INC_DIRS))
+  $(addprefix -I,$(STD_INC_DIRS)) \
+  $(addprefix -I,$(INC_DIRS)) \
 
 CXX_FLAGS := \
   $(C_FLAGS) \
@@ -64,6 +67,8 @@ BPF_LLD_FLAGS := \
   --Bdynamic \
   $(LOCAL_PATH)bpf.ld \
   --entry entrypoint \
+  -L $(STD_LIB_DIRS) \
+  -lc \
 
 OBJ_DUMP_FLAGS := \
   --source \
@@ -114,6 +119,10 @@ help:
 	@echo '      INC_DIRS=$(INC_DIRS)'
 	@echo '    - List of system include directories:'
 	@echo '      SYSTEM_INC_DIRS=$(SYSTEM_INC_DIRS)'
+	@echo '    - List of standard library include directories:'
+	@echo '      STD_INC_DIRS=$(STD_INC_DIRS)'
+	@echo '    - List of standard library archive directories:'
+	@echo '      STD_LIB_DIRS=$(STD_LIB_DIRS)'
 	@echo '    - Location of source directories:'
 	@echo '      SRC_DIR=$(SRC_DIR)'
 	@echo '    - Location to place output files:'

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.15
+version=v1.18
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -466,7 +466,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     install_if_missing(
         config,
         "bpf-tools",
-        "v1.15",
+        "v1.18",
         "https://github.com/solana-labs/bpf-tools/releases/download",
         bpf_tools_download_file_name,
     )


### PR DESCRIPTION
- added newlib standard C library to clang toolchain
- fixed BPF backend bug that accidentally deleted code, issue #20538

