### PR TITLE
Add compute budget noops

### DIFF
--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -158,7 +158,7 @@ fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
                 solana_sdk::compute_budget::id(),
                 solana_compute_budget_program::process_instruction,
             ),
-            feature_set::tx_wide_compute_cap::id(),
+            feature_set::add_compute_budget_program::id(),
             ActivationType::NewProgram,
         ),
         // TODO when feature `prevent_calling_precompiles_as_programs` is

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -253,6 +253,10 @@ pub mod disable_fee_calculator {
     solana_sdk::declare_id!("2jXx2yDmGysmBKfKYNgLj2DQyAQv6mMk2BPh4eSbyB4H");
 }
 
+pub mod add_compute_budget_program {
+    solana_sdk::declare_id!("4d5AKtxoh93Dwm1vHXUU3iRATuMndx1c431KgT2td52r");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -311,6 +315,7 @@ lazy_static! {
         (turbine_peers_shuffle::id(), "turbine peers shuffle patch"),
         (requestable_heap_size::id(), "Requestable heap frame size"),
         (disable_fee_calculator::id(), "deprecate fee calculator"),
+        (add_compute_budget_program::id(), "Add compute_budget_program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

#### Summary of Changes

To help the transition to the tx-wide compute cap add the compute program as a noop.  That way clients can start including the requests safely before the tx-wide compute budget feature is enabled.

Fixes #
