### PR TITLE
Reject vote withdraws that create non-rent-exempt accounts

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -193,11 +193,19 @@ impl<'a> InvokeContext<'a> {
         accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
         builtin_programs: &'a [BuiltinProgram],
     ) -> Self {
+        Self::new_mock_with_sysvars(accounts, builtin_programs, &[])
+    }
+
+    pub fn new_mock_with_sysvars(
+        accounts: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
+        builtin_programs: &'a [BuiltinProgram],
+        sysvars: &'a [(Pubkey, Vec<u8>)],
+    ) -> Self {
         Self::new(
             Rent::default(),
             accounts,
             builtin_programs,
-            &[],
+            sysvars,
             Some(LogCollector::new_ref()),
             ComputeBudget::default(),
             Rc::new(RefCell::new(Executors::default())),
@@ -915,11 +923,12 @@ pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
     callback(&mut invoke_context)
 }
 
-pub fn mock_process_instruction(
+pub fn mock_process_instruction_with_sysvars(
     loader_id: &Pubkey,
     mut program_indices: Vec<usize>,
     instruction_data: &[u8],
     keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
+    sysvars: &[(Pubkey, Vec<u8>)],
     process_instruction: ProcessInstructionWithContext,
 ) -> Result<(), InstructionError> {
     let mut preparation =
@@ -927,7 +936,8 @@ pub fn mock_process_instruction(
     let processor_account = AccountSharedData::new_ref(0, 0, &solana_sdk::native_loader::id());
     program_indices.insert(0, preparation.accounts.len());
     preparation.accounts.push((*loader_id, processor_account));
-    let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
+    let mut invoke_context =
+        InvokeContext::new_mock_with_sysvars(&preparation.accounts, &[], sysvars);
     invoke_context.push(
         &preparation.message,
         &preparation.message.instructions[0],
@@ -935,6 +945,23 @@ pub fn mock_process_instruction(
         Some(&preparation.account_indices),
     )?;
     process_instruction(1, instruction_data, &mut invoke_context)
+}
+
+pub fn mock_process_instruction(
+    loader_id: &Pubkey,
+    program_indices: Vec<usize>,
+    instruction_data: &[u8],
+    keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
+    process_instruction: ProcessInstructionWithContext,
+) -> Result<(), InstructionError> {
+    mock_process_instruction_with_sysvars(
+        loader_id,
+        program_indices,
+        instruction_data,
+        keyed_accounts,
+        &[],
+        process_instruction,
+    )
 }
 
 #[cfg(test)]

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -508,11 +508,15 @@ mod tests {
             .zip(accounts.into_iter())
             .map(|(meta, account)| (meta.is_signer, meta.is_writable, meta.pubkey, account))
             .collect();
-        solana_program_runtime::invoke_context::mock_process_instruction(
+
+        let rent = Rent::default();
+        let rent_sysvar = (sysvar::rent::id(), bincode::serialize(&rent).unwrap());
+        solana_program_runtime::invoke_context::mock_process_instruction_with_sysvars(
             &id(),
             Vec::new(),
             &instruction.data,
             &keyed_accounts,
+            &[rent_sysvar],
             super::process_instruction,
         )
     }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -267,6 +267,10 @@ pub mod fixed_memcpy_nonoverlapping_check {
     solana_sdk::declare_id!("36PRUK2Dz6HWYdG9SpjeAsF5F3KxnFCakA2BZMbtMhSb");
 }
 
+pub mod reject_non_rent_exempt_vote_withdraws {
+    solana_sdk::declare_id!("7txXZZD6Um59YoLMF7XUNimbMjsqsWhc7g2EniiTrmp1");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -328,6 +332,7 @@ lazy_static! {
         (leave_nonce_on_success::id(), "leave nonce as is on success"),
         (reject_empty_instruction_without_program::id(), "fail instructions which have native_loader as program_id directly"),
         (fixed_memcpy_nonoverlapping_check::id(), "use correct check for nonoverlapping regions in memcpy syscall"),
+        (reject_non_rent_exempt_vote_withdraws::id(), "fail vote withdraw instructions which leave the account non-rent-exempt"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The remaining balance after a vote withdraw is not checked to see if it meets the rent exempt threshold.

#### Summary of Changes
- Add feature to enforce that withdraws do not result in non-rent-exempt vote accounts

Fixes #
