### PR TITLE
Support building solana-program on 32-bit architectures that do not have 64-bit atomics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5346,6 +5346,7 @@ dependencies = [
  "log 0.4.14",
  "num-derive",
  "num-traits",
+ "parking_lot 0.11.2",
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "rustversion",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "rustversion",

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -19,7 +19,7 @@ bs58 = "0.4.0"
 bytemuck = { version = "1.7.2", features = ["derive"] }
 bv = { version = "0.11.1", features = ["serde"] }
 hex = "0.4.2"
-itertools =  "0.10.1"
+itertools = "0.10.1"
 lazy_static = "1.4.0"
 log = "0.4.14"
 num-derive = "0.3"
@@ -43,6 +43,9 @@ libsecp256k1 = "0.6.0"
 rand = "0.7.0"
 solana-logger = { path = "../../logger", version = "=1.9.0" }
 itertools = "0.10.1"
+
+[target.'cfg(not(target_pointer_width = "64"))'.dependencies]
+parking_lot = "0.11"
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/sdk/program/src/atomic_u64.rs
+++ b/sdk/program/src/atomic_u64.rs
@@ -1,0 +1,38 @@
+pub(crate) use implementation::AtomicU64;
+
+#[cfg(target_pointer_width = "64")]
+mod implementation {
+    use std::sync::atomic;
+
+    pub(crate) struct AtomicU64(atomic::AtomicU64);
+
+    impl AtomicU64 {
+        pub(crate) const fn new(initial: u64) -> Self {
+            Self(atomic::AtomicU64::new(initial))
+        }
+
+        pub(crate) fn fetch_add(&self, v: u64) -> u64 {
+            self.0.fetch_add(v, atomic::Ordering::Relaxed)
+        }
+    }
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+mod implementation {
+    use parking_lot::{const_mutex, Mutex};
+
+    pub(crate) struct AtomicU64(Mutex<u64>);
+
+    impl AtomicU64 {
+        pub(crate) const fn new(initial: u64) -> Self {
+            Self(const_mutex(initial))
+        }
+
+        pub(crate) fn fetch_add(&self, v: u64) -> u64 {
+            let mut lock = self.0.lock();
+            let i = *lock;
+            *lock = i + v;
+            i
+        }
+    }
+}

--- a/sdk/program/src/blake3.rs
+++ b/sdk/program/src/blake3.rs
@@ -103,11 +103,11 @@ impl Hash {
 
     /// unique Hash for tests and benchmarks.
     pub fn new_unique() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        use crate::atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);
 
         let mut b = [0u8; HASH_BYTES];
-        let i = I.fetch_add(1, Ordering::Relaxed);
+        let i = I.fetch_add(1);
         b[0..8].copy_from_slice(&i.to_le_bytes());
         Self::new(&b)
     }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -106,11 +106,11 @@ impl Hash {
 
     /// unique Hash for tests and benchmarks.
     pub fn new_unique() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        use crate::atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);
 
         let mut b = [0u8; HASH_BYTES];
-        let i = I.fetch_add(1, Ordering::Relaxed);
+        let i = I.fetch_add(1);
         b[0..8].copy_from_slice(&i.to_le_bytes());
         Self::new(&b)
     }

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -104,11 +104,11 @@ impl Hash {
 
     /// unique Hash for tests and benchmarks.
     pub fn new_unique() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        use crate::atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);
 
         let mut b = [0u8; HASH_BYTES];
-        let i = I.fetch_add(1, Ordering::Relaxed);
+        let i = I.fetch_add(1);
         b[0..8].copy_from_slice(&i.to_le_bytes());
         Self::new(&b)
     }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate self as solana_program;
 
 pub mod account_info;
+pub(crate) mod atomic_u64;
 pub mod blake3;
 pub mod borsh;
 pub mod bpf_loader;

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -148,11 +148,11 @@ impl Pubkey {
 
     /// unique Pubkey for tests and benchmarks.
     pub fn new_unique() -> Self {
-        use std::sync::atomic::{AtomicU64, Ordering};
+        use crate::atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);
 
         let mut b = [0u8; 32];
-        let i = I.fetch_add(1, Ordering::Relaxed);
+        let i = I.fetch_add(1);
         b[0..8].copy_from_slice(&i.to_le_bytes());
         Self::new(&b)
     }


### PR DESCRIPTION
Support building solana-program on 32-bit architectures that do not have 64-bit atomics by using a Mutex<u64> on 32-bit architectures. The functions that utilize atomics are currently only to support tests and benchmarks.

#### Problem
32-bit PowerPC and MIPS platforms do not have native 64-bit atomic instructions. In order to compile solana-program for these architectures, it must avoid the use of `AtomicU64`. While some 32-bit architectures (ARM and x86 for example) support 64-bit atomics, these two in particular do not. Some "modern" HSMs run on PPC or MIPS chips, for example, nCipher runs a 32-bit PPC processor.

#### Summary of Changes
Creates a small abstraction for `AtomicU64` that uses a native 64-bit atomic on 64-bit architectures, and a `Mutex<u64>` on 32-bit architectures. Since the affected functions are only used in tests and benchmarks, I found it reasonable to use a lightweight lock for all non-64-bit architectures, rather than isolating specific ones.

Fixes #19726 
