### PR TITLE
Refactor: Unifies `ThisInvokeContext` and `dyn trait InvokeContext`.

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -24,7 +24,7 @@ use solana_client::{
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
     tpu_client::{TpuClient, TpuClientConfig},
 };
-use solana_program_runtime::invoke_context::ThisInvokeContext;
+use solana_program_runtime::invoke_context::InvokeContext;
 use solana_rbpf::{elf::Executable, verifier, vm::Config};
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
@@ -1991,7 +1991,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+    let mut invoke_context = InvokeContext::new_mock(&[], &[]);
 
     // Verify the program
     Executable::<BpfError, ThisInstructionMeter>::from_elf(

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -33,7 +33,7 @@ use thiserror::Error;
 pub type LoaderEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     instruction_data: &[u8],
-    invoke_context: &dyn InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError>;
 
 // Prototype of a native program entry point
@@ -165,7 +165,7 @@ impl NativeLoader {
         &self,
         first_instruction_account: usize,
         instruction_data: &[u8],
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
             let program_id = invoke_context.get_caller()?;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -84,26 +84,25 @@ pub enum ProgramTestError {
 }
 
 thread_local! {
-    static INVOKE_CONTEXT: RefCell<Option<(usize, usize)>> = RefCell::new(None);
+    static INVOKE_CONTEXT: RefCell<Option<usize>> = RefCell::new(None);
 }
-fn set_invoke_context(new: &mut dyn InvokeContext) {
-    INVOKE_CONTEXT.with(|invoke_context| unsafe {
-        invoke_context.replace(Some(transmute::<_, (usize, usize)>(new)))
-    });
+fn set_invoke_context(new: &mut InvokeContext) {
+    INVOKE_CONTEXT
+        .with(|invoke_context| unsafe { invoke_context.replace(Some(transmute::<_, usize>(new))) });
 }
-fn get_invoke_context<'a>() -> &'a mut dyn InvokeContext {
-    let fat = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {
+fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
+    let ptr = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {
         Some(val) => val,
         None => panic!("Invoke context not set!"),
     });
-    unsafe { transmute::<(usize, usize), &mut dyn InvokeContext>(fat) }
+    unsafe { transmute::<usize, &mut InvokeContext>(ptr) }
 }
 
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     _first_instruction_account: usize,
     input: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
@@ -187,7 +186,7 @@ macro_rules! processor {
         Some(
             |first_instruction_account: usize,
              input: &[u8],
-             invoke_context: &mut dyn solana_program_test::InvokeContext| {
+             invoke_context: &mut solana_program_test::InvokeContext| {
                 $crate::builtin_process_instruction(
                     $process_instruction,
                     first_instruction_account,

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -11,7 +11,7 @@ use solana_bpf_loader_program::{
     ThisInstructionMeter,
 };
 use solana_measure::measure::Measure;
-use solana_program_runtime::invoke_context::{with_mock_invoke_context, InvokeContext};
+use solana_program_runtime::invoke_context::with_mock_invoke_context;
 use solana_rbpf::{
     elf::Executable,
     vm::{Config, InstructionMeter, SyscallRegistry},

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -18,7 +18,7 @@ use solana_bpf_rust_invoke::instructions::*;
 use solana_bpf_rust_realloc::instructions::*;
 use solana_bpf_rust_realloc_invoke::instructions::*;
 use solana_cli_output::display::println_transaction;
-use solana_program_runtime::invoke_context::{with_mock_invoke_context, InvokeContext};
+use solana_program_runtime::invoke_context::with_mock_invoke_context;
 use solana_rbpf::{
     elf::Executable,
     static_analysis::Analysis,

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -313,9 +313,7 @@ pub fn deserialize_parameters_aligned(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_program_runtime::invoke_context::{
-        prepare_mock_invoke_context, InvokeContext, ThisInvokeContext,
-    };
+    use solana_program_runtime::invoke_context::{prepare_mock_invoke_context, InvokeContext};
     use solana_sdk::{
         account::{Account, AccountSharedData},
         account_info::AccountInfo,
@@ -448,7 +446,7 @@ mod tests {
         let program_indices = [0];
         let preparation =
             prepare_mock_invoke_context(&program_indices, &instruction_data, &keyed_accounts);
-        let mut invoke_context = ThisInvokeContext::new_mock(&preparation.accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
         invoke_context
             .push(
                 &preparation.message,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -44,7 +44,7 @@ use solana_sdk::{
 };
 use std::{
     alloc::Layout,
-    cell::{Ref, RefCell, RefMut},
+    cell::{RefCell, RefMut},
     mem::{align_of, size_of},
     rc::Rc,
     slice::from_raw_parts_mut,
@@ -115,7 +115,7 @@ impl SyscallConsume for Rc<RefCell<ComputeMeter>> {
 use crate::allocator_bump::BpfAllocator;
 
 pub fn register_syscalls(
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<SyscallRegistry, EbpfError<BpfError>> {
     let mut syscall_registry = SyscallRegistry::default();
 
@@ -206,9 +206,9 @@ macro_rules! bind_feature_gated_syscall_context_object {
     };
 }
 
-pub fn bind_syscall_context_objects<'a>(
+pub fn bind_syscall_context_objects<'a, 'b>(
     vm: &mut EbpfVm<'a, BpfError, crate::ThisInstructionMeter>,
-    invoke_context: &'a mut dyn InvokeContext,
+    invoke_context: &'a mut InvokeContext<'b>,
     heap: AlignedMemory,
     orig_data_lens: &'a [usize],
 ) -> Result<(), EbpfError<BpfError>> {
@@ -534,10 +534,10 @@ impl SyscallObject<BpfError> for SyscallAbort {
 /// Panic syscall function, called when the BPF program calls 'sol_panic_()`
 /// Causes the BPF program to be halted immediately
 /// Log a user's info message
-pub struct SyscallPanic<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallPanic<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallPanic<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallPanic<'a, 'b> {
     fn call(
         &mut self,
         file: u64,
@@ -573,10 +573,10 @@ impl<'a> SyscallObject<BpfError> for SyscallPanic<'a> {
 }
 
 /// Log a user's info message
-pub struct SyscallLog<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallLog<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallLog<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallLog<'a, 'b> {
     fn call(
         &mut self,
         addr: u64,
@@ -619,10 +619,10 @@ impl<'a> SyscallObject<BpfError> for SyscallLog<'a> {
 }
 
 /// Log 5 64-bit values
-pub struct SyscallLogU64<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallLogU64<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallLogU64<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallLogU64<'a, 'b> {
     fn call(
         &mut self,
         arg1: u64,
@@ -654,10 +654,10 @@ impl<'a> SyscallObject<BpfError> for SyscallLogU64<'a> {
 }
 
 /// Log current compute consumption
-pub struct SyscallLogBpfComputeUnits<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallLogBpfComputeUnits<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a, 'b> {
     fn call(
         &mut self,
         _arg1: u64,
@@ -686,10 +686,10 @@ impl<'a> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a> {
 }
 
 /// Log 5 64-bit values
-pub struct SyscallLogPubkey<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallLogPubkey<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallLogPubkey<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallLogPubkey<'a, 'b> {
     fn call(
         &mut self,
         pubkey_addr: u64,
@@ -800,10 +800,10 @@ fn translate_and_check_program_address_inputs<'a>(
 }
 
 /// Create a program address
-struct SyscallCreateProgramAddress<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallCreateProgramAddress<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a, 'b> {
     fn call(
         &mut self,
         seeds_addr: u64,
@@ -859,10 +859,10 @@ impl<'a> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a> {
 }
 
 /// Create a program address
-struct SyscallTryFindProgramAddress<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallTryFindProgramAddress<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a, 'b> {
     fn call(
         &mut self,
         seeds_addr: u64,
@@ -932,10 +932,10 @@ impl<'a> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a> {
 }
 
 /// SHA256
-pub struct SyscallSha256<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallSha256<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallSha256<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallSha256<'a, 'b> {
     fn call(
         &mut self,
         vals_addr: u64,
@@ -1004,7 +1004,7 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId>(
     var_addr: u64,
     loader_id: &Pubkey,
     memory_mapping: &MemoryMapping,
-    invoke_context: Rc<RefCell<&mut dyn InvokeContext>>,
+    invoke_context: Rc<RefCell<&mut InvokeContext>>,
 ) -> Result<u64, EbpfError<BpfError>> {
     let invoke_context = invoke_context
         .try_borrow()
@@ -1022,10 +1022,10 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId>(
 }
 
 /// Get a Clock sysvar
-struct SyscallGetClockSysvar<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallGetClockSysvar<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallGetClockSysvar<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallGetClockSysvar<'a, 'b> {
     fn call(
         &mut self,
         var_addr: u64,
@@ -1058,10 +1058,10 @@ impl<'a> SyscallObject<BpfError> for SyscallGetClockSysvar<'a> {
     }
 }
 /// Get a EpochSchedule sysvar
-struct SyscallGetEpochScheduleSysvar<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallGetEpochScheduleSysvar<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a, 'b> {
     fn call(
         &mut self,
         var_addr: u64,
@@ -1094,11 +1094,11 @@ impl<'a> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a> {
     }
 }
 /// Get a Fees sysvar
-struct SyscallGetFeesSysvar<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallGetFeesSysvar<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
 #[allow(deprecated)]
-impl<'a> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a, 'b> {
     fn call(
         &mut self,
         var_addr: u64,
@@ -1131,10 +1131,10 @@ impl<'a> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a> {
     }
 }
 /// Get a Rent sysvar
-struct SyscallGetRentSysvar<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+struct SyscallGetRentSysvar<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallGetRentSysvar<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallGetRentSysvar<'a, 'b> {
     fn call(
         &mut self,
         var_addr: u64,
@@ -1168,10 +1168,10 @@ impl<'a> SyscallObject<BpfError> for SyscallGetRentSysvar<'a> {
 }
 
 // Keccak256
-pub struct SyscallKeccak256<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallKeccak256<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallKeccak256<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallKeccak256<'a, 'b> {
     fn call(
         &mut self,
         vals_addr: u64,
@@ -1246,10 +1246,10 @@ fn check_overlapping(src_addr: u64, dst_addr: u64, n: u64) -> bool {
 }
 
 /// memcpy
-pub struct SyscallMemcpy<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallMemcpy<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallMemcpy<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
     fn call(
         &mut self,
         dst_addr: u64,
@@ -1295,10 +1295,10 @@ impl<'a> SyscallObject<BpfError> for SyscallMemcpy<'a> {
     }
 }
 /// memmove
-pub struct SyscallMemmove<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallMemmove<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallMemmove<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallMemmove<'a, 'b> {
     fn call(
         &mut self,
         dst_addr: u64,
@@ -1339,10 +1339,10 @@ impl<'a> SyscallObject<BpfError> for SyscallMemmove<'a> {
     }
 }
 /// memcmp
-pub struct SyscallMemcmp<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallMemcmp<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallMemcmp<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcmp<'a, 'b> {
     fn call(
         &mut self,
         s1_addr: u64,
@@ -1396,10 +1396,10 @@ impl<'a> SyscallObject<BpfError> for SyscallMemcmp<'a> {
     }
 }
 /// memset
-pub struct SyscallMemset<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallMemset<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallMemset<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallMemset<'a, 'b> {
     fn call(
         &mut self,
         s_addr: u64,
@@ -1437,11 +1437,11 @@ impl<'a> SyscallObject<BpfError> for SyscallMemset<'a> {
 }
 
 /// secp256k1_recover
-pub struct SyscallSecp256k1Recover<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallSecp256k1Recover<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
 
-impl<'a> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a, 'b> {
     fn call(
         &mut self,
         hash_addr: u64,
@@ -1538,10 +1538,10 @@ impl<'a> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a> {
 }
 
 // Blake3
-pub struct SyscallBlake3<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallBlake3<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallBlake3<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallBlake3<'a, 'b> {
     fn call(
         &mut self,
         vals_addr: u64,
@@ -1629,25 +1629,24 @@ type TranslatedAccounts<'a> = (
 );
 
 /// Implemented by language specific data structure translators
-trait SyscallInvokeSigned<'a> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut dyn InvokeContext>, EbpfError<BpfError>>;
-    fn get_context(&self) -> Result<Ref<&'a mut dyn InvokeContext>, EbpfError<BpfError>>;
+trait SyscallInvokeSigned<'a, 'b> {
+    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>>;
     fn translate_instruction(
         &self,
         loader_id: &Pubkey,
         addr: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Instruction, EbpfError<BpfError>>;
-    fn translate_accounts(
-        &self,
+    fn translate_accounts<'c>(
+        &'c self,
         loader_id: &Pubkey,
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, EbpfError<BpfError>>;
+        invoke_context: &mut InvokeContext,
+    ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>>;
     fn translate_signers(
         &self,
         loader_id: &Pubkey,
@@ -1659,27 +1658,23 @@ trait SyscallInvokeSigned<'a> {
 }
 
 /// Cross-program invocation called from Rust
-pub struct SyscallInvokeSignedRust<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallInvokeSignedRust<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
     orig_data_lens: &'a [usize],
 }
-impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut dyn InvokeContext>, EbpfError<BpfError>> {
+impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
+    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
         self.invoke_context
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
     }
-    fn get_context(&self) -> Result<Ref<&'a mut dyn InvokeContext>, EbpfError<BpfError>> {
-        self.invoke_context
-            .try_borrow()
-            .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
-    }
+
     fn translate_instruction(
         &self,
         loader_id: &Pubkey,
         addr: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix = translate_type::<Instruction>(memory_mapping, addr, loader_id)?;
 
@@ -1706,15 +1701,15 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
         })
     }
 
-    fn translate_accounts(
-        &self,
+    fn translate_accounts<'c>(
+        &'c self,
         loader_id: &Pubkey,
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, EbpfError<BpfError>> {
+        invoke_context: &mut InvokeContext,
+    ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>> {
         let account_infos = translate_slice::<AccountInfo>(
             memory_mapping,
             account_infos_addr,
@@ -1733,7 +1728,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
             })
             .collect::<Result<Vec<_>, EbpfError<BpfError>>>()?;
 
-        let translate = |account_info: &AccountInfo, invoke_context: &dyn InvokeContext| {
+        let translate = |account_info: &AccountInfo, invoke_context: &InvokeContext| {
             // Translate the account from user space
 
             let lamports = {
@@ -1866,7 +1861,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
         }
     }
 }
-impl<'a> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a, 'b> {
     fn call(
         &mut self,
         instruction_addr: u64,
@@ -1940,19 +1935,14 @@ struct SolSignerSeedsC {
 }
 
 /// Cross-program invocation called from C
-pub struct SyscallInvokeSignedC<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallInvokeSignedC<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
     orig_data_lens: &'a [usize],
 }
-impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut dyn InvokeContext>, EbpfError<BpfError>> {
+impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
+    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
         self.invoke_context
             .try_borrow_mut()
-            .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
-    }
-    fn get_context(&self) -> Result<Ref<&'a mut dyn InvokeContext>, EbpfError<BpfError>> {
-        self.invoke_context
-            .try_borrow()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
     }
 
@@ -1961,7 +1951,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
         loader_id: &Pubkey,
         addr: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, loader_id)?;
 
@@ -2000,15 +1990,15 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
         })
     }
 
-    fn translate_accounts(
-        &self,
+    fn translate_accounts<'c>(
+        &'c self,
         loader_id: &Pubkey,
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
         memory_mapping: &MemoryMapping,
-        invoke_context: &mut dyn InvokeContext,
-    ) -> Result<TranslatedAccounts<'a>, EbpfError<BpfError>> {
+        invoke_context: &mut InvokeContext,
+    ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>> {
         let account_infos = translate_slice::<SolAccountInfo>(
             memory_mapping,
             account_infos_addr,
@@ -2023,7 +2013,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
             })
             .collect::<Result<Vec<_>, EbpfError<BpfError>>>()?;
 
-        let translate = |account_info: &SolAccountInfo, invoke_context: &dyn InvokeContext| {
+        let translate = |account_info: &SolAccountInfo, invoke_context: &InvokeContext| {
             // Translate the account from user space
 
             let lamports =
@@ -2133,7 +2123,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
         }
     }
 }
-impl<'a> SyscallObject<BpfError> for SyscallInvokeSignedC<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedC<'a, 'b> {
     fn call(
         &mut self,
         instruction_addr: u64,
@@ -2160,12 +2150,12 @@ fn get_translated_accounts<'a, T, F>(
     message: &Message,
     account_info_keys: &[&Pubkey],
     account_infos: &[T],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
     orig_data_lens: &[usize],
     do_translate: F,
 ) -> Result<TranslatedAccounts<'a>, EbpfError<BpfError>>
 where
-    F: Fn(&T, &dyn InvokeContext) -> Result<CallerAccount<'a>, EbpfError<BpfError>>,
+    F: Fn(&T, &InvokeContext) -> Result<CallerAccount<'a>, EbpfError<BpfError>>,
 {
     let demote_program_write_locks =
         invoke_context.is_feature_active(&demote_program_write_locks::id());
@@ -2248,7 +2238,7 @@ where
 fn check_instruction_size(
     num_accounts: usize,
     data_len: usize,
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), EbpfError<BpfError>> {
     let size = num_accounts
         .saturating_mul(size_of::<AccountMeta>())
@@ -2262,7 +2252,7 @@ fn check_instruction_size(
 
 fn check_account_infos(
     len: usize,
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), EbpfError<BpfError>> {
     if len * size_of::<Pubkey>() > invoke_context.get_compute_budget().max_cpi_instruction_size {
         // Cap the number of account_infos a caller can pass to approximate
@@ -2275,7 +2265,7 @@ fn check_account_infos(
 fn check_authorized_program(
     program_id: &Pubkey,
     instruction_data: &[u8],
-    invoke_context: &dyn InvokeContext,
+    invoke_context: &InvokeContext,
 ) -> Result<(), EbpfError<BpfError>> {
     #[allow(clippy::blocks_in_if_conditions)]
     if native_loader::check_id(program_id)
@@ -2296,8 +2286,8 @@ fn check_authorized_program(
 }
 
 /// Call process instruction, common to both Rust and C
-fn call<'a>(
-    syscall: &mut dyn SyscallInvokeSigned<'a>,
+fn call<'a, 'b: 'a>(
+    syscall: &mut dyn SyscallInvokeSigned<'a, 'b>,
     instruction_addr: u64,
     account_infos_addr: u64,
     account_infos_len: u64,
@@ -2413,10 +2403,10 @@ fn call<'a>(
 }
 
 // Return data handling
-pub struct SyscallSetReturnData<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallSetReturnData<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallSetReturnData<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
     fn call(
         &mut self,
         addr: u64,
@@ -2474,10 +2464,10 @@ impl<'a> SyscallObject<BpfError> for SyscallSetReturnData<'a> {
     }
 }
 
-pub struct SyscallGetReturnData<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallGetReturnData<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallGetReturnData<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallGetReturnData<'a, 'b> {
     fn call(
         &mut self,
         return_data_addr: u64,
@@ -2541,10 +2531,10 @@ impl<'a> SyscallObject<BpfError> for SyscallGetReturnData<'a> {
 }
 
 // Log data handling
-pub struct SyscallLogData<'a> {
-    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+pub struct SyscallLogData<'a, 'b> {
+    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
 }
-impl<'a> SyscallObject<BpfError> for SyscallLogData<'a> {
+impl<'a, 'b> SyscallObject<BpfError> for SyscallLogData<'a, 'b> {
     fn call(
         &mut self,
         addr: u64,
@@ -2624,7 +2614,7 @@ impl<'a> SyscallObject<BpfError> for SyscallLogData<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_program_runtime::invoke_context::ThisInvokeContext;
+    use solana_program_runtime::invoke_context::InvokeContext;
     use solana_rbpf::{
         ebpf::HOST_ALIGN, memory_region::MemoryRegion, user_error::UserError, vm::Config,
     };
@@ -2945,7 +2935,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();
@@ -3022,7 +3012,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();
@@ -3126,7 +3116,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();
@@ -3168,7 +3158,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();
@@ -3433,7 +3423,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .get_compute_meter()
             .borrow_mut()
@@ -3540,7 +3530,7 @@ mod tests {
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_clock).unwrap();
             let sysvars = [(sysvar::clock::id(), data)];
-            let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+            let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
                 &accounts,
                 &[],
                 &sysvars,
@@ -3589,7 +3579,7 @@ mod tests {
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
             let sysvars = [(sysvar::epoch_schedule::id(), data)];
-            let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+            let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
                 &accounts,
                 &[],
                 &sysvars,
@@ -3645,7 +3635,7 @@ mod tests {
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_fees).unwrap();
             let sysvars = [(sysvar::fees::id(), data)];
-            let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+            let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
                 &accounts,
                 &[],
                 &sysvars,
@@ -3692,7 +3682,7 @@ mod tests {
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_rent).unwrap();
             let sysvars = [(sysvar::rent::id(), data)];
-            let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+            let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
                 &accounts,
                 &[],
                 &sysvars,
@@ -3802,7 +3792,7 @@ mod tests {
     }
 
     fn create_program_address(
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<Pubkey, EbpfError<BpfError>> {
@@ -3814,7 +3804,7 @@ mod tests {
     }
 
     fn try_find_program_address(
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<(Pubkey, u8), EbpfError<BpfError>> {
@@ -3835,7 +3825,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();
@@ -3951,7 +3941,7 @@ mod tests {
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
             None,
         );
-        let mut invoke_context = ThisInvokeContext::new_mock(&accounts, &[]);
+        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
         invoke_context
             .push(&message, &message.instructions[0], &[0], None)
             .unwrap();

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -4,7 +4,7 @@ use solana_sdk::instruction::InstructionError;
 pub fn process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     // Do nothing, compute budget instructions handled by the runtime
     Ok(())

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeSet;
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -25,7 +25,7 @@ pub use solana_sdk::stake::instruction::*;
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
@@ -327,7 +327,7 @@ mod tests {
     use crate::stake_state::{Meta, StakeState};
     use bincode::serialize;
     use solana_program_runtime::invoke_context::{
-        mock_process_instruction, prepare_mock_invoke_context, ThisInvokeContext,
+        mock_process_instruction, prepare_mock_invoke_context, InvokeContext,
     };
     use solana_sdk::{
         account::{self, AccountSharedData},
@@ -416,7 +416,7 @@ mod tests {
         let mut data = Vec::with_capacity(sysvar::clock::Clock::size_of());
         bincode::serialize_into(&mut data, &sysvar::clock::Clock::default()).unwrap();
         let sysvars = [(sysvar::clock::id(), data)];
-        let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+        let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
             &preparation.accounts,
             &[],
             &sysvars,
@@ -1066,7 +1066,7 @@ mod tests {
         let mut data = Vec::with_capacity(sysvar::clock::Clock::size_of());
         bincode::serialize_into(&mut data, &sysvar::clock::Clock::default()).unwrap();
         let sysvars = [(sysvar::clock::id(), data)];
-        let mut invoke_context = ThisInvokeContext::new_mock_with_sysvars_and_features(
+        let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
             &preparation.accounts,
             &[],
             &sysvars,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -395,7 +395,7 @@ pub trait StakeAccount {
     ) -> Result<(), InstructionError>;
     fn merge(
         &self,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         source_stake: &KeyedAccount,
         clock: &Clock,
         stake_history: &StakeHistory,
@@ -701,7 +701,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
 
     fn merge(
         &self,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         source_account: &KeyedAccount,
         clock: &Clock,
         stake_history: &StakeHistory,
@@ -865,7 +865,7 @@ impl MergeKind {
     }
 
     fn get_if_mergeable(
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         stake_keyed_account: &KeyedAccount,
         clock: &Clock,
         stake_history: &StakeHistory,
@@ -897,7 +897,7 @@ impl MergeKind {
     }
 
     fn metas_can_merge(
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         stake: &Meta,
         source: &Meta,
         clock: Option<&Clock>,
@@ -926,7 +926,7 @@ impl MergeKind {
     }
 
     fn active_delegations_can_merge(
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         stake: &Delegation,
         source: &Delegation,
     ) -> Result<(), InstructionError> {
@@ -946,7 +946,7 @@ impl MergeKind {
 
     // Remove this when the `stake_merge_with_unmatched_credits_observed` feature is removed
     fn active_stakes_can_merge(
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         stake: &Stake,
         source: &Stake,
     ) -> Result<(), InstructionError> {
@@ -969,7 +969,7 @@ impl MergeKind {
 
     fn merge(
         self,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
         source: Self,
         clock: Option<&Clock>,
     ) -> Result<Option<StakeState>, InstructionError> {
@@ -1033,7 +1033,7 @@ impl MergeKind {
 }
 
 fn merge_delegation_stake_and_credits_observed(
-    invoke_context: &dyn InvokeContext,
+    invoke_context: &InvokeContext,
     stake: &mut Stake,
     absorbed_lamports: u64,
     absorbed_credits_observed: u64,
@@ -1372,7 +1372,7 @@ fn do_create_account(
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use solana_program_runtime::invoke_context::ThisInvokeContext;
+    use solana_program_runtime::invoke_context::InvokeContext;
     use solana_sdk::{
         account::{AccountSharedData, WritableAccount},
         clock::UnixTimestamp,
@@ -5068,7 +5068,7 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5178,7 +5178,7 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
         let signers = HashSet::from_iter(vec![authority_pubkey]);
@@ -5223,7 +5223,7 @@ mod tests {
 
     #[test]
     fn test_merge_incorrect_authorized_staker() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5292,7 +5292,7 @@ mod tests {
 
     #[test]
     fn test_merge_invalid_account_data() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5342,7 +5342,7 @@ mod tests {
 
     #[test]
     fn test_merge_fake_stake_source() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5384,7 +5384,7 @@ mod tests {
 
     #[test]
     fn test_merge_active_stake() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let base_lamports = 4242424242;
         let stake_address = Pubkey::new_unique();
         let source_address = Pubkey::new_unique();
@@ -5453,7 +5453,7 @@ mod tests {
         );
 
         fn try_merge(
-            invoke_context: &dyn InvokeContext,
+            invoke_context: &InvokeContext,
             stake_account: &KeyedAccount,
             source_account: &KeyedAccount,
             clock: &Clock,
@@ -6006,7 +6006,7 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let good_stake = Stake {
             credits_observed: 4242,
             delegation: Delegation {
@@ -6104,7 +6104,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_pre_v4() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6190,7 +6190,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_v4() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6336,7 +6336,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
         let rent = Rent::default();
@@ -6568,7 +6568,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let lamports = 424242;
         let meta = Meta {
             rent_exempt_reserve: 42,
@@ -6646,7 +6646,7 @@ mod tests {
 
     #[test]
     fn test_active_stake_merge() {
-        let invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+        let invoke_context = InvokeContext::new_mock(&[], &[]);
         let delegation_a = 4_242_424_242u64;
         let delegation_b = 6_200_000_000u64;
         let credits_a = 124_521_000u64;

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -310,7 +310,7 @@ fn verify_rent_exemption(
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -5,9 +5,7 @@ use solana_bpf_loader_program::{
     create_vm, serialization::serialize_parameters, syscalls::register_syscalls, BpfError,
     ThisInstructionMeter,
 };
-use solana_program_runtime::invoke_context::{
-    prepare_mock_invoke_context, InvokeContext, ThisInvokeContext,
-};
+use solana_program_runtime::invoke_context::{prepare_mock_invoke_context, InvokeContext};
 use solana_rbpf::{
     assembler::assemble,
     elf::Executable,
@@ -202,7 +200,7 @@ native machine code before execting it in the virtual machine.",
     };
     let program_indices = [0, 1];
     let preparation = prepare_mock_invoke_context(&program_indices, &[], &keyed_accounts);
-    let mut invoke_context = ThisInvokeContext::new_mock(&preparation.accounts, &[]);
+    let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
     invoke_context
         .push(
             &preparation.message,

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -34,7 +34,7 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 fn process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     Ok(())
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6958,7 +6958,7 @@ pub(crate) mod tests {
     fn mock_process_instruction(
         first_instruction_account: usize,
         data: &[u8],
-        invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
         if let Ok(instruction) = bincode::deserialize(data) {
@@ -10709,7 +10709,7 @@ pub(crate) mod tests {
         fn mock_vote_processor(
             _first_instruction_account: usize,
             _instruction_data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let program_id = invoke_context.get_caller()?;
             if mock_vote_program_id() != *program_id {
@@ -10767,7 +10767,7 @@ pub(crate) mod tests {
         fn mock_vote_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Err(InstructionError::Custom(42))
         }
@@ -10817,7 +10817,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Err(InstructionError::Custom(42))
         }
@@ -11705,7 +11705,7 @@ pub(crate) mod tests {
         fn mock_process_instruction(
             first_instruction_account: usize,
             data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let lamports = data[0] as u64;
@@ -11763,7 +11763,7 @@ pub(crate) mod tests {
         fn mock_process_instruction(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             Ok(())
         }
@@ -11949,7 +11949,7 @@ pub(crate) mod tests {
     fn mock_ok_vote_processor(
         _first_instruction_account: usize,
         _data: &[u8],
-        _invoke_context: &mut dyn InvokeContext,
+        _invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         Ok(())
     }
@@ -12199,7 +12199,7 @@ pub(crate) mod tests {
         fn nested_processor(
             first_instruction_account: usize,
             _data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
@@ -12473,7 +12473,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
         }
@@ -12522,7 +12522,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            _context: &mut dyn InvokeContext,
+            _context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
         }
@@ -12899,11 +12899,11 @@ pub(crate) mod tests {
     #[derive(Debug)]
     struct TestExecutor {}
     impl Executor for TestExecutor {
-        fn execute(
+        fn execute<'a, 'b>(
             &self,
             _first_instruction_account: usize,
             _instruction_data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &'a mut InvokeContext<'b>,
             _use_jit: bool,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
@@ -13422,7 +13422,7 @@ pub(crate) mod tests {
         fn mock_process_instruction(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), solana_sdk::instruction::InstructionError> {
             Ok(())
         }
@@ -14923,7 +14923,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             first_instruction_account: usize,
             _data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             use solana_sdk::account::WritableAccount;
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
@@ -15135,7 +15135,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let compute_budget = invoke_context.get_compute_budget();
             assert_eq!(
@@ -15180,7 +15180,7 @@ pub(crate) mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let compute_budget = invoke_context.get_compute_budget();
             assert_eq!(

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -15,7 +15,7 @@ fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
     let program_id = invoke_context.get_caller()?;
@@ -35,7 +35,7 @@ macro_rules! with_program_logging {
     ($process_instruction:expr) => {
         |first_instruction_account: usize,
          instruction_data: &[u8],
-         invoke_context: &mut dyn InvokeContext| {
+         invoke_context: &mut InvokeContext| {
             process_instruction_with_program_logging(
                 $process_instruction,
                 first_instruction_account,
@@ -135,7 +135,7 @@ fn genesis_builtins() -> Vec<Builtin> {
 fn dummy_process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     Ok(())
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_program_runtime::{
     instruction_recorder::InstructionRecorder,
-    invoke_context::{BuiltinProgram, ComputeMeter, Executors, InvokeContext, ThisInvokeContext},
+    invoke_context::{BuiltinProgram, ComputeMeter, Executors, InvokeContext},
     log_collector::LogCollector,
     timings::ExecuteDetailsTimings,
 };
@@ -56,7 +56,7 @@ impl MessageProcessor {
         blockhash: Hash,
         lamports_per_signature: u64,
     ) -> Result<(), TransactionError> {
-        let mut invoke_context = ThisInvokeContext::new(
+        let mut invoke_context = InvokeContext::new(
             rent,
             accounts,
             builtin_programs,
@@ -165,7 +165,7 @@ mod tests {
         fn mock_system_process_instruction(
             first_instruction_account: usize,
             data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             if let Ok(instruction) = bincode::deserialize(data) {
@@ -336,7 +336,7 @@ mod tests {
         fn mock_system_process_instruction(
             first_instruction_account: usize,
             data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             if let Ok(instruction) = bincode::deserialize(data) {
@@ -537,7 +537,7 @@ mod tests {
         fn mock_process_instruction(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Err(InstructionError::Custom(0xbabb1e))
         }

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -16,7 +16,7 @@ pub trait NonceKeyedAccount {
     fn advance_nonce_account(
         &self,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError>;
     fn withdraw_nonce_account(
         &self,
@@ -24,19 +24,19 @@ pub trait NonceKeyedAccount {
         to: &KeyedAccount,
         rent: &Rent,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError>;
     fn initialize_nonce_account(
         &self,
         nonce_authority: &Pubkey,
         rent: &Rent,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError>;
     fn authorize_nonce_account(
         &self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError>;
 }
 
@@ -44,7 +44,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
     fn advance_nonce_account(
         &self,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -108,7 +108,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         to: &KeyedAccount,
         rent: &Rent,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -194,7 +194,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         &self,
         nonce_authority: &Pubkey,
         rent: &Rent,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -245,7 +245,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         &self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &InvokeContext,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -294,7 +294,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_program_runtime::invoke_context::ThisInvokeContext;
+    use solana_program_runtime::invoke_context::InvokeContext;
     use solana_sdk::{
         account::ReadableAccount,
         account_utils::State as AccountUtilsState,
@@ -322,8 +322,8 @@ mod test {
         )
     }
 
-    fn create_invoke_context_with_blockhash<'a>(seed: usize) -> ThisInvokeContext<'a> {
-        let mut invoke_context = ThisInvokeContext::new_mock(&[], &[]);
+    fn create_invoke_context_with_blockhash<'a>(seed: usize) -> InvokeContext<'a> {
+        let mut invoke_context = InvokeContext::new_mock(&[], &[]);
         let (blockhash, lamports_per_signature) = create_test_blockhash(seed);
         invoke_context.set_blockhash(blockhash);
         invoke_context.set_lamports_per_signature(lamports_per_signature);
@@ -1017,7 +1017,7 @@ mod test {
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &ThisInvokeContext::new_mock(&[], &[]),
+                &InvokeContext::new_mock(&[], &[]),
             );
             assert_eq!(result, Err(InstructionError::InvalidAccountData));
         })


### PR DESCRIPTION
#### Problem
`ThisInvokeContext` is the only `impl` of `trait InvokeContext`

#### Summary of Changes
- Removes `trait InvokeContext`
- Renames `ThisInvokeContext` to `InvokeContext`
- Marks all `ThisInvokeContext` methods as `pub` and copies their doc comments from `trait InvokeContext`
- Adjusts the lifetimes of `InvokeContext` references.

Fixes #
