### PR TITLE
Use underscore for hacky rust-analyzer script

### DIFF
--- a/scripts/sed-i-all-rs-files-for-rust-analyzer.sh
+++ b/scripts/sed-i-all-rs-files-for-rust-analyzer.sh
@@ -9,17 +9,17 @@ if [[ $1 = "doit" ]]; then
   # it's true that we put true just for truely-aligned lines
   # shellcheck disable=SC2046 # our rust files are sanely named with no need to escape
   true &&
-    sed -i -e 's/#\[cfg(test)\]/#[cfg(escaped-cfg-test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[bench\]/#[cfg(escaped-bench)]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[test\]/#[cfg(escaped-test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[tokio::test\]/#[cfg(escaped-tokio-test)]/g' $(git ls-files :**.rs :^**/build.rs)
+    sed -i -e 's/#\[cfg(test)\]/#[cfg(escaped_cfg_test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[bench\]/#[cfg(escaped_bench)]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[test\]/#[cfg(escaped_test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[tokio::test\]/#[cfg(escaped_tokio_test)]/g' $(git ls-files :**.rs :^**/build.rs)
 elif [[ $1 = "undoit" ]]; then
   # shellcheck disable=SC2046 # our rust files are sanely named with no need to escape
   true &&
-    sed -i -e 's/#\[cfg(escaped-cfg-test)\]/#[cfg(test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[cfg(escaped-bench)\]/#[bench]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[cfg(escaped-test)\]/#[test]/g' $(git ls-files :**.rs :^**/build.rs) &&
-    sed -i -e 's/#\[cfg(escaped-tokio-test)\]/#[tokio::test]/g' $(git ls-files :**.rs :^**/build.rs)
+    sed -i -e 's/#\[cfg(escaped_cfg_test)\]/#[cfg(test)]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[cfg(escaped_bench)\]/#[bench]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[cfg(escaped_test)\]/#[test]/g' $(git ls-files :**.rs :^**/build.rs) &&
+    sed -i -e 's/#\[cfg(escaped_tokio_test)\]/#[tokio::test]/g' $(git ls-files :**.rs :^**/build.rs)
 else
   echo "usage: $0 [doit|undoit]" > /dev/stderr
   exit 1


### PR DESCRIPTION
Using dashes prevents the code from building, which is annoying
if you quickly want to test some hack.
With underscore we get the same effect but the code still builds.

Or was it intentional because the script is so hacky that you shouldn't build without undoing first?

#### Problem

Code does not build after `./scripts/sed-i-all-rs-files-for-rust-analyzer.sh doit`

#### Summary of Changes

Fix by using `_` instead of `-` for escaping. 


