### PR TITLE
rewrites Shredder::try_recovery

### DIFF
--- a/ledger/src/erasure.rs
+++ b/ledger/src/erasure.rs
@@ -41,9 +41,10 @@
 //!
 //!
 
-use reed_solomon_erasure::galois_8::Field;
-use reed_solomon_erasure::ReedSolomon;
-use serde::{Deserialize, Serialize};
+use {
+    reed_solomon_erasure::{galois_8::Field, ReconstructShard, ReedSolomon},
+    serde::{Deserialize, Serialize},
+};
 
 //TODO(sakridge) pick these values
 /// Number of data shreds
@@ -113,14 +114,11 @@ impl Session {
     }
 
     /// Recover data + coding blocks into data blocks
-    /// # Arguments
-    /// * `data` - array of data blocks to recover into
-    /// * `coding` - array of coding blocks
-    /// * `erasures` - list of indices in data where blocks should be recovered
-    pub fn decode_blocks(&self, blocks: &mut [(&mut [u8], bool)]) -> Result<()> {
-        self.0.reconstruct_data(blocks)?;
-
-        Ok(())
+    pub fn decode_blocks<T>(&self, blocks: &mut [T]) -> Result<()>
+    where
+        T: ReconstructShard<Field>,
+    {
+        self.0.reconstruct_data(blocks)
     }
 }
 


### PR DESCRIPTION
#### Problem
* For every missing data-shred, `Shredder::try_recovery` calls into `new_empty_data_shred` which does a redundant serialization into payload buffer which is then immediately overwritten by the erasure recovery:
  https://github.com/solana-labs/solana/blob/696501500/ledger/src/shred.rs#L372-L417
* The implementation is unnecessary complex hindering upcoming changes to erasure coding generation
  https://github.com/solana-labs/solana/blob/696501500/ledger/src/shred.rs#L814-L938

#### Summary of Changes
* simplified the `Shredder::try_recovery` implementation.