### PR TITLE
Charge for sol_log_data translates

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2396,9 +2396,16 @@ impl<'a> SyscallObject<BpfError> for SyscallLogData<'a> {
         );
 
         question_mark!(
-            invoke_context
-                .get_compute_meter()
-                .consume(untranslated_fields.iter().map(|e| e.len() as u64).sum()),
+            invoke_context.get_compute_meter().consume(
+                budget
+                    .syscall_base_cost
+                    .saturating_mul(untranslated_fields.len() as u64)
+                    .saturating_add(
+                        untranslated_fields
+                            .iter()
+                            .fold(0, |total, e| total.saturating_add(e.len() as u64))
+                    )
+            ),
             result
         );
 


### PR DESCRIPTION
#### Problem

`sol_log_data` does not charge the compute budget for translations of the sub slices if the subslices themselves are zero-length

#### Summary of Changes

Charge a base cost for each sub-slice

Fixes #
