### PR TITLE
mergify: don't request reviews for community pr's if already reviewed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,14 @@ pull_request_rules:
       label:
         add:
           - community
+  - name: request review for community changes
+    conditions:
+      - author≠@core-contributors
+      - author≠mergify[bot]
+      - author≠dependabot[bot]
+      - "#review-requested=0"
+      - "#commented-reviews-by=0"
+    actions:
       request_reviews:
         teams:
           - "@solana-labs/community-pr-subscribers"


### PR DESCRIPTION
#### Problem
It's pretty annoying when reviews are requested multiple times for the same community PR

#### Summary of Changes
Only request reviews from @solana-labs/community-pr-subscribers (hi) if there are no assigned reviewers and no one has reviewed the PR yet

Fixes #
