### PR TITLE
Accountsdb plugin transaction part 2: transaction selector

### DIFF
--- a/accountsdb-plugin-interface/src/accountsdb_plugin_interface.rs
+++ b/accountsdb-plugin-interface/src/accountsdb_plugin_interface.rs
@@ -79,21 +79,36 @@ pub trait AccountsDbPlugin: Any + Send + Sync + std::fmt::Debug {
     fn on_unload(&mut self) {}
 
     /// Called when an account is updated at a slot.
+    #[allow(unused_variables)]
     fn update_account(
         &mut self,
         account: ReplicaAccountInfoVersions,
         slot: u64,
         is_startup: bool,
-    ) -> Result<()>;
+    ) -> Result<()> {
+        Ok(())
+    }
 
     /// Called when all accounts are notified of during startup.
-    fn notify_end_of_startup(&mut self) -> Result<()>;
+    fn notify_end_of_startup(&mut self) -> Result<()> {
+        Ok(())
+    }
 
     /// Called when a slot status is updated
+    #[allow(unused_variables)]
     fn update_slot_status(
         &mut self,
         slot: u64,
         parent: Option<u64>,
         status: SlotStatus,
-    ) -> Result<()>;
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check if the plugin is interested in account data
+    /// Default is true -- if the plugin is not interested in
+    /// account data, please return false.
+    fn to_notify_account_data(&self) -> bool {
+        true
+    }
 }

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_manager.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_manager.rs
@@ -52,4 +52,14 @@ impl AccountsDbPluginManager {
             drop(lib);
         }
     }
+
+    /// Check if there is any plugin interested in account data
+    pub fn to_notify_account_data(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.to_notify_account_data() {
+                return true;
+            }
+        }
+        false
+    }
 }

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
@@ -164,7 +164,7 @@ impl AccountsDbPluginService {
     }
 
     pub fn join(self) -> thread::Result<()> {
-        if let Some(slot_status_observer) = self.slot_status_observer {
+        if let Some(mut slot_status_observer) = self.slot_status_observer {
             slot_status_observer.join()?;
         }
         self.plugin_manager.write().unwrap().unload();

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
@@ -78,8 +78,7 @@ impl AccountsDbPluginService {
 
         let plugin_manager = Arc::new(RwLock::new(plugin_manager));
 
-        let accounts_update_notifier: Option<AccountsUpdateNotifier> = if to_notify_account_data
-        {
+        let accounts_update_notifier: Option<AccountsUpdateNotifier> = if to_notify_account_data {
             let accounts_update_notifier = AccountsUpdateNotifierImpl::new(plugin_manager.clone());
             Some(Arc::new(RwLock::new(accounts_update_notifier)))
         } else {

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
@@ -164,8 +164,8 @@ impl AccountsDbPluginService {
     }
 
     pub fn join(self) -> thread::Result<()> {
-        if self.slot_status_observer.is_some() {
-            self.slot_status_observer.unwrap().join()?;
+        if let Some(slot_status_observer) = self.slot_status_observer {
+            slot_status_observer.join()?;
         }
         self.plugin_manager.write().unwrap().unload();
         Ok(())

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_service.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         accounts_update_notifier::AccountsUpdateNotifierImpl,
         accountsdb_plugin_manager::AccountsDbPluginManager,
-        slot_status_observer::SlotStatusObserver,
+        slot_status_notifier::SlotStatusNotifierImpl, slot_status_observer::SlotStatusObserver,
     },
     crossbeam_channel::Receiver,
     log::*,
@@ -42,9 +42,9 @@ pub enum AccountsdbPluginServiceError {
 
 /// The service managing the AccountsDb plugin workflow.
 pub struct AccountsDbPluginService {
-    slot_status_observer: SlotStatusObserver,
+    slot_status_observer: Option<SlotStatusObserver>,
     plugin_manager: Arc<RwLock<AccountsDbPluginManager>>,
-    accounts_update_notifier: AccountsUpdateNotifier,
+    accounts_update_notifier: Option<AccountsUpdateNotifier>,
 }
 
 impl AccountsDbPluginService {
@@ -74,13 +74,28 @@ impl AccountsDbPluginService {
         for accountsdb_plugin_config_file in accountsdb_plugin_config_files {
             Self::load_plugin(&mut plugin_manager, accountsdb_plugin_config_file)?;
         }
+        let to_notify_account_data = plugin_manager.to_notify_account_data();
 
         let plugin_manager = Arc::new(RwLock::new(plugin_manager));
-        let accounts_update_notifier = Arc::new(RwLock::new(AccountsUpdateNotifierImpl::new(
-            plugin_manager.clone(),
-        )));
-        let slot_status_observer =
-            SlotStatusObserver::new(confirmed_bank_receiver, accounts_update_notifier.clone());
+
+        let accounts_update_notifier: Option<AccountsUpdateNotifier> = if to_notify_account_data
+        {
+            let accounts_update_notifier = AccountsUpdateNotifierImpl::new(plugin_manager.clone());
+            Some(Arc::new(RwLock::new(accounts_update_notifier)))
+        } else {
+            None
+        };
+
+        let slot_status_observer = if to_notify_account_data {
+            let slot_status_notifier = SlotStatusNotifierImpl::new(plugin_manager.clone());
+            let slot_status_notifier = Arc::new(RwLock::new(slot_status_notifier));
+            Some(SlotStatusObserver::new(
+                confirmed_bank_receiver,
+                slot_status_notifier,
+            ))
+        } else {
+            None
+        };
 
         info!("Started AccountsDbPluginService");
         Ok(AccountsDbPluginService {
@@ -145,12 +160,14 @@ impl AccountsDbPluginService {
         Ok(())
     }
 
-    pub fn get_accounts_update_notifier(&self) -> AccountsUpdateNotifier {
+    pub fn get_accounts_update_notifier(&self) -> Option<AccountsUpdateNotifier> {
         self.accounts_update_notifier.clone()
     }
 
-    pub fn join(mut self) -> thread::Result<()> {
-        self.slot_status_observer.join()?;
+    pub fn join(self) -> thread::Result<()> {
+        if self.slot_status_observer.is_some() {
+            self.slot_status_observer.unwrap().join()?;
+        }
         self.plugin_manager.write().unwrap().unload();
         Ok(())
     }

--- a/accountsdb-plugin-manager/src/lib.rs
+++ b/accountsdb-plugin-manager/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod accounts_update_notifier;
 pub mod accountsdb_plugin_manager;
 pub mod accountsdb_plugin_service;
+pub mod slot_status_notifier;
 pub mod slot_status_observer;

--- a/accountsdb-plugin-manager/src/slot_status_notifier.rs
+++ b/accountsdb-plugin-manager/src/slot_status_notifier.rs
@@ -1,0 +1,81 @@
+use {
+    crate::accountsdb_plugin_manager::AccountsDbPluginManager,
+    log::*,
+    solana_accountsdb_plugin_interface::accountsdb_plugin_interface::SlotStatus,
+    solana_measure::measure::Measure,
+    solana_metrics::*,
+    solana_sdk::clock::Slot,
+    std::sync::{Arc, RwLock},
+};
+
+pub trait SlotStatusNotifierInterface {
+    /// Notified when a slot is optimistically confirmed
+    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>);
+
+    /// Notified when a slot is marked frozen.
+    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>);
+
+    /// Notified when a slot is rooted.
+    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
+}
+
+pub type SlotStatusNotifier = Arc<RwLock<dyn SlotStatusNotifierInterface + Sync + Send>>;
+
+pub struct SlotStatusNotifierImpl {
+    plugin_manager: Arc<RwLock<AccountsDbPluginManager>>,
+}
+
+impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
+    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>) {
+        self.notify_slot_status(slot, parent, SlotStatus::Confirmed);
+    }
+
+    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>) {
+        self.notify_slot_status(slot, parent, SlotStatus::Processed);
+    }
+
+    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>) {
+        self.notify_slot_status(slot, parent, SlotStatus::Rooted);
+    }
+}
+
+impl SlotStatusNotifierImpl {
+    pub fn new(plugin_manager: Arc<RwLock<AccountsDbPluginManager>>) -> Self {
+        Self { plugin_manager }
+    }
+
+    pub fn notify_slot_status(&self, slot: Slot, parent: Option<Slot>, slot_status: SlotStatus) {
+        let mut plugin_manager = self.plugin_manager.write().unwrap();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        for plugin in plugin_manager.plugins.iter_mut() {
+            let mut measure = Measure::start("accountsdb-plugin-update-slot");
+            match plugin.update_slot_status(slot, parent, slot_status.clone()) {
+                Err(err) => {
+                    error!(
+                        "Failed to update slot status at slot {}, error: {} to plugin {}",
+                        slot,
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Successfully updated slot status at slot {} to plugin {}",
+                        slot,
+                        plugin.name()
+                    );
+                }
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "accountsdb-plugin-update-slot-us",
+                measure.as_us() as usize,
+                1000,
+                1000
+            );
+        }
+    }
+}

--- a/accountsdb-plugin-postgres/src/accounts_selector.rs
+++ b/accountsdb-plugin-postgres/src/accounts_selector.rs
@@ -48,6 +48,11 @@ impl AccountsSelector {
     pub fn is_account_selected(&self, account: &[u8], owner: &[u8]) -> bool {
         self.select_all_accounts || self.accounts.contains(account) || self.owners.contains(owner)
     }
+
+    /// Check if any account is of interested at all
+    pub fn is_enabled(&self) -> bool {
+        self.select_all_accounts || !self.accounts.is_empty() || !self.owners.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
+++ b/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
@@ -276,6 +276,15 @@ impl AccountsDbPlugin for AccountsDbPluginPostgres {
         }
         Ok(())
     }
+
+    /// Check if the plugin is interested in account data
+    /// Default is true -- if the plugin is not interested in
+    /// account data, please return false.
+    fn to_notify_account_data(&self) -> bool {
+        self.accounts_selector
+            .as_ref()
+            .map_or_else(|| false, |selector| selector.is_enabled())
+    }
 }
 
 impl AccountsDbPluginPostgres {

--- a/accountsdb-plugin-postgres/src/lib.rs
+++ b/accountsdb-plugin-postgres/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod accounts_selector;
 pub mod accountsdb_plugin_postgres;
 pub mod postgres_client;
+pub mod transaction_selector;

--- a/accountsdb-plugin-postgres/src/transaction_selector.rs
+++ b/accountsdb-plugin-postgres/src/transaction_selector.rs
@@ -1,0 +1,184 @@
+/// The transaction selector is responsible for filtering transactions
+/// in the plugin framework.
+use {log::*, solana_sdk::pubkey::Pubkey, std::collections::HashSet};
+
+pub(crate) struct TransactionSelector {
+    pub mentions: HashSet<Vec<u8>>,
+    pub select_all_transactions: bool,
+    pub select_all_vote_transactions: bool,
+}
+
+impl TransactionSelector {
+    pub fn default() -> Self {
+        Self {
+            mentions: HashSet::default(),
+            select_all_transactions: false,
+            select_all_vote_transactions: false,
+        }
+    }
+
+    pub fn new(accounts: &[String]) -> Self {
+        info!("Creating TransactionSelector from accounts: {:?}", accounts);
+
+        let select_all_transactions = accounts.iter().any(|key| key == "*" || key == "all");
+        if select_all_transactions {
+            return Self {
+                mentions: HashSet::default(),
+                select_all_transactions,
+                select_all_vote_transactions: true,
+            };
+        }
+        let select_all_vote_transactions = accounts.iter().any(|key| key == "all_votes");
+        if select_all_vote_transactions {
+            return Self {
+                mentions: HashSet::default(),
+                select_all_transactions,
+                select_all_vote_transactions: true,
+            };
+        }
+
+        let accounts = accounts
+            .iter()
+            .map(|key| bs58::decode(key).into_vec().unwrap())
+            .collect();
+
+        Self {
+            mentions: accounts,
+            select_all_transactions: false,
+            select_all_vote_transactions: false,
+        }
+    }
+
+    /// Check if a transaction is of interest.
+    pub fn is_transaction_selected(
+        &self,
+        is_vote: bool,
+        accounts: Box<dyn Iterator<Item = &Pubkey> + '_>,
+    ) -> bool {
+        if !self.is_interested_in_any_transaction() {
+            return false;
+        }
+
+        if self.select_all_transactions || (self.select_all_vote_transactions && is_vote) {
+            return true;
+        }
+        for account in accounts {
+            if self.mentions.contains(account.as_ref()) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if any transaction is of interested at all
+    pub fn is_interested_in_any_transaction(&self) -> bool {
+        self.select_all_transactions
+            || self.select_all_vote_transactions
+            || !self.mentions.is_empty()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&[pubkey1.to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_transaction_using_wildcard() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["*".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_transaction_all() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["all".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_vote_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["all_votes".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_no_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&[]);
+
+        assert!(!selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+    }
+}

--- a/accountsdb-plugin-postgres/src/transaction_selector.rs
+++ b/accountsdb-plugin-postgres/src/transaction_selector.rs
@@ -8,6 +8,7 @@ pub(crate) struct TransactionSelector {
     pub select_all_vote_transactions: bool,
 }
 
+#[allow(dead_code)]
 impl TransactionSelector {
     pub fn default() -> Self {
         Self {
@@ -55,7 +56,7 @@ impl TransactionSelector {
         is_vote: bool,
         accounts: Box<dyn Iterator<Item = &Pubkey> + '_>,
     ) -> bool {
-        if !self.is_interested_in_any_transaction() {
+        if !self.is_enabled() {
             return false;
         }
 
@@ -71,7 +72,7 @@ impl TransactionSelector {
     }
 
     /// Check if any transaction is of interested at all
-    pub fn is_interested_in_any_transaction(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         self.select_all_transactions
             || self.select_all_vote_transactions
             || !self.mentions.is_empty()
@@ -89,7 +90,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&[pubkey1.to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -109,7 +110,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["*".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -129,7 +130,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["all".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -149,7 +150,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["all_votes".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -169,7 +170,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&[]);
 
-        assert!(!selector.is_interested_in_any_transaction());
+        assert!(!selector.is_enabled());
 
         let accounts = [pubkey1];
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -414,14 +414,12 @@ impl Validator {
 
         let accounts_package_channel = channel();
 
-        let accounts_update_notifier = if accountsdb_plugin_service.is_some() {
+        let accounts_update_notifier =
             accountsdb_plugin_service
                 .as_ref()
-                .unwrap()
-                .get_accounts_update_notifier()
-        } else {
-            None
-        };
+                .and_then(|accountsdb_plugin_service| {
+                    accountsdb_plugin_service.get_accounts_update_notifier()
+                });
         info!(
             "AccountsDb plugin: accounts_update_notifier: {}",
             accounts_update_notifier.is_some()

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -414,6 +414,19 @@ impl Validator {
 
         let accounts_package_channel = channel();
 
+        let accounts_update_notifier = if accountsdb_plugin_service.is_some() {
+            accountsdb_plugin_service
+                .as_ref()
+                .unwrap()
+                .get_accounts_update_notifier()
+        } else {
+            None
+        };
+        info!(
+            "AccountsDb plugin: accounts_update_notifier: {}",
+            accounts_update_notifier.is_some()
+        );
+
         let (
             genesis_config,
             bank_forks,
@@ -444,9 +457,7 @@ impl Validator {
             &start_progress,
             config.no_poh_speed_test,
             accounts_package_channel.0.clone(),
-            accountsdb_plugin_service
-                .as_ref()
-                .map(|plugin_service| plugin_service.get_accounts_update_notifier()),
+            accounts_update_notifier,
         );
 
         *start_progress.write().unwrap() = ValidatorStartProgress::StartingServices;

--- a/runtime/src/accounts_db/accountsdb_plugin_utils.rs
+++ b/runtime/src/accounts_db/accountsdb_plugin_utils.rs
@@ -202,15 +202,6 @@ pub mod tests {
                 .push((slot, account.clone_account()));
         }
 
-        /// Notified when a slot is optimistically confirmed
-        fn notify_slot_confirmed(&self, _slot: Slot, _parent: Option<Slot>) {}
-
-        /// Notified when a slot is marked frozen.
-        fn notify_slot_processed(&self, _slot: Slot, _parent: Option<Slot>) {}
-
-        /// Notified when a slot is rooted.
-        fn notify_slot_rooted(&self, _slot: Slot, _parent: Option<Slot>) {}
-
         fn notify_end_of_restore_from_snapshot(&self) {
             self.is_startup_done.store(true, Ordering::Relaxed);
         }

--- a/runtime/src/accounts_update_notifier_interface.rs
+++ b/runtime/src/accounts_update_notifier_interface.rs
@@ -14,15 +14,6 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);
-
-    /// Notified when a slot is optimistically confirmed
-    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>);
-
-    /// Notified when a slot is marked frozen.
-    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>);
-
-    /// Notified when a slot is rooted.
-    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
 }
 
 pub type AccountsUpdateNotifier = Arc<RwLock<dyn AccountsUpdateNotifierInterface + Sync + Send>>;


### PR DESCRIPTION
#### Problem
In the plugin framework -- not all transactions might be of interest. We need to allow the user to select transactions for storage.

#### Summary of Changes
Created the transaction_selector which allows the user to configure the transactions to stream:
1. all transactions
2. all vote transactions 
3. transactions mentioning accounts

Note: this is the second part of https://github.com/solana-labs/solana/pull/21247.

Fixes #
