### PR TITLE
Add missing InstructionError::IllegalOwner conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5763,6 +5763,7 @@ version = "1.9.0"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
+ "enum-iterator",
  "prost",
  "serde",
  "solana-account-decoder",

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -12,12 +12,14 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.3"
 bs58 = "0.4.0"
-enum-iterator = "0.7.0"
 prost = "0.9.0"
 serde = "1.0.130"
 solana-account-decoder = { path = "../account-decoder", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.9.0" }
+
+[dev-dependencies]
+enum-iterator = "0.7.0"
 
 [lib]
 crate-type = ["lib"]

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.3"
 bs58 = "0.4.0"
+enum-iterator = "0.7.0"
 prost = "0.9.0"
 serde = "1.0.130"
 solana-account-decoder = { path = "../account-decoder", version = "=1.9.0" }

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -12,5 +12,13 @@ fn main() -> Result<(), std::io::Error> {
         .build_client(true)
         .build_server(false)
         .format(true)
+        .type_attribute(
+            "TransactionErrorType",
+            "#[derive(enum_iterator::IntoEnumIterator)]",
+        )
+        .type_attribute(
+            "InstructionErrorType",
+            "#[derive(enum_iterator::IntoEnumIterator)]",
+        )
         .compile(&protos, &[proto_base_path])
 }

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -14,11 +14,11 @@ fn main() -> Result<(), std::io::Error> {
         .format(true)
         .type_attribute(
             "TransactionErrorType",
-            "#[derive(enum_iterator::IntoEnumIterator)]",
+            "#[cfg_attr(test, derive(enum_iterator::IntoEnumIterator))]",
         )
         .type_attribute(
             "InstructionErrorType",
-            "#[derive(enum_iterator::IntoEnumIterator)]",
+            "#[cfg_attr(test, derive(enum_iterator::IntoEnumIterator))]",
         )
         .compile(&protos, &[proto_base_path])
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -523,6 +523,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
                     46 => InstructionError::InvalidAccountOwner,
                     47 => InstructionError::ArithmeticOverflow,
                     48 => InstructionError::UnsupportedSysvar,
+                    49 => InstructionError::IllegalOwner,
                     _ => return Err("Invalid InstructionError"),
                 };
 

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -853,7 +853,7 @@ impl TryFrom<tx_by_addr::TransactionByAddr> for Vec<TransactionByAddrInfo> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, enum_iterator::IntoEnumIterator};
 
     #[test]
     fn test_reward_type_encode() {
@@ -1449,5 +1449,56 @@ mod test {
             transaction_error,
             tx_by_addr_transaction_error.try_into().unwrap()
         );
+    }
+
+    #[test]
+    fn test_error_enums() {
+        let ix_index = 1;
+        let custom_error = 42;
+        for error in tx_by_addr::TransactionErrorType::into_enum_iter() {
+            if error != tx_by_addr::TransactionErrorType::InstructionError {
+                let tx_by_addr_error = tx_by_addr::TransactionError {
+                    transaction_error: error as i32,
+                    instruction_error: None,
+                };
+                let transaction_error: TransactionError = tx_by_addr_error
+                    .clone()
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("{:?} conversion implemented?", error));
+                assert_eq!(tx_by_addr_error, transaction_error.into());
+            } else {
+                for ix_error in tx_by_addr::InstructionErrorType::into_enum_iter() {
+                    if ix_error != tx_by_addr::InstructionErrorType::Custom {
+                        let tx_by_addr_error = tx_by_addr::TransactionError {
+                            transaction_error: error as i32,
+                            instruction_error: Some(tx_by_addr::InstructionError {
+                                index: ix_index,
+                                error: ix_error as i32,
+                                custom: None,
+                            }),
+                        };
+                        let transaction_error: TransactionError = tx_by_addr_error
+                            .clone()
+                            .try_into()
+                            .unwrap_or_else(|_| panic!("{:?} conversion implemented?", ix_error));
+                        assert_eq!(tx_by_addr_error, transaction_error.into());
+                    } else {
+                        let tx_by_addr_error = tx_by_addr::TransactionError {
+                            transaction_error: error as i32,
+                            instruction_error: Some(tx_by_addr::InstructionError {
+                                index: ix_index,
+                                error: ix_error as i32,
+                                custom: Some(tx_by_addr::CustomError {
+                                    custom: custom_error,
+                                }),
+                            }),
+                        };
+                        let transaction_error: TransactionError =
+                            tx_by_addr_error.clone().try_into().unwrap();
+                        assert_eq!(tx_by_addr_error, transaction_error.into());
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
#### Problem
Some BigTable reads are failing on BigTableError(ObjectCorrupt("Failed to deserialize: Invalid InstructionError: tx-by-addr/<ADDR>/<KEY>")). This is because the InstructionError::IllegalOwner conversion was only implemented one direction here https://github.com/solana-labs/solana/commit/fcabaa7effe35cc80997401e60b5a79081e5e3dd

#### Summary of Changes
Add missing conversion
*Also*, add test that will fail if the conversion is incompletely done in the future

Fixes #21442
