### PR TITLE
optimizes and simplifies SlotMeta::completed_data_indexes ops

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -28,8 +28,8 @@ pub struct SlotMeta {
     // True if this slot is full (consumed == last_index + 1) and if every
     // slot that is a parent of this slot is also connected.
     pub is_connected: bool,
-    // List of start indexes for completed data slots
-    pub completed_data_indexes: Vec<u32>,
+    // Shreds indices which are marked data complete.
+    pub completed_data_indexes: BTreeSet<u32>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -199,14 +199,10 @@ impl SlotMeta {
     pub(crate) fn new(slot: Slot, parent_slot: Slot) -> Self {
         SlotMeta {
             slot,
-            consumed: 0,
-            received: 0,
-            first_shred_timestamp: 0,
             parent_slot,
-            next_slots: vec![],
             is_connected: slot == 0,
             last_index: std::u64::MAX,
-            completed_data_indexes: vec![],
+            ..SlotMeta::default()
         }
     }
 


### PR DESCRIPTION
#### Problem
SlotMeta::completed_data_indexes is defined as a Vec<u32>:
https://github.com/solana-labs/solana/blob/a8d78e89d/ledger/src/blockstore_meta.rs#L31-L32

which results in inefficient updates:
https://github.com/solana-labs/solana/blob/a8d78e89d/ledger/src/blockstore.rs#L3245-L3326


#### Summary of Changes
This commit changes the type to BTreeSet<u32> for efficient and simpler
updates and lookups.

The change should be backward compatible because Vec<T> and BTreeSet<T>
are both serialized as seq:
https://github.com/serde-rs/serde/blob/ce0844b9e/serde/src/ser/impls.rs#L207-L208
https://github.com/serde-rs/serde/blob/ce0844b9e/serde/src/ser/impls.rs#L216-L217
