### PR TITLE
Bump bpf-tools to v1.20

### DIFF
--- a/programs/bpf/c/src/stdlib/stdlib.c
+++ b/programs/bpf/c/src/stdlib/stdlib.c
@@ -1,0 +1,20 @@
+/**
+ * @brief Example C based BPF program that uses C standard
+ * library functions.  The test fails if the C standard
+ * library is not available.
+ *
+ * Only re-entrant versions of standard C library functions are
+ * available.  We have to use the _reent structure and pass a pointer
+ * to it as a parameter to a re-entrant function.  In this test
+ * _atoi_r is a re-entrant version of the standard atoi function.
+ */
+#include <sol/assert.h>
+#include <stdlib.h>
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  struct _reent reent;
+  int value = _atoi_r(&reent, "137");
+  sol_assert(value == 137);
+
+  return SUCCESS;
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -441,6 +441,7 @@ fn test_program_bpf_sanity() {
             ("sanity++", true),
             ("secp256k1_recover", true),
             ("sha", true),
+            ("stdlib", true),
             ("struct_pass", true),
             ("struct_ret", true),
         ]);

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.19
+version=v1.20
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -473,7 +473,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         eprintln!("Can't get home directory path: {}", err);
         exit(1);
     }));
-    let version = "v1.19";
+    let version = "v1.20";
     let package = "bpf-tools";
     let target_path = home_dir
         .join(".cache")


### PR DESCRIPTION
- Fix C standard library to include only reentrant versions of functions
- Use a version of solana_rbpf with fixed relocations handling
- Add a test of using C standard library functions in on-chain program
