### PR TITLE
Add stats subcmd to ledger-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5082,6 +5082,7 @@ dependencies = [
  "solana-entry",
  "solana-ledger",
  "solana-logger 1.9.0",
+ "solana-measure",
  "solana-runtime",
  "solana-sdk",
  "solana-stake-program",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -28,6 +28,7 @@ solana-core = { path = "../core", version = "=1.9.0" }
 solana-entry = { path = "../entry", version = "=1.9.0" }
 solana-ledger = { path = "../ledger", version = "=1.9.0" }
 solana-logger = { path = "../logger", version = "=1.9.0" }
+solana-measure = { path = "../measure", version = "=1.9.0" }
 solana-runtime = { path = "../runtime", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.9.0" }


### PR DESCRIPTION
The stats subcommand gets total accounts stats by scanning all the
accounts in a bank.

Here's an example of what would be printed at the end:

```
TotalAccountsStats {
    num_accounts: 3716396,
    data_len: 91398670325,
    num_executable_accounts: 2674,
    executable_data_len: 131024153,
}
```
