### PR TITLE
Fix issue where SPL tokens (without decimals) that are not NFTs show …

### DIFF
--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -4,7 +4,6 @@ export default function isMetaplexNFT(data?: ProgramData, decimals?: number) {
   return (
     data?.program === "spl-token" &&
     data?.parsed.type === "mint" &&
-    data?.nftData &&
-    decimals === 0
+    data?.nftData
   );
 }


### PR DESCRIPTION
…up as NFT in Explorer.

#### Problem
A malicious actor has published NFT metadata using the SDOGE market symbol, resulting in the token showing up as NFT when it is not.

Josh is aware of this, as is lisenmayben.

#### Summary of Changes
Remove the check for decimals being null as a way to identify an NFT.

Fixes #
Remove the check for decimals being null as a way to identify an NFT.