### PR TITLE
Retain trusted peer snapshot hashes bugfix

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1275,7 +1275,9 @@ mod with_incremental_snapshots {
                 .get(&peer_snapshot_hash.snapshot_hash.full)
                 .map(|trusted_incremental_hashes| {
                     if peer_snapshot_hash.snapshot_hash.incr.is_none() {
-                        false
+                        // If the peer's full snapshot hashes match, but doesn't have any
+                        // incremental snapshots, that's fine; keep 'em!
+                        true
                     } else {
                         trusted_incremental_hashes
                             .contains(peer_snapshot_hash.snapshot_hash.incr.as_ref().unwrap())

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1701,11 +1701,14 @@ mod with_incremental_snapshots {
                 ),
             ];
 
-            let expected = vec![PeerSnapshotHash::new(
-                contact_info,
-                *trusted_full_snapshot_hash,
-                Some(*trusted_incremental_snapshot_hash),
-            )];
+            let expected = vec![
+                PeerSnapshotHash::new(contact_info.clone(), *trusted_full_snapshot_hash, None),
+                PeerSnapshotHash::new(
+                    contact_info,
+                    *trusted_full_snapshot_hash,
+                    Some(*trusted_incremental_snapshot_hash),
+                ),
+            ];
             let mut actual = peer_snapshot_hashes;
             retain_trusted_peer_snapshot_hashes(&trusted_snapshot_hashes, &mut actual);
             assert_eq!(expected, actual);


### PR DESCRIPTION
#### Problem

If a peer did not have any incremental snapshot hashes, that would cause us to discard its matching full snapshot hashes erroneously.

#### Summary of Changes

If the peer's full snapshot hashes match, but doesn't have any incremental snapshot hashes, retain 'em.