### PR TITLE
ci: fix up pr subscribers review request automation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,8 +18,12 @@ pull_request_rules:
       - author≠@core-contributors
       - author≠mergify[bot]
       - author≠dependabot[bot]
-      - "#review-requested=0"
+      # Only request reviews from the pr subscribers group if no one
+      # has reviewed the community PR yet. These checks only match
+      # reviewers with admin, write or maintain permission on the repository.
+      - "#approved-reviews-by=0"
       - "#commented-reviews-by=0"
+      - "#changes-requested-reviews-by=0"
     actions:
       request_reviews:
         teams:


### PR DESCRIPTION
#### Problem
The mergify automation still repeatedly requests reviews when there is already an active reviewer

#### Summary of Changes

Fixes #
