### PR TITLE
SDK: Add stdlib.h include to pull in `abort()`

### DIFF
--- a/sdk/bpf/c/inc/sol/assert.h
+++ b/sdk/bpf/c/inc/sol/assert.h
@@ -32,6 +32,7 @@ if (!(expr)) {          \
  * Stub functions when building tests
  */
 #include <stdio.h>
+#include <stdlib.h>
 
 void sol_panic_(const char *file, uint64_t len, uint64_t line, uint64_t column) {
   printf("Panic in %s at %d:%d\n", file, line, column);


### PR DESCRIPTION
#### Problem

While upgrading SPL to 1.8.6, there was an error building the C programs.  `abort` isn't pulled in because stdlib.h isn't included.  Here's the error: https://github.com/solana-labs/solana-program-library/runs/4450436070?check_suite_focus=true

#### Summary of Changes

Add the required import for the header to work

Fixes #
