### PR TITLE
Bumps solana_rbpf to v0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6090,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc53d7522cccfd4a86a82a2fad79328002b70910d944f5be3ba72ac96c64c518"
+checksum = "3af7860a2bf51e63a07c4098966b1c80e8cbfdab3cf4ac36aac7fdd80ea1094c"
 dependencies = [
  "byteorder",
  "combine",
@@ -6105,7 +6105,6 @@ dependencies = [
  "scroll",
  "thiserror",
  "time 0.1.43",
- "version_check 0.9.3",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ solana-config-program = { path = "../programs/config", version = "=1.9.0" }
 solana-faucet = { path = "../faucet", version = "=1.9.0" }
 solana-logger = { path = "../logger", version = "=1.9.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.9.0" }
-solana_rbpf = "=0.2.15"
+solana_rbpf = "=0.2.16"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.9.0" }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -25,10 +25,7 @@ use solana_client::{
     tpu_client::{TpuClient, TpuClientConfig},
 };
 use solana_program_runtime::invoke_context::ThisInvokeContext;
-use solana_rbpf::{
-    verifier,
-    vm::{Config, Executable},
-};
+use solana_rbpf::{elf::Executable, verifier, vm::Config};
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     account::Account,
@@ -1997,7 +1994,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut invoke_context = ThisInvokeContext::new_mock(&[], &[]);
 
     // Verify the program
-    <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+    Executable::<BpfError, ThisInstructionMeter>::from_elf(
         &program_data,
         Some(verifier::check),
         Config {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3575,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc53d7522cccfd4a86a82a2fad79328002b70910d944f5be3ba72ac96c64c518"
+checksum = "3af7860a2bf51e63a07c4098966b1c80e8cbfdab3cf4ac36aac7fdd80ea1094c"
 dependencies = [
  "byteorder 1.4.3",
  "combine",
@@ -3590,7 +3590,6 @@ dependencies = [
  "scroll",
  "thiserror",
  "time",
- "version_check",
 ]
 
 [[package]]

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.9
 solana-cli-output = { path = "../../cli-output", version = "=1.9.0" }
 solana-logger = { path = "../../logger", version = "=1.9.0" }
 solana-measure = { path = "../../measure", version = "=1.9.0" }
-solana_rbpf = "=0.2.15"
+solana_rbpf = "=0.2.16"
 solana-runtime = { path = "../../runtime", version = "=1.9.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.9.0" }
 solana-sdk = { path = "../../sdk", version = "=1.9.0" }

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -12,7 +12,7 @@ use solana_bpf_loader_program::{
 };
 use solana_measure::measure::Measure;
 use solana_program_runtime::invoke_context::{with_mock_invoke_context, InvokeContext};
-use solana_rbpf::vm::{Config, Executable, InstructionMeter, SyscallRegistry};
+use solana_rbpf::{elf::Executable, vm::{Config, InstructionMeter, SyscallRegistry}};
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,
@@ -74,7 +74,7 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
     let elf = load_elf("bench_alu").unwrap();
 
     bencher.iter(|| {
-        let _ = <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+        let _ = Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -96,7 +96,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let elf = load_elf("bench_alu").unwrap();
     let loader_id = bpf_loader::id();
     with_mock_invoke_context(loader_id, 10000001, |invoke_context| {
-        let mut executable = <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+        let mut executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -108,7 +108,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
         let mut instruction_meter = ThisInstructionMeter { compute_meter };
         let mut vm = create_vm(
             &loader_id,
-            executable.as_ref(),
+            &executable,
             &mut inner_iter,
             invoke_context,
             &[],
@@ -220,7 +220,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
         )
         .unwrap();
 
-        let executable = <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+        let executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -231,7 +231,7 @@ fn bench_create_vm(bencher: &mut Bencher) {
         bencher.iter(|| {
             let _ = create_vm(
                 &loader_id,
-                executable.as_ref(),
+                &executable,
                 serialized.as_slice_mut(),
                 invoke_context,
                 &account_lengths,
@@ -264,7 +264,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         )
         .unwrap();
 
-        let executable = <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+        let executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &elf,
             None,
             Config::default(),
@@ -274,7 +274,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         let mut instruction_meter = ThisInstructionMeter { compute_meter };
         let mut vm = create_vm(
             &loader_id,
-            executable.as_ref(),
+            &executable,
             serialized.as_slice_mut(),
             invoke_context,
             &account_lengths,

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -21,7 +21,7 @@ openssl = "^0.10.38"
 solana-measure = { path = "../../measure", version = "=1.9.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.9.0" }
 solana-sdk = { path = "../../sdk", version = "=1.9.0" }
-solana_rbpf = "=0.2.15"
+solana_rbpf = "=0.2.16"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -16,5 +16,5 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.9.0
 solana-logger = { path = "../logger", version = "=1.9.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
-solana_rbpf = "=0.2.15"
+solana_rbpf = "=0.2.16"
 time = "0.3.5"

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -10,9 +10,10 @@ use solana_program_runtime::invoke_context::{
 };
 use solana_rbpf::{
     assembler::assemble,
+    elf::Executable,
     static_analysis::Analysis,
     verifier::check,
-    vm::{Config, DynamicAnalysis, Executable},
+    vm::{Config, DynamicAnalysis},
 };
 use solana_sdk::{account::AccountSharedData, bpf_loader, pubkey::Pubkey};
 use std::{fs::File, io::Read, io::Seek, io::SeekFrom, path::Path};
@@ -230,7 +231,7 @@ native machine code before execting it in the virtual machine.",
     file.read_to_end(&mut contents).unwrap();
     let syscall_registry = register_syscalls(&mut invoke_context).unwrap();
     let mut executable = if magic == [0x7f, 0x45, 0x4c, 0x46] {
-        <dyn Executable<BpfError, ThisInstructionMeter>>::from_elf(
+        Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &contents,
             None,
             config,
@@ -252,7 +253,7 @@ native machine code before execting it in the virtual machine.",
         check(text_bytes, &config).unwrap();
     }
     executable.jit_compile().unwrap();
-    let analysis = Analysis::from_executable(executable.as_ref());
+    let analysis = Analysis::from_executable(&executable);
 
     match matches.value_of("use") {
         Some("cfg") => {
@@ -271,7 +272,7 @@ native machine code before execting it in the virtual machine.",
     let id = bpf_loader::id();
     let mut vm = create_vm(
         &id,
-        executable.as_ref(),
+        &executable,
         parameter_bytes.as_slice_mut(),
         &mut invoke_context,
         &account_lengths,
@@ -291,7 +292,7 @@ native machine code before execting it in the virtual machine.",
     if matches.is_present("trace") {
         println!("Trace is saved in trace.out");
         let mut file = File::create("trace.out").unwrap();
-        let analysis = Analysis::from_executable(executable.as_ref());
+        let analysis = Analysis::from_executable(&executable);
         vm.get_tracer().write(&mut file, &analysis).unwrap();
     }
     if matches.is_present("profile") {


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/rbpf/releases/tag/v0.2.16 was just released.

#### Summary of Changes
`solana_rbpf::elf::Executable` is not a `dyn Trait` anymore as that caused problems in the interface between JIT and a change of Rust internal structures as of Rust 1.56.0.

Fixes #21278
