### PR TITLE
adds back ErasureMeta::first_coding_index field

### DIFF
--- a/ledger/src/erasure.rs
+++ b/ledger/src/erasure.rs
@@ -53,18 +53,18 @@ pub struct ErasureConfig {
 }
 
 impl ErasureConfig {
-    pub fn new(num_data: usize, num_coding: usize) -> ErasureConfig {
+    pub(crate) fn new(num_data: usize, num_coding: usize) -> ErasureConfig {
         ErasureConfig {
             num_data,
             num_coding,
         }
     }
 
-    pub fn num_data(self) -> usize {
+    pub(crate) fn num_data(self) -> usize {
         self.num_data
     }
 
-    pub fn num_coding(self) -> usize {
+    pub(crate) fn num_coding(self) -> usize {
         self.num_coding
     }
 }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/16646
removed first_coding_index since the field is currently redundant and
always equal to fec_set_index.
However, with upcoming changes to erasure coding schema, this will no
longer be the same as fec_set_index and so requires a dedicated field to
represent.

#### Summary of Changes
* added back `ErasureMeta::first_coding_index`.
* some reworks around `ErasureMeta` construction and `fec_set_index`.