### PR TITLE
AcctIdx: move zero lamport out of accounts index

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -1,3 +1,7 @@
+//! AccountInfo represents a reference to AccountSharedData in either an AppendVec or the write cache.
+//! AccountInfo is not persisted anywhere between program runs.
+//! AccountInfo is purely runtime state.
+//! Note that AccountInfo is saved to disk buckets during runtime, but disk buckets are recreated at startup.
 use crate::{
     accounts_db::{AppendVecId, CACHE_VIRTUAL_OFFSET, CACHE_VIRTUAL_STORAGE_ID},
     accounts_index::{IsCached, ZeroLamport},
@@ -22,16 +26,16 @@ pub struct AccountInfo {
 
     /// needed to track shrink candidacy in bytes. Used to update the number
     /// of alive bytes in an AppendVec as newer slots purge outdated entries
+    /// Note that highest bit is used for ZERO_LAMPORT_BIT
     stored_size: usize,
-
-    /// lamports in the account used when squashing kept for optimization
-    /// purposes to remove accounts with zero balance.
-    lamports: u64,
 }
+
+/// presence of this bit in stored_size indicates this account info references an account with zero lamports
+const ZERO_LAMPORT_BIT: usize = 1 << (usize::BITS - 1);
 
 impl ZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
-        self.lamports == 0
+        self.stored_size & ZERO_LAMPORT_BIT == ZERO_LAMPORT_BIT
     }
 }
 
@@ -42,16 +46,19 @@ impl IsCached for AccountInfo {
 }
 
 impl AccountInfo {
-    pub fn new(storage_location: StorageLocation, stored_size: usize, lamports: u64) -> Self {
+    pub fn new(storage_location: StorageLocation, mut stored_size: usize, lamports: u64) -> Self {
         let (store_id, offset) = match storage_location {
             StorageLocation::AppendVec(store_id, offset) => (store_id, offset),
             StorageLocation::Cached => (CACHE_VIRTUAL_STORAGE_ID, CACHE_VIRTUAL_OFFSET),
         };
+        assert!(stored_size < ZERO_LAMPORT_BIT);
+        if lamports == 0 {
+            stored_size |= ZERO_LAMPORT_BIT;
+        }
         Self {
             store_id,
             offset,
             stored_size,
-            lamports,
         }
     }
 
@@ -60,6 +67,7 @@ impl AccountInfo {
     }
 
     pub fn stored_size(&self) -> usize {
-        self.stored_size
+        // elminate the special bit that indicates the info references an account with zero lamports
+        self.stored_size & !ZERO_LAMPORT_BIT
     }
 }


### PR DESCRIPTION
#### Problem
Lamport balance in account index is an optimization for shrinking (maybe also cleaning). But, this information already exists in the code path that produces lists of pubkeys.
Thus, lamports in the accounts index require the accounts index entries to be larger. Larger means more space in memory, less cache hits, more size on disk, more pages needing to map in, etc. These issues become worse with disk buckets and 10B accounts.
#### Summary of Changes
Remove lamports from an AccountsIndex entry for perf.
Note that the first attempt was trying to calculate the zero lamport information in clean and shrink. This proved to be difficult with deferred dirty keys.
Fixes #
