### PR TITLE
Update fee api to use blockhash

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -248,7 +248,7 @@ fn run_accounts_bench(
     let executor = TransactionExecutor::new(entrypoint_addr);
 
     // Create and close messages both require 2 signatures, fake a 2 signature message to calculate fees
-    let message = Message::new(
+    let mut message = Message::new(
         &[
             Instruction::new_with_bytes(
                 Pubkey::new_unique(),
@@ -270,6 +270,7 @@ fn run_accounts_bench(
             latest_blockhash = Instant::now();
         }
 
+        message.recent_blockhash = blockhash;
         let fee = client
             .get_fee_for_message(&message)
             .expect("get_fee_for_message");

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -289,7 +289,7 @@ impl Banks for BanksServer {
     ) -> Option<u64> {
         let bank = self.bank(commitment);
         let sanitized_message = SanitizedMessage::try_from(message).ok()?;
-        Some(bank.get_fee_for_message(&sanitized_message))
+        bank.get_fee_for_message(&sanitized_message)
     }
 }
 

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -8,7 +8,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::{self, datapoint_info};
 use solana_sdk::{
     client::Client,
-    clock::{DEFAULT_S_PER_SLOT, MAX_PROCESSING_AGE},
+    clock::{DEFAULT_MS_PER_SLOT, DEFAULT_S_PER_SLOT, MAX_PROCESSING_AGE},
     commitment_config::CommitmentConfig,
     hash::Hash,
     instruction::{AccountMeta, Instruction},
@@ -389,6 +389,22 @@ fn generate_txs(
     }
 }
 
+fn get_new_latest_blockhash<T: Client>(client: &Arc<T>, blockhash: &Hash) -> Option<Hash> {
+    let start = Instant::now();
+    while start.elapsed().as_secs() < 5 {
+        if let Ok(new_blockhash) = client.get_latest_blockhash() {
+            if new_blockhash != *blockhash {
+                return Some(new_blockhash);
+            }
+        }
+        debug!("Got same blockhash ({:?}), will retry...", blockhash);
+
+        // Retry ~twice during a slot
+        sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2));
+    }
+    None
+}
+
 fn poll_blockhash<T: Client>(
     exit_signal: &Arc<AtomicBool>,
     blockhash: &Arc<RwLock<Hash>>,
@@ -400,7 +416,7 @@ fn poll_blockhash<T: Client>(
     loop {
         let blockhash_updated = {
             let old_blockhash = *blockhash.read().unwrap();
-            if let Ok(new_blockhash) = client.get_new_latest_blockhash(&old_blockhash) {
+            if let Some(new_blockhash) = get_new_latest_blockhash(client, &old_blockhash) {
                 *blockhash.write().unwrap() = new_blockhash;
                 blockhash_last_updated = Instant::now();
                 true

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -888,13 +888,14 @@ pub fn generate_and_fund_keypairs<T: 'static + Client + Send + Sync>(
     //   pay for the transaction fees in a new run.
     let enough_lamports = 8 * lamports_per_account / 10;
     if first_keypair_balance < enough_lamports || last_keypair_balance < enough_lamports {
-        let single_sig_message = Message::new(
+        let single_sig_message = Message::new_with_blockhash(
             &[Instruction::new_with_bytes(
                 Pubkey::new_unique(),
                 &[],
                 vec![AccountMeta::new(Pubkey::new_unique(), true)],
             )],
             None,
+            &client.get_latest_blockhash().unwrap(),
         );
         let max_fee = client.get_fee_for_message(&single_sig_message).unwrap();
         let extra_fees = extra * max_fee;

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1710,6 +1710,7 @@ fn do_process_program_write_and_deploy(
 ) -> ProcessResult {
     // Build messages to calculate fees
     let mut messages: Vec<&Message> = Vec::new();
+    let blockhash = rpc_client.get_latest_blockhash()?;
 
     // Initialize buffer account or complete if already partially initialized
     let (initial_message, write_messages, balance_needed) =
@@ -1755,9 +1756,10 @@ fn do_process_program_write_and_deploy(
                 )
             };
             let initial_message = if !initial_instructions.is_empty() {
-                Some(Message::new(
+                Some(Message::new_with_blockhash(
                     &initial_instructions,
                     Some(&config.signers[0].pubkey()),
+                    &blockhash,
                 ))
             } else {
                 None
@@ -1777,7 +1779,7 @@ fn do_process_program_write_and_deploy(
                 } else {
                     loader_instruction::write(buffer_pubkey, loader_id, offset, bytes)
                 };
-                Message::new(&[instruction], Some(&payer_pubkey))
+                Message::new_with_blockhash(&[instruction], Some(&payer_pubkey), &blockhash)
             };
 
             let mut write_messages = vec![];
@@ -1806,7 +1808,7 @@ fn do_process_program_write_and_deploy(
 
     let final_message = if let Some(program_signers) = program_signers {
         let message = if loader_id == &bpf_loader_upgradeable::id() {
-            Message::new(
+            Message::new_with_blockhash(
                 &bpf_loader_upgradeable::deploy_with_max_program_len(
                     &config.signers[0].pubkey(),
                     &program_signers[0].pubkey(),
@@ -1818,11 +1820,13 @@ fn do_process_program_write_and_deploy(
                     programdata_len,
                 )?,
                 Some(&config.signers[0].pubkey()),
+                &blockhash,
             )
         } else {
-            Message::new(
+            Message::new_with_blockhash(
                 &[loader_instruction::finalize(buffer_pubkey, loader_id)],
                 Some(&config.signers[0].pubkey()),
+                &blockhash,
             )
         };
         Some(message)
@@ -1876,6 +1880,7 @@ fn do_process_program_upgrade(
 
     // Build messages to calculate fees
     let mut messages: Vec<&Message> = Vec::new();
+    let blockhash = rpc_client.get_latest_blockhash()?;
 
     let (initial_message, write_messages, balance_needed) =
         if let Some(buffer_signer) = buffer_signer {
@@ -1907,9 +1912,10 @@ fn do_process_program_upgrade(
             };
 
             let initial_message = if !initial_instructions.is_empty() {
-                Some(Message::new(
+                Some(Message::new_with_blockhash(
                     &initial_instructions,
                     Some(&config.signers[0].pubkey()),
+                    &blockhash,
                 ))
             } else {
                 None
@@ -1925,7 +1931,7 @@ fn do_process_program_upgrade(
                     offset,
                     bytes,
                 );
-                Message::new(&[instruction], Some(&payer_pubkey))
+                Message::new_with_blockhash(&[instruction], Some(&payer_pubkey), &blockhash)
             };
 
             // Create and add write messages
@@ -1952,7 +1958,7 @@ fn do_process_program_upgrade(
     }
 
     // Create and add final message
-    let final_message = Message::new(
+    let final_message = Message::new_with_blockhash(
         &[bpf_loader_upgradeable::upgrade(
             program_id,
             buffer_pubkey,
@@ -1960,6 +1966,7 @@ fn do_process_program_upgrade(
             &config.signers[0].pubkey(),
         )],
         Some(&config.signers[0].pubkey()),
+        &blockhash,
     );
     messages.push(&final_message);
 

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    checks::{check_account_for_balance_with_commitment, get_fee_for_message},
+    checks::{check_account_for_balance_with_commitment, get_fee_for_messages},
     cli::CliError,
 };
 use clap::ArgMatches;
@@ -144,9 +144,10 @@ where
     F: Fn(u64) -> Message,
 {
     let fee = match blockhash {
-        Some(_) => {
-            let dummy_message = build_message(0);
-            get_fee_for_message(rpc_client, &[&dummy_message])?
+        Some(blockhash) => {
+            let mut dummy_message = build_message(0);
+            dummy_message.recent_blockhash = *blockhash;
+            get_fee_for_messages(rpc_client, &[&dummy_message])?
         }
         None => 0, // Offline, cannot calulate fee
     };

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4802,7 +4802,9 @@ impl RpcClient {
     #[allow(deprecated)]
     pub fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
         if self.get_node_version()? < semver::Version::new(1, 9, 0) {
-            let Fees { fee_calculator, .. } = self.get_fees()?;
+            let fee_calculator = self
+                .get_fee_calculator_for_blockhash(&message.recent_blockhash)?
+                .ok_or_else(|| ClientErrorKind::Custom("Invalid blockhash".to_string()))?;
             Ok(fee_calculator
                 .lamports_per_signature
                 .saturating_mul(message.header.num_required_signatures as u64))

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4285,7 +4285,7 @@ impl RpcClient {
 
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_new_latest_blockhash` instead"
+        note = "Please do not use, will no longer be available in the future"
     )]
     #[allow(deprecated)]
     pub fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -605,12 +605,6 @@ impl SyncClient for ThinClient {
             .get_fee_for_message(message)
             .map_err(|e| e.into())
     }
-
-    fn get_new_latest_blockhash(&self, blockhash: &Hash) -> TransportResult<Hash> {
-        self.rpc_client()
-            .get_new_latest_blockhash(blockhash)
-            .map_err(|e| e.into())
-    }
 }
 
 impl AsyncClient for ThinClient {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1978,10 +1978,10 @@ impl JsonRpcRequestProcessor {
         &self,
         message: &SanitizedMessage,
         commitment: Option<CommitmentConfig>,
-    ) -> Result<RpcResponse<Option<u64>>> {
+    ) -> RpcResponse<Option<u64>> {
         let bank = self.bank(commitment);
         let fee = bank.get_fee_for_message(message);
-        Ok(new_response(&bank, Some(fee)))
+        new_response(&bank, fee)
     }
 }
 
@@ -3706,11 +3706,10 @@ pub mod rpc_full {
             debug!("get_fee_for_message rpc request received");
             let (_, message) =
                 decode_and_deserialize::<Message>(data, UiTransactionEncoding::Base64)?;
-            SanitizedMessage::try_from(message)
-                .map_err(|err| {
-                    Error::invalid_params(format!("invalid transaction message: {}", err))
-                })
-                .and_then(|message| meta.get_fee_for_message(&message, commitment))
+            let sanitized_message = SanitizedMessage::try_from(message).map_err(|err| {
+                Error::invalid_params(format!("invalid transaction message: {}", err))
+            })?;
+            Ok(meta.get_fee_for_message(&sanitized_message, commitment))
         }
     }
 }

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -304,18 +304,6 @@ impl SyncClient for BankClient {
         Ok((blockhash, last_valid_block_height))
     }
 
-    fn get_new_latest_blockhash(&self, blockhash: &Hash) -> Result<Hash> {
-        let latest_blockhash = self.get_latest_blockhash()?;
-        if latest_blockhash != *blockhash {
-            Ok(latest_blockhash)
-        } else {
-            Err(TransportError::IoError(io::Error::new(
-                io::ErrorKind::Other,
-                "Unable to get new blockhash",
-            )))
-        }
-    }
-
     fn is_blockhash_valid(
         &self,
         blockhash: &Hash,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3042,18 +3042,19 @@ mod tests {
 
         let slot = slot + 1;
         let bank2 = Arc::new(Bank::new_from_parent(&bank1, &collector, slot));
+        let blockhash = bank2.last_blockhash();
         let tx = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
             &key1,
             &key2.pubkey(),
             lamports_to_transfer,
-            bank2.last_blockhash(),
+            blockhash,
         ));
-        let fee = bank2.get_fee_for_message(tx.message());
+        let fee = bank2.get_fee_for_message(tx.message()).unwrap();
         let tx = system_transaction::transfer(
             &key1,
             &key2.pubkey(),
             lamports_to_transfer - fee,
-            bank2.last_blockhash(),
+            blockhash,
         );
         bank2.process_transaction(&tx).unwrap();
         assert_eq!(

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -245,6 +245,14 @@ impl Message {
     }
 
     pub fn new(instructions: &[Instruction], payer: Option<&Pubkey>) -> Self {
+        Self::new_with_blockhash(instructions, payer, &Hash::default())
+    }
+
+    pub fn new_with_blockhash(
+        instructions: &[Instruction],
+        payer: Option<&Pubkey>,
+        blockhash: &Hash,
+    ) -> Self {
         let InstructionKeys {
             mut signed_keys,
             unsigned_keys,
@@ -259,7 +267,7 @@ impl Message {
             num_readonly_signed_accounts,
             num_readonly_unsigned_accounts,
             signed_keys,
-            Hash::default(),
+            *blockhash,
             instructions,
         )
     }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -87,7 +87,7 @@ pub trait SyncClient {
     /// Get recent blockhash. Uses explicit commitment configuration.
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
+        note = "Please use `get_latest_blockhash_with_commitment` and `get_latest_blockhash_with_commitment` instead"
     )]
     fn get_recent_blockhash_with_commitment(
         &self,
@@ -151,7 +151,7 @@ pub trait SyncClient {
 
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_new_latest_blockhash` instead"
+        note = "Please do not use, will no longer be available in the future"
     )]
     fn get_new_blockhash(&self, blockhash: &Hash) -> Result<(Hash, FeeCalculator)>;
 
@@ -163,9 +163,6 @@ pub trait SyncClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> Result<(Hash, u64)>;
-
-    /// Get a new blockhash after the one specified
-    fn get_new_latest_blockhash(&self, blockhash: &Hash) -> Result<Hash>;
 
     /// Check if the blockhash is valid
     fn is_blockhash_valid(&self, blockhash: &Hash, commitment: CommitmentConfig) -> Result<bool>;

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -164,14 +164,14 @@ pub trait SyncClient {
         commitment_config: CommitmentConfig,
     ) -> Result<(Hash, u64)>;
 
+    /// Get a new blockhash after the one specified
+    fn get_new_latest_blockhash(&self, blockhash: &Hash) -> Result<Hash>;
+
     /// Check if the blockhash is valid
     fn is_blockhash_valid(&self, blockhash: &Hash, commitment: CommitmentConfig) -> Result<bool>;
 
     /// Calculate the fee for a `Message`
     fn get_fee_for_message(&self, message: &Message) -> Result<u64>;
-
-    /// Get a new blockhash after the one specified
-    fn get_new_latest_blockhash(&self, blockhash: &Hash) -> Result<Hash>;
 }
 
 pub trait AsyncClient {


### PR DESCRIPTION
#### Problem

The new `get_fee_for_message` API assumed the latest blockhash which isn't good for deterministic fees.

#### Summary of Changes

Base the fee calculation on the message's blockhash

Fixes #
