### PR TITLE
Adjust "solana rent" sub command to clarify automatic inclusion of account overhead

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -451,11 +451,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("rent")
-<<<<<<< HEAD
                 .about("Calculate per-epoch and rent-exempt-minimum values for a given account data field length.")
-=======
-                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data length (account overhead is already included).")
->>>>>>> Adjust CLI rent command description and help to clarify account overhead already included
                 .arg(
                     Arg::with_name("data_length")
                         .index(1)
@@ -466,11 +462,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
-<<<<<<< HEAD
                         .help("Length of data field in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
-=======
-                        .help("Length of data in the account to calculate rent for (excluding account overhead), or moniker: [nonce, stake, system, vote]"),
->>>>>>> Adjust CLI rent command description and help to clarify account overhead already included
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -451,7 +451,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("rent")
-                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data length (account overhead is already included).")
+                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data field length.")
                 .arg(
                     Arg::with_name("data_length")
                         .index(1)

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -462,7 +462,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
-                        .help("Length of data in the account to calculate rent for (excluding account overhead), or moniker: [nonce, stake, system, vote]"),
+                        .help("Length of data field in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -451,7 +451,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("rent")
-                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data length.")
+                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data length (account overhead is already included).")
                 .arg(
                     Arg::with_name("data_length")
                         .index(1)
@@ -462,7 +462,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
-                        .help("Length of data in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
+                        .help("Length of data in the account to calculate rent for (excluding account overhead), or moniker: [nonce, stake, system, vote]"),
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -451,7 +451,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("rent")
+<<<<<<< HEAD
                 .about("Calculate per-epoch and rent-exempt-minimum values for a given account data field length.")
+=======
+                .about("Calculate per-epoch and rent-exempt-minimum values for a given account data length (account overhead is already included).")
+>>>>>>> Adjust CLI rent command description and help to clarify account overhead already included
                 .arg(
                     Arg::with_name("data_length")
                         .index(1)
@@ -462,7 +466,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
+<<<<<<< HEAD
                         .help("Length of data field in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
+=======
+                        .help("Length of data in the account to calculate rent for (excluding account overhead), or moniker: [nonce, stake, system, vote]"),
+>>>>>>> Adjust CLI rent command description and help to clarify account overhead already included
                 )
                 .arg(
                     Arg::with_name("lamports")


### PR DESCRIPTION
#### Problem
Users might be unaware that the solana rent sub-command already includes the account overhead in the rent calculation.

#### Summary of Changes
Adjusted the sub-command description and help printout to clarify that account overhead is already included in the rent calculation.

Fixes #
