### PR TITLE
Reject the deployment of programs with unresolved syscall symbols

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -31,7 +31,8 @@ use solana_sdk::{
     clock::Clock,
     entrypoint::{HEAP_LENGTH, SUCCESS},
     feature_set::{
-        do_support_realloc, reduce_required_deploy_balance, requestable_heap_size,
+        do_support_realloc, reduce_required_deploy_balance,
+        reject_deployment_of_unresolved_syscalls, requestable_heap_size,
         stop_verify_mul64_imm_nonzero,
     },
     ic_logger_msg, ic_msg,
@@ -74,6 +75,7 @@ pub fn create_executor(
     programdata_offset: usize,
     invoke_context: &mut dyn InvokeContext,
     use_jit: bool,
+    reject_unresolved_syscalls: bool,
 ) -> Result<Arc<BpfExecutor>, InstructionError> {
     let syscall_registry = syscalls::register_syscalls(invoke_context).map_err(|e| {
         ic_msg!(invoke_context, "Failed to register syscalls: {}", e);
@@ -84,6 +86,8 @@ pub fn create_executor(
         max_call_depth: compute_budget.max_call_depth,
         stack_frame_size: compute_budget.stack_frame_size,
         enable_instruction_tracing: log_enabled!(Trace),
+        reject_unresolved_syscalls: reject_unresolved_syscalls
+            && invoke_context.is_feature_active(&reject_deployment_of_unresolved_syscalls::id()),
         verify_mul64_imm_nonzero: !invoke_context
             .is_feature_active(&stop_verify_mul64_imm_nonzero::id()), // TODO: Feature gate and then remove me
         ..Config::default()
@@ -271,6 +275,7 @@ fn process_instruction_common(
                     program_data_offset,
                     invoke_context,
                     use_jit,
+                    false,
                 )?;
                 let program_id = invoke_context.get_caller()?;
                 invoke_context.add_executor(program_id, executor.clone());
@@ -475,6 +480,7 @@ fn process_loader_upgradeable_instruction(
                 buffer_data_offset,
                 invoke_context,
                 use_jit,
+                true,
             )?;
             invoke_context.add_executor(&new_program_id, executor);
 
@@ -619,6 +625,7 @@ fn process_loader_upgradeable_instruction(
                 buffer_data_offset,
                 invoke_context,
                 use_jit,
+                true,
             )?;
             invoke_context.add_executor(&new_program_id, executor);
 
@@ -872,7 +879,8 @@ fn process_loader_instruction(
                 return Err(InstructionError::MissingRequiredSignature);
             }
 
-            let executor = create_executor(first_instruction_account, 0, invoke_context, use_jit)?;
+            let executor =
+                create_executor(first_instruction_account, 0, invoke_context, use_jit, true)?;
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             invoke_context.add_executor(program.unsigned_key(), executor);

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -233,6 +233,10 @@ pub mod add_compute_budget_program {
     solana_sdk::declare_id!("4d5AKtxoh93Dwm1vHXUU3iRATuMndx1c431KgT2td52r");
 }
 
+pub mod reject_deployment_of_unresolved_syscalls {
+    solana_sdk::declare_id!("DqniU3MfvdpU3yhmNF1RKeaM5TZQELZuyFGosASRVUoy");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -286,6 +290,7 @@ lazy_static! {
         (requestable_heap_size::id(), "Requestable heap frame size"),
         (disable_fee_calculator::id(), "deprecate fee calculator"),
         (add_compute_budget_program::id(), "Add compute_budget_program"),
+        (reject_deployment_of_unresolved_syscalls::id(), "Reject deployment of programs with unresolved syscall symbols"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Programs with unresolved syscall symbols can still be deployed, even though they are rejected by the CLI and would fail at runtime.

#### Summary of Changes
Adds a feature gate to reject the deployment of programs with unresolved syscall symbols.

Fixes #
