### PR TITLE
Pass Epoch by value in StakeHistory::get()

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2221,7 +2221,7 @@ mod tests {
         }
 
         for epoch in 0..=stake.deactivation_epoch + 1 {
-            let history = stake_history.get(&epoch).unwrap();
+            let history = stake_history.get(epoch).unwrap();
             let other_activations: u64 = other_activations[..=epoch as usize].iter().sum();
             let expected_stake = history.effective - base_stake - other_activations;
             let (expected_activating, expected_deactivating) = if epoch < stake.deactivation_epoch {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2159,7 +2159,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes.read().unwrap().history().get(&prev_epoch)
+            self.stakes.read().unwrap().history().get(prev_epoch)
         {
             stake_history_entry.effective
         } else {
@@ -2259,7 +2259,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes.read().unwrap().history().get(&prev_epoch)
+            self.stakes.read().unwrap().history().get(prev_epoch)
         {
             stake_history_entry.effective
         } else {

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -404,7 +404,7 @@ impl Delegation {
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
-                    .get(&self.deactivation_epoch)
+                    .get(self.deactivation_epoch)
                     .map(|cluster_stake_at_deactivation_epoch| {
                         (
                             history,
@@ -448,7 +448,7 @@ impl Delegation {
                 if current_epoch >= target_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                if let Some(current_cluster_stake) = history.get(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {
@@ -488,7 +488,7 @@ impl Delegation {
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
             history.and_then(|history| {
                 history
-                    .get(&self.activation_epoch)
+                    .get(self.activation_epoch)
                     .map(|cluster_stake_at_activation_epoch| {
                         (
                             history,
@@ -533,7 +533,7 @@ impl Delegation {
                 if current_epoch >= target_epoch || current_epoch >= self.deactivation_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(&current_epoch) {
+                if let Some(current_cluster_stake) = history.get(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -56,8 +56,7 @@ impl std::ops::Add for StakeHistoryEntry {
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn get(&self, epoch: &Epoch) -> Option<&StakeHistoryEntry> {
+    pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()
             .map(|index| &self[index].1)
@@ -98,9 +97,9 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(&0), None);
+        assert_eq!(stake_history.get(0), None);
         assert_eq!(
-            stake_history.get(&1),
+            stake_history.get(1),
             Some(&StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -54,9 +54,9 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(&0), None);
+        assert_eq!(stake_history.get(0), None);
         assert_eq!(
-            stake_history.get(&1),
+            stake_history.get(1),
             Some(&StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()


### PR DESCRIPTION
#### Problem

`StakeHistory::get()` passes the `epoch` parameter by reference, even though `Epoch` is a `u64`. Here's the fn:

```rust
#[allow(clippy::trivially_copy_pass_by_ref)]
pub fn get(&self, epoch: &Epoch) -> Option<&StakeHistoryEntry> {
```

#### Summary of Changes

Pass `epoch` by value.