### PR TITLE
add --no-os-network-stats-reporting option

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -98,12 +98,12 @@ pub fn verify_udp_stats_access() -> Result<(), String> {
 }
 
 impl SystemMonitorService {
-    pub fn new(exit: Arc<AtomicBool>) -> Self {
+    pub fn new(exit: Arc<AtomicBool>, report_os_network_stats: bool) -> Self {
         info!("Starting SystemMonitorService");
         let thread_hdl = Builder::new()
             .name("system-monitor".to_string())
             .spawn(move || {
-                Self::run(exit);
+                Self::run(exit, report_os_network_stats);
             })
             .unwrap();
 
@@ -226,7 +226,7 @@ impl SystemMonitorService {
         }
     }
 
-    pub fn run(exit: Arc<AtomicBool>) {
+    pub fn run(exit: Arc<AtomicBool>, report_os_network_stats: bool) {
         let mut udp_stats = None;
 
         let udp_timer = AtomicInterval::default();
@@ -236,7 +236,7 @@ impl SystemMonitorService {
                 break;
             }
 
-            if udp_timer.should_update(SAMPLE_INTERVAL_UDP_MS) {
+            if report_os_network_stats && udp_timer.should_update(SAMPLE_INTERVAL_UDP_MS) {
                 SystemMonitorService::process_udp_stats(&mut udp_stats);
             }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -453,7 +453,7 @@ impl Validator {
 
         if !config.no_os_network_stats_reporting {
             verify_udp_stats_access().unwrap_or_else(|err| {
-                error!("Failed to access UDP stats: {}", err);
+                error!("Failed to access UDP stats: {}. Bypass check with --no-os-network-stats-reporting.", err);
                 abort();
             });
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -151,6 +151,7 @@ pub struct ValidatorConfig {
     pub bpf_jit: bool,
     pub send_transaction_service_config: send_transaction_service::Config,
     pub no_poh_speed_test: bool,
+    pub no_os_network_stats_reporting: bool,
     pub poh_pinned_cpu_core: usize,
     pub poh_hashes_per_batch: u64,
     pub account_indexes: AccountSecondaryIndexes,
@@ -211,6 +212,7 @@ impl Default for ValidatorConfig {
             bpf_jit: false,
             send_transaction_service_config: send_transaction_service::Config::default(),
             no_poh_speed_test: true,
+            no_os_network_stats_reporting: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
             account_indexes: AccountSecondaryIndexes::default(),
@@ -449,11 +451,16 @@ impl Validator {
 
         *start_progress.write().unwrap() = ValidatorStartProgress::StartingServices;
 
-        verify_udp_stats_access().unwrap_or_else(|err| {
-            error!("Failed to access UDP stats: {}", err);
-            abort();
-        });
-        let system_monitor_service = Some(SystemMonitorService::new(Arc::clone(&exit)));
+        if !config.no_os_network_stats_reporting {
+            verify_udp_stats_access().unwrap_or_else(|err| {
+                error!("Failed to access UDP stats: {}", err);
+                abort();
+            });
+        }
+        let system_monitor_service = Some(SystemMonitorService::new(
+            Arc::clone(&exit),
+            !config.no_os_network_stats_reporting,
+        ));
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let bank = bank_forks.working_bank();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1989,7 +1989,7 @@ fn main() {
             }
 
             let exit_signal = Arc::new(AtomicBool::new(false));
-            let system_monitor_service = SystemMonitorService::new(Arc::clone(&exit_signal));
+            let system_monitor_service = SystemMonitorService::new(Arc::clone(&exit_signal), false);
 
             if let Some(limit) = value_t!(arg_matches, "accounts_index_memory_limit_mb", usize).ok()
             {

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -46,6 +46,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         bpf_jit: config.bpf_jit,
         send_transaction_service_config: config.send_transaction_service_config.clone(),
         no_poh_speed_test: config.no_poh_speed_test,
+        no_os_network_stats_reporting: config.no_os_network_stats_reporting,
         poh_pinned_cpu_core: config.poh_pinned_cpu_core,
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -959,6 +959,11 @@ pub fn main() {
                 .help("Skip checks for OS network limits.")
         )
         .arg(
+            Arg::with_name("no_os_network_stats_reporting")
+                .long("no-os-network-stats-reporting")
+                .help("Disable reporting of OS network statistics.")
+        )
+        .arg(
             Arg::with_name("accounts-hash-interval-slots")
                 .long("accounts-hash-interval-slots")
                 .value_name("NUMBER")
@@ -2262,6 +2267,7 @@ pub fn main() {
             ),
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
+        no_os_network_stats_reporting: matches.is_present("no_os_network_stats_reporting"),
         poh_pinned_cpu_core: value_of(&matches, "poh_pinned_cpu_core")
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         poh_hashes_per_batch: value_of(&matches, "poh_hashes_per_batch")


### PR DESCRIPTION
#### Problem
Add ability to bypass OS network stats reporting. Useful for running under WSL.

#### Summary of Changes
add --no-os-network-stats-reporting option

Fixes #
#21253