### PR TITLE
Accept only decimal digits in file names inside snapshot

### DIFF
--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -346,7 +346,7 @@ fn all_digits(v: &str) -> bool {
         return false;
     }
     for x in v.chars() {
-        if !x.is_numeric() {
+        if !x.is_digit(10) {
             return false;
         }
     }
@@ -357,7 +357,7 @@ fn like_storage(v: &str) -> bool {
     let mut periods = 0;
     let mut saw_numbers = false;
     for x in v.chars() {
-        if !x.is_numeric() {
+        if !x.is_digit(10) {
             if x == '.' {
                 if periods > 0 || !saw_numbers {
                     return false;
@@ -522,6 +522,10 @@ mod tests {
             tar::EntryType::Directory
         ));
         assert!(!is_valid_snapshot_archive_entry(
+            &["snapshots", "①"],
+            tar::EntryType::Directory
+        ));
+        assert!(!is_valid_snapshot_archive_entry(
             &["snapshots", "0", "aa"],
             tar::EntryType::Regular
         ));
@@ -565,6 +569,10 @@ mod tests {
         ));
         assert!(!is_valid_snapshot_archive_entry(
             &["accounts", "232323"],
+            tar::EntryType::Regular
+        ));
+        assert!(!is_valid_snapshot_archive_entry(
+            &["accounts", "৬.¾"],
             tar::EntryType::Regular
         ));
     }


### PR DESCRIPTION
This also should make snapshot validation a bit faster.

#### Problem

`is_numeric()` considers a lot of non-ASCII characters as "numeric".

#### Summary of Changes

Replace `is_numeric()` with `is_digit(10)`.