### PR TITLE
Add cargo-build-bpf logic to recover from failed package downloads

### DIFF
--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -132,6 +132,20 @@ fn install_if_missing(
         .join(version)
         .join(package);
 
+    // Check whether the target path is an empty directory. This can
+    // happen if package download failed on previous run of
+    // cargo-build-bpf.  Remove the target_path directory in this
+    // case.
+    if target_path.is_dir()
+        && target_path
+            .read_dir()
+            .map_err(|err| err.to_string())?
+            .next()
+            .is_none()
+    {
+        fs::remove_dir(&target_path).map_err(|err| err.to_string())?;
+    }
+
     if !target_path.is_dir()
         && !target_path
             .symlink_metadata()


### PR DESCRIPTION
#### Problem

cargo-build-bpf can't recover from a failed download of bpf-tools tarball. All subsequent invocations of cargo-build-bpf report an error 'failed to install bpf-tools'

#### Summary of Changes

Check that the bpf-tools installation directory in ~/.cache/solana is not empty and remove it otherwise, allowing cargo-build-bpf to proceed with downloading the bpf-tools tarball and unpacking it in a correct location.

Fixes #21053 
