### PR TITLE
explorer: fix stake account activating state

### DIFF
--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -296,5 +296,11 @@ function isFullyInactivated(
     return false;
   }
 
-  return stake.delegation.stake.toString() === activation.inactive.toString();
+  const delegatedStake = stake.delegation.stake.toNumber();
+  const inactiveStake = activation.inactive;
+
+  return (
+    !stake.delegation.deactivationEpoch.eq(MAX_EPOCH) &&
+    delegatedStake === inactiveStake
+  );
 }


### PR DESCRIPTION
#### Problem
Stake account is displayed as inactive if all of its stake is inactive still during activation

#### Fixes
Only show stake as inactive if it was deactivated