### PR TITLE
[Explorer] Reverted a change to require that Metaplex NFTs have a `MasterEdition` and added a decimal check

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -1,4 +1,9 @@
-import { Account, NFTData, useFetchAccountInfo } from "providers/accounts";
+import {
+  Account,
+  NFTData,
+  TokenProgramData,
+  useFetchAccountInfo,
+} from "providers/accounts";
 import {
   TokenAccount,
   MintAccountInfo,
@@ -20,6 +25,7 @@ import { CoingeckoStatus, useCoinGecko } from "utils/coingecko";
 import { displayTimestampWithoutDate } from "utils/date";
 import { LoadingCard } from "components/common/LoadingCard";
 import { PublicKey } from "@solana/web3.js";
+import isMetaplexNFT from "providers/accounts/utils/isMetaplexNFT";
 
 const getEthAddress = (link?: string) => {
   let address = "";
@@ -48,14 +54,11 @@ export function TokenAccountSection({
       case "mint": {
         const info = create(tokenAccount.info, MintAccountInfo);
 
-        if (
-          account.details?.data?.program === "spl-token" &&
-          account.details.data.nftData
-        ) {
+        if (isMetaplexNFT(account.details?.data, info.decimals)) {
           return (
             <NonFungibleTokenMintAccountCard
               account={account}
-              nftData={account.details.data.nftData}
+              nftData={(account.details!.data as TokenProgramData).nftData!}
               mintInfo={info}
             />
           );

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -7,6 +7,7 @@ import {
   Account,
   ProgramData,
   TokenProgramData,
+  useMintAccountInfo,
 } from "providers/accounts";
 import { StakeAccountSection } from "components/account/StakeAccountSection";
 import { TokenAccountSection } from "components/account/TokenAccountSection";
@@ -159,10 +160,11 @@ export function AccountHeader({
 }) {
   const { tokenRegistry } = useTokenRegistry();
   const tokenDetails = tokenRegistry.get(address);
+  const mintInfo = useMintAccountInfo(address);
   const account = info?.data;
   const data = account?.details?.data;
   const isToken = data?.program === "spl-token" && data?.parsed.type === "mint";
-  const isNFT = isToken && data.nftData;
+  const isNFT = isToken && data.nftData && mintInfo?.decimals === 0;
 
   if (isNFT) {
     return <NFTHeader nftData={data.nftData!} address={address} />;

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -39,6 +39,7 @@ import { RewardsCard } from "components/account/RewardsCard";
 import { MetaplexMetadataCard } from "components/account/MetaplexMetadataCard";
 import { NFTHeader } from "components/account/MetaplexNFTHeader";
 import { DomainsCard } from "components/account/DomainsCard";
+import isMetaplexNFT from "providers/accounts/utils/isMetaplexNFT";
 
 const IDENTICON_WIDTH = 64;
 
@@ -164,10 +165,14 @@ export function AccountHeader({
   const account = info?.data;
   const data = account?.details?.data;
   const isToken = data?.program === "spl-token" && data?.parsed.type === "mint";
-  const isNFT = isToken && data.nftData && mintInfo?.decimals === 0;
 
-  if (isNFT) {
-    return <NFTHeader nftData={data.nftData!} address={address} />;
+  if (isMetaplexNFT(data, mintInfo?.decimals)) {
+    return (
+      <NFTHeader
+        nftData={(data as TokenProgramData).nftData!}
+        address={address}
+      />
+    );
   }
 
   if (tokenDetails || isToken) {

--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -251,10 +251,6 @@ async function fetchAccountInfo(
                       connection
                     );
 
-                    if (!editionInfo.masterEdition && !editionInfo.edition) {
-                      throw new Error("No edition found");
-                    }
-
                     nftData = { metadata: metadata.data, editionInfo };
                   }
                 }

--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -1,0 +1,10 @@
+import { ProgramData } from "..";
+
+export default function isMetaplexNFT(data?: ProgramData, decimals?: number) {
+  return (
+    data?.program === "spl-token" &&
+    data?.parsed.type === "mint" &&
+    data?.nftData &&
+    decimals === 0
+  );
+}


### PR DESCRIPTION
#### Problem

Metaplex NFTs without `MasterEditions` weren't being shown as NFTs. This eliminated a lot of previously minted NFTs and isn't reasonable to enforce any longer. Non-NFT Tokens were also improperly being shown as Metaplex NFTs.

#### Summary of Changes

Revert the `MasterEdition` required to be a Metaplex NFT and added a `decimal` is 0 check to properly gate non-NFTs with Metaplex Metadata from using the `NFTHeader` assets.

**_Test Addresses_**

- 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU (Non NFT Token with Metaplex Metadata)
- DXps43e9CEr7tciENzcF6nBAfLdjToyJETF3qPdctzTJ (NFT without a `MasterEdition`)

**Non-NFT Token with Metadata after change**

![image](https://user-images.githubusercontent.com/3758645/139786584-b39ed42a-6d2e-4d50-943d-0f251cb6fac3.png)

**NFT without a `MasterEdition` after change**

![image](https://user-images.githubusercontent.com/3758645/139784986-89991187-ff81-4d6b-80b9-c5276543c915.png)
