### PR TITLE
Check and unwrap() Option instead of .iter().for_each()

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1154,8 +1154,8 @@ mod with_incremental_snapshots {
             HashMap::new();
         validator_config
         .trusted_validators
-        .iter()
-        .for_each(|trusted_validators| {
+        .as_ref()
+        .map(|trusted_validators| {
             trusted_validators
             .iter()
             .for_each(|trusted_validator| {

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1152,10 +1152,7 @@ mod with_incremental_snapshots {
     ) -> HashMap<(Slot, Hash), HashSet<(Slot, Hash)>> {
         let mut trusted_snapshot_hashes: HashMap<(Slot, Hash), HashSet<(Slot, Hash)>> =
             HashMap::new();
-        validator_config
-        .trusted_validators
-        .as_ref()
-        .map(|trusted_validators| {
+        if let Some(trusted_validators) = validator_config.trusted_validators.as_ref() {
             trusted_validators
             .iter()
             .for_each(|trusted_validator| {
@@ -1198,7 +1195,7 @@ mod with_incremental_snapshots {
                     }
                 }
             })
-        });
+        }
 
         trace!("trusted snapshot hashes: {:?}", &trusted_snapshot_hashes);
         trusted_snapshot_hashes

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1150,10 +1150,15 @@ mod with_incremental_snapshots {
         cluster_info: &ClusterInfo,
         validator_config: &ValidatorConfig,
     ) -> HashMap<(Slot, Hash), HashSet<(Slot, Hash)>> {
+        if validator_config.trusted_validators.is_none() {
+            trace!("no trusted validators, so no trusted snapshot hashes");
+            return HashMap::new();
+        }
+        let trusted_validators = validator_config.trusted_validators.as_ref().unwrap();
+
         let mut trusted_snapshot_hashes: HashMap<(Slot, Hash), HashSet<(Slot, Hash)>> =
             HashMap::new();
-        if let Some(trusted_validators) = validator_config.trusted_validators.as_ref() {
-            trusted_validators
+        trusted_validators
             .iter()
             .for_each(|trusted_validator| {
                 if let Some(crds_value::IncrementalSnapshotHashes {base: full_snapshot_hash, hashes: incremental_snapshot_hashes, ..}) = cluster_info.get_incremental_snapshot_hashes_for_node(trusted_validator) {
@@ -1194,8 +1199,7 @@ mod with_incremental_snapshots {
                         }
                     }
                 }
-            })
-        }
+            });
 
         trace!("trusted snapshot hashes: {:?}", &trusted_snapshot_hashes);
         trusted_snapshot_hashes


### PR DESCRIPTION
The trusted validators is an `Option<HashSet<Pubkey>>`, and that HashSet needs to be iterated over. Before it was doing two `.iter().for_each()` calls, which technically works, but is strange... So instead do check and `.unwrap()` then `.iter().for_each()`.