### PR TITLE
Refactor accounts.rs to improve `lock accounts with results` code path.

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -940,7 +940,8 @@ impl BankingStage {
         // Once accounts are locked, other threads cannot encode transactions that will modify the
         // same account state
         let mut lock_time = Measure::start("lock_time");
-        let batch = bank.prepare_sanitized_batch_with_results(txs, transactions_qos_results.iter());
+        let batch =
+            bank.prepare_sanitized_batch_with_results(txs, transactions_qos_results.into_iter());
         lock_time.stop();
 
         // retryable_txs includes AccountInUse, WouldExceedMaxBlockCostLimit and

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -24,6 +24,10 @@ use {
 };
 
 pub struct QosService {
+    // cost_model instance is owned by validator, shared between replay_stage and
+    // banking_stage. replay_stage writes the latest on-chain program timings to
+    // it; banking_stage's qos_service reads that information to calculate
+    // transaction cost, hence RwLock wrapped.
     cost_model: Arc<RwLock<CostModel>>,
     metrics: Arc<QosServiceMetrics>,
     reporting_thread: Option<JoinHandle<()>>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3356,7 +3356,7 @@ impl Bank {
     pub fn prepare_sanitized_batch_with_results<'a, 'b>(
         &'a self,
         transactions: &'b [SanitizedTransaction],
-        transaction_results: impl Iterator<Item = &'b Result<()>>,
+        transaction_results: impl Iterator<Item = Result<()>>,
     ) -> TransactionBatch<'a, 'b> {
         // this lock_results could be: Ok, AccountInUse, WouldExceedBlockMaxLimit or WouldExceedAccountMaxLimit
         let lock_results = self.rc.accounts.lock_accounts_with_results(

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -14,17 +14,15 @@ use std::collections::HashMap;
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
 
 // costs are stored in number of 'compute unit's
-#[derive(AbiExample, Debug)]
+#[derive(Debug)]
 pub struct TransactionCost {
     pub writable_accounts: Vec<Pubkey>,
     pub signature_cost: u64,
     pub write_lock_cost: u64,
     pub data_bytes_cost: u64,
     pub execution_cost: u64,
-    // `cost_weight` is a multiplier to be applied to tx cost, that
-    // allows to increase/decrease tx cost linearly based on algo.
-    // for example, vote tx could have weight zero to bypass cost
-    // limit checking during block packing.
+    // `cost_weight` is a multiplier could be applied to transaction cost,
+    // if set to zero allows the transaction to bypass cost limit check.
     pub cost_weight: u32,
 }
 


### PR DESCRIPTION
#### Problem

This PR is to respond to @jstarry's review comments; fixes is a bug that could unlock accounts that weren't locked.

#### Summary of Changes
- add test to the refactored function
- skip enumerating transaction accounts if qos results is an error
- add #[must_use] annotation
- avoid clone error in results
- add qos error code to unlock_accounts match statement
- remove unnecessary AbiExample


Fixes #
