### PR TITLE
uses enum for shred type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,6 +5084,8 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "matches",
+ "num-derive",
+ "num-traits",
  "num_cpus",
  "prost 0.9.0",
  "rand 0.7.3",

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -22,7 +22,7 @@ use {
         contact_info::ContactInfo,
     },
     solana_ledger::{
-        shred::Shred,
+        shred::{Shred, ShredType},
         {blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
     },
     solana_measure::measure::Measure,
@@ -143,14 +143,14 @@ impl RetransmitStats {
     }
 }
 
-// Map of shred (slot, index, is_data) => list of hash values seen for that key.
-type ShredFilter = LruCache<(Slot, u32, bool), Vec<u64>>;
+// Map of shred (slot, index, type) => list of hash values seen for that key.
+type ShredFilter = LruCache<(Slot, u32, ShredType), Vec<u64>>;
 
 type ShredFilterAndHasher = (ShredFilter, PacketHasher);
 
 // Returns true if shred is already received and should skip retransmit.
 fn should_skip_retransmit(shred: &Shred, shreds_received: &Mutex<ShredFilterAndHasher>) -> bool {
-    let key = (shred.slot(), shred.index(), shred.is_data());
+    let key = (shred.slot(), shred.index(), shred.shred_type());
     let mut shreds_received = shreds_received.lock().unwrap();
     let (cache, hasher) = shreds_received.deref_mut();
     match cache.get_mut(&key) {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -218,8 +218,8 @@ fn run_check_duplicate(
             if let Some(existing_shred_payload) = blockstore.is_shred_duplicate(
                 shred_slot,
                 shred.index(),
-                &shred.payload,
-                shred.is_data(),
+                shred.payload.clone(),
+                shred.shred_type(),
             ) {
                 cluster_info.push_duplicate_shred(&shred, &existing_shred_payload)?;
                 blockstore.store_duplicate_slot(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -18,7 +18,7 @@ use {
     solana_ledger::{
         blockstore::{self, Blockstore, BlockstoreInsertionMetrics, MAX_DATA_SHREDS_PER_SLOT},
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{Nonce, Shred},
+        shred::{Nonce, Shred, ShredType},
     },
     solana_measure::measure::Measure,
     solana_metrics::{inc_new_counter_debug, inc_new_counter_error},
@@ -162,12 +162,11 @@ impl ReceiveWindowStats {
 }
 
 fn verify_shred_slot(shred: &Shred, root: u64) -> bool {
-    if shred.is_data() {
+    match shred.shred_type() {
         // Only data shreds have parent information
-        blockstore::verify_shred_slots(shred.slot(), shred.parent(), root)
-    } else {
+        ShredType::Data => blockstore::verify_shred_slots(shred.slot(), shred.parent(), root),
         // Filter out outdated coding shreds
-        shred.slot() >= root
+        ShredType::Code => shred.slot() >= root,
     }
 }
 

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -259,7 +259,7 @@ pub fn make_accounts_hashes_message(
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[frozen_abi(digest = "4VqzaZbxQkeTgo916HVoLtaWoM8bbGaQZy6Qgw7K9kLf")]
+#[frozen_abi(digest = "4qB65g6HSnHFxkhZuvMEBCLHARBda1HBwJ8qeQ5RZ6Pk")]
 #[derive(Serialize, Deserialize, Debug, AbiEnumVisitor, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -21,6 +21,8 @@ itertools = "0.10.1"
 lazy_static = "1.4.0"
 libc = "0.2.107"
 log = { version = "0.4.14" }
+num-derive = "0.3"
+num-traits = "0.2"
 num_cpus = "1.13.0"
 prost = "0.9.0"
 rand = "0.7.0"

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -13,7 +13,10 @@ use {
         erasure::ErasureConfig,
         leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
-        shred::{Result as ShredResult, Shred, ShredType, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK},
+        shred::{
+            Result as ShredResult, Shred, ShredType, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
+            SHRED_PAYLOAD_SIZE,
+        },
     },
     bincode::deserialize,
     log::*,
@@ -1326,7 +1329,6 @@ impl Blockstore {
         leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
     ) -> bool {
-        use crate::shred::SHRED_PAYLOAD_SIZE;
         let shred_index = u64::from(shred.index());
         let slot = shred.slot();
         let last_in_slot = if shred.last_in_slot() {
@@ -1555,7 +1557,6 @@ impl Blockstore {
     }
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
-        use crate::shred::SHRED_PAYLOAD_SIZE;
         self.data_shred_cf.get_bytes((slot, index)).map(|data| {
             data.map(|mut d| {
                 // Only data_header.size bytes stored in the blockstore so
@@ -3033,32 +3034,18 @@ impl Blockstore {
         &self,
         slot: u64,
         index: u32,
-        new_shred_raw: &[u8],
-        // TODO: change arg type to ShredType.
-        is_data: bool,
+        mut payload: Vec<u8>,
+        shred_type: ShredType,
     ) -> Option<Vec<u8>> {
-        let res = if is_data {
-            self.get_data_shred(slot, index as u64)
-                .expect("fetch from DuplicateSlots column family failed")
-        } else {
-            self.get_coding_shred(slot, index as u64)
-                .expect("fetch from DuplicateSlots column family failed")
-        };
-
-        let mut payload = new_shred_raw.to_vec();
-        payload.resize(
-            std::cmp::max(new_shred_raw.len(), crate::shred::SHRED_PAYLOAD_SIZE),
-            0,
-        );
+        let existing_shred = match shred_type {
+            ShredType::Data => self.get_data_shred(slot, index as u64),
+            ShredType::Code => self.get_coding_shred(slot, index as u64),
+        }
+        .expect("fetch from DuplicateSlots column family failed")?;
+        let size = payload.len().max(SHRED_PAYLOAD_SIZE);
+        payload.resize(size, 0u8);
         let new_shred = Shred::new_from_serialized_shred(payload).unwrap();
-        res.map(|existing_shred| {
-            if existing_shred != new_shred.payload {
-                Some(existing_shred)
-            } else {
-                None
-            }
-        })
-        .unwrap_or(None)
+        (existing_shred != new_shred.payload).then(|| existing_shred)
     }
 
     pub fn has_duplicate_shreds_in_slot(&self, slot: Slot) -> bool {
@@ -8115,8 +8102,8 @@ pub mod tests {
             blockstore.is_shred_duplicate(
                 slot,
                 0,
-                &duplicate_shred.payload,
-                duplicate_shred.is_data()
+                duplicate_shred.payload.clone(),
+                duplicate_shred.shred_type(),
             ),
             Some(shred.payload.to_vec())
         );
@@ -8124,8 +8111,8 @@ pub mod tests {
             .is_shred_duplicate(
                 slot,
                 0,
-                &non_duplicate_shred.payload,
-                duplicate_shred.is_data()
+                non_duplicate_shred.payload.clone(),
+                non_duplicate_shred.shred_type(),
             )
             .is_none());
 
@@ -8595,8 +8582,8 @@ pub mod tests {
             .is_shred_duplicate(
                 slot,
                 even_smaller_last_shred_duplicate.index(),
-                &even_smaller_last_shred_duplicate.payload,
-                true
+                even_smaller_last_shred_duplicate.payload.clone(),
+                ShredType::Data,
             )
             .is_some());
         blockstore


### PR DESCRIPTION
#### Problem
Current code is using `u8` which does not have any type-safety and can contain invalid values:
https://github.com/solana-labs/solana/blob/66fa062f1/ledger/src/shred.rs#L167

#### Summary of Changes
* use enum for shred type with `#[repr(u8)]`.
* backward compatibility is maintained by implementing `Serialize` and `Deserialize` compatible with `u8`.
