### PR TITLE
Add support for a new, larger batch size limit, controlled by envvar SOLANA_ALT_BATCH_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,6 +4743,7 @@ dependencies = [
  "jsonrpc-core-client",
  "jsonrpc-derive",
  "jsonrpc-pubsub",
+ "lazy_static",
  "log 0.4.14",
  "lru",
  "matches",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,6 +61,7 @@ solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.9.0" }
 sys-info = "0.9.1"
 tokio = { version = "1", features = ["full"] }
 trees = "0.4.2"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 jsonrpc-core = "18.0.0"


### PR DESCRIPTION
#### Problem
With changes to add more GPU acceleration and faster systems, batch size may become a bottleneck, so we want to allow users to set a larger batch size limit if their systems will allow it
#### Summary of Changes
Adds the environment variable SOLANA_ALT_BATCH_SIZE to allow users to use a larger max batch size
Fixes #
