### PR TITLE
AcctIdx: tests can use index-buckets with an env var

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -44,7 +44,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: Some(1),
+    index_limit_mb: None,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
 };
@@ -840,7 +840,13 @@ pub struct AccountsIndex<T: IndexValue> {
 
 impl<T: IndexValue> AccountsIndex<T> {
     pub fn default_for_tests() -> Self {
-        Self::new(Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING))
+        let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
+        if let Ok(limit) = std::env::var("SOLANA_TEST_ACCOUNTS_INDEX_MEMORY_LIMIT_MB") {
+            // allocate with disk buckets
+            config.index_limit_mb = Some(limit.parse::<usize>().unwrap());
+        }
+
+        Self::new(Some(config))
     }
 
     pub fn new(config: Option<AccountsIndexConfig>) -> Self {


### PR DESCRIPTION
#### Problem
we have 2 code paths:
1. using disk buckets
2. not using disk buckets (in-mem only)

The 2 paths are connected (disk-buckets use in-mem for some operations). But, they are separate logic in multiple places. All tests that use accounts index ideally need to run ideally against both code paths.

#### Summary of Changes
default to in-mem
env var causes us to use disk buckets
Not:Randomly choose for each test to use disk buckets or not. Can we come up with a better solution other than replicating or parameterizing every test?

Fixes #
