### PR TITLE
wip: eliminate accounts index arc and rwlock

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -27,10 +27,9 @@ use {
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_hash::{AccountsHash, CalculateHashIntermediate, HashStats, PreviousPass},
         accounts_index::{
-            AccountIndexGetResult, AccountSecondaryIndexes, AccountsIndex, AccountsIndexConfig,
-            AccountsIndexRootsStats, IndexKey, IndexValue, IsCached, RefCount, ScanConfig,
-            ScanResult, SlotList, SlotSlice, ZeroLamport, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
-            ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
+            AccountSecondaryIndexes, AccountsIndex, AccountsIndexConfig, AccountsIndexRootsStats,
+            IndexKey, IndexValue, IsCached, RefCount, ScanConfig, ScanResult, SlotList, SlotSlice,
+            ZeroLamport, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
         },
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::Ancestors,
@@ -2575,21 +2574,31 @@ impl AccountsDb {
         let mut alive = 0;
         let mut dead = 0;
         iter.for_each(|(pubkey, stored_account)| {
-            let lookup = self.accounts_index.get_account_read_entry(pubkey);
-            if let Some(locked_entry) = lookup {
-                let is_alive = locked_entry.slot_list().iter().any(|(_slot, acct_info)| {
-                    acct_info.matches_storage_location(
-                        stored_account.store_id,
-                        stored_account.account.offset,
-                    )
-                });
+            let is_alive = self.accounts_index.get_mut_entry(pubkey, |locked_entry| {
+                locked_entry.map(|locked_entry| {
+                    let is_alive = locked_entry.slot_list().iter().any(|(_slot, acct_info)| {
+                        acct_info.matches_storage_location(
+                            stored_account.store_id,
+                            stored_account.account.offset,
+                        )
+                    });
+                    if !is_alive {
+                        // This pubkey was found in the storage, but no longer exists in the index.
+                        // It would have had a ref to the storage from the initial store, but it will
+                        // not exist in the re-written slot. Unref it to keep the index consistent with
+                        // rewriting the storage entries.
+                        locked_entry.add_un_ref(false);
+                    }
+                    is_alive
+                })
+            });
+            if let Some(is_alive) = is_alive {
                 if !is_alive {
                     // This pubkey was found in the storage, but no longer exists in the index.
                     // It would have had a ref to the storage from the initial store, but it will
                     // not exist in the re-written slot. Unref it to keep the index consistent with
                     // rewriting the storage entries.
                     unrefed_pubkeys.push(pubkey);
-                    locked_entry.unref();
                     dead += 1;
                 } else {
                     alive_accounts.push((pubkey, stored_account));
@@ -2697,9 +2706,11 @@ impl AccountsDb {
                 .skipped_shrink
                 .fetch_add(1, Ordering::Relaxed);
             for pubkey in unrefed_pubkeys {
-                if let Some(locked_entry) = self.accounts_index.get_account_read_entry(pubkey) {
-                    locked_entry.addref();
-                }
+                self.accounts_index.get_mut_entry(pubkey, |locked_entry| {
+                    if let Some(locked_entry) = locked_entry {
+                        locked_entry.add_un_ref(true);
+                    }
+                })
             }
             return 0;
         }
@@ -3307,17 +3318,16 @@ impl AccountsDb {
         max_root: Option<Slot>,
         clone_in_lock: bool,
     ) -> Option<(Slot, StorageLocation, Option<LoadedAccountAccessor<'a>>)> {
-        let (lock, index) = match self.accounts_index.get(pubkey, Some(ancestors), max_root) {
-            AccountIndexGetResult::Found(lock, index) => (lock, index),
-            // we bail out pretty early for missing.
-            AccountIndexGetResult::NotFound => {
-                return None;
-            }
-        };
+        let (slot, storage_location) =
+            self.accounts_index
+                .get(pubkey, Some(ancestors), max_root, |entry| {
+                    entry.map(|(lock, index)| {
+                        let slot_list = lock.slot_list();
+                        let (slot, info) = slot_list[index];
+                        (slot, info.storage_location())
+                    })
+                })?;
 
-        let slot_list = lock.slot_list();
-        let (slot, info) = slot_list[index];
-        let storage_location = info.storage_location();
         let some_from_slow_path = if clone_in_lock {
             // the fast path must have failed.... so take the slower approach
             // of copying potentially large Account::data inside the lock.
@@ -5090,9 +5100,8 @@ impl AccountsDb {
                             if self.is_filler_account(pubkey) {
                                 return None;
                             }
-                            if let AccountIndexGetResult::Found(lock, index) =
-                                self.accounts_index.get(pubkey, Some(ancestors), Some(slot))
-                            {
+                            self.accounts_index.get(pubkey, Some(ancestors), Some(slot), |entry| {
+                                entry.and_then(|(lock, index)| {
                                 let (slot, account_info) = &lock.slot_list()[index];
                                 if !account_info.is_zero_lamport() {
                                     // Because we're keeping the `lock' here, there is no need
@@ -5129,13 +5138,12 @@ impl AccountsDb {
                                             Some(loaded_hash)
                                         },
                                     )
-                                } else {
+                                }
+                                else {
                                     None
                                 }
-                            } else {
-                                None
-                            }
-                        })
+                            })
+                        })})
                         .collect();
                     let mut total = total_lamports.lock().unwrap();
                     *total =
@@ -6930,25 +6938,27 @@ impl AccountsDb {
                             let mut lookup_time = Measure::start("lookup_time");
                             for account in accounts_map.into_iter() {
                                 let (key, account_info) = account;
-                                let lock = self.accounts_index.get_account_maps_read_lock(&key);
-                                let x = lock.get(&key).unwrap();
-                                let sl = x.slot_list.read().unwrap();
-                                let mut count = 0;
-                                for (slot2, account_info2) in sl.iter() {
-                                    if slot2 == slot {
-                                        count += 1;
-                                        let ai = AccountInfo::new(
-                                            StorageLocation::AppendVec(
-                                                account_info.store_id,
-                                                account_info.stored_account.offset,
-                                            ), // will never be cached
-                                            account_info.stored_account.stored_size as StoredSize, // stored_size should never exceed StoredSize::MAX because of max data len const
-                                            account_info.stored_account.account_meta.lamports,
-                                        );
-                                        assert_eq!(&ai, account_info2);
+                                self.accounts_index.get_entry(&key, |entry| {
+                                    let entry = entry.unwrap();
+                                    let sl = &entry.slot_list();
+                                    let mut count = 0;
+                                    for (slot2, account_info2) in sl.iter() {
+                                        if slot2 == slot {
+                                            count += 1;
+                                            let ai = AccountInfo::new(
+                                                StorageLocation::AppendVec(
+                                                    account_info.store_id,
+                                                    account_info.stored_account.offset,
+                                                ), // will never be cached
+                                                account_info.stored_account.stored_size
+                                                    as StoredSize, // stored_size should never exceed StoredSize::MAX because of max data len const
+                                                account_info.stored_account.account_meta.lamports,
+                                            );
+                                            assert_eq!(&ai, account_info2);
+                                        }
                                     }
-                                }
-                                assert_eq!(1, count);
+                                    assert_eq!(1, count);
+                                });
                             }
                             lookup_time.stop();
                             lookup_time.as_us()
@@ -7047,15 +7057,18 @@ impl AccountsDb {
     fn pubkeys_to_duplicate_accounts_data_len(&self, pubkeys: &[Pubkey]) -> u64 {
         let mut accounts_data_len_from_duplicates = 0;
         pubkeys.iter().for_each(|pubkey| {
-            if let Some(entry) = self.accounts_index.get_account_read_entry(pubkey) {
-                let slot_list = entry.slot_list();
-                if slot_list.len() < 2 {
-                    return;
-                }
+            if let Some(mut slot_list) = self.accounts_index.get_entry(pubkey, |entry| {
+                entry.and_then(|entry| {
+                    let slot_list = entry.slot_list();
+                    if slot_list.len() < 2 {
+                        return None;
+                    }
+                    Some(slot_list.clone())
+                })
+            }) {
                 // Only the account data len in the highest slot should be used, and the rest are
                 // duplicates.  So sort the slot list in descending slot order, skip the first
                 // item, then sum up the remaining data len, which are the duplicates.
-                let mut slot_list = slot_list.clone();
                 slot_list
                     .select_nth_unstable_by(0, |a, b| b.0.cmp(&a.0))
                     .2
@@ -7167,12 +7180,14 @@ impl AccountsDb {
         let full_pubkey_range = Pubkey::new(&[0; 32])..=Pubkey::new(&[0xff; 32]);
 
         self.accounts_index.account_maps.iter().for_each(|map| {
-            for (pubkey, account_entry) in map.read().unwrap().items(&full_pubkey_range) {
-                info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
-                info!(
-                    "      slots: {:?}",
-                    *account_entry.slot_list.read().unwrap()
-                );
+            for pubkey in map.read().unwrap().items(&full_pubkey_range) {
+                map.read().unwrap().get_internal(&pubkey, |account_entry| {
+                    if let Some(account_entry) = account_entry {
+                        info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
+                        info!("      slots: {:?}", account_entry.slot_list);
+                    }
+                    (false, ())
+                });
             }
         });
     }
@@ -7245,8 +7260,10 @@ impl AccountsDb {
 
     pub fn get_append_vec_id(&self, pubkey: &Pubkey, slot: Slot) -> Option<AppendVecId> {
         let ancestors = vec![(slot, 1)].into_iter().collect();
-        let result = self.accounts_index.get(pubkey, Some(&ancestors), None);
-        result.map(|(list, index)| list.slot_list()[index].1.store_id())
+        self.accounts_index
+            .get(pubkey, Some(&ancestors), None, |result| {
+                result.map(|(list, index)| list.slot_list()[index].1.store_id())
+            })
     }
 
     pub fn alive_account_count_in_slot(&self, slot: Slot) -> usize {
@@ -8326,7 +8343,7 @@ pub mod tests {
             .insert(unrooted_slot, BankHashInfo::default());
         assert!(db
             .accounts_index
-            .get(&key, Some(&ancestors), None)
+            .get(&key, Some(&ancestors), None, |entry| entry.map(|_| true))
             .is_some());
         assert_load_account(&db, unrooted_slot, key, 1);
 
@@ -8336,10 +8353,13 @@ pub mod tests {
         assert!(db.bank_hashes.read().unwrap().get(&unrooted_slot).is_none());
         assert!(db.accounts_cache.slot_cache(unrooted_slot).is_none());
         assert!(db.storage.0.get(&unrooted_slot).is_none());
-        assert!(db.accounts_index.get_account_read_entry(&key).is_none());
         assert!(db
             .accounts_index
-            .get(&key, Some(&ancestors), None)
+            .get_entry(&key, |entry| entry.map(|_| true))
+            .is_none());
+        assert!(db
+            .accounts_index
+            .get(&key, Some(&ancestors), None, |entry| entry.map(|_| true))
             .is_none());
 
         // Test we can store for the same slot again and get the right information

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8074,18 +8074,20 @@ pub(crate) mod tests {
 
     impl Bank {
         fn slots_by_pubkey(&self, pubkey: &Pubkey, ancestors: &Ancestors) -> Vec<Slot> {
-            let (locked_entry, _) = self
-                .rc
-                .accounts
-                .accounts_db
-                .accounts_index
-                .get(pubkey, Some(ancestors), None)
-                .unwrap();
-            locked_entry
-                .slot_list()
-                .iter()
-                .map(|(slot, _)| *slot)
-                .collect::<Vec<Slot>>()
+            self.rc.accounts.accounts_db.accounts_index.get(
+                pubkey,
+                Some(ancestors),
+                None,
+                |entry| {
+                    entry
+                        .unwrap()
+                        .0
+                        .slot_list()
+                        .iter()
+                        .map(|(slot, _)| *slot)
+                        .collect::<Vec<Slot>>()
+                },
+            )
         }
 
         fn first_slot_in_next_epoch(&self) -> Slot {

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -20,7 +20,7 @@ use {
         ops::{Bound, RangeBounds, RangeInclusive},
         sync::{
             atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
-            Arc, RwLock, RwLockWriteGuard,
+            Arc, RwLock,
         },
     },
 };
@@ -116,7 +116,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
     }
 
-    pub fn items<R>(&self, range: &R) -> Vec<(K, AccountMapEntry<T>)>
+    pub fn items<R>(&self, range: &R) -> Vec<K>
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
@@ -124,9 +124,9 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         self.hold_range_in_memory(range, true);
         let map = self.map().read().unwrap();
         let mut result = Vec::with_capacity(map.len());
-        map.iter().for_each(|(k, v)| {
+        map.iter().for_each(|(k, _v)| {
             if range.contains(k) {
-                result.push((*k, Arc::clone(v)));
+                result.push(*k);
             }
         });
         self.hold_range_in_memory(range, false);
@@ -198,11 +198,6 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         })
     }
 
-    /// lookup 'pubkey' in index (in mem or on disk)
-    pub fn get(&self, pubkey: &K) -> Option<AccountMapEntry<T>> {
-        self.get_internal(pubkey, |entry| (true, entry.map(Arc::clone)))
-    }
-
     /// lookup 'pubkey' in index (in_mem or disk).
     /// call 'callback' whether found or not
     pub(crate) fn get_internal<RT>(
@@ -241,6 +236,38 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         })
     }
 
+    /// lookup 'pubkey' in index (in_mem or disk).
+    /// call 'callback' whether found or not
+    pub(crate) fn get_mut_internal<RT>(
+        &self,
+        pubkey: &K,
+        // return true if item should be added to in_mem cache
+        callback: impl for<'a> FnOnce(Option<&mut AccountMapEntry<T>>) -> (bool, RT),
+    ) -> RT {
+        let mut map = self.map().write().unwrap();
+        let entry = map.entry(*pubkey);
+        match entry {
+            Entry::Occupied(mut occupied) => {
+                let result = callback(Some(occupied.get_mut())).1;
+                occupied.get().set_age(self.storage.future_age_to_flush());
+                result
+            }
+            Entry::Vacant(vacant) => {
+                let stats = &self.stats();
+                let mut disk_entry = self.load_account_entry_from_disk(pubkey);
+                let (add_to_cache, rt) = callback(disk_entry.as_mut());
+
+                if add_to_cache {
+                    if let Some(disk_entry) = disk_entry {
+                        stats.insert_or_delete_mem(true, self.bin);
+                        vacant.insert(disk_entry);
+                    }
+                }
+                rt
+            }
+        }
+    }
+
     fn remove_if_slot_list_empty_value(&self, slot_list: SlotSlice<T>) -> bool {
         if slot_list.is_empty() {
             self.stats().insert_or_delete(false, self.bin);
@@ -258,9 +285,8 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 
     fn remove_if_slot_list_empty_entry(&self, entry: Entry<K, AccountMapEntry<T>>) -> bool {
         match entry {
-            Entry::Occupied(occupied) => {
-                let result =
-                    self.remove_if_slot_list_empty_value(&occupied.get().slot_list.read().unwrap());
+            Entry::Occupied(mut occupied) => {
+                let result = self.remove_if_slot_list_empty_value(&occupied.get_mut().slot_list);
                 if result {
                     // note there is a potential race here that has existed.
                     // if someone else holds the arc,
@@ -313,13 +339,13 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     pub fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
-        user: impl for<'a> FnOnce(&mut RwLockWriteGuard<'a, SlotList<T>>) -> RT,
+        user: impl for<'a> FnOnce(&mut SlotList<T>) -> RT,
     ) -> Option<RT> {
-        self.get_internal(pubkey, |entry| {
+        self.get_mut_internal(pubkey, |entry| {
             (
                 true,
                 entry.map(|entry| {
-                    let result = user(&mut entry.slot_list.write().unwrap());
+                    let result = user(&mut entry.slot_list);
                     entry.set_dirty(true);
                     result
                 }),
@@ -328,7 +354,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     }
 
     pub fn unref(&self, pubkey: &Pubkey) {
-        self.get_internal(pubkey, |entry| {
+        self.get_mut_internal(pubkey, |entry| {
             if let Some(entry) = entry {
                 entry.add_un_ref(false)
             }
@@ -343,81 +369,68 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,
     ) {
-        // try to get it just from memory first using only a read lock
-        self.get_only_in_mem(pubkey, |entry| {
-            if let Some(entry) = entry {
+        let mut m = Measure::start("entry");
+        let mut map = self.map().write().unwrap();
+        let entry = map.entry(*pubkey);
+        m.stop();
+        let found = matches!(entry, Entry::Occupied(_));
+        match entry {
+            Entry::Occupied(mut occupied) => {
+                let current = occupied.get_mut();
                 Self::lock_and_update_slot_list(
-                    entry,
+                    current,
                     new_value.into(),
                     reclaims,
                     previous_slot_entry_was_cached,
                 );
+                current.set_age(self.storage.future_age_to_flush());
                 Self::update_stat(&self.stats().updates_in_mem, 1);
-            } else {
-                let mut m = Measure::start("entry");
-                let mut map = self.map().write().unwrap();
-                let entry = map.entry(*pubkey);
-                m.stop();
-                let found = matches!(entry, Entry::Occupied(_));
-                match entry {
-                    Entry::Occupied(mut occupied) => {
-                        let current = occupied.get_mut();
+            }
+            Entry::Vacant(vacant) => {
+                // not in cache, look on disk
+
+                // desired to be this for filler accounts: self.storage.get_startup();
+                // but, this has proven to be far too slow at high account counts
+                let directly_to_disk = false;
+                if directly_to_disk {
+                    // We may like this to always run, but it is unclear.
+                    // If disk bucket needs to resize, then this call can stall for a long time.
+                    // Right now, we know it is safe during startup.
+                    let already_existed = self.upsert_on_disk(
+                        vacant,
+                        new_value,
+                        reclaims,
+                        previous_slot_entry_was_cached,
+                    );
+                    if !already_existed {
+                        self.stats().insert_or_delete(true, self.bin);
+                    }
+                } else {
+                    // go to in-mem cache first
+                    let disk_entry = self.load_account_entry_from_disk(vacant.key());
+                    let new_value = if let Some(mut disk_entry) = disk_entry {
+                        // on disk, so merge new_value with what was on disk
                         Self::lock_and_update_slot_list(
-                            current,
+                            &mut disk_entry,
                             new_value.into(),
                             reclaims,
                             previous_slot_entry_was_cached,
                         );
-                        current.set_age(self.storage.future_age_to_flush());
-                        Self::update_stat(&self.stats().updates_in_mem, 1);
-                    }
-                    Entry::Vacant(vacant) => {
-                        // not in cache, look on disk
-
-                        // desired to be this for filler accounts: self.storage.get_startup();
-                        // but, this has proven to be far too slow at high account counts
-                        let directly_to_disk = false;
-                        if directly_to_disk {
-                            // We may like this to always run, but it is unclear.
-                            // If disk bucket needs to resize, then this call can stall for a long time.
-                            // Right now, we know it is safe during startup.
-                            let already_existed = self.upsert_on_disk(
-                                vacant,
-                                new_value,
-                                reclaims,
-                                previous_slot_entry_was_cached,
-                            );
-                            if !already_existed {
-                                self.stats().insert_or_delete(true, self.bin);
-                            }
-                        } else {
-                            // go to in-mem cache first
-                            let disk_entry = self.load_account_entry_from_disk(vacant.key());
-                            let new_value = if let Some(disk_entry) = disk_entry {
-                                // on disk, so merge new_value with what was on disk
-                                Self::lock_and_update_slot_list(
-                                    &disk_entry,
-                                    new_value.into(),
-                                    reclaims,
-                                    previous_slot_entry_was_cached,
-                                );
-                                disk_entry
-                            } else {
-                                // not on disk, so insert new thing
-                                self.stats().insert_or_delete(true, self.bin);
-                                new_value.into_account_map_entry(&self.storage)
-                            };
-                            assert!(new_value.dirty());
-                            vacant.insert(new_value);
-                            self.stats().insert_or_delete_mem(true, self.bin);
-                        }
-                    }
+                        disk_entry
+                    } else {
+                        // not on disk, so insert new thing
+                        self.stats().insert_or_delete(true, self.bin);
+                        new_value.into_account_map_entry(&self.storage)
+                    };
+                    assert!(new_value.dirty());
+                    vacant.insert(new_value);
+                    self.stats().insert_or_delete_mem(true, self.bin);
                 }
+            }
+        }
 
-                drop(map);
-                self.update_entry_stats(m, found);
-            };
-        })
+        drop(map);
+        self.update_entry_stats(m, found);
     }
 
     fn update_entry_stats(&self, stopped_measure: Measure, found: bool) {
@@ -435,15 +448,15 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     // already exists in the list, remove the older item, add it to `reclaims`, and insert
     // the new item.
     pub fn lock_and_update_slot_list(
-        current: &AccountMapEntryInner<T>,
+        current: &mut AccountMapEntryInner<T>,
         new_value: (Slot, T),
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,
     ) {
-        let mut slot_list = current.slot_list.write().unwrap();
+        let slot_list = &mut current.slot_list;
         let (slot, new_entry) = new_value;
         let addref = Self::update_slot_list(
-            &mut slot_list,
+            slot_list,
             slot,
             new_entry,
             reclaims,
@@ -498,11 +511,11 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         slot_list: SlotList<T>,
         ref_count: RefCount,
     ) -> AccountMapEntry<T> {
-        Arc::new(AccountMapEntryInner::new(
+        AccountMapEntry {
             slot_list,
             ref_count,
-            AccountMapEntryMeta::new_dirty(&self.storage),
-        ))
+            meta: AccountMapEntryMeta::new_dirty(&self.storage),
+        }
     }
 
     pub fn len_for_stats(&self) -> usize {
@@ -520,11 +533,11 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         m.stop();
         let new_entry_zero_lamports = new_entry.is_zero_lamport();
         let (found_in_mem, already_existed) = match entry {
-            Entry::Occupied(occupied) => {
+            Entry::Occupied(mut occupied) => {
                 // in cache, so merge into cache
                 let (slot, account_info) = new_entry.into();
                 InMemAccountsIndex::lock_and_update_slot_list(
-                    occupied.get(),
+                    occupied.get_mut(),
                     (slot, account_info),
                     &mut Vec::default(),
                     false,
@@ -547,10 +560,10 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 } else {
                     let disk_entry = self.load_account_entry_from_disk(vacant.key());
                     self.stats().insert_or_delete_mem(true, self.bin);
-                    if let Some(disk_entry) = disk_entry {
+                    if let Some(mut disk_entry) = disk_entry {
                         let (slot, account_info) = new_entry.into();
                         InMemAccountsIndex::lock_and_update_slot_list(
-                            &disk_entry,
+                            &mut disk_entry,
                             (slot, account_info),
                             &mut Vec::default(),
                             false,
@@ -818,7 +831,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         // we could look at more ages or we could throw out more items we are choosing to keep in the cache
         if startup || (current_age == entry.age()) {
             // only read the slot list if we are planning to throw the item out
-            let slot_list = entry.slot_list.read().unwrap();
+            let slot_list = &entry.slot_list;
             if slot_list.len() != 1 {
                 if update_stats {
                     Self::update_stat(&self.stats().held_in_mem_slot_list_len, 1);
@@ -881,8 +894,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         //  That prevents dropping an item from cache before disk is updated to latest in mem.
                         // happens inside of lock on in-mem cache. This is because of deleting items
                         // it is possible that the item in the cache is marked as dirty while these updates are happening. That is ok.
-                        disk_resize =
-                            disk.try_write(k, (&v.slot_list.read().unwrap(), v.ref_count()));
+                        disk_resize = disk.try_write(k, (&v.slot_list, v.ref_count()));
                         if disk_resize.is_ok() {
                             flush_entries_updated_on_disk += 1;
                         } else {
@@ -948,12 +960,6 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         for k in removes {
             if let Entry::Occupied(occupied) = map.entry(k) {
                 let v = occupied.get();
-                if Arc::strong_count(v) > 1 {
-                    // someone is holding the value arc's ref count and could modify it, so do not remove this from in-mem cache
-                    completed_scan = false;
-                    continue;
-                }
-
                 if v.dirty()
                     || (!randomly_evicted
                         && !self.should_remove_from_mem(current_age, v, startup, false))


### PR DESCRIPTION
#### Problem
With changes to accounts index, it becomes not necessary to have the per pubkey locking that exists currently in the accounts index.
I have indications that this Arc<RwLock<...>> combination is leading to memory usage, perhaps even indicating leaks. Doing the work to help understand that caused me to go down the path of resurrecting this change and modernizing it for experiments. The result is less memory usage in all scenarios. The time perf impact is not measured yet. It is true we will hold write locks more often and longer with this change, but the write locks are 1 per bin. Currently, we have 8k bins. We expect this to grow to 32k or 64k bins or more with 10B accounts.
#### Summary of Changes
Eliminate the Arc<RwLock<...>> aspect of the in-mem accounts index.
Fixes #
