### PR TITLE
Prevent creation of rent-paying accounts with non-empty data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
  "dashmap",
  "dir-diff",
  "ed25519-dalek",
+ "enum-iterator",
  "flate2",
  "fnv",
  "itertools 0.10.1",

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -183,57 +183,6 @@ async fn clock_sysvar_updated_from_warp() {
 }
 
 #[tokio::test]
-async fn rent_collected_from_warp() {
-    let program_id = Pubkey::new_unique();
-    // Initialize and start the test network
-    let program_test = ProgramTest::default();
-
-    let mut context = program_test.start_with_context().await;
-    let account_size = 100;
-    let keypair = Keypair::new();
-    let account_lamports = Rent::default().minimum_balance(account_size) - 100; // not rent exempt
-    let instruction = system_instruction::create_account(
-        &context.payer.pubkey(),
-        &keypair.pubkey(),
-        account_lamports,
-        account_size as u64,
-        &program_id,
-    );
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &keypair],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
-    let account = context
-        .banks_client
-        .get_account(keypair.pubkey())
-        .await
-        .expect("account exists")
-        .unwrap();
-    assert_eq!(account.lamports, account_lamports);
-
-    // Warp forward and see that rent has been collected
-    // This test was a bit flaky with one warp, but two warps always works
-    let slots_per_epoch = context.genesis_config().epoch_schedule.slots_per_epoch;
-    context.warp_to_slot(slots_per_epoch).unwrap();
-    context.warp_to_slot(slots_per_epoch * 2).unwrap();
-
-    let account = context
-        .banks_client
-        .get_account(keypair.pubkey())
-        .await
-        .expect("account exists")
-        .unwrap();
-    assert!(account.lamports < account_lamports);
-}
-
-#[tokio::test]
 async fn stake_rewards_from_warp() {
     // Initialize and start the test network
     let program_test = ProgramTest::default();

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -801,6 +801,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.6",
+ "syn 1.0.67",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,6 +3407,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "dir-diff",
+ "enum-iterator",
  "flate2",
  "fnv",
  "itertools 0.10.1",

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1931,7 +1931,7 @@ mod tests {
             Some(&mint_keypair.pubkey()),
         );
         assert_eq!(
-            TransactionError::InstructionError(1, InstructionError::ExecutableAccountNotRentExempt),
+            TransactionError::InvalidRentPayingAccount,
             bank_client
                 .send_and_confirm_message(
                     &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
@@ -1964,7 +1964,7 @@ mod tests {
         );
         let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
         assert_eq!(
-            TransactionError::InstructionError(1, InstructionError::ExecutableAccountNotRentExempt),
+            TransactionError::InvalidRentPayingAccount,
             bank_client
                 .send_and_confirm_message(
                     &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,6 +19,7 @@ bzip2 = "0.4.3"
 dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 crossbeam-channel = "0.5"
 dir-diff = "0.3.2"
+enum-iterator = "0.7.0"
 flate2 = "1.0.22"
 fnv = "1.0.7"
 itertools = "0.10.1"

--- a/runtime/src/account_rent_state.rs
+++ b/runtime/src/account_rent_state.rs
@@ -1,0 +1,165 @@
+use {
+    crate::bank::TransactionAccountRefCell,
+    enum_iterator::IntoEnumIterator,
+    solana_sdk::{account::ReadableAccount, native_loader, rent::Rent, sysvar},
+};
+
+#[derive(Debug, PartialEq, IntoEnumIterator)]
+pub(crate) enum RentState {
+    Uninitialized, // account.lamports == 0
+    NativeOrSysvar,
+    EmptyData,  // account.data.len == 0
+    RentPaying, // 0 < account.lamports < rent-exempt-minimum for non-zero data size
+    RentExempt, // account.lamports >= rent-exempt-minimum for non-zero data size
+}
+
+impl RentState {
+    pub(crate) fn from_account(account: &TransactionAccountRefCell, rent: &Rent) -> Self {
+        let account = account.1.borrow();
+        if account.lamports() == 0 {
+            Self::Uninitialized
+        } else if native_loader::check_id(account.owner()) || sysvar::is_sysvar_id(account.owner())
+        {
+            Self::NativeOrSysvar
+        } else if account.data().is_empty() {
+            Self::EmptyData
+        } else if !rent.is_exempt(account.lamports(), account.data().len()) {
+            Self::RentPaying
+        } else {
+            Self::RentExempt
+        }
+    }
+
+    pub(crate) fn transition_allowed_from(&self, pre_rent_state: &RentState) -> bool {
+        // Only a legacy RentPaying account may end in the RentPaying state after message processing
+        !(self == &Self::RentPaying && pre_rent_state != &Self::RentPaying)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{account::AccountSharedData, pubkey::Pubkey, system_program},
+        std::{cell::RefCell, rc::Rc},
+    };
+
+    #[test]
+    fn test_from_account() {
+        let account_address = Pubkey::new_unique();
+        let program_id = Pubkey::new_unique();
+        let uninitialized_account = Rc::new(RefCell::new(AccountSharedData::new(
+            0,
+            0,
+            &Pubkey::default(),
+        )));
+        let native_program_account = Rc::new(RefCell::new(AccountSharedData::new(
+            1,
+            42,
+            &native_loader::id(),
+        )));
+        let sysvar_account = Rc::new(RefCell::new(AccountSharedData::new(
+            1,
+            42,
+            &sysvar::clock::id(),
+        )));
+        let empty_data_system_account = Rc::new(RefCell::new(AccountSharedData::new(
+            10,
+            0,
+            &system_program::id(),
+        )));
+        let empty_data_other_account =
+            Rc::new(RefCell::new(AccountSharedData::new(10, 0, &program_id)));
+
+        let account_data_size = 100;
+
+        let rent = Rent::free();
+        let rent_exempt_account = Rc::new(RefCell::new(AccountSharedData::new(
+            1,
+            account_data_size,
+            &program_id,
+        ))); // if rent is free, all accounts with non-zero lamports and non-empty data are rent-exempt
+
+        assert_eq!(
+            RentState::from_account(&(account_address, uninitialized_account.clone()), &rent),
+            RentState::Uninitialized
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, native_program_account.clone()), &rent),
+            RentState::NativeOrSysvar
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, sysvar_account.clone()), &rent),
+            RentState::NativeOrSysvar
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, empty_data_system_account.clone()), &rent),
+            RentState::EmptyData
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, empty_data_other_account.clone()), &rent),
+            RentState::EmptyData
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, rent_exempt_account), &rent),
+            RentState::RentExempt
+        );
+
+        let rent = Rent::default();
+        let rent_minimum_balance = rent.minimum_balance(account_data_size);
+        let rent_paying_account = Rc::new(RefCell::new(AccountSharedData::new(
+            rent_minimum_balance.saturating_sub(1),
+            account_data_size,
+            &program_id,
+        )));
+        let rent_exempt_account = Rc::new(RefCell::new(AccountSharedData::new(
+            rent.minimum_balance(account_data_size),
+            account_data_size,
+            &program_id,
+        )));
+
+        assert_eq!(
+            RentState::from_account(&(account_address, uninitialized_account), &rent),
+            RentState::Uninitialized
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, native_program_account), &rent),
+            RentState::NativeOrSysvar
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, sysvar_account), &rent),
+            RentState::NativeOrSysvar
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, empty_data_system_account), &rent),
+            RentState::EmptyData
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, empty_data_other_account), &rent),
+            RentState::EmptyData
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, rent_paying_account), &rent),
+            RentState::RentPaying
+        );
+        assert_eq!(
+            RentState::from_account(&(account_address, rent_exempt_account), &rent),
+            RentState::RentExempt
+        );
+    }
+
+    #[test]
+    fn test_transition_allowed_from() {
+        for post_rent_state in RentState::into_enum_iter() {
+            for pre_rent_state in RentState::into_enum_iter() {
+                if post_rent_state == RentState::RentPaying
+                    && pre_rent_state != RentState::RentPaying
+                {
+                    assert!(!post_rent_state.transition_allowed_from(&pre_rent_state));
+                } else {
+                    assert!(post_rent_state.transition_allowed_from(&pre_rent_state));
+                }
+            }
+        }
+    }
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -232,7 +232,8 @@ impl ExecuteTimings {
 type BankStatusCache = StatusCache<Result<()>>;
 #[frozen_abi(digest = "5Br3PNyyX1L7XoS4jYLt5JTeMXowLSsu7v9LhokC8vnq")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
-type TransactionAccountRefCells = Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>;
+pub(crate) type TransactionAccountRefCell = (Pubkey, Rc<RefCell<AccountSharedData>>);
+type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;
 
 // Eager rent collection repeats in cyclic manner.
 // Each cycle is composed of <partition_count> number of tiny pubkey subranges

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -231,7 +231,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "5Br3PNyyX1L7XoS4jYLt5JTeMXowLSsu7v9LhokC8vnq")]
+#[frozen_abi(digest = "cMyLGdRLBURFNiZCWQT7nm4TtavaF4niwjGeXsNEULq")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 pub(crate) type TransactionAccountRefCell = (Pubkey, Rc<RefCell<AccountSharedData>>);
 type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
+pub mod account_rent_state;
 pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -97,9 +97,9 @@ impl MessageProcessor {
 
             // Fixup the special instructions key if present
             // before the account pre-values are taken care of
-            for (pubkey, accont) in accounts.iter().take(message.account_keys.len()) {
+            for (pubkey, account) in accounts.iter().take(message.account_keys.len()) {
                 if instructions::check_id(pubkey) {
-                    let mut mut_account_ref = accont.borrow_mut();
+                    let mut mut_account_ref = account.borrow_mut();
                     instructions::store_current_index(
                         mut_account_ref.data_as_mut_slice(),
                         instruction_index as u16,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1,3 +1,4 @@
+use crate::bank::TransactionAccountRefCell;
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_program_runtime::{
@@ -7,7 +8,7 @@ use solana_program_runtime::{
     log_collector::LogCollector,
 };
 use solana_sdk::{
-    account::{AccountSharedData, WritableAccount},
+    account::WritableAccount,
     compute_budget::ComputeBudget,
     feature_set::{
         neon_evm_compute_budget, prevent_calling_precompiles_as_programs, requestable_heap_size,
@@ -47,7 +48,7 @@ impl MessageProcessor {
         instruction_processor: &InstructionProcessor,
         message: &Message,
         program_indices: &[Vec<usize>],
-        accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        accounts: &[TransactionAccountRefCell],
         rent: Rent,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
@@ -156,7 +157,7 @@ mod tests {
     use crate::rent_collector::RentCollector;
     use solana_program_runtime::invoke_context::ThisComputeMeter;
     use solana_sdk::{
-        account::ReadableAccount,
+        account::{AccountSharedData, ReadableAccount},
         instruction::{AccountMeta, Instruction, InstructionError},
         keyed_account::keyed_account_at_index,
         message::Message,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -233,6 +233,10 @@ pub mod add_compute_budget_program {
     solana_sdk::declare_id!("4d5AKtxoh93Dwm1vHXUU3iRATuMndx1c431KgT2td52r");
 }
 
+pub mod require_rent_exempt_accounts {
+    solana_sdk::declare_id!("BkFDxiJQWZXGTZaJQxH7wVEHkAmwCgSEVkrvswFfRJPD");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -286,6 +290,7 @@ lazy_static! {
         (requestable_heap_size::id(), "Requestable heap frame size"),
         (disable_fee_calculator::id(), "deprecate fee calculator"),
         (add_compute_budget_program::id(), "Add compute_budget_program"),
+        (require_rent_exempt_accounts::id(), "require all new transaction accounts with data to be rent-exempt"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -122,6 +122,12 @@ pub enum TransactionError {
     /// Transaction loads a writable account that cannot be written
     #[error("Transaction loads a writable account that cannot be written")]
     InvalidWritableAccount,
+
+    /// Transaction leaves an account with a lower balance than rent-exempt minimum
+    #[error(
+        "Transaction leaves an account with data with a lower balance than rent-exempt minimum"
+    )]
+    InvalidRentPayingAccount,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -44,6 +44,7 @@ enum TransactionErrorType {
     WOULD_EXCEED_MAX_BLOCK_COST_LIMIT = 17;
     UNSUPPORTED_VERSION = 18;
     INVALID_WRITABLE_ACCOUNT = 19;
+    INVALID_RENT_PAYING_ACCOUNT = 20;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -553,6 +553,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             17 => TransactionError::WouldExceedMaxBlockCostLimit,
             18 => TransactionError::UnsupportedVersion,
             19 => TransactionError::InvalidWritableAccount,
+            20 => TransactionError::InvalidRentPayingAccount,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -619,6 +620,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::InvalidWritableAccount => {
                     tx_by_addr::TransactionErrorType::InvalidWritableAccount
+                }
+                TransactionError::InvalidRentPayingAccount => {
+                    tx_by_addr::TransactionErrorType::InvalidRentPayingAccount
                 }
             } as i32,
             instruction_error: match transaction_error {


### PR DESCRIPTION
#### Problem
A single epoch's worth of rent for an account with data is too little relative to the costs of storing that data.

#### Summary of Changes
Compare rent-exemption status pre- and post-processing; fail if any end up RentPaying that didn't start that way.
