### PR TITLE
AcctIdx: insert goes directly to disk to avoid unnecessary allocations

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -292,6 +292,17 @@ pub enum PreAllocatedAccountMapEntry<T: IndexValue> {
     Raw((Slot, T)),
 }
 
+impl<T: IndexValue> ZeroLamport for PreAllocatedAccountMapEntry<T> {
+    fn is_zero_lamport(&self) -> bool {
+        match self {
+            PreAllocatedAccountMapEntry::Entry(entry) => {
+                entry.slot_list.read().unwrap()[0].1.is_zero_lamport()
+            }
+            PreAllocatedAccountMapEntry::Raw(raw) => raw.1.is_zero_lamport(),
+        }
+    }
+}
+
 impl<T: IndexValue> From<PreAllocatedAccountMapEntry<T>> for (Slot, T) {
     fn from(source: PreAllocatedAccountMapEntry<T>) -> (Slot, T) {
         match source {

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -9,7 +9,10 @@ use rand::Rng;
 use solana_bucket_map::bucket_api::BucketApi;
 use solana_measure::measure::Measure;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{
+    hash_map::{Entry, VacantEntry},
+    HashMap,
+};
 use std::ops::{Bound, RangeBounds, RangeInclusive};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
@@ -351,24 +354,43 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                     }
                     Entry::Vacant(vacant) => {
                         // not in cache, look on disk
-                        let disk_entry = self.load_account_entry_from_disk(vacant.key());
-                        let new_value = if let Some(disk_entry) = disk_entry {
-                            // on disk, so merge new_value with what was on disk
-                            Self::lock_and_update_slot_list(
-                                &disk_entry,
-                                new_value.into(),
+                        let directly_to_disk = self.storage.get_startup();
+                        if directly_to_disk {
+                            // We may like this to always run, but it is unclear.
+                            // If disk bucket needs to resize, then this call can stall for a long time.
+                            // Right now, we know it is safe during startup.
+                            let mut new_entry_zero_lamports = false;
+                            let already_existed = self.upsert_on_disk(
+                                vacant,
+                                new_value,
+                                &mut new_entry_zero_lamports,
                                 reclaims,
                                 previous_slot_entry_was_cached,
                             );
-                            disk_entry
+                            if !already_existed {
+                                self.stats().insert_or_delete(true, self.bin);
+                            }
                         } else {
-                            // not on disk, so insert new thing
-                            self.stats().insert_or_delete(true, self.bin);
-                            new_value.into_account_map_entry(&self.storage)
-                        };
-                        assert!(new_value.dirty());
-                        vacant.insert(new_value);
-                        self.stats().insert_or_delete_mem(true, self.bin);
+                            // go to in-mem cache first
+                            let disk_entry = self.load_account_entry_from_disk(vacant.key());
+                            let new_value = if let Some(disk_entry) = disk_entry {
+                                // on disk, so merge new_value with what was on disk
+                                Self::lock_and_update_slot_list(
+                                    &disk_entry,
+                                    new_value.into(),
+                                    reclaims,
+                                    previous_slot_entry_was_cached,
+                                );
+                                disk_entry
+                            } else {
+                                // not on disk, so insert new thing
+                                self.stats().insert_or_delete(true, self.bin);
+                                new_value.into_account_map_entry(&self.storage)
+                            };
+                            assert!(new_value.dirty());
+                            vacant.insert(new_value);
+                            self.stats().insert_or_delete_mem(true, self.bin);
+                        }
                     }
                 }
 
@@ -491,6 +513,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         let entry = map.entry(pubkey);
         m.stop();
         let mut new_entry_zero_lamports = false;
+        let mut _reclaims = vec![];
         let (found_in_mem, already_existed) = match entry {
             Entry::Occupied(occupied) => {
                 // in cache, so merge into cache
@@ -509,40 +532,13 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
             }
             Entry::Vacant(vacant) => {
                 // not in cache, look on disk
-                let mut existed = false;
-                if let Some(disk) = self.bucket.as_ref() {
-                    let (slot, account_info) = new_entry.into();
-                    new_entry_zero_lamports = account_info.is_zero_lamport();
-                    disk.update(vacant.key(), |current| {
-                        if let Some((slot_list, mut ref_count)) = current {
-                            // on disk, so merge and update disk
-                            let mut slot_list = slot_list.to_vec();
-                            let addref = Self::update_slot_list(
-                                &mut slot_list,
-                                slot,
-                                account_info,
-                                &mut Vec::default(),
-                                false,
-                            );
-                            if addref {
-                                ref_count += 1
-                            };
-                            existed = true;
-                            Some((slot_list, ref_count))
-                        } else {
-                            // doesn't exist on disk yet, so insert it
-                            let ref_count = if account_info.is_cached() { 0 } else { 1 };
-                            Some((vec![(slot, account_info)], ref_count))
-                        }
-                    });
-                } else {
-                    // not using disk, so insert into mem
-                    self.stats().insert_or_delete_mem(true, self.bin);
-                    let new_entry: AccountMapEntry<T> =
-                        new_entry.into_account_map_entry(&self.storage);
-                    assert!(new_entry.dirty());
-                    vacant.insert(new_entry);
-                }
+                let existed = self.upsert_on_disk(
+                    vacant,
+                    new_entry,
+                    &mut new_entry_zero_lamports,
+                    &mut _reclaims,
+                    false,
+                );
                 (false, existed)
             }
         };
@@ -561,6 +557,51 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         } else {
             InsertNewEntryResults::ExistedNewEntryNonZeroLamports
         }
+    }
+
+    /// return true if item was newly added to index
+    fn upsert_on_disk(
+        &self,
+        vacant: VacantEntry<K, AccountMapEntry<T>>,
+        new_entry: PreAllocatedAccountMapEntry<T>,
+        new_entry_zero_lamports: &mut bool,
+        reclaims: &mut SlotList<T>,
+        previous_slot_entry_was_cached: bool,
+    ) -> bool {
+        let mut existed = false;
+        if let Some(disk) = self.bucket.as_ref() {
+            let (slot, account_info) = new_entry.into();
+            *new_entry_zero_lamports = account_info.is_zero_lamport();
+            disk.update(vacant.key(), |current| {
+                if let Some((slot_list, mut ref_count)) = current {
+                    // on disk, so merge and update disk
+                    let mut slot_list = slot_list.to_vec();
+                    let addref = Self::update_slot_list(
+                        &mut slot_list,
+                        slot,
+                        account_info,
+                        reclaims,
+                        previous_slot_entry_was_cached,
+                    );
+                    if addref {
+                        ref_count += 1
+                    };
+                    existed = true;
+                    Some((slot_list, ref_count))
+                } else {
+                    // doesn't exist on disk yet, so insert it
+                    let ref_count = if account_info.is_cached() { 0 } else { 1 };
+                    Some((vec![(slot, account_info)], ref_count))
+                }
+            });
+        } else {
+            // not using disk, so insert into mem
+            self.stats().insert_or_delete_mem(true, self.bin);
+            let new_entry: AccountMapEntry<T> = new_entry.into_account_map_entry(&self.storage);
+            assert!(new_entry.dirty());
+            vacant.insert(new_entry);
+        };
+        existed
     }
 
     pub fn just_set_hold_range_in_memory<R>(&self, range: &R, start_holding: bool)
@@ -643,8 +684,8 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 
         // load from disk
         if let Some(disk) = self.bucket.as_ref() {
-            let items = disk.items_in_range(range);
             let mut map = self.map().write().unwrap();
+            let items = disk.items_in_range(range); // map's lock has to be held while we are getting items from disk
             let future_age = self.storage.future_age_to_flush();
             for item in items {
                 let entry = map.entry(item.pubkey);


### PR DESCRIPTION
#### Problem
Upsert currently inserts into the cache. It appears there is a correlation between increased memory usage and the common allocation of arc/rwlock/meta for each account index in order to go into the in-mem accounts index cache.
This is definitely present in filler accounts. Filler accounts are added using a standard store, which causes them to go through the 'upsert' path. Filler accounts are added while 'startup' is true.
#### Summary of Changes
When calling 'upsert' during startup, add directly to the disk index for more efficient startup, with fewer allocations and churn. We already have to do the lookup in the index anyway, so we already have to page in the specific part of the disk index we need. This change should have zero impact on a normal validator.
Fixes #
