### PR TITLE
fix account index

### DIFF
--- a/programs/bpf/rust/invoke/src/processor.rs
+++ b/programs/bpf/rust/invoke/src/processor.rs
@@ -386,6 +386,21 @@ fn process_instruction(
                     ))
                 );
             }
+
+            msg!("Test accounts re-ordering");
+            {
+                let instruction = create_instruction(
+                    *accounts[INVOKED_PROGRAM_INDEX].key,
+                    &[(accounts[FROM_INDEX].key, true, true)],
+                    vec![RETURN_OK],
+                );
+                // put the relavant account at the end of a larger account list
+                let mut reordered_accounts = accounts.to_vec();
+                let ai = reordered_accounts.remove(FROM_INDEX);
+                reordered_accounts.push(accounts[0].clone());
+                reordered_accounts.push(ai);
+                invoke(&instruction, &reordered_accounts)?;
+            }
         }
         TEST_PRIVILEGE_ESCALATION_SIGNER => {
             msg!("Test privilege escalation signer");

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -953,6 +953,7 @@ fn test_program_bpf_invoke_sanity() {
                 invoked_program_id.clone(),
                 system_program::id(),
                 invoked_program_id.clone(),
+                invoked_program_id.clone(),
             ],
         };
         assert_eq!(invoked_programs.len(), expected_invoked_programs.len());


### PR DESCRIPTION
#### Problem

The account index used to look up original data lengths makes the assumption that the account_infos passed are in the same order as they were passed to the program.

The issue only exists on master

#### Summary of Changes

- Lookup the correct index and guard against bad behavior
- Optimized by only doing any of this work when necessary 

Fixes #
