### PR TITLE
install: Check all releases

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -859,39 +859,54 @@ fn check_for_newer_github_release(
     version_filter: Option<semver::VersionReq>,
     prerelease_allowed: bool,
 ) -> reqwest::Result<Option<String>> {
-    let url =
-        reqwest::Url::parse("https://api.github.com/repos/solana-labs/solana/releases").unwrap();
+    let mut page = 1;
+    const PER_PAGE: usize = 100;
     let client = reqwest::blocking::Client::builder()
         .user_agent("solana-install")
         .build()?;
-    let request = client.get(url).build()?;
-    let response = client.execute(request)?;
+    let mut all_releases = vec![];
+    let mut releases = vec![];
 
-    let mut releases = response
-        .json::<GithubReleases>()?
-        .0
-        .into_iter()
-        .filter_map(
-            |GithubRelease {
-                 tag_name,
-                 prerelease,
-             }| {
-                if let Ok(version) = semver_of(&tag_name) {
-                    if (prerelease_allowed || !prerelease)
-                        && version_filter
-                            .as_ref()
-                            .map_or(true, |version_filter| version_filter.matches(&version))
-                    {
-                        return Some(version);
-                    }
-                }
-                None
-            },
+    while page == 1 || releases.len() == PER_PAGE {
+        let url = reqwest::Url::parse_with_params(
+            "https://api.github.com/repos/solana-labs/solana/releases",
+            &[
+                ("per_page", &format!("{}", PER_PAGE)),
+                ("page", &format!("{}", page)),
+            ],
         )
-        .collect::<Vec<_>>();
+        .unwrap();
+        let request = client.get(url).build()?;
+        let response = client.execute(request)?;
 
-    releases.sort();
-    Ok(releases.pop().map(|r| r.to_string()))
+        releases = response
+            .json::<GithubReleases>()?
+            .0
+            .into_iter()
+            .filter_map(
+                |GithubRelease {
+                     tag_name,
+                     prerelease,
+                 }| {
+                    if let Ok(version) = semver_of(&tag_name) {
+                        if (prerelease_allowed || !prerelease)
+                            && version_filter
+                                .as_ref()
+                                .map_or(true, |version_filter| version_filter.matches(&version))
+                        {
+                            return Some(version);
+                        }
+                    }
+                    None
+                },
+            )
+            .collect::<Vec<_>>();
+        all_releases.extend_from_slice(&releases);
+        page += 1;
+    }
+
+    all_releases.sort();
+    Ok(all_releases.pop().map(|r| r.to_string()))
 }
 
 pub enum SemverUpdateType {


### PR DESCRIPTION
#### Problem

I tried to do a program verification on the current token program, built against 1.7.4, and received `Error: "Unknown release: 1.7.4"` when trying to download the 1.7.4 tools, which is a bit unexpected.

If we want to do easier program verification, we'll need to be able to fetch any CLI version.

#### Summary of Changes

Just fetch all of the GitHub releases instead of the 30 most recent.  According to the API docs for releases, we can fetch up to 100 results, and they're paginated: https://docs.github.com/en/rest/reference/repos#list-releases

This keeps it simple and just gets everything.  We could potentially just search based on the tag, but that likely won't be a big problem until when we have thousands of releases.

Fixes #
