### PR TITLE
feat: add fetch option to support cloudflare worker

### DIFF
--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3338,5 +3338,20 @@ describe('Connection', () => {
       const version = await connection.getVersion();
       expect(version['solana-core']).to.be.ok;
     });
+
+    it('custom fetch option', async () => {
+      let count = 0;
+      const connection = new Connection(
+        'https://api.mainnet-beta.solana.com',
+        {},
+        (input, init) => {
+          count++;
+          return fetch(input, init);
+        },
+      );
+      const version = await connection.getVersion();
+      expect(version['solana-core']).to.be.ok;
+      expect(count).to.eq(1);
+    });
   }
 });


### PR DESCRIPTION
#### Problem

Cloudflare workers unable to use XMLHttpRequest which cross-fetch use. fauna-db has this issue as well and added a fetch option to solve it. https://github.com/fauna/faunadb-js/issues/207#issuecomment-561475356

faunadb pr: https://github.com/fauna/faunadb-js/pull/214/files

#### Summary of Changes

Added a fetch option to Connection. I tested locally with cloudflare worker and it is able to fetch account info with Connection object

Fixes #

1. cloudflare worker has its own fetch to use.
2. cross-fetch has an old api for browser which cloudflare worker dont support, which is the XMLHttpRequest