### PR TITLE
Constrain memory ordering on AppendVec::id

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -699,7 +699,7 @@ impl AccountStorageEntry {
         self.accounts.reset();
         *count_and_status = (0, AccountStorageStatus::Available);
         self.slot.store(slot, Ordering::Release);
-        self.id.store(id, Ordering::Relaxed);
+        self.id.store(id, Ordering::Release);
         self.approx_store_count.store(0, Ordering::Relaxed);
         self.alive_bytes.store(0, Ordering::Relaxed);
     }
@@ -737,7 +737,7 @@ impl AccountStorageEntry {
     }
 
     pub fn append_vec_id(&self) -> AppendVecId {
-        self.id.load(Ordering::Relaxed)
+        self.id.load(Ordering::Acquire)
     }
 
     pub fn flush(&self) -> Result<(), IoError> {
@@ -5407,7 +5407,7 @@ impl AccountsDb {
                 if let Some(storages) = storages.get(slot) {
                     storages.iter().for_each(|store| {
                         self.dirty_stores
-                            .insert((slot, store.id.load(Ordering::Relaxed)), store.clone());
+                            .insert((slot, store.append_vec_id()), store.clone());
                     });
                 }
             }


### PR DESCRIPTION
I started going down this rabbit hole while looking at Issue #14960, which deals with duplicate `write_version`s. This should never happen, but it did. I didn't fully inspect the code at the time the issue was first raised, so maybe there was (is?) also another underlying bug to deal with. Minimally, I looking at `write_version`. I noticed that currently we use `write_version` to check and control logic, which is a big red flag with `Ordering::Relaxed`.

Basically, `Relaxed` does _not_ do anything for guaranteeing visibility, guaranteeing _other_ loads/stores nearby aren't re-ordered, nor does it constrain speculation. Anytime `Relaxed` is used, it should be considered akin to writing `unsafe { }`, where guarantees about its usage should be declared. `Relaxed` basically only guarantees there will be no partial loads/stores to that memory, but that's it. Matched `Acquire` and `Release` (or fences) are required to enforce a "happens before" relationship on atomic accesses across threads, which is how they become safe.

For background, refer to everything by Paul McKenney, who's been the owner of the Linux Kernel Memory Model for decades, where correctness and performance are fundamental, and across many architectures.
- [Article on Rust's memory model](https://paulmck.livejournal.com/66175.html)
- [Video on (in)correct uses of Relaxed](https://youtu.be/cWkUqK71DZ0)

Additional information:

We've likely avoided any serious issue so far due to x86, and interactions with other locks that take full memory barriers/fences around blocks. x86 is quite a "strong" architecture w.r.t. atomicity, unlike ARM/PowerPC. IIRC, either loads or stores implicitly get an Acquire or Release (or fence) generated for them by the compiler/cpu.

"Will this make our code slow?"
No. For two reasons. First, most of our memory accesses to atomics are already made stricter by x86, so in this case we're only documenting these requirements in our code. Second, if a relaxed atomic mis-speculates (or any other wrong behavior occurs) and the resulting value is ultimately incorrect, that could be disastrous for the network. Incorrect code is never fast if it can ever be wrong.

#### Problem

`AppendVec::id` is used for logic but its atomic accesses are not constrained for such operations.

#### Summary of Changes

Constrain with `Release` and `Acquire`.
