### PR TITLE
add new macro: `pubkey!`

### DIFF
--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -93,6 +93,36 @@ fn deprecated_id_to_tokens(
     });
 }
 
+struct SdkPubkey(proc_macro2::TokenStream);
+
+impl Parse for SdkPubkey {
+    fn parse(input: ParseStream) -> Result<Self> {
+        parse_id(input, quote! { ::solana_sdk::pubkey::Pubkey }).map(Self)
+    }
+}
+
+impl ToTokens for SdkPubkey {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let id = &self.0;
+        tokens.extend(quote! {#id})
+    }
+}
+
+struct ProgramSdkPubkey(proc_macro2::TokenStream);
+
+impl Parse for ProgramSdkPubkey {
+    fn parse(input: ParseStream) -> Result<Self> {
+        parse_id(input, quote! { ::solana_program::pubkey::Pubkey }).map(Self)
+    }
+}
+
+impl ToTokens for ProgramSdkPubkey {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let id = &self.0;
+        tokens.extend(quote! {#id})
+    }
+}
+
 struct Id(proc_macro2::TokenStream);
 
 impl Parse for Id {
@@ -211,6 +241,18 @@ pub fn respan(input: TokenStream) -> TokenStream {
         })
         .collect();
     TokenStream::from(to_respan)
+}
+
+#[proc_macro]
+pub fn pubkey(input: TokenStream) -> TokenStream {
+    let id = parse_macro_input!(input as SdkPubkey);
+    TokenStream::from(quote! {#id})
+}
+
+#[proc_macro]
+pub fn program_pubkey(input: TokenStream) -> TokenStream {
+    let id = parse_macro_input!(input as ProgramSdkPubkey);
+    TokenStream::from(quote! {#id})
 }
 
 #[proc_macro]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -63,22 +63,6 @@ pub mod vote {
     }
 }
 
-/// Convenience macro to define a static public key
-///
-/// Input: a single literal base58 string representation of a Pubkey
-///
-/// # Example
-///
-/// ```
-/// use std::str::FromStr;
-/// use solana_program::{pubkey, pubkey::Pubkey};
-///
-/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
-///
-/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
-/// assert_eq!(ID, my_id);
-/// ```
-pub use solana_sdk_macro::program_pubkey as pubkey;
 /// Same as `declare_id` except report that this id has been deprecated
 pub use solana_sdk_macro::program_declare_deprecated_id as declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it
@@ -103,6 +87,22 @@ pub use solana_sdk_macro::program_declare_deprecated_id as declare_deprecated_id
 /// assert_eq!(id(), my_id);
 /// ```
 pub use solana_sdk_macro::program_declare_id as declare_id;
+/// Convenience macro to define a static public key
+///
+/// Input: a single literal base58 string representation of a Pubkey
+///
+/// # Example
+///
+/// ```
+/// use std::str::FromStr;
+/// use solana_program::{pubkey, pubkey::Pubkey};
+///
+/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
+///
+/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
+/// assert_eq!(ID, my_id);
+/// ```
+pub use solana_sdk_macro::program_pubkey as pubkey;
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -63,6 +63,22 @@ pub mod vote {
     }
 }
 
+/// Convenience macro to define a static public key
+///
+/// Input: a single literal base58 string representation of a Pubkey
+///
+/// # Example
+///
+/// ```
+/// use std::str::FromStr;
+/// use solana_program::{pubkey, pubkey::Pubkey};
+///
+/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
+///
+/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
+/// assert_eq!(ID, my_id);
+/// ```
+pub use solana_sdk_macro::program_pubkey as pubkey;
 /// Same as `declare_id` except report that this id has been deprecated
 pub use solana_sdk_macro::program_declare_deprecated_id as declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -49,6 +49,22 @@ pub mod timing;
 pub mod transaction;
 pub mod transport;
 
+/// Convenience macro to define a static public key
+///
+/// Input: a single literal base58 string representation of a Pubkey
+///
+/// # Example
+///
+/// ```
+/// use std::str::FromStr;
+/// use solana_program::{pubkey, pubkey::Pubkey};
+///
+/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
+///
+/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
+/// assert_eq!(ID, my_id);
+/// ```
+pub use solana_sdk_macro::pubkey;
 /// Same as `declare_id` except report that this id has been deprecated
 pub use solana_sdk_macro::declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -49,22 +49,6 @@ pub mod timing;
 pub mod transaction;
 pub mod transport;
 
-/// Convenience macro to define a static public key
-///
-/// Input: a single literal base58 string representation of a Pubkey
-///
-/// # Example
-///
-/// ```
-/// use std::str::FromStr;
-/// use solana_program::{pubkey, pubkey::Pubkey};
-///
-/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
-///
-/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
-/// assert_eq!(ID, my_id);
-/// ```
-pub use solana_sdk_macro::pubkey;
 /// Same as `declare_id` except report that this id has been deprecated
 pub use solana_sdk_macro::declare_deprecated_id;
 /// Convenience macro to declare a static public key and functions to interact with it
@@ -89,6 +73,22 @@ pub use solana_sdk_macro::declare_deprecated_id;
 /// assert_eq!(id(), my_id);
 /// ```
 pub use solana_sdk_macro::declare_id;
+/// Convenience macro to define a static public key
+///
+/// Input: a single literal base58 string representation of a Pubkey
+///
+/// # Example
+///
+/// ```
+/// use std::str::FromStr;
+/// use solana_program::{pubkey, pubkey::Pubkey};
+///
+/// static ID: Pubkey = pubkey!("My11111111111111111111111111111111111111111");
+///
+/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
+/// assert_eq!(ID, my_id);
+/// ```
+pub use solana_sdk_macro::pubkey;
 pub use solana_sdk_macro::pubkeys;
 #[rustversion::since(1.46.0)]
 pub use solana_sdk_macro::respan;


### PR DESCRIPTION
#### Problem

In [Anchor](https://github.com/project-serum/anchor) [Discord](https://discord.gg/sxy4zxBckh) devs often ask how to create static Pubkey from the literal. There are two ways right now:
- deserialize literal to `&[u8]` in other program and use `Pubkey::new_from_array`
- introduce new `mod` and use `declare_id`

#### Summary of Changes

Add macro `pubkey!` which only generates `Pubkey` from literal and left variable declaration to a developer.
