### PR TITLE
Deny and fix Rust 2018 edition idioms

### DIFF
--- a/accountsdb-plugin-interface/src/accountsdb_plugin_interface.rs
+++ b/accountsdb-plugin-interface/src/accountsdb_plugin_interface.rs
@@ -96,7 +96,7 @@ pub trait AccountsDbPlugin: Any + Send + Sync + std::fmt::Debug {
     #[allow(unused_variables)]
     fn update_account(
         &mut self,
-        account: ReplicaAccountInfoVersions,
+        account: ReplicaAccountInfoVersions<'_>,
         slot: u64,
         is_startup: bool,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ pub trait AccountsDbPlugin: Any + Send + Sync + std::fmt::Debug {
     #[allow(unused_variables)]
     fn notify_transaction(
         &mut self,
-        transaction: ReplicaTransactionInfoVersions,
+        transaction: ReplicaTransactionInfoVersions<'_>,
         slot: u64,
     ) -> Result<()> {
         Ok(())

--- a/accountsdb-plugin-manager/src/accounts_update_notifier.rs
+++ b/accountsdb-plugin-manager/src/accounts_update_notifier.rs
@@ -29,7 +29,7 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
         }
     }
 
-    fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta) {
+    fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta<'_>) {
         let mut measure_all = Measure::start("accountsdb-plugin-notify-account-restore-all");
         let mut measure_copy = Measure::start("accountsdb-plugin-copy-stored-account-info");
 
@@ -111,7 +111,7 @@ impl AccountsUpdateNotifierImpl {
 
     fn accountinfo_from_stored_account_meta<'a>(
         &self,
-        stored_account_meta: &'a StoredAccountMeta,
+        stored_account_meta: &'a StoredAccountMeta<'_>,
     ) -> Option<ReplicaAccountInfo<'a>> {
         Some(ReplicaAccountInfo {
             pubkey: stored_account_meta.meta.pubkey.as_ref(),
@@ -126,7 +126,7 @@ impl AccountsUpdateNotifierImpl {
 
     fn notify_plugins_of_account_update(
         &self,
-        account: ReplicaAccountInfo,
+        account: ReplicaAccountInfo<'_>,
         slot: Slot,
         is_startup: bool,
     ) {

--- a/accountsdb-plugin-manager/src/accountsdb_plugin_manager.rs
+++ b/accountsdb-plugin-manager/src/accountsdb_plugin_manager.rs
@@ -31,7 +31,7 @@ impl AccountsDbPluginManager {
     ) -> Result<(), Box<dyn Error>> {
         type PluginConstructor = unsafe fn() -> *mut dyn AccountsDbPlugin;
         let lib = Library::new(libpath)?;
-        let constructor: Symbol<PluginConstructor> = lib.get(b"_create_plugin")?;
+        let constructor: Symbol<'_, PluginConstructor> = lib.get(b"_create_plugin")?;
         let plugin_raw = constructor();
         let mut plugin = Box::from_raw(plugin_raw);
         plugin.on_load(config_file)?;

--- a/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
+++ b/accountsdb-plugin-postgres/src/accountsdb_plugin_postgres.rs
@@ -166,7 +166,7 @@ impl AccountsDbPlugin for AccountsDbPluginPostgres {
 
     fn update_account(
         &mut self,
-        account: ReplicaAccountInfoVersions,
+        account: ReplicaAccountInfoVersions<'_>,
         slot: u64,
         is_startup: bool,
     ) -> Result<()> {
@@ -297,7 +297,7 @@ impl AccountsDbPlugin for AccountsDbPluginPostgres {
 
     fn notify_transaction(
         &mut self,
-        transaction_info: ReplicaTransactionInfoVersions,
+        transaction_info: ReplicaTransactionInfoVersions<'_>,
         slot: u64,
     ) -> Result<()> {
         match &mut self.client {

--- a/accountsdb-plugin-postgres/src/postgres_client.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client.rs
@@ -794,7 +794,7 @@ impl ParallelPostgresClient {
 
     pub fn update_account(
         &mut self,
-        account: &ReplicaAccountInfo,
+        account: &ReplicaAccountInfo<'_>,
         slot: u64,
         is_startup: bool,
     ) -> Result<(), AccountsDbPluginError> {

--- a/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
@@ -445,7 +445,7 @@ impl From<&TransactionStatusMeta> for DbTransactionStatusMeta {
     }
 }
 
-fn build_db_transaction(slot: u64, transaction_info: &ReplicaTransactionInfo) -> DbTransaction {
+fn build_db_transaction(slot: u64, transaction_info: &ReplicaTransactionInfo<'_>) -> DbTransaction {
     DbTransaction {
         signature: transaction_info.signature.as_ref().to_vec(),
         is_vote: transaction_info.is_vote,
@@ -545,7 +545,7 @@ impl SimplePostgresClient {
 impl ParallelPostgresClient {
     fn build_transaction_request(
         slot: u64,
-        transaction_info: &ReplicaTransactionInfo,
+        transaction_info: &ReplicaTransactionInfo<'_>,
     ) -> LogTransactionRequest {
         LogTransactionRequest {
             transaction_info: build_db_transaction(slot, transaction_info),
@@ -554,7 +554,7 @@ impl ParallelPostgresClient {
 
     pub fn log_transaction_info(
         &mut self,
-        transaction_info: &ReplicaTransactionInfo,
+        transaction_info: &ReplicaTransactionInfo<'_>,
         slot: u64,
     ) -> Result<(), AccountsDbPluginError> {
         let wrk_item = DbWorkItem::LogTransaction(Box::new(Self::build_transaction_request(
@@ -1213,7 +1213,7 @@ pub(crate) mod tests {
 
     fn check_transaction(
         slot: u64,
-        transaction: &ReplicaTransactionInfo,
+        transaction: &ReplicaTransactionInfo<'_>,
         db_transaction: &DbTransaction,
     ) {
         assert_eq!(transaction.signature.as_ref(), db_transaction.signature);

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -196,7 +196,7 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
 /// * `matches` - command line arguments parsed by clap
 /// # Panics
 /// Panics if there is trouble parsing any of the arguments
-pub fn extract_args(matches: &ArgMatches) -> Config {
+pub fn extract_args(matches: &ArgMatches<'_>) -> Config {
     let mut args = Config::default();
 
     if let Some(addr) = matches.value_of("entrypoint") {

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -85,7 +85,7 @@ impl<T: Clone + Copy> BucketApi<T> {
         }
     }
 
-    fn get_write_bucket(&self) -> RwLockWriteGuard<Option<Bucket<T>>> {
+    fn get_write_bucket(&self) -> RwLockWriteGuard<'_, Option<Bucket<T>>> {
         let mut bucket = self.bucket.write().unwrap();
         if bucket.is_none() {
             *bucket = Some(Bucket::new(

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -58,7 +58,7 @@ if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
   fi
 
   # Ensure nightly and --benches
-  _ scripts/cargo-for-all-lock-files.sh nightly check --locked --all-targets
+  _ scripts/cargo-for-all-lock-files.sh nightly check --locked --all-targets -- --deny=rust_2018_idioms
 else
   echo "Note: cargo-for-all-lock-files.sh skipped because $CI_BASE_BRANCH != $EDGE_CHANNEL"
 fi
@@ -67,7 +67,7 @@ _ ci/order-crates-for-publishing.py
 
 # -Z... is needed because of clippy bug: https://github.com/rust-lang/rust-clippy/issues/4612
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there
-_ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=warnings --deny=clippy::integer_arithmetic
+_ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=rust_2018_idioms --deny=warnings --deny=clippy::integer_arithmetic
 
 _ "$cargo" stable fmt --all -- --check
 
@@ -79,7 +79,7 @@ _ ci/do-audit.sh
     echo "+++ do_bpf_checks $project"
     (
       cd "$project"
-      _ "$cargo" nightly clippy -- --deny=warnings --allow=clippy::missing_safety_doc
+      _ "$cargo" nightly clippy -- --deny=warnings --deny=rust_2018_idioms --allow=clippy::missing_safety_doc
       _ "$cargo" stable fmt -- --check
     )
   done

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -58,7 +58,7 @@ if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
   fi
 
   # Ensure nightly and --benches
-  _ scripts/cargo-for-all-lock-files.sh nightly check --locked --all-targets -- --deny=rust_2018_idioms
+  _ scripts/cargo-for-all-lock-files.sh nightly check --locked --all-targets
 else
   echo "Note: cargo-for-all-lock-files.sh skipped because $CI_BASE_BRANCH != $EDGE_CHANNEL"
 fi

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -303,7 +303,7 @@ impl DefaultSigner {
     /// ```
     pub fn signer_from_path(
         &self,
-        matches: &ArgMatches,
+        matches: &ArgMatches<'_>,
         wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
         signer_from_path(matches, self.path()?, &self.arg_name, wallet_manager)
@@ -356,7 +356,7 @@ impl DefaultSigner {
     /// ```
     pub fn signer_from_path_with_config(
         &self,
-        matches: &ArgMatches,
+        matches: &ArgMatches<'_>,
         wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
         config: &SignerFromPathConfig,
     ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
@@ -421,7 +421,7 @@ impl AsRef<str> for SignerSourceKind {
 }
 
 impl std::fmt::Debug for SignerSourceKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s: &str = self.as_ref();
         write!(f, "{}", s)
     }
@@ -683,7 +683,7 @@ pub struct SignerFromPathConfig {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn signer_from_path(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     path: &str,
     keypair_name: &str,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
@@ -750,7 +750,7 @@ pub fn signer_from_path(
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn signer_from_path_with_config(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     path: &str,
     keypair_name: &str,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
@@ -857,7 +857,7 @@ pub fn signer_from_path_with_config(
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn pubkey_from_path(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     path: &str,
     keypair_name: &str,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
@@ -870,7 +870,7 @@ pub fn pubkey_from_path(
 }
 
 pub fn resolve_signer_from_path(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     path: &str,
     keypair_name: &str,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
@@ -996,7 +996,7 @@ pub fn prompt_passphrase(prompt: &str) -> Result<String, Box<dyn error::Error>> 
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn keypair_from_path(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     path: &str,
     keypair_name: &str,
     confirm_pubkey: bool,

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -18,7 +18,7 @@ impl DisplayError {
 }
 
 impl std::fmt::Debug for DisplayError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "{}", self.0)
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -46,7 +46,7 @@ use {
     },
 };
 
-static WARNING: Emoji = Emoji("⚠️", "!");
+static WARNING: Emoji<'_, '_> = Emoji("⚠️", "!");
 
 #[derive(PartialEq, Debug)]
 pub enum OutputFormat {
@@ -107,7 +107,7 @@ impl QuietDisplay for CliAccount {}
 impl VerboseDisplay for CliAccount {}
 
 impl fmt::Display for CliAccount {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Public Key:", &self.keyed_account.pubkey)?;
         writeln_name_value(
@@ -152,7 +152,7 @@ impl QuietDisplay for CliBlockProduction {}
 impl VerboseDisplay for CliBlockProduction {}
 
 impl fmt::Display for CliBlockProduction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(
             f,
@@ -259,7 +259,7 @@ impl QuietDisplay for CliEpochInfo {}
 impl VerboseDisplay for CliEpochInfo {}
 
 impl fmt::Display for CliEpochInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(
             f,
@@ -380,9 +380,9 @@ impl QuietDisplay for CliValidators {}
 impl VerboseDisplay for CliValidators {}
 
 impl fmt::Display for CliValidators {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn write_vote_account(
-            f: &mut fmt::Formatter,
+            f: &mut fmt::Formatter<'_>,
             validator: &CliValidator,
             total_active_stake: u64,
             use_lamports_unit: bool,
@@ -698,7 +698,7 @@ impl QuietDisplay for CliNonceAccount {}
 impl VerboseDisplay for CliNonceAccount {}
 
 impl fmt::Display for CliNonceAccount {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "Balance: {}",
@@ -746,7 +746,7 @@ impl VerboseDisplay for CliStakeVec {
 }
 
 impl fmt::Display for CliStakeVec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for state in &self.0 {
             writeln!(f)?;
             write!(f, "{}", state)?;
@@ -772,7 +772,7 @@ impl VerboseDisplay for CliKeyedStakeState {
 }
 
 impl fmt::Display for CliKeyedStakeState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Stake Pubkey: {}", self.stake_pubkey)?;
         write!(f, "{}", self.stake_state)
     }
@@ -817,7 +817,7 @@ impl QuietDisplay for CliKeyedEpochRewards {}
 impl VerboseDisplay for CliKeyedEpochRewards {}
 
 impl fmt::Display for CliKeyedEpochRewards {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.rewards.is_empty() {
             writeln!(f, "No rewards found in epoch")?;
             return Ok(());
@@ -865,7 +865,7 @@ impl fmt::Display for CliKeyedEpochRewards {
 }
 
 fn show_votes_and_credits(
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
     votes: &[CliLockout],
     epoch_voting_history: &[CliEpochVotingHistory],
 ) -> fmt::Result {
@@ -958,7 +958,7 @@ fn show_votes_and_credits(
 }
 
 fn show_epoch_rewards(
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
     epoch_rewards: &Option<Vec<CliEpochReward>>,
 ) -> fmt::Result {
     if let Some(epoch_rewards) = epoch_rewards {
@@ -1042,13 +1042,13 @@ impl VerboseDisplay for CliStakeState {
 }
 
 impl fmt::Display for CliStakeState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn show_authorized(f: &mut fmt::Formatter, authorized: &CliAuthorized) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn show_authorized(f: &mut fmt::Formatter<'_>, authorized: &CliAuthorized) -> fmt::Result {
             writeln!(f, "Stake Authority: {}", authorized.staker)?;
             writeln!(f, "Withdraw Authority: {}", authorized.withdrawer)?;
             Ok(())
         }
-        fn show_lockup(f: &mut fmt::Formatter, lockup: Option<&CliLockup>) -> fmt::Result {
+        fn show_lockup(f: &mut fmt::Formatter<'_>, lockup: Option<&CliLockup>) -> fmt::Result {
             if let Some(lockup) = lockup {
                 if lockup.unix_timestamp != UnixTimestamp::default() {
                     writeln!(
@@ -1217,7 +1217,7 @@ impl QuietDisplay for CliStakeHistory {}
 impl VerboseDisplay for CliStakeHistory {}
 
 impl fmt::Display for CliStakeHistory {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(
             f,
@@ -1319,7 +1319,7 @@ impl QuietDisplay for CliValidatorInfoVec {}
 impl VerboseDisplay for CliValidatorInfoVec {}
 
 impl fmt::Display for CliValidatorInfoVec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0.is_empty() {
             writeln!(f, "No validator info accounts found")?;
         }
@@ -1343,7 +1343,7 @@ impl QuietDisplay for CliValidatorInfo {}
 impl VerboseDisplay for CliValidatorInfo {}
 
 impl fmt::Display for CliValidatorInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Validator Identity:", &self.identity_pubkey)?;
         writeln_name_value(f, "  Info Address:", &self.info_pubkey)?;
         for (key, value) in self.info.iter() {
@@ -1381,7 +1381,7 @@ impl QuietDisplay for CliVoteAccount {}
 impl VerboseDisplay for CliVoteAccount {}
 
 impl fmt::Display for CliVoteAccount {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "Account Balance: {}",
@@ -1422,7 +1422,7 @@ impl QuietDisplay for CliAuthorizedVoters {}
 impl VerboseDisplay for CliAuthorizedVoters {}
 
 impl fmt::Display for CliAuthorizedVoters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.authorized_voters)
     }
 }
@@ -1476,7 +1476,7 @@ impl QuietDisplay for CliBlockTime {}
 impl VerboseDisplay for CliBlockTime {}
 
 impl fmt::Display for CliBlockTime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Block:", &self.slot.to_string())?;
         writeln_name_value(f, "Date:", &unix_timestamp_to_string(self.timestamp))
     }
@@ -1493,7 +1493,7 @@ impl QuietDisplay for CliLeaderSchedule {}
 impl VerboseDisplay for CliLeaderSchedule {}
 
 impl fmt::Display for CliLeaderSchedule {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for entry in &self.leader_schedule_entries {
             writeln!(f, "  {:<15} {:<44}", entry.slot, entry.leader)?;
         }
@@ -1519,7 +1519,7 @@ impl QuietDisplay for CliInflation {}
 impl VerboseDisplay for CliInflation {}
 
 impl fmt::Display for CliInflation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", style("Inflation Governor:").bold())?;
         if (self.governor.initial - self.governor.terminal).abs() < f64::EPSILON {
             writeln!(
@@ -1606,7 +1606,7 @@ impl QuietDisplay for CliSignOnlyData {}
 impl VerboseDisplay for CliSignOnlyData {}
 
 impl fmt::Display for CliSignOnlyData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         if let Some(message) = self.message.as_ref() {
@@ -1644,7 +1644,7 @@ impl QuietDisplay for CliSignature {}
 impl VerboseDisplay for CliSignature {}
 
 impl fmt::Display for CliSignature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Signature:", &self.signature)?;
         Ok(())
@@ -1661,7 +1661,7 @@ impl QuietDisplay for CliAccountBalances {}
 impl VerboseDisplay for CliAccountBalances {}
 
 impl fmt::Display for CliAccountBalances {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "{}",
@@ -1706,7 +1706,7 @@ impl QuietDisplay for CliSupply {}
 impl VerboseDisplay for CliSupply {}
 
 impl fmt::Display for CliSupply {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Total:", &format!("{} SOL", lamports_to_sol(self.total)))?;
         writeln_name_value(
             f,
@@ -1743,7 +1743,7 @@ impl QuietDisplay for CliFeesInner {}
 impl VerboseDisplay for CliFeesInner {}
 
 impl fmt::Display for CliFeesInner {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         writeln_name_value(
             f,
@@ -1769,7 +1769,7 @@ impl QuietDisplay for CliFees {}
 impl VerboseDisplay for CliFees {}
 
 impl fmt::Display for CliFees {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.inner.as_ref() {
             Some(inner) => write!(f, "{}", inner),
             None => write!(f, "Fees unavailable"),
@@ -1812,7 +1812,7 @@ impl QuietDisplay for CliTokenAccount {}
 impl VerboseDisplay for CliTokenAccount {}
 
 impl fmt::Display for CliTokenAccount {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Address:", &self.address)?;
         let account = &self.token_account;
@@ -1854,7 +1854,7 @@ impl QuietDisplay for CliProgramId {}
 impl VerboseDisplay for CliProgramId {}
 
 impl fmt::Display for CliProgramId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Program Id:", &self.program_id)
     }
 }
@@ -1869,7 +1869,7 @@ impl QuietDisplay for CliProgramBuffer {}
 impl VerboseDisplay for CliProgramBuffer {}
 
 impl fmt::Display for CliProgramBuffer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Buffer:", &self.buffer)
     }
 }
@@ -1892,7 +1892,7 @@ impl QuietDisplay for CliProgramAuthority {}
 impl VerboseDisplay for CliProgramAuthority {}
 
 impl fmt::Display for CliProgramAuthority {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_name_value(f, "Account Type:", &format!("{:?}", self.account_type))?;
         writeln_name_value(f, "Authority:", &self.authority)
     }
@@ -1908,7 +1908,7 @@ pub struct CliProgram {
 impl QuietDisplay for CliProgram {}
 impl VerboseDisplay for CliProgram {}
 impl fmt::Display for CliProgram {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Program Id:", &self.program_id)?;
         writeln_name_value(f, "Owner:", &self.owner)?;
@@ -1937,7 +1937,7 @@ pub struct CliUpgradeableProgram {
 impl QuietDisplay for CliUpgradeableProgram {}
 impl VerboseDisplay for CliUpgradeableProgram {}
 impl fmt::Display for CliUpgradeableProgram {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Program Id:", &self.program_id)?;
         writeln_name_value(f, "Owner:", &self.owner)?;
@@ -1972,7 +1972,7 @@ pub struct CliUpgradeablePrograms {
 impl QuietDisplay for CliUpgradeablePrograms {}
 impl VerboseDisplay for CliUpgradeablePrograms {}
 impl fmt::Display for CliUpgradeablePrograms {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(
             f,
@@ -2011,7 +2011,7 @@ pub struct CliUpgradeableProgramClosed {
 impl QuietDisplay for CliUpgradeableProgramClosed {}
 impl VerboseDisplay for CliUpgradeableProgramClosed {}
 impl fmt::Display for CliUpgradeableProgramClosed {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(
             f,
@@ -2036,7 +2036,7 @@ pub struct CliUpgradeableBuffer {
 impl QuietDisplay for CliUpgradeableBuffer {}
 impl VerboseDisplay for CliUpgradeableBuffer {}
 impl fmt::Display for CliUpgradeableBuffer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Buffer Address:", &self.address)?;
         writeln_name_value(f, "Authority:", &self.authority)?;
@@ -2065,7 +2065,7 @@ pub struct CliUpgradeableBuffers {
 impl QuietDisplay for CliUpgradeableBuffers {}
 impl VerboseDisplay for CliUpgradeableBuffers {}
 impl fmt::Display for CliUpgradeableBuffers {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f)?;
         writeln!(
             f,
@@ -2230,7 +2230,7 @@ impl CliSignatureVerificationStatus {
 }
 
 impl fmt::Display for CliSignatureVerificationStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::None => write!(f, "none"),
             Self::Pass => write!(f, "pass"),
@@ -2252,7 +2252,7 @@ impl QuietDisplay for CliBlock {}
 impl VerboseDisplay for CliBlock {}
 
 impl fmt::Display for CliBlock {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Slot: {}", self.slot)?;
         writeln!(
             f,
@@ -2362,7 +2362,7 @@ impl QuietDisplay for CliTransaction {}
 impl VerboseDisplay for CliTransaction {}
 
 impl fmt::Display for CliTransaction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln_transaction(
             f,
             &self.decoded_transaction,
@@ -2418,7 +2418,7 @@ impl VerboseDisplay for CliTransactionConfirmation {
 }
 
 impl fmt::Display for CliTransactionConfirmation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.confirmation_status {
             None => write!(f, "Not found"),
             Some(confirmation_status) => {
@@ -2482,7 +2482,7 @@ where
 }
 
 impl fmt::Display for CliGossipNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:15} | {:44} | {:6} | {:5} | {:21} | {}",
@@ -2505,7 +2505,7 @@ impl VerboseDisplay for CliGossipNode {}
 pub struct CliGossipNodes(pub Vec<CliGossipNode>);
 
 impl fmt::Display for CliGossipNodes {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "IP Address      | Node identifier                              \
@@ -2635,7 +2635,7 @@ mod tests {
         #[derive(Deserialize, Serialize)]
         struct FallbackToDisplay {}
         impl std::fmt::Display for FallbackToDisplay {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "display")
             }
         }
@@ -2653,7 +2653,7 @@ mod tests {
         #[derive(Deserialize, Serialize)]
         struct DiscreteVerbosityDisplay {}
         impl std::fmt::Display for DiscreteVerbosityDisplay {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "display")
             }
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -860,7 +860,7 @@ pub fn parse_command(
 
 pub type ProcessResult = Result<String, Box<dyn std::error::Error>>;
 
-pub fn process_command(config: &CliConfig) -> ProcessResult {
+pub fn process_command(config: &CliConfig<'_>) -> ProcessResult {
     if config.verbose && config.output_format == OutputFormat::DisplayVerbose {
         println_name_value("RPC URL:", &config.json_rpc_url);
         println_name_value("Default Signer Path:", &config.keypair_path);
@@ -1541,7 +1541,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
 pub fn request_and_confirm_airdrop(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     to_pubkey: &Pubkey,
     lamports: u64,
 ) -> ClientResult<Signature> {
@@ -1569,7 +1569,7 @@ where
 
 pub fn log_instruction_custom_error<E>(
     result: ClientResult<Signature>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
 ) -> ProcessResult
 where
     E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
@@ -1579,7 +1579,7 @@ where
 
 pub fn log_instruction_custom_error_ex<E, F>(
     result: ClientResult<Signature>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     error_adapter: F,
 ) -> ProcessResult
 where

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -72,8 +72,8 @@ use std::{
 };
 use thiserror::Error;
 
-static CHECK_MARK: Emoji = Emoji("✅ ", "");
-static CROSS_MARK: Emoji = Emoji("❌ ", "");
+static CHECK_MARK: Emoji<'_, '_> = Emoji("✅ ", "");
+static CROSS_MARK: Emoji<'_, '_> = Emoji("❌ ", "");
 
 pub trait ClusterQuerySubCommands {
     fn cluster_query_subcommands(self) -> Self;
@@ -705,7 +705,7 @@ pub fn parse_transaction_history(
 
 pub fn process_catchup(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     node_pubkey: Option<Pubkey>,
     mut node_json_rpc_url: Option<String>,
     follow: bool,
@@ -918,7 +918,7 @@ pub fn process_catchup(
     }
 }
 
-pub fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+pub fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig<'_>) -> ProcessResult {
     let result = rpc_client.get_account_with_commitment(&sysvar::clock::id(), config.commitment)?;
     if let Some(clock_account) = result.value {
         let clock: Clock = from_account(&clock_account).ok_or_else(|| {
@@ -934,7 +934,7 @@ pub fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig) -> Proce
     }
 }
 
-pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig<'_>) -> ProcessResult {
     let remote_version = rpc_client.get_version()?;
 
     if config.verbose {
@@ -946,7 +946,7 @@ pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig) -> Pr
 
 pub fn process_fees(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     blockhash: Option<&Hash>,
 ) -> ProcessResult {
     let fees = if let Some(recent_blockhash) = blockhash {
@@ -995,7 +995,7 @@ pub fn parse_leader_schedule(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
 
 pub fn process_leader_schedule(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     epoch: Option<Epoch>,
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
@@ -1043,7 +1043,7 @@ pub fn process_leader_schedule(
 
 pub fn process_get_block(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     slot: Option<Slot>,
 ) -> ProcessResult {
     let slot = if let Some(slot) = slot {
@@ -1071,7 +1071,7 @@ pub fn process_get_block(
 
 pub fn process_get_block_time(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     slot: Option<Slot>,
 ) -> ProcessResult {
     let slot = if let Some(slot) = slot {
@@ -1084,12 +1084,12 @@ pub fn process_get_block_time(
     Ok(config.output_format.formatted_string(&block_time))
 }
 
-pub fn process_get_epoch(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+pub fn process_get_epoch(rpc_client: &RpcClient, _config: &CliConfig<'_>) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
     Ok(epoch_info.epoch.to_string())
 }
 
-pub fn process_get_epoch_info(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+pub fn process_get_epoch_info(rpc_client: &RpcClient, config: &CliConfig<'_>) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
     let average_slot_time_ms = rpc_client
         .get_recent_performance_samples(Some(60))
@@ -1119,12 +1119,12 @@ pub fn process_get_genesis_hash(rpc_client: &RpcClient) -> ProcessResult {
     Ok(genesis_hash.to_string())
 }
 
-pub fn process_get_slot(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+pub fn process_get_slot(rpc_client: &RpcClient, _config: &CliConfig<'_>) -> ProcessResult {
     let slot = rpc_client.get_slot()?;
     Ok(slot.to_string())
 }
 
-pub fn process_get_block_height(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+pub fn process_get_block_height(rpc_client: &RpcClient, _config: &CliConfig<'_>) -> ProcessResult {
     let block_height = rpc_client.get_block_height()?;
     Ok(block_height.to_string())
 }
@@ -1141,7 +1141,7 @@ pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliComman
 
 pub fn process_show_block_production(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     epoch: Option<Epoch>,
     slot_limit: Option<u64>,
 ) -> ProcessResult {
@@ -1319,7 +1319,7 @@ pub fn process_show_block_production(
 
 pub fn process_largest_accounts(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     filter: Option<RpcLargestAccountsFilter>,
 ) -> ProcessResult {
     let accounts = rpc_client
@@ -1334,7 +1334,7 @@ pub fn process_largest_accounts(
 
 pub fn process_supply(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     print_accounts: bool,
 ) -> ProcessResult {
     let supply_response = rpc_client.supply()?;
@@ -1343,19 +1343,22 @@ pub fn process_supply(
     Ok(config.output_format.formatted_string(&supply))
 }
 
-pub fn process_total_supply(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+pub fn process_total_supply(rpc_client: &RpcClient, _config: &CliConfig<'_>) -> ProcessResult {
     let supply = rpc_client.supply()?.value;
     Ok(format!("{} SOL", lamports_to_sol(supply.total)))
 }
 
-pub fn process_get_transaction_count(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
+pub fn process_get_transaction_count(
+    rpc_client: &RpcClient,
+    _config: &CliConfig<'_>,
+) -> ProcessResult {
     let transaction_count = rpc_client.get_transaction_count()?;
     Ok(transaction_count.to_string())
 }
 
 pub fn process_ping(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     lamports: u64,
     interval: &Duration,
     count: &Option<u64>,
@@ -1552,7 +1555,7 @@ pub fn parse_logs(
     })
 }
 
-pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> ProcessResult {
+pub fn process_logs(config: &CliConfig<'_>, filter: &RpcTransactionLogsFilter) -> ProcessResult {
     println!(
         "Streaming transaction logs{}. {:?} commitment",
         match filter {
@@ -1596,7 +1599,7 @@ pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> Pr
     }
 }
 
-pub fn process_live_slots(config: &CliConfig) -> ProcessResult {
+pub fn process_live_slots(config: &CliConfig<'_>) -> ProcessResult {
     let exit = Arc::new(AtomicBool::new(false));
 
     let mut current: Option<SlotInfo> = None;
@@ -1681,7 +1684,7 @@ pub fn process_live_slots(config: &CliConfig) -> ProcessResult {
     Ok("".to_string())
 }
 
-pub fn process_show_gossip(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+pub fn process_show_gossip(rpc_client: &RpcClient, config: &CliConfig<'_>) -> ProcessResult {
     let cluster_nodes = rpc_client.get_cluster_nodes()?;
 
     let nodes: Vec<_> = cluster_nodes
@@ -1696,7 +1699,7 @@ pub fn process_show_gossip(rpc_client: &RpcClient, config: &CliConfig) -> Proces
 
 pub fn process_show_stakes(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     use_lamports_unit: bool,
     vote_account_pubkeys: Option<&[Pubkey]>,
 ) -> ProcessResult {
@@ -1796,7 +1799,7 @@ pub fn process_show_stakes(
 
 pub fn process_wait_for_max_stake(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     max_stake_percent: f32,
 ) -> ProcessResult {
     let now = std::time::Instant::now();
@@ -1806,7 +1809,7 @@ pub fn process_wait_for_max_stake(
 
 pub fn process_show_validators(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     use_lamports_unit: bool,
     validators_sort_order: CliValidatorsSortOrder,
     validators_reverse_sort: bool,
@@ -1965,7 +1968,7 @@ pub fn process_show_validators(
 
 pub fn process_transaction_history(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     address: &Pubkey,
     before: Option<Signature>,
     until: Option<Signature>,
@@ -2057,7 +2060,7 @@ impl CliRentCalculation {
 }
 
 impl fmt::Display for CliRentCalculation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let per_byte_year = self.build_balance_message(self.lamports_per_byte_year);
         let per_epoch = self.build_balance_message(self.lamports_per_epoch);
         let exempt_minimum = self.build_balance_message(self.rent_exempt_minimum_lamports);
@@ -2113,7 +2116,7 @@ impl FromStr for RentLengthValue {
 
 pub fn process_calculate_rent(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     data_length: usize,
     use_lamports_unit: bool,
 ) -> ProcessResult {

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -70,7 +70,7 @@ pub struct CliFeatures {
 }
 
 impl fmt::Display for CliFeatures {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.features.len() > 1 {
             writeln!(
                 f,
@@ -216,7 +216,7 @@ pub fn parse_feature_subcommand(
 
 pub fn process_feature_subcommand(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     feature_subcommand: &FeatureCliCommand,
 ) -> ProcessResult {
     match feature_subcommand {
@@ -518,7 +518,7 @@ pub fn get_feature_is_active(
 
 fn process_status(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     feature_ids: &[Pubkey],
 ) -> ProcessResult {
     let mut features: Vec<CliFeature> = vec![];
@@ -559,7 +559,7 @@ fn process_status(
 
 fn process_activate(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     feature_id: Pubkey,
     force: ForceActivation,
 ) -> ProcessResult {

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -72,7 +72,7 @@ pub fn parse_inflation_subcommand(
 
 pub fn process_inflation_subcommand(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     inflation_subcommand: &InflationCliCommand,
 ) -> ProcessResult {
     match inflation_subcommand {
@@ -83,7 +83,7 @@ pub fn process_inflation_subcommand(
     }
 }
 
-fn process_show(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+fn process_show(rpc_client: &RpcClient, config: &CliConfig<'_>) -> ProcessResult {
     let governor = rpc_client.get_inflation_governor()?;
     let current_rate = rpc_client.get_inflation_rate()?;
 
@@ -97,7 +97,7 @@ fn process_show(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
 
 fn process_rewards(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     addresses: &[Pubkey],
     rewards_epoch: Option<Epoch>,
 ) -> ProcessResult {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -21,8 +21,6 @@ macro_rules! pubkey {
 #[macro_use]
 extern crate const_format;
 
-extern crate serde_derive;
-
 pub mod checks;
 pub mod clap_app;
 pub mod cli;

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -345,7 +345,7 @@ pub fn check_nonce_account(
 
 pub fn process_authorize_nonce_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account: &Pubkey,
     nonce_authority: SignerIndex,
     memo: Option<&String>,
@@ -389,7 +389,7 @@ pub fn process_authorize_nonce_account(
 
 pub fn process_create_nonce_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account: SignerIndex,
     seed: Option<String>,
     nonce_authority: Option<Pubkey>,
@@ -506,7 +506,7 @@ pub fn process_create_nonce_account(
 
 pub fn process_get_nonce(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account_pubkey: &Pubkey,
 ) -> ProcessResult {
     #[allow(clippy::redundant_closure)]
@@ -520,7 +520,7 @@ pub fn process_get_nonce(
 
 pub fn process_new_nonce(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account: &Pubkey,
     nonce_authority: SignerIndex,
     memo: Option<&String>,
@@ -573,7 +573,7 @@ pub fn process_new_nonce(
 
 pub fn process_show_nonce_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account_pubkey: &Pubkey,
     use_lamports_unit: bool,
 ) -> ProcessResult {
@@ -603,7 +603,7 @@ pub fn process_show_nonce_account(
 
 pub fn process_withdraw_from_nonce_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     nonce_account: &Pubkey,
     nonce_authority: SignerIndex,
     memo: Option<&String>,

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -655,7 +655,7 @@ pub fn parse_program_subcommand(
 
 pub fn process_program_subcommand(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_subcommand: &ProgramCliCommand,
 ) -> ProcessResult {
     match program_subcommand {
@@ -783,7 +783,7 @@ fn get_default_program_keypair(program_location: &Option<String>) -> Keypair {
 #[allow(clippy::too_many_arguments)]
 fn process_program_deploy(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_location: &Option<String>,
     program_signer_index: Option<SignerIndex>,
     program_pubkey: Option<Pubkey>,
@@ -977,7 +977,7 @@ fn process_program_deploy(
 
 fn process_write_buffer(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_location: &str,
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
@@ -1060,7 +1060,7 @@ fn process_write_buffer(
 
 fn process_set_authority(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_pubkey: Option<Pubkey>,
     buffer_pubkey: Option<Pubkey>,
     authority: Option<SignerIndex>,
@@ -1286,7 +1286,7 @@ fn get_accounts_with_filter(
 
 fn process_show(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     account_pubkey: Option<Pubkey>,
     authority_pubkey: Pubkey,
     programs: bool,
@@ -1383,7 +1383,7 @@ fn process_show(
 
 fn process_dump(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     account_pubkey: Option<Pubkey>,
     output_location: &str,
 ) -> ProcessResult {
@@ -1446,7 +1446,7 @@ fn process_dump(
 
 fn close(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     account_pubkey: &Pubkey,
     recipient_pubkey: &Pubkey,
     authority_signer: &dyn Signer,
@@ -1496,7 +1496,7 @@ fn close(
 
 fn process_close(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     account_pubkey: Option<Pubkey>,
     recipient_pubkey: Pubkey,
     authority_index: SignerIndex,
@@ -1631,7 +1631,7 @@ fn process_close(
 /// Deploy using non-upgradeable loader
 pub fn process_deploy(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_location: &str,
     buffer_signer_index: Option<SignerIndex>,
     use_deprecated_loader: bool,
@@ -1693,7 +1693,7 @@ where
 #[allow(clippy::too_many_arguments)]
 fn do_process_program_write_and_deploy(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_data: &[u8],
     buffer_data_len: usize,
     programdata_len: usize,
@@ -1862,7 +1862,7 @@ fn do_process_program_write_and_deploy(
 
 fn do_process_program_upgrade(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     program_data: &[u8],
     program_id: &Pubkey,
     upgrade_authority: &dyn Signer,
@@ -2063,7 +2063,7 @@ fn complete_partial_program_init(
 
 fn check_payer(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     balance_needed: u64,
     messages: &[&Message],
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2080,7 +2080,7 @@ fn check_payer(
 
 fn send_deploy_messages(
     rpc_client: Arc<RpcClient>,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     initial_message: &Option<Message>,
     write_messages: &Option<Vec<Message>>,
     final_message: &Option<Message>,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1185,7 +1185,7 @@ pub fn parse_show_stake_history(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 #[allow(clippy::too_many_arguments)]
 pub fn process_create_stake_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account: SignerIndex,
     seed: &Option<String>,
     staker: &Option<Pubkey>,
@@ -1337,7 +1337,7 @@ pub fn process_create_stake_account(
 #[allow(clippy::too_many_arguments)]
 pub fn process_stake_authorize(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     new_authorizations: &[StakeAuthorizationIndexed],
     custodian: Option<SignerIndex>,
@@ -1470,7 +1470,7 @@ pub fn process_stake_authorize(
 #[allow(clippy::too_many_arguments)]
 pub fn process_deactivate_stake_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     stake_authority: SignerIndex,
     sign_only: bool,
@@ -1544,7 +1544,7 @@ pub fn process_deactivate_stake_account(
 #[allow(clippy::too_many_arguments)]
 pub fn process_withdraw_stake(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     destination_account_pubkey: &Pubkey,
     amount: SpendAmount,
@@ -1641,7 +1641,7 @@ pub fn process_withdraw_stake(
 #[allow(clippy::too_many_arguments)]
 pub fn process_split_stake(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     stake_authority: SignerIndex,
     sign_only: bool,
@@ -1784,7 +1784,7 @@ pub fn process_split_stake(
 #[allow(clippy::too_many_arguments)]
 pub fn process_merge_stake(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     source_stake_account_pubkey: &Pubkey,
     stake_authority: SignerIndex,
@@ -1893,7 +1893,7 @@ pub fn process_merge_stake(
 #[allow(clippy::too_many_arguments)]
 pub fn process_stake_set_lockup(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     lockup: &LockupArgs,
     new_custodian_signer: Option<SignerIndex>,
@@ -2211,7 +2211,7 @@ pub(crate) fn fetch_epoch_rewards(
 
 pub fn process_show_stake_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_address: &Pubkey,
     use_lamports_unit: bool,
     with_rewards: Option<usize>,
@@ -2267,7 +2267,7 @@ pub fn process_show_stake_account(
 
 pub fn process_show_stake_history(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     use_lamports_unit: bool,
     limit_results: usize,
 ) -> ProcessResult {
@@ -2301,7 +2301,7 @@ pub fn process_show_stake_history(
 #[allow(clippy::too_many_arguments)]
 pub fn process_delegate_stake(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     stake_account_pubkey: &Pubkey,
     vote_account_pubkey: &Pubkey,
     stake_authority: SignerIndex,

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -239,7 +239,7 @@ pub fn parse_get_validator_info_command(
 
 pub fn process_set_validator_info(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     validator_info: &Value,
     force_keybase: bool,
     info_pubkey: Option<Pubkey>,
@@ -366,7 +366,7 @@ pub fn process_set_validator_info(
 
 pub fn process_get_validator_info(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     pubkey: Option<Pubkey>,
 ) -> ProcessResult {
     let validator_info: Vec<(Pubkey, Account)> = if let Some(validator_info_pubkey) = pubkey {

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -618,7 +618,7 @@ pub fn parse_close_vote_account(
 
 pub fn process_create_vote_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account: SignerIndex,
     seed: &Option<String>,
     identity_account: SignerIndex,
@@ -716,7 +716,7 @@ pub fn process_create_vote_account(
 
 pub fn process_vote_authorize(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_pubkey: &Pubkey,
     new_authorized_pubkey: &Pubkey,
     vote_authorize: VoteAuthorize,
@@ -791,7 +791,7 @@ pub fn process_vote_authorize(
 
 pub fn process_vote_update_validator(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_pubkey: &Pubkey,
     new_identity_account: SignerIndex,
     withdraw_authority: SignerIndex,
@@ -827,7 +827,7 @@ pub fn process_vote_update_validator(
 
 pub fn process_vote_update_commission(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_pubkey: &Pubkey,
     commission: u8,
     withdraw_authority: SignerIndex,
@@ -885,7 +885,7 @@ fn get_vote_account(
 
 pub fn process_show_vote_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_address: &Pubkey,
     use_lamports_unit: bool,
     with_rewards: Option<usize>,
@@ -945,7 +945,7 @@ pub fn process_show_vote_account(
 
 pub fn process_withdraw_from_vote_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_pubkey: &Pubkey,
     withdraw_authority: SignerIndex,
     withdraw_amount: SpendAmount,
@@ -994,7 +994,7 @@ pub fn process_withdraw_from_vote_account(
 
 pub fn process_close_vote_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     vote_account_pubkey: &Pubkey,
     withdraw_authority: SignerIndex,
     destination_account_pubkey: &Pubkey,

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -437,7 +437,7 @@ pub fn parse_transfer(
 
 pub fn process_show_account(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     account_pubkey: &Pubkey,
     output_file: &Option<String>,
     use_lamports_unit: bool,
@@ -479,7 +479,7 @@ pub fn process_show_account(
 
 pub fn process_airdrop(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     pubkey: &Option<Pubkey>,
     lamports: u64,
 ) -> ProcessResult {
@@ -516,7 +516,7 @@ pub fn process_airdrop(
 
 pub fn process_balance(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     pubkey: &Option<Pubkey>,
     use_lamports_unit: bool,
 ) -> ProcessResult {
@@ -531,7 +531,7 @@ pub fn process_balance(
 
 pub fn process_confirm(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     signature: &Signature,
 ) -> ProcessResult {
     match rpc_client.get_signature_statuses_with_history(&[*signature]) {
@@ -594,7 +594,10 @@ pub fn process_confirm(
 }
 
 #[allow(clippy::unnecessary_wraps)]
-pub fn process_decode_transaction(config: &CliConfig, transaction: &Transaction) -> ProcessResult {
+pub fn process_decode_transaction(
+    config: &CliConfig<'_>,
+    transaction: &Transaction,
+) -> ProcessResult {
     let sigverify_status = CliSignatureVerificationStatus::verify_transaction(transaction);
     let decode_transaction = CliTransaction {
         decoded_transaction: transaction.clone(),
@@ -609,7 +612,7 @@ pub fn process_decode_transaction(config: &CliConfig, transaction: &Transaction)
 }
 
 pub fn process_create_address_with_seed(
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     from_pubkey: Option<&Pubkey>,
     seed: &str,
     program_id: &Pubkey,
@@ -626,7 +629,7 @@ pub fn process_create_address_with_seed(
 #[allow(clippy::too_many_arguments)]
 pub fn process_transfer(
     rpc_client: &RpcClient,
-    config: &CliConfig,
+    config: &CliConfig<'_>,
     amount: SpendAmount,
     to: &Pubkey,
     from: SignerIndex,

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -124,7 +124,7 @@ pub struct Memcmp {
 }
 
 impl Memcmp {
-    pub fn bytes(&self) -> Option<Cow<Vec<u8>>> {
+    pub fn bytes(&self) -> Option<Cow<'_, Vec<u8>>> {
         use MemcmpEncodedBytes::*;
         match &self.bytes {
             Binary(bytes) | Base58(bytes) => bs58::decode(bytes).into_vec().ok().map(Cow::Owned),

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -222,7 +222,7 @@ pub enum RpcResponseErrorData {
 }
 
 impl fmt::Display for RpcResponseErrorData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RpcResponseErrorData::SendTransactionPreflightFailure(
                 RpcSimulateTransactionResult {

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -263,13 +263,13 @@ pub struct RpcVersionInfo {
 }
 
 impl fmt::Debug for RpcVersionInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.solana_core)
     }
 }
 
 impl fmt::Display for RpcVersionInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(version) = self.solana_core.split_whitespace().next() {
             // Display just the semver if possible
             write!(f, "{}", version)

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate solana_core;
 extern crate test;
 
 use {

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate solana_core;
 extern crate test;
 
 use {

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate solana_core;
 extern crate test;
 
 use crossbeam_channel::unbounded;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -810,7 +810,7 @@ impl BankingStage {
     fn process_and_record_transactions_locked(
         bank: &Arc<Bank>,
         poh: &TransactionRecorder,
-        batch: &TransactionBatch,
+        batch: &TransactionBatch<'_, '_>,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
     ) -> (Result<usize, PohRecorderError>, Vec<usize>) {

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -590,7 +590,7 @@ impl HeaviestSubtreeForkChoice {
         }
     }
 
-    fn ancestor_iterator(&self, start_slot_hash_key: SlotHashKey) -> AncestorIterator {
+    fn ancestor_iterator(&self, start_slot_hash_key: SlotHashKey) -> AncestorIterator<'_> {
         AncestorIterator::new(start_slot_hash_key, &self.fork_infos)
     }
 

--- a/core/tests/fork-selection.rs
+++ b/core/tests/fork-selection.rs
@@ -73,7 +73,6 @@
 //! ```
 #![allow(clippy::integer_arithmetic)]
 
-extern crate rand;
 use rand::{thread_rng, Rng};
 use std::collections::{HashMap, VecDeque};
 

--- a/docs/src/developing/on-chain-programs/developing-rust.md
+++ b/docs/src/developing/on-chain-programs/developing-rust.md
@@ -145,7 +145,7 @@ call must be of this form:
 
 ```rust
 pub type ProcessInstruction =
-    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+    fn(program_id: &Pubkey, accounts: &[AccountInfo<'_>], instruction_data: &[u8]) -> ProgramResult;
 ```
 
 Refer to [helloworld's use of the
@@ -182,7 +182,7 @@ function with the following parameters:
 
 ```rust
 program_id: &Pubkey,
-accounts: &[AccountInfo],
+accounts: &[AccountInfo<'_>],
 instruction_data: &[u8]
 ```
 

--- a/docs/src/developing/programming-model/calling-between-programs.md
+++ b/docs/src/developing/programming-model/calling-between-programs.md
@@ -39,11 +39,11 @@ invocation:
 mod acme {
     use token_instruction;
 
-    fn launch_missiles(accounts: &[AccountInfo]) -> Result<()> {
+    fn launch_missiles(accounts: &[AccountInfo<'_>]) -> Result<()> {
         ...
     }
 
-    fn pay_and_launch_missiles(accounts: &[AccountInfo]) -> Result<()> {
+    fn pay_and_launch_missiles(accounts: &[AccountInfo<'_>]) -> Result<()> {
         let alice_pubkey = accounts[1].key;
         let instruction = token_instruction::pay(&alice_pubkey);
         invoke(&instruction, accounts)?;
@@ -265,7 +265,7 @@ as if it had the private key to sign the transaction.
 ```rust,ignore
 fn transfer_one_token_from_escrow(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
 ) -> ProgramResult {
     // User supplies the destination
     let alice_pubkey = keyed_accounts[1].unsigned_key();
@@ -310,7 +310,7 @@ Within the program, this becomes:
 ```rust,ignore
 fn transfer_one_token_from_escrow2(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
 ) -> ProgramResult {
     // User supplies the destination
     let alice_pubkey = keyed_accounts[1].unsigned_key();

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -14,8 +14,8 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-static TRUCK: Emoji = Emoji("🚚 ", "");
-static SPARKLE: Emoji = Emoji("✨ ", "");
+static TRUCK: Emoji<'_, '_> = Emoji("🚚 ", "");
+static SPARKLE: Emoji<'_, '_> = Emoji("✨ ", "");
 
 /// Creates a new process bar for processing that will take an unknown amount of time
 fn new_spinner_progress_bar() -> ProgressBar {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -46,7 +46,7 @@ thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::
 pub type EntrySender = Sender<Vec<Entry>>;
 pub type EntryReceiver = Receiver<Vec<Entry>>;
 
-static mut API: Option<Container<Api>> = None;
+static mut API: Option<Container<Api<'_>>> = None;
 
 pub fn init_poh() {
     init(OsStr::new("libpoh-simd.so"));

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -1,5 +1,3 @@
 #![allow(clippy::integer_arithmetic)]
 pub mod entry;
 pub mod poh;
-
-extern crate log;

--- a/frozen-abi/build.rs
+++ b/frozen-abi/build.rs
@@ -1,4 +1,3 @@
-extern crate rustc_version;
 use rustc_version::{version_meta, Channel};
 
 fn main() {

--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 // This file littered with these essential cfgs so ensure them.
 #[cfg(not(any(RUSTC_WITH_SPECIALIZATION, RUSTC_WITHOUT_SPECIALIZATION)))]
 compile_error!("rustc_version is missing in build dependency and build.rs is not specified");
@@ -338,7 +336,7 @@ fn frozen_abi_struct_type(input: ItemStruct, expected_digest: &str) -> TokenStre
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 fn quote_sample_variant(
     type_name: &Ident,
-    ty_generics: &syn::TypeGenerics,
+    ty_generics: &syn::TypeGenerics<'_>,
     variant: &Variant,
 ) -> TokenStream2 {
     let variant_name = &variant.ident;

--- a/frozen-abi/src/hash.rs
+++ b/frozen-abi/src/hash.rs
@@ -22,7 +22,7 @@ impl Hasher {
 }
 
 impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -216,7 +216,7 @@ impl Signable for PruneData {
         self.pubkey
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         #[derive(Serialize)]
         struct SignData {
             pubkey: Pubkey,
@@ -620,7 +620,7 @@ impl ClusterInfo {
         self.my_contact_info.read().unwrap().id
     }
 
-    pub fn keypair(&self) -> RwLockReadGuard<Arc<Keypair>> {
+    pub fn keypair(&self) -> RwLockReadGuard<'_, Arc<Keypair>> {
         self.keypair.read().unwrap()
     }
 
@@ -920,7 +920,7 @@ impl ClusterInfo {
         &'a self,
         label: &'static str,
         counter: &'a Counter,
-    ) -> TimedGuard<'a, RwLockReadGuard<Crds>> {
+    ) -> TimedGuard<'a, RwLockReadGuard<'_, Crds>> {
         TimedGuard::new(self.gossip.crds.read().unwrap(), label, counter)
     }
 

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -657,7 +657,9 @@ impl CrdsGossipPull {
     }
 
     #[cfg(test)]
-    pub(crate) fn pull_request_time(&self) -> std::sync::RwLockReadGuard<LruCache<Pubkey, u64>> {
+    pub(crate) fn pull_request_time(
+        &self,
+    ) -> std::sync::RwLockReadGuard<'_, LruCache<Pubkey, u64>> {
         self.pull_request_time.read().unwrap()
     }
 }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -57,7 +57,7 @@ impl Signable for CrdsValue {
         self.pubkey()
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Owned(serialize(&self.data).expect("failed to serialize CrdsData"))
     }
 

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -153,7 +153,7 @@ fn parse_matches() -> ArgMatches<'static> {
         .get_matches()
 }
 
-fn parse_gossip_host(matches: &ArgMatches, entrypoint_addr: Option<SocketAddr>) -> IpAddr {
+fn parse_gossip_host(matches: &ArgMatches<'_>, entrypoint_addr: Option<SocketAddr>) -> IpAddr {
     matches
         .value_of("gossip_host")
         .map(|gossip_host| {
@@ -217,7 +217,10 @@ fn process_spy_results(
     }
 }
 
-fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std::io::Result<()> {
+fn process_spy(
+    matches: &ArgMatches<'_>,
+    socket_addr_space: SocketAddrSpace,
+) -> std::io::Result<()> {
     let num_nodes_exactly = matches
         .value_of("num_nodes_exactly")
         .map(|num| num.to_string().parse().unwrap());
@@ -266,7 +269,7 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
     Ok(())
 }
 
-fn parse_entrypoint(matches: &ArgMatches) -> Option<SocketAddr> {
+fn parse_entrypoint(matches: &ArgMatches<'_>) -> Option<SocketAddr> {
     matches.value_of("entrypoint").map(|entrypoint| {
         solana_net_utils::parse_host_port(entrypoint).unwrap_or_else(|e| {
             eprintln!("failed to parse entrypoint address: {}", e);
@@ -276,7 +279,7 @@ fn parse_entrypoint(matches: &ArgMatches) -> Option<SocketAddr> {
 }
 
 fn process_rpc_url(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     socket_addr_space: SocketAddrSpace,
 ) -> std::io::Result<()> {
     let any = matches.is_present("any");

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -86,7 +86,7 @@ impl<T: Serialize> Signable for Ping<T> {
         self.from
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Owned(serialize(&self.token).unwrap())
     }
 
@@ -124,7 +124,7 @@ impl Signable for Pong {
         self.from
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Owned(self.hash.as_ref().into())
     }
 

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -35,14 +35,14 @@ pub struct ReleaseVersion {
     channel: String,
 }
 
-static TRUCK: Emoji = Emoji("🚚 ", "");
-static LOOKING_GLASS: Emoji = Emoji("🔍 ", "");
-static BULLET: Emoji = Emoji("• ", "* ");
-static SPARKLE: Emoji = Emoji("✨ ", "");
-static WRAPPED_PRESENT: Emoji = Emoji("🎁 ", "");
-static PACKAGE: Emoji = Emoji("📦 ", "");
-static INFORMATION: Emoji = Emoji("ℹ️  ", "");
-static RECYCLING: Emoji = Emoji("♻️  ", "");
+static TRUCK: Emoji<'_, '_> = Emoji("🚚 ", "");
+static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍 ", "");
+static BULLET: Emoji<'_, '_> = Emoji("• ", "* ");
+static SPARKLE: Emoji<'_, '_> = Emoji("✨ ", "");
+static WRAPPED_PRESENT: Emoji<'_, '_> = Emoji("🎁 ", "");
+static PACKAGE: Emoji<'_, '_> = Emoji("📦 ", "");
+static INFORMATION: Emoji<'_, '_> = Emoji("ℹ️  ", "");
+static RECYCLING: Emoji<'_, '_> = Emoji("♻️  ", "");
 
 /// Creates a new process bar for processing that will take an unknown amount of time
 fn new_spinner_progress_bar() -> ProgressBar {

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -31,7 +31,7 @@ impl Signable for SignedUpdateManifest {
         self.account_pubkey
     }
 
-    fn signable_data(&self) -> Cow<[u8]> {
+    fn signable_data(&self) -> Cow<'_, [u8]> {
         Cow::Owned(bincode::serialize(&self.manifest).expect("serialize"))
     }
     fn get_signature(&self) -> Signature {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -121,7 +121,7 @@ impl KeyGenerationCommonArgs for App<'_, '_> {
     }
 }
 
-fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
+fn check_for_overwrite(outfile: &str, matches: &ArgMatches<'_>) {
     let force = matches.is_present("force");
     if !force && Path::new(outfile).exists() {
         eprintln!("Refusing to overwrite {} without --force flag", outfile);
@@ -130,7 +130,7 @@ fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
 }
 
 fn get_keypair_from_matches(
-    matches: &ArgMatches,
+    matches: &ArgMatches<'_>,
     config: Config,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -705,7 +705,7 @@ fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
 }
 
 fn load_bank_forks(
-    arg_matches: &ArgMatches,
+    arg_matches: &ArgMatches<'_>,
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     process_options: ProcessOptions,
@@ -2686,7 +2686,7 @@ fn main() {
                             let stake_calculation_details: DashMap<Pubkey, CalculationDetail> =
                                 DashMap::new();
                             let last_point_value = Arc::new(RwLock::new(None));
-                            let tracer = |event: &RewardCalculationEvent| {
+                            let tracer = |event: &RewardCalculationEvent<'_, '_>| {
                                 // Currently RewardCalculationEvent enum has only Staking variant
                                 // because only staking tracing is supported!
                                 #[allow(irrefutable_let_patterns)]

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 #![feature(test)]
-extern crate solana_ledger;
+
 extern crate test;
 
 use rand::Rng;

--- a/ledger/build.rs
+++ b/ledger/build.rs
@@ -1,4 +1,3 @@
-extern crate rustc_version;
 use rustc_version::{version_meta, Channel};
 
 fn main() {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -320,7 +320,7 @@ impl Blockstore {
     /// records. **This method is very slow.**
     fn purge_special_columns_exact(
         &self,
-        batch: &mut WriteBatch,
+        batch: &mut WriteBatch<'_>,
         from_slot: Slot,
         to_slot: Slot, // Exclusive
     ) -> Result<()> {
@@ -359,7 +359,7 @@ impl Blockstore {
     /// primary index has a max-slot less than the highest slot being purged.
     fn purge_special_columns_with_primary_index(
         &self,
-        write_batch: &mut WriteBatch,
+        write_batch: &mut WriteBatch<'_>,
         columns_purged: &mut bool,
         w_active_transaction_status_index: &mut u64,
         to_slot: Slot,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -543,7 +543,11 @@ impl Rocks {
         Ok(())
     }
 
-    fn iterator_cf<C>(&self, cf: &ColumnFamily, iterator_mode: IteratorMode<C::Index>) -> DBIterator
+    fn iterator_cf<C>(
+        &self,
+        cf: &ColumnFamily,
+        iterator_mode: IteratorMode<C::Index>,
+    ) -> DBIterator<'_>
     where
         C: Column,
     {
@@ -559,7 +563,7 @@ impl Rocks {
         self.0.iterator_cf(cf, iterator_mode)
     }
 
-    fn raw_iterator_cf(&self, cf: &ColumnFamily) -> DBRawIterator {
+    fn raw_iterator_cf(&self, cf: &ColumnFamily) -> DBRawIterator<'_> {
         self.0.raw_iterator_cf(cf)
     }
 
@@ -1080,11 +1084,11 @@ impl Database {
     }
 
     #[inline]
-    pub fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator> {
+    pub fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator<'_>> {
         Ok(self.backend.raw_iterator_cf(cf))
     }
 
-    pub fn batch(&self) -> Result<WriteBatch> {
+    pub fn batch(&self) -> Result<WriteBatch<'_>> {
         let write_batch = self.backend.batch();
         let map = self
             .backend
@@ -1096,7 +1100,7 @@ impl Database {
         Ok(WriteBatch { write_batch, map })
     }
 
-    pub fn write(&self, batch: WriteBatch) -> Result<()> {
+    pub fn write(&self, batch: WriteBatch<'_>) -> Result<()> {
         self.backend.write(batch.write_batch)
     }
 
@@ -1105,7 +1109,7 @@ impl Database {
     }
 
     // Adds a range to delete to the given write batch
-    pub fn delete_range_cf<C>(&self, batch: &mut WriteBatch, from: Slot, to: Slot) -> Result<()>
+    pub fn delete_range_cf<C>(&self, batch: &mut WriteBatch<'_>, from: Slot, to: Slot) -> Result<()>
     where
         C: Column + ColumnName,
     {
@@ -1143,7 +1147,7 @@ where
 
     pub fn delete_slot(
         &self,
-        batch: &mut WriteBatch,
+        batch: &mut WriteBatch<'_>,
         from: Option<Slot>,
         to: Option<Slot>,
     ) -> Result<bool>

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -111,7 +111,7 @@ fn first_err(results: &[Result<()>]) -> Result<()> {
 
 // Includes transaction signature for unit-testing
 fn get_first_error(
-    batch: &TransactionBatch,
+    batch: &TransactionBatch<'_, '_>,
     fee_collection_results: Vec<Result<()>>,
 ) -> Option<(Result<()>, Signature)> {
     let mut first_err = None;
@@ -154,7 +154,7 @@ fn aggregate_total_execution_units(execute_timings: &ExecuteTimings) -> u64 {
 }
 
 fn execute_batch(
-    batch: &TransactionBatch,
+    batch: &TransactionBatch<'_, '_>,
     bank: &Arc<Bank>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
@@ -248,7 +248,7 @@ fn execute_batch(
 
 fn execute_batches(
     bank: &Arc<Bank>,
-    batches: &[TransactionBatch],
+    batches: &[TransactionBatch<'_, '_>],
     entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<&TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::integer_arithmetic)]
-extern crate byte_unit;
 
 use byte_unit::Byte;
 use clap::{crate_description, crate_name, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
@@ -97,7 +96,7 @@ fn map_ip_address(mappings: &[IpAddrMapping], target: String) -> String {
     target
 }
 
-fn process_iftop_logs(matches: &ArgMatches) {
+fn process_iftop_logs(matches: &ArgMatches<'_>) {
     let mut map_list: Vec<IpAddrMapping> = vec![];
     if let ("map-IP", Some(args_matches)) = matches.subcommand() {
         let mut list = args_matches
@@ -149,7 +148,7 @@ fn process_iftop_logs(matches: &ArgMatches) {
     println!("{}", serde_json::to_string(&output).unwrap());
 }
 
-fn analyze_logs(matches: &ArgMatches) {
+fn analyze_logs(matches: &ArgMatches<'_>) {
     let dir_path = PathBuf::from(value_t_or_exit!(matches, "folder", String));
     assert!(
         dir_path.is_dir(),

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -11,11 +11,11 @@ lazy_static! {
 struct LoggerShim {}
 
 impl log::Log for LoggerShim {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         LOGGER.read().unwrap().enabled(metadata)
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         LOGGER.read().unwrap().log(record);
     }
 

--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -83,7 +83,7 @@ impl Measure {
 }
 
 impl fmt::Display for Measure {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.duration == 0 {
             write!(f, "{} running", self.name)
         } else if self.as_us() < 1 {

--- a/merkle-root-bench/src/main.rs
+++ b/merkle-root-bench/src/main.rs
@@ -1,4 +1,3 @@
-extern crate log;
 use clap::{crate_description, crate_name, value_t, App, Arg};
 use solana_measure::measure::Measure;
 use solana_runtime::accounts_hash::AccountsHash;

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -139,7 +139,7 @@ impl MerkleTree {
         self.nodes.iter().last()
     }
 
-    pub fn find_path(&self, index: usize) -> Option<Proof> {
+    pub fn find_path(&self, index: usize) -> Option<Proof<'_>> {
         if index >= self.leaf_count {
             return None;
         }

--- a/net-shaper/src/main.rs
+++ b/net-shaper/src/main.rs
@@ -368,7 +368,7 @@ fn partition_id_to_tos(partition: usize) -> u8 {
     }
 }
 
-fn shape_network(matches: &ArgMatches) {
+fn shape_network(matches: &ArgMatches<'_>) {
     let config_path = PathBuf::from(value_t_or_exit!(matches, "file", String));
     let config = fs::read_to_string(&config_path).expect("Unable to read config file");
     let topology: NetworkTopology =
@@ -467,7 +467,7 @@ fn cleanup_network(interface: &str) {
     flush_iptables_rule();
 }
 
-fn configure(matches: &ArgMatches) {
+fn configure(matches: &ArgMatches<'_>) {
     let config = if !matches.is_present("random") {
         NetworkTopology::new_from_stdin()
     } else {

--- a/perf/src/perf_libs.rs
+++ b/perf/src/perf_libs.rs
@@ -79,7 +79,7 @@ pub struct Api<'a> {
         Symbol<'a, unsafe extern "C" fn(packed_ge: *const u8) -> c_int>,
 }
 
-static mut API: Option<Container<Api>> = None;
+static mut API: Option<Container<Api<'_>>> = None;
 
 fn init(name: &OsStr) {
     static INIT_HOOK: Once = Once::new();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -22,7 +22,7 @@ use solana_sdk::{
 use std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc};
 
 pub type ProcessInstructionWithContext =
-    fn(usize, &[u8], &mut InvokeContext) -> Result<(), InstructionError>;
+    fn(usize, &[u8], &mut InvokeContext<'_>) -> Result<(), InstructionError>;
 
 #[derive(Clone)]
 pub struct BuiltinProgram {
@@ -31,7 +31,7 @@ pub struct BuiltinProgram {
 }
 
 impl std::fmt::Debug for BuiltinProgram {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // These are just type aliases for work around of Debug-ing above pointers
         type ErasedProcessInstructionWithContext = fn(
             usize,
@@ -745,7 +745,7 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Get the list of keyed accounts
-    pub fn get_keyed_accounts(&self) -> Result<&[KeyedAccount], InstructionError> {
+    pub fn get_keyed_accounts(&self) -> Result<&[KeyedAccount<'_>], InstructionError> {
         self.invoke_stack
             .last()
             .map(|frame| &frame.keyed_accounts[frame.keyed_accounts_range.clone()])
@@ -753,7 +753,7 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Get the list of keyed accounts skipping `first_instruction_account` many entries
-    pub fn get_instruction_keyed_accounts(&self) -> Result<&[KeyedAccount], InstructionError> {
+    pub fn get_instruction_keyed_accounts(&self) -> Result<&[KeyedAccount<'_>], InstructionError> {
         let frame = self
             .invoke_stack
             .last()
@@ -872,7 +872,7 @@ impl<'a> InvokeContext<'a> {
 // This method which has a generic parameter is outside of the InvokeContext,
 // because the InvokeContext is a dyn Trait.
 pub fn get_sysvar<T: Sysvar>(
-    invoke_context: &InvokeContext,
+    invoke_context: &InvokeContext<'_>,
     id: &Pubkey,
 ) -> Result<T, InstructionError> {
     invoke_context
@@ -952,7 +952,7 @@ pub fn prepare_mock_invoke_context(
     }
 }
 
-pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
+pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext<'_>) -> R>(
     loader_id: Pubkey,
     account_size: usize,
     mut callback: F,
@@ -1039,7 +1039,7 @@ mod tests {
         fn mock_process_instruction(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut InvokeContext,
+            _invoke_context: &mut InvokeContext<'_>,
         ) -> Result<(), InstructionError> {
             Ok(())
         }
@@ -1047,7 +1047,7 @@ mod tests {
         fn mock_ix_processor(
             _first_instruction_account: usize,
             _data: &[u8],
-            _context: &mut InvokeContext,
+            _context: &mut InvokeContext<'_>,
         ) -> Result<(), InstructionError> {
             Ok(())
         }
@@ -1068,7 +1068,7 @@ mod tests {
     fn mock_process_instruction(
         first_instruction_account: usize,
         data: &[u8],
-        invoke_context: &mut InvokeContext,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let program_id = invoke_context.get_caller()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -33,7 +33,7 @@ use thiserror::Error;
 pub type LoaderEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     instruction_data: &[u8],
-    invoke_context: &InvokeContext,
+    invoke_context: &InvokeContext<'_>,
 ) -> Result<(), InstructionError>;
 
 // Prototype of a native program entry point
@@ -43,7 +43,7 @@ pub type LoaderEntrypoint = unsafe extern "C" fn(
 /// instruction_data: Instruction data
 pub type ProgramEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     instruction_data: &[u8],
 ) -> Result<(), InstructionError>;
 
@@ -165,7 +165,7 @@ impl NativeLoader {
         &self,
         first_instruction_account: usize,
         instruction_data: &[u8],
-        invoke_context: &mut InvokeContext,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
             let program_id = invoke_context.get_caller()?;

--- a/program-runtime/src/pre_account.rs
+++ b/program-runtime/src/pre_account.rs
@@ -168,7 +168,7 @@ impl PreAccount {
         &self.key
     }
 
-    pub fn data(&self) -> Ref<[u8]> {
+    pub fn data(&self) -> Ref<'_, [u8]> {
         Ref::map(self.account.borrow(), |account| account.data())
     }
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -86,7 +86,7 @@ pub enum ProgramTestError {
 thread_local! {
     static INVOKE_CONTEXT: RefCell<Option<usize>> = RefCell::new(None);
 }
-fn set_invoke_context(new: &mut InvokeContext) {
+fn set_invoke_context(new: &mut InvokeContext<'_>) {
     INVOKE_CONTEXT
         .with(|invoke_context| unsafe { invoke_context.replace(Some(transmute::<_, usize>(new))) });
 }
@@ -95,14 +95,14 @@ fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
         Some(val) => val,
         None => panic!("Invoke context not set!"),
     });
-    unsafe { transmute::<usize, &mut InvokeContext>(ptr) }
+    unsafe { transmute::<usize, &mut InvokeContext<'_>>(ptr) }
 }
 
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     _first_instruction_account: usize,
     input: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
@@ -140,7 +140,7 @@ pub fn builtin_process_instruction(
         .collect();
 
     // Create AccountInfos
-    let account_infos: Vec<AccountInfo> = keyed_accounts
+    let account_infos: Vec<AccountInfo<'_>> = keyed_accounts
         .iter()
         .map(|keyed_account| {
             let key = keyed_account.unsigned_key();
@@ -233,7 +233,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
     fn sol_invoke_signed(
         &self,
         instruction: &Instruction,
-        account_infos: &[AccountInfo],
+        account_infos: &[AccountInfo<'_>],
         signers_seeds: &[&[&[u8]]],
     ) -> ProgramResult {
         //

--- a/program-test/tests/cpi.rs
+++ b/program-test/tests/cpi.rs
@@ -15,7 +15,7 @@ use {
 // Process instruction to invoke into another program
 fn invoker_process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _input: &[u8],
 ) -> ProgramResult {
     // if we can call `msg!` successfully, then InvokeContext exists as required
@@ -34,7 +34,7 @@ fn invoker_process_instruction(
 #[allow(clippy::unnecessary_wraps)]
 fn invoked_process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _input: &[u8],
 ) -> ProgramResult {
     // if we can call `msg!` successfully, then InvokeContext exists as required

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -11,7 +11,7 @@ use {
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _input: &[u8],
 ) -> ProgramResult {
     msg!("Processing instruction");

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -10,7 +10,7 @@ use {
 // Process instruction to invoke into another program
 fn sysvar_getter_process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _input: &[u8],
 ) -> ProgramResult {
     msg!("sysvar_getter");

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -107,7 +107,7 @@ async fn setup_vote(context: &mut ProgramTestContext) -> Pubkey {
 
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     input: &[u8],
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();

--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests loop iteration
 
-extern crate solana_program;
 use solana_program::{custom_panic_default, entrypoint::SUCCESS};
 
 #[no_mangle]

--- a/programs/bpf/rust/128bit_dep/src/lib.rs
+++ b/programs/bpf/rust/128bit_dep/src/lib.rs
@@ -1,6 +1,5 @@
 //! Solana Rust-based BPF program utility functions and types
 
-extern crate solana_program;
 
 pub fn uadd(x: u128, y: u128) -> u128 {
     x + y

--- a/programs/bpf/rust/caller_access/src/lib.rs
+++ b/programs/bpf/rust/caller_access/src/lib.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     if instruction_data.len() == 32 {

--- a/programs/bpf/rust/custom_heap/src/lib.rs
+++ b/programs/bpf/rust/custom_heap/src/lib.rs
@@ -56,7 +56,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Custom heap");

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests dependent crates
 
-extern crate solana_program;
 use byteorder::{ByteOrder, LittleEndian};
 use solana_program::entrypoint::SUCCESS;
 

--- a/programs/bpf/rust/deprecated_loader/src/lib.rs
+++ b/programs/bpf/rust/deprecated_loader/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![allow(unreachable_code)]
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, bpf_loader, entrypoint_deprecated,
     entrypoint_deprecated::ProgramResult, log::*, msg, pubkey::Pubkey,
@@ -30,7 +29,7 @@ entrypoint_deprecated!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Program identifier:");

--- a/programs/bpf/rust/dup_accounts/src/lib.rs
+++ b/programs/bpf/rust/dup_accounts/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program that tests duplicate accounts passed via accounts
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo,
     entrypoint,
@@ -15,7 +14,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     match instruction_data[0] {

--- a/programs/bpf/rust/error_handling/src/lib.rs
+++ b/programs/bpf/rust/error_handling/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program that exercises error handling
 
-extern crate solana_program;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use solana_program::{
@@ -47,7 +46,7 @@ impl PrintProgramError for MyError {
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     match instruction_data[0] {

--- a/programs/bpf/rust/external_spend/src/lib.rs
+++ b/programs/bpf/rust/external_spend/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program that moves a lamport from one account to another
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };
@@ -9,7 +8,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     // account 0 is the mint and not owned by this program, any debit of its lamports

--- a/programs/bpf/rust/finalize/src/lib.rs
+++ b/programs/bpf/rust/finalize/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![allow(unreachable_code)]
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult,
     loader_instruction, msg, program::invoke, pubkey::Pubkey,
@@ -11,7 +10,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Finalize a program");

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program that exercises instruction introspection
 
-extern crate solana_program;
 use solana_program::{
     account_info::next_account_info,
     account_info::AccountInfo,
@@ -17,7 +16,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     if instruction_data.is_empty() {

--- a/programs/bpf/rust/invoke/src/processor.rs
+++ b/programs/bpf/rust/invoke/src/processor.rs
@@ -17,7 +17,7 @@ use solana_program::{
     system_instruction,
 };
 
-fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo]) -> ProgramResult {
+fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo<'_>]) -> ProgramResult {
     assert!(accounts[ARGUMENT_INDEX].is_signer);
 
     let pre_argument_lamports = accounts[ARGUMENT_INDEX].lamports();
@@ -53,7 +53,7 @@ fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo]) -> Progr
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("invoke Rust program");

--- a/programs/bpf/rust/invoke_and_error/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_error/src/lib.rs
@@ -9,7 +9,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let to_call = accounts[0].key;

--- a/programs/bpf/rust/invoke_and_ok/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_ok/src/lib.rs
@@ -10,7 +10,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let to_call = accounts[0].key;

--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -10,7 +10,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let to_call = accounts[0].key;

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -18,7 +18,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::cognitive_complexity)]
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Invoked program");

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests loop iteration
 
-extern crate solana_program;
 use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
 
 #[no_mangle]

--- a/programs/bpf/rust/log_data/src/lib.rs
+++ b/programs/bpf/rust/log_data/src/lib.rs
@@ -11,7 +11,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::cognitive_complexity)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let fields: Vec<&[u8]> = instruction_data.split(|e| *e == 0).collect();

--- a/programs/bpf/rust/many_args/src/helper.rs
+++ b/programs/bpf/rust/many_args/src/helper.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests loop iteration
 
-extern crate solana_program;
 use solana_program::log::*;
 
 pub fn many_args(

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -1,7 +1,6 @@
 //! Example Rust-based BPF program tests loop iteration
 
 mod helper;
-extern crate solana_program;
 use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
 
 #[no_mangle]

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -1,6 +1,5 @@
 //! Solana Rust-based BPF program utility functions and types
 
-extern crate solana_program;
 use solana_program::msg;
 
 pub fn many_args(

--- a/programs/bpf/rust/mem/src/entrypoint.rs
+++ b/programs/bpf/rust/mem/src/entrypoint.rs
@@ -13,7 +13,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     // Via syscalls

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF noop program
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };
@@ -9,7 +8,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     Ok(())

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -8,7 +8,6 @@ fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     solana_program::msg!(&format!("{}", info));
 }
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };
@@ -17,7 +16,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     assert_eq!(1, 2);

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests loop iteration
 
-extern crate solana_program;
 use solana_bpf_rust_param_passing_dep::{Data, TestDep};
 use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
 

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program tests loop iteration
 
-extern crate solana_program;
 
 #[derive(Debug)]
 pub struct Data<'a> {

--- a/programs/bpf/rust/rand/src/lib.rs
+++ b/programs/bpf/rust/rand/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![allow(unreachable_code)]
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
 };
@@ -11,7 +10,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("rand");

--- a/programs/bpf/rust/realloc/src/processor.rs
+++ b/programs/bpf/rust/realloc/src/processor.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "program")]
 
-extern crate solana_program;
 use crate::instructions::*;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
@@ -15,7 +14,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let account = &accounts[0];

--- a/programs/bpf/rust/realloc_invoke/src/processor.rs
+++ b/programs/bpf/rust/realloc_invoke/src/processor.rs
@@ -2,7 +2,6 @@
 
 #![cfg(feature = "program")]
 
-extern crate solana_program;
 use crate::instructions::*;
 use solana_bpf_rust_realloc::instructions::*;
 use solana_program::{
@@ -22,7 +21,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let account = &accounts[0];

--- a/programs/bpf/rust/ro_account_modify/src/lib.rs
+++ b/programs/bpf/rust/ro_account_modify/src/lib.rs
@@ -18,7 +18,7 @@ const INSTRUCTION_VERIFY_MODIFIED: u8 = 3;
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     assert!(!accounts[ARGUMENT_INDEX].is_writable);

--- a/programs/bpf/rust/ro_modify/src/lib.rs
+++ b/programs/bpf/rust/ro_modify/src/lib.rs
@@ -94,7 +94,7 @@ const PUBKEY: Pubkey = Pubkey::new_from_array([
 ]);
 
 fn check_preconditions(
-    in_infos: &[AccountInfo],
+    in_infos: &[AccountInfo<'_>],
     static_infos: &[SolAccountInfo],
 ) -> Result<(), ProgramError> {
     for (in_info, static_info) in in_infos.iter().zip(static_infos) {
@@ -119,7 +119,7 @@ fn check_preconditions(
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     check_preconditions(accounts, READONLY_ACCOUNTS)?;

--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![allow(unreachable_code)]
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult, log::*, msg,
     pubkey::Pubkey,
@@ -24,7 +23,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Program identifier:");

--- a/programs/bpf/rust/secp256k1_recover/src/lib.rs
+++ b/programs/bpf/rust/secp256k1_recover/src/lib.rs
@@ -1,6 +1,5 @@
 //! Secp256k1Recover Syscall test
 
-extern crate solana_program;
 use solana_program::{custom_panic_default, msg};
 
 fn test_secp256k1_recover() {

--- a/programs/bpf/rust/sha/src/lib.rs
+++ b/programs/bpf/rust/sha/src/lib.rs
@@ -1,6 +1,5 @@
 //! SHA Syscall test
 
-extern crate solana_program;
 use solana_program::{custom_panic_default, msg};
 
 fn test_sha256_hasher() {

--- a/programs/bpf/rust/spoof1/src/lib.rs
+++ b/programs/bpf/rust/spoof1/src/lib.rs
@@ -13,7 +13,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     let fake_system = &accounts[1];

--- a/programs/bpf/rust/spoof1_system/src/lib.rs
+++ b/programs/bpf/rust/spoof1_system/src/lib.rs
@@ -6,7 +6,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     let from = &accounts[0];

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF program that tests sysvar use
 
-extern crate solana_program;
 #[allow(deprecated)]
 use solana_program::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_program::{
@@ -21,7 +20,7 @@ entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     // Clock

--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF upgradeable program
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
     sysvar::clock,
@@ -9,7 +8,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgradeable program");

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF upgraded program
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
     sysvar::clock,
@@ -9,7 +8,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgraded program");

--- a/programs/bpf_loader/src/alloc.rs
+++ b/programs/bpf_loader/src/alloc.rs
@@ -10,7 +10,7 @@ pub trait Alloc {
 pub struct AllocErr;
 
 impl fmt::Display for AllocErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Error: Memory allocation failed")
     }
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -69,7 +69,7 @@ pub enum BpfError {
 }
 impl UserDefinedError for BpfError {}
 
-fn map_ebpf_error(invoke_context: &InvokeContext, e: EbpfError<BpfError>) -> InstructionError {
+fn map_ebpf_error(invoke_context: &InvokeContext<'_>, e: EbpfError<BpfError>) -> InstructionError {
     ic_msg!(invoke_context, "{}", e);
     InstructionError::InvalidAccountData
 }
@@ -77,7 +77,7 @@ fn map_ebpf_error(invoke_context: &InvokeContext, e: EbpfError<BpfError>) -> Ins
 pub fn create_executor(
     programdata_account_index: usize,
     programdata_offset: usize,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
     use_jit: bool,
     reject_unresolved_syscalls: bool,
 ) -> Result<Arc<BpfExecutor>, InstructionError> {
@@ -123,7 +123,7 @@ fn write_program_data(
     program_account_index: usize,
     program_data_offset: usize,
     bytes: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let program = keyed_account_at_index(keyed_accounts, program_account_index)?;
@@ -174,7 +174,7 @@ pub fn create_vm<'a, 'b>(
 pub fn process_instruction(
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
         first_instruction_account,
@@ -187,7 +187,7 @@ pub fn process_instruction(
 pub fn process_instruction_jit(
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
         first_instruction_account,
@@ -200,7 +200,7 @@ pub fn process_instruction_jit(
 fn process_instruction_common(
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
@@ -317,7 +317,7 @@ fn process_instruction_common(
 fn process_loader_upgradeable_instruction(
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
@@ -838,9 +838,9 @@ fn process_loader_upgradeable_instruction(
 
 fn common_close_account(
     authority_address: &Option<Pubkey>,
-    authority_account: &KeyedAccount,
-    close_account: &KeyedAccount,
-    recipient_account: &KeyedAccount,
+    authority_account: &KeyedAccount<'_>,
+    close_account: &KeyedAccount<'_>,
+    recipient_account: &KeyedAccount<'_>,
     log_collector: &Option<Rc<RefCell<LogCollector>>>,
 ) -> Result<(), InstructionError> {
     if authority_address.is_none() {
@@ -867,7 +867,7 @@ fn common_close_account(
 fn process_loader_instruction(
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let program_id = invoke_context.get_caller()?;
@@ -943,7 +943,7 @@ pub struct BpfExecutor {
 
 // Well, implement Debug for solana_rbpf::vm::Executable in solana-rbpf...
 impl Debug for BpfExecutor {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "BpfExecutor({:p})", self)
     }
 }
@@ -1309,7 +1309,7 @@ mod tests {
                 &keyed_accounts,
                 |first_instruction_account: usize,
                  instruction_data: &[u8],
-                 invoke_context: &mut InvokeContext| {
+                 invoke_context: &mut InvokeContext<'_>| {
                     let compute_meter = invoke_context.get_compute_meter();
                     let remaining = compute_meter.borrow_mut().get_remaining();
                     compute_meter.borrow_mut().consume(remaining).unwrap();

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
 use std::{io::prelude::*, mem::size_of};
 
 /// Look for a duplicate account and return its position if found
-pub fn is_dup(accounts: &[KeyedAccount], keyed_account: &KeyedAccount) -> (bool, usize) {
+pub fn is_dup(accounts: &[KeyedAccount<'_>], keyed_account: &KeyedAccount<'_>) -> (bool, usize) {
     for (i, account) in accounts.iter().enumerate() {
         if account == keyed_account {
             return (true, i);
@@ -24,7 +24,7 @@ pub fn is_dup(accounts: &[KeyedAccount], keyed_account: &KeyedAccount) -> (bool,
 pub fn serialize_parameters(
     loader_id: &Pubkey,
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     data: &[u8],
 ) -> Result<(AlignedMemory, Vec<usize>), InstructionError> {
     if *loader_id == bpf_loader_deprecated::id() {
@@ -43,7 +43,7 @@ pub fn serialize_parameters(
 
 pub fn deserialize_parameters(
     loader_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     buffer: &[u8],
     account_lengths: &[usize],
     do_support_realloc: bool,
@@ -56,7 +56,7 @@ pub fn deserialize_parameters(
 }
 
 pub fn get_serialized_account_size_unaligned(
-    keyed_account: &KeyedAccount,
+    keyed_account: &KeyedAccount<'_>,
 ) -> Result<usize, InstructionError> {
     let data_len = keyed_account.data_len()?;
     Ok(
@@ -74,7 +74,7 @@ pub fn get_serialized_account_size_unaligned(
 
 pub fn serialize_parameters_unaligned(
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     instruction_data: &[u8],
 ) -> Result<AlignedMemory, InstructionError> {
     // Calculate size in order to alloc once
@@ -131,7 +131,7 @@ pub fn serialize_parameters_unaligned(
 }
 
 pub fn deserialize_parameters_unaligned(
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     buffer: &[u8],
     account_lengths: &[usize],
 ) -> Result<(), InstructionError> {
@@ -166,7 +166,7 @@ pub fn deserialize_parameters_unaligned(
 }
 
 pub fn get_serialized_account_size_aligned(
-    keyed_account: &KeyedAccount,
+    keyed_account: &KeyedAccount<'_>,
 ) -> Result<usize, InstructionError> {
     let data_len = keyed_account.data_len()?;
     Ok(
@@ -187,7 +187,7 @@ pub fn get_serialized_account_size_aligned(
 
 pub fn serialize_parameters_aligned(
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     instruction_data: &[u8],
 ) -> Result<AlignedMemory, InstructionError> {
     // Calculate size in order to alloc once
@@ -257,7 +257,7 @@ pub fn serialize_parameters_aligned(
 }
 
 pub fn deserialize_parameters_aligned(
-    keyed_accounts: &[KeyedAccount],
+    keyed_accounts: &[KeyedAccount<'_>],
     buffer: &[u8],
     account_lengths: &[usize],
     do_support_realloc: bool,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -115,7 +115,7 @@ impl SyscallConsume for Rc<RefCell<ComputeMeter>> {
 use crate::allocator_bump::BpfAllocator;
 
 pub fn register_syscalls(
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<SyscallRegistry, EbpfError<BpfError>> {
     let mut syscall_registry = SyscallRegistry::default();
 
@@ -409,7 +409,7 @@ pub fn bind_syscall_context_objects<'a, 'b>(
 }
 
 fn translate(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     access_type: AccessType,
     vm_addr: u64,
     len: u64,
@@ -418,7 +418,7 @@ fn translate(
 }
 
 fn translate_type_inner<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     access_type: AccessType,
     vm_addr: u64,
     loader_id: &Pubkey,
@@ -433,14 +433,14 @@ fn translate_type_inner<'a, T>(
     Ok(unsafe { &mut *(host_addr as *mut T) })
 }
 fn translate_type_mut<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     vm_addr: u64,
     loader_id: &Pubkey,
 ) -> Result<&'a mut T, EbpfError<BpfError>> {
     translate_type_inner::<T>(memory_mapping, AccessType::Store, vm_addr, loader_id)
 }
 fn translate_type<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     vm_addr: u64,
     loader_id: &Pubkey,
 ) -> Result<&'a T, EbpfError<BpfError>> {
@@ -449,7 +449,7 @@ fn translate_type<'a, T>(
 }
 
 fn translate_slice_inner<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     access_type: AccessType,
     vm_addr: u64,
     len: u64,
@@ -474,7 +474,7 @@ fn translate_slice_inner<'a, T>(
     Ok(unsafe { from_raw_parts_mut(host_addr as *mut T, len as usize) })
 }
 fn translate_slice_mut<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     vm_addr: u64,
     len: u64,
     loader_id: &Pubkey,
@@ -482,7 +482,7 @@ fn translate_slice_mut<'a, T>(
     translate_slice_inner::<T>(memory_mapping, AccessType::Store, vm_addr, len, loader_id)
 }
 fn translate_slice<'a, T>(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     vm_addr: u64,
     len: u64,
     loader_id: &Pubkey,
@@ -494,7 +494,7 @@ fn translate_slice<'a, T>(
 /// Take a virtual pointer to a string (points to BPF VM memory space), translate it
 /// pass it to a user-defined work function
 fn translate_string_and_do(
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     addr: u64,
     len: u64,
     loader_id: &Pubkey,
@@ -524,7 +524,7 @@ impl SyscallObject<BpfError> for SyscallAbort {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         *result = Err(SyscallError::Abort.into());
@@ -545,7 +545,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallPanic<'a, 'b> {
         line: u64,
         column: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -584,7 +584,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLog<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -630,7 +630,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogU64<'a, 'b> {
         arg3: u64,
         arg4: u64,
         arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -665,7 +665,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -697,7 +697,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogPubkey<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -742,7 +742,7 @@ impl SyscallObject<BpfError> for SyscallAllocFree {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        _memory_mapping: &MemoryMapping,
+        _memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let align = if self.aligned {
@@ -773,7 +773,7 @@ fn translate_and_check_program_address_inputs<'a>(
     seeds_addr: u64,
     seeds_len: u64,
     program_id_addr: u64,
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
     loader_id: &Pubkey,
 ) -> Result<(Vec<&'a [u8]>, &'a Pubkey), EbpfError<BpfError>> {
     let untranslated_seeds =
@@ -811,7 +811,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a, 'b> {
         program_id_addr: u64,
         address_addr: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -870,7 +870,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a, 'b> {
         program_id_addr: u64,
         address_addr: u64,
         bump_seed_addr: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -943,7 +943,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSha256<'a, 'b> {
         result_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1003,8 +1003,8 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId>(
     id: &Pubkey,
     var_addr: u64,
     loader_id: &Pubkey,
-    memory_mapping: &MemoryMapping,
-    invoke_context: Rc<RefCell<&mut InvokeContext>>,
+    memory_mapping: &MemoryMapping<'_>,
+    invoke_context: Rc<RefCell<&mut InvokeContext<'_>>>,
 ) -> Result<u64, EbpfError<BpfError>> {
     let invoke_context = invoke_context
         .try_borrow()
@@ -1033,7 +1033,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetClockSysvar<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1069,7 +1069,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1106,7 +1106,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1142,7 +1142,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetRentSysvar<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1179,7 +1179,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallKeccak256<'a, 'b> {
         result_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1257,7 +1257,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         if check_overlapping(src_addr, dst_addr, n) {
@@ -1306,7 +1306,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemmove<'a, 'b> {
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1350,7 +1350,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcmp<'a, 'b> {
         n: u64,
         cmp_result_addr: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1407,7 +1407,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemset<'a, 'b> {
         n: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1449,7 +1449,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a, 'b> {
         signature_addr: u64,
         result_addr: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1549,7 +1549,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallBlake3<'a, 'b> {
         result_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -1630,13 +1630,14 @@ type TranslatedAccounts<'a> = (
 
 /// Implemented by language specific data structure translators
 trait SyscallInvokeSigned<'a, 'b> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>>;
+    fn get_context_mut(&self)
+        -> Result<RefMut<'_, &'a mut InvokeContext<'b>>, EbpfError<BpfError>>;
     fn translate_instruction(
         &self,
         loader_id: &Pubkey,
         addr: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<Instruction, EbpfError<BpfError>>;
     fn translate_accounts<'c>(
         &'c self,
@@ -1644,8 +1645,8 @@ trait SyscallInvokeSigned<'a, 'b> {
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>>;
     fn translate_signers(
         &self,
@@ -1653,7 +1654,7 @@ trait SyscallInvokeSigned<'a, 'b> {
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
     ) -> Result<Vec<Pubkey>, EbpfError<BpfError>>;
 }
 
@@ -1663,7 +1664,9 @@ pub struct SyscallInvokeSignedRust<'a, 'b> {
     orig_data_lens: &'a [usize],
 }
 impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
+    fn get_context_mut(
+        &self,
+    ) -> Result<RefMut<'_, &'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
         self.invoke_context
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
@@ -1673,8 +1676,8 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
         &self,
         loader_id: &Pubkey,
         addr: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix = translate_type::<Instruction>(memory_mapping, addr, loader_id)?;
 
@@ -1707,10 +1710,10 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>> {
-        let account_infos = translate_slice::<AccountInfo>(
+        let account_infos = translate_slice::<AccountInfo<'_>>(
             memory_mapping,
             account_infos_addr,
             account_infos_len,
@@ -1728,7 +1731,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
             })
             .collect::<Result<Vec<_>, EbpfError<BpfError>>>()?;
 
-        let translate = |account_info: &AccountInfo, invoke_context: &InvokeContext| {
+        let translate = |account_info: &AccountInfo<'_>, invoke_context: &InvokeContext<'_>| {
             // Translate the account from user space
 
             let lamports = {
@@ -1814,7 +1817,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
     ) -> Result<Vec<Pubkey>, EbpfError<BpfError>> {
         let mut signers = Vec::new();
         if signers_seeds_len > 0 {
@@ -1869,7 +1872,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a, 'b> {
         account_infos_len: u64,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         *result = call(
@@ -1940,7 +1943,9 @@ pub struct SyscallInvokeSignedC<'a, 'b> {
     orig_data_lens: &'a [usize],
 }
 impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
-    fn get_context_mut(&self) -> Result<RefMut<&'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
+    fn get_context_mut(
+        &self,
+    ) -> Result<RefMut<'_, &'a mut InvokeContext<'b>>, EbpfError<BpfError>> {
         self.invoke_context
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
@@ -1950,8 +1955,8 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
         &self,
         loader_id: &Pubkey,
         addr: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, loader_id)?;
 
@@ -1996,8 +2001,8 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
         message: &Message,
         account_infos_addr: u64,
         account_infos_len: u64,
-        memory_mapping: &MemoryMapping,
-        invoke_context: &mut InvokeContext,
+        memory_mapping: &MemoryMapping<'_>,
+        invoke_context: &mut InvokeContext<'_>,
     ) -> Result<TranslatedAccounts<'c>, EbpfError<BpfError>> {
         let account_infos = translate_slice::<SolAccountInfo>(
             memory_mapping,
@@ -2013,7 +2018,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
             })
             .collect::<Result<Vec<_>, EbpfError<BpfError>>>()?;
 
-        let translate = |account_info: &SolAccountInfo, invoke_context: &InvokeContext| {
+        let translate = |account_info: &SolAccountInfo, invoke_context: &InvokeContext<'_>| {
             // Translate the account from user space
 
             let lamports =
@@ -2081,7 +2086,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
         program_id: &Pubkey,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
     ) -> Result<Vec<Pubkey>, EbpfError<BpfError>> {
         if signers_seeds_len > 0 {
             let signers_seeds = translate_slice::<SolSignerSeedC>(
@@ -2131,7 +2136,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedC<'a, 'b> {
         account_infos_len: u64,
         signers_seeds_addr: u64,
         signers_seeds_len: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         *result = call(
@@ -2150,12 +2155,12 @@ fn get_translated_accounts<'a, T, F>(
     message: &Message,
     account_info_keys: &[&Pubkey],
     account_infos: &[T],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
     orig_data_lens: &[usize],
     do_translate: F,
 ) -> Result<TranslatedAccounts<'a>, EbpfError<BpfError>>
 where
-    F: Fn(&T, &InvokeContext) -> Result<CallerAccount<'a>, EbpfError<BpfError>>,
+    F: Fn(&T, &InvokeContext<'_>) -> Result<CallerAccount<'a>, EbpfError<BpfError>>,
 {
     let demote_program_write_locks =
         invoke_context.is_feature_active(&demote_program_write_locks::id());
@@ -2238,7 +2243,7 @@ where
 fn check_instruction_size(
     num_accounts: usize,
     data_len: usize,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), EbpfError<BpfError>> {
     let size = num_accounts
         .saturating_mul(size_of::<AccountMeta>())
@@ -2252,7 +2257,7 @@ fn check_instruction_size(
 
 fn check_account_infos(
     len: usize,
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), EbpfError<BpfError>> {
     if len * size_of::<Pubkey>() > invoke_context.get_compute_budget().max_cpi_instruction_size {
         // Cap the number of account_infos a caller can pass to approximate
@@ -2265,7 +2270,7 @@ fn check_account_infos(
 fn check_authorized_program(
     program_id: &Pubkey,
     instruction_data: &[u8],
-    invoke_context: &InvokeContext,
+    invoke_context: &InvokeContext<'_>,
 ) -> Result<(), EbpfError<BpfError>> {
     #[allow(clippy::blocks_in_if_conditions)]
     if native_loader::check_id(program_id)
@@ -2293,7 +2298,7 @@ fn call<'a, 'b: 'a>(
     account_infos_len: u64,
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
-    memory_mapping: &MemoryMapping,
+    memory_mapping: &MemoryMapping<'_>,
 ) -> Result<u64, EbpfError<BpfError>> {
     let mut invoke_context = syscall.get_context_mut()?;
     invoke_context
@@ -2414,7 +2419,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let mut invoke_context = question_mark!(
@@ -2475,7 +2480,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetReturnData<'a, 'b> {
         program_id_addr: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -2542,7 +2547,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogData<'a, 'b> {
         _arg3: u64,
         _arg4: u64,
         _arg5: u64,
-        memory_mapping: &MemoryMapping,
+        memory_mapping: &MemoryMapping<'_>,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
         let invoke_context = question_mark!(
@@ -3792,7 +3797,7 @@ mod tests {
     }
 
     fn create_program_address(
-        invoke_context: &mut InvokeContext,
+        invoke_context: &mut InvokeContext<'_>,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<Pubkey, EbpfError<BpfError>> {
@@ -3804,7 +3809,7 @@ mod tests {
     }
 
     fn try_find_program_address(
-        invoke_context: &mut InvokeContext,
+        invoke_context: &mut InvokeContext<'_>,
         seeds: &[&[u8]],
         address: &Pubkey,
     ) -> Result<(Pubkey, u8), EbpfError<BpfError>> {

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -4,7 +4,7 @@ use solana_sdk::instruction::InstructionError;
 pub fn process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut InvokeContext,
+    _invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     // Do nothing, compute budget instructions handled by the runtime
     Ok(())

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeSet;
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 

--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -22,7 +22,7 @@ pub fn from<T: ReadableAccount>(account: &T) -> Option<Config> {
         .and_then(|data| deserialize(data).ok())
 }
 
-pub fn from_keyed_account(account: &KeyedAccount) -> Result<Config, InstructionError> {
+pub fn from_keyed_account(account: &KeyedAccount<'_>) -> Result<Config, InstructionError> {
     if !config::check_id(account.unsigned_key()) {
         return Err(InstructionError::InvalidArgument);
     }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -25,7 +25,7 @@ pub use solana_sdk::stake::instruction::*;
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -362,7 +362,7 @@ pub trait StakeAccount {
     ) -> Result<(), InstructionError>;
     fn authorize_with_seed(
         &self,
-        authority_base: &KeyedAccount,
+        authority_base: &KeyedAccount<'_>,
         authority_seed: &str,
         authority_owner: &Pubkey,
         new_authority: &Pubkey,
@@ -373,7 +373,7 @@ pub trait StakeAccount {
     ) -> Result<(), InstructionError>;
     fn delegate(
         &self,
-        vote_account: &KeyedAccount,
+        vote_account: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
         config: &Config,
@@ -390,13 +390,13 @@ pub trait StakeAccount {
     fn split(
         &self,
         lamports: u64,
-        split_stake: &KeyedAccount,
+        split_stake: &KeyedAccount<'_>,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError>;
     fn merge(
         &self,
-        invoke_context: &InvokeContext,
-        source_stake: &KeyedAccount,
+        invoke_context: &InvokeContext<'_>,
+        source_stake: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
         signers: &HashSet<Pubkey>,
@@ -405,11 +405,11 @@ pub trait StakeAccount {
     fn withdraw(
         &self,
         lamports: u64,
-        to: &KeyedAccount,
+        to: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
-        withdraw_authority: &KeyedAccount,
-        custodian: Option<&KeyedAccount>,
+        withdraw_authority: &KeyedAccount<'_>,
+        custodian: Option<&KeyedAccount<'_>>,
         prevent_withdraw_to_zero: bool,
     ) -> Result<(), InstructionError>;
 }
@@ -485,7 +485,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     }
     fn authorize_with_seed(
         &self,
-        authority_base: &KeyedAccount,
+        authority_base: &KeyedAccount<'_>,
         authority_seed: &str,
         authority_owner: &Pubkey,
         new_authority: &Pubkey,
@@ -513,7 +513,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     }
     fn delegate(
         &self,
-        vote_account: &KeyedAccount,
+        vote_account: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
         config: &Config,
@@ -585,7 +585,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     fn split(
         &self,
         lamports: u64,
-        split: &KeyedAccount,
+        split: &KeyedAccount<'_>,
         signers: &HashSet<Pubkey>,
     ) -> Result<(), InstructionError> {
         if split.owner()? != id() {
@@ -701,8 +701,8 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
 
     fn merge(
         &self,
-        invoke_context: &InvokeContext,
-        source_account: &KeyedAccount,
+        invoke_context: &InvokeContext<'_>,
+        source_account: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
         signers: &HashSet<Pubkey>,
@@ -757,11 +757,11 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
     fn withdraw(
         &self,
         lamports: u64,
-        to: &KeyedAccount,
+        to: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
-        withdraw_authority: &KeyedAccount,
-        custodian: Option<&KeyedAccount>,
+        withdraw_authority: &KeyedAccount<'_>,
+        custodian: Option<&KeyedAccount<'_>>,
         prevent_withdraw_to_zero: bool,
     ) -> Result<(), InstructionError> {
         let mut signers = HashSet::new();
@@ -865,8 +865,8 @@ impl MergeKind {
     }
 
     fn get_if_mergeable(
-        invoke_context: &InvokeContext,
-        stake_keyed_account: &KeyedAccount,
+        invoke_context: &InvokeContext<'_>,
+        stake_keyed_account: &KeyedAccount<'_>,
         clock: &Clock,
         stake_history: &StakeHistory,
     ) -> Result<Self, InstructionError> {
@@ -897,7 +897,7 @@ impl MergeKind {
     }
 
     fn metas_can_merge(
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
         stake: &Meta,
         source: &Meta,
         clock: Option<&Clock>,
@@ -926,7 +926,7 @@ impl MergeKind {
     }
 
     fn active_delegations_can_merge(
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
         stake: &Delegation,
         source: &Delegation,
     ) -> Result<(), InstructionError> {
@@ -946,7 +946,7 @@ impl MergeKind {
 
     // Remove this when the `stake_merge_with_unmatched_credits_observed` feature is removed
     fn active_stakes_can_merge(
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
         stake: &Stake,
         source: &Stake,
     ) -> Result<(), InstructionError> {
@@ -969,7 +969,7 @@ impl MergeKind {
 
     fn merge(
         self,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
         source: Self,
         clock: Option<&Clock>,
     ) -> Result<Option<StakeState>, InstructionError> {
@@ -1033,7 +1033,7 @@ impl MergeKind {
 }
 
 fn merge_delegation_stake_and_credits_observed(
-    invoke_context: &InvokeContext,
+    invoke_context: &InvokeContext<'_>,
     stake: &mut Stake,
     absorbed_lamports: u64,
     absorbed_credits_observed: u64,
@@ -5453,9 +5453,9 @@ mod tests {
         );
 
         fn try_merge(
-            invoke_context: &InvokeContext,
-            stake_account: &KeyedAccount,
-            source_account: &KeyedAccount,
+            invoke_context: &InvokeContext<'_>,
+            stake_account: &KeyedAccount<'_>,
+            source_account: &KeyedAccount<'_>,
             clock: &Clock,
             stake_history: &StakeHistory,
             signers: &HashSet<Pubkey>,

--- a/programs/vote/src/authorized_voters.rs
+++ b/programs/vote/src/authorized_voters.rs
@@ -76,7 +76,7 @@ impl AuthorizedVoters {
         self.authorized_voters.get(&epoch).is_some()
     }
 
-    pub fn iter(&self) -> std::collections::btree_map::Iter<Epoch, Pubkey> {
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, Epoch, Pubkey> {
         self.authorized_voters.iter()
     }
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -296,8 +296,8 @@ pub fn withdraw(
 }
 
 fn verify_rent_exemption(
-    keyed_account: &KeyedAccount,
-    rent_sysvar_account: &KeyedAccount,
+    keyed_account: &KeyedAccount<'_>,
+    rent_sysvar_account: &KeyedAccount<'_>,
 ) -> Result<(), InstructionError> {
     let rent: sysvar::rent::Rent = from_keyed_account(rent_sysvar_account)?;
     if !rent.is_exempt(keyed_account.lamports()?, keyed_account.data_len()?) {
@@ -310,7 +310,7 @@ fn verify_rent_exemption(
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -597,7 +597,7 @@ impl VoteState {
 /// but will implicitly withdraw authorization from the previously authorized
 /// key
 pub fn authorize<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     authorized: &Pubkey,
     vote_authorize: VoteAuthorize,
     signers: &HashSet<Pubkey, S>,
@@ -627,7 +627,7 @@ pub fn authorize<S: std::hash::BuildHasher>(
 
 /// Update the node_pubkey, requires signature of the authorized voter
 pub fn update_validator_identity<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     node_pubkey: &Pubkey,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
@@ -647,7 +647,7 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
 
 /// Update the vote account's commission
 pub fn update_commission<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     commission: u8,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
@@ -675,9 +675,9 @@ fn verify_authorized_signer<S: std::hash::BuildHasher>(
 
 /// Withdraw funds from the vote account
 pub fn withdraw<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     lamports: u64,
-    to_account: &KeyedAccount,
+    to_account: &KeyedAccount<'_>,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
     let vote_state: VoteState =
@@ -706,7 +706,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 /// Assumes that the account is being init as part of a account creation or balance transfer and
 /// that the transaction must be signed by the staker's keys
 pub fn initialize_account<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     vote_init: &VoteInit,
     signers: &HashSet<Pubkey, S>,
     clock: &Clock,
@@ -729,7 +729,7 @@ pub fn initialize_account<S: std::hash::BuildHasher>(
 }
 
 pub fn process_vote<S: std::hash::BuildHasher>(
-    vote_account: &KeyedAccount,
+    vote_account: &KeyedAccount<'_>,
     slot_hashes: &[SlotHash],
     clock: &Clock,
     vote: &Vote,

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -13,7 +13,7 @@ use {
     std::{cmp::min, convert::TryFrom, fmt, sync::Arc},
 };
 
-static CHECK_MARK: Emoji = Emoji("✅ ", "");
+static CHECK_MARK: Emoji<'_, '_> = Emoji("✅ ", "");
 
 const DEPRECATE_VERSION_BEFORE: FirmwareVersion = FirmwareVersion::new(0, 2, 0);
 

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -61,7 +61,7 @@ impl AsRef<str> for Manufacturer {
 }
 
 impl std::fmt::Display for Manufacturer {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s: &str = self.as_ref();
         write!(f, "{}", s)
     }
@@ -94,7 +94,7 @@ pub struct Locator {
 }
 
 impl std::fmt::Display for Locator {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let maybe_path = self.pubkey.map(|p| p.to_string());
         let path = maybe_path.as_deref().unwrap_or("/");
 

--- a/replica-lib/src/replica_accounts_server.rs
+++ b/replica-lib/src/replica_accounts_server.rs
@@ -21,7 +21,7 @@ pub(crate) struct ReplicaAccountsServerImpl {
 impl Eq for ReplicaAccountInfo {}
 
 impl ReplicaAccountInfo {
-    fn from_stored_account_meta(stored_account_meta: &StoredAccountMeta) -> Self {
+    fn from_stored_account_meta(stored_account_meta: &StoredAccountMeta<'_>) -> Self {
         let account_meta = Some(ReplicaAccountMeta {
             pubkey: stored_account_meta.meta.pubkey.to_bytes().to_vec(),
             lamports: stored_account_meta.account_meta.lamports,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -39,7 +39,7 @@ pub enum BankNotification {
 }
 
 impl std::fmt::Debug for BankNotification {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BankNotification::OptimisticallyConfirmed(slot) => {
                 write!(f, "OptimisticallyConfirmed({:?})", slot)

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -101,7 +101,7 @@ pub enum NotificationEntry {
 }
 
 impl std::fmt::Debug for NotificationEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NotificationEntry::Root(root) => write!(f, "Root({})", root),
             NotificationEntry::Vote(vote) => write!(f, "Vote({:?})", vote),

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -34,7 +34,7 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 fn process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut InvokeContext,
+    _invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     Ok(())
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -563,16 +563,16 @@ impl Accounts {
     /// returns only the latest/current version of B for this slot
     pub fn scan_slot<F, B>(&self, slot: Slot, func: F) -> Vec<B>
     where
-        F: Fn(LoadedAccount) -> Option<B> + Send + Sync,
+        F: Fn(LoadedAccount<'_>) -> Option<B> + Send + Sync,
         B: Sync + Send + Default + std::cmp::Eq,
     {
         let scan_result = self.accounts_db.scan_account_storage(
             slot,
-            |loaded_account: LoadedAccount| {
+            |loaded_account: LoadedAccount<'_>| {
                 // Cache only has one version per key, don't need to worry about versioning
                 func(loaded_account)
             },
-            |accum: &DashMap<Pubkey, (u64, B)>, loaded_account: LoadedAccount| {
+            |accum: &DashMap<Pubkey, (u64, B)>, loaded_account: LoadedAccount<'_>| {
                 let loaded_account_pubkey = *loaded_account.pubkey();
                 let loaded_write_version = loaded_account.write_version();
                 let should_insert = accum

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -64,7 +64,7 @@ impl DropCallback for SendDroppedBankCallback {
 }
 
 impl Debug for SendDroppedBankCallback {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "SendDroppedBankCallback({:p})", self)
     }
 }

--- a/runtime/src/accounts_db/accountsdb_plugin_utils.rs
+++ b/runtime/src/accounts_db/accountsdb_plugin_utils.rs
@@ -80,7 +80,7 @@ impl AccountsDb {
         let slot_stores = self.storage.get_slot_stores(slot).unwrap();
 
         let slot_stores = slot_stores.read().unwrap();
-        let mut accounts_to_stream: HashMap<Pubkey, StoredAccountMeta> = HashMap::default();
+        let mut accounts_to_stream: HashMap<Pubkey, StoredAccountMeta<'_>> = HashMap::default();
         let mut measure_filter = Measure::start("accountsdb-plugin-filtering-accounts");
         for (_, storage_entry) in slot_stores.iter() {
             let mut accounts = storage_entry.all_accounts();
@@ -116,7 +116,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         notified_accounts: &mut HashSet<Pubkey>,
-        accounts_to_stream: &HashMap<Pubkey, StoredAccountMeta>,
+        accounts_to_stream: &HashMap<Pubkey, StoredAccountMeta<'_>>,
         notify_stats: &mut AccountsDbPluginNotifyAtSnapshotRestoreStats,
     ) {
         let notifier = self
@@ -195,7 +195,11 @@ pub mod tests {
 
         /// Notified when the AccountsDb is initialized at start when restored
         /// from a snapshot.
-        fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta) {
+        fn notify_account_restore_from_snapshot(
+            &self,
+            slot: Slot,
+            account: &StoredAccountMeta<'_>,
+        ) {
             self.accounts_notified
                 .entry(account.meta.pubkey)
                 .or_insert(Vec::default())

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -253,7 +253,7 @@ pub struct ReadAccountMapEntry<T: IndexValue> {
 }
 
 impl<T: IndexValue> Debug for ReadAccountMapEntry<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.borrow_owned_entry())
     }
 }
@@ -652,7 +652,7 @@ pub struct AccountsIndexIterator<'a, T: IndexValue> {
 
 impl<'a, T: IndexValue> AccountsIndexIterator<'a, T> {
     fn range<R>(
-        map: &AccountMapsReadLock<T>,
+        map: &AccountMapsReadLock<'_, T>,
         range: R,
         collect_all_unsorted: bool,
     ) -> Vec<(Pubkey, AccountMapEntry<T>)>
@@ -888,7 +888,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         (account_maps, bin_calculator, storage)
     }
 
-    fn iter<R>(&self, range: Option<&R>, collect_all_unsorted: bool) -> AccountsIndexIterator<T>
+    fn iter<R>(&self, range: Option<&R>, collect_all_unsorted: bool) -> AccountsIndexIterator<'_, T>
     where
         R: RangeBounds<Pubkey>,
     {
@@ -1344,7 +1344,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         )
     }
 
-    pub fn get_rooted_entries(&self, slice: SlotSlice<T>, max: Option<Slot>) -> SlotList<T> {
+    pub fn get_rooted_entries(&self, slice: SlotSlice<'_, T>, max: Option<Slot>) -> SlotList<T> {
         let max = max.unwrap_or(Slot::MAX);
         let lock = &self.roots_tracker.read().unwrap().roots;
         slice
@@ -1404,7 +1404,7 @@ impl<T: IndexValue> AccountsIndex<T> {
     fn latest_slot(
         &self,
         ancestors: Option<&Ancestors>,
-        slice: SlotSlice<T>,
+        slice: SlotSlice<'_, T>,
         max_root: Option<Slot>,
     ) -> Option<usize> {
         let mut current_max = 0;
@@ -1527,7 +1527,7 @@ impl<T: IndexValue> AccountsIndex<T> {
     // Get the maximum root <= `max_allowed_root` from the given `slice`
     fn get_newest_root_in_slot_list(
         roots: &RollingBitField,
-        slice: SlotSlice<T>,
+        slice: SlotSlice<'_, T>,
         max_allowed_root: Option<Slot>,
     ) -> Slot {
         let mut max_root = 0;
@@ -1598,13 +1598,13 @@ impl<T: IndexValue> AccountsIndex<T> {
         }
     }
 
-    fn get_account_maps_write_lock(&self, pubkey: &Pubkey) -> AccountMapsWriteLock<T> {
+    fn get_account_maps_write_lock(&self, pubkey: &Pubkey) -> AccountMapsWriteLock<'_, T> {
         self.account_maps[self.bin_calculator.bin_from_pubkey(pubkey)]
             .write()
             .unwrap()
     }
 
-    pub(crate) fn get_account_maps_read_lock(&self, pubkey: &Pubkey) -> AccountMapsReadLock<T> {
+    pub(crate) fn get_account_maps_read_lock(&self, pubkey: &Pubkey) -> AccountMapsReadLock<'_, T> {
         self.account_maps[self.bin_calculator.bin_from_pubkey(pubkey)]
             .read()
             .unwrap()

--- a/runtime/src/accounts_update_notifier_interface.rs
+++ b/runtime/src/accounts_update_notifier_interface.rs
@@ -10,7 +10,7 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
 
     /// Notified when the AccountsDb is initialized at start when restored
     /// from a snapshot.
-    fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta);
+    fn notify_account_restore_from_snapshot(&self, slot: Slot, account: &StoredAccountMeta<'_>);
 
     /// Notified when all accounts have been notified when restoring from a snapshot.
     fn notify_end_of_restore_from_snapshot(&self);

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -463,7 +463,7 @@ impl AppendVec {
     }
 
     /// Return account metadata for each account, starting from `offset`.
-    pub fn accounts(&self, mut offset: usize) -> Vec<StoredAccountMeta> {
+    pub fn accounts(&self, mut offset: usize) -> Vec<StoredAccountMeta<'_>> {
         let mut accounts = vec![];
         while let Some((account, next)) = self.get_account(offset) {
             accounts.push(account);

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -127,7 +127,7 @@ impl BlockhashQueue {
         note = "Please do not use, will no longer be available in the future"
     )]
     #[allow(deprecated)]
-    pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem> {
+    pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem<'_>> {
         (&self.ages).iter().map(|(k, v)| {
             recent_blockhashes::IterItem(v.hash_height, k, v.fee_calculator.lamports_per_signature)
         })

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -15,7 +15,7 @@ fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
     first_instruction_account: usize,
     instruction_data: &[u8],
-    invoke_context: &mut InvokeContext,
+    invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
     let program_id = invoke_context.get_caller()?;
@@ -35,7 +35,7 @@ macro_rules! with_program_logging {
     ($process_instruction:expr) => {
         |first_instruction_account: usize,
          instruction_data: &[u8],
-         invoke_context: &mut InvokeContext| {
+         invoke_context: &mut InvokeContext<'_>| {
             process_instruction_with_program_logging(
                 $process_instruction,
                 first_instruction_account,
@@ -75,7 +75,7 @@ impl Builtin {
 }
 
 impl fmt::Debug for Builtin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Builtin [name={}, id={}]", self.name, self.id)
     }
 }
@@ -135,7 +135,7 @@ fn genesis_builtins() -> Vec<Builtin> {
 fn dummy_process_instruction(
     _first_instruction_account: usize,
     _data: &[u8],
-    _invoke_context: &mut InvokeContext,
+    _invoke_context: &mut InvokeContext<'_>,
 ) -> Result<(), InstructionError> {
     Ok(())
 }

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -222,7 +222,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         })
     }
 
-    fn remove_if_slot_list_empty_value(&self, slot_list: SlotSlice<T>) -> bool {
+    fn remove_if_slot_list_empty_value(&self, slot_list: SlotSlice<'_, T>) -> bool {
         if slot_list.is_empty() {
             self.stats().insert_or_delete(false, self.bin);
             true
@@ -237,7 +237,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
     }
 
-    fn remove_if_slot_list_empty_entry(&self, entry: Entry<K, AccountMapEntry<T>>) -> bool {
+    fn remove_if_slot_list_empty_entry(&self, entry: Entry<'_, K, AccountMapEntry<T>>) -> bool {
         match entry {
             Entry::Occupied(occupied) => {
                 let result =
@@ -540,7 +540,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     /// true if item already existed in the index
     fn upsert_on_disk(
         &self,
-        vacant: VacantEntry<K, AccountMapEntry<T>>,
+        vacant: VacantEntry<'_, K, AccountMapEntry<T>>,
         new_entry: PreAllocatedAccountMapEntry<T>,
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -166,7 +166,7 @@ mod tests {
         fn mock_system_process_instruction(
             first_instruction_account: usize,
             data: &[u8],
-            invoke_context: &mut InvokeContext,
+            invoke_context: &mut InvokeContext<'_>,
         ) -> Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             if let Ok(instruction) = bincode::deserialize(data) {
@@ -337,7 +337,7 @@ mod tests {
         fn mock_system_process_instruction(
             first_instruction_account: usize,
             data: &[u8],
-            invoke_context: &mut InvokeContext,
+            invoke_context: &mut InvokeContext<'_>,
         ) -> Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             if let Ok(instruction) = bincode::deserialize(data) {
@@ -538,7 +538,7 @@ mod tests {
         fn mock_process_instruction(
             _first_instruction_account: usize,
             _data: &[u8],
-            _invoke_context: &mut InvokeContext,
+            _invoke_context: &mut InvokeContext<'_>,
         ) -> Result<(), InstructionError> {
             Err(InstructionError::Custom(0xbabb1e))
         }

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -16,27 +16,27 @@ pub trait NonceKeyedAccount {
     fn advance_nonce_account(
         &self,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError>;
     fn withdraw_nonce_account(
         &self,
         lamports: u64,
-        to: &KeyedAccount,
+        to: &KeyedAccount<'_>,
         rent: &Rent,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError>;
     fn initialize_nonce_account(
         &self,
         nonce_authority: &Pubkey,
         rent: &Rent,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError>;
     fn authorize_nonce_account(
         &self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError>;
 }
 
@@ -44,7 +44,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
     fn advance_nonce_account(
         &self,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -105,10 +105,10 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
     fn withdraw_nonce_account(
         &self,
         lamports: u64,
-        to: &KeyedAccount,
+        to: &KeyedAccount<'_>,
         rent: &Rent,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -194,7 +194,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         &self,
         nonce_authority: &Pubkey,
         rent: &Rent,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -245,7 +245,7 @@ impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
         &self,
         nonce_authority: &Pubkey,
         signers: &HashSet<Pubkey>,
-        invoke_context: &InvokeContext,
+        invoke_context: &InvokeContext<'_>,
     ) -> Result<(), InstructionError> {
         let merge_nonce_error_into_system_error = invoke_context
             .is_feature_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -307,7 +307,7 @@ mod test {
 
     fn with_test_keyed_account<F>(lamports: u64, signer: bool, f: F)
     where
-        F: Fn(&KeyedAccount),
+        F: Fn(&KeyedAccount<'_>),
     {
         let pubkey = Pubkey::new_unique();
         let account = create_account(lamports);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -190,7 +190,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn bank_from_streams<R>(
     serde_style: SerdeStyle,
-    snapshot_streams: &mut SnapshotStreams<R>,
+    snapshot_streams: &mut SnapshotStreams<'_, R>,
     account_paths: &[PathBuf],
     unpacked_append_vec_map: UnpackedAppendVecMap,
     genesis_config: &GenesisConfig,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -70,7 +70,7 @@ impl Default for SnapshotVersion {
 }
 
 impl fmt::Display for SnapshotVersion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(From::from(*self))
     }
 }
@@ -464,7 +464,7 @@ pub fn deserialize_snapshot_data_file<T: Sized>(
     data_file_path: &Path,
     deserializer: impl FnOnce(&mut BufReader<File>) -> Result<T>,
 ) -> Result<T> {
-    let wrapped_deserializer = move |streams: &mut SnapshotStreams<File>| -> Result<T> {
+    let wrapped_deserializer = move |streams: &mut SnapshotStreams<'_, File>| -> Result<T> {
         deserializer(streams.full_snapshot_stream)
     };
 
@@ -482,7 +482,7 @@ pub fn deserialize_snapshot_data_file<T: Sized>(
 
 fn deserialize_snapshot_data_files<T: Sized>(
     snapshot_root_paths: &SnapshotRootPaths,
-    deserializer: impl FnOnce(&mut SnapshotStreams<File>) -> Result<T>,
+    deserializer: impl FnOnce(&mut SnapshotStreams<'_, File>) -> Result<T>,
 ) -> Result<T> {
     deserialize_snapshot_data_files_capped(
         snapshot_root_paths,
@@ -518,7 +518,7 @@ where
 fn deserialize_snapshot_data_files_capped<T: Sized>(
     snapshot_root_paths: &SnapshotRootPaths,
     maximum_file_size: u64,
-    deserializer: impl FnOnce(&mut SnapshotStreams<File>) -> Result<T>,
+    deserializer: impl FnOnce(&mut SnapshotStreams<'_, File>) -> Result<T>,
 ) -> Result<T> {
     let (full_snapshot_file_size, mut full_snapshot_data_file_stream) =
         create_snapshot_data_file_stream(

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -56,7 +56,7 @@ impl VoteAccount {
         self.account().lamports
     }
 
-    pub fn vote_state(&self) -> RwLockReadGuard<Result<VoteState, InstructionError>> {
+    pub fn vote_state(&self) -> RwLockReadGuard<'_, Result<VoteState, InstructionError>> {
         let inner = &self.0;
         inner.vote_state_once.call_once(|| {
             let vote_state = VoteState::deserialize(&inner.account.data);

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -114,7 +114,7 @@ where
 
 // Check whether a package is installed and install it if missing.
 fn install_if_missing(
-    config: &Config,
+    config: &Config<'_>,
     package: &str,
     version: &str,
     url: &str,
@@ -292,7 +292,7 @@ fn postprocess_dump(program_dump: &Path) {
 
 // Check whether the built .so file contains undefined symbols that are
 // not known to the runtime and warn about them if any.
-fn check_undefined_symbols(config: &Config, program: &Path) {
+fn check_undefined_symbols(config: &Config<'_>, program: &Path) {
     let syscalls_txt = config.bpf_sdk.join("syscalls.txt");
     let file = match File::open(syscalls_txt) {
         Ok(x) => x,
@@ -345,7 +345,7 @@ fn check_undefined_symbols(config: &Config, program: &Path) {
 }
 
 // check whether custom BPF toolchain is linked, and link it if it is not.
-fn link_bpf_toolchain(config: &Config) {
+fn link_bpf_toolchain(config: &Config<'_>) {
     let toolchain_path = config
         .bpf_sdk
         .join("dependencies")
@@ -396,7 +396,11 @@ fn link_bpf_toolchain(config: &Config) {
     }
 }
 
-fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_metadata::Package) {
+fn build_bpf_package(
+    config: &Config<'_>,
+    target_directory: &Path,
+    package: &cargo_metadata::Package,
+) {
     let program_name = {
         let cdylib_targets = package
             .targets
@@ -638,7 +642,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     }
 }
 
-fn build_bpf(config: Config, manifest_path: Option<PathBuf>) {
+fn build_bpf(config: Config<'_>, manifest_path: Option<PathBuf>) {
     let mut metadata_command = cargo_metadata::MetadataCommand::new();
     if let Some(manifest_path) = manifest_path {
         metadata_command.manifest_path(manifest_path);

--- a/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF noop program
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };
@@ -8,7 +7,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     // error to make build fail: no return value

--- a/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
@@ -1,6 +1,5 @@
 //! Example Rust-based BPF noop program
 
-extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
 };
@@ -8,7 +7,7 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    _accounts: &[AccountInfo<'_>],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     Ok(())

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! Input: a single literal base58 string representation of a program's id
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use proc_macro2::{Delimiter, Span, TokenTree};
 use quote::{quote, ToTokens};
@@ -18,7 +16,7 @@ use syn::{
 };
 
 fn parse_id(
-    input: ParseStream,
+    input: ParseStream<'_>,
     pubkey_type: proc_macro2::TokenStream,
 ) -> Result<proc_macro2::TokenStream> {
     let id = if input.peek(syn::LitStr) {
@@ -96,7 +94,7 @@ fn deprecated_id_to_tokens(
 struct SdkPubkey(proc_macro2::TokenStream);
 
 impl Parse for SdkPubkey {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_sdk::pubkey::Pubkey }).map(Self)
     }
 }
@@ -111,7 +109,7 @@ impl ToTokens for SdkPubkey {
 struct ProgramSdkPubkey(proc_macro2::TokenStream);
 
 impl Parse for ProgramSdkPubkey {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_program::pubkey::Pubkey }).map(Self)
     }
 }
@@ -126,7 +124,7 @@ impl ToTokens for ProgramSdkPubkey {
 struct Id(proc_macro2::TokenStream);
 
 impl Parse for Id {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_sdk::pubkey::Pubkey }).map(Self)
     }
 }
@@ -140,7 +138,7 @@ impl ToTokens for Id {
 struct IdDeprecated(proc_macro2::TokenStream);
 
 impl Parse for IdDeprecated {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_sdk::pubkey::Pubkey }).map(Self)
     }
 }
@@ -153,7 +151,7 @@ impl ToTokens for IdDeprecated {
 
 struct ProgramSdkId(proc_macro2::TokenStream);
 impl Parse for ProgramSdkId {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_program::pubkey::Pubkey }).map(Self)
     }
 }
@@ -166,7 +164,7 @@ impl ToTokens for ProgramSdkId {
 
 struct ProgramSdkIdDeprecated(proc_macro2::TokenStream);
 impl Parse for ProgramSdkIdDeprecated {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         parse_id(input, quote! { ::solana_program::pubkey::Pubkey }).map(Self)
     }
 }
@@ -184,7 +182,7 @@ struct RespanInput {
 }
 
 impl Parse for RespanInput {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let to_respan: Path = input.parse()?;
         let _comma: Token![,] = input.parse()?;
         let respan_tree: TokenTree = input.parse()?;
@@ -306,7 +304,7 @@ struct Pubkeys {
     pubkeys: proc_macro2::TokenStream,
 }
 impl Parse for Pubkeys {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let pubkey_type = quote! {
             ::solana_sdk::pubkey::Pubkey
         };

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -92,25 +92,25 @@ impl<'a> AccountInfo<'a> {
         Ok(self.try_borrow_data()?.is_empty())
     }
 
-    pub fn try_borrow_lamports(&self) -> Result<Ref<&mut u64>, ProgramError> {
+    pub fn try_borrow_lamports(&self) -> Result<Ref<'_, &mut u64>, ProgramError> {
         self.lamports
             .try_borrow()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<&'a mut u64>, ProgramError> {
+    pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<'_, &'a mut u64>, ProgramError> {
         self.lamports
             .try_borrow_mut()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_data(&self) -> Result<Ref<&mut [u8]>, ProgramError> {
+    pub fn try_borrow_data(&self) -> Result<Ref<'_, &mut [u8]>, ProgramError> {
         self.data
             .try_borrow()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_mut_data(&self) -> Result<RefMut<&'a mut [u8]>, ProgramError> {
+    pub fn try_borrow_mut_data(&self) -> Result<RefMut<'_, &'a mut [u8]>, ProgramError> {
         self.data
             .try_borrow_mut()
             .map_err(|_| ProgramError::AccountBorrowFailed)

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -270,7 +270,7 @@ impl<'a, T: Account> IntoAccountInfo<'a> for &'a mut (Pubkey, T) {
 ///
 /// pub fn process_instruction(
 ///     program_id: &Pubkey,
-///     accounts: &[AccountInfo],
+///     accounts: &[AccountInfo<'_>],
 ///     instruction_data: &[u8],
 /// ) -> ProgramResult {
 ///     let accounts_iter = &mut accounts.iter();
@@ -321,7 +321,7 @@ pub fn next_account_info<'a, 'b, I: Iterator<Item = &'a AccountInfo<'b>>>(
 ///
 /// pub fn process_instruction(
 ///     program_id: &Pubkey,
-///     accounts: &[AccountInfo],
+///     accounts: &[AccountInfo<'_>],
 ///     instruction_data: &[u8],
 /// ) -> ProgramResult {
 ///     let accounts_iter = &mut accounts.iter();

--- a/sdk/program/src/blake3.rs
+++ b/sdk/program/src/blake3.rs
@@ -55,13 +55,13 @@ impl AsRef<[u8]> for Hash {
 }
 
 impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
 impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -22,7 +22,7 @@ pub type ProgramResult = ResultGeneric<(), ProgramError>;
 /// program_id: Program ID of the currently executing program accounts: Accounts
 /// passed as part of the instruction instruction_data: Instruction data
 pub type ProcessInstruction =
-    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+    fn(program_id: &Pubkey, accounts: &[AccountInfo<'_>], instruction_data: &[u8]) -> ProgramResult;
 
 /// Programs indicate success with a return value of 0
 pub const SUCCESS: u64 = 0;

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -49,7 +49,7 @@ pub const HEAP_LENGTH: usize = 32 * 1024;
 /// ```ignore
 /// fn process_instruction(
 ///     program_id: &Pubkey,      // Public key of the account the program was loaded into
-///     accounts: &[AccountInfo], // All accounts required to process the instruction
+///     accounts: &[AccountInfo<'_>], // All accounts required to process the instruction
 ///     instruction_data: &[u8],  // Serialized instruction-specific data
 /// ) -> ProgramResult;
 /// ```
@@ -101,7 +101,7 @@ pub const HEAP_LENGTH: usize = 32 * 1024;
 ///
 ///     pub fn process_instruction(
 ///         program_id: &Pubkey,
-///         accounts: &[AccountInfo],
+///         accounts: &[AccountInfo<'_>],
 ///         instruction_data: &[u8],
 ///     ) -> ProgramResult {
 ///         msg!("Hello world");

--- a/sdk/program/src/entrypoint_deprecated.rs
+++ b/sdk/program/src/entrypoint_deprecated.rs
@@ -23,7 +23,7 @@ pub type ProgramResult = ResultGeneric<(), ProgramError>;
 /// accounts: Accounts passed as part of the instruction
 /// instruction_data: Instruction data
 pub type ProcessInstruction =
-    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+    fn(program_id: &Pubkey, accounts: &[AccountInfo<'_>], instruction_data: &[u8]) -> ProgramResult;
 
 /// Programs indicate success with a return value of 0
 pub const SUCCESS: u64 = 0;

--- a/sdk/program/src/feature.rs
+++ b/sdk/program/src/feature.rs
@@ -31,7 +31,7 @@ impl Feature {
         .unwrap() as usize
     }
 
-    pub fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
+    pub fn from_account_info(account_info: &AccountInfo<'_>) -> Result<Self, ProgramError> {
         if *account_info.owner != id() {
             return Err(ProgramError::InvalidArgument);
         }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -58,13 +58,13 @@ impl AsRef<[u8]> for Hash {
 }
 
 impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
 impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -56,13 +56,13 @@ impl AsRef<[u8]> for Hash {
 }
 
 impl fmt::Debug for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
 impl fmt::Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -117,7 +117,7 @@ pub fn sol_log_slice(slice: &[u8]) {
 /// @param ka - A pointer to an array of `AccountInfo` to print
 /// @param data - A pointer to the instruction data to print
 #[allow(dead_code)]
-pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
+pub fn sol_log_params(accounts: &[AccountInfo<'_>], data: &[u8]) {
     for (i, account) in accounts.iter().enumerate() {
         msg!("AccountInfo");
         msg!(0, 0, 0, 0, i);

--- a/sdk/program/src/message/mapped.rs
+++ b/sdk/program/src/message/mapped.rs
@@ -114,7 +114,8 @@ impl MappedMessage {
     /// Returns true if the account at the specified index is called as a program by an instruction
     pub fn is_key_called_as_program(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
-            self.message.instructions
+            self.message
+                .instructions
                 .iter()
                 .any(|ix| ix.program_id_index == key_index)
         } else {
@@ -279,13 +280,11 @@ mod tests {
                     num_readonly_unsigned_accounts: 0,
                 },
                 account_keys: vec![key0],
-                instructions: vec![
-                    CompiledInstruction {
-                        program_id_index: 2,
-                        accounts: vec![1],
-                        data: vec![],
-                    }
-                ],
+                instructions: vec![CompiledInstruction {
+                    program_id_index: 2,
+                    accounts: vec![1],
+                    data: vec![],
+                }],
                 ..v0::Message::default()
             },
             mapped_addresses: MappedAddresses {

--- a/sdk/program/src/message/versions.rs
+++ b/sdk/program/src/message/versions.rs
@@ -147,7 +147,7 @@ impl<'de> Deserialize<'de> for MessagePrefix {
         impl<'de> Visitor<'de> for PrefixVisitor {
             type Value = MessagePrefix;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("message prefix byte")
             }
 
@@ -174,7 +174,7 @@ impl<'de> Deserialize<'de> for VersionedMessage {
         impl<'de> Visitor<'de> for MessageVisitor {
             type Value = VersionedMessage;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("message bytes")
             }
 

--- a/sdk/program/src/native_token.rs
+++ b/sdk/program/src/native_token.rs
@@ -16,7 +16,7 @@ use std::fmt::{Debug, Display, Formatter, Result};
 pub struct Sol(pub u64);
 
 impl Sol {
-    fn write_in_sol(&self, f: &mut Formatter) -> Result {
+    fn write_in_sol(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
             "◎{}.{:09}",
@@ -27,13 +27,13 @@ impl Sol {
 }
 
 impl Display for Sol {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.write_in_sol(f)
     }
 }
 
 impl Debug for Sol {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.write_in_sol(f)
     }
 }

--- a/sdk/program/src/program.rs
+++ b/sdk/program/src/program.rs
@@ -9,7 +9,7 @@ use crate::{
 ///   `invoke_unchecked` instead, but at your own risk.
 /// - The program id of the instruction being issued must also be included in
 ///   `account_infos`.
-pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {
+pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo<'_>]) -> ProgramResult {
     invoke_signed(instruction, account_infos, &[])
 }
 
@@ -21,7 +21,10 @@ pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> Progr
 ///   include the checks call `invoke` instead.
 /// - The program id of the instruction being issued must also be included in
 ///   `account_infos`.
-pub fn invoke_unchecked(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {
+pub fn invoke_unchecked(
+    instruction: &Instruction,
+    account_infos: &[AccountInfo<'_>],
+) -> ProgramResult {
     invoke_signed_unchecked(instruction, account_infos, &[])
 }
 
@@ -34,7 +37,7 @@ pub fn invoke_unchecked(instruction: &Instruction, account_infos: &[AccountInfo]
 ///   `account_infos`.
 pub fn invoke_signed(
     instruction: &Instruction,
-    account_infos: &[AccountInfo],
+    account_infos: &[AccountInfo<'_>],
     signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     // Check that the account RefCells are consistent with the request
@@ -67,7 +70,7 @@ pub fn invoke_signed(
 ///   `account_infos`.
 pub fn invoke_signed_unchecked(
     instruction: &Instruction,
-    account_infos: &[AccountInfo],
+    account_infos: &[AccountInfo<'_>],
     signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     #[cfg(target_arch = "bpf")]

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -30,7 +30,7 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_invoke_signed(
         &self,
         _instruction: &Instruction,
-        _account_infos: &[AccountInfo],
+        _account_infos: &[AccountInfo<'_>],
         _signers_seeds: &[&[&[u8]]],
     ) -> ProgramResult {
         sol_log("SyscallStubs: sol_invoke_signed() not available");
@@ -111,7 +111,7 @@ pub(crate) fn sol_log_compute_units() {
 
 pub(crate) fn sol_invoke_signed(
     instruction: &Instruction,
-    account_infos: &[AccountInfo],
+    account_infos: &[AccountInfo<'_>],
     signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     SYSCALL_STUBS

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -380,13 +380,13 @@ impl AsMut<[u8]> for Pubkey {
 }
 
 impl fmt::Debug for Pubkey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
 impl fmt::Display for Pubkey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/sdk/program/src/short_vec.rs
+++ b/sdk/program/src/short_vec.rs
@@ -118,7 +118,7 @@ struct ShortU16Visitor;
 impl<'de> Visitor<'de> for ShortU16Visitor {
     type Value = ShortU16;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a ShortU16")
     }
 
@@ -190,7 +190,7 @@ where
 {
     type Value = Vec<T>;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a Vec with a multi-byte length")
     }
 

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -40,7 +40,7 @@ pub fn load_current_index(data: &[u8]) -> u16 {
 /// Load the current `Instruction`'s index in the currently executing
 /// `Transaction`
 pub fn load_current_index_checked(
-    instruction_sysvar_account_info: &AccountInfo,
+    instruction_sysvar_account_info: &AccountInfo<'_>,
 ) -> Result<u16, ProgramError> {
     if !check_id(instruction_sysvar_account_info.key) {
         return Err(ProgramError::UnsupportedSysvar);
@@ -73,7 +73,7 @@ pub fn load_instruction_at(index: usize, data: &[u8]) -> Result<Instruction, San
 /// specified index
 pub fn load_instruction_at_checked(
     index: usize,
-    instruction_sysvar_account_info: &AccountInfo,
+    instruction_sysvar_account_info: &AccountInfo<'_>,
 ) -> Result<Instruction, ProgramError> {
     if !check_id(instruction_sysvar_account_info.key) {
         return Err(ProgramError::UnsupportedSysvar);
@@ -92,7 +92,7 @@ pub fn load_instruction_at_checked(
 /// currently executing `Transaction`
 pub fn get_instruction_relative(
     index_relative_to_current: i64,
-    instruction_sysvar_account_info: &AccountInfo,
+    instruction_sysvar_account_info: &AccountInfo<'_>,
 ) -> Result<Instruction, ProgramError> {
     if !check_id(instruction_sysvar_account_info.key) {
         return Err(ProgramError::UnsupportedSysvar);

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -99,13 +99,13 @@ pub trait Sysvar:
     fn size_of() -> usize {
         bincode::serialized_size(&Self::default()).unwrap() as usize
     }
-    fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
+    fn from_account_info(account_info: &AccountInfo<'_>) -> Result<Self, ProgramError> {
         if !Self::check_id(account_info.unsigned_key()) {
             return Err(ProgramError::InvalidArgument);
         }
         bincode::deserialize(&account_info.data.borrow()).map_err(|_| ProgramError::InvalidArgument)
     }
-    fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
+    fn to_account_info(&self, account_info: &mut AccountInfo<'_>) -> Option<()> {
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()
     }
     fn get() -> Result<Self, ProgramError> {

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -14,7 +14,7 @@ impl Sysvar for SlotHashes {
         // hard-coded so that we don't have to construct an empty
         20_488 // golden, update if MAX_ENTRIES changes
     }
-    fn from_account_info(_account_info: &AccountInfo) -> Result<Self, ProgramError> {
+    fn from_account_info(_account_info: &AccountInfo<'_>) -> Result<Self, ProgramError> {
         // This sysvar is too large to bincode::deserialize in-program
         Err(ProgramError::UnsupportedSysvar)
     }

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -17,7 +17,7 @@ impl Sysvar for SlotHistory {
         // hard-coded so that we don't have to construct an empty
         131_097 // golden, update if MAX_ENTRIES changes
     }
-    fn from_account_info(_account_info: &AccountInfo) -> Result<Self, ProgramError> {
+    fn from_account_info(_account_info: &AccountInfo<'_>) -> Result<Self, ProgramError> {
         // This sysvar is too large to bincode::deserialize in-program
         Err(ProgramError::UnsupportedSysvar)
     }

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -220,7 +220,7 @@ impl FromStr for CommitmentLevel {
 }
 
 impl std::fmt::Display for CommitmentLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             CommitmentLevel::Max => "max",
             CommitmentLevel::Recent => "recent",

--- a/sdk/src/derivation_path.rs
+++ b/sdk/src/derivation_path.rs
@@ -234,7 +234,7 @@ impl AsRef<str> for QueryKey {
 }
 
 impl std::fmt::Display for QueryKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s: &str = self.as_ref();
         write!(f, "{}", s)
     }

--- a/sdk/src/exit.rs
+++ b/sdk/src/exit.rs
@@ -24,7 +24,7 @@ impl Exit {
 }
 
 impl fmt::Debug for Exit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} exits", self.exits.len())
     }
 }

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -235,7 +235,7 @@ impl GenesisConfig {
 }
 
 impl fmt::Display for GenesisConfig {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "\

--- a/sdk/src/hard_forks.rs
+++ b/sdk/src/hard_forks.rs
@@ -27,7 +27,7 @@ impl HardForks {
     }
 
     // Returns a sorted-by-slot iterator over the registered hark forks
-    pub fn iter(&self) -> std::slice::Iter<(Slot, usize)> {
+    pub fn iter(&self) -> std::slice::Iter<'_, (Slot, usize)> {
         self.hard_forks.iter()
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -104,8 +104,7 @@ macro_rules! program_stubs {
 
 #[macro_use]
 extern crate serde_derive;
-pub extern crate bs58;
-extern crate log as logger;
+pub use bs58;
 
 #[macro_use]
 extern crate solana_frozen_abi_macro;

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -63,7 +63,7 @@ pub trait Signable {
     }
 
     fn pubkey(&self) -> Pubkey;
-    fn signable_data(&self) -> Cow<[u8]>;
+    fn signable_data(&self) -> Cow<'_, [u8]>;
     fn get_signature(&self) -> Signature;
     fn set_signature(&mut self, signature: Signature);
 }
@@ -75,13 +75,13 @@ impl AsRef<[u8]> for Signature {
 }
 
 impl fmt::Debug for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }
 
 impl fmt::Display for Signature {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())
     }
 }

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -88,7 +88,7 @@ impl PartialEq for dyn Signer {
 }
 
 impl std::fmt::Debug for dyn Signer {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "Signer: {:?}", self.pubkey())
     }
 }

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -137,7 +137,10 @@ impl SanitizedTransaction {
     }
 
     /// Return the list of accounts that must be locked during processing this transaction.
-    pub fn get_account_locks(&self, demote_program_write_locks: bool) -> TransactionAccountLocks {
+    pub fn get_account_locks(
+        &self,
+        demote_program_write_locks: bool,
+    ) -> TransactionAccountLocks<'_> {
         let message = &self.message;
         let num_readonly_accounts = message.num_readonly_accounts();
         let num_writable_accounts = message

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -720,7 +720,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
 }
 
 pub(crate) fn deserialize_protobuf_or_bincode_cell_data<B, P>(
-    row_data: RowDataSlice,
+    row_data: RowDataSlice<'_>,
     table: &str,
     key: RowKey,
 ) -> Result<CellData<B, P>>
@@ -739,7 +739,7 @@ where
 }
 
 pub(crate) fn deserialize_protobuf_cell_data<T>(
-    row_data: RowDataSlice,
+    row_data: RowDataSlice<'_>,
     table: &str,
     key: RowKey,
 ) -> Result<T>
@@ -760,7 +760,7 @@ where
 }
 
 pub(crate) fn deserialize_bincode_cell_data<T>(
-    row_data: RowDataSlice,
+    row_data: RowDataSlice<'_>,
     table: &str,
     key: RowKey,
 ) -> Result<T>

--- a/tokens/src/token_display.rs
+++ b/tokens/src/token_display.rs
@@ -20,7 +20,7 @@ pub struct Token {
 }
 
 impl Token {
-    fn write_with_symbol(&self, f: &mut Formatter) -> Result {
+    fn write_with_symbol(&self, f: &mut Formatter<'_>) -> Result {
         match &self.token_type {
             TokenType::Sol => {
                 let amount = lamports_to_sol(self.amount);
@@ -51,13 +51,13 @@ impl Token {
 }
 
 impl Display for Token {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.write_with_symbol(f)
     }
 }
 
 impl Debug for Token {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         self.write_with_symbol(f)
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -606,7 +606,7 @@ pub enum UiTransactionEncoding {
 }
 
 impl fmt::Display for UiTransactionEncoding {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let v = serde_json::to_value(self).map_err(|_| fmt::Error)?;
         let s = v.as_str().ok_or(fmt::Error)?;
         write!(f, "{}", s)

--- a/transaction-status/src/token_balances.rs
+++ b/transaction-status/src/token_balances.rs
@@ -55,7 +55,7 @@ fn get_mint_decimals(bank: &Bank, mint: &Pubkey) -> Option<u8> {
 
 pub fn collect_token_balances(
     bank: &Bank,
-    batch: &TransactionBatch,
+    batch: &TransactionBatch<'_, '_>,
     mint_decimals: &mut HashMap<Pubkey, u8>,
 ) -> TransactionTokenBalances {
     let mut balances: TransactionTokenBalances = vec![];

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -186,11 +186,12 @@ pub fn run(ledger_path: &Path, metadata: AdminRpcRequestMetadata) {
             io.extend_with(AdminRpcImpl.to_delegate());
 
             let validator_exit = metadata.validator_exit.clone();
-            let server = ServerBuilder::with_meta_extractor(io, move |_req: &RequestContext| {
-                metadata.clone()
-            })
-            .event_loop_executor(event_loop.handle().clone())
-            .start(&format!("{}", admin_rpc_path.display()));
+            let server =
+                ServerBuilder::with_meta_extractor(io, move |_req: &RequestContext<'_>| {
+                    metadata.clone()
+                })
+                .event_loop_executor(event_loop.handle().clone())
+                .start(&format!("{}", admin_rpc_path.display()));
 
             match server {
                 Err(err) => {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2661,7 +2661,7 @@ pub fn main() {
     info!("Validator exiting..");
 }
 
-fn process_account_indexes(matches: &ArgMatches) -> AccountSecondaryIndexes {
+fn process_account_indexes(matches: &ArgMatches<'_>) -> AccountSecondaryIndexes {
     let account_indexes: HashSet<AccountIndex> = matches
         .values_of("account_indexes")
         .unwrap_or_default()

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 
-extern crate serde_derive;
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::sanitize::Sanitize;
 use std::{convert::TryInto, fmt};

--- a/web3.js/test/fixtures/noop-program/src/lib.rs
+++ b/web3.js/test/fixtures/noop-program/src/lib.rs
@@ -20,7 +20,7 @@ fn return_sstruct() -> SStruct {
 entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    accounts: &[AccountInfo<'_>],
     instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Program identifier:");


### PR DESCRIPTION
#### Problem

Implicit elided lifetimes are not idiomatic Rust because person reading the code wouldn't know that lifetimes are elided.

#### Summary of Changes

Deny rust_2018_idioms lint group in CI and fix all lints. (including implicit elided lifetimes and unneeded extern crates)

Fixes #
