### PR TITLE
Avoid entropy sources when constructing a solana_program::message::Message.

### DIFF
--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -14,9 +14,8 @@ use {
         },
         short_vec, system_instruction, system_program, sysvar,
     },
-    itertools::Itertools,
     lazy_static::lazy_static,
-    std::{convert::TryFrom, str::FromStr},
+    std::{collections::BTreeSet, convert::TryFrom, str::FromStr},
 };
 
 lazy_static! {
@@ -159,10 +158,11 @@ fn get_keys(instructions: &[Instruction], payer: Option<&Pubkey>) -> Instruction
 
 /// Return program ids referenced by all instructions.  No duplicates and order is preserved.
 fn get_program_ids(instructions: &[Instruction]) -> Vec<Pubkey> {
+    let mut set = BTreeSet::new();
     instructions
         .iter()
         .map(|ix| ix.program_id)
-        .unique()
+        .filter(|&program_id| set.insert(program_id))
         .collect()
 }
 


### PR DESCRIPTION
#### Problem
The solana-program crate can be used in certain embedded environments (HSMs) where
the source of entropy, whether used for cryptographic purposes or not, is tightly
controlled. In these cases, using the default OS source of entrophy is not always
acceptable. Thus, using the default Rust stdlib entropy source for seeding its
default hasher, is prohibited. This means any use of HashMap/HashSet must be able
to be constructed and used with a custom hasher implementation.

#### Summary of Changes
This commit removes the use of Itertools::unique() to dedupe Instructions that are
being compiled into a new Message, which uses a default-configured HashMap
under-the-hood. Instead, we use a BTreeSet which does not invoke any entropy
source in order to seed a hash implementation.

_**Alternative solution to #21678**_