### PR TITLE
cli: always print feature version info with status query

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -344,7 +344,7 @@ fn feature_activation_allowed(rpc_client: &RpcClient, quiet: bool) -> Result<boo
         )
         .unwrap_or((false, false));
 
-    if !stake_allowed && !rpc_allowed && !quiet {
+    if !quiet {
         if feature_set_stats.get(&my_feature_set).is_none() {
             println!(
                 "{}",


### PR DESCRIPTION
#### Problem

`solana feature status` only displays feature version info when both blocking cases are in effect

#### Summary of Changes

~DeMorgan properly~

Print them so long as `--quient` isn't in force