### PR TITLE
Move solana-remote-wallet to feature in clap-utils

### DIFF
--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 clap = "2.33.0"
 rpassword = "5.0"
 solana-perf = { path = "../perf", version = "=1.10.0" }
-solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0", default-features = false}
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1226,17 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hidapi"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c4cc7279df8353788ac551186920e44959d5948aec404be02b28544a598bce"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,7 +3405,6 @@ version = "1.10.0"
 dependencies = [
  "console",
  "dialoguer",
- "hidapi",
  "log",
  "num-derive",
  "num-traits",

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/solana-remote-wallet"
 [dependencies]
 console = "0.15.0"
 dialoguer = "0.9.0"
-hidapi = { version = "1.3.2", default-features = false }
+hidapi = { version = "1.3.2", default-features = false, optional = true}
 log = "0.4.14"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
@@ -24,7 +24,7 @@ thiserror = "1.0"
 uriparse = "0.6.3"
 
 [features]
-default = ["linux-static-hidraw"]
+default = ["linux-static-hidraw", "hidapi"]
 linux-static-libusb = ["hidapi/linux-static-libusb"]
 linux-static-hidraw = ["hidapi/linux-static-hidraw"]
 linux-shared-libusb = ["hidapi/linux-shared-libusb"]

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -1,16 +1,20 @@
 use {
-    crate::{
-        ledger_error::LedgerError,
-        locator::Manufacturer,
-        remote_wallet::{RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletManager},
+    crate::remote_wallet::{
+        RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletManager,
     },
     console::Emoji,
     dialoguer::{theme::ColorfulTheme, Select},
+    semver::Version as FirmwareVersion,
+    solana_sdk::derivation_path::DerivationPath,
+    std::{fmt, sync::Arc},
+};
+#[cfg(feature = "hidapi")]
+use {
+    crate::{ledger_error::LedgerError, locator::Manufacturer},
     log::*,
     num_traits::FromPrimitive,
-    semver::Version as FirmwareVersion,
-    solana_sdk::{derivation_path::DerivationPath, pubkey::Pubkey, signature::Signature},
-    std::{cmp::min, convert::TryFrom, fmt, sync::Arc},
+    solana_sdk::{pubkey::Pubkey, signature::Signature},
+    std::{cmp::min, convert::TryFrom},
 };
 
 static CHECK_MARK: Emoji = Emoji("✅ ", "");
@@ -79,6 +83,7 @@ pub struct LedgerSettings {
 
 /// Ledger Wallet device
 pub struct LedgerWallet {
+    #[cfg(feature = "hidapi")]
     pub device: hidapi::HidDevice,
     pub pretty_path: String,
     pub version: FirmwareVersion,
@@ -90,6 +95,7 @@ impl fmt::Debug for LedgerWallet {
     }
 }
 
+#[cfg(feature = "hidapi")]
 impl LedgerWallet {
     pub fn new(device: hidapi::HidDevice) -> Self {
         Self {
@@ -347,7 +353,10 @@ impl LedgerWallet {
     }
 }
 
-impl RemoteWallet for LedgerWallet {
+#[cfg(not(feature = "hidapi"))]
+impl RemoteWallet<Self> for LedgerWallet {}
+#[cfg(feature = "hidapi")]
+impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
     fn name(&self) -> &str {
         "Ledger hardware wallet"
     }

--- a/remote-wallet/src/lib.rs
+++ b/remote-wallet/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
+#![allow(dead_code)]
 pub mod ledger;
 pub mod ledger_error;
 pub mod locator;

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -211,12 +211,12 @@ impl RemoteWalletManager {
 #[allow(unused_variables)]
 pub trait RemoteWallet<T> {
     fn name(&self) -> &str {
-        "remote wallet"
+        "unimplemented"
     }
 
     /// Parse device info and get device base pubkey
     fn read_device(&mut self, dev_info: &T) -> Result<RemoteWalletInfo, RemoteWalletError> {
-        unreachable!();
+        unimplemented!();
     }
 
     /// Get solana pubkey from a RemoteWallet
@@ -225,7 +225,7 @@ pub trait RemoteWallet<T> {
         derivation_path: &DerivationPath,
         confirm_key: bool,
     ) -> Result<Pubkey, RemoteWalletError> {
-        unreachable!();
+        unimplemented!();
     }
 
     /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
@@ -234,7 +234,7 @@ pub trait RemoteWallet<T> {
         derivation_path: &DerivationPath,
         data: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
-        unreachable!();
+        unimplemented!();
     }
 }
 


### PR DESCRIPTION
#### Problem
The solana-client pulls in the hidapi package via the transitive dependency chain:
`solana-client => solana-clap-utils => solana-remote-wallet => hidapi`
And also in a similar manner via faucet:
`solana-client => solana-faucet => solana-clap-utils => solana-remote-wallet => hidapi`

This causes compilation for the `x86_64-unknown-linux-musl` target to fail (see #20702 )

#### Summary of Changes

I've moved all solana-remote-wallet deps in the clap-utils crate behind a default feature flag and opted faucet and client out of the remote-wallet feature since they don't need the remote wallet functions present in clap-utils.

Fixes #20702
