### PR TITLE
Constrain memory ordering on AccountsDb::write_version

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4391,7 +4391,7 @@ impl AccountsDb {
 
     fn bulk_assign_write_version(&self, count: usize) -> StoredMetaWriteVersion {
         self.write_version
-            .fetch_add(count as StoredMetaWriteVersion, Ordering::Relaxed)
+            .fetch_add(count as StoredMetaWriteVersion, Ordering::AcqRel)
     }
 
     fn write_accounts_to_storage<F: FnMut(Slot, usize) -> Arc<AccountStorageEntry>>(
@@ -9193,8 +9193,8 @@ pub mod tests {
         let daccounts = reconstruct_accounts_db_via_serialization(&accounts, latest_slot);
 
         assert_eq!(
-            daccounts.write_version.load(Ordering::Relaxed),
-            accounts.write_version.load(Ordering::Relaxed)
+            daccounts.write_version.load(Ordering::Acquire),
+            accounts.write_version.load(Ordering::Acquire)
         );
 
         // Get the hash for the latest slot, which should be the only hash in the

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -536,7 +536,7 @@ where
         .store(next_append_vec_id, Ordering::Relaxed);
     accounts_db
         .write_version
-        .fetch_add(snapshot_version, Ordering::Relaxed);
+        .fetch_add(snapshot_version, Ordering::Release);
 
     let mut measure_notify = Measure::start("accounts_notify");
 

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -242,7 +242,7 @@ impl<'a> TypeContext<'a> for Context {
         let version = serializable_db
             .accounts_db
             .write_version
-            .load(Ordering::Relaxed);
+            .load(Ordering::Acquire);
 
         // (1st of 3 elements) write the list of account storage entry lists out as a map
         let entry_count = RefCell::<usize>::new(0);


### PR DESCRIPTION
I started going down this rabbit hole while looking at Issue #14960, which deals with duplicate `write_version`s. This should never happen, but it did. I didn't fully inspect the code at the time the issue was first raised, so maybe there was (is?) also another underlying bug to deal with. Minimally, I looking at `write_version`. I noticed that currently we use `write_version` to check and control logic, which is a big red flag with `Ordering::Relaxed`.

Basically, `Relaxed` does _not_ do anything for guaranteeing visibility, guaranteeing _other_ loads/stores nearby aren't re-ordered, nor does it constrain speculation. Anytime `Relaxed` is used, it should be considered akin to writing `unsafe { }`, where guarantees about its usage should be declared. `Relaxed` basically only guarantees there will be no partial loads/stores to that memory, but that's it. Matched `Acquire` and `Release` (or fences) are required to enforce a "happens before" relationship on atomic accesses across threads, which is how they become safe.

For background, refer to everything by Paul McKenney, who's been the owner of the Linux Kernel Memory Model for decades, where correctness and performance are fundamental, and across many architectures.
- [Article on Rust's memory model](https://paulmck.livejournal.com/66175.html)
- [Video on (in)correct uses of Relaxed](https://youtu.be/cWkUqK71DZ0)

Additional information:

We've likely avoided any serious issue so far due to x86, and interactions with other locks that take full memory barriers/fences around blocks. x86 is quite a "strong" architecture w.r.t. atomicity, unlike ARM/PowerPC. IIRC, either loads or stores implicitly get an Acquire or Release (or fence) generated for them by the compiler/cpu.

"Will this make our code slow?"
No. For two reasons. First, most of our memory accesses to atomics are already made stricter by x86, so in this case we're only documenting these requirements in our code. Second, if a relaxed atomic mis-speculates (or any other wrong behavior occurs) and the resulting value is ultimately incorrect, that could be disastrous for the network. Incorrect code is never fast if it can ever be wrong.

#### Problem

`AccountsDb::write_version` is used for logic but its atomic accesses are not constrained for such operations.

#### Summary of Changes

Constrain with `Release` and `Acquire`.
