### PR TITLE
Feature gates for rbpf v0.2.16

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1999,7 +1999,9 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         Some(verifier::check),
         Config {
             reject_unresolved_syscalls: true,
-            verify_mul64_imm_nonzero: true, // TODO: Remove me after feature gate
+            verify_mul64_imm_nonzero: false,
+            verify_shift32_imm: true,
+            reject_section_virtual_address_file_offset_mismatch: true,
             ..Config::default()
         },
         register_syscalls(&mut invoke_context).unwrap(),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -209,6 +209,10 @@ fn run_program(name: &str) -> u64 {
         let mut instruction_meter = ThisInstructionMeter { compute_meter };
         let config = Config {
             enable_instruction_tracing: true,
+            reject_unresolved_syscalls: true,
+            reject_section_virtual_address_file_offset_mismatch: true,
+            verify_mul64_imm_nonzero: false,
+            verify_shift32_imm: true,
             ..Config::default()
         };
         let mut executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -152,6 +152,7 @@ native machine code before execting it in the virtual machine.",
 
     let config = Config {
         enable_instruction_tracing: matches.is_present("trace") || matches.is_present("profile"),
+        enable_symbol_and_section_labels: true,
         ..Config::default()
     };
     let loader_id = bpf_loader::id();

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -139,6 +139,10 @@ pub mod stop_verify_mul64_imm_nonzero {
     solana_sdk::declare_id!("EHFwHg2vhwUb7ifm7BuY9RMbsyt1rS1rUii7yeDJtGnN");
 }
 
+pub mod start_verify_shift32_imm {
+    solana_sdk::declare_id!("CqvdhqAYMc6Eq6tjW3H42Qg39TK2SCsL8ydMsC363PRp");
+}
+
 pub mod merge_nonce_error_into_system_error {
     solana_sdk::declare_id!("21AWDosvp3pBamFW91KB35pNoaoZVTM7ess8nr2nt53B");
 }
@@ -237,6 +241,10 @@ pub mod reject_deployment_of_unresolved_syscalls {
     solana_sdk::declare_id!("DqniU3MfvdpU3yhmNF1RKeaM5TZQELZuyFGosASRVUoy");
 }
 
+pub mod reject_section_virtual_address_file_offset_mismatch {
+    solana_sdk::declare_id!("5N4NikcJLEiZNqwndhNyvZw15LvFXp1oF7AJQTNTZY5k");
+}
+
 pub mod nonce_must_be_writable {
     solana_sdk::declare_id!("BiCU7M5w8ZCMykVSyhZ7Q3m2SWoR2qrEQ86ERcDX77ME");
 }
@@ -279,6 +287,7 @@ lazy_static! {
         (tx_wide_compute_cap::id(), "transaction wide compute cap"),
         (spl_token_v2_set_authority_fix::id(), "spl-token set_authority fix"),
         (stop_verify_mul64_imm_nonzero::id(), "sets rbpf vm config verify_mul64_imm_nonzero to false"),
+        (start_verify_shift32_imm::id(), "sets rbpf vm config verify_shift32_imm to true"),
         (merge_nonce_error_into_system_error::id(), "merge NonceError into SystemError"),
         (disable_fees_sysvar::id(), "disable fees sysvar"),
         (stake_merge_with_unmatched_credits_observed::id(), "allow merging active stakes with unmatched credits_observed #18985"),
@@ -303,6 +312,7 @@ lazy_static! {
         (disable_fee_calculator::id(), "deprecate fee calculator"),
         (add_compute_budget_program::id(), "Add compute_budget_program"),
         (reject_deployment_of_unresolved_syscalls::id(), "Reject deployment of programs with unresolved syscall symbols"),
+        (reject_section_virtual_address_file_offset_mismatch::id(), "enforce section virtual addresses and file offsets in ELF to be equal"),
         (nonce_must_be_writable::id(), "nonce must be writable"),
         (spl_token_v3_3_0_release::id(), "spl-token v3.3.0 release"),
         (leave_nonce_on_success::id(), "leave nonce as is on success"),


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/rbpf/releases/tag/v0.2.16 added config options which need to be feature gated here.

#### Summary of Changes
- Adds feature `reject_section_virtual_address_file_offset_mismatch`
- Adds feature `start_verify_shift32_imm`
- Enables `enable_symbol_and_section_labels` only in the rbpf-cli

Fixes #
