### PR TITLE
Stop caching sysvars, instead load them ahead of time

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1400,9 +1400,9 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_noop", 480),
             ("solana_bpf_rust_param_passing", 146),
             ("solana_bpf_rust_rand", 487),
-            ("solana_bpf_rust_sanity", 8406),
+            ("solana_bpf_rust_sanity", 8454),
             ("solana_bpf_rust_secp256k1_recover", 25216),
-            ("solana_bpf_rust_sha", 30704),
+            ("solana_bpf_rust_sha", 30692),
         ]);
     }
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3284,10 +3284,8 @@ mod tests {
             let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_clock).unwrap();
-            invoke_context
-                .get_sysvars()
-                .borrow_mut()
-                .push((sysvar::clock::id(), Some(Rc::new(data))));
+            let sysvars = &[(sysvar::clock::id(), data)];
+            invoke_context.sysvars = sysvars;
 
             let mut syscall = SyscallGetClockSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3330,10 +3328,8 @@ mod tests {
             let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
-            invoke_context
-                .get_sysvars()
-                .borrow_mut()
-                .push((sysvar::epoch_schedule::id(), Some(Rc::new(data))));
+            let sysvars = &[(sysvar::epoch_schedule::id(), data)];
+            invoke_context.sysvars = sysvars;
 
             let mut syscall = SyscallGetEpochScheduleSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3383,10 +3379,8 @@ mod tests {
             let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_fees).unwrap();
-            invoke_context
-                .get_sysvars()
-                .borrow_mut()
-                .push((sysvar::fees::id(), Some(Rc::new(data))));
+            let sysvars = &[(sysvar::fees::id(), data)];
+            invoke_context.sysvars = sysvars;
 
             let mut syscall = SyscallGetFeesSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3427,10 +3421,8 @@ mod tests {
             let mut invoke_context = MockInvokeContext::new(&Pubkey::default(), vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_rent).unwrap();
-            invoke_context
-                .get_sysvars()
-                .borrow_mut()
-                .push((sysvar::rent::id(), Some(Rc::new(data))));
+            let sysvars = &[(sysvar::rent::id(), data)];
+            invoke_context.sysvars = sysvars;
 
             let mut syscall = SyscallGetRentSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -340,7 +340,7 @@ mod tests {
         },
         sysvar::{stake_history::StakeHistory, Sysvar},
     };
-    use std::{cell::RefCell, rc::Rc, str::FromStr};
+    use std::{cell::RefCell, str::FromStr};
 
     fn create_default_account() -> RefCell<AccountSharedData> {
         RefCell::new(AccountSharedData::default())
@@ -444,10 +444,8 @@ mod tests {
             );
             let mut data = Vec::with_capacity(sysvar::clock::Clock::size_of());
             bincode::serialize_into(&mut data, &sysvar::clock::Clock::default()).unwrap();
-            invoke_context
-                .get_sysvars()
-                .borrow_mut()
-                .push((sysvar::clock::id(), Some(Rc::new(data))));
+            let sysvars = &[(sysvar::clock::id(), data)];
+            invoke_context.sysvars = sysvars;
             super::process_instruction(1, &instruction.data, &mut invoke_context)
         }
     }
@@ -1102,10 +1100,8 @@ mod tests {
             MockInvokeContext::new(&id(), create_keyed_accounts_unified(&keyed_accounts));
         let mut data = Vec::with_capacity(sysvar::clock::Clock::size_of());
         bincode::serialize_into(&mut data, &sysvar::clock::Clock::default()).unwrap();
-        invoke_context
-            .get_sysvars()
-            .borrow_mut()
-            .push((sysvar::clock::id(), Some(Rc::new(data))));
+        let sysvars = &[(sysvar::clock::id(), data)];
+        invoke_context.sysvars = sysvars;
 
         assert_eq!(
             super::process_instruction(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1006,6 +1006,8 @@ pub struct Bank {
     vote_only_bank: bool,
 
     pub cost_tracker: RwLock<CostTracker>,
+
+    sysvar_cache: RwLock<Vec<(Pubkey, Vec<u8>)>>,
 }
 
 impl Default for BlockhashQueue {
@@ -1145,6 +1147,7 @@ impl Bank {
             freeze_started: AtomicBool::default(),
             vote_only_bank: false,
             cost_tracker: RwLock::<CostTracker>::default(),
+            sysvar_cache: RwLock::new(Vec::new()),
         }
     }
 
@@ -1254,6 +1257,7 @@ impl Bank {
         bank.update_rent();
         bank.update_epoch_schedule();
         bank.update_recent_blockhashes();
+        bank.fill_sysvar_cache();
         bank
     }
 
@@ -1402,6 +1406,7 @@ impl Bank {
             )),
             freeze_started: AtomicBool::new(false),
             cost_tracker: RwLock::new(CostTracker::default()),
+            sysvar_cache: RwLock::new(Vec::new()),
         };
 
         datapoint_info!(
@@ -1458,6 +1463,7 @@ impl Bank {
             new.update_stake_history(Some(parent_epoch));
             new.update_clock(Some(parent_epoch));
             new.update_fees();
+            new.fill_sysvar_cache();
 
             return new;
         }
@@ -1473,6 +1479,7 @@ impl Bank {
         new.update_stake_history(Some(parent_epoch));
         new.update_clock(Some(parent_epoch));
         new.update_fees();
+        new.fill_sysvar_cache();
         new
     }
 
@@ -1589,6 +1596,7 @@ impl Bank {
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
             vote_only_bank: false,
             cost_tracker: RwLock::new(CostTracker::default()),
+            sysvar_cache: RwLock::new(Vec::new()),
         };
         bank.finish_init(
             genesis_config,
@@ -1767,6 +1775,14 @@ impl Bank {
         }
 
         self.store_account_and_update_capitalization(pubkey, &new_account);
+
+        // Update the entry in the cache
+        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        if let Some(position) = sysvar_cache.iter().position(|(id, _data)| id == pubkey) {
+            sysvar_cache[position].1 = new_account.data().to_vec();
+        } else {
+            sysvar_cache.push((*pubkey, new_account.data().to_vec()));
+        }
     }
 
     fn inherit_specially_retained_account_fields(
@@ -1902,6 +1918,17 @@ impl Bank {
                 self.inherit_specially_retained_account_fields(account),
             )
         });
+    }
+
+    fn fill_sysvar_cache(&mut self) {
+        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        for id in sysvar::ALL_IDS.iter() {
+            if !sysvar_cache.iter().any(|(key, _data)| key == id) {
+                if let Some(account) = self.get_account_with_fixed_root(id) {
+                    sysvar_cache.push((*id, account.data().to_vec()));
+                }
+            }
+        }
     }
 
     pub fn get_slot_history(&self) -> SlotHistory {
@@ -3858,8 +3885,7 @@ impl Bank {
                                 compute_budget,
                                 compute_meter,
                                 &mut timings.details,
-                                self.rc.accounts.clone(),
-                                &self.ancestors,
+                                &*self.sysvar_cache.read().unwrap(),
                                 blockhash,
                                 lamports_per_signature,
                             );

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -1,6 +1,7 @@
 //! named accounts for synthesized data accounts for bank state, etc.
 //!
 use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use lazy_static::lazy_static;
 
 pub mod clock;
 pub mod epoch_schedule;
@@ -13,18 +14,25 @@ pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
 
-#[allow(deprecated)]
+lazy_static! {
+    pub static ref ALL_IDS: Vec<Pubkey> = vec![
+        clock::id(),
+        epoch_schedule::id(),
+        #[allow(deprecated)]
+        fees::id(),
+        #[allow(deprecated)]
+        recent_blockhashes::id(),
+        rent::id(),
+        rewards::id(),
+        slot_hashes::id(),
+        slot_history::id(),
+        stake_history::id(),
+        instructions::id(),
+    ];
+}
+
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
-    clock::check_id(id)
-        || epoch_schedule::check_id(id)
-        || fees::check_id(id)
-        || recent_blockhashes::check_id(id)
-        || rent::check_id(id)
-        || rewards::check_id(id)
-        || slot_hashes::check_id(id)
-        || slot_history::check_id(id)
-        || stake_history::check_id(id)
-        || instructions::check_id(id)
+    ALL_IDS.iter().any(|key| key == id)
 }
 
 #[macro_export]

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -121,10 +121,7 @@ pub trait InvokeContext {
         deserialize_us: u64,
     );
     /// Get sysvars
-    #[allow(clippy::type_complexity)]
-    fn get_sysvars(&self) -> &RefCell<Vec<(Pubkey, Option<Rc<Vec<u8>>>)>>;
-    /// Get sysvar data
-    fn get_sysvar_data(&self, id: &Pubkey) -> Option<Rc<Vec<u8>>>;
+    fn get_sysvars(&self) -> &[(Pubkey, Vec<u8>)];
     /// Get this invocation's compute budget
     fn get_compute_budget(&self) -> &ComputeBudget;
     /// Set this invocation's blockhash
@@ -175,15 +172,20 @@ pub fn get_sysvar<T: Sysvar>(
     invoke_context: &dyn InvokeContext,
     id: &Pubkey,
 ) -> Result<T, InstructionError> {
-    let sysvar_data = invoke_context.get_sysvar_data(id).ok_or_else(|| {
-        ic_msg!(invoke_context, "Unable to get sysvar {}", id);
-        InstructionError::UnsupportedSysvar
-    })?;
-
-    bincode::deserialize(&sysvar_data).map_err(|err| {
-        ic_msg!(invoke_context, "Unable to get sysvar {}: {:?}", id, err);
-        InstructionError::UnsupportedSysvar
-    })
+    invoke_context
+        .get_sysvars()
+        .iter()
+        .find_map(|(key, data)| {
+            if id == key {
+                bincode::deserialize(data).ok()
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            ic_msg!(invoke_context, "Unable to get sysvar {}", id);
+            InstructionError::UnsupportedSysvar
+        })
 }
 
 /// Compute meter
@@ -356,8 +358,7 @@ pub struct MockInvokeContext<'a> {
     pub compute_meter: Rc<RefCell<dyn ComputeMeter>>,
     pub programs: Vec<(Pubkey, ProcessInstructionWithContext)>,
     pub accounts: Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>,
-    #[allow(clippy::type_complexity)]
-    pub sysvars: RefCell<Vec<(Pubkey, Option<Rc<Vec<u8>>>)>>,
+    pub sysvars: &'a [(Pubkey, Vec<u8>)],
     pub disabled_features: HashSet<Pubkey>,
     pub blockhash: Hash,
     pub lamports_per_signature: u64,
@@ -376,7 +377,7 @@ impl<'a> MockInvokeContext<'a> {
             })),
             programs: vec![],
             accounts: vec![],
-            sysvars: RefCell::new(Vec::new()),
+            sysvars: &[],
             disabled_features: HashSet::default(),
             blockhash: Hash::default(),
             lamports_per_signature: 0,
@@ -490,15 +491,8 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
         _deserialize_us: u64,
     ) {
     }
-    #[allow(clippy::type_complexity)]
-    fn get_sysvars(&self) -> &RefCell<Vec<(Pubkey, Option<Rc<Vec<u8>>>)>> {
-        &self.sysvars
-    }
-    fn get_sysvar_data(&self, id: &Pubkey) -> Option<Rc<Vec<u8>>> {
+    fn get_sysvars(&self) -> &[(Pubkey, Vec<u8>)] {
         self.sysvars
-            .borrow()
-            .iter()
-            .find_map(|(key, sysvar)| if id == key { sysvar.clone() } else { None })
     }
     fn get_compute_budget(&self) -> &ComputeBudget {
         &self.compute_budget


### PR DESCRIPTION
#### Problem
#20881 will require the `sysvars` to be loaded AOT in order to avoid a `dyn Trait` after `ThisInvokeContext` is moved in the program-runtime crate.

#### Summary of Changes
Use `get_program_accounts()` in the bank to load the `sysvars` once per `load_and_execute_transactions()` instead of loading them on demand in `ThisInvokeContext`.

Fixes #
