### PR TITLE
Adds feature reject_empty_instruction_without_program.

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -249,6 +249,10 @@ pub mod leave_nonce_on_success {
     solana_sdk::declare_id!("E8MkiWZNNPGU6n55jkGzyj8ghUmjCHRmDFdYYFYHxWhQ");
 }
 
+pub mod reject_empty_instruction_without_program {
+    solana_sdk::declare_id!("9kdtFSrXHQg3hKkbXkQ6trJ3Ja1xpJ22CTFSNAciEwmL");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -306,6 +310,7 @@ lazy_static! {
         (nonce_must_be_writable::id(), "nonce must be writable"),
         (spl_token_v3_3_0_release::id(), "spl-token v3.3.0 release"),
         (leave_nonce_on_success::id(), "leave nonce as is on success"),
+        (reject_empty_instruction_without_program::id(), "fail instructions which have native_loader as program_id directly"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
#21346 found that empty instructions (in which `program_id` is just `native_loader::id()`) were not handled consistently.
So after this feature gate they will be rejected with `InstructionError::UnsupportedProgramId`.

#### Summary of Changes
- Adds feature `reject_empty_instruction_without_program`.
- Adjusts `test_an_empty_instruction_without_program` to test the behavior before and after the feature gate. 

Fixes #21347
