### PR TITLE
Quash M1 build warning

### DIFF
--- a/ledger/src/builtins.rs
+++ b/ledger/src/builtins.rs
@@ -1,5 +1,7 @@
-use solana_runtime::builtins::{ActivationType, Builtin, Builtins};
-use solana_sdk::pubkey::Pubkey;
+use {
+    solana_runtime::builtins::{ActivationType, Builtin, Builtins},
+    solana_sdk::pubkey::Pubkey,
+};
 
 macro_rules! to_builtin {
     ($b:expr) => {
@@ -13,7 +15,12 @@ fn genesis_builtins(bpf_jit: bool) -> Vec<Builtin> {
     // !x86_64: https://github.com/qmonnet/rbpf/issues/48
     // Windows: https://github.com/solana-labs/rbpf/issues/217
     #[cfg(any(not(target_arch = "x86_64"), target_family = "windows"))]
-    let bpf_jit = false;
+    let bpf_jit = {
+        if bpf_jit {
+            info!("BPF JIT is not supported on this target");
+        }
+        false
+    };
 
     vec![
         to_builtin!(solana_bpf_loader_deprecated_program!()),


### PR DESCRIPTION
```
warning: unused variable: `bpf_jit`
  --> ledger/src/builtins.rs:13:21
   |
13 | fn genesis_builtins(bpf_jit: bool) -> Vec<Builtin> {
   |                     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_bpf_jit`
   |
```
begone!