### PR TITLE
deprecate FeeCalculator in BanksClients

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -17,6 +17,7 @@ use {
     solana_sdk::{
         account::{from_account, Account},
         commitment_config::CommitmentLevel,
+        message::Message,
         signature::Signature,
         transaction::{self, Transaction},
         transport,
@@ -65,6 +66,7 @@ impl BanksClient {
         ctx: Context,
         commitment: CommitmentLevel,
     ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, u64)>> + '_ {
+        #[allow(deprecated)]
         self.inner
             .get_fees_with_commitment_and_context(ctx, commitment)
     }
@@ -311,6 +313,16 @@ impl BanksClient {
 
         // Convert Vec<Result<_, _>> to Result<Vec<_>>
         statuses.into_iter().collect()
+    }
+
+    pub fn get_fee_for_message_with_commitment_and_context(
+        &mut self,
+        ctx: Context,
+        commitment: CommitmentLevel,
+        message: Message,
+    ) -> impl Future<Output = io::Result<Option<u64>>> + '_ {
+        self.inner
+            .get_fee_for_message_with_commitment_and_context(ctx, commitment, message)
     }
 }
 

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use {
     serde::{Deserialize, Serialize},
     solana_sdk::{
@@ -6,6 +8,7 @@ use {
         commitment_config::CommitmentLevel,
         fee_calculator::FeeCalculator,
         hash::Hash,
+        message::Message,
         pubkey::Pubkey,
         signature::Signature,
         transaction::{self, Transaction, TransactionError},
@@ -30,6 +33,10 @@ pub struct TransactionStatus {
 #[tarpc::service]
 pub trait Banks {
     async fn send_transaction_with_context(transaction: Transaction);
+    #[deprecated(
+        since = "1.9.0",
+        note = "Please use `get_fee_for_message_with_commitment_and_context` instead"
+    )]
     async fn get_fees_with_commitment_and_context(
         commitment: CommitmentLevel,
     ) -> (FeeCalculator, Hash, Slot);
@@ -45,6 +52,10 @@ pub trait Banks {
         address: Pubkey,
         commitment: CommitmentLevel,
     ) -> Option<Account>;
+    async fn get_fee_for_message_with_commitment_and_context(
+        commitment: CommitmentLevel,
+        message: Message,
+    ) -> Option<u64>;
 }
 
 #[cfg(test)]

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -13,6 +13,7 @@ use {
         commitment_config::CommitmentLevel,
         fee_calculator::FeeCalculator,
         hash::Hash,
+        message::{Message, SanitizedMessage},
         pubkey::Pubkey,
         signature::Signature,
         transaction::{self, Transaction},
@@ -22,6 +23,7 @@ use {
         tpu_info::NullTpuInfo,
     },
     std::{
+        convert::TryFrom,
         io,
         net::{Ipv4Addr, SocketAddr},
         sync::{
@@ -277,6 +279,17 @@ impl Banks for BanksServer {
     ) -> Option<Account> {
         let bank = self.bank(commitment);
         bank.get_account(&address).map(Account::from)
+    }
+
+    async fn get_fee_for_message_with_commitment_and_context(
+        self,
+        _: Context,
+        commitment: CommitmentLevel,
+        message: Message,
+    ) -> Option<u64> {
+        let bank = self.bank(commitment);
+        let sanitized_message = SanitizedMessage::try_from(message).ok()?;
+        Some(bank.get_fee_for_message(&sanitized_message))
     }
 }
 


### PR DESCRIPTION
#### Problem

`BanksClient` is returning deprecated `FeeClient`

#### Summary of Changes

Deprecate `BanksClient` APIs that returns `FeeClient` and add updated API

Fixes #
