### PR TITLE
Bumps solana_rbpf to v0.2.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6020,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af7860a2bf51e63a07c4098966b1c80e8cbfdab3cf4ac36aac7fdd80ea1094c"
+checksum = "dcd409d0fba8427ef41b5c1ef79dcabb592f1cff144b77e07094b66c010c2d52"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ solana-config-program = { path = "../programs/config", version = "=1.10.0" }
 solana-faucet = { path = "../faucet", version = "=1.10.0" }
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
-solana_rbpf = "=0.2.16"
+solana_rbpf = "=0.2.17"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.10.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3480,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af7860a2bf51e63a07c4098966b1c80e8cbfdab3cf4ac36aac7fdd80ea1094c"
+checksum = "dcd409d0fba8427ef41b5c1ef79dcabb592f1cff144b77e07094b66c010c2d52"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.10.0" }
 solana-logger = { path = "../../logger", version = "=1.10.0" }
 solana-measure = { path = "../../measure", version = "=1.10.0" }
-solana_rbpf = "=0.2.16"
+solana_rbpf = "=0.2.17"
 solana-runtime = { path = "../../runtime", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -20,7 +20,7 @@ libsecp256k1 = "0.6.0"
 solana-measure = { path = "../../measure", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.16"
+solana_rbpf = "=0.2.17"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -16,5 +16,5 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.10.
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.16"
+solana_rbpf = "=0.2.17"
 time = "0.3.5"


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.17](https://github.com/solana-labs/rbpf/releases/tag/v0.2.17) was released.

#### Summary of Changes
Guards integer arithmetics in ELF parsing.

Fixes #
