### PR TITLE
Allows to set a custom instance id on bigtable

### DIFF
--- a/storage-bigtable/README.md
+++ b/storage-bigtable/README.md
@@ -16,6 +16,8 @@ Export a standard `GOOGLE_APPLICATION_CREDENTIALS` environment variable to your
 service account credentials.  The project should contain a BigTable instance
 called `solana-ledger` that has been initialized by running the `./init-bigtable.sh` script.
 
+You can also set the `instance ID` of your BigTable exporting `BIGTABLE_INSTANCE_ID`. If not defined, the default value is `solana-ledger`.
+
 Depending on what operation mode is required, either the
 `https://www.googleapis.com/auth/bigtable.data` or
 `https://www.googleapis.com/auth/bigtable.data.readonly` OAuth scope will be

--- a/storage-bigtable/init-bigtable.sh
+++ b/storage-bigtable/init-bigtable.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-instance=solana-ledger
+[[ -z "${BIGTABLE_INSTANCE_ID}" ]] && instance='solana-ledger' || instance="${BIGTABLE_INSTANCE_ID}"
 
 cbt=(
   cbt

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -345,9 +345,10 @@ pub struct LedgerStorage {
 }
 
 impl LedgerStorage {
+
     pub async fn new(read_only: bool, timeout: Option<std::time::Duration>) -> Result<Self> {
         let connection =
-            bigtable::BigTableConnection::new("solana-ledger", read_only, timeout).await?;
+            bigtable::BigTableConnection::new(&std::env::var("BIGTABLE_INSTANCE_ID").unwrap_or("solana-ledger".to_string()), read_only, timeout).await?;
         Ok(Self { connection })
     }
 


### PR DESCRIPTION
#### Problem

The storage bigtable is hard-coded to [solana-ledger]( https://github.com/solana-labs/solana/blob/f3f8d2e4f3de73d018404bf719df20a4ef5ae395/storage-bigtable/src/lib.rs#L350) making impossible to create more instances without using replication since the instance id is unique. 

#### Summary of Changes

This pr allows to set a custom instance id of your `BigTable` by exporting `BIGTABLE_INSTANCE_ID`, if not specified it fallback to `solana-ledger`.