### PR TITLE
ledger-tool uses jemalloc like validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,6 +5150,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
+ "tikv-jemallocator",
  "tokio",
 ]
 

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -38,6 +38,9 @@ solana-version = { path = "../version", version = "=1.9.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.0" }
 tokio = { version = "1", features = ["full"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = {package = "tikv-jemallocator", version = "0.4.1", features = ["unprefixed_malloc_on_supported_platforms"]}
+
 [dev-dependencies]
 assert_cmd = "2.0"
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -833,6 +833,12 @@ fn assert_capitalization(bank: &Bank) {
     let debug_verify = true;
     assert!(bank.calculate_and_verify_capitalization(debug_verify));
 }
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {


### PR DESCRIPTION
#### Problem
ledger-tool is useful for profiling startup and various systems (like accounts index). It would be nice if it ran with the same allocator as validator.
#### Summary of Changes

Fixes #
