### PR TITLE
Fix flaky test

### DIFF
--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -43,6 +43,13 @@ impl Drop for QosService {
 
 impl QosService {
     pub fn new(cost_model: Arc<RwLock<CostModel>>) -> Self {
+        Self::new_with_reporting_duration(cost_model, 1000u64)
+    }
+
+    pub fn new_with_reporting_duration(
+        cost_model: Arc<RwLock<CostModel>>,
+        reporting_duration_ms: u64,
+    ) -> Self {
         let running_flag = Arc::new(AtomicBool::new(true));
         let metrics = Arc::new(QosServiceMetrics::default());
 
@@ -52,7 +59,7 @@ impl QosService {
             Builder::new()
                 .name("solana-qos-service-metrics-repoting".to_string())
                 .spawn(move || {
-                    Self::reporting_loop(running_flag_clone, metrics_clone);
+                    Self::reporting_loop(running_flag_clone, metrics_clone, reporting_duration_ms);
                 })
                 .unwrap(),
         );
@@ -133,10 +140,13 @@ impl QosService {
         select_results
     }
 
-    fn reporting_loop(running_flag: Arc<AtomicBool>, metrics: Arc<QosServiceMetrics>) {
+    fn reporting_loop(
+        running_flag: Arc<AtomicBool>,
+        metrics: Arc<QosServiceMetrics>,
+        reporting_duration_ms: u64,
+    ) {
         while running_flag.load(Ordering::Relaxed) {
-            // hardcode to report every 1000ms
-            metrics.report(1000u64);
+            metrics.report(reporting_duration_ms);
             thread::sleep(Duration::from_millis(100));
         }
     }
@@ -311,7 +321,7 @@ mod tests {
         //solana_logger::setup_with_default("solana=info");
 
         // make a vec of txs
-        let txs_count = 128usize;
+        let txs_count = 2048usize;
         let keypair = Keypair::new();
         let transfer_tx = SanitizedTransaction::from_transaction_for_tests(
             system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
@@ -323,8 +333,10 @@ mod tests {
             txs_2.push(transfer_tx.clone());
         }
 
+        // set reporting duration to long enough so the stats wouldn't reset during testing
+        let ten_min = 600_000u64;
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
-        let qos_service = Arc::new(QosService::new(cost_model));
+        let qos_service = Arc::new(QosService::new_with_reporting_duration(cost_model, ten_min));
         let qos_service_1 = qos_service.clone();
         let qos_service_2 = qos_service.clone();
 


### PR DESCRIPTION
#### Problem
There is a timing issue in the flaky test. Thanks to @lijunwangs for identifying it. Essentially stats reporting thread can kick in the middle of testing therefor to reset counter to zero.

#### Summary of Changes
Setting the report period real long for tests, so it wouldn't reset counters. I am also working on a PR to change reporting by slot instead of timer, which should permanently fix the test.

Fixes #
