### PR TITLE
chore(web3): fix examples link in docs

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -88,7 +88,7 @@ console.log(solanaWeb3);
 
 Example scripts for the web3.js repo and native programs:
 
-- [Web3 Examples](https://github.com/solana-labs/solana-program-library/tree/master/examples)
+- [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
 
 Example scripts for the Solana Program Library:
 

--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -88,7 +88,7 @@ console.log(solanaWeb3);
 
 Example scripts for the web3.js repo and native programs:
 
-- [Web3 Examples](./examples)
+- [Web3 Examples](https://github.com/solana-labs/solana-program-library/tree/master/examples)
 
 Example scripts for the Solana Program Library:
 


### PR DESCRIPTION
#### Problem
The Web3 Examples link is broken in the published documentation under https://solana-labs.github.io/solana-web3.js/

![image](https://user-images.githubusercontent.com/2914096/138938375-f5049e59-e7f0-4dc7-9f7d-5db18b8a543f.png)

#### Summary of Changes
Using an absoute URL, like in the case of the "Token Program Examples" should fix the issue.

I have changed the link to be an absolute link

Fixes the broken link.
