### PR TITLE
LoadedAccountAccessor::Cached does not store Pubkey

### DIFF
--- a/replica-lib/src/replica_accounts_server.rs
+++ b/replica-lib/src/replica_accounts_server.rs
@@ -73,7 +73,7 @@ impl ReplicaAccountsServer for ReplicaAccountsServerImpl {
                     LoadedAccount::Stored(stored_account_meta) => Some(
                         ReplicaAccountInfo::from_stored_account_meta(&stored_account_meta),
                     ),
-                    LoadedAccount::Cached((_pubkey, cached_account)) => {
+                    LoadedAccount::Cached(cached_account) => {
                         Some(ReplicaAccountInfo::from_cached_account(&cached_account))
                     }
                 });

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -134,8 +134,8 @@ impl CachedAccountInner {
             }
         }
     }
-    pub fn pubkey(&self) -> Pubkey {
-        self.pubkey
+    pub fn pubkey(&self) -> &Pubkey {
+        &self.pubkey
     }
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -410,7 +410,7 @@ pub enum LoadedAccountAccessor<'a> {
     // AccountStorageEntry
     Stored(Option<(Arc<AccountStorageEntry>, usize)>),
     // None value in Cached variant means the cache was flushed
-    Cached(Option<(Pubkey, Cow<'a, CachedAccount>)>),
+    Cached(Option<Cow<'a, CachedAccount>>),
 }
 
 mod accountsdb_plugin_utils;
@@ -444,10 +444,9 @@ impl<'a> LoadedAccountAccessor<'a> {
     fn get_loaded_account(&mut self) -> Option<LoadedAccount> {
         match self {
             LoadedAccountAccessor::Cached(cached_account) => {
-                let cached_account: (Pubkey, Cow<'a, CachedAccount>) =
-                    cached_account.take().expect(
-                        "Cache flushed/purged should be handled before trying to fetch account",
-                    );
+                let cached_account: Cow<'a, CachedAccount> = cached_account.take().expect(
+                    "Cache flushed/purged should be handled before trying to fetch account",
+                );
                 Some(LoadedAccount::Cached(cached_account))
             }
             LoadedAccountAccessor::Stored(maybe_storage_entry) => {
@@ -468,14 +467,14 @@ impl<'a> LoadedAccountAccessor<'a> {
 
 pub enum LoadedAccount<'a> {
     Stored(StoredAccountMeta<'a>),
-    Cached((Pubkey, Cow<'a, CachedAccount>)),
+    Cached(Cow<'a, CachedAccount>),
 }
 
 impl<'a> LoadedAccount<'a> {
     pub fn owner(&self) -> &Pubkey {
         match self {
             LoadedAccount::Stored(stored_account_meta) => &stored_account_meta.account_meta.owner,
-            LoadedAccount::Cached((_, cached_account)) => cached_account.account.owner(),
+            LoadedAccount::Cached(cached_account) => cached_account.account.owner(),
         }
     }
 
@@ -484,21 +483,21 @@ impl<'a> LoadedAccount<'a> {
             LoadedAccount::Stored(stored_account_meta) => {
                 stored_account_meta.account_meta.executable
             }
-            LoadedAccount::Cached((_, cached_account)) => cached_account.account.executable(),
+            LoadedAccount::Cached(cached_account) => cached_account.account.executable(),
         }
     }
 
     pub fn loaded_hash(&self) -> Hash {
         match self {
             LoadedAccount::Stored(stored_account_meta) => *stored_account_meta.hash,
-            LoadedAccount::Cached((_, cached_account)) => cached_account.hash(),
+            LoadedAccount::Cached(cached_account) => cached_account.hash(),
         }
     }
 
     pub fn pubkey(&self) -> &Pubkey {
         match self {
             LoadedAccount::Stored(stored_account_meta) => &stored_account_meta.meta.pubkey,
-            LoadedAccount::Cached((pubkey, _)) => pubkey,
+            LoadedAccount::Cached(cached_account) => cached_account.pubkey(),
         }
     }
 
@@ -514,7 +513,7 @@ impl<'a> LoadedAccount<'a> {
             LoadedAccount::Stored(stored_account_meta) => {
                 AccountsDb::hash_stored_account(slot, stored_account_meta)
             }
-            LoadedAccount::Cached((_, cached_account)) => {
+            LoadedAccount::Cached(cached_account) => {
                 AccountsDb::hash_account(slot, &cached_account.account, pubkey)
             }
         }
@@ -530,14 +529,14 @@ impl<'a> LoadedAccount<'a> {
     pub fn lamports(&self) -> u64 {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.account_meta.lamports,
-            LoadedAccount::Cached((_, cached_account)) => cached_account.account.lamports(),
+            LoadedAccount::Cached(cached_account) => cached_account.account.lamports(),
         }
     }
 
     pub fn take_account(self) -> AccountSharedData {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.clone_account(),
-            LoadedAccount::Cached((_, cached_account)) => match cached_account {
+            LoadedAccount::Cached(cached_account) => match cached_account {
                 Cow::Owned(cached_account) => cached_account.account.clone(),
                 Cow::Borrowed(cached_account) => cached_account.account.clone(),
             },
@@ -3208,9 +3207,8 @@ impl AccountsDb {
                     slot_cache
                         .par_iter()
                         .filter_map(|cached_account| {
-                            cache_map_func(LoadedAccount::Cached((
-                                *cached_account.key(),
-                                Cow::Borrowed(cached_account.value()),
+                            cache_map_func(LoadedAccount::Cached(Cow::Borrowed(
+                                cached_account.value(),
                             )))
                         })
                         .collect()
@@ -3220,9 +3218,8 @@ impl AccountsDb {
                     slot_cache
                         .iter()
                         .filter_map(|cached_account| {
-                            cache_map_func(LoadedAccount::Cached((
-                                *cached_account.key(),
-                                Cow::Borrowed(cached_account.value()),
+                            cache_map_func(LoadedAccount::Cached(Cow::Borrowed(
+                                cached_account.value(),
                             )))
                         })
                         .collect(),
@@ -3683,10 +3680,7 @@ impl AccountsDb {
         offset: usize,
     ) -> LoadedAccountAccessor<'a> {
         if store_id == CACHE_VIRTUAL_STORAGE_ID {
-            let maybe_cached_account = self
-                .accounts_cache
-                .load(slot, pubkey)
-                .map(|cached_account| (*pubkey, Cow::Owned(cached_account)));
+            let maybe_cached_account = self.accounts_cache.load(slot, pubkey).map(Cow::Owned);
             LoadedAccountAccessor::Cached(maybe_cached_account)
         } else {
             let maybe_storage_entry = self
@@ -5365,10 +5359,9 @@ impl AccountsDb {
                                 let keys = slot_cache.get_all_pubkeys();
                                 for key in keys {
                                     if let Some(cached_account) = slot_cache.get_cloned(&key) {
-                                        let mut accessor = LoadedAccountAccessor::Cached(Some((
-                                            key,
+                                        let mut accessor = LoadedAccountAccessor::Cached(Some(
                                             Cow::Owned(cached_account),
-                                        )));
+                                        ));
                                         let account = accessor.get_loaded_account().unwrap();
                                         scan_func(account, &mut retval, slot);
                                     };


### PR DESCRIPTION
#### Problem
Scanning in general is slow. As # accts increase, everything that is per entry gets worse. Hash calc is one place where storage scans occur. Copying pubkeys unnecessarily is expensive.
#### Summary of Changes
Avoid making copies of pubkeys in scans.
Fixes #
