### PR TITLE
Add more reporting for invalid stake cache members and prune them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5578,6 +5578,8 @@ dependencies = [
  "libsecp256k1 0.6.0",
  "log 0.4.14",
  "memmap2 0.5.0",
+ "num-derive",
+ "num-traits",
  "num_cpus",
  "ouroboros",
  "rand 0.7.3",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3290,6 +3290,8 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2 0.5.0",
+ "num-derive",
+ "num-traits",
  "num_cpus",
  "ouroboros",
  "rand 0.7.3",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,8 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 memmap2 = "0.5.0"
 num_cpus = "1.13.0"
+num-derive = { version = "0.3" }
+num-traits = { version = "0.2" }
 ouroboros = "0.13.0"
 rand = "0.7.0"
 rayon = "1.5.1"

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -63,7 +63,7 @@ use {
         vote_account::VoteAccount,
     },
     byteorder::{ByteOrder, LittleEndian},
-    dashmap::DashMap,
+    dashmap::{DashMap, DashSet},
     itertools::Itertools,
     log::*,
     rayon::{
@@ -1052,6 +1052,12 @@ struct VoteWithStakeDelegations {
     vote_state: Arc<VoteState>,
     vote_account: AccountSharedData,
     delegations: Vec<(Pubkey, (StakeState, AccountSharedData))>,
+}
+
+struct LoadVoteAndStakeAccountsResult {
+    vote_with_stake_delegations_map: DashMap<Pubkey, VoteWithStakeDelegations>,
+    invalid_stake_keys_set: DashSet<Pubkey>,
+    invalid_vote_keys_set: DashSet<Pubkey>,
 }
 
 #[derive(Debug, Default)]
@@ -2166,9 +2172,12 @@ impl Bank {
         &self,
         thread_pool: &ThreadPool,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
-    ) -> DashMap<Pubkey, VoteWithStakeDelegations> {
+    ) -> LoadVoteAndStakeAccountsResult {
         let stakes = self.stakes.read().unwrap();
-        let accounts = DashMap::with_capacity(stakes.vote_accounts().as_ref().len());
+        let vote_with_stake_delegations_map =
+            DashMap::with_capacity(stakes.vote_accounts().as_ref().len());
+        let invalid_stake_keys_set: DashSet<Pubkey> = DashSet::new();
+        let invalid_vote_keys_set: DashSet<Pubkey> = DashSet::new();
 
         thread_pool.install(|| {
             stakes
@@ -2176,87 +2185,87 @@ impl Bank {
                 .par_iter()
                 .for_each(|(stake_pubkey, delegation)| {
                     let vote_pubkey = &delegation.voter_pubkey;
-                    let stake_account = match self.get_account_with_fixed_root(stake_pubkey) {
-                        Some(stake_account) => stake_account,
-                        None => return,
-                    };
+                    if invalid_vote_keys_set.contains(vote_pubkey) {
+                        return;
+                    }
 
-                    // fetch vote account from stakes cache if it hasn't been cached locally
-                    let fetched_vote_account = if !accounts.contains_key(vote_pubkey) {
-                        let vote_account = match self.get_account_with_fixed_root(vote_pubkey) {
-                            Some(vote_account) => vote_account,
-                            None => return,
-                        };
+                    let stake_delegation = match self.get_account_with_fixed_root(stake_pubkey) {
+                        Some(stake_account) => {
+                            if stake_account.owner() != &solana_stake_program::id() {
+                                invalid_stake_keys_set.insert(*stake_pubkey);
+                                return;
+                            }
 
-                        let vote_state: VoteState =
-                            match StateMut::<VoteStateVersions>::state(&vote_account) {
-                                Ok(vote_state) => vote_state.convert_to_current(),
-                                Err(err) => {
-                                    debug!(
-                                        "failed to deserialize vote account {}: {}",
-                                        vote_pubkey, err
-                                    );
+                            match stake_account.state().ok() {
+                                Some(stake_state) => (*stake_pubkey, (stake_state, stake_account)),
+                                None => {
+                                    invalid_stake_keys_set.insert(*stake_pubkey);
                                     return;
                                 }
-                            };
-
-                        Some((vote_state, vote_account))
-                    } else {
-                        None
+                            }
+                        }
+                        None => {
+                            invalid_stake_keys_set.insert(*stake_pubkey);
+                            return;
+                        }
                     };
 
-                    let fetched_vote_account_owner = fetched_vote_account
-                        .as_ref()
-                        .map(|(_vote_state, vote_account)| vote_account.owner());
+                    let mut vote_delegations = if let Some(vote_delegations) =
+                        vote_with_stake_delegations_map.get_mut(vote_pubkey)
+                    {
+                        vote_delegations
+                    } else {
+                        let vote_account = match self.get_account_with_fixed_root(vote_pubkey) {
+                            Some(vote_account) => {
+                                if vote_account.owner() != &solana_vote_program::id() {
+                                    invalid_vote_keys_set.insert(*vote_pubkey);
+                                    return;
+                                }
+                                vote_account
+                            }
+                            None => {
+                                invalid_vote_keys_set.insert(*vote_pubkey);
+                                return;
+                            }
+                        };
+
+                        let vote_state = if let Ok(vote_state) =
+                            StateMut::<VoteStateVersions>::state(&vote_account)
+                        {
+                            vote_state.convert_to_current()
+                        } else {
+                            invalid_vote_keys_set.insert(*vote_pubkey);
+                            return;
+                        };
+
+                        vote_with_stake_delegations_map
+                            .entry(*vote_pubkey)
+                            .or_insert_with(|| VoteWithStakeDelegations {
+                                vote_state: Arc::new(vote_state),
+                                vote_account,
+                                delegations: vec![],
+                            })
+                    };
 
                     if let Some(reward_calc_tracer) = reward_calc_tracer.as_ref() {
                         reward_calc_tracer(&RewardCalculationEvent::Staking(
                             stake_pubkey,
                             &InflationPointCalculationEvent::Delegation(
                                 *delegation,
-                                fetched_vote_account_owner
-                                    .cloned()
-                                    .unwrap_or_else(solana_vote_program::id),
+                                solana_vote_program::id(),
                             ),
                         ));
                     }
 
-                    // filter invalid delegation accounts
-                    if stake_account.owner() != &solana_stake_program::id()
-                        || (fetched_vote_account_owner.is_some()
-                            && fetched_vote_account_owner != Some(&solana_vote_program::id()))
-                    {
-                        datapoint_warn!(
-                            "bank-stake_delegation_accounts-invalid-account",
-                            ("slot", self.slot() as i64, i64),
-                            ("stake-address", format!("{:?}", stake_pubkey), String),
-                            ("vote-address", format!("{:?}", vote_pubkey), String),
-                        );
-                        return;
-                    }
-
-                    let stake_delegation = match stake_account.state().ok() {
-                        Some(stake_state) => (*stake_pubkey, (stake_state, stake_account)),
-                        None => return,
-                    };
-
-                    if let Some((vote_state, vote_account)) = fetched_vote_account {
-                        accounts
-                            .entry(*vote_pubkey)
-                            .or_insert_with(|| VoteWithStakeDelegations {
-                                vote_state: Arc::new(vote_state),
-                                vote_account,
-                                delegations: vec![],
-                            });
-                    }
-
-                    if let Some(mut stake_delegation_accounts) = accounts.get_mut(vote_pubkey) {
-                        stake_delegation_accounts.delegations.push(stake_delegation);
-                    }
+                    vote_delegations.delegations.push(stake_delegation);
                 });
         });
 
-        accounts
+        LoadVoteAndStakeAccountsResult {
+            vote_with_stake_delegations_map,
+            invalid_vote_keys_set,
+            invalid_stake_keys_set,
+        }
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
@@ -2270,13 +2279,52 @@ impl Bank {
         thread_pool: &ThreadPool,
     ) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
-        let vote_and_stake_accounts = self.load_vote_and_stake_accounts_with_thread_pool(
+        let LoadVoteAndStakeAccountsResult {
+            vote_with_stake_delegations_map,
+            invalid_stake_keys_set,
+            invalid_vote_keys_set,
+        } = self.load_vote_and_stake_accounts_with_thread_pool(
             thread_pool,
             reward_calc_tracer.as_ref(),
         );
 
+        {
+            // Prune invalid stake delegations and vote accounts that were
+            // not properly evicted in normal operation.
+            let mut maybe_stakes_cache = if self
+                .feature_set
+                .is_active(&feature_set::evict_invalid_stakes_cache_entries::id())
+            {
+                Some(self.stakes.write().unwrap())
+            } else {
+                None
+            };
+
+            for stake_pubkey in invalid_stake_keys_set {
+                if let Some(stakes_cache) = maybe_stakes_cache.as_mut() {
+                    stakes_cache.remove_stake_delegation(&stake_pubkey);
+                }
+                datapoint_warn!(
+                    "bank-stake_delegation_accounts-invalid-account",
+                    ("slot", self.slot() as i64, i64),
+                    ("stake-address", format!("{:?}", stake_pubkey), String),
+                );
+            }
+
+            for vote_pubkey in invalid_vote_keys_set {
+                if let Some(stakes_cache) = maybe_stakes_cache.as_mut() {
+                    stakes_cache.remove_vote_account(&vote_pubkey);
+                }
+                datapoint_warn!(
+                    "bank-stake_delegation_accounts-invalid-account",
+                    ("slot", self.slot() as i64, i64),
+                    ("vote-address", format!("{:?}", vote_pubkey), String),
+                );
+            }
+        }
+
         let points: u128 = thread_pool.install(|| {
-            vote_and_stake_accounts
+            vote_with_stake_delegations_map
                 .par_iter()
                 .map(|entry| {
                     let VoteWithStakeDelegations {
@@ -2307,8 +2355,8 @@ impl Bank {
         // pay according to point value
         let point_value = PointValue { rewards, points };
         let vote_account_rewards: DashMap<Pubkey, (AccountSharedData, u8, u64, bool)> =
-            DashMap::with_capacity(vote_and_stake_accounts.len());
-        let stake_delegation_iterator = vote_and_stake_accounts.into_par_iter().flat_map(
+            DashMap::with_capacity(vote_with_stake_delegations_map.len());
+        let stake_delegation_iterator = vote_with_stake_delegations_map.into_par_iter().flat_map(
             |(
                 vote_pubkey,
                 VoteWithStakeDelegations {
@@ -8279,6 +8327,7 @@ pub(crate) mod tests {
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let validator_points: u128 = bank0
             .load_vote_and_stake_accounts_with_thread_pool(&thread_pool, null_tracer())
+            .vote_with_stake_delegations_map
             .into_iter()
             .map(
                 |(
@@ -14284,8 +14333,9 @@ pub(crate) mod tests {
         );
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
-        let vote_and_stake_accounts =
-            bank.load_vote_and_stake_accounts_with_thread_pool(&thread_pool, null_tracer());
+        let vote_and_stake_accounts = bank
+            .load_vote_and_stake_accounts_with_thread_pool(&thread_pool, null_tracer())
+            .vote_with_stake_delegations_map;
         assert_eq!(vote_and_stake_accounts.len(), 2);
 
         let mut vote_account = bank
@@ -14325,8 +14375,9 @@ pub(crate) mod tests {
 
         // Accounts must be valid stake and vote accounts
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
-        let vote_and_stake_accounts =
-            bank.load_vote_and_stake_accounts_with_thread_pool(&thread_pool, null_tracer());
+        let vote_and_stake_accounts = bank
+            .load_vote_and_stake_accounts_with_thread_pool(&thread_pool, null_tracer())
+            .vote_with_stake_delegations_map;
         assert_eq!(vote_and_stake_accounts.len(), 0);
     }
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -150,6 +150,18 @@ impl Stakes {
                 && account.data().len() >= std::mem::size_of::<StakeState>()
     }
 
+    pub fn remove_vote_account(&mut self, vote_pubkey: &Pubkey) {
+        self.vote_accounts.remove(vote_pubkey);
+    }
+
+    pub fn remove_stake_delegation(&mut self, stake_pubkey: &Pubkey) {
+        if let Some(removed_delegation) = self.stake_delegations.remove(stake_pubkey) {
+            let removed_stake = removed_delegation.stake(self.epoch, Some(&self.stake_history));
+            self.vote_accounts
+                .sub_stake(&removed_delegation.voter_pubkey, removed_stake);
+        }
+    }
+
     pub fn store(
         &mut self,
         pubkey: &Pubkey,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -271,6 +271,10 @@ pub mod reject_non_rent_exempt_vote_withdraws {
     solana_sdk::declare_id!("7txXZZD6Um59YoLMF7XUNimbMjsqsWhc7g2EniiTrmp1");
 }
 
+pub mod evict_invalid_stakes_cache_entries {
+    solana_sdk::declare_id!("EMX9Q7TVFAmQ9V1CggAkhMzhXSg8ECp7fHrWQX2G1chf");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -333,6 +337,7 @@ lazy_static! {
         (reject_empty_instruction_without_program::id(), "fail instructions which have native_loader as program_id directly"),
         (fixed_memcpy_nonoverlapping_check::id(), "use correct check for nonoverlapping regions in memcpy syscall"),
         (reject_non_rent_exempt_vote_withdraws::id(), "fail vote withdraw instructions which leave the account non-rent-exempt"),
+        (evict_invalid_stakes_cache_entries::id(), "evict invalid stakes cache entries on epoch boundaries"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Due to a lack of confidence that the stakes cache is consistent with accounts db, we don't make use of it when calculating stake rewards on epoch boundaries. We have some warning metrics for some scenarios where the cache is inconsistent, but not all cases are covered. We also don't have a way to remove any new invalid stakes cache entries.

#### Summary of Changes
- Add feature to evict detected invalid stakes cache entries
- Report metrics for more scenarios when stakes cache entries are invalid

Fixes #
