### PR TITLE
start system monitor earlier in validator so we get memory stats at startup

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -425,6 +425,11 @@ impl Validator {
             accounts_update_notifier.is_some()
         );
 
+        let system_monitor_service = Some(SystemMonitorService::new(
+            Arc::clone(&exit),
+            !config.no_os_network_stats_reporting,
+        ));
+
         let (
             genesis_config,
             bank_forks,
@@ -466,10 +471,6 @@ impl Validator {
                 abort();
             });
         }
-        let system_monitor_service = Some(SystemMonitorService::new(
-            Arc::clone(&exit),
-            !config.no_os_network_stats_reporting,
-        ));
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let bank = bank_forks.working_bank();


### PR DESCRIPTION
#### Problem
mem stats during startup are useful
#### Summary of Changes

Fixes #
