### PR TITLE
Fix #21397

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2003,7 +2003,7 @@ where
     let demote_program_write_locks =
         invoke_context.is_feature_active(&demote_program_write_locks::id());
     let keyed_accounts = invoke_context
-        .get_keyed_accounts()
+        .get_instruction_keyed_accounts()
         .map_err(SyscallError::InstructionError)?;
     let mut account_indices = Vec::with_capacity(message.account_keys.len());
     let mut accounts = Vec::with_capacity(message.account_keys.len());


### PR DESCRIPTION
#### Problem
#20448 changed how the program `keyed_accounts` are popped from the front from using `InvokeContext::remove_first_keyed_account()` to instead using a parameter called `first_instruction_account`.
However, while the change was applied to most of the program runtime, CPI was left out.
Luckily, `InvokeContextStackFrame::number_of_program_accounts` is set to `program_indices.len()` (which is the same value as `first_instruction_account + 1`) in `InvokeContext::push()` so we can use that in CPI without routing `first_instruction_account` explicitly as a parameter.

#### Summary of Changes
Adds `InvokeContext::get_instruction_keyed_accounts()` to skip `first_instruction_account` `keyed_accounts` in CPI.

Fixes #21397
