### PR TITLE
Don't check x86 features on non-x86 architectures

### DIFF
--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -54,7 +54,10 @@ pub fn report_target_features() {
     // when run on machines without AVX causing a non-obvious process abort.  Instead detect
     // the mismatch and error cleanly.
     if !is_rosetta_emulated() {
-        #[cfg(build_target_feature_avx)]
+        #[cfg(all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            build_target_feature_avx
+        ))]
         {
             if is_x86_feature_detected!("avx") {
                 info!("AVX detected");
@@ -66,7 +69,10 @@ pub fn report_target_features() {
             }
         }
 
-        #[cfg(build_target_feature_avx2)]
+        #[cfg(all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            build_target_feature_avx2
+        ))]
         {
             if is_x86_feature_detected!("avx2") {
                 info!("AVX2 detected");


### PR DESCRIPTION
Allows `perf` to compile on non-x86 architectures. See `perf` section of https://github.com/solana-labs/solana/issues/21553 for context.