### PR TITLE
Rename `process_entries` to indicate it's only for tests

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -11,7 +11,7 @@ use solana_core::banking_stage::{BankingStage, BankingStageStats};
 use solana_entry::entry::{next_hash, Entry};
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_gossip::cluster_info::Node;
-use solana_ledger::blockstore_processor::process_entries;
+use solana_ledger::blockstore_processor::process_entries_for_tests;
 use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
 use solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path};
 use solana_perf::packet::to_packets_chunked;
@@ -321,7 +321,7 @@ fn simulate_process_entries(
         hash: next_hash(&bank.last_blockhash(), 1, &tx_vector),
         transactions: tx_vector,
     };
-    process_entries(&bank, vec![entry], randomize_txs, None, None).unwrap();
+    process_entries_for_tests(&bank, vec![entry], randomize_txs, None, None).unwrap();
 }
 
 #[allow(clippy::same_item_push)]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4248,7 +4248,7 @@ pub fn create_test_transactions_and_populate_blockstore(
 
     // Check that process_entries successfully writes can_commit transactions statuses, and
     // that they are matched properly by get_rooted_block
-    let _result = solana_ledger::blockstore_processor::process_entries(
+    let _result = solana_ledger::blockstore_processor::process_entries_for_tests(
         &bank,
         entries,
         true,


### PR DESCRIPTION
#### Problem
Unclear that the `process_entries` method is only used by tests / benches 

#### Summary of Changes
Rename `process_entries` to `process_entries_for_tests`

Fixes #
