### PR TITLE
Fix authority in bpf_loader_upgradeable::close_any

### DIFF
--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -261,7 +261,7 @@ pub fn close_any(
         AccountMeta::new(*recipient_address, false),
     ];
     if let Some(authority_address) = authority_address {
-        metas.push(AccountMeta::new(*authority_address, true));
+        metas.push(AccountMeta::new_readonly(*authority_address, true));
     }
     if let Some(program_address) = program_address {
         metas.push(AccountMeta::new(*program_address, false));


### PR DESCRIPTION
#### Problem

Authority not required to be `writeable`.
https://github.com/solana-labs/solana/blob/89102540b171c57f25daad82f3759643d64e9c0e/programs/bpf_loader/src/lib.rs#L727-L815

#### Summary of Changes

Change `AccountMeta::new` to `AccountMeta::new_readonly`
