### PR TITLE
[sdk] Remove unused dependency

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -45,7 +45,7 @@ borsh = "0.9.0"
 base64 = "0.13"
 bs58 = "0.4.0"
 byteorder = { version = "1.4.3", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { default-features = false, features = ["alloc"], version = "0.4", optional = true }
 curve25519-dalek = { version = "3.2.0", optional = true }
 derivation-path = { version = "0.1.3", default-features = false }
 digest = { version = "0.9.0", optional = true }


### PR DESCRIPTION
Removes one unused transient dependency of the `sdk` crate.

Not sure why `Cargo.lock` wasn't modified but changes are confirmed when `cd sdk` and then `cargo build/check` before and after this PR.