### PR TITLE
solana-test-validator no longer limits the size of the genesis archive

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -93,6 +93,7 @@ pub struct TestValidatorGenesis {
     pub start_progress: Arc<RwLock<ValidatorStartProgress>>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub max_ledger_shreds: Option<u64>,
+    pub max_genesis_archive_unpacked_size: Option<u64>,
 }
 
 impl TestValidatorGenesis {
@@ -428,7 +429,9 @@ impl TestValidator {
                 let _ = create_new_ledger(
                     ledger_path,
                     &genesis_config,
-                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                    config
+                        .max_genesis_archive_unpacked_size
+                        .unwrap_or(MAX_GENESIS_ARCHIVE_UNPACKED_SIZE),
                     solana_ledger::blockstore_db::AccessType::PrimaryOnly,
                 )
                 .map_err(|err| {

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -507,6 +507,7 @@ fn main() {
 
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
+    genesis.max_genesis_archive_unpacked_size = Some(u64::MAX);
 
     let tower_storage = Arc::new(FileTowerStorage::new(ledger_path.clone()));
 


### PR DESCRIPTION
When using `--clone` with a large number of accounts it is possible to surpass the default 10MB limit

Fixes #21452
