### PR TITLE
Add sanity test to verify floating point std math lib works for BPF

### DIFF
--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -62,6 +62,15 @@ pub fn process_instruction(
         panic!();
     }
 
+    {
+        // Test - float math functions
+        let zero = accounts[0].try_borrow_mut_data()?.len() as f64;
+        let num = zero + 8.0f64;
+        let num = num.powf(0.333f64);
+        // check that the result is in a correct interval close to 1.998614185980905
+        assert!(1.9986f64 < num && num < 2.0f64);
+    }
+
     sol_log_compute_units();
     Ok(())
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1400,7 +1400,7 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_noop", 480),
             ("solana_bpf_rust_param_passing", 146),
             ("solana_bpf_rust_rand", 487),
-            ("solana_bpf_rust_sanity", 1716),
+            ("solana_bpf_rust_sanity", 8397),
             ("solana_bpf_rust_secp256k1_recover", 25216),
             ("solana_bpf_rust_sha", 30704),
         ]);


### PR DESCRIPTION
#### Problem

On-chain programs frequently require floating point operations. In
addition standard library functions are expected to be available.

#### Summary of Changes

This change adds a simple sanity check that such functions are
available and work correctly when compiled to BPF.

@jackcmay I'm not sure if sanity test is the proper place, but we need to have such tests somewhere. Any suggestions?