### PR TITLE
Bump bpf-tools to v1.20

### DIFF
--- a/sdk/bpf/c/bpf.mk
+++ b/sdk/bpf/c/bpf.mk
@@ -17,6 +17,8 @@ OS := $(shell uname)
 LLVM_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/llvm
 LLVM_SYSTEM_INC_DIRS := $(LLVM_DIR)/lib/clang/12.0.1/include
 COMPILER_RT_DIR = $(LOCAL_PATH)../dependencies/bpf-tools/rust/lib/rustlib/bpfel-unknown-unknown/lib
+STD_INC_DIRS := $(LLVM_DIR)/include
+STD_LIB_DIRS := $(LLVM_DIR)/lib
 
 ifdef LLVM_DIR
 CC := $(LLVM_DIR)/bin/clang
@@ -36,7 +38,8 @@ C_FLAGS := \
   -fno-builtin \
   -std=c17 \
   $(addprefix -isystem,$(SYSTEM_INC_DIRS)) \
-  $(addprefix -I,$(INC_DIRS))
+  $(addprefix -I,$(STD_INC_DIRS)) \
+  $(addprefix -I,$(INC_DIRS)) \
 
 CXX_FLAGS := \
   $(C_FLAGS) \
@@ -64,6 +67,8 @@ BPF_LLD_FLAGS := \
   --Bdynamic \
   $(LOCAL_PATH)bpf.ld \
   --entry entrypoint \
+  -L $(STD_LIB_DIRS) \
+  -lc \
 
 OBJ_DUMP_FLAGS := \
   --source \
@@ -114,6 +119,10 @@ help:
 	@echo '      INC_DIRS=$(INC_DIRS)'
 	@echo '    - List of system include directories:'
 	@echo '      SYSTEM_INC_DIRS=$(SYSTEM_INC_DIRS)'
+	@echo '    - List of standard library include directories:'
+	@echo '      STD_INC_DIRS=$(STD_INC_DIRS)'
+	@echo '    - List of standard library archive directories:'
+	@echo '      STD_LIB_DIRS=$(STD_LIB_DIRS)'
 	@echo '    - Location of source directories:'
 	@echo '      SRC_DIR=$(SRC_DIR)'
 	@echo '    - Location to place output files:'
@@ -147,14 +156,28 @@ define C_RULE
 $1: $2
 	@echo "[cc] $1 ($2)"
 	$(_@)mkdir -p $(dir $1)
-	$(_@)$(CC) $(BPF_C_FLAGS) -o $1 -c $2 -MD -MF $(1:.o=.d)
+	$(_@)$(CC) $(BPF_C_FLAGS) -o $1 -c $2
 endef
 
 define CC_RULE
 $1: $2
 	@echo "[cxx] $1 ($2)"
 	$(_@)mkdir -p $(dir $1)
-	$(_@)$(CXX) $(BPF_CXX_FLAGS) -o $1 -c $2 -MD -MF $(1:.o=.d)
+	$(_@)$(CXX) $(BPF_CXX_FLAGS) -o $1 -c $2
+endef
+
+define D_RULE
+$1: $2 $(LOCAL_PATH)/bpf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) -M -MT '$(basename $1).o' $(BPF_C_FLAGS) $2 | sed 's,\($(basename $1)\)\.o[ :]*,\1.o $1 : ,g' > $1
+endef
+
+define DXX_RULE
+$1: $2 $(LOCAL_PATH)/bpf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) -M -MT '$(basename $1).o' $(BPF_CXX_FLAGS) $2 | sed 's,\($(basename $1)\)\.o[ :]*,\1.o $1 : ,g' > $1
 endef
 
 define O_RULE
@@ -180,7 +203,7 @@ define TEST_C_RULE
 $1: $2
 	@echo "[test cc] $1 ($2)"
 	$(_@)mkdir -p $(dir $1)
-	$(_@)$(CC) $(TEST_C_FLAGS) -o $1 $2 -MD -MF $(1:.o=.d)
+	$(_@)$(CC) $(TEST_C_FLAGS) -o $1 $2
 	$(_@)$(MACOS_ADJUST_TEST_DYLIB) $1
 endef
 
@@ -188,8 +211,22 @@ define TEST_CC_RULE
 $1: $2
 	@echo "[test cxx] $1 ($2)"
 	$(_@)mkdir -p $(dir $1)
-	$(_@)$(CXX) $(TEST_CXX_FLAGS) -o $1 $2 -MD -MF $(1:.o=.d)
+	$(_@)$(CXX) $(TEST_CXX_FLAGS) -o $1 $2
 	$(_@)$(MACOS_ADJUST_TEST_DYLIB) $1
+endef
+
+define TEST_D_RULE
+$1: $2 $(LOCAL_PATH)/bpf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CC) -M -MT '$(basename $1)' $(TEST_C_FLAGS) $2 | sed 's,\($(basename $1)\)[ :]*,\1 $1 : ,g' > $1
+endef
+
+define TEST_DXX_RULE
+$1: $2 $(LOCAL_PATH)/bpf.mk
+	@echo "[GEN] $1 ($2)"
+	$(_@)mkdir -p $(dir $1)
+	$(_@)$(CXX) -M -MT '$(basename $1)' $(TEST_CXX_FLAGS) $2 | sed 's,\($(basename $1)\)[ :]*,\1 $1 : ,g' > $1
 endef
 
 define TEST_EXEC_RULE
@@ -224,8 +261,10 @@ $(foreach PROGRAM, $(PROGRAM_NAMES), \
 	$(eval $($(PROGRAM)_SRCS): $(INSTALL_SH)) \
   $(eval $(call SO_RULE,$(OUT_DIR)/$(PROGRAM).so,$($(PROGRAM)_OBJS))) \
   $(foreach _,$(filter %.c,$($(PROGRAM)_SRCS)), \
+    $(eval $(call D_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.d)),$_)) \
     $(eval $(call C_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.o)),$_))) \
   $(foreach _,$(filter %.cc,$($(PROGRAM)_SRCS)), \
+    $(eval $(call DXX_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.d)),$_)) \
     $(eval $(call CC_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.o)),$_))) \
   \
   $(eval TESTS := $(notdir $(basename $(wildcard $(SRC_DIR)/$(PROGRAM)/$(TEST_PREFIX)*.c)))) \
@@ -237,8 +276,10 @@ $(foreach PROGRAM, $(PROGRAM_NAMES), \
       $(notdir $(wildcard $(SRC_DIR)/$(PROGRAM)/$(TEST).c $(SRC_DIR)/$(PROGRAM)/$(TEST).cc)))) \
 		$(eval $($(TEST)_SRCS): $(INSTALL_SH)) \
     $(foreach _,$(filter %.c,$($(TEST)_SRCS)), \
+      $(eval $(call TEST_D_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%.d)),$_)) \
       $(eval $(call TEST_C_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.c=%)),$_))) \
     $(foreach _,$(filter %.cc, $($(TEST)_SRCS)), \
+      $(eval $(call TEST_DXX_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%.d)),$_)) \
       $(eval $(call TEST_CC_RULE,$(subst $(SRC_DIR),$(OUT_DIR),$(_:%.cc=%)),$_))) \
     $(eval $(call TEST_EXEC_RULE,$(TEST),$(addprefix $(OUT_DIR)/$(PROGRAM)/, $(TEST)))) \
    ) \

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.19
+version=v1.20
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -477,7 +477,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         eprintln!("Can't get home directory path: {}", err);
         exit(1);
     }));
-    let version = "v1.19";
+    let version = "v1.20";
     let package = "bpf-tools";
     let target_path = home_dir
         .join(".cache")


### PR DESCRIPTION
- Fix C standard library to include only reentrant versions of functions
- Use a version of solana_rbpf with fixed relocations handling
- Add a test of using C standard library functions in on-chain program
