### PR TITLE
Use max_complete_transaction_status_slot in BigTableUploadService

### DIFF
--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -1,21 +1,14 @@
 use {
     crate::{bigtable_upload, blockstore::Blockstore},
-    solana_runtime::commitment::BlockCommitmentCache,
     std::{
-        sync::atomic::{AtomicBool, Ordering},
-        sync::{Arc, RwLock},
+        sync::{
+            atomic::{AtomicBool, AtomicU64, Ordering},
+            Arc,
+        },
         thread::{self, Builder, JoinHandle},
     },
     tokio::runtime::Runtime,
 };
-
-// Delay uploading the largest confirmed root for this many slots.  This is done in an attempt to
-// ensure that the `CacheBlockMetaService` has had enough time to add the block time for the root
-// before it's uploaded to BigTable.
-//
-// A more direct connection between CacheBlockMetaService and BigTableUploadService would be
-// preferable...
-const LARGEST_CONFIRMED_ROOT_UPLOAD_DELAY: usize = 100;
 
 pub struct BigTableUploadService {
     thread: JoinHandle<()>,
@@ -26,7 +19,7 @@ impl BigTableUploadService {
         runtime: Arc<Runtime>,
         bigtable_ledger_storage: solana_storage_bigtable::LedgerStorage,
         blockstore: Arc<Blockstore>,
-        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        max_complete_transaction_status_slot: Arc<AtomicU64>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         info!("Starting BigTable upload service");
@@ -37,7 +30,7 @@ impl BigTableUploadService {
                     runtime,
                     bigtable_ledger_storage,
                     blockstore,
-                    block_commitment_cache,
+                    max_complete_transaction_status_slot,
                     exit,
                 )
             })
@@ -50,7 +43,7 @@ impl BigTableUploadService {
         runtime: Arc<Runtime>,
         bigtable_ledger_storage: solana_storage_bigtable::LedgerStorage,
         blockstore: Arc<Blockstore>,
-        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        max_complete_transaction_status_slot: Arc<AtomicU64>,
         exit: Arc<AtomicBool>,
     ) {
         let mut start_slot = 0;
@@ -59,11 +52,7 @@ impl BigTableUploadService {
                 break;
             }
 
-            let end_slot = block_commitment_cache
-                .read()
-                .unwrap()
-                .highest_confirmed_root()
-                .saturating_sub(LARGEST_CONFIRMED_ROOT_UPLOAD_DELAY as u64);
+            let end_slot = max_complete_transaction_status_slot.load(Ordering::SeqCst);
 
             if end_slot <= start_slot {
                 std::thread::sleep(std::time::Duration::from_secs(1));

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -355,6 +355,7 @@ impl JsonRpcService {
                                 runtime.clone(),
                                 bigtable_ledger_storage.clone(),
                                 blockstore.clone(),
+                                block_commitment_cache.clone(),
                                 current_transaction_status_slot.clone(),
                                 exit_bigtable_ledger_upload_service.clone(),
                             )))

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -355,7 +355,7 @@ impl JsonRpcService {
                                 runtime.clone(),
                                 bigtable_ledger_storage.clone(),
                                 blockstore.clone(),
-                                block_commitment_cache.clone(),
+                                current_transaction_status_slot.clone(),
                                 exit_bigtable_ledger_upload_service.clone(),
                             )))
                         } else {


### PR DESCRIPTION
#### Problem
The BigTableUploadService uses a 100-slot delay from the most-recently finalized slot to determine which slots are safe to upload. In most cases, this should protect the validator from uploading blocks with incomplete transaction data if the TransactionStatusService is behind, but the partial upload can happen -- we've seen it in the wild -- and it's quite difficult to identify to fix. Much better if we can prevent the partial upload instead.

We are already passing a notification about the max_complete_transaction_status_slot to various places; rpc.rs uses it for getBlock requests. 

#### Summary of Changes
- Pass max_complete_transaction_status_slot into BigTableUploadService and use that instead of block_commitment_cache to determine which slots are safe to upload.

Toward #21367 (part 2)
