### PR TITLE
Constrain memory ordering on AccountsDb::next_id

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1716,7 +1716,7 @@ impl AccountsDb {
         AccountStorageEntry::new(
             path,
             slot,
-            self.next_id.fetch_add(1, Ordering::Relaxed),
+            self.next_id.fetch_add(1, Ordering::AcqRel),
             size,
         )
     }
@@ -3721,7 +3721,7 @@ impl AccountsDb {
                     let ret = recycle_stores.remove_entry(i);
                     drop(recycle_stores);
                     let old_id = ret.append_vec_id();
-                    ret.recycle(slot, self.next_id.fetch_add(1, Ordering::Relaxed));
+                    ret.recycle(slot, self.next_id.fetch_add(1, Ordering::AcqRel));
                     debug!(
                         "recycling store: {} {:?} old_id: {}",
                         ret.append_vec_id(),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -463,7 +463,7 @@ where
                 // Remap the AppendVec ID to handle any duplicate IDs that may previously existed
                 // due to full snapshots and incremental snapshots generated from different nodes
                 let (remapped_append_vec_id, remapped_append_vec_path) = loop {
-                    let remapped_append_vec_id = next_append_vec_id.fetch_add(1, Ordering::Relaxed);
+                    let remapped_append_vec_id = next_append_vec_id.fetch_add(1, Ordering::AcqRel);
                     let remapped_file_name = AppendVec::file_name(*slot, remapped_append_vec_id);
                     let remapped_append_vec_path =
                         append_vec_path.parent().unwrap().join(&remapped_file_name);
@@ -512,7 +512,7 @@ where
         "At least one storage entry must exist from deserializing stream"
     );
 
-    let next_append_vec_id = next_append_vec_id.load(Ordering::Relaxed);
+    let next_append_vec_id = next_append_vec_id.load(Ordering::Acquire);
     let max_append_vec_id = next_append_vec_id - 1;
     assert!(
         max_append_vec_id <= AppendVecId::MAX / 2,
@@ -533,7 +533,7 @@ where
     );
     accounts_db
         .next_id
-        .store(next_append_vec_id, Ordering::Relaxed);
+        .store(next_append_vec_id, Ordering::Release);
     accounts_db
         .write_version
         .fetch_add(snapshot_version, Ordering::Relaxed);


### PR DESCRIPTION
I started going down this rabbit hole while looking at Issue #14960, which deals with duplicate `write_version`s. This should never happen, but it did. I didn't fully inspect the code at the time the issue was first raised, so maybe there was (is?) also another underlying bug to deal with. Minimally, I looking at `write_version`. I noticed that currently we use `write_version` to check and control logic, which is a big red flag with `Ordering::Relaxed`.

Basically, `Relaxed` does _not_ do anything for guaranteeing visibility, guaranteeing _other_ loads/stores nearby aren't re-ordered, nor does it constrain speculation. Anytime `Relaxed` is used, it should be considered akin to writing `unsafe { }`, where guarantees about its usage should be declared. `Relaxed` basically only guarantees there will be no partial loads/stores to that memory, but that's it. Matched `Acquire` and `Release` (or fences) are required to enforce a "happens before" relationship on atomic accesses across threads, which is how they become safe.

For background, refer to everything by Paul McKenney, who's been the owner of the Linux Kernel Memory Model for decades, where correctness and performance are fundamental, and across many architectures.
- [Article on Rust's memory model](https://paulmck.livejournal.com/66175.html)
- [Video on (in)correct uses of Relaxed](https://youtu.be/cWkUqK71DZ0)

Additional information:

We've likely avoided any serious issue so far due to x86, and interactions with other locks that take full memory barriers/fences around blocks. x86 is quite a "strong" architecture w.r.t. atomicity, unlike ARM/PowerPC. IIRC, either loads or stores implicitly get an Acquire or Release (or fence) generated for them by the compiler/cpu.

"Will this make our code slow?"
No. For two reasons. First, most of our memory accesses to atomics are already made stricter by x86, so in this case we're only documenting these requirements in our code. Second, if a relaxed atomic mis-speculates (or any other wrong behavior occurs) and the resulting value is ultimately incorrect, that could be disastrous for the network. Incorrect code is never fast if it can ever be wrong.

#### Problem

`AccountsDb::next_id` is used for logic but its atomic accesses are not constrained for such operations.

#### Summary of Changes

Constrain with `Release` and `Acquire`.
