### PR TITLE
Update restart-cluster.md

### DIFF
--- a/docs/src/running-validator/restart-cluster.md
+++ b/docs/src/running-validator/restart-cluster.md
@@ -34,6 +34,8 @@ Then restart the validator.
 
 Confirm with the log that the validator booted and is now in a holding pattern at `SLOT_X`, waiting for a super majority.
 
+Once NEW_SHRED_VERSION is determined, nudge foundation entrypoint operators to update entrypoints.
+
 ### Step 5. Announce the restart on Discord:
 
 Post something like the following to #announcements (adjusting the text as appropriate):


### PR DESCRIPTION
#### Problem
Foundation entrypoints keep translating old shred version after network restart.

#### Summary of Changes
Update documentation with recommendation to inform entrypoint operators update entrypoints.

Fixes # 
