### PR TITLE
[Explorer] Added a Supply check to confirm if a SPL Token is a Metaplex NFT or not

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -54,7 +54,7 @@ export function TokenAccountSection({
       case "mint": {
         const info = create(tokenAccount.info, MintAccountInfo);
 
-        if (isMetaplexNFT(account.details?.data, info.decimals)) {
+        if (isMetaplexNFT(account.details?.data, info)) {
           return (
             <NonFungibleTokenMintAccountCard
               account={account}

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -166,7 +166,7 @@ export function AccountHeader({
   const data = account?.details?.data;
   const isToken = data?.program === "spl-token" && data?.parsed.type === "mint";
 
-  if (isMetaplexNFT(data, mintInfo?.decimals)) {
+  if (isMetaplexNFT(data, mintInfo)) {
     return (
       <NFTHeader
         nftData={(data as TokenProgramData).nftData!}

--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -1,10 +1,15 @@
+import { MintAccountInfo } from "validators/accounts/token";
 import { ProgramData } from "..";
 
-export default function isMetaplexNFT(data?: ProgramData, decimals?: number) {
+export default function isMetaplexNFT(
+  data?: ProgramData,
+  mintInfo?: MintAccountInfo
+) {
   return (
     data?.program === "spl-token" &&
     data?.parsed.type === "mint" &&
     data?.nftData &&
-    decimals === 0
+    mintInfo?.decimals === 0 &&
+    parseInt(mintInfo.supply) === 1
   );
 }


### PR DESCRIPTION
#### Problem

Checking if a SPL Token was a Metaplex NFT was a bit busted since it only checked if `decimals` was 0.

#### Summary of Changes

Add a check for `supply` is 1 in addition to the `decimals` is 0.

_Tested with the SolDoge Token found [here](https://explorer.solana.com/address/8ymi88q5DtmdNTn2sPRNFkvMkszMHuLJ1e3RVdWjPa3s)._

**After change**

![Screen Shot 2021-11-02 at 8 22 52 PM](https://user-images.githubusercontent.com/3758645/140006217-2ccba1d1-33ba-4289-bcaa-d0293c6fe5ce.png)


**Before change**

![Screen Shot 2021-11-02 at 8 23 08 PM](https://user-images.githubusercontent.com/3758645/140006216-c535d9bc-fdb7-4c7d-86c0-b7041a06b334.png)


