### PR TITLE
Web3.js: added maxRetries option to SendOptions

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3670,8 +3670,6 @@ export class Connection {
     const preflightCommitment =
       (options && options.preflightCommitment) || this.commitment;
 
-    const maxRetries = options && options.maxRetries;
-
     if (options && options.maxRetries) {
       config.maxRetries = maxRetries;
     }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3672,7 +3672,7 @@ export class Connection {
 
     const maxRetries = options && options.maxRetries;
 
-    if (maxRetries) {
+    if (!isNaN(maxRetries)) {
       config.maxRetries = maxRetries;
     }
     if (skipPreflight) {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -99,6 +99,8 @@ export type SendOptions = {
   skipPreflight?: boolean;
   /** preflight commitment level */
   preflightCommitment?: Commitment;
+  /** Maximum number of times for the RPC node to retry sending the transaction to the leader*/
+  maxRetries?: Number;
 };
 
 /**
@@ -111,6 +113,8 @@ export type ConfirmOptions = {
   commitment?: Commitment;
   /** preflight commitment level */
   preflightCommitment?: Commitment;
+  /** Maximum number of times for the RPC node to retry sending the transaction to the leader */
+  maxRetries?: Number;
 };
 
 /**
@@ -3666,6 +3670,11 @@ export class Connection {
     const preflightCommitment =
       (options && options.preflightCommitment) || this.commitment;
 
+    const maxRetries = options && options.maxRetries;
+
+    if (maxRetries) {
+      config.maxRetries = maxRetries;
+    }
     if (skipPreflight) {
       config.skipPreflight = skipPreflight;
     }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3671,7 +3671,7 @@ export class Connection {
       (options && options.preflightCommitment) || this.commitment;
 
     if (options && options.maxRetries) {
-      config.maxRetries = maxRetries;
+      config.maxRetries = options.maxRetries;
     }
     if (skipPreflight) {
       config.skipPreflight = skipPreflight;
@@ -3679,7 +3679,6 @@ export class Connection {
     if (preflightCommitment) {
       config.preflightCommitment = preflightCommitment;
     }
-
     const args = [encodedTransaction, config];
     const unsafeRes = await this._rpcRequest('sendTransaction', args);
     const res = create(unsafeRes, SendTransactionRpcResult);

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3672,7 +3672,7 @@ export class Connection {
 
     const maxRetries = options && options.maxRetries;
 
-    if (!isNaN(maxRetries)) {
+    if (options && options.maxRetries) {
       config.maxRetries = maxRetries;
     }
     if (skipPreflight) {

--- a/web3.js/src/util/send-and-confirm-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-transaction.ts
@@ -24,6 +24,7 @@ export async function sendAndConfirmTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
+    maxRetries: options.maxRetries,
   };
 
   const signature = await connection.sendTransaction(


### PR DESCRIPTION
This pull request implements a solution for issue #21071 

#### Problem (by @brianlong) 
There are certain use-cases, like NFT drops, where the default RPC retry behavior is counterproductive. NFT drops are designed to sell out quickly. After that point, 100% of transactions will fail and we do not want to retry TXs.

Developers should have the option to designate the max number of retries when submitting a TX. The sendTransaction RPC API method includes a maxRetries parameter, but that parameter is not present in Web3.js SendOptions.


#### Summary of Changes
- Added maxRetries parameter to SendOptions
- Added logic to sendEncodedTransaction that adds maxRetries to the rpc request config if available. 
- Added maxRetries parameter to ConfirmOptions for use in sendAndConfirmTransaction and sendAndConfirmRawTransaction


```javascript
  // Sign transaction, broadcast, and confirm
  const signature = await web3.sendAndConfirmTransaction(
    connection,
    transaction,
    [from],
    {
      maxRetries: 5, // Maximum number of times for the RPC node to retry sending the transaction to the leader 
    },
  );

```
@CriesofCarrots for visibility 
