### PR TITLE
filler accts: only add filler accts to slots in the current epoch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4550,6 +4550,8 @@ impl Bank {
         Self::get_partitions(self.slot(), self.parent_slot(), slot_count_in_two_day)
     }
 
+    /// used only by filler accounts in debug path
+    /// previous means slot - 1, not parent
     pub fn variable_cycle_partition_from_previous_slot(
         epoch_schedule: &EpochSchedule,
         slot: Slot,
@@ -4634,7 +4636,7 @@ impl Bank {
         )
     }
 
-    pub fn get_partition_from_slot_indexes(
+    fn get_partition_from_slot_indexes(
         cycle_params: RentCollectionCycleParams,
         start_slot_index: SlotIndex,
         end_slot_index: SlotIndex,
@@ -4709,7 +4711,7 @@ impl Bank {
         self.do_partition_from_slot_indexes(start_slot_index, end_slot_index, epoch, true)
     }
 
-    pub fn rent_single_epoch_collection_cycle_params(
+    fn rent_single_epoch_collection_cycle_params(
         epoch: Epoch,
         slot_count_per_epoch: SlotCount,
     ) -> RentCollectionCycleParams {


### PR DESCRIPTION
#### Problem
A snapshot often contains slots/storages that are more than 1 epoch old and had not been cleaned/shrunk yet. Adding filler accounts to these old slots result in filler accounts in old slots which will not have rent collected for almost an epoch.
Also, some minor cleanup.
#### Summary of Changes
Only add filler accounts to slots not older than an epoch from max.
Fixes #
