### PR TITLE
Amend transactions v2 proposal with flag to disable signer propagation

### DIFF
--- a/docs/src/proposals/transactions-v2.md
+++ b/docs/src/proposals/transactions-v2.md
@@ -179,10 +179,6 @@ pub struct CompiledInstructionV2 {
   /// unchanged
   pub program_id_index: u8,
 
-  /// NEW: Only programs in this list may be invoked by this instruction
-  #[serde(with = "short_vec")]
-  pub invokable_program_id_indexes: Vec<u8>,
-
   /// unchanged
   #[serde(with = "short_vec")]
   pub accounts: Vec<u8>,
@@ -209,13 +205,6 @@ can be confident that the invoked program can't act as them when invoking other
 programs. The preferred design pattern is using delegations to grant temporary
 authority to an invoked program to, for instance, transfer a certain number of tokens.
 
-#### Invokable programs
-
-The new transaction format supports lists of programs that a transaction
-instruction may use when invoking inner instructions. This provides extra
-protection to the caller by ensuring that only the programs listed in
-`inner_programs` may be invoked.
-
 #### Size changes
 
 - 1 byte for `prefix` field
@@ -223,7 +212,6 @@ protection to the caller by ensuring that only the programs listed in
 - 1 byte for `address_maps` length
 - Each map requires 2 bytes for `entries` length and `num_readonly`
 - Each map entry is 1 byte (u8)
-- Each instruction requires 2 extra bytes for the config flags and the length of `invokable_program_id_indexes`
 
 #### Cost changes
 


### PR DESCRIPTION
#### Problem
As outlined in https://github.com/solana-labs/solana/issues/17762, the default runtime behavior of allowing signers to be propagated to inner instructions can be taken advantage of by malicious parties. For example, if a user passes the transaction signer account to a malicious program, that program can invoke the system program to drain the signer's funds.

#### Summary of Changes
- Proposed adding wallet-configurable flags to each transaction instruction. The first (and only) flag is the `DISABLE_SIGNER_PROPAGATION` flag which will not allow invoked programs to propagate the signer privileges that they received from their caller when invoking other programs.

Addresses: https://github.com/solana-labs/solana/issues/15323
Addresses: https://github.com/solana-labs/solana/issues/17762
