### PR TITLE
changing the repo clone link from the "ssh" to "https" to fix issue o…

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -104,7 +104,8 @@ function launch_testnet() {
 
   execution_step "Fetch reusable testnet keypairs"
   if [[ ! -d "${REPO_ROOT}"/net/keypairs ]]; then
-    git clone git@github.com:solana-labs/testnet-keypairs.git "${REPO_ROOT}"/net/keypairs
+    git clone https://github.com/solana-labs/testnet-keypairs.git "${REPO_ROOT}"/net/keypairs
+    #git clone git@github.com:solana-labs/testnet-keypairs.git "${REPO_ROOT}"/net/keypairs
     # If we have provider-specific keys (CoLo*, GCE*, etc) use them instead of generic val*
     if [[ -d "${REPO_ROOT}"/net/keypairs/"${CLOUD_PROVIDER}" ]]; then
       cp "${REPO_ROOT}"/net/keypairs/"${CLOUD_PROVIDER}"/* "${REPO_ROOT}"/net/keypairs/


### PR DESCRIPTION
…f "unable to clone"

#### Problem

Cloning into '/var/lib/buildkite-agent/builds/buildkite-agents-3x6q-1/solana-labs/system-performance-tests/system-test/../net/keypairs'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

#### Summary of Changes


Fixes #
