### PR TITLE
explorer: fix modal backdrop z-index

### DIFF
--- a/explorer/src/components/ClusterModal.tsx
+++ b/explorer/src/components/ClusterModal.tsx
@@ -32,10 +32,7 @@ export function ClusterModal() {
 
   return (
     <>
-      <div
-        className={`offcanvas offcanvas-end${show ? " show" : ""}`}
-        onClick={onClose}
-      >
+      <div className={`offcanvas offcanvas-end${show ? " show" : ""}`}>
         <div className="modal-body" onClick={(e) => e.stopPropagation()}>
           <span className="c-pointer" onClick={onClose}>
             &times;

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -76,6 +76,8 @@ ul.log-messages {
 
 .offcanvas {
   visibility: visible;
+  // Bootstrap 5.1 updates modal-backdrop to a higher z-index
+  z-index: 1060;
 }
 
 .c-pointer {


### PR DESCRIPTION
#### Problem
Bootstrap v5.1 modal backdrop z-index updated and is now higher than the cluster off canvas modal

#### Summary of Changes
Bump z-index of off canvas modal

Fixes #
