### PR TITLE
Accountsdb plugin transaction part 2: transaction selector

### DIFF
--- a/accountsdb-plugin-postgres/src/lib.rs
+++ b/accountsdb-plugin-postgres/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod accounts_selector;
 pub mod accountsdb_plugin_postgres;
 pub mod postgres_client;
+pub mod transaction_selector;

--- a/accountsdb-plugin-postgres/src/transaction_selector.rs
+++ b/accountsdb-plugin-postgres/src/transaction_selector.rs
@@ -1,0 +1,184 @@
+/// The transaction selector is responsible for filtering transactions
+/// in the plugin framework.
+use {log::*, solana_sdk::pubkey::Pubkey, std::collections::HashSet};
+
+pub(crate) struct TransactionSelector {
+    pub mentions: HashSet<Vec<u8>>,
+    pub select_all_transactions: bool,
+    pub select_all_vote_transactions: bool,
+}
+
+impl TransactionSelector {
+    pub fn default() -> Self {
+        Self {
+            mentions: HashSet::default(),
+            select_all_transactions: false,
+            select_all_vote_transactions: false,
+        }
+    }
+
+    pub fn new(accounts: &[String]) -> Self {
+        info!("Creating TransactionSelector from accounts: {:?}", accounts);
+
+        let select_all_transactions = accounts.iter().any(|key| key == "*" || key == "all");
+        if select_all_transactions {
+            return Self {
+                mentions: HashSet::default(),
+                select_all_transactions,
+                select_all_vote_transactions: true,
+            };
+        }
+        let select_all_vote_transactions = accounts.iter().any(|key| key == "all_votes");
+        if select_all_vote_transactions {
+            return Self {
+                mentions: HashSet::default(),
+                select_all_transactions,
+                select_all_vote_transactions: true,
+            };
+        }
+
+        let accounts = accounts
+            .iter()
+            .map(|key| bs58::decode(key).into_vec().unwrap())
+            .collect();
+
+        Self {
+            mentions: accounts,
+            select_all_transactions: false,
+            select_all_vote_transactions: false,
+        }
+    }
+
+    /// Check if a transaction is of interest.
+    pub fn is_transaction_selected(
+        &self,
+        is_vote: bool,
+        accounts: Box<dyn Iterator<Item = &Pubkey> + '_>,
+    ) -> bool {
+        if !self.is_interested_in_any_transaction() {
+            return false;
+        }
+
+        if self.select_all_transactions || (self.select_all_vote_transactions && is_vote) {
+            return true;
+        }
+        for account in accounts {
+            if self.mentions.contains(account.as_ref()) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if any transaction is of interested at all
+    pub fn is_interested_in_any_transaction(&self) -> bool {
+        self.select_all_transactions
+            || self.select_all_vote_transactions
+            || !self.mentions.is_empty()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&[pubkey1.to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_transaction_using_wildcard() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["*".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_transaction_all() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["all".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_all_vote_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&["all_votes".to_string()]);
+
+        assert!(selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+    }
+
+    #[test]
+    fn test_select_no_transaction() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let selector = TransactionSelector::new(&[]);
+
+        assert!(!selector.is_interested_in_any_transaction());
+
+        let accounts = [pubkey1];
+
+        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+
+        let accounts = [pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+
+        let accounts = [pubkey1, pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+    }
+}

--- a/accountsdb-plugin-postgres/src/transaction_selector.rs
+++ b/accountsdb-plugin-postgres/src/transaction_selector.rs
@@ -3,7 +3,7 @@
 use {log::*, solana_sdk::pubkey::Pubkey, std::collections::HashSet};
 
 pub(crate) struct TransactionSelector {
-    pub mentions: HashSet<Vec<u8>>,
+    pub mentioned_addresses: HashSet<Vec<u8>>,
     pub select_all_transactions: bool,
     pub select_all_vote_transactions: bool,
 }
@@ -12,39 +12,48 @@ pub(crate) struct TransactionSelector {
 impl TransactionSelector {
     pub fn default() -> Self {
         Self {
-            mentions: HashSet::default(),
+            mentioned_addresses: HashSet::default(),
             select_all_transactions: false,
             select_all_vote_transactions: false,
         }
     }
 
-    pub fn new(accounts: &[String]) -> Self {
-        info!("Creating TransactionSelector from accounts: {:?}", accounts);
+    /// Create a selector based on the mentioned addresses
+    /// To select all transactions use ["*"] or ["all"]
+    /// To select all vote transactions, use ["all_votes"]
+    /// To select transactions mentioning specific addresses use ["<pubkey1>", "<pubkey2>", ...]
+    pub fn new(mentioned_addresses: &[String]) -> Self {
+        info!(
+            "Creating TransactionSelector from addresses: {:?}",
+            mentioned_addresses
+        );
 
-        let select_all_transactions = accounts.iter().any(|key| key == "*" || key == "all");
+        let select_all_transactions = mentioned_addresses
+            .iter()
+            .any(|key| key == "*" || key == "all");
         if select_all_transactions {
             return Self {
-                mentions: HashSet::default(),
+                mentioned_addresses: HashSet::default(),
                 select_all_transactions,
                 select_all_vote_transactions: true,
             };
         }
-        let select_all_vote_transactions = accounts.iter().any(|key| key == "all_votes");
+        let select_all_vote_transactions = mentioned_addresses.iter().any(|key| key == "all_votes");
         if select_all_vote_transactions {
             return Self {
-                mentions: HashSet::default(),
+                mentioned_addresses: HashSet::default(),
                 select_all_transactions,
                 select_all_vote_transactions: true,
             };
         }
 
-        let accounts = accounts
+        let mentioned_addresses = mentioned_addresses
             .iter()
             .map(|key| bs58::decode(key).into_vec().unwrap())
             .collect();
 
         Self {
-            mentions: accounts,
+            mentioned_addresses,
             select_all_transactions: false,
             select_all_vote_transactions: false,
         }
@@ -54,7 +63,7 @@ impl TransactionSelector {
     pub fn is_transaction_selected(
         &self,
         is_vote: bool,
-        accounts: Box<dyn Iterator<Item = &Pubkey> + '_>,
+        mentioned_addresses: Box<dyn Iterator<Item = &Pubkey> + '_>,
     ) -> bool {
         if !self.is_enabled() {
             return false;
@@ -63,19 +72,19 @@ impl TransactionSelector {
         if self.select_all_transactions || (self.select_all_vote_transactions && is_vote) {
             return true;
         }
-        for account in accounts {
-            if self.mentions.contains(account.as_ref()) {
+        for address in mentioned_addresses {
+            if self.mentioned_addresses.contains(address.as_ref()) {
                 return true;
             }
         }
         false
     }
 
-    /// Check if any transaction is of interested at all
+    /// Check if any transaction is of interest at all
     pub fn is_enabled(&self) -> bool {
         self.select_all_transactions
             || self.select_all_vote_transactions
-            || !self.mentions.is_empty()
+            || !self.mentioned_addresses.is_empty()
     }
 }
 
@@ -92,15 +101,15 @@ pub(crate) mod tests {
 
         assert!(selector.is_enabled());
 
-        let accounts = [pubkey1];
+        let addresses = [pubkey1];
 
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey2];
-        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey2];
+        assert!(!selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey1, pubkey2];
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
     }
 
     #[test]
@@ -112,15 +121,15 @@ pub(crate) mod tests {
 
         assert!(selector.is_enabled());
 
-        let accounts = [pubkey1];
+        let addresses = [pubkey1];
 
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey2];
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey1, pubkey2];
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
     }
 
     #[test]
@@ -132,15 +141,15 @@ pub(crate) mod tests {
 
         assert!(selector.is_enabled());
 
-        let accounts = [pubkey1];
+        let addresses = [pubkey1];
 
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey2];
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey1, pubkey2];
-        assert!(selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        let addresses = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(false, Box::new(addresses.iter())));
     }
 
     #[test]
@@ -152,15 +161,15 @@ pub(crate) mod tests {
 
         assert!(selector.is_enabled());
 
-        let accounts = [pubkey1];
+        let addresses = [pubkey1];
 
-        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        assert!(!selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey2];
-        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+        let addresses = [pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(addresses.iter())));
 
-        let accounts = [pubkey1, pubkey2];
-        assert!(selector.is_transaction_selected(true, Box::new(accounts.iter())));
+        let addresses = [pubkey1, pubkey2];
+        assert!(selector.is_transaction_selected(true, Box::new(addresses.iter())));
     }
 
     #[test]
@@ -172,14 +181,14 @@ pub(crate) mod tests {
 
         assert!(!selector.is_enabled());
 
-        let accounts = [pubkey1];
+        let addresses = [pubkey1];
 
-        assert!(!selector.is_transaction_selected(false, Box::new(accounts.iter())));
+        assert!(!selector.is_transaction_selected(false, Box::new(addresses.iter())));
 
-        let accounts = [pubkey2];
-        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+        let addresses = [pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(addresses.iter())));
 
-        let accounts = [pubkey1, pubkey2];
-        assert!(!selector.is_transaction_selected(true, Box::new(accounts.iter())));
+        let addresses = [pubkey1, pubkey2];
+        assert!(!selector.is_transaction_selected(true, Box::new(addresses.iter())));
     }
 }

--- a/accountsdb-plugin-postgres/src/transaction_selector.rs
+++ b/accountsdb-plugin-postgres/src/transaction_selector.rs
@@ -8,6 +8,7 @@ pub(crate) struct TransactionSelector {
     pub select_all_vote_transactions: bool,
 }
 
+#[allow(dead_code)]
 impl TransactionSelector {
     pub fn default() -> Self {
         Self {
@@ -55,7 +56,7 @@ impl TransactionSelector {
         is_vote: bool,
         accounts: Box<dyn Iterator<Item = &Pubkey> + '_>,
     ) -> bool {
-        if !self.is_interested_in_any_transaction() {
+        if !self.is_enabled() {
             return false;
         }
 
@@ -71,7 +72,7 @@ impl TransactionSelector {
     }
 
     /// Check if any transaction is of interested at all
-    pub fn is_interested_in_any_transaction(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         self.select_all_transactions
             || self.select_all_vote_transactions
             || !self.mentions.is_empty()
@@ -89,7 +90,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&[pubkey1.to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -109,7 +110,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["*".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -129,7 +130,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["all".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -149,7 +150,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&["all_votes".to_string()]);
 
-        assert!(selector.is_interested_in_any_transaction());
+        assert!(selector.is_enabled());
 
         let accounts = [pubkey1];
 
@@ -169,7 +170,7 @@ pub(crate) mod tests {
 
         let selector = TransactionSelector::new(&[]);
 
-        assert!(!selector.is_interested_in_any_transaction());
+        assert!(!selector.is_enabled());
 
         let accounts = [pubkey1];
 


### PR DESCRIPTION
#Problem

In the plugin framework -- not all transactions might be of interest. We need to allow the user to select transactions for storage.

#Summary of Changes

Created the transaction_selector which allows the user to configure the transactions to stream:

all transactions
all vote transactions
transactions mentioning accounts
Note: this is the second part of #21247.

#Fixes #