### PR TITLE
Perform async operations that don't depend on each other, concurrently

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3262,9 +3262,9 @@ export class Connection {
     startSlot: number,
     endSlot: number,
   ): Promise<Array<TransactionSignature>> {
-    let options: any = {};
+    const options: any = {};
 
-    let firstAvailableBlock = await this.getFirstAvailableBlock();
+    const firstAvailableBlock = await this.getFirstAvailableBlock();
     while (!('until' in options)) {
       startSlot--;
       if (startSlot <= 0 || startSlot < firstAvailableBlock) {
@@ -3289,7 +3289,7 @@ export class Connection {
       }
     }
 
-    let highestConfirmedRoot = await this.getSlot('finalized');
+    const highestConfirmedRoot = await this.getSlot('finalized');
     while (!('before' in options)) {
       endSlot++;
       if (endSlot > highestConfirmedRoot) {

--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -64,15 +64,11 @@ export class Loader {
     data: Buffer | Uint8Array | Array<number>,
   ): Promise<boolean> {
     {
-      const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
-        data.length,
-      );
-
-      // Fetch program account info to check if it has already been created
-      const programInfo = await connection.getAccountInfo(
-        program.publicKey,
-        'confirmed',
-      );
+      const [balanceNeeded, programInfo] = await Promise.all([
+        connection.getMinimumBalanceForRentExemption(data.length),
+        // Fetch program account info to check if it has already been created
+        connection.getAccountInfo(program.publicKey, 'confirmed'),
+      ]);
 
       let transaction: Transaction | null = null;
       if (programInfo !== null) {


### PR DESCRIPTION
#### Problem

When two RPC calls are made that depend neither on the sequence in which they are made, nor on the result of each other, we should make them concurrently, for performance. Code like this might appear to achieve this:

```
const foo = await getFoo();
const bar = await getBar();
```

…but what that code actually does is to block `getBar()` from _even starting_ until the result of `getFoo()` is available. This is because promises start eagerly, but `await` is blocking – the promise created by `getBar()` never gets a chance to start until the result of the promise returned by `getFoo()` is available.

This code, on the other hand _does_ perform both operations concurrently.

```
// The promises returned by `getFoo` and `getBar` will start right away.
const fooPromise = getFoo();
const barPromise = getBar();
// Awaiting them at this point will block on the result, but won't prevent either operation from starting.
const foo = await fooPromise;
const bar = await barPromise;
```

A more ergonomic way of expressing this is:

```
const [foo, bar] = await Promise.all([
  getFoo(), 
  getBar(),
]);
```

#### Summary of Changes

In this pull request I modify two functions that feature (probably) unintentional serial awaits. After this change, the RPC calls they make will take flight concurrently, but the program will still block until all of their results are available.
