### PR TITLE
fix(explorer): do not display NFTs without an edition

### DIFF
--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -250,6 +250,11 @@ async function fetchAccountInfo(
                       metadata,
                       connection
                     );
+
+                    if (!editionInfo.masterEdition && !editionInfo.edition) {
+                      throw new Error("No edition found");
+                    }
+
                     nftData = { metadata: metadata.data, editionInfo };
                   }
                 }


### PR DESCRIPTION
#### Problem
Token metadata exists for some fungible mints and shouldn't be displayed as an NFT. 

#### Summary of Changes
If no editions exist, don't display as NFT.

Fixes #
