### PR TITLE
AcctIdx: stats are usize

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6921,10 +6921,10 @@ impl AccountsDb {
                 .account_maps
                 .iter()
                 .map(|map_bin| {
-                    let len = map_bin.read().unwrap().len();
+                    let len = map_bin.read().unwrap().len_for_stats();
                     min_bin_size = std::cmp::min(min_bin_size, len);
                     max_bin_size = std::cmp::max(max_bin_size, len);
-                    len
+                    len as usize
                 })
                 .sum();
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -3052,10 +3052,10 @@ pub mod tests {
 
         let new_entry =
             PreAllocatedAccountMapEntry::new(slot, account_info, &index.storage.storage, false);
-        assert_eq!(0, account_maps_len_expensive(&index));
+        assert_eq!(0, account_maps_stats_len(&index));
         assert_eq!((slot, account_info), new_entry.clone().into());
 
-        assert_eq!(0, account_maps_len_expensive(&index));
+        assert_eq!(0, account_maps_stats_len(&index));
         let w_account_maps = index.get_account_maps_write_lock(&key.pubkey());
         w_account_maps.upsert(
             &key.pubkey(),
@@ -3064,7 +3064,7 @@ pub mod tests {
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
         drop(w_account_maps);
-        assert_eq!(1, account_maps_len_expensive(&index));
+        assert_eq!(1, account_maps_stats_len(&index));
 
         let mut ancestors = Ancestors::default();
         assert!(index.get(&key.pubkey(), Some(&ancestors), None).is_none());
@@ -3615,7 +3615,7 @@ pub mod tests {
         assert!(found_key);
     }
 
-    fn account_maps_len_expensive<T: IndexValue>(index: &AccountsIndex<T>) -> usize {
+    fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T>) -> usize {
         index.storage.storage.stats.total_count()
     }
 
@@ -3624,7 +3624,7 @@ pub mod tests {
         let key = Keypair::new();
         let index = AccountsIndex::<u64>::default_for_tests();
         let mut gc = Vec::new();
-        assert_eq!(0, account_maps_len_expensive(&index));
+        assert_eq!(0, account_maps_stats_len(&index));
         index.upsert(
             1,
             &key.pubkey(),
@@ -3635,7 +3635,7 @@ pub mod tests {
             &mut gc,
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
-        assert_eq!(1, account_maps_len_expensive(&index));
+        assert_eq!(1, account_maps_stats_len(&index));
 
         index.upsert(
             1,
@@ -3647,7 +3647,7 @@ pub mod tests {
             &mut gc,
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
-        assert_eq!(1, account_maps_len_expensive(&index));
+        assert_eq!(1, account_maps_stats_len(&index));
 
         let purges = index.purge_roots(&key.pubkey());
         assert_eq!(purges, (vec![], false));
@@ -3656,7 +3656,7 @@ pub mod tests {
         let purges = index.purge_roots(&key.pubkey());
         assert_eq!(purges, (vec![(1, 10)], true));
 
-        assert_eq!(1, account_maps_len_expensive(&index));
+        assert_eq!(1, account_maps_stats_len(&index));
         index.upsert(
             1,
             &key.pubkey(),
@@ -3667,7 +3667,7 @@ pub mod tests {
             &mut gc,
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
-        assert_eq!(1, account_maps_len_expensive(&index));
+        assert_eq!(1, account_maps_stats_len(&index));
     }
 
     #[test]

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -3616,11 +3616,7 @@ pub mod tests {
     }
 
     fn account_maps_len_expensive<T: IndexValue>(index: &AccountsIndex<T>) -> usize {
-        index
-            .account_maps
-            .iter()
-            .map(|bin_map| bin_map.read().unwrap().len())
-            .sum()
+        index.storage.storage.stats.total_count()
     }
 
     #[test]

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -463,12 +463,8 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         ))
     }
 
-    pub fn len(&self) -> usize {
-        self.map().read().unwrap().len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn len_for_stats(&self) -> usize {
+        self.stats().count_in_bucket(self.bin)
     }
 
     fn insert_returner(
@@ -880,12 +876,12 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
         self.stats()
             .insert_or_delete_mem_count(false, self.bin, removed);
-        Self::update_stat(&self.stats().flush_entries_removed_from_mem, removed);
+        Self::update_stat(&self.stats().flush_entries_removed_from_mem, removed as u64);
 
         completed_scan
     }
 
-    fn stats(&self) -> &BucketMapHolderStats {
+    pub fn stats(&self) -> &BucketMapHolderStats {
         &self.storage.stats
     }
 


### PR DESCRIPTION
#### Problem
'len' of accounts index is complicated. Streamline the code so we use the stats, which are now kept up to date for both disk and non-disk. This would work better if we use usize instead of u64. Will probably take a further step later to move more similar stats to usize.

This current change is made necessary because refactoring of disk index exposes brittleness in test code regarding disk vs non-disk index.

#### Summary of Changes

Fixes #
