### PR TITLE
Prevent missing tx metadata from BigTableUploadService

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -35,7 +35,6 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.9.0
 solana-entry = { path = "../entry", version = "=1.9.0" }
 solana-frozen-abi = { path = "../frozen-abi", version = "=1.9.0" }
 solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.9.0" }
-solana-transaction-status = { path = "../transaction-status", version = "=1.9.0" }
 solana-logger = { path = "../logger", version = "=1.9.0" }
 solana-measure = { path = "../measure", version = "=1.9.0" }
 solana-metrics = { path = "../metrics", version = "=1.9.0" }
@@ -45,6 +44,7 @@ solana-runtime = { path = "../runtime", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.9.0" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.9.0" }
+solana-transaction-status = { path = "../transaction-status", version = "=1.9.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.0" }
 tempfile = "3.2.0"
 thiserror = "1.0"

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -1,15 +1,17 @@
-use crate::blockstore::Blockstore;
-use log::*;
-use solana_measure::measure::Measure;
-use solana_sdk::clock::Slot;
-use std::{
-    collections::HashSet,
-    result::Result,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
+use {
+    crate::blockstore::Blockstore,
+    log::*,
+    solana_measure::measure::Measure,
+    solana_sdk::clock::Slot,
+    std::{
+        collections::HashSet,
+        result::Result,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
     },
-    time::Duration,
 };
 
 // Attempt to upload this many blocks in parallel

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -28,6 +28,7 @@ impl BigTableUploadService {
         blockstore: Arc<Blockstore>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         exit: Arc<AtomicBool>,
+        allow_missing_metadata: bool,
     ) -> Self {
         info!("Starting BigTable upload service");
         let thread = Builder::new()
@@ -39,6 +40,7 @@ impl BigTableUploadService {
                     blockstore,
                     block_commitment_cache,
                     exit,
+                    allow_missing_metadata,
                 )
             })
             .unwrap();
@@ -52,6 +54,7 @@ impl BigTableUploadService {
         blockstore: Arc<Blockstore>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         exit: Arc<AtomicBool>,
+        allow_missing_metadata: bool,
     ) {
         let mut start_slot = 0;
         loop {
@@ -75,7 +78,7 @@ impl BigTableUploadService {
                 bigtable_ledger_storage.clone(),
                 start_slot,
                 Some(end_slot),
-                true,
+                allow_missing_metadata,
                 false,
                 exit.clone(),
             ));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -148,6 +148,7 @@ pub struct JsonRpcConfig {
     pub minimal_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
+    pub bigtable_allow_missing_metadata: bool,
 }
 
 #[derive(Clone)]

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -357,6 +357,7 @@ impl JsonRpcService {
                                 blockstore.clone(),
                                 block_commitment_cache.clone(),
                                 exit_bigtable_ledger_upload_service.clone(),
+                                config.bigtable_allow_missing_metadata,
                             )))
                         } else {
                             None

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -48,6 +48,9 @@ pub enum Error {
 
     #[error("Signature not found")]
     SignatureNotFound,
+
+    #[error("Transaction metadata missing from slot {0}")]
+    TransactionMetadataMissing(Slot),
 }
 
 impl std::convert::From<bigtable::Error> for Error {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1198,6 +1198,13 @@ pub fn main() {
                 .help("Number of seconds before timing out RPC requests backed by BigTable"),
         )
         .arg(
+            Arg::with_name("bigtable_upload_allow_missing_metadata")
+                .long("bigtable-upload-allow-missing-metadata")
+                .takes_value(false)
+                .requires("enable_bigtable_ledger_upload")
+                .help("Allow upload to BigTable even if transaction metadata is missing in Blockstore"),
+        )
+        .arg(
             Arg::with_name("rpc_pubsub_worker_threads")
                 .long("rpc-pubsub-worker-threads")
                 .takes_value(true)
@@ -2215,6 +2222,7 @@ pub fn main() {
                 .map(Duration::from_secs),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            bigtable_allow_missing_metadata: matches.is_present("bigtable_allow_missing_metadata"),
         },
         accountsdb_repl_service_config,
         accountsdb_plugin_config_files,


### PR DESCRIPTION
#### Problem
The BigTableUploadService always allows block uploads with missing transaction metadata:
https://github.com/solana-labs/solana/blob/0bda0c3e0cf46ee44de2cad366afa3593f76fc6d/ledger/src/bigtable_upload_service.rs#L78
This means that BigTable archives can be incomplete without node operators realizing it until someone tries to query that block.

#### Summary of Changes
- Change missing-metadata behavior from panic to return error
- Change default behavior to prevent missing metadata
- Impl solana-validator cli flag to allow node operators to optionally allow-missing-metadata

Toward #21367 (part 1)
