### PR TITLE
removes redundant args from Shredder::try_recovery

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -148,14 +148,7 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
         true, // is_last_in_slot
     );
     bencher.iter(|| {
-        Shredder::try_recovery(
-            coding_shreds[..].to_vec(),
-            symbol_count,
-            symbol_count,
-            0, // first index
-            1, // slot
-        )
-        .unwrap();
+        Shredder::try_recovery(coding_shreds[..].to_vec()).unwrap();
     })
 }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -725,13 +725,7 @@ impl Blockstore {
             code_cf,
         );
 
-        if let Ok(mut result) = Shredder::try_recovery(
-            available_shreds,
-            erasure_meta.config.num_data(),
-            erasure_meta.config.num_coding(),
-            set_index as usize,
-            slot,
-        ) {
+        if let Ok(mut result) = Shredder::try_recovery(available_shreds) {
             Self::submit_metrics(
                 slot,
                 set_index,

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -72,14 +72,7 @@ fn test_multi_fec_block_coding() {
             .filter_map(|(i, b)| if i % 2 != 0 { Some(b.clone()) } else { None })
             .collect();
 
-        let recovered_data = Shredder::try_recovery(
-            shred_info.clone(),
-            MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
-            MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
-            shred_start_index,
-            slot,
-        )
-        .unwrap();
+        let recovered_data = Shredder::try_recovery(shred_info.clone()).unwrap();
 
         for (i, recovered_shred) in recovered_data.into_iter().enumerate() {
             let index = shred_start_index + (i * 2);
@@ -122,17 +115,13 @@ fn test_multi_fec_block_different_size_coding() {
         let first_data_index = fec_data_shreds.first().unwrap().index() as usize;
         let first_code_index = fec_coding_shreds.first().unwrap().index() as usize;
         assert_eq!(first_data_index, first_code_index);
-        let num_data = fec_data_shreds.len();
-        let num_coding = fec_coding_shreds.len();
         let all_shreds: Vec<Shred> = fec_data_shreds
             .iter()
             .step_by(2)
             .chain(fec_coding_shreds.iter().step_by(2))
             .cloned()
             .collect();
-        let recovered_data =
-            Shredder::try_recovery(all_shreds, num_data, num_coding, first_data_index, slot)
-                .unwrap();
+        let recovered_data = Shredder::try_recovery(all_shreds).unwrap();
         // Necessary in order to ensure the last shred in the slot
         // is part of the recovered set, and that the below `index`
         // calcuation in the loop is correct


### PR DESCRIPTION
#### Problem
`Shredder::try_recovery` is taking a `Vec<Shred>`. All other arguments are
already embedded in the shreds.

#### Summary of Changes
* removed the extra args, simplifying the interface for upcoming erasure coding changes.
* added debug sanity checks for slot and fec parameters.