### PR TITLE
add --accounts-index-scan-results-limit-mb to allow scans to abort

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2251,7 +2251,7 @@ fn main() {
 
                     if remove_stake_accounts {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), ScanConfig::default())
+                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
                             .unwrap()
                             .into_iter()
                         {
@@ -2275,7 +2275,7 @@ fn main() {
 
                     if !vote_accounts_to_destake.is_empty() {
                         for (address, mut account) in bank
-                            .get_program_accounts(&stake::program::id(), ScanConfig::default())
+                            .get_program_accounts(&stake::program::id(), &ScanConfig::default())
                             .unwrap()
                             .into_iter()
                         {
@@ -2313,7 +2313,7 @@ fn main() {
 
                         // Delete existing vote accounts
                         for (address, mut account) in bank
-                            .get_program_accounts(&solana_vote_program::id(), ScanConfig::default())
+                            .get_program_accounts(&solana_vote_program::id(), &ScanConfig::default())
                             .unwrap()
                             .into_iter()
                         {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2313,7 +2313,10 @@ fn main() {
 
                         // Delete existing vote accounts
                         for (address, mut account) in bank
-                            .get_program_accounts(&solana_vote_program::id(), &ScanConfig::default())
+                            .get_program_accounts(
+                                &solana_vote_program::id(),
+                                &ScanConfig::default(),
+                            )
                             .unwrap()
                             .into_iter()
                         {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1841,11 +1841,13 @@ impl JsonRpcRequestProcessor {
                         account.owner() == program_id && filter_closure(account)
                     },
                     &ScanConfig::default(),
+                    bank.byte_limit_for_scans(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),
                 })?)
         } else {
+            // this path does not need to provide a mb limit because we only want to support secondary indexes
             Ok(bank
                 .get_filtered_program_accounts(program_id, filter_closure, &ScanConfig::default())
                 .map_err(|e| RpcCustomError::ScanError {
@@ -1902,6 +1904,7 @@ impl JsonRpcRequestProcessor {
                             })
                     },
                     &ScanConfig::default(),
+                    bank.byte_limit_for_scans(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),
@@ -1958,6 +1961,7 @@ impl JsonRpcRequestProcessor {
                             })
                     },
                     &ScanConfig::default(),
+                    bank.byte_limit_for_scans(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1840,14 +1840,14 @@ impl JsonRpcRequestProcessor {
                         // accounts.
                         account.owner() == program_id && filter_closure(account)
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),
                 })?)
         } else {
             Ok(bank
-                .get_filtered_program_accounts(program_id, filter_closure, ScanConfig::default())
+                .get_filtered_program_accounts(program_id, filter_closure, &ScanConfig::default())
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),
                 })?)
@@ -1901,7 +1901,7 @@ impl JsonRpcRequestProcessor {
                                 }
                             })
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),
@@ -1957,7 +1957,7 @@ impl JsonRpcRequestProcessor {
                                 }
                             })
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .map_err(|e| RpcCustomError::ScanError {
                     message: e.to_string(),

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -267,7 +267,7 @@ fn bench_concurrent_scan_write(bencher: &mut Bencher) {
                     &Ancestors::default(),
                     0,
                     AccountSharedData::default().owner(),
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .unwrap(),
         );

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -787,7 +787,7 @@ impl Accounts {
         index_key: &IndexKey,
         filter: F,
         config: &ScanConfig,
-        byte_limit: Option<usize>,
+        byte_limit_for_scan: Option<usize>,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         let sum = AtomicUsize::default();
         let config = ScanConfig {
@@ -804,14 +804,14 @@ impl Accounts {
                     Self::load_while_filtering(collector, some_account_tuple, |account| {
                         let use_account = filter(account);
                         if use_account {
-                            if let Some(byte_limit) = byte_limit.as_ref() {
+                            if let Some(byte_limit_for_scan) = byte_limit_for_scan.as_ref() {
                                 let added = account.data().len()
                                     + std::mem::size_of::<AccountSharedData>()
                                     + std::mem::size_of::<Pubkey>();
                                 if sum
                                     .fetch_add(added, Ordering::Relaxed)
                                     .saturating_add(added)
-                                    > *byte_limit
+                                    > *byte_limit_for_scan
                                 {
                                     // total size of results exceeds size limit, so abort scan
                                     config.abort();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -667,7 +667,7 @@ impl Accounts {
                     collector.push(Reverse((account.lamports(), *pubkey)));
                 }
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         )?;
         Ok(account_balances
             .into_sorted_vec()
@@ -745,7 +745,7 @@ impl Accounts {
         ancestors: &Ancestors,
         bank_id: BankId,
         program_id: &Pubkey,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.accounts_db.scan_accounts(
             ancestors,
@@ -765,7 +765,7 @@ impl Accounts {
         bank_id: BankId,
         program_id: &Pubkey,
         filter: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.accounts_db.scan_accounts(
             ancestors,
@@ -785,7 +785,7 @@ impl Accounts {
         bank_id: BankId,
         index_key: &IndexKey,
         filter: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.accounts_db
             .index_scan_accounts(
@@ -821,7 +821,7 @@ impl Accounts {
                     collector.push((*pubkey, account, slot))
                 }
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         )
     }
 
@@ -843,7 +843,7 @@ impl Accounts {
             "load_to_collect_rent_eagerly_scan_elapsed",
             ancestors,
             range,
-            ScanConfig::new(true),
+            &ScanConfig::new(true),
             |collector: &mut Vec<(Pubkey, AccountSharedData)>, option| {
                 Self::load_while_filtering(collector, option, |_| true)
             },

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -4,7 +4,7 @@ use crate::{
         LoadHint, LoadedAccount, ScanStorageResult, ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
         ACCOUNTS_DB_CONFIG_FOR_TESTING,
     },
-    accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult},
+    accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError, ScanResult},
     accounts_update_notifier_interface::AccountsUpdateNotifier,
     ancestors::Ancestors,
     bank::{
@@ -42,6 +42,7 @@ use std::{
     collections::{hash_map, BinaryHeap, HashMap, HashSet},
     ops::RangeBounds,
     path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
     sync::{Arc, Mutex},
 };
 
@@ -786,20 +787,50 @@ impl Accounts {
         index_key: &IndexKey,
         filter: F,
         config: &ScanConfig,
+        byte_limit: Option<usize>,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
-        self.accounts_db
+        let sum = AtomicUsize::default();
+        let config = ScanConfig {
+            abort: Some(config.abort.as_ref().map(Arc::clone).unwrap_or_default()),
+            collect_all_unsorted: config.collect_all_unsorted,
+        };
+        let result = self
+            .accounts_db
             .index_scan_accounts(
                 ancestors,
                 bank_id,
                 *index_key,
                 |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
                     Self::load_while_filtering(collector, some_account_tuple, |account| {
-                        filter(account)
-                    })
+                        let use_account = filter(account);
+                        if use_account {
+                            if let Some(byte_limit) = byte_limit.as_ref() {
+                                let added = account.data().len()
+                                    + std::mem::size_of::<AccountSharedData>()
+                                    + std::mem::size_of::<Pubkey>();
+                                if sum
+                                    .fetch_add(added, Ordering::Relaxed)
+                                    .saturating_add(added)
+                                    > *byte_limit
+                                {
+                                    // total size of results exceeds size limit, so abort scan
+                                    config.abort();
+                                }
+                            }
+                        }
+                        use_account
+                    });
                 },
-                config,
+                &config,
             )
-            .map(|result| result.0)
+            .map(|result| result.0);
+        if config.is_aborted() {
+            ScanResult::Err(ScanError::Aborted(
+                "The accumulated scan results exceeded the limit".to_string(),
+            ))
+        } else {
+            result
+        }
     }
 
     pub fn account_indexes_include_key(&self, key: &Pubkey) -> bool {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3059,7 +3059,7 @@ impl AccountsDb {
         ancestors: &Ancestors,
         bank_id: BankId,
         scan_func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<A>
     where
         F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
@@ -3089,7 +3089,7 @@ impl AccountsDb {
         metric_name: &'static str,
         ancestors: &Ancestors,
         scan_func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> A
     where
         F: Fn(&mut A, (&Pubkey, LoadedAccount, Slot)),
@@ -3117,7 +3117,7 @@ impl AccountsDb {
         metric_name: &'static str,
         ancestors: &Ancestors,
         range: R,
-        config: ScanConfig,
+        config: &ScanConfig,
         scan_func: F,
     ) -> A
     where
@@ -3158,7 +3158,7 @@ impl AccountsDb {
         bank_id: BankId,
         index_key: IndexKey,
         scan_func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<(A, bool)>
     where
         F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
@@ -8072,7 +8072,7 @@ pub mod tests {
             |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.take_account());
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(accounts, vec![account1]);
     }
@@ -8982,7 +8982,7 @@ pub mod tests {
                 |key, _| {
                     found_accounts.insert(*key);
                 },
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(found_accounts.len(), 2);
@@ -9003,7 +9003,7 @@ pub mod tests {
                     |collection: &mut HashSet<Pubkey>, account| {
                         collection.insert(*account.unwrap().0);
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .unwrap();
             assert!(!found_accounts.1);
@@ -9022,7 +9022,7 @@ pub mod tests {
                     |collection: &mut HashSet<Pubkey>, account| {
                         collection.insert(*account.unwrap().0);
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .unwrap();
             assert!(found_accounts.1);
@@ -9056,7 +9056,7 @@ pub mod tests {
                 bank_id,
                 IndexKey::SplTokenMint(mint_key),
                 |key, _| found_accounts.push(*key),
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(found_accounts, vec![pubkey2]);
@@ -9612,7 +9612,7 @@ pub mod tests {
             |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.take_account());
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(accounts, vec![account0]);
 
@@ -9623,7 +9623,7 @@ pub mod tests {
             |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.take_account());
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(accounts.len(), 2);
     }
@@ -11797,7 +11797,7 @@ pub mod tests {
                             }
                         }
                     },
-                    ScanConfig::default(),
+                    &ScanConfig::default(),
                 )
                 .unwrap();
             })

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -865,7 +865,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         scan_bank_id: BankId,
         func: F,
         scan_type: ScanTypes<R>,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> Result<(), ScanError>
     where
         F: FnMut(&Pubkey, (&T, Slot)),
@@ -1085,7 +1085,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         ancestors: &Ancestors,
         func: F,
         range: Option<R>,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
         R: RangeBounds<Pubkey> + std::fmt::Debug,
@@ -1103,7 +1103,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         mut func: F,
         range: Option<R>,
         max_root: Option<Slot>,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
         R: RangeBounds<Pubkey> + std::fmt::Debug,
@@ -1166,7 +1166,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         index: &SecondaryIndex<SecondaryIndexEntryType>,
         index_key: &Pubkey,
         max_root: Option<Slot>,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {
@@ -1236,7 +1236,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         ancestors: &Ancestors,
         scan_bank_id: BankId,
         func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> Result<(), ScanError>
     where
         F: FnMut(&Pubkey, (&T, Slot)),
@@ -1257,7 +1257,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         metric_name: &'static str,
         ancestors: &Ancestors,
         func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {
@@ -1276,7 +1276,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         metric_name: &'static str,
         ancestors: &Ancestors,
         range: R,
-        config: ScanConfig,
+        config: &ScanConfig,
         func: F,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
@@ -1293,7 +1293,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         scan_bank_id: BankId,
         index_key: IndexKey,
         func: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> Result<(), ScanError>
     where
         F: FnMut(&Pubkey, (&T, Slot)),
@@ -2693,7 +2693,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
     }
@@ -2771,7 +2771,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
     }
@@ -2810,7 +2810,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
         ancestors.insert(slot, 0);
@@ -2820,7 +2820,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 1);
 
@@ -2839,7 +2839,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
         ancestors.insert(slot, 0);
@@ -2849,7 +2849,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 1);
     }
@@ -3036,7 +3036,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
         ancestors.insert(slot, 0);
@@ -3045,7 +3045,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 1);
     }
@@ -3075,7 +3075,7 @@ pub mod tests {
             "",
             &ancestors,
             |_pubkey, _index| num += 1,
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 0);
     }
@@ -3112,7 +3112,7 @@ pub mod tests {
                 };
                 num += 1
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 1);
         assert!(found_key);
@@ -3185,7 +3185,7 @@ pub mod tests {
             "",
             &ancestors,
             pubkey_range,
-            ScanConfig::default(),
+            &ScanConfig::default(),
             |pubkey, _index| {
                 scanned_keys.insert(*pubkey);
             },
@@ -3264,7 +3264,7 @@ pub mod tests {
             |pubkey, _index| {
                 scanned_keys.insert(*pubkey);
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(scanned_keys.len(), num_pubkeys);
     }
@@ -3570,7 +3570,7 @@ pub mod tests {
                 };
                 num += 1
             },
-            ScanConfig::default(),
+            &ScanConfig::default(),
         );
         assert_eq!(num, 1);
         assert!(found_key);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1520,6 +1520,14 @@ impl Bank {
         new
     }
 
+    pub fn byte_limit_for_scans(&self) -> Option<usize> {
+        self.rc
+            .accounts
+            .accounts_db
+            .accounts_index
+            .scan_results_limit_bytes
+    }
+
     /// Returns all ancestors excluding self.slot.
     pub(crate) fn proper_ancestors(&self) -> impl Iterator<Item = Slot> + '_ {
         self.ancestors
@@ -5281,6 +5289,7 @@ impl Bank {
         index_key: &IndexKey,
         filter: F,
         config: &ScanConfig,
+        byte_limit: Option<usize>,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.rc.accounts.load_by_index_key_with_filter(
             &self.ancestors,
@@ -5288,6 +5297,7 @@ impl Bank {
             index_key,
             filter,
             config,
+            byte_limit,
         )
     }
 
@@ -10565,6 +10575,7 @@ pub(crate) mod tests {
                 &IndexKey::ProgramId(program_id),
                 |_| true,
                 &ScanConfig::default(),
+                None,
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10582,6 +10593,7 @@ pub(crate) mod tests {
                 &IndexKey::ProgramId(program_id),
                 |_| true,
                 &ScanConfig::default(),
+                None,
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10591,6 +10603,7 @@ pub(crate) mod tests {
                 &IndexKey::ProgramId(another_program_id),
                 |_| true,
                 &ScanConfig::default(),
+                None,
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10602,6 +10615,7 @@ pub(crate) mod tests {
                 &IndexKey::ProgramId(program_id),
                 |account| account.owner() == &program_id,
                 &ScanConfig::default(),
+                None,
             )
             .unwrap();
         assert!(indexed_accounts.is_empty());
@@ -10610,6 +10624,7 @@ pub(crate) mod tests {
                 &IndexKey::ProgramId(another_program_id),
                 |account| account.owner() == &another_program_id,
                 &ScanConfig::default(),
+                None,
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5254,7 +5254,7 @@ impl Bank {
     pub fn get_program_accounts(
         &self,
         program_id: &Pubkey,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.rc
             .accounts
@@ -5265,7 +5265,7 @@ impl Bank {
         &self,
         program_id: &Pubkey,
         filter: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.rc.accounts.load_by_program_with_filter(
             &self.ancestors,
@@ -5280,7 +5280,7 @@ impl Bank {
         &self,
         index_key: &IndexKey,
         filter: F,
-        config: ScanConfig,
+        config: &ScanConfig,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.rc.accounts.load_by_index_key_with_filter(
             &self.ancestors,
@@ -10501,13 +10501,13 @@ pub(crate) mod tests {
         bank1.squash();
         assert_eq!(
             bank0
-                .get_program_accounts(&program_id, ScanConfig::default(),)
+                .get_program_accounts(&program_id, &ScanConfig::default(),)
                 .unwrap(),
             vec![(pubkey0, account0.clone())]
         );
         assert_eq!(
             bank1
-                .get_program_accounts(&program_id, ScanConfig::default(),)
+                .get_program_accounts(&program_id, &ScanConfig::default(),)
                 .unwrap(),
             vec![(pubkey0, account0)]
         );
@@ -10529,14 +10529,14 @@ pub(crate) mod tests {
         bank3.squash();
         assert_eq!(
             bank1
-                .get_program_accounts(&program_id, ScanConfig::default(),)
+                .get_program_accounts(&program_id, &ScanConfig::default(),)
                 .unwrap()
                 .len(),
             2
         );
         assert_eq!(
             bank3
-                .get_program_accounts(&program_id, ScanConfig::default(),)
+                .get_program_accounts(&program_id, &ScanConfig::default(),)
                 .unwrap()
                 .len(),
             2
@@ -10564,7 +10564,7 @@ pub(crate) mod tests {
             .get_filtered_indexed_accounts(
                 &IndexKey::ProgramId(program_id),
                 |_| true,
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10581,7 +10581,7 @@ pub(crate) mod tests {
             .get_filtered_indexed_accounts(
                 &IndexKey::ProgramId(program_id),
                 |_| true,
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10590,7 +10590,7 @@ pub(crate) mod tests {
             .get_filtered_indexed_accounts(
                 &IndexKey::ProgramId(another_program_id),
                 |_| true,
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -10601,7 +10601,7 @@ pub(crate) mod tests {
             .get_filtered_indexed_accounts(
                 &IndexKey::ProgramId(program_id),
                 |account| account.owner() == &program_id,
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert!(indexed_accounts.is_empty());
@@ -10609,7 +10609,7 @@ pub(crate) mod tests {
             .get_filtered_indexed_accounts(
                 &IndexKey::ProgramId(another_program_id),
                 |account| account.owner() == &another_program_id,
-                ScanConfig::default(),
+                &ScanConfig::default(),
             )
             .unwrap();
         assert_eq!(indexed_accounts.len(), 1);
@@ -13245,7 +13245,7 @@ pub(crate) mod tests {
             Bank::new_from_parent(&bank1, &Pubkey::default(), bank1.first_slot_in_next_epoch());
         assert_eq!(
             bank2
-                .get_program_accounts(&sysvar::id(), ScanConfig::default(),)
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default(),)
                 .unwrap()
                 .len(),
             8
@@ -13257,7 +13257,7 @@ pub(crate) mod tests {
         // no sysvar should be deleted due to rent
         assert_eq!(
             bank2
-                .get_program_accounts(&sysvar::id(), ScanConfig::default(),)
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default(),)
                 .unwrap()
                 .len(),
             8
@@ -13295,7 +13295,7 @@ pub(crate) mod tests {
 
         {
             let sysvars = bank1
-                .get_program_accounts(&sysvar::id(), ScanConfig::default())
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default())
                 .unwrap();
             assert_eq!(sysvars.len(), 8);
             assert!(sysvars
@@ -13332,7 +13332,7 @@ pub(crate) mod tests {
 
         {
             let sysvars = bank2
-                .get_program_accounts(&sysvar::id(), ScanConfig::default())
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default())
                 .unwrap();
             assert_eq!(sysvars.len(), 8);
             assert!(sysvars
@@ -13411,7 +13411,7 @@ pub(crate) mod tests {
         );
         {
             let sysvars = bank1
-                .get_program_accounts(&sysvar::id(), ScanConfig::default())
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default())
                 .unwrap();
             assert_eq!(sysvars.len(), 9);
             assert!(sysvars
@@ -13448,7 +13448,7 @@ pub(crate) mod tests {
         );
         {
             let sysvars = bank2
-                .get_program_accounts(&sysvar::id(), ScanConfig::default())
+                .get_program_accounts(&sysvar::id(), &ScanConfig::default())
                 .unwrap();
             assert_eq!(sysvars.len(), 9);
             assert!(sysvars
@@ -13819,7 +13819,7 @@ pub(crate) mod tests {
                         {
                             info!("scanning program accounts for slot {}", bank_to_scan.slot());
                             let accounts_result = bank_to_scan
-                                .get_program_accounts(&program_id, ScanConfig::default());
+                                .get_program_accounts(&program_id, &ScanConfig::default());
                             let _ = scan_finished_sender.send(bank_to_scan.bank_id());
                             num_banks_scanned.fetch_add(1, Relaxed);
                             match (&acceptable_scan_results, accounts_result.is_err()) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5289,7 +5289,7 @@ impl Bank {
         index_key: &IndexKey,
         filter: F,
         config: &ScanConfig,
-        byte_limit: Option<usize>,
+        byte_limit_for_scan: Option<usize>,
     ) -> ScanResult<Vec<(Pubkey, AccountSharedData)>> {
         self.rc.accounts.load_by_index_key_with_filter(
             &self.ancestors,
@@ -5297,7 +5297,7 @@ impl Bank {
             index_key,
             filter,
             config,
-            byte_limit,
+            byte_limit_for_scan,
         )
     }
 

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -28,7 +28,7 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCircu
     let withdraw_authority_list = withdraw_authority();
 
     let clock = bank.clock();
-    let config = ScanConfig::default();
+    let config = &ScanConfig::default();
     let stake_accounts = if bank
         .rc
         .accounts

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -44,6 +44,7 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> ScanResult<NonCircu
             // updates. We include the redundant filter here to avoid returning these accounts.
             |account| account.owner() == &stake::program::id(),
             config,
+            None,
         )?
     } else {
         bank.get_program_accounts(&stake::program::id(), config)?

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1509,6 +1509,14 @@ pub fn main() {
                       This option is for use during testing."),
         )
         .arg(
+            Arg::with_name("accounts_index_scan_results_limit_mb")
+                .long("accounts-index-scan-results-limit-mb")
+                .value_name("MEGABYTES")
+                .validator(is_parsable::<usize>)
+                .takes_value(true)
+                .help("How large accumulated results from an accounts index scan can become. If this is exceeded, the scan aborts."),
+        )
+        .arg(
             Arg::with_name("accounts_index_memory_limit_mb")
                 .long("accounts-index-memory-limit-mb")
                 .value_name("MEGABYTES")
@@ -2116,6 +2124,12 @@ pub fn main() {
         }
         accounts_index_config.drives = Some(accounts_index_paths);
     }
+
+    const MB: usize = 1_024 * 1_024;
+    accounts_index_config.scan_results_limit_bytes =
+        value_t!(matches, "accounts_index_scan_results_limit_mb", usize)
+            .ok()
+            .map(|mb| mb * MB);
 
     let filler_account_count = value_t!(matches, "accounts_filler_count", usize).ok();
     let mut accounts_db_config = AccountsDbConfig {


### PR DESCRIPTION
#### Problem
rpc scans can accumulate large # of results. This will take a while and time out. The scans will continue accumulating results until the scan completes.
#### Summary of Changes
Allow validators to limit the max mb of data for a scan to accumulate. Once exceeded, the scan will abort.
Fixes #
