### PR TITLE
Remove empty lib to avoid name collision with entry package

### DIFF
--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -29,9 +29,5 @@ systemstat = "0.1.10"
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.9.0" }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_entry"
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client-test/src/lib.rs
+++ b/client-test/src/lib.rs
@@ -1,1 +1,0 @@
-// This is a test-only crate

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -30,9 +30,5 @@ tokio = { version = "1", features = ["full"] }
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.9.0" }
 
-[lib]
-crate-type = ["lib"]
-name = "solana_entry"
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/rpc-test/src/lib.rs
+++ b/rpc-test/src/lib.rs
@@ -1,1 +1,0 @@
-// This is a test-only crate


### PR DESCRIPTION
#### Problem
Saw the following warnings building `master` recently:
```
$ cargo build
warning: output filename collision.
The lib target `solana_entry` in package `solana-entry v1.9.0 (/.../solana/entry)` has the same output filename as the lib target `solana_entry` in package `solana-client-test v1.9.0 (/.../solana/client-test)`.
Colliding filename is: /.../solana/target/debug/libsolana_entry.rlib
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: output filename collision.
The lib target `solana_entry` in package `solana-rpc-test v1.9.0 (/.../solana/rpc-test)` has the same output filename as the lib target `solana_entry` in package `solana-entry v1.9.0 (/.../solana/entry)`.
Colliding filename is: /.../solana/target/debug/libsolana_entry.rlib
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```
#### Summary of Changes
- Removes the `lib` target from Cargo.toml files
- Remove `src/lib.rs` file as these are empty aside from a comment saying they are empty.

These still build and `cargo test` still runs the tests in these folders, so I don't see any reason to keep the `src/lib` files around, but someone please correct me if I'm mistaken. If there is a reason to keep the `lib`'s around, then we should at the very least rename them to avoid the collision.
