### PR TITLE
RPC: Ensure innerInstructions/logMessages metadata is `null` when `--enable-cpi-and-log-storage` is disabled

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -394,10 +394,10 @@ The result field will be an object with the following fields:
       - `fee: <u64>` - fee this transaction was charged, as u64 integer
       - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
       - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-      - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
+      - `innerInstructions: <array|null>` - List of [inner instructions](#inner-instructions-structure) or `null` if inner instruction recording was not enabled during this transaction
       - `preTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from before the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
       - `postTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from after the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
-      - `logMessages: <array>` - array of string log messages or omitted if log message recording was not yet enabled during this transaction
+      - `logMessages: <array|null>` - array of string log messages or `null` if log message recording was not enabled during this transaction
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -520,8 +520,8 @@ Result:
         "meta": {
           "err": null,
           "fee": 5000,
-          "innerInstructions": [],
-          "logMessages": [],
+          "innerInstructions": null,
+          "logMessages": null,
           "postBalances": [
             499998932500,
             26858640,
@@ -2752,10 +2752,10 @@ Returns transaction details for a confirmed transaction
     - `fee: <u64>` - fee this transaction was charged, as u64 integer
     - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
     - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-    - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
+    - `innerInstructions: <array|null>` - List of [inner instructions](#inner-instructions-structure) or `null` if inner instruction recording was not enabled during this transaction
     - `preTokenBalances: <array|undefined>` - List of  [token balances](#token-balances-structure) from before the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
     - `postTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from after the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
-    - `logMessages: <array>` - array of string log messages or omitted if log message recording was not yet enabled during this transaction
+    - `logMessages: <array|null>` - array of string log messages or `null` if log message recording was not enabled during this transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -4144,10 +4144,10 @@ The result field will be an object with the following fields:
       - `fee: <u64>` - fee this transaction was charged, as u64 integer
       - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
       - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-      - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
+      - `innerInstructions: <array|null>` - List of [inner instructions](#inner-instructions-structure) or `null` if inner instruction recording was not enabled during this transaction
       - `preTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from before the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
       - `postTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from after the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
-      - `logMessages: <array>` - array of string log messages or omitted if log message recording was not yet enabled during this transaction
+      - `logMessages: <array|null>` - array of string log messages or `null` if log message recording was not enabled during this transaction
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -4460,10 +4460,10 @@ Returns transaction details for a confirmed transaction
     - `fee: <u64>` - fee this transaction was charged, as u64 integer
     - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
     - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-    - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
+    - `innerInstructions: <array|null>` - List of [inner instructions](#inner-instructions-structure) or `null` if inner instruction recording was not enabled during this transaction
     - `preTokenBalances: <array|undefined>` - List of  [token balances](#token-balances-structure) from before the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
     - `postTokenBalances: <array|undefined>` - List of [token balances](#token-balances-structure) from after the transaction was processed or omitted if token balance recording was not yet enabled during this transaction
-    - `logMessages: <array>` - array of string log messages or omitted if log message recording was not yet enabled during this transaction
+    - `logMessages: <array|null>` - array of string log messages or `null` if log message recording was not enabled during this transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -41,7 +41,9 @@ message TransactionStatusMeta {
     repeated uint64 pre_balances = 3;
     repeated uint64 post_balances = 4;
     repeated InnerInstructions inner_instructions = 5;
+    bool inner_instructions_none = 10;
     repeated string log_messages = 6;
+    bool log_messages_none = 11;
     repeated TokenBalance pre_token_balances = 7;
     repeated TokenBalance post_token_balances = 8;
     repeated Reward rewards = 9;

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -283,11 +283,13 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
                 err: bincode::serialize(&err).expect("transaction error to serialize to bytes"),
             }),
         };
+        let inner_instructions_none = inner_instructions.is_none();
         let inner_instructions = inner_instructions
             .unwrap_or_default()
             .into_iter()
             .map(|ii| ii.into())
             .collect();
+        let log_messages_none = log_messages.is_none();
         let log_messages = log_messages.unwrap_or_default();
         let pre_token_balances = pre_token_balances
             .unwrap_or_default()
@@ -311,7 +313,9 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             pre_balances,
             post_balances,
             inner_instructions,
+            inner_instructions_none,
             log_messages,
+            log_messages_none,
             pre_token_balances,
             post_token_balances,
             rewards,
@@ -336,7 +340,9 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             pre_balances,
             post_balances,
             inner_instructions,
+            inner_instructions_none,
             log_messages,
+            log_messages_none,
             pre_token_balances,
             post_token_balances,
             rewards,
@@ -345,13 +351,21 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             None => Ok(()),
             Some(tx_error) => Err(bincode::deserialize(&tx_error.err)?),
         };
-        let inner_instructions = Some(
-            inner_instructions
-                .into_iter()
-                .map(|inner| inner.into())
-                .collect(),
-        );
-        let log_messages = Some(log_messages);
+        let inner_instructions = if inner_instructions_none {
+            None
+        } else {
+            Some(
+                inner_instructions
+                    .into_iter()
+                    .map(|inner| inner.into())
+                    .collect(),
+            )
+        };
+        let log_messages = if log_messages_none {
+            None
+        } else {
+            Some(log_messages)
+        };
         let pre_token_balances = Some(
             pre_token_balances
                 .into_iter()


### PR DESCRIPTION
The `innerInstructions` and `logMessages` transaction metadata fields currently return `[]` in two very different cases:
1. When `--enable-cpi-and-log-storage` is disabled
2. When a transaction actually has no inner instructions or produces no logs

An RPC client that wants to ensure the server they're talking to in fact has `--enable-cpi-and-log-storage` enabled currently has no way to distinguish between 1 and 2.

Existing transactions will still confund the two cases, but not so going forward.