### PR TITLE
Panic if there is an error saving transactions via plugin when configured 

### DIFF
--- a/accountsdb-plugin-postgres/src/postgres_client.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client.rs
@@ -670,7 +670,12 @@ impl PostgresClientWorker {
                         }
                     }
                     DbWorkItem::LogTransaction(transaction_log_info) => {
-                        self.client.log_transaction(*transaction_log_info)?;
+                        if let Err(err) = self.client.log_transaction(*transaction_log_info) {
+                            error!("Failed to update transaction: ({})", err);
+                            if panic_on_db_errors {
+                                abort();
+                            }
+                        }
                     }
                 },
                 Err(err) => match err {


### PR DESCRIPTION

#### Problem
The plugin ignored db errors with transaction even panic_on_db_errors is set.

#### Summary of Changes
Abort when there is an error saving transactions via plugin when configured 
Fixes #
