### PR TITLE
Add BigTable query logs and counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5822,6 +5822,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smpl_jwt",
+ "solana-metrics",
  "solana-sdk",
  "solana-storage-proto",
  "solana-transaction-status",

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -22,6 +22,7 @@ prost-types = "0.9.0"
 serde = "1.0.130"
 serde_derive = "1.0.103"
 smpl_jwt = "0.6.0"
+solana-metrics = { path = "../metrics", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.9.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.9.0" }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -2,6 +2,7 @@
 use {
     log::*,
     serde::{Deserialize, Serialize},
+    solana_metrics::inc_new_counter_debug,
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         deserialize_utils::default_on_eof,
@@ -23,6 +24,9 @@ use {
     },
     thiserror::Error,
 };
+
+#[macro_use]
+extern crate solana_metrics;
 
 #[macro_use]
 extern crate serde_derive;
@@ -350,6 +354,7 @@ impl LedgerStorage {
     /// Return the available slot that contains a block
     pub async fn get_first_available_block(&self) -> Result<Option<Slot>> {
         debug!("LedgerStorage::get_first_available_block request received");
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let blocks = bigtable.get_row_keys("blocks", None, None, 1).await?;
         if blocks.is_empty() {
@@ -368,6 +373,7 @@ impl LedgerStorage {
             "LedgerStorage::get_confirmed_blocks request received: {:?} {:?}",
             start_slot, limit
         );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let blocks = bigtable
             .get_row_keys(
@@ -386,6 +392,7 @@ impl LedgerStorage {
             "LedgerStorage::get_confirmed_block request received: {:?}",
             slot
         );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let block_cell_data = bigtable
             .get_protobuf_or_bincode_cell::<StoredConfirmedBlock, generated::ConfirmedBlock>(
@@ -410,6 +417,7 @@ impl LedgerStorage {
             "LedgerStorage::get_signature_status request received: {:?}",
             signature
         );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let transaction_info = bigtable
             .get_bincode_cell::<TransactionInfo>("tx", signature.to_string())
@@ -430,6 +438,7 @@ impl LedgerStorage {
             "LedgerStorage::get_confirmed_transaction request received: {:?}",
             signature
         );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
 
         // Figure out which block the transaction is located in
@@ -489,6 +498,7 @@ impl LedgerStorage {
             "LedgerStorage::get_confirmed_signatures_for_address request received: {:?}",
             address
         );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let address_prefix = format!("{}/", address);
 

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -349,6 +349,7 @@ impl LedgerStorage {
 
     /// Return the available slot that contains a block
     pub async fn get_first_available_block(&self) -> Result<Option<Slot>> {
+        debug!("LedgerStorage::get_first_available_block request received");
         let mut bigtable = self.connection.client();
         let blocks = bigtable.get_row_keys("blocks", None, None, 1).await?;
         if blocks.is_empty() {
@@ -363,6 +364,10 @@ impl LedgerStorage {
     /// limit: stop after this many slots have been found; if limit==0, all records in the table
     /// after start_slot will be read
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
+        debug!(
+            "LedgerStorage::get_confirmed_blocks request received: {:?} {:?}",
+            start_slot, limit
+        );
         let mut bigtable = self.connection.client();
         let blocks = bigtable
             .get_row_keys(
@@ -377,6 +382,10 @@ impl LedgerStorage {
 
     /// Fetch the confirmed block from the desired slot
     pub async fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
+        debug!(
+            "LedgerStorage::get_confirmed_block request received: {:?}",
+            slot
+        );
         let mut bigtable = self.connection.client();
         let block_cell_data = bigtable
             .get_protobuf_or_bincode_cell::<StoredConfirmedBlock, generated::ConfirmedBlock>(
@@ -397,6 +406,10 @@ impl LedgerStorage {
     }
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
+        debug!(
+            "LedgerStorage::get_signature_status request received: {:?}",
+            signature
+        );
         let mut bigtable = self.connection.client();
         let transaction_info = bigtable
             .get_bincode_cell::<TransactionInfo>("tx", signature.to_string())
@@ -413,6 +426,10 @@ impl LedgerStorage {
         &self,
         signature: &Signature,
     ) -> Result<Option<ConfirmedTransaction>> {
+        debug!(
+            "LedgerStorage::get_confirmed_transaction request received: {:?}",
+            signature
+        );
         let mut bigtable = self.connection.client();
 
         // Figure out which block the transaction is located in
@@ -468,6 +485,10 @@ impl LedgerStorage {
             u32, /*slot index*/
         )>,
     > {
+        debug!(
+            "LedgerStorage::get_confirmed_signatures_for_address request received: {:?}",
+            address
+        );
         let mut bigtable = self.connection.client();
         let address_prefix = format!("{}/", address);
 


### PR DESCRIPTION
#### Problem
An rpc node operator has very little insight into when and why the node falls back to long-term storage to serve queries.

#### Summary of Changes
Add a log and counter for each LedgerStorage read request
