### PR TITLE
Fix feature gate of #18981

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -154,7 +154,7 @@ pub fn register_syscalls(
         b"sol_get_epoch_schedule_sysvar",
         SyscallGetEpochScheduleSysvar::call,
     )?;
-    if invoke_context.is_feature_active(&disable_fees_sysvar::id()) {
+    if !invoke_context.is_feature_active(&disable_fees_sysvar::id()) {
         syscall_registry
             .register_syscall_by_name(b"sol_get_fees_sysvar", SyscallGetFeesSysvar::call)?;
     }


### PR DESCRIPTION
#### Problem
#18981 introduced the following paradox feature gate conditions:
  * `register_syscall_by_name()` is on if `invoke_context.is_feature_active(&disable_fees_sysvar::id())`
  * `bind_feature_gated_syscall_context_object()` is on if `!invoke_context.is_feature_active(&disable_fees_sysvar::id())`

Fortunately, it was not back-ported it seems and I checked [1.8.4](https://github.com/solana-labs/solana/blob/v1.8.4/programs/bpf_loader/src/lib.rs) to be unaffected.

#### Summary of Changes
Inverts `disable_fees_sysvar` feature gating condition at `register_syscall_by_name()` to match `is_fee_sysvar_via_syscall_active` at `bind_feature_gated_syscall_context_object()`.

