### PR TITLE
Spit log data charge into two

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2403,11 +2403,14 @@ impl<'a> SyscallObject<BpfError> for SyscallLogData<'a> {
                 budget
                     .syscall_base_cost
                     .saturating_mul(untranslated_fields.len() as u64)
-                    .saturating_add(
-                        untranslated_fields
-                            .iter()
-                            .fold(0, |total, e| total.saturating_add(e.len() as u64))
-                    )
+            ),
+            result
+        );
+        question_mark!(
+            invoke_context.get_compute_meter().consume(
+                untranslated_fields
+                    .iter()
+                    .fold(0, |total, e| total.saturating_add(e.len() as u64))
             ),
             result
         );


### PR DESCRIPTION
#### Problem

The `sol_log_data` charges for both the number of subslices and the length of each subslice.  But the calculations are done together.  There could be a very large number of sub-slices, enough to exhaust the compute budget by itself, but because the calculations are done together the cluster would spend time iterating the subslices unnecessarily.

#### Summary of Changes

Split up the calculations and charge separately so that the call bails as early as possible.

Fixes #
