### PR TITLE
bank: get hash and fee rate from the same source when storing accounts

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3153,6 +3153,15 @@ impl Bank {
         self.blockhash_queue.read().unwrap().last_hash()
     }
 
+    pub fn last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
+        let blockhash_queue = self.blockhash_queue.read().unwrap();
+        let last_hash = blockhash_queue.last_hash();
+        let last_lamports_per_signature = blockhash_queue
+            .get_lamports_per_signature(&last_hash)
+            .unwrap(); // safe so long as the BlockhashQueue is consistent
+        (last_hash, last_lamports_per_signature)
+    }
+
     pub fn is_blockhash_valid(&self, hash: &Hash) -> bool {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         blockhash_queue.check_hash(hash)
@@ -4149,6 +4158,7 @@ impl Bank {
             self.is_delta.store(true, Relaxed);
         }
 
+        let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
         let mut write_time = Measure::start("write_time");
         self.rc.accounts.store_cached(
             self.slot(),
@@ -4156,8 +4166,8 @@ impl Bank {
             executed_results,
             loaded_txs,
             &self.rent_collector,
-            &self.last_blockhash(),
-            self.get_lamports_per_signature(),
+            &blockhash,
+            lamports_per_signature,
             self.rent_for_sysvars(),
             self.merge_nonce_error_into_system_error(),
             self.demote_program_write_locks(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3862,16 +3862,8 @@ impl Bank {
 
                         let compute_meter = ComputeMeter::new_ref(compute_budget.max_units);
 
-                        let (blockhash, lamports_per_signature) = {
-                            let blockhash_queue = self.blockhash_queue.read().unwrap();
-                            let blockhash = blockhash_queue.last_hash();
-                            (
-                                blockhash,
-                                blockhash_queue
-                                    .get_lamports_per_signature(&blockhash)
-                                    .unwrap_or(self.fee_rate_governor.lamports_per_signature),
-                            )
-                        };
+                        let (blockhash, lamports_per_signature) =
+                            self.last_blockhash_and_lamports_per_signature();
 
                         if let Some(legacy_message) = tx.message().legacy_message() {
                             process_result = MessageProcessor::process_message(


### PR DESCRIPTION
#### Problem

The `lamports_per_signature` used when advancing nonce accounts used to be sourced from the last blockhash, but got changed to the current bank's congestion adjusted rate governor in this change:

https://github.com/jackcmay/solana/commit/bfbbc53dac93b3a5c6be9b4b65f679fdb13e41d9

#### Summary of Changes

Query both the blockhash and fee rate from the blockhash queu's last entry when advancing durable nonce accounts from runtime.

Fixes #21500
