### PR TITLE
Deprecate more  Fee/Blockhash APIs

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -61,6 +61,10 @@ impl BanksClient {
         self.inner.send_transaction_with_context(ctx, transaction)
     }
 
+    #[deprecated(
+        since = "1.9.0",
+        note = "Please use `get_fee_for_message` or `is_blockhash_valid` instead"
+    )]
     pub fn get_fees_with_commitment_and_context(
         &mut self,
         ctx: Context,
@@ -129,9 +133,14 @@ impl BanksClient {
     /// Return the fee parameters associated with a recent, rooted blockhash. The cluster
     /// will use the transaction's blockhash to look up these same fee parameters and
     /// use them to calculate the transaction fee.
+    #[deprecated(
+        since = "1.9.0",
+        note = "Please use `get_fee_for_message` or `is_blockhash_valid` instead"
+    )]
     pub fn get_fees(
         &mut self,
     ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, u64)>> + '_ {
+        #[allow(deprecated)]
         self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::default())
     }
 
@@ -153,8 +162,9 @@ impl BanksClient {
     /// Return a recent, rooted blockhash from the server. The cluster will only accept
     /// transactions with a blockhash that has not yet expired. Use the `get_fees`
     /// method to get both a blockhash and the blockhash's last valid slot.
+    #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
     pub fn get_recent_blockhash(&mut self) -> impl Future<Output = io::Result<Hash>> + '_ {
-        self.get_fees().map(|result| Ok(result?.1))
+        self.get_latest_blockhash()
     }
 
     /// Send a transaction and return after the transaction has been rejected or
@@ -315,6 +325,31 @@ impl BanksClient {
         statuses.into_iter().collect()
     }
 
+    pub fn get_latest_blockhash(&mut self) -> impl Future<Output = io::Result<Hash>> + '_ {
+        self.get_latest_blockhash_with_commitment(CommitmentLevel::default())
+            .map(|result| {
+                result?
+                    .map(|x| x.0)
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "account not found"))
+            })
+    }
+
+    pub fn get_latest_blockhash_with_commitment(
+        &mut self,
+        commitment: CommitmentLevel,
+    ) -> impl Future<Output = io::Result<Option<(Hash, u64)>>> + '_ {
+        self.get_latest_blockhash_with_commitment_and_context(context::current(), commitment)
+    }
+
+    pub fn get_latest_blockhash_with_commitment_and_context(
+        &mut self,
+        ctx: Context,
+        commitment: CommitmentLevel,
+    ) -> impl Future<Output = io::Result<Option<(Hash, u64)>>> + '_ {
+        self.inner
+            .get_latest_blockhash_with_commitment_and_context(ctx, commitment)
+    }
+
     pub fn get_fee_for_message_with_commitment_and_context(
         &mut self,
         ctx: Context,
@@ -386,7 +421,7 @@ mod tests {
                     .await;
             let mut banks_client = start_client(client_transport).await?;
 
-            let recent_blockhash = banks_client.get_recent_blockhash().await?;
+            let recent_blockhash = banks_client.get_latest_blockhash().await?;
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);
             banks_client.process_transaction(transaction).await.unwrap();
             assert_eq!(banks_client.get_balance(bob_pubkey).await?, 1);
@@ -418,7 +453,10 @@ mod tests {
                 start_local_server(bank_forks, block_commitment_cache, Duration::from_millis(1))
                     .await;
             let mut banks_client = start_client(client_transport).await?;
-            let (_, recent_blockhash, last_valid_block_height) = banks_client.get_fees().await?;
+            let (recent_blockhash, last_valid_block_height) = banks_client
+                .get_latest_blockhash_with_commitment(CommitmentLevel::default())
+                .await?
+                .unwrap();
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);
             let signature = transaction.signatures[0];
             banks_client.send_transaction(transaction).await?;

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -52,6 +52,10 @@ pub trait Banks {
         address: Pubkey,
         commitment: CommitmentLevel,
     ) -> Option<Account>;
+    async fn get_latest_blockhash_with_context() -> Hash;
+    async fn get_latest_blockhash_with_commitment_and_context(
+        commitment: CommitmentLevel,
+    ) -> Option<(Hash, u64)>;
     async fn get_fee_for_message_with_commitment_and_context(
         commitment: CommitmentLevel,
         message: Message,

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -281,6 +281,22 @@ impl Banks for BanksServer {
         bank.get_account(&address).map(Account::from)
     }
 
+    async fn get_latest_blockhash_with_context(self, _: Context) -> Hash {
+        let bank = self.bank(CommitmentLevel::default());
+        bank.last_blockhash()
+    }
+
+    async fn get_latest_blockhash_with_commitment_and_context(
+        self,
+        _: Context,
+        commitment: CommitmentLevel,
+    ) -> Option<(Hash, u64)> {
+        let bank = self.bank(commitment);
+        let blockhash = bank.last_blockhash();
+        let last_valid_block_height = bank.get_blockhash_last_valid_block_height(&blockhash)?;
+        Some((blockhash, last_valid_block_height))
+    }
+
     async fn get_fee_for_message_with_commitment_and_context(
         self,
         _: Context,

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -423,10 +423,9 @@ async fn get_blockhash_post_warp() {
 
     let new_blockhash = context
         .banks_client
-        .get_new_blockhash(&context.last_blockhash)
+        .get_new_latest_blockhash(&context.last_blockhash)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
     let mut tx = Transaction::new_with_payer(&[], Some(&context.payer.pubkey()));
     tx.sign(&[&context.payer], new_blockhash);
     context.banks_client.process_transaction(tx).await.unwrap();
@@ -435,10 +434,9 @@ async fn get_blockhash_post_warp() {
 
     let new_blockhash = context
         .banks_client
-        .get_new_blockhash(&context.last_blockhash)
+        .get_new_latest_blockhash(&context.last_blockhash)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     let mut tx = Transaction::new_with_payer(&[], Some(&context.payer.pubkey()));
     tx.sign(&[&context.payer], new_blockhash);

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -158,7 +158,7 @@ pub trait SyncClient {
     /// Get last known blockhash
     fn get_latest_blockhash(&self) -> Result<Hash>;
 
-    /// Get recent blockhash. Uses explicit commitment configuration.
+    /// Get latest blockhash with last valid block height. Uses explicit commitment configuration.
     fn get_latest_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,


### PR DESCRIPTION
#### Problem

Some `BanksClient` APIs use FeeCalculator or old names

#### Summary of Changes

Deprecate and add updated function replacements

Fixes #
