### PR TITLE
Unchecked integer arithmetic in program-runtime-crate

### DIFF
--- a/program-runtime/src/instruction_processor.rs
+++ b/program-runtime/src/instruction_processor.rs
@@ -58,14 +58,20 @@ pub struct ExecuteDetailsTimings {
 }
 impl ExecuteDetailsTimings {
     pub fn accumulate(&mut self, other: &ExecuteDetailsTimings) {
-        self.serialize_us += other.serialize_us;
-        self.create_vm_us += other.create_vm_us;
-        self.execute_us += other.execute_us;
-        self.deserialize_us += other.deserialize_us;
-        self.changed_account_count += other.changed_account_count;
-        self.total_account_count += other.total_account_count;
-        self.total_data_size += other.total_data_size;
-        self.data_size_changed += other.data_size_changed;
+        self.serialize_us = self.serialize_us.saturating_add(other.serialize_us);
+        self.create_vm_us = self.create_vm_us.saturating_add(other.create_vm_us);
+        self.execute_us = self.execute_us.saturating_add(other.execute_us);
+        self.deserialize_us = self.deserialize_us.saturating_add(other.deserialize_us);
+        self.changed_account_count = self
+            .changed_account_count
+            .saturating_add(other.changed_account_count);
+        self.total_account_count = self
+            .total_account_count
+            .saturating_add(other.total_account_count);
+        self.total_data_size = self.total_data_size.saturating_add(other.total_data_size);
+        self.data_size_changed = self
+            .data_size_changed
+            .saturating_add(other.data_size_changed);
         for (id, other) in &other.per_program_timings {
             let program_timing = self.per_program_timings.entry(*id).or_default();
             program_timing.accumulated_us = program_timing
@@ -209,8 +215,8 @@ impl PreAccount {
         }
 
         if outermost_call {
-            timings.total_account_count += 1;
-            timings.total_data_size += post.data().len();
+            timings.total_account_count = timings.total_account_count.saturating_add(1);
+            timings.total_data_size = timings.total_data_size.saturating_add(post.data().len());
             if owner_changed
                 || lamports_changed
                 || data_len_changed
@@ -218,8 +224,9 @@ impl PreAccount {
                 || rent_epoch_changed
                 || self.changed
             {
-                timings.changed_account_count += 1;
-                timings.data_size_changed += post.data().len();
+                timings.changed_account_count = timings.changed_account_count.saturating_add(1);
+                timings.data_size_changed =
+                    timings.data_size_changed.saturating_add(post.data().len());
             }
         }
 

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
-#![allow(clippy::integer_arithmetic)] // TODO: Remove
 
 pub mod instruction_processor;
 pub mod instruction_recorder;

--- a/program-runtime/src/log_collector.rs
+++ b/program-runtime/src/log_collector.rs
@@ -17,14 +17,14 @@ pub struct LogCollector {
 impl LogCollector {
     pub fn log(&self, message: &str) {
         let mut inner = self.inner.borrow_mut();
-
-        if inner.bytes_written + message.len() >= LOG_MESSAGES_BYTES_LIMIT {
+        let bytes_written = inner.bytes_written.saturating_add(message.len());
+        if bytes_written >= LOG_MESSAGES_BYTES_LIMIT {
             if !inner.limit_warning {
                 inner.limit_warning = true;
                 inner.messages.push(String::from("Log truncated"));
             }
         } else {
-            inner.bytes_written += message.len();
+            inner.bytes_written = bytes_written;
             inner.messages.push(message.to_string());
         }
     }


### PR DESCRIPTION
#### Problem
Crate wide `#![allow(clippy::integer_arithmetic)]` in the program-runtime.

#### Summary of Changes
Replaces unchecked integer arithmetic by guarded versions. 

Fixes #
