### PR TITLE
Add reduce only to mango instruction parsing

### DIFF
--- a/explorer/src/components/instruction/mango/PlacePerpOrderDetailsCard.tsx
+++ b/explorer/src/components/instruction/mango/PlacePerpOrderDetailsCard.tsx
@@ -95,7 +95,6 @@ export function PlacePerpOrderDetailsCard(props: {
         <td>Order type</td>
         <td className="text-lg-end">{info.orderType}</td>
       </tr>
-      
       <tr>
         <td>side</td>
         <td className="text-lg-end">{info.side}</td>
@@ -114,7 +113,6 @@ export function PlacePerpOrderDetailsCard(props: {
           <td className="text-lg-end">{orderLotDetails?.size}</td>
         </tr>
       )}
-
       <tr>
         <td>Reduce only</td>
         <td className="text-lg-end">{info.reduceOnly}</td>

--- a/explorer/src/components/instruction/mango/PlacePerpOrderDetailsCard.tsx
+++ b/explorer/src/components/instruction/mango/PlacePerpOrderDetailsCard.tsx
@@ -95,6 +95,7 @@ export function PlacePerpOrderDetailsCard(props: {
         <td>Order type</td>
         <td className="text-lg-end">{info.orderType}</td>
       </tr>
+      
       <tr>
         <td>side</td>
         <td className="text-lg-end">{info.side}</td>
@@ -113,6 +114,11 @@ export function PlacePerpOrderDetailsCard(props: {
           <td className="text-lg-end">{orderLotDetails?.size}</td>
         </tr>
       )}
+
+      <tr>
+        <td>Reduce only</td>
+        <td className="text-lg-end">{info.reduceOnly}</td>
+      </tr>
     </InstructionCard>
   );
 }

--- a/explorer/src/components/instruction/mango/types.ts
+++ b/explorer/src/components/instruction/mango/types.ts
@@ -192,7 +192,9 @@ export type PlacePerpOrder = {
   clientOrderId: String;
   side: String;
   orderType: String;
+  reduceOnly: String;
 };
+
 export const decodePlacePerpOrder = (
   ix: TransactionInstruction
 ): PlacePerpOrder => {
@@ -203,6 +205,7 @@ export const decodePlacePerpOrder = (
     clientOrderId: decoded.PlacePerpOrder.clientOrderId.toString(),
     side: decoded.PlacePerpOrder.side.toString(),
     orderType: decoded.PlacePerpOrder.orderType.toString(),
+    reduceOnly: decoded.PlacePerpOrder.reduceOnly.toString(),
   };
 
   return placePerpOrder;


### PR DESCRIPTION
#### Problem

Mango's PlacePerpOrder instruction was missing the reduce only flag in the explorer.

#### Summary of Changes

Added reduce only to the explorer's parsing of mango instructions

![Screen Shot 2021-12-03 at 2 30 59 AM](https://user-images.githubusercontent.com/1254942/144562859-9fffa944-efd3-40e8-ba72-83b1220f5273.png)
s
