### PR TITLE
Build OpenSSL statically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "arc-swap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "arrayref"
@@ -2751,6 +2751,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.0.2+3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2768,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5743,6 +5753,7 @@ dependencies = [
  "flate2",
  "goauth",
  "log 0.4.14",
+ "openssl",
  "prost",
  "prost-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,7 +4428,6 @@ dependencies = [
  "byteorder",
  "libsecp256k1 0.6.0",
  "log 0.4.14",
- "openssl",
  "rand 0.7.3",
  "regex",
  "solana-measure",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -919,21 +919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,33 +1723,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2576,7 +2534,6 @@ dependencies = [
  "byteorder 1.4.3",
  "libsecp256k1 0.6.0",
  "log",
- "openssl",
  "regex",
  "solana-measure",
  "solana-program-runtime",
@@ -4122,12 +4079,6 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -17,7 +17,6 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 log = "0.4.14"
 libsecp256k1 = "0.6.0"
-openssl = "^0.10.38"
 solana-measure = { path = "../../measure", version = "=1.9.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.9.0" }
 solana-sdk = { path = "../../sdk", version = "=1.9.0" }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -21,7 +21,7 @@ prost = "0.9.0"
 prost-types = "0.9.0"
 serde = "1.0.130"
 serde_derive = "1.0.103"
-smpl_jwt = "0.6.0"
+smpl_jwt = "0.6.1"
 solana-metrics = { path = "../metrics", version = "=1.9.0" }
 solana-sdk = { path = "../sdk", version = "=1.9.0" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.9.0" }
@@ -29,6 +29,11 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.9.0"
 thiserror = "1.0"
 tonic = { version = "0.6.1", features = ["tls", "transport"] }
 zstd = "0.9.0"
+
+# openssl is a dependency of the goauth and smpl_jwt crates, but explicitly
+# declare it here as well to activate the "vendored" feature that builds OpenSSL
+# statically
+openssl = { version = "0.10", features = ["vendored"] }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
The mac x86 `solana-validator`/`solana-test-validator` release binaries don't run on a mac arm64 under Rosetta due to a missing `/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib`.  Build OpenSSL statically and avoid the problem entirely 