### PR TITLE
Typo in web3 README (production bundle was labeled as un-minified)

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -45,7 +45,7 @@ $ npm install --save @solana/web3.js
 <!-- Development (un-minified) -->
 <script src="https://unpkg.com/@solana/web3.js@latest/lib/index.iife.js"></script>
 
-<!-- Production (un-minified) -->
+<!-- Production (minified) -->
 <script src="https://unpkg.com/@solana/web3.js@latest/lib/index.iife.min.js"></script>
 ```
 


### PR DESCRIPTION
#### Problem
Web3 README had the production browser bundle labeled as un-minified when it was minified. Quick and easy fix

#### Summary of Changes
- Changed Production (un-minified) to Production (minified)

Thanks guys. 