### PR TITLE
AcctIdx: reset_mem when set_startup(false)

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -896,6 +896,11 @@ impl<T: IndexValue> AccountsIndex<T> {
         AccountsIndexIterator::new(self, range, collect_all_unsorted)
     }
 
+    /// is the accounts index using disk as a backing store
+    pub fn is_disk_index_enabled(&self) -> bool {
+        self.storage.storage.is_disk_index_enabled()
+    }
+
     fn do_checked_scan_accounts<F, R>(
         &self,
         metric_name: &'static str,

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -102,9 +102,16 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
         }
         self.storage.set_startup(value);
         if !value {
+            // transitioning from startup to !startup (ie. steady state)
             // shutdown the bg threads
             *self.startup_worker_threads.lock().unwrap() = None;
+            // maybe shrink hashmaps
+            self.shrink_to_fit();
         }
+    }
+
+    fn shrink_to_fit(&self) {
+        self.in_mem.iter().for_each(|mem| mem.shrink_to_fit())
     }
 
     fn num_threads() -> usize {


### PR DESCRIPTION
#### Problem
Hashmaps grow with use
When using disk buckets, we initially add items to the in-mem hashmaps, then flush them to disk.
The result is that we end up with hashmaps with larger capacity than they need.
The transition from startup to not startup is a good time to resize the hashmaps down to their current size.
We are seeing an accumulation of memory over time with disk buckets and high # accts.

#### Summary of Changes

Fixes #
