### PR TITLE
fix(web3.js): VoteAccount.fromAccountData() throws range error

### DIFF
--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -579,54 +579,58 @@ console.log(voteAccountFromData);
 /*
 VoteAccount {
   nodePubkey: PublicKey {
-    _bn: <BN: 65b8cc98c213ee79edbe8ce6640c611cae35112d490d60f837447c187de0599b>
+    _bn: <BN: cf1c635246d4a2ebce7b96bf9f44cacd7feed5552be3c714d8813c46c7e5ec02>
   },
   authorizedWithdrawer: PublicKey {
-    _bn: <BN: 65b8cc98c213ee79edbe8ce6640c611cae35112d490d60f837447c187de0599b>
+    _bn: <BN: b76ae0caa56f2b9906a37f1b2d4f8c9d2a74c1420cd9eebe99920b364d5cde54>
   },
-  commission: 100,
-  rootSlot: 104543648,
+  commission: 10,
+  rootSlot: 104570885,
   votes: [
-    { slot: 104543649, confirmationCount: 31 },
-    { slot: 104543650, confirmationCount: 30 },
-    { slot: 104543651, confirmationCount: 29 },
-    { slot: 104543652, confirmationCount: 28 },
-    { slot: 104543653, confirmationCount: 27 },
-    { slot: 104543654, confirmationCount: 26 },
-    { slot: 104543655, confirmationCount: 25 },
-    { slot: 104543656, confirmationCount: 24 },
-    { slot: 104543657, confirmationCount: 23 },
-    { slot: 104543658, confirmationCount: 22 },
-    { slot: 104543659, confirmationCount: 21 },
-    { slot: 104543660, confirmationCount: 20 },
-    { slot: 104543661, confirmationCount: 19 },
-    { slot: 104543662, confirmationCount: 18 },
-    { slot: 104543663, confirmationCount: 17 },
-    { slot: 104543664, confirmationCount: 16 },
-    { slot: 104543665, confirmationCount: 15 },
-    { slot: 104543666, confirmationCount: 14 },
-    { slot: 104543667, confirmationCount: 13 },
-    { slot: 104543668, confirmationCount: 12 },
-    { slot: 104543669, confirmationCount: 11 },
-    { slot: 104543670, confirmationCount: 10 },
-    { slot: 104543671, confirmationCount: 9 },
-    { slot: 104543672, confirmationCount: 8 },
-    { slot: 104543673, confirmationCount: 7 },
-    { slot: 104543674, confirmationCount: 6 },
-    { slot: 104543675, confirmationCount: 5 },
-    { slot: 104543676, confirmationCount: 4 },
-    { slot: 104543688, confirmationCount: 2 },
-    { slot: 104543689, confirmationCount: 1 }
+    { slot: 104570886, confirmationCount: 31 },
+    { slot: 104570887, confirmationCount: 30 },
+    { slot: 104570888, confirmationCount: 29 },
+    { slot: 104570889, confirmationCount: 28 },
+    { slot: 104570890, confirmationCount: 27 },
+    { slot: 104570891, confirmationCount: 26 },
+    { slot: 104570892, confirmationCount: 25 },
+    { slot: 104570893, confirmationCount: 24 },
+    { slot: 104570894, confirmationCount: 23 },
+    ...
   ],
-  authorizedVoters: [
-    {
-      epoch: 241,
-      authorizedVoter: <Buffer 65 b8 cc 98 c2 13 ee 79 ed be 8c e6 64 0c 61 1c ae 35 11 2d 49 0d 60 f8 37 44 7c 18 7d e0 59 9b>
-    }
+  authorizedVoters: [ { epoch: 242, authorizedVoter: [PublicKey] } ],
+  priorVoters: {
+    buf: [
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object], [Object],
+      [Object], [Object]
+    ],
+    idx: 31,
+    isEmpty: 1
+  },
+  epochCredits: [
+    { epoch: 179, credits: 33723163, prevCredits: 33431259 },
+    { epoch: 180, credits: 34022643, prevCredits: 33723163 },
+    { epoch: 181, credits: 34331103, prevCredits: 34022643 },
+    { epoch: 182, credits: 34619348, prevCredits: 34331103 },
+    { epoch: 183, credits: 34880375, prevCredits: 34619348 },
+    { epoch: 184, credits: 35074055, prevCredits: 34880375 },
+    { epoch: 185, credits: 35254965, prevCredits: 35074055 },
+    { epoch: 186, credits: 35437863, prevCredits: 35254965 },
+    { epoch: 187, credits: 35672671, prevCredits: 35437863 },
+    { epoch: 188, credits: 35950286, prevCredits: 35672671 },
+    { epoch: 189, credits: 36228439, prevCredits: 35950286 },
+    ...
   ],
-  priorVoters: [],
-  epochCredits: [],
-  lastTimestamp: { slot: 0, timestamp: 0 }
+  lastTimestamp: { slot: 104570916, timestamp: 1635730116 }
 }
 */
 ```

--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -578,34 +578,55 @@ let voteAccountFromData = web3.VoteAccount.fromAccountData(voteAccountInfo[0].ac
 console.log(voteAccountFromData);
 /*
 VoteAccount {
-    nodePubkey: PublicKey {
-        _bn: <BN: 100000096c4e1e61a6393e51937e548aee2c062e23c67cbaa8d04f289d18232>
-    },
-    authorizedVoterPubkey: PublicKey {
-        _bn: <BN: 5862b94396c4e1e61a6393e51937e548aee2c062e23c67cbaa8d04f289d18232>
-    },
-    authorizedWithdrawerPubkey: PublicKey {
-        _bn: <BN: 5862b9430a0800000000000000cb136204000000001f000000cc136204000000>
-    },
-    commission: 0,
-    votes: [
-        { slot: 124554051584, confirmationCount: 73536462 },
-        { slot: 120259084288, confirmationCount: 73536463 },
-        { slot: 115964116992, confirmationCount: 73536464 },
-        { slot: 111669149696, confirmationCount: 73536465 },
-        { slot: 107374182400, confirmationCount: 96542804 },
-        { slot: 4294967296, confirmationCount: 1645464065 },
-        { slot: 1099511627780, confirmationCount: 0 },
-        { slot: 57088, confirmationCount: 3787757056 },
-        { slot: 16516698632215534000, confirmationCount: 3236081224 },
-        { slot: 328106138455040640, confirmationCount: 2194770418 },
-        { slot: 290873038898, confirmationCount: 0 },
-    ],
-    rootSlot: null,
-    epoch: 0,
-    credits: 0,
-    lastEpochCredits: 0,
-    epochCredits: []
+  nodePubkey: PublicKey {
+    _bn: <BN: 65b8cc98c213ee79edbe8ce6640c611cae35112d490d60f837447c187de0599b>
+  },
+  authorizedWithdrawer: PublicKey {
+    _bn: <BN: 65b8cc98c213ee79edbe8ce6640c611cae35112d490d60f837447c187de0599b>
+  },
+  commission: 100,
+  rootSlot: 104543648,
+  votes: [
+    { slot: 104543649, confirmationCount: 31 },
+    { slot: 104543650, confirmationCount: 30 },
+    { slot: 104543651, confirmationCount: 29 },
+    { slot: 104543652, confirmationCount: 28 },
+    { slot: 104543653, confirmationCount: 27 },
+    { slot: 104543654, confirmationCount: 26 },
+    { slot: 104543655, confirmationCount: 25 },
+    { slot: 104543656, confirmationCount: 24 },
+    { slot: 104543657, confirmationCount: 23 },
+    { slot: 104543658, confirmationCount: 22 },
+    { slot: 104543659, confirmationCount: 21 },
+    { slot: 104543660, confirmationCount: 20 },
+    { slot: 104543661, confirmationCount: 19 },
+    { slot: 104543662, confirmationCount: 18 },
+    { slot: 104543663, confirmationCount: 17 },
+    { slot: 104543664, confirmationCount: 16 },
+    { slot: 104543665, confirmationCount: 15 },
+    { slot: 104543666, confirmationCount: 14 },
+    { slot: 104543667, confirmationCount: 13 },
+    { slot: 104543668, confirmationCount: 12 },
+    { slot: 104543669, confirmationCount: 11 },
+    { slot: 104543670, confirmationCount: 10 },
+    { slot: 104543671, confirmationCount: 9 },
+    { slot: 104543672, confirmationCount: 8 },
+    { slot: 104543673, confirmationCount: 7 },
+    { slot: 104543674, confirmationCount: 6 },
+    { slot: 104543675, confirmationCount: 5 },
+    { slot: 104543676, confirmationCount: 4 },
+    { slot: 104543688, confirmationCount: 2 },
+    { slot: 104543689, confirmationCount: 1 }
+  ],
+  authorizedVoters: [
+    {
+      epoch: 241,
+      authorizedVoter: <Buffer 65 b8 cc 98 c2 13 ee 79 ed be 8c e6 64 0c 61 1c ae 35 11 2d 49 0d 60 f8 37 44 7c 18 7d e0 59 9b>
+    }
+  ],
+  priorVoters: [],
+  epochCredits: [],
+  lastTimestamp: { slot: 0, timestamp: 0 }
 }
 */
 ```

--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -599,8 +599,7 @@ VoteAccount {
     ...
   ],
   authorizedVoters: [ { epoch: 242, authorizedVoter: [PublicKey] } ],
-  priorVoters: {
-    buf: [
+  priorVoters: [
       [Object], [Object], [Object],
       [Object], [Object], [Object],
       [Object], [Object], [Object],
@@ -612,10 +611,7 @@ VoteAccount {
       [Object], [Object], [Object],
       [Object], [Object], [Object],
       [Object], [Object]
-    ],
-    idx: 31,
-    isEmpty: 1
-  },
+   ],
   epochCredits: [
     { epoch: 179, credits: 33723163, prevCredits: 33431259 },
     { epoch: 180, credits: 34022643, prevCredits: 33723163 },

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -204,5 +204,5 @@ function getPriorVoters({
     return [];
   }
 
-  return [...buf.slice(idx).map(parsePriorVoters), ...buf.slice(0, idx - 1)];
+  return [...buf.slice(idx + 1).map(parsePriorVoters), ...buf.slice(0, idx)];
 }

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -67,14 +67,20 @@ const VoteAccountLayout = BufferLayout.struct([
     BufferLayout.offset(BufferLayout.u32(), -8),
     'authorizedVoters',
   ),
-  BufferLayout.nu64(), // priorVoters.length
-  BufferLayout.seq(
-    BufferLayout.struct([
-      Layout.publicKey('authorizedPubkey'),
-      BufferLayout.nu64('epochOfLastAuthorizedSwitch'),
-      BufferLayout.nu64('targetEpoch'),
-    ]),
-    BufferLayout.offset(BufferLayout.u32(), -8),
+  BufferLayout.struct(
+    [
+      BufferLayout.seq(
+        BufferLayout.struct([
+          Layout.publicKey('authorizedPubkey'),
+          BufferLayout.nu64('epochOfLastAuthorizedSwitch'),
+          BufferLayout.nu64('targetEpoch'),
+        ]),
+        32,
+        'buf',
+      ),
+      BufferLayout.nu64('idx'),
+      BufferLayout.u8('isEmpty'),
+    ],
     'priorVoters',
   ),
   BufferLayout.nu64(), // epochCredits.length

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -170,30 +170,32 @@ export class VoteAccount {
       commission: va.commission,
       votes: va.votes,
       rootSlot,
-      authorizedVoters: va.authorizedVoters.map(
-        ({epoch, authorizedVoter}: AuthorizedVoter) => {
-          return ({
-            epoch,
-            authorizedVoter: new PublicKey(authorizedVoter),
-          });
-        },
-      ),
+      authorizedVoters: va.authorizedVoters.map(parseAuthorizedVoter),
       priorVoters: {
         ...va.priorVoters,
-        buf: va.priorVoters.buf.map(
-          ({
-            authorizedPubkey,
-            epochOfLastAuthorizedSwitch,
-            targetEpoch,
-          }: Buf) => ({
-            authorizedPubkey: new PublicKey(authorizedPubkey),
-            epochOfLastAuthorizedSwitch,
-            targetEpoch,
-          }),
-        ),
+        buf: va.priorVoters.buf.map(parsePriorVoters),
       },
       epochCredits: va.epochCredits,
       lastTimestamp: va.lastTimestamp,
     });
   }
+}
+
+function parseAuthorizedVoter({epoch, authorizedVoter}: AuthorizedVoter) {
+  return {
+    epoch,
+    authorizedVoter: new PublicKey(authorizedVoter),
+  };
+}
+
+function parsePriorVoters({
+  authorizedPubkey,
+  epochOfLastAuthorizedSwitch,
+  targetEpoch,
+}: Buf) {
+  return {
+    authorizedPubkey: new PublicKey(authorizedPubkey),
+    epochOfLastAuthorizedSwitch,
+    targetEpoch,
+  };
 }

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -17,17 +17,24 @@ export type Lockout = {
 /**
  * History of how many credits earned by the end of each epoch
  */
-export type EpochCredits = {
+export type EpochCredit = {
   epoch: number;
   credits: number;
   prevCredits: number;
 };
 
-export type AuthorizedVoters = {
-  [key: string]: PublicKey;
+export type AuthorizedVoter = {
+  epoch: number;
+  authorizedVoter: PublicKey;
 };
 
 export type PriorVoters = {
+  buf: Buf;
+  idx: number;
+  isEmpty: boolean;
+};
+
+export type Buf = {
   authorizedPubkey: PublicKey;
   epochOfLastAuthorizedSwitch: number;
   targetEpoch: number;
@@ -105,9 +112,9 @@ type VoteAccountArgs = {
   commission: number;
   rootSlot: number | null;
   votes: Lockout[];
-  authorizedVoters: AuthorizedVoters[];
-  priorVoters: PriorVoters[];
-  epochCredits: EpochCredits[];
+  authorizedVoters: AuthorizedVoter[];
+  priorVoters: PriorVoters;
+  epochCredits: EpochCredit[];
   lastTimestamp: Timestamp;
 };
 
@@ -120,9 +127,9 @@ export class VoteAccount {
   commission: number;
   rootSlot: number | null;
   votes: Lockout[];
-  authorizedVoters: AuthorizedVoters[];
-  priorVoters: PriorVoters[];
-  epochCredits: EpochCredits[];
+  authorizedVoters: AuthorizedVoter[];
+  priorVoters: PriorVoters;
+  epochCredits: EpochCredit[];
   lastTimestamp: Timestamp;
 
   /**
@@ -163,8 +170,28 @@ export class VoteAccount {
       commission: va.commission,
       votes: va.votes,
       rootSlot,
-      authorizedVoters: va.authorizedVoters,
-      priorVoters: va.priorVoters,
+      authorizedVoters: va.authorizedVoters.map(
+        ({epoch, authorizedVoter}: AuthorizedVoter) => {
+          return ({
+            epoch,
+            authorizedVoter: new PublicKey(authorizedVoter),
+          });
+        },
+      ),
+      priorVoters: {
+        ...va.priorVoters,
+        buf: va.priorVoters.buf.map(
+          ({
+            authorizedPubkey,
+            epochOfLastAuthorizedSwitch,
+            targetEpoch,
+          }: Buf) => ({
+            authorizedPubkey: new PublicKey(authorizedPubkey),
+            epochOfLastAuthorizedSwitch,
+            targetEpoch,
+          }),
+        ),
+      },
       epochCredits: va.epochCredits,
       lastTimestamp: va.lastTimestamp,
     });

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -165,9 +165,7 @@ export class VoteAccount {
       votes: va.votes,
       rootSlot,
       authorizedVoters: va.authorizedVoters.map(parseAuthorizedVoter),
-      priorVoters: va.priorVoters.isEmpty
-        ? []
-        : va.priorVoters.buf.slice(va.priorVoters.idx).map(parsePriorVoters),
+      priorVoters: getPriorVoters(va.priorVoters),
       epochCredits: va.epochCredits,
       lastTimestamp: va.lastTimestamp,
     });
@@ -191,4 +189,20 @@ function parsePriorVoters({
     epochOfLastAuthorizedSwitch,
     targetEpoch,
   };
+}
+
+function getPriorVoters({
+  buf,
+  idx,
+  isEmpty,
+}: {
+  buf: PriorVoter[];
+  idx: number;
+  isEmpty: boolean;
+}): PriorVoter[] {
+  if (isEmpty) {
+    return [];
+  }
+
+  return [...buf.slice(idx).map(parsePriorVoters), ...buf.slice(0, idx - 1)];
 }

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -17,7 +17,7 @@ export type Lockout = {
 /**
  * History of how many credits earned by the end of each epoch
  */
-export type EpochCredit = {
+export type EpochCredits = {
   epoch: number;
   credits: number;
   prevCredits: number;
@@ -28,19 +28,13 @@ export type AuthorizedVoter = {
   authorizedVoter: PublicKey;
 };
 
-export type PriorVoters = {
-  buf: Buf;
-  idx: number;
-  isEmpty: boolean;
-};
-
-export type Buf = {
+export type PriorVoter = {
   authorizedPubkey: PublicKey;
   epochOfLastAuthorizedSwitch: number;
   targetEpoch: number;
 };
 
-export type Timestamp = {
+export type BlockTimestamp = {
   slot: number;
   timetamp: number;
 };
@@ -113,9 +107,9 @@ type VoteAccountArgs = {
   rootSlot: number | null;
   votes: Lockout[];
   authorizedVoters: AuthorizedVoter[];
-  priorVoters: PriorVoters;
-  epochCredits: EpochCredit[];
-  lastTimestamp: Timestamp;
+  priorVoters: PriorVoter[];
+  epochCredits: EpochCredits[];
+  lastTimestamp: BlockTimestamp;
 };
 
 /**
@@ -128,9 +122,9 @@ export class VoteAccount {
   rootSlot: number | null;
   votes: Lockout[];
   authorizedVoters: AuthorizedVoter[];
-  priorVoters: PriorVoters;
-  epochCredits: EpochCredit[];
-  lastTimestamp: Timestamp;
+  priorVoters: PriorVoter[];
+  epochCredits: EpochCredits[];
+  lastTimestamp: BlockTimestamp;
 
   /**
    * @internal
@@ -171,10 +165,7 @@ export class VoteAccount {
       votes: va.votes,
       rootSlot,
       authorizedVoters: va.authorizedVoters.map(parseAuthorizedVoter),
-      priorVoters: {
-        ...va.priorVoters,
-        buf: va.priorVoters.buf.map(parsePriorVoters),
-      },
+      priorVoters: va.priorVoters.isEmpty ? [] : va.priorVoters.buf.map(parsePriorVoters),
       epochCredits: va.epochCredits,
       lastTimestamp: va.lastTimestamp,
     });
@@ -192,7 +183,7 @@ function parsePriorVoters({
   authorizedPubkey,
   epochOfLastAuthorizedSwitch,
   targetEpoch,
-}: Buf) {
+}: PriorVoter) {
   return {
     authorizedPubkey: new PublicKey(authorizedPubkey),
     epochOfLastAuthorizedSwitch,

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -165,7 +165,9 @@ export class VoteAccount {
       votes: va.votes,
       rootSlot,
       authorizedVoters: va.authorizedVoters.map(parseAuthorizedVoter),
-      priorVoters: va.priorVoters.isEmpty ? [] : va.priorVoters.buf.map(parsePriorVoters),
+      priorVoters: va.priorVoters.isEmpty
+        ? []
+        : va.priorVoters.buf.slice(va.priorVoters.idx).map(parsePriorVoters),
       epochCredits: va.epochCredits,
       lastTimestamp: va.lastTimestamp,
     });

--- a/web3.js/src/vote-account.ts
+++ b/web3.js/src/vote-account.ts
@@ -23,6 +23,21 @@ export type EpochCredits = {
   prevCredits: number;
 };
 
+export type AuthorizedVoters = {
+  [key: string]: PublicKey;
+};
+
+export type PriorVoters = {
+  authorizedPubkey: PublicKey;
+  epochOfLastAuthorizedSwitch: number;
+  targetEpoch: number;
+};
+
+export type Timestamp = {
+  slot: number;
+  timetamp: number;
+};
+
 /**
  * See https://github.com/solana-labs/solana/blob/8a12ed029cfa38d4a45400916c2463fb82bbec8c/programs/vote_api/src/vote_state.rs#L68-L88
  *
@@ -30,8 +45,7 @@ export type EpochCredits = {
  */
 const VoteAccountLayout = BufferLayout.struct([
   Layout.publicKey('nodePubkey'),
-  Layout.publicKey('authorizedVoterPubkey'),
-  Layout.publicKey('authorizedWithdrawerPubkey'),
+  Layout.publicKey('authorizedWithdrawer'),
   BufferLayout.u8('commission'),
   BufferLayout.nu64(), // votes.length
   BufferLayout.seq(
@@ -44,9 +58,25 @@ const VoteAccountLayout = BufferLayout.struct([
   ),
   BufferLayout.u8('rootSlotValid'),
   BufferLayout.nu64('rootSlot'),
-  BufferLayout.nu64('epoch'),
-  BufferLayout.nu64('credits'),
-  BufferLayout.nu64('lastEpochCredits'),
+  BufferLayout.nu64(), // authorizedVoters.length
+  BufferLayout.seq(
+    BufferLayout.struct([
+      BufferLayout.nu64('epoch'),
+      Layout.publicKey('authorizedVoter'),
+    ]),
+    BufferLayout.offset(BufferLayout.u32(), -8),
+    'authorizedVoters',
+  ),
+  BufferLayout.nu64(), // priorVoters.length
+  BufferLayout.seq(
+    BufferLayout.struct([
+      Layout.publicKey('authorizedPubkey'),
+      BufferLayout.nu64('epochOfLastAuthorizedSwitch'),
+      BufferLayout.nu64('targetEpoch'),
+    ]),
+    BufferLayout.offset(BufferLayout.u32(), -8),
+    'priorVoters',
+  ),
   BufferLayout.nu64(), // epochCredits.length
   BufferLayout.seq(
     BufferLayout.struct([
@@ -57,19 +87,22 @@ const VoteAccountLayout = BufferLayout.struct([
     BufferLayout.offset(BufferLayout.u32(), -8),
     'epochCredits',
   ),
+  BufferLayout.struct(
+    [BufferLayout.nu64('slot'), BufferLayout.nu64('timestamp')],
+    'lastTimestamp',
+  ),
 ]);
 
 type VoteAccountArgs = {
   nodePubkey: PublicKey;
-  authorizedVoterPubkey: PublicKey;
-  authorizedWithdrawerPubkey: PublicKey;
+  authorizedWithdrawer: PublicKey;
   commission: number;
-  votes: Array<Lockout>;
   rootSlot: number | null;
-  epoch: number;
-  credits: number;
-  lastEpochCredits: number;
-  epochCredits: Array<EpochCredits>;
+  votes: Lockout[];
+  authorizedVoters: AuthorizedVoters[];
+  priorVoters: PriorVoters[];
+  epochCredits: EpochCredits[];
+  lastTimestamp: Timestamp;
 };
 
 /**
@@ -77,30 +110,28 @@ type VoteAccountArgs = {
  */
 export class VoteAccount {
   nodePubkey: PublicKey;
-  authorizedVoterPubkey: PublicKey;
-  authorizedWithdrawerPubkey: PublicKey;
+  authorizedWithdrawer: PublicKey;
   commission: number;
-  votes: Array<Lockout>;
   rootSlot: number | null;
-  epoch: number;
-  credits: number;
-  lastEpochCredits: number;
-  epochCredits: Array<EpochCredits>;
+  votes: Lockout[];
+  authorizedVoters: AuthorizedVoters[];
+  priorVoters: PriorVoters[];
+  epochCredits: EpochCredits[];
+  lastTimestamp: Timestamp;
 
   /**
    * @internal
    */
   constructor(args: VoteAccountArgs) {
     this.nodePubkey = args.nodePubkey;
-    this.authorizedVoterPubkey = args.authorizedVoterPubkey;
-    this.authorizedWithdrawerPubkey = args.authorizedWithdrawerPubkey;
+    this.authorizedWithdrawer = args.authorizedWithdrawer;
     this.commission = args.commission;
-    this.votes = args.votes;
     this.rootSlot = args.rootSlot;
-    this.epoch = args.epoch;
-    this.credits = args.credits;
-    this.lastEpochCredits = args.lastEpochCredits;
+    this.votes = args.votes;
+    this.authorizedVoters = args.authorizedVoters;
+    this.priorVoters = args.priorVoters;
     this.epochCredits = args.epochCredits;
+    this.lastTimestamp = args.lastTimestamp;
   }
 
   /**
@@ -112,7 +143,8 @@ export class VoteAccount {
   static fromAccountData(
     buffer: Buffer | Uint8Array | Array<number>,
   ): VoteAccount {
-    const va = VoteAccountLayout.decode(toBuffer(buffer), 0);
+    const versionOffset = 4;
+    const va = VoteAccountLayout.decode(toBuffer(buffer), versionOffset);
 
     let rootSlot: number | null = va.rootSlot;
     if (!va.rootSlotValid) {
@@ -121,15 +153,14 @@ export class VoteAccount {
 
     return new VoteAccount({
       nodePubkey: new PublicKey(va.nodePubkey),
-      authorizedVoterPubkey: new PublicKey(va.authorizedVoterPubkey),
-      authorizedWithdrawerPubkey: new PublicKey(va.authorizedWithdrawerPubkey),
+      authorizedWithdrawer: new PublicKey(va.authorizedWithdrawer),
       commission: va.commission,
       votes: va.votes,
       rootSlot,
-      epoch: va.epoch,
-      credits: va.credits,
-      lastEpochCredits: va.lastEpochCredits,
+      authorizedVoters: va.authorizedVoters,
+      priorVoters: va.priorVoters,
       epochCredits: va.epochCredits,
+      lastTimestamp: va.lastTimestamp,
     });
   }
 }


### PR DESCRIPTION
- fix(vote-account): rangeError [ERR_OUT_OF_RANGE] error
- docs(vote account): update reference to match new payload

#### Problem

VoteAccount.fromAccountData() throws RangeError on any vote account data

#### Summary of Changes

- Update bufferLayout
- Update docs to match new payload

The web3 buffer layout is out-of-date with the current `VoteState` implementation. The buffer layout is updated to match the structure in https://github.com/solana-labs/solana/blob/master/account-decoder/src/parse_vote.rs

Fixes #20786
