### PR TITLE
Add `set_root` bank drop logging

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -16,7 +16,6 @@ use std::{
 };
 
 struct SetRootTimings {
-    root: i64,
     total_banks: i64,
     total_squash_cache_ms: i64,
     total_squash_accounts_ms: i64,
@@ -278,7 +277,6 @@ impl BankForks {
         drop_parent_banks_time.stop();
 
         SetRootTimings {
-            root: root as i64,
             total_banks: total_banks as i64,
             total_squash_cache_ms,
             total_squash_accounts_ms,
@@ -308,7 +306,7 @@ impl BankForks {
                 timing::duration_as_ms(&set_root_start.elapsed()) as usize,
                 i64
             ),
-            ("slot", set_root_metrics.root, i64),
+            ("slot", root, i64),
             ("total_banks", set_root_metrics.total_banks, i64),
             (
                 "total_squash_cache_ms",

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -15,6 +15,17 @@ use std::{
     time::Instant,
 };
 
+struct SetRootTimings {
+    root: i64,
+    total_banks: i64,
+    total_squash_cache_ms: i64,
+    total_squash_accounts_ms: i64,
+    total_snapshot_ms: i64,
+    tx_count: i64,
+    prune_non_rooted_ms: i64,
+    drop_parent_banks_ms: i64,
+}
+
 pub struct BankForks {
     banks: HashMap<Slot, Arc<Bank>>,
     descendants: HashMap<Slot, HashSet<Slot>>,
@@ -172,15 +183,14 @@ impl BankForks {
         self[self.highest_slot()].clone()
     }
 
-    pub fn set_root(
+    fn do_set_root_return_metrics(
         &mut self,
         root: Slot,
         accounts_background_request_sender: &AbsRequestSender,
         highest_confirmed_root: Option<Slot>,
-    ) {
+    ) -> SetRootTimings {
         let old_epoch = self.root_bank().epoch();
         self.root = root;
-        let set_root_start = Instant::now();
         let root_bank = self
             .banks
             .get(&root)
@@ -189,9 +199,9 @@ impl BankForks {
         if old_epoch != new_epoch {
             info!(
                 "Root entering
-                epoch: {},
-                next_epoch_start_slot: {},
-                epoch_stakes: {:#?}",
+                    epoch: {},
+                    next_epoch_start_slot: {},
+                    epoch_stakes: {:#?}",
                 new_epoch,
                 root_bank
                     .epoch_schedule()
@@ -223,8 +233,8 @@ impl BankForks {
             {
                 self.last_accounts_hash_slot = bank_slot;
                 let squash_timing = bank.squash();
-                total_squash_accounts_ms += squash_timing.squash_accounts_ms;
-                total_squash_cache_ms += squash_timing.squash_cache_ms;
+                total_squash_accounts_ms += squash_timing.squash_accounts_ms as i64;
+                total_squash_cache_ms += squash_timing.squash_cache_ms as i64;
                 is_root_bank_squashed = bank_slot == root;
 
                 let mut snapshot_time = Measure::start("squash::snapshot_time");
@@ -249,20 +259,48 @@ impl BankForks {
                     }
                 }
                 snapshot_time.stop();
-                total_snapshot_ms += snapshot_time.as_ms();
+                total_snapshot_ms += snapshot_time.as_ms() as i64;
                 break;
             }
         }
         if !is_root_bank_squashed {
             let squash_timing = root_bank.squash();
-            total_squash_accounts_ms += squash_timing.squash_accounts_ms;
-            total_squash_cache_ms += squash_timing.squash_cache_ms;
+            total_squash_accounts_ms += squash_timing.squash_accounts_ms as i64;
+            total_squash_cache_ms += squash_timing.squash_cache_ms as i64;
         }
         let new_tx_count = root_bank.transaction_count();
         let mut prune_time = Measure::start("set_root::prune");
         self.prune_non_rooted(root, highest_confirmed_root);
         prune_time.stop();
 
+        let mut drop_parent_banks_time = Measure::start("set_root::drop_banks");
+        drop(parents);
+        drop_parent_banks_time.stop();
+
+        SetRootTimings {
+            root: root as i64,
+            total_banks: total_banks as i64,
+            total_squash_cache_ms,
+            total_squash_accounts_ms,
+            total_snapshot_ms,
+            tx_count: (new_tx_count - root_tx_count) as i64,
+            prune_non_rooted_ms: prune_time.as_ms() as i64,
+            drop_parent_banks_ms: drop_parent_banks_time.as_ms() as i64,
+        }
+    }
+
+    pub fn set_root(
+        &mut self,
+        root: Slot,
+        accounts_background_request_sender: &AbsRequestSender,
+        highest_confirmed_root: Option<Slot>,
+    ) {
+        let set_root_start = Instant::now();
+        let set_root_metrics = self.do_set_root_return_metrics(
+            root,
+            accounts_background_request_sender,
+            highest_confirmed_root,
+        );
         datapoint_info!(
             "bank-forks_set_root",
             (
@@ -270,13 +308,30 @@ impl BankForks {
                 timing::duration_as_ms(&set_root_start.elapsed()) as usize,
                 i64
             ),
-            ("slot", root, i64),
-            ("total_banks", total_banks, i64),
-            ("total_squash_cache_ms", total_squash_cache_ms, i64),
-            ("total_squash_accounts_ms", total_squash_accounts_ms, i64),
-            ("total_snapshot_ms", total_snapshot_ms, i64),
-            ("tx_count", (new_tx_count - root_tx_count) as usize, i64),
-            ("prune_non_rooted_ms", prune_time.as_ms(), i64),
+            ("slot", set_root_metrics.root, i64),
+            ("total_banks", set_root_metrics.total_banks, i64),
+            (
+                "total_squash_cache_ms",
+                set_root_metrics.total_squash_cache_ms,
+                i64
+            ),
+            (
+                "total_squash_accounts_ms",
+                set_root_metrics.total_squash_accounts_ms,
+                i64
+            ),
+            ("total_snapshot_ms", set_root_metrics.total_snapshot_ms, i64),
+            ("tx_count", set_root_metrics.tx_count, i64),
+            (
+                "prune_non_rooted_ms",
+                set_root_metrics.prune_non_rooted_ms,
+                i64
+            ),
+            (
+                "drop_parent_banks_ms",
+                set_root_metrics.drop_parent_banks_ms,
+                i64
+            ),
         );
     }
 


### PR DESCRIPTION
#### Problem
Any slow bank cleanup that happens when the `Bank` is deallocated at the end of `set_root` will not be captured by the `bank-forks_set_root` metric
  
#### Summary of Changes
Wrap the entire call to 
Fixes #
