### PR TITLE
Adds check for tx simulation error before returning account length error

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3539,7 +3539,7 @@ pub mod rpc_full {
                     return Err(Error::invalid_params("base58 encoding not supported"));
                 }
 
-                if !result.is_err() && config_accounts.addresses.len() > post_simulation_accounts.len() {
+                if result.is_ok() && config_accounts.addresses.len() > post_simulation_accounts.len() {
                     return Err(Error::invalid_params(format!(
                         "Too many accounts provided; max {}",
                         post_simulation_accounts.len()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3539,7 +3539,7 @@ pub mod rpc_full {
                     return Err(Error::invalid_params("base58 encoding not supported"));
                 }
 
-                if config_accounts.addresses.len() > post_simulation_accounts.len() {
+                if !result.is_err() && config_accounts.addresses.len() > post_simulation_accounts.len() {
                     return Err(Error::invalid_params(format!(
                         "Too many accounts provided; max {}",
                         post_simulation_accounts.len()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3539,7 +3539,9 @@ pub mod rpc_full {
                     return Err(Error::invalid_params("base58 encoding not supported"));
                 }
 
-                if result.is_ok() && config_accounts.addresses.len() > post_simulation_accounts.len() {
+                if result.is_ok()
+                    && config_accounts.addresses.len() > post_simulation_accounts.len()
+                { 
                     return Err(Error::invalid_params(format!(
                         "Too many accounts provided; max {}",
                         post_simulation_accounts.len()

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3541,7 +3541,7 @@ pub mod rpc_full {
 
                 if result.is_ok()
                     && config_accounts.addresses.len() > post_simulation_accounts.len()
-                { 
+                {
                     return Err(Error::invalid_params(format!(
                         "Too many accounts provided; max {}",
                         post_simulation_accounts.len()


### PR DESCRIPTION
#### Problem
The transaction simulation can take an optional list of accounts to return. When a simulation fails, the error from the simulation is not returned. The RPC call incorrectly returns `Too many accounts provided; max 0`. 

This PR fixes: https://github.com/solana-labs/solana/issues/21655

#### Summary of Changes

Fixes #
Adds a check for simulation error state before checking the length of accounts.