### PR TITLE
percent stats 0-1 -> 0-100

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -129,7 +129,7 @@ impl BucketMapHolderStats {
         if elapsed_ms == 0 {
             0.0
         } else {
-            ms as f32 / elapsed_ms as f32
+            (ms as f32 / elapsed_ms as f32) * 100.0
         }
     }
 


### PR DESCRIPTION
#### Problem
ram/cpu stats report as 0-100 instead of 0-1. So, precedence favors 0-100.
#### Summary of Changes

Fixes #
