### PR TITLE
Make cargo-build-bpf clean up after failed installation of bpf-tools

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1400,7 +1400,7 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_noop", 480),
             ("solana_bpf_rust_param_passing", 146),
             ("solana_bpf_rust_rand", 487),
-            ("solana_bpf_rust_sanity", 8397),
+            ("solana_bpf_rust_sanity", 8406),
             ("solana_bpf_rust_secp256k1_recover", 25216),
             ("solana_bpf_rust_sha", 30704),
         ]);


### PR DESCRIPTION
#### Problem

Installation of bpf-tools may fail for multiple reasons leaving the file system in a state that would prevent cargo-build-bpf to work correctly after such a failure.  It's necessary to clean up after such failures removing the directory that cargo-build-bpf might have created and which does not contain a valid installation of bpf-tools.

#### Summary of Changes

Add clean up logic to cargo-build-bpf.
