### PR TITLE
Explorer: Add Metaplex Metadata Name to token addresses

### DIFF
--- a/explorer/src/components/account/OwnedTokensCard.tsx
+++ b/explorer/src/components/account/OwnedTokensCard.tsx
@@ -196,7 +196,7 @@ function HoldingsSummaryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
           </td>
         )}
         <td>
-          <Address pubkey={new PublicKey(mintAddress)} link />
+          <Address pubkey={new PublicKey(mintAddress)} link useMetadata />
         </td>
         <td>
           {totalByMint} {tokenDetails && tokenDetails.symbol}


### PR DESCRIPTION
#### Problem

When viewing an accounts token holdings, registered spl-tokens have their address changed to their token name; a feature like this has not been implemented for Metaplex NFTs. It becomes a difficult task to have to click through every token in your holdings in order to find the explorer page for your NFT. 

#### Summary of Changes

- Added an attribute to the Address component "useMetadata" which will fetch and display the Metaplex name instead of the token address.  
- Added "useMetadata" attribute to HoldingsSummaryTable address components in the account page to display the NFT name instead of address. 

Ive added an attribute to the address because I feel like it would be too extensive to check every single address for metaplex metadata, and only want to limit it to specific parts of the explorer. 


(used a random account I found on solsea) 

Token holdings before changes (unable to see what NFTs are held) 

![Screen Shot 2021-11-30 at 7 44 24 PM](https://user-images.githubusercontent.com/31865497/144169416-d54eb243-7f36-4460-83af-27c714be52e7.png)

Token holdings after changes (Genet Egg # 2430 is now displayed) 

![Screen Shot 2021-11-30 at 7 44 28 PM](https://user-images.githubusercontent.com/31865497/144169431-0e5fdf77-17fb-44ad-8cc9-b397492bf934.png)
