### PR TITLE
Add validator options to change priority of snapshot packager and RPC threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,6 +4535,7 @@ dependencies = [
  "chrono",
  "clap 2.33.3",
  "rpassword",
+ "solana-perf",
  "solana-remote-wallet",
  "solana-sdk",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bf7211aad104ce2769ec05efcdfabf85ee84ac92461d142f22cf8badd0e54c"
+dependencies = [
+ "errno",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1279,27 @@ dependencies = [
  "log 0.4.14",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5243,12 +5275,15 @@ name = "solana-perf"
 version = "1.9.0"
 dependencies = [
  "bincode",
+ "caps",
  "curve25519-dalek 3.2.0",
  "dlopen",
  "dlopen_derive",
  "lazy_static",
+ "libc",
  "log 0.4.14",
  "matches",
+ "nix",
  "rand 0.7.3",
  "rayon",
  "serde",

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 rpassword = "5.0"
+solana-perf = { path = "../perf", version = "=1.9.0" }
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 thiserror = "1.0.30"

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -370,6 +370,27 @@ where
     }
 }
 
+pub fn is_niceness_adjustment_valid<T>(value: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    let adjustment = value.as_ref().parse::<i8>().map_err(|err| {
+        format!(
+            "error parsing niceness adjustment value '{}': {}",
+            value, err
+        )
+    })?;
+    if solana_perf::thread::is_renice_allowed(adjustment) {
+        Ok(())
+    } else {
+        Err(String::from(
+            "niceness adjustment supported only on Linux; negative adjustment \
+             (priority increase) requires root or CAP_SYS_NICE (see `man 7 capabilities` \
+             for details)",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,5 +406,12 @@ mod tests {
         assert!(is_derivation("4294967296").is_err());
         assert!(is_derivation("a/b").is_err());
         assert!(is_derivation("0/4294967296").is_err());
+    }
+
+    #[test]
+    fn test_is_niceness_adjustment_valid() {
+        assert_eq!(is_niceness_adjustment_valid("0"), Ok(()));
+        assert!(is_niceness_adjustment_valid("128").is_err());
+        assert!(is_niceness_adjustment_valid("-129").is_err());
     }
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,6 +1,7 @@
 use solana_gossip::cluster_info::{
     ClusterInfo, MAX_INCREMENTAL_SNAPSHOT_HASHES, MAX_SNAPSHOT_HASHES,
 };
+use solana_perf::thread::renice_this_thread;
 use solana_runtime::{
     snapshot_archive_info::SnapshotArchiveInfoGetter,
     snapshot_config::SnapshotConfig,
@@ -48,6 +49,7 @@ impl SnapshotPackagerService {
         let t_snapshot_packager = Builder::new()
             .name("snapshot-packager".to_string())
             .spawn(move || {
+                renice_this_thread(snapshot_config.packager_thread_niceness_adj).unwrap();
                 let mut snapshot_gossip_manager = if enable_gossip_push {
                     Some(SnapshotGossipManager {
                         cluster_info,

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -25,6 +25,11 @@ solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.9.0" }
 
+[target."cfg(target_os = \"linux\")".dependencies]
+caps = "0.5.3"
+libc = "0.2.105"
+nix = "0.23.0"
+
 [lib]
 name = "solana_perf"
 

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -6,6 +6,7 @@ pub mod recycler;
 pub mod recycler_cache;
 pub mod sigverify;
 pub mod test_tx;
+pub mod thread;
 
 #[macro_use]
 extern crate lazy_static;

--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -1,0 +1,105 @@
+/// Wrapper for `nice(3)`.
+#[cfg(target_os = "linux")]
+fn nice(adjustment: i8) -> Result<i8, nix::errno::Errno> {
+    use std::convert::TryFrom;
+
+    unsafe {
+        *libc::__errno_location() = 0;
+        let niceness = libc::nice(libc::c_int::from(adjustment));
+        let errno = *libc::__errno_location();
+        if (niceness == -1) && (errno != 0) {
+            Err(errno)
+        } else {
+            Ok(niceness)
+        }
+    }
+    .map(|niceness| i8::try_from(niceness).expect("Unexpected niceness value"))
+    .map_err(nix::errno::from_i32)
+}
+
+/// Adds `adjustment` to the nice value of calling thread. Negative `adjustment` increases priority,
+/// positive `adjustment` decreases priority. New thread inherits nice value from current thread
+/// when created.
+///
+/// Fails on non-Linux systems for all `adjustment` values except of zero.
+#[cfg(target_os = "linux")]
+pub fn renice_this_thread(adjustment: i8) -> Result<(), String> {
+    // On Linux, the nice value is a per-thread attribute. See `man 7 sched` for details.
+    // Other systems probably should use pthread_setschedprio(), but, on Linux, thread priority
+    // is fixed to zero for SCHED_OTHER threads (which is the default).
+    nice(adjustment)
+        .map(|_| ())
+        .map_err(|err| format!("Failed to change thread's nice value: {}", err))
+}
+
+/// Adds `adjustment` to the nice value of calling thread. Negative `adjustment` increases priority,
+/// positive `adjustment` decreases priority. New thread inherits nice value from current thread
+/// when created.
+///
+/// Fails on non-Linux systems for all `adjustment` values except of zero.
+#[cfg(not(target_os = "linux"))]
+pub fn renice_this_thread(adjustment: i8) -> Result<(), String> {
+    if adjustment == 0 {
+        Ok(())
+    } else {
+        Err(String::from(
+            "Failed to change thread's nice value: only supported on Linux",
+        ))
+    }
+}
+
+/// Check whether the nice value can be changed by `adjustment`.
+#[cfg(target_os = "linux")]
+pub fn is_renice_allowed(adjustment: i8) -> bool {
+    use caps::{CapSet, Capability};
+
+    if adjustment >= 0 {
+        true
+    } else {
+        nix::unistd::geteuid().is_root()
+            || caps::has_cap(None, CapSet::Effective, Capability::CAP_SYS_NICE)
+                .map_err(|err| warn!("Failed to get thread's capabilities: {}", err))
+                .unwrap_or(false)
+    }
+}
+
+/// Check whether the nice value can be changed by `adjustment`.
+#[cfg(not(target_os = "linux"))]
+pub fn is_renice_allowed(adjustment: i8) -> bool {
+    adjustment == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_nice() {
+        // No change / get current niceness
+        let niceness = nice(0).unwrap();
+
+        // Decrease priority (allowed for unprivileged processes)
+        let result = std::thread::spawn(|| nice(1)).join().unwrap();
+        assert_eq!(result, Ok(niceness + 1));
+
+        // Sanity check: ensure that current thread's nice value not changed after previous call
+        // from different thread
+        assert_eq!(nice(0), Ok(niceness));
+
+        // Sanity check: ensure that new thread inherits nice value from current thread
+        let inherited_niceness = std::thread::spawn(|| {
+            nice(1).unwrap();
+            std::thread::spawn(|| nice(0).unwrap()).join().unwrap()
+        })
+        .join()
+        .unwrap();
+        assert_eq!(inherited_niceness, niceness + 1);
+
+        if !is_renice_allowed(-1) {
+            // Increase priority (not allowed for unprivileged processes)
+            let result = std::thread::spawn(|| nice(-1)).join().unwrap();
+            assert!(result.is_err());
+        }
+    }
+}

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -364,6 +364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61bf7211aad104ce2769ec05efcdfabf85ee84ac92461d142f22cf8badd0e54c"
+dependencies = [
+ "errno",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +692,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e80ad39f814a9abe68583cd50a2d45c8a67561c3361ab8da240587dda80937"
+dependencies = [
+ "dlopen_derive",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f236d9e1b1fbd81cea0f9cbdc8dcc7e8ebcd80e6659cd7cb2ad5f6c05946c581"
+dependencies = [
+ "libc",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +837,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2879,6 +2934,7 @@ dependencies = [
  "chrono",
  "clap",
  "rpassword",
+ "solana-perf",
  "solana-remote-wallet",
  "solana-sdk",
  "thiserror",
@@ -3131,6 +3187,29 @@ dependencies = [
  "solana-version",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "solana-perf"
+version = "1.9.0"
+dependencies = [
+ "bincode",
+ "caps",
+ "curve25519-dalek 3.2.0",
+ "dlopen",
+ "dlopen_derive",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "solana-logger 1.9.0",
+ "solana-metrics",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
+ "solana-vote-program",
 ]
 
 [[package]]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -143,6 +143,7 @@ pub struct JsonRpcConfig {
     pub max_multiple_accounts: Option<usize>,
     pub account_indexes: AccountSecondaryIndexes,
     pub rpc_threads: usize,
+    pub rpc_niceness_adj: i8,
     pub rpc_bigtable_timeout: Option<Duration>,
     pub minimal_api: bool,
     pub obsolete_v1_7_api: bool,

--- a/runtime/src/snapshot_config.rs
+++ b/runtime/src/snapshot_config.rs
@@ -35,6 +35,9 @@ pub struct SnapshotConfig {
 
     /// This is the `debug_verify` parameter to use when calling `update_accounts_hash()`
     pub accounts_hash_debug_verify: bool,
+
+    // Thread niceness adjustment for snapshot packager service
+    pub packager_thread_niceness_adj: i8,
 }
 
 impl Default for SnapshotConfig {
@@ -54,6 +57,7 @@ impl Default for SnapshotConfig {
                 snapshot_utils::DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             accounts_hash_use_index: false,
             accounts_hash_debug_verify: false,
+            packager_thread_niceness_adj: 0,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -10,8 +10,8 @@ use {
     solana_clap_utils::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
         input_validators::{
-            is_keypair, is_keypair_or_ask_keyword, is_parsable, is_pow2, is_pubkey,
-            is_pubkey_or_keypair, is_slot, is_valid_percentage,
+            is_keypair, is_keypair_or_ask_keyword, is_niceness_adjustment_valid, is_parsable,
+            is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
@@ -916,6 +916,16 @@ pub fn main() {
                 .takes_value(true)
                 .default_value(default_maximum_incremental_snapshot_archives_to_retain)
                 .help("The maximum number of incremental snapshot archives to hold on to when purging older snapshots.")
+        )
+        .arg(
+            Arg::with_name("snapshot_packager_niceness_adj")
+                .long("snapshot-packager-niceness-adjustment")
+                .value_name("ADJUSTMENT")
+                .takes_value(true)
+                .validator(is_niceness_adjustment_valid)
+                .default_value("0")
+                .help("Add this value to niceness of snapshot packager thread. Negative value \
+                      increases priority, positive value decreases priority.")
         )
         .arg(
             Arg::with_name("minimal_snapshot_download_speed")
@@ -2336,6 +2346,8 @@ pub fn main() {
         value_t_or_exit!(matches, "maximum_full_snapshots_to_retain", usize);
     let maximum_incremental_snapshot_archives_to_retain =
         value_t_or_exit!(matches, "maximum_incremental_snapshots_to_retain", usize);
+    let snapshot_packager_niceness_adj =
+        value_t_or_exit!(matches, "snapshot_packager_niceness_adj", i8);
     let minimal_snapshot_download_speed =
         value_t_or_exit!(matches, "minimal_snapshot_download_speed", f32);
     let maximum_snapshot_download_abort =
@@ -2403,6 +2415,7 @@ pub fn main() {
         maximum_incremental_snapshot_archives_to_retain,
         accounts_hash_use_index: validator_config.accounts_db_use_index_hash_calculation,
         accounts_hash_debug_verify: validator_config.accounts_db_test_hash_calculation,
+        packager_thread_niceness_adj: snapshot_packager_niceness_adj,
     });
 
     validator_config.accounts_hash_interval_slots =

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1181,6 +1181,16 @@ pub fn main() {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
+            Arg::with_name("rpc_niceness_adj")
+                .long("rpc-niceness-adjustment")
+                .value_name("ADJUSTMENT")
+                .takes_value(true)
+                .validator(is_niceness_adjustment_valid)
+                .default_value("0")
+                .help("Add this value to niceness of RPC threads. Negative value \
+                      increases priority, positive value decreases priority.")
+        )
+        .arg(
             Arg::with_name("rpc_bigtable_timeout")
                 .long("rpc-bigtable-timeout")
                 .value_name("SECONDS")
@@ -2188,6 +2198,7 @@ pub fn main() {
                 u64
             ),
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
+            rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             rpc_bigtable_timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
                 .ok()
                 .map(Duration::from_secs),


### PR DESCRIPTION
#### Problem

For a quite some time, I had `tar` wrapper script that runs regular `tar` under `nice` so that archiving and compressing processes do not steal CPU time from more important Solana threads. Solana recently switched from calling external binaries to using pure-rust libraries for snapshots, and that broke my setup a little.

#### Summary of Changes

I added simple thread renice mechanism and corresponding CLI option for `solana-validator`. Then found RPC-related issue and decided to fix it too.

Fixes https://github.com/solana-labs/solana/issues/14556
