### PR TITLE
Add new IncrementalSnapshotHashes to CRDS

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,5 +1,5 @@
 use solana_gossip::cluster_info::{
-    ClusterInfo, MAX_INCREMENTAL_SNAPSHOT_HASHES, MAX_SNAPSHOT_HASHES,
+    ClusterInfo, MAX_LEGACY_INCREMENTAL_SNAPSHOT_HASHES, MAX_SNAPSHOT_HASHES,
 };
 use solana_perf::thread::renice_this_thread;
 use solana_runtime::{
@@ -42,7 +42,7 @@ impl SnapshotPackagerService {
             snapshot_config.maximum_full_snapshot_archives_to_retain,
         );
         let max_incremental_snapshot_hashes = std::cmp::min(
-            MAX_INCREMENTAL_SNAPSHOT_HASHES,
+            MAX_LEGACY_INCREMENTAL_SNAPSHOT_HASHES,
             snapshot_config.maximum_incremental_snapshot_archives_to_retain,
         );
 
@@ -195,7 +195,7 @@ impl SnapshotGossipManager {
         // Check to see what changed in `push_incremental_snapshot_hashes()` and handle the new
         // error condition here.
         self.cluster_info
-            .push_incremental_snapshot_hashes(
+            .push_legacy_incremental_snapshot_hashes(
                 self.incremental_snapshot_hashes.base,
                 self.incremental_snapshot_hashes.hashes.clone(),
             )

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -498,6 +498,17 @@ pub(crate) fn submit_gossip_stats(
             crds_stats.pull.counts[10],
             i64
         ),
+        ("IncrementalSnapshotHashes", counts[11], i64),
+        (
+            "IncrementalSnapshotHashes-push",
+            crds_stats.push.counts[11],
+            i64
+        ),
+        (
+            "IncrementalSnapshotHashes-pull",
+            crds_stats.pull.counts[11],
+            i64
+        ),
         ("all", counts.iter().sum::<usize>(), i64),
         (
             "all-push",
@@ -558,6 +569,17 @@ pub(crate) fn submit_gossip_stats(
         (
             "LegacyIncrementalSnapshotHashes-pull",
             crds_stats.pull.fails[10],
+            i64
+        ),
+        ("IncrementalSnapshotHashes", fails[11], i64),
+        (
+            "IncrementalSnapshotHashes-push",
+            crds_stats.push.fails[11],
+            i64
+        ),
+        (
+            "IncrementalSnapshotHashes-pull",
+            crds_stats.pull.fails[11],
             i64
         ),
         ("all", fails.iter().sum::<usize>(), i64),

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -487,14 +487,14 @@ pub(crate) fn submit_gossip_stats(
         ("DuplicateShred", counts[9], i64),
         ("DuplicateShred-push", crds_stats.push.counts[9], i64),
         ("DuplicateShred-pull", crds_stats.pull.counts[9], i64),
-        ("IncrementalSnapshotHashes", counts[10], i64),
+        ("LegacyIncrementalSnapshotHashes", counts[10], i64),
         (
-            "IncrementalSnapshotHashes-push",
+            "LegacyIncrementalSnapshotHashes-push",
             crds_stats.push.counts[10],
             i64
         ),
         (
-            "IncrementalSnapshotHashes-pull",
+            "LegacyIncrementalSnapshotHashes-pull",
             crds_stats.pull.counts[10],
             i64
         ),
@@ -549,14 +549,14 @@ pub(crate) fn submit_gossip_stats(
         ("DuplicateShred", fails[9], i64),
         ("DuplicateShred-push", crds_stats.push.fails[9], i64),
         ("DuplicateShred-pull", crds_stats.pull.fails[9], i64),
-        ("IncrementalSnapshotHashes", fails[10], i64),
+        ("LegacyIncrementalSnapshotHashes", fails[10], i64),
         (
-            "IncrementalSnapshotHashes-push",
+            "LegacyIncrementalSnapshotHashes-push",
             crds_stats.push.fails[10],
             i64
         ),
         (
-            "IncrementalSnapshotHashes-pull",
+            "LegacyIncrementalSnapshotHashes-pull",
             crds_stats.pull.fails[10],
             i64
         ),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -91,7 +91,7 @@ pub enum GossipRoute {
     PushMessage,
 }
 
-type CrdsCountsArray = [usize; 11];
+type CrdsCountsArray = [usize; 12];
 
 pub(crate) struct CrdsDataStats {
     pub(crate) counts: CrdsCountsArray,
@@ -653,6 +653,7 @@ impl CrdsDataStats {
             CrdsData::NodeInstance(_) => 8,
             CrdsData::DuplicateShred(_, _) => 9,
             CrdsData::LegacyIncrementalSnapshotHashes(_) => 10,
+            CrdsData::IncrementalSnapshotHashes(_) => 11,
         }
     }
 }

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -652,7 +652,7 @@ impl CrdsDataStats {
             CrdsData::Version(_) => 7,
             CrdsData::NodeInstance(_) => 8,
             CrdsData::DuplicateShred(_, _) => 9,
-            CrdsData::IncrementalSnapshotHashes(_) => 10,
+            CrdsData::LegacyIncrementalSnapshotHashes(_) => 10,
         }
     }
 }

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -3,7 +3,7 @@ use {
         contact_info::ContactInfo,
         crds::VersionedCrdsValue,
         crds_value::{
-            CrdsData, CrdsValue, CrdsValueLabel, IncrementalSnapshotHashes, LegacyVersion,
+            CrdsData, CrdsValue, CrdsValueLabel, LegacyIncrementalSnapshotHashes, LegacyVersion,
             LowestSlot, SnapshotHashes, Version,
         },
     },
@@ -58,9 +58,9 @@ impl_crds_entry!(LegacyVersion, CrdsData::LegacyVersion(version), version);
 impl_crds_entry!(LowestSlot, CrdsData::LowestSlot(_, slot), slot);
 impl_crds_entry!(Version, CrdsData::Version(version), version);
 impl_crds_entry!(
-    IncrementalSnapshotHashes,
-    CrdsData::IncrementalSnapshotHashes(incremental_snapshot_hashes),
-    incremental_snapshot_hashes
+    LegacyIncrementalSnapshotHashes,
+    CrdsData::LegacyIncrementalSnapshotHashes(legacy_incremental_snapshot_hashes),
+    legacy_incremental_snapshot_hashes
 );
 
 impl<'a, 'b> CrdsEntry<'a, 'b> for &'a SnapshotHashes {
@@ -127,8 +127,11 @@ mod tests {
                 CrdsData::SnapshotHashes(hash) => {
                     assert_eq!(crds.get::<&SnapshotHashes>(key), Some(hash))
                 }
-                CrdsData::IncrementalSnapshotHashes(hash) => {
-                    assert_eq!(crds.get::<&IncrementalSnapshotHashes>(key), Some(hash))
+                CrdsData::LegacyIncrementalSnapshotHashes(hash) => {
+                    assert_eq!(
+                        crds.get::<&LegacyIncrementalSnapshotHashes>(key),
+                        Some(hash)
+                    )
                 }
                 _ => (),
             }

--- a/gossip/src/crds_entry.rs
+++ b/gossip/src/crds_entry.rs
@@ -3,8 +3,8 @@ use {
         contact_info::ContactInfo,
         crds::VersionedCrdsValue,
         crds_value::{
-            CrdsData, CrdsValue, CrdsValueLabel, LegacyIncrementalSnapshotHashes, LegacyVersion,
-            LowestSlot, SnapshotHashes, Version,
+            CrdsData, CrdsValue, CrdsValueLabel, IncrementalSnapshotHashes,
+            LegacyIncrementalSnapshotHashes, LegacyVersion, LowestSlot, SnapshotHashes, Version,
         },
     },
     indexmap::IndexMap,
@@ -61,6 +61,11 @@ impl_crds_entry!(
     LegacyIncrementalSnapshotHashes,
     CrdsData::LegacyIncrementalSnapshotHashes(legacy_incremental_snapshot_hashes),
     legacy_incremental_snapshot_hashes
+);
+impl_crds_entry!(
+    IncrementalSnapshotHashes,
+    CrdsData::IncrementalSnapshotHashes(incremental_snapshot_hashes),
+    incremental_snapshot_hashes
 );
 
 impl<'a, 'b> CrdsEntry<'a, 'b> for &'a SnapshotHashes {
@@ -132,6 +137,9 @@ mod tests {
                         crds.get::<&LegacyIncrementalSnapshotHashes>(key),
                         Some(hash)
                     )
+                }
+                CrdsData::IncrementalSnapshotHashes(hash) => {
+                    assert_eq!(crds.get::<&IncrementalSnapshotHashes>(key), Some(hash))
                 }
                 _ => (),
             }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -91,7 +91,7 @@ pub enum CrdsData {
     Version(Version),
     NodeInstance(NodeInstance),
     DuplicateShred(DuplicateShredIndex, DuplicateShred),
-    IncrementalSnapshotHashes(IncrementalSnapshotHashes),
+    LegacyIncrementalSnapshotHashes(LegacyIncrementalSnapshotHashes),
 }
 
 impl Sanitize for CrdsData {
@@ -128,7 +128,7 @@ impl Sanitize for CrdsData {
                     shred.sanitize()
                 }
             }
-            CrdsData::IncrementalSnapshotHashes(val) => val.sanitize(),
+            CrdsData::LegacyIncrementalSnapshotHashes(val) => val.sanitize(),
         }
     }
 }
@@ -208,14 +208,14 @@ impl SnapshotHashes {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, AbiExample)]
-pub struct IncrementalSnapshotHashes {
+pub struct LegacyIncrementalSnapshotHashes {
     pub from: Pubkey,
     pub base: (Slot, Hash),
     pub hashes: Vec<(Slot, Hash)>,
     pub wallclock: u64,
 }
 
-impl Sanitize for IncrementalSnapshotHashes {
+impl Sanitize for LegacyIncrementalSnapshotHashes {
     fn sanitize(&self) -> Result<(), SanitizeError> {
         sanitize_wallclock(self.wallclock)?;
         if self.base.0 >= MAX_SLOT {
@@ -496,7 +496,7 @@ pub enum CrdsValueLabel {
     Version(Pubkey),
     NodeInstance(Pubkey),
     DuplicateShred(DuplicateShredIndex, Pubkey),
-    IncrementalSnapshotHashes(Pubkey),
+    LegacyIncrementalSnapshotHashes(Pubkey),
 }
 
 impl fmt::Display for CrdsValueLabel {
@@ -512,8 +512,8 @@ impl fmt::Display for CrdsValueLabel {
             CrdsValueLabel::Version(_) => write!(f, "Version({})", self.pubkey()),
             CrdsValueLabel::NodeInstance(pk) => write!(f, "NodeInstance({})", pk),
             CrdsValueLabel::DuplicateShred(ix, pk) => write!(f, "DuplicateShred({}, {})", ix, pk),
-            CrdsValueLabel::IncrementalSnapshotHashes(_) => {
-                write!(f, "IncrementalSnapshotHashes({})", self.pubkey())
+            CrdsValueLabel::LegacyIncrementalSnapshotHashes(_) => {
+                write!(f, "LegacyIncrementalSnapshotHashes({})", self.pubkey())
             }
         }
     }
@@ -532,7 +532,7 @@ impl CrdsValueLabel {
             CrdsValueLabel::Version(p) => *p,
             CrdsValueLabel::NodeInstance(p) => *p,
             CrdsValueLabel::DuplicateShred(_, p) => *p,
-            CrdsValueLabel::IncrementalSnapshotHashes(p) => *p,
+            CrdsValueLabel::LegacyIncrementalSnapshotHashes(p) => *p,
         }
     }
 }
@@ -581,7 +581,7 @@ impl CrdsValue {
             CrdsData::Version(version) => version.wallclock,
             CrdsData::NodeInstance(node) => node.wallclock,
             CrdsData::DuplicateShred(_, shred) => shred.wallclock,
-            CrdsData::IncrementalSnapshotHashes(hash) => hash.wallclock,
+            CrdsData::LegacyIncrementalSnapshotHashes(hash) => hash.wallclock,
         }
     }
     pub fn pubkey(&self) -> Pubkey {
@@ -596,7 +596,7 @@ impl CrdsValue {
             CrdsData::Version(version) => version.from,
             CrdsData::NodeInstance(node) => node.from,
             CrdsData::DuplicateShred(_, shred) => shred.from,
-            CrdsData::IncrementalSnapshotHashes(hash) => hash.from,
+            CrdsData::LegacyIncrementalSnapshotHashes(hash) => hash.from,
         }
     }
     pub fn label(&self) -> CrdsValueLabel {
@@ -611,8 +611,8 @@ impl CrdsValue {
             CrdsData::Version(_) => CrdsValueLabel::Version(self.pubkey()),
             CrdsData::NodeInstance(node) => CrdsValueLabel::NodeInstance(node.from),
             CrdsData::DuplicateShred(ix, shred) => CrdsValueLabel::DuplicateShred(*ix, shred.from),
-            CrdsData::IncrementalSnapshotHashes(_) => {
-                CrdsValueLabel::IncrementalSnapshotHashes(self.pubkey())
+            CrdsData::LegacyIncrementalSnapshotHashes(_) => {
+                CrdsValueLabel::LegacyIncrementalSnapshotHashes(self.pubkey())
             }
         }
     }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1224,7 +1224,7 @@ mod with_incremental_snapshots {
 
                 // Then get the Crds::IncrementalSnapshotHashes for each trusted validator and add
                 // them as the values in the trusted snapshot hashes HashMap.
-                if let Some(crds_value::IncrementalSnapshotHashes {base: full_snapshot_hash, hashes: incremental_snapshot_hashes, ..}) = cluster_info.get_incremental_snapshot_hashes_for_node(trusted_validator) {
+                if let Some(crds_value::LegacyIncrementalSnapshotHashes {base: full_snapshot_hash, hashes: incremental_snapshot_hashes, ..}) = cluster_info.get_legacy_incremental_snapshot_hashes_for_node(trusted_validator) {
                     if let Some(hashes) = trusted_snapshot_hashes.get_mut(&full_snapshot_hash) {
                         // Do not add this hash if there's already an incremental snapshot hash
                         // with the same slot, but with a _different_ hash.
@@ -1650,9 +1650,9 @@ mod with_incremental_snapshots {
         peer: &Pubkey,
     ) -> Option<SnapshotHash> {
         cluster_info
-            .get_incremental_snapshot_hashes_for_node(peer)
+            .get_legacy_incremental_snapshot_hashes_for_node(peer)
             .map(
-                |crds_value::IncrementalSnapshotHashes { base, hashes, .. }| {
+                |crds_value::LegacyIncrementalSnapshotHashes { base, hashes, .. }| {
                     let highest_incremental_snapshot_hash = hashes.into_iter().max();
                     SnapshotHash {
                         full: base,


### PR DESCRIPTION
- Rename IncrementalSnapshotHashes to LegacyIncrementalSnapshotHashes
- Add new IncrementalSnapshotHashes

#### Problem

Per the discussion in #21130, `IncrementalSnapshotHashes.base` needs to include the _block height_ in order for bootstrap to operate usefully (when incremental snapshots are enabled and common in the network). However, block height is not included yet.

#### Summary of Changes

* Rename the current `IncrementalSnapshotHashes` to `LegacyIncrementalSnapshotHashes`
* Add new CRDS type called `IncrementalSnapshotHashes`, which has a block height field in `base`

Note that this purposely does _not_ make changes to bootstrap _nor_ SnapshotPackagerService.
