### PR TITLE
Fix serum-dex downstream build

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -87,6 +87,7 @@ serum_dex() {
 [workspace]
 exclude = [
     "crank",
+    "permissioned",
 ]
 EOF
     $cargo build


### PR DESCRIPTION
#### Problem
CI downstream-projects build is broken because serum-dex added a new crate in `dex` that is listed in their top-level workspace.

#### Summary of Changes
Extend exclusion to include new `permissioned` crate
