### PR TITLE
Fix transaction log collector indexing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -556,7 +556,7 @@ pub struct TransactionLogCollectorConfig {
     pub filter: TransactionLogCollectorFilter,
 }
 
-#[derive(AbiExample, Clone, Debug)]
+#[derive(AbiExample, Clone, Debug, PartialEq)]
 pub struct TransactionLogInfo {
     pub signature: Signature,
     pub result: Result<()>,
@@ -15394,5 +15394,21 @@ pub(crate) mod tests {
         let message = Message::new(&[ix], Some(&mint_keypair.pubkey()));
         let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
         bank.process_transaction(&tx).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_transaction_log_collector_get_logs_for_address() {
+        let address = Pubkey::new_unique();
+        let mut mentioned_address_map = HashMap::new();
+        mentioned_address_map.insert(address, vec![0]);
+        let transaction_log_collector = TransactionLogCollector {
+            mentioned_address_map,
+            ..TransactionLogCollector::default()
+        };
+        assert_eq!(
+            transaction_log_collector.get_logs_for_address(Some(&address)),
+            Some(Vec::<TransactionLogInfo>::new()),
+        );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -582,10 +582,12 @@ impl TransactionLogCollector {
     ) -> Option<Vec<TransactionLogInfo>> {
         match address {
             None => Some(self.logs.clone()),
-            Some(address) => self
-                .mentioned_address_map
-                .get(address)
-                .map(|log_indices| log_indices.iter().map(|i| self.logs[*i].clone()).collect()),
+            Some(address) => self.mentioned_address_map.get(address).map(|log_indices| {
+                log_indices
+                    .iter()
+                    .filter_map(|i| self.logs.get(*i).cloned())
+                    .collect()
+            }),
         }
     }
 }
@@ -15397,7 +15399,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_transaction_log_collector_get_logs_for_address() {
         let address = Pubkey::new_unique();
         let mut mentioned_address_map = HashMap::new();


### PR DESCRIPTION
#### Problem

Panic on logs subscription as reported on Discord.

```
[2021-11-24T18:42:42.170382073Z INFO  solana_metrics::metrics] datapoint: optimistic_slot slot=108517898i
thread 'sol-sub-notif-7' panicked at 'index out of bounds: the len is 0 but the index is 0', runtime/src/bank.rs:5038:34
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at ./rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/panicking.rs:92:14
   2: core::panicking::panic_bounds_check
             at ./rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/panicking.rs:69:5
   3: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
   4: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
   5: solana_runtime::bank::Bank::get_transaction_logs
   6: solana_rpc::rpc_subscriptions::RpcSubscriptions::notify_accounts_logs_programs_signatures::{{closure}}
   7: rayon::iter::plumbing::bridge_producer_consumer::helper
   8: <rayon::vec::IntoIter<T> as rayon::iter::IndexedParallelIterator>::with_producer
   9: solana_rpc::rpc_subscriptions::RpcSubscriptions::notify_accounts_logs_programs_signatures
  10: solana_rpc::rpc_subscriptions::RpcSubscriptions::process_notifications
  11: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
  12: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
  13: rayon_core::registry::WorkerThread::wait_until_cold
  14: rayon_core::registry::ThreadBuilder::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
[2021-11-24T18:42:42.202271887Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="sol-sub-notif-7" one=1i message="panicked at 'index out of bounds: the len is 0 but the index is 0', runtime/src/bank.rs:5038:34" location="runtime/src/bank.rs:5038:34"
```

#### Summary of Changes

Unfortunately the reporter didn't provide enough information to fully debug the root cause.  Luckily, the code is suspicious enough to hint at where to harden

* `get()` instead of blind-indexing into the `logs` vec
* Only push address mappings after we've pushed a log message