### PR TITLE
Absolute path for web3 examples

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -88,7 +88,7 @@ console.log(solanaWeb3);
 
 Example scripts for the web3.js repo and native programs:
 
-- [Web3 Examples](./examples)
+- [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
 
 Example scripts for the Solana Program Library:
 


### PR DESCRIPTION
The relative path causes a broken link on the github pages for https://solana-labs.github.io/solana-web3.js/.

It currently points to https://solana-labs.github.io/solana-web3.js/examples, which DNE.

#### Problem

#### Summary of Changes

Fixes #
