### PR TITLE
Encapsulate QoS Service metrics reporting within service itself

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -8,6 +8,7 @@ use log::*;
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana_core::banking_stage::{BankingStage, BankingStageStats};
+use solana_core::qos_service::QosService;
 use solana_entry::entry::{next_hash, Entry};
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_gossip::cluster_info::Node;
@@ -93,7 +94,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
-                &Arc::new(RwLock::new(CostModel::default())),
+                &Arc::new(QosService::new(Arc::new(RwLock::new(CostModel::default())))),
             );
         });
 


### PR DESCRIPTION
#### Problem
`banking_stage` creates `qos_service_stats` object, passing it to `qos_service` APIs as `&mut` parameter to be updated, then reported by `banking_stage`. This flow is messy, `banking_stage` unnecessarily taking ownership of `qos_service_stats`, which should be a private property of `qos_service`.

#### Summary of Changes
- encapsulate `qos_service_metrics` within `qos_service`
- spawn a service thread to call `datapoint_info` based on a timer
- remove dead cost-tracker related stats from `banking_stage`


Fixes #
