### PR TITLE
explorer: Display more decimals for small token prices

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -108,8 +108,12 @@ function FungibleTokenMintAccountCard({
   const coinInfo = useCoinGecko(tokenInfo?.extensions?.coingeckoId);
 
   let tokenPriceInfo;
+  let tokenPriceDecimals = 2;
   if (coinInfo?.status === CoingeckoStatus.Success) {
     tokenPriceInfo = coinInfo.coinInfo;
+    if (tokenPriceInfo && tokenPriceInfo.price < 1) {
+      tokenPriceDecimals = 6;
+    }
   }
 
   return (
@@ -130,7 +134,7 @@ function FungibleTokenMintAccountCard({
                   </span>
                 </h4>
                 <h1 className="mb-0">
-                  ${tokenPriceInfo.price.toFixed(2)}{" "}
+                  ${tokenPriceInfo.price.toFixed(tokenPriceDecimals)}{" "}
                   {tokenPriceInfo.price_change_percentage_24h > 0 && (
                     <small className="change-positive">
                       &uarr;{" "}


### PR DESCRIPTION
#### Problem
Some token prices are less than a cent and show as "$0.00"

#### Summary of Changes
<img width="446" alt="Screen Shot 2021-11-15 at 1 40 01 PM" src="https://user-images.githubusercontent.com/1076145/141783710-1f6332d4-a410-499d-b479-2a0419079822.png">
