### PR TITLE
Feature: TransactionContext, InstructionContext and BorrowedAccount

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -42,6 +42,7 @@ use {
         system_instruction::{self, SystemError},
         system_program,
         transaction::{Transaction, TransactionError},
+        transaction_context::TransactionContext,
     },
     std::{
         fs::File,
@@ -1990,7 +1991,8 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut invoke_context = InvokeContext::new_mock(&[], &[]);
+    let transaction_context = TransactionContext::new(Vec::new(), 1);
+    let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
 
     // Verify the program
     Executable::<BpfError, ThisInstructionMeter>::from_elf(

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -20,19 +20,10 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         sysvar::Sysvar,
+        transaction_context::{InstructionAccount, TransactionAccount, TransactionContext},
     },
     std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc},
 };
-
-pub type TransactionAccountRefCell = (Pubkey, RefCell<AccountSharedData>);
-pub type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;
-
-#[derive(Clone, Debug)]
-pub struct InstructionAccount {
-    pub index: usize,
-    pub is_signer: bool,
-    pub is_writable: bool,
-}
 
 pub type ProcessInstructionWithContext =
     fn(usize, &[u8], &mut InvokeContext) -> Result<(), InstructionError>;
@@ -144,10 +135,11 @@ impl<'a> StackFrame<'a> {
 }
 
 pub struct InvokeContext<'a> {
+    pub transaction_context: &'a TransactionContext,
+    pub return_data: (Pubkey, Vec<u8>),
     invoke_stack: Vec<StackFrame<'a>>,
     rent: Rent,
     pre_accounts: Vec<PreAccount>,
-    accounts: &'a [TransactionAccountRefCell],
     builtin_programs: &'a [BuiltinProgram],
     pub sysvars: &'a [(Pubkey, Vec<u8>)],
     log_collector: Option<Rc<RefCell<LogCollector>>>,
@@ -160,14 +152,13 @@ pub struct InvokeContext<'a> {
     pub timings: ExecuteDetailsTimings,
     pub blockhash: Hash,
     pub lamports_per_signature: u64,
-    pub return_data: (Pubkey, Vec<u8>),
 }
 
 impl<'a> InvokeContext<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        transaction_context: &'a TransactionContext,
         rent: Rent,
-        accounts: &'a [TransactionAccountRefCell],
         builtin_programs: &'a [BuiltinProgram],
         sysvars: &'a [(Pubkey, Vec<u8>)],
         log_collector: Option<Rc<RefCell<LogCollector>>>,
@@ -179,10 +170,11 @@ impl<'a> InvokeContext<'a> {
         lamports_per_signature: u64,
     ) -> Self {
         Self {
+            transaction_context,
+            return_data: (Pubkey::default(), Vec::new()),
             invoke_stack: Vec::with_capacity(compute_budget.max_invoke_depth),
             rent,
             pre_accounts: Vec::new(),
-            accounts,
             builtin_programs,
             sysvars,
             log_collector,
@@ -195,17 +187,16 @@ impl<'a> InvokeContext<'a> {
             timings: ExecuteDetailsTimings::default(),
             blockhash,
             lamports_per_signature,
-            return_data: (Pubkey::default(), Vec::new()),
         }
     }
 
     pub fn new_mock(
-        accounts: &'a [TransactionAccountRefCell],
+        transaction_context: &'a TransactionContext,
         builtin_programs: &'a [BuiltinProgram],
     ) -> Self {
         Self::new(
+            transaction_context,
             Rent::default(),
-            accounts,
             builtin_programs,
             &[],
             Some(LogCollector::new_ref()),
@@ -228,9 +219,10 @@ impl<'a> InvokeContext<'a> {
             return Err(InstructionError::CallDepth);
         }
 
-        let program_id = program_indices
-            .last()
-            .map(|index_of_program_id| &self.accounts[*index_of_program_id].0);
+        let program_id = program_indices.last().map(|account_index| {
+            self.transaction_context
+                .get_key_of_account_at_index(*account_index)
+        });
         if program_id.is_none()
             && self
                 .feature_set
@@ -262,10 +254,17 @@ impl<'a> InvokeContext<'a> {
 
             self.pre_accounts = Vec::with_capacity(instruction_accounts.len());
             let mut work = |_index_in_instruction: usize, entry: &InstructionAccount| {
-                if entry.index < self.accounts.len() {
-                    let account = self.accounts[entry.index].1.borrow().clone();
-                    self.pre_accounts
-                        .push(PreAccount::new(&self.accounts[entry.index].0, account));
+                if entry.index < self.transaction_context.get_number_of_accounts() {
+                    let account = self
+                        .transaction_context
+                        .get_account_at_index(entry.index)
+                        .borrow()
+                        .clone();
+                    self.pre_accounts.push(PreAccount::new(
+                        self.transaction_context
+                            .get_key_of_account_at_index(entry.index),
+                        account,
+                    ));
                     return Ok(());
                 }
                 Err(InstructionError::MissingAccount)
@@ -294,16 +293,20 @@ impl<'a> InvokeContext<'a> {
                 (
                     false,
                     false,
-                    &self.accounts[*account_index].0,
-                    &self.accounts[*account_index].1 as &RefCell<AccountSharedData>,
+                    self.transaction_context
+                        .get_key_of_account_at_index(*account_index),
+                    self.transaction_context
+                        .get_account_at_index(*account_index),
                 )
             })
             .chain(instruction_accounts.iter().map(|instruction_account| {
                 (
                     instruction_account.is_signer,
                     instruction_account.is_writable,
-                    &self.accounts[instruction_account.index].0,
-                    &self.accounts[instruction_account.index].1 as &RefCell<AccountSharedData>,
+                    self.transaction_context
+                        .get_key_of_account_at_index(instruction_account.index),
+                    self.transaction_context
+                        .get_account_at_index(instruction_account.index),
                 )
             }))
             .collect::<Vec<_>>();
@@ -340,8 +343,8 @@ impl<'a> InvokeContext<'a> {
 
         // Verify all executable accounts have zero outstanding refs
         for account_index in program_indices.iter() {
-            self.accounts[*account_index]
-                .1
+            self.transaction_context
+                .get_account_at_index(*account_index)
                 .try_borrow_mut()
                 .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
         }
@@ -352,14 +355,18 @@ impl<'a> InvokeContext<'a> {
         let mut work = |_index_in_instruction: usize, instruction_account: &InstructionAccount| {
             {
                 // Verify account has no outstanding references
-                let _ = self.accounts[instruction_account.index]
-                    .1
+                let _ = self
+                    .transaction_context
+                    .get_account_at_index(instruction_account.index)
                     .try_borrow_mut()
                     .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
             }
             let pre_account = &self.pre_accounts[pre_account_index];
             pre_account_index = pre_account_index.saturating_add(1);
-            let account = self.accounts[instruction_account.index].1.borrow();
+            let account = self
+                .transaction_context
+                .get_account_at_index(instruction_account.index)
+                .borrow();
             pre_account
                 .verify(
                     program_id,
@@ -410,15 +417,17 @@ impl<'a> InvokeContext<'a> {
             .ok_or(InstructionError::CallDepth)?;
         let rent = &self.rent;
         let log_collector = &self.log_collector;
-        let accounts = &self.accounts;
+        let transaction_context = self.transaction_context;
         let pre_accounts = &mut self.pre_accounts;
         let timings = &mut self.timings;
 
         // Verify the per-account instruction results
         let (mut pre_sum, mut post_sum) = (0_u128, 0_u128);
         let mut work = |index_in_instruction: usize, instruction_account: &InstructionAccount| {
-            if instruction_account.index < accounts.len() {
-                let (key, account) = &accounts[instruction_account.index];
+            if instruction_account.index < transaction_context.get_number_of_accounts() {
+                let key =
+                    transaction_context.get_key_of_account_at_index(instruction_account.index);
+                let account = transaction_context.get_account_at_index(instruction_account.index);
                 let is_writable = if let Some(caller_write_privileges) = caller_write_privileges {
                     caller_write_privileges[index_in_instruction]
                 } else {
@@ -487,8 +496,9 @@ impl<'a> InvokeContext<'a> {
             self.prepare_instruction(&instruction, signers)?;
         let mut prev_account_sizes = Vec::with_capacity(instruction_accounts.len());
         for instruction_account in instruction_accounts.iter() {
-            let account_length = self.accounts[instruction_account.index]
-                .1
+            let account_length = self
+                .transaction_context
+                .get_account_at_index(instruction_account.index)
                 .borrow()
                 .data()
                 .len();
@@ -506,7 +516,13 @@ impl<'a> InvokeContext<'a> {
         let do_support_realloc = self.feature_set.is_active(&do_support_realloc::id());
         for (account_index, prev_size) in prev_account_sizes.into_iter() {
             if !do_support_realloc
-                && prev_size != self.accounts[account_index].1.borrow().data().len()
+                && prev_size
+                    != self
+                        .transaction_context
+                        .get_account_at_index(account_index)
+                        .borrow()
+                        .data()
+                        .len()
                 && prev_size != 0
             {
                 // Only support for `CreateAccount` at this time.
@@ -536,9 +552,8 @@ impl<'a> InvokeContext<'a> {
         let mut duplicate_indicies = Vec::with_capacity(instruction.accounts.len());
         for account_meta in instruction.accounts.iter() {
             let account_index = self
-                .accounts
-                .iter()
-                .position(|(key, _account)| key == &account_meta.pubkey)
+                .transaction_context
+                .find_index_of_account(&account_meta.pubkey)
                 .ok_or_else(|| {
                     ic_msg!(
                         self,
@@ -617,15 +632,17 @@ impl<'a> InvokeContext<'a> {
             .iter()
             .find(|keyed_account| &callee_program_id == keyed_account.unsigned_key())
             .and_then(|_keyed_account| {
-                self.accounts
-                    .iter()
-                    .rposition(|(key, _account)| key == &callee_program_id)
+                self.transaction_context
+                    .find_index_of_program_account(&callee_program_id)
             })
             .ok_or_else(|| {
                 ic_msg!(self, "Unknown program {}", callee_program_id);
                 InstructionError::MissingAccount
             })?;
-        let program_account = self.accounts[program_account_index].1.borrow();
+        let program_account = self
+            .transaction_context
+            .get_account_at_index(program_account_index)
+            .borrow();
         if !program_account.executable() {
             ic_msg!(self, "Account {} is not executable", callee_program_id);
             return Err(InstructionError::AccountNotExecutable);
@@ -637,9 +654,8 @@ impl<'a> InvokeContext<'a> {
             } = program_account.state()?
             {
                 if let Some(programdata_account_index) = self
-                    .accounts
-                    .iter()
-                    .rposition(|(key, _account)| key == &programdata_address)
+                    .transaction_context
+                    .find_index_of_program_account(&programdata_address)
                 {
                     program_indices.push(programdata_account_index);
                 } else {
@@ -678,7 +694,7 @@ impl<'a> InvokeContext<'a> {
     ) -> Result<u64, InstructionError> {
         let program_id = program_indices
             .last()
-            .map(|index| self.accounts[*index].0)
+            .map(|index| *self.transaction_context.get_key_of_account_at_index(*index))
             .unwrap_or_else(native_loader::id);
 
         let is_lowest_invocation_level = self.invoke_stack.is_empty();
@@ -694,9 +710,8 @@ impl<'a> InvokeContext<'a> {
             if let Some(instruction_recorder) = &self.instruction_recorder {
                 let compiled_instruction = CompiledInstruction {
                     program_id_index: self
-                        .accounts
-                        .iter()
-                        .position(|(key, _account)| *key == program_id)
+                        .transaction_context
+                        .find_index_of_account(&program_id)
                         .unwrap_or(0) as u8,
                     data: instruction_data.to_vec(),
                     accounts: instruction_accounts
@@ -852,16 +867,6 @@ impl<'a> InvokeContext<'a> {
         self.executors.borrow().get(pubkey)
     }
 
-    /// Returns an account by its account_index
-    pub fn get_account_key_at_index(&self, account_index: usize) -> &Pubkey {
-        &self.accounts[account_index].0
-    }
-
-    /// Returns an account by its account_index
-    pub fn get_account_at_index(&self, account_index: usize) -> &RefCell<AccountSharedData> {
-        &self.accounts[account_index].1
-    }
-
     /// Get this invocation's compute budget
     pub fn get_compute_budget(&self) -> &ComputeBudget {
         &self.current_compute_budget
@@ -886,18 +891,14 @@ impl<'a> InvokeContext<'a> {
 }
 
 pub struct MockInvokeContextPreparation {
-    pub transaction_accounts: TransactionAccountRefCells,
+    pub transaction_accounts: Vec<TransactionAccount>,
     pub instruction_accounts: Vec<InstructionAccount>,
 }
 
 pub fn prepare_mock_invoke_context(
-    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    transaction_accounts: Vec<TransactionAccount>,
     instruction_accounts: Vec<AccountMeta>,
 ) -> MockInvokeContextPreparation {
-    let transaction_accounts: TransactionAccountRefCells = transaction_accounts
-        .into_iter()
-        .map(|(pubkey, account)| (pubkey, RefCell::new(account)))
-        .collect();
     let instruction_accounts = instruction_accounts
         .iter()
         .map(|account_meta| InstructionAccount {
@@ -941,7 +942,11 @@ pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
         is_writable: false,
     }];
     let preparation = prepare_mock_invoke_context(transaction_accounts, instruction_accounts);
-    let mut invoke_context = InvokeContext::new_mock(&preparation.transaction_accounts, &[]);
+    let transaction_context = TransactionContext::new(
+        preparation.transaction_accounts,
+        ComputeBudget::default().max_invoke_depth,
+    );
+    let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
     invoke_context
         .push(&preparation.instruction_accounts, &program_indices)
         .unwrap();
@@ -952,41 +957,38 @@ pub fn mock_process_instruction_with_sysvars(
     loader_id: &Pubkey,
     mut program_indices: Vec<usize>,
     instruction_data: &[u8],
-    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    transaction_accounts: Vec<TransactionAccount>,
     instruction_accounts: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
     sysvars: &[(Pubkey, Vec<u8>)],
     process_instruction: ProcessInstructionWithContext,
 ) -> Vec<AccountSharedData> {
     let mut preparation = prepare_mock_invoke_context(transaction_accounts, instruction_accounts);
-    let processor_account = RefCell::new(AccountSharedData::new(
-        0,
-        0,
-        &solana_sdk::native_loader::id(),
-    ));
+    let processor_account = AccountSharedData::new(0, 0, &solana_sdk::native_loader::id());
     program_indices.insert(0, preparation.transaction_accounts.len());
     preparation
         .transaction_accounts
         .push((*loader_id, processor_account));
-    let mut invoke_context = InvokeContext::new_mock(&preparation.transaction_accounts, &[]);
+    let transaction_context = TransactionContext::new(
+        preparation.transaction_accounts,
+        ComputeBudget::default().max_invoke_depth,
+    );
+    let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
     invoke_context.sysvars = sysvars;
     let result = invoke_context
         .push(&preparation.instruction_accounts, &program_indices)
         .and_then(|_| process_instruction(1, instruction_data, &mut invoke_context));
-    preparation.transaction_accounts.pop();
     assert_eq!(result, expected_result);
-    preparation
-        .transaction_accounts
-        .into_iter()
-        .map(|(_key, account)| account.into_inner())
-        .collect()
+    let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();
+    transaction_accounts.pop();
+    transaction_accounts
 }
 
 pub fn mock_process_instruction(
     loader_id: &Pubkey,
     program_indices: Vec<usize>,
     instruction_data: &[u8],
-    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    transaction_accounts: Vec<TransactionAccount>,
     instruction_accounts: Vec<AccountMeta>,
     expected_result: Result<(), InstructionError>,
     process_instruction: ProcessInstructionWithContext,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -252,7 +252,9 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         // Convert AccountInfos into Accounts
         let mut accounts = Vec::with_capacity(instruction_accounts.len());
         for instruction_account in instruction_accounts.iter() {
-            let account_key = invoke_context.get_account_key_at_index(instruction_account.index);
+            let account_key = invoke_context
+                .transaction_context
+                .get_key_of_account_at_index(instruction_account.index);
             let account_info = account_infos
                 .iter()
                 .find(|account_info| account_info.unsigned_key() == account_key)
@@ -260,6 +262,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
                 .unwrap();
             {
                 let mut account = invoke_context
+                    .transaction_context
                     .get_account_at_index(instruction_account.index)
                     .borrow_mut();
                 account.copy_into_owner_from_slice(account_info.owner.as_ref());
@@ -284,7 +287,9 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
         // Copy writeable account modifications back into the caller's AccountInfos
         for (account_index, account_info) in accounts.into_iter() {
-            let account = invoke_context.get_account_at_index(account_index);
+            let account = invoke_context
+                .transaction_context
+                .get_account_at_index(account_index);
             let account_borrow = account.borrow();
             **account_info.try_borrow_mut_lamports().unwrap() = account_borrow.lamports();
             let mut data = account_info.try_borrow_mut_data()?;

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -323,6 +323,7 @@ mod tests {
             bpf_loader,
             entrypoint::deserialize,
             instruction::AccountMeta,
+            transaction_context::TransactionContext,
         },
         std::{
             cell::RefCell,
@@ -452,7 +453,8 @@ mod tests {
         let program_indices = [0];
         let preparation =
             prepare_mock_invoke_context(transaction_accounts.clone(), instruction_accounts);
-        let mut invoke_context = InvokeContext::new_mock(&preparation.transaction_accounts, &[]);
+        let transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context
             .push(&preparation.instruction_accounts, &program_indices)
             .unwrap();

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2675,6 +2675,7 @@ mod tests {
         },
         solana_sdk::{
             account::AccountSharedData, bpf_loader, fee_calculator::FeeCalculator, hash::hashv,
+            transaction_context::TransactionContext,
         },
         std::str::FromStr,
     };
@@ -2985,9 +2986,11 @@ mod tests {
     #[should_panic(expected = "UserError(SyscallError(Panic(\"Gaggablaghblagh!\", 42, 84)))")]
     fn test_syscall_sol_panic() {
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let mut syscall_panic = SyscallPanic {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3056,9 +3059,11 @@ mod tests {
     #[test]
     fn test_syscall_sol_log() {
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let mut syscall_sol_log = SyscallLog {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3154,9 +3159,11 @@ mod tests {
     #[test]
     fn test_syscall_sol_log_u64() {
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let cost = invoke_context.get_compute_budget().log_64_units;
         let mut syscall_sol_log_u64 = SyscallLogU64 {
@@ -3190,9 +3197,11 @@ mod tests {
     #[test]
     fn test_syscall_sol_pubkey() {
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let cost = invoke_context.get_compute_budget().log_pubkey_units;
         let mut syscall_sol_pubkey = SyscallLogPubkey {
@@ -3396,10 +3405,14 @@ mod tests {
     fn test_syscall_sha256() {
         let config = Config::default();
         let program_id = Pubkey::new_unique();
-        let program_account =
-            RefCell::new(AccountSharedData::new(0, 0, &bpf_loader_deprecated::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(
+                program_id,
+                AccountSharedData::new(0, 0, &bpf_loader_deprecated::id()),
+            )],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
 
         let bytes1 = "Gaggablaghblagh!";
@@ -3517,11 +3530,55 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_syscall_get_sysvar() {
         let config = Config::default();
+        let src_clock = Clock {
+            slot: 1,
+            epoch_start_timestamp: 2,
+            epoch: 3,
+            leader_schedule_epoch: 4,
+            unix_timestamp: 5,
+        };
+        let mut data_clock = vec![];
+        bincode::serialize_into(&mut data_clock, &src_clock).unwrap();
+        let src_epochschedule = EpochSchedule {
+            slots_per_epoch: 1,
+            leader_schedule_slot_offset: 2,
+            warmup: false,
+            first_normal_epoch: 3,
+            first_normal_slot: 4,
+        };
+        let mut data_epochschedule = vec![];
+        bincode::serialize_into(&mut data_epochschedule, &src_epochschedule).unwrap();
+        let src_fees = Fees {
+            fee_calculator: FeeCalculator {
+                lamports_per_signature: 1,
+            },
+        };
+        let mut data_fees = vec![];
+        bincode::serialize_into(&mut data_fees, &src_fees).unwrap();
+        let src_rent = Rent {
+            lamports_per_byte_year: 1,
+            exemption_threshold: 2.0,
+            burn_percent: 3,
+        };
+        let mut data_rent = vec![];
+        bincode::serialize_into(&mut data_rent, &src_rent).unwrap();
+        let sysvars = [
+            (sysvar::clock::id(), data_clock),
+            (sysvar::epoch_schedule::id(), data_epochschedule),
+            (sysvar::fees::id(), data_fees),
+            (sysvar::rent::id(), data_rent),
+        ];
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
+        invoke_context.sysvars = &sysvars;
+        invoke_context.push(&[], &[0]).unwrap();
 
         // Test clock sysvar
         {
@@ -3542,20 +3599,6 @@ mod tests {
                 &config,
             )
             .unwrap();
-
-            let src_clock = Clock {
-                slot: 1,
-                epoch_start_timestamp: 2,
-                epoch: 3,
-                leader_schedule_epoch: 4,
-                unix_timestamp: 5,
-            };
-            let mut data = vec![];
-            bincode::serialize_into(&mut data, &src_clock).unwrap();
-            let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
-            let sysvars = [(sysvar::clock::id(), data)];
-            invoke_context.sysvars = &sysvars;
-            invoke_context.push(&[], &[0]).unwrap();
             let mut syscall = SyscallGetClockSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             };
@@ -3585,20 +3628,6 @@ mod tests {
                 &config,
             )
             .unwrap();
-
-            let src_epochschedule = EpochSchedule {
-                slots_per_epoch: 1,
-                leader_schedule_slot_offset: 2,
-                warmup: false,
-                first_normal_epoch: 3,
-                first_normal_slot: 4,
-            };
-            let mut data = vec![];
-            bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
-            let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
-            let sysvars = [(sysvar::epoch_schedule::id(), data)];
-            invoke_context.sysvars = &sysvars;
-            invoke_context.push(&[], &[0]).unwrap();
             let mut syscall = SyscallGetEpochScheduleSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             };
@@ -3618,7 +3647,6 @@ mod tests {
         }
 
         // Test fees sysvar
-        #[allow(deprecated)]
         {
             let got_fees = Fees::default();
             let got_fees_va = 0x100000000;
@@ -3637,18 +3665,6 @@ mod tests {
                 &config,
             )
             .unwrap();
-
-            let src_fees = Fees {
-                fee_calculator: FeeCalculator {
-                    lamports_per_signature: 1,
-                },
-            };
-            let mut data = vec![];
-            bincode::serialize_into(&mut data, &src_fees).unwrap();
-            let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
-            let sysvars = [(sysvar::fees::id(), data)];
-            invoke_context.sysvars = &sysvars;
-            invoke_context.push(&[], &[0]).unwrap();
             let mut syscall = SyscallGetFeesSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             };
@@ -3678,18 +3694,6 @@ mod tests {
                 &config,
             )
             .unwrap();
-
-            let src_rent = Rent {
-                lamports_per_byte_year: 1,
-                exemption_threshold: 2.0,
-                burn_percent: 3,
-            };
-            let mut data = vec![];
-            bincode::serialize_into(&mut data, &src_rent).unwrap();
-            let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
-            let sysvars = [(sysvar::rent::id(), data)];
-            invoke_context.sysvars = &sysvars;
-            invoke_context.push(&[], &[0]).unwrap();
             let mut syscall = SyscallGetRentSysvar {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             };
@@ -3818,9 +3822,11 @@ mod tests {
         // These tests duplicate the direct tests in solana_program::pubkey
 
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let address = bpf_loader_upgradeable::id();
 
@@ -3928,9 +3934,11 @@ mod tests {
     #[test]
     fn test_find_program_address() {
         let program_id = Pubkey::new_unique();
-        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
-        let accounts = [(program_id, program_account)];
-        let mut invoke_context = InvokeContext::new_mock(&accounts, &[]);
+        let transaction_context = TransactionContext::new(
+            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
+        );
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.push(&[], &[0]).unwrap();
         let cost = invoke_context
             .get_compute_budget()

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1308,6 +1308,7 @@ mod tests {
             native_token,
             pubkey::Pubkey,
             system_program,
+            transaction_context::TransactionContext,
         },
         solana_vote_program::vote_state,
         std::{cell::RefCell, iter::FromIterator},
@@ -4998,7 +4999,8 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5108,7 +5110,8 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
         let signers = HashSet::from_iter(vec![authority_pubkey]);
@@ -5153,7 +5156,8 @@ mod tests {
 
     #[test]
     fn test_merge_incorrect_authorized_staker() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5222,7 +5226,8 @@ mod tests {
 
     #[test]
     fn test_merge_invalid_account_data() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5272,7 +5277,8 @@ mod tests {
 
     #[test]
     fn test_merge_fake_stake_source() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5314,7 +5320,8 @@ mod tests {
 
     #[test]
     fn test_merge_active_stake() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let base_lamports = 4242424242;
         let stake_address = Pubkey::new_unique();
         let source_address = Pubkey::new_unique();
@@ -5936,7 +5943,8 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let good_stake = Stake {
             credits_observed: 4242,
             delegation: Delegation {
@@ -6034,7 +6042,8 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_pre_v4() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6120,7 +6129,8 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_v4() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
@@ -6266,7 +6276,8 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
         let rent = Rent::default();
@@ -6498,7 +6509,8 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let lamports = 424242;
         let meta = Meta {
             rent_exempt_reserve: 42,
@@ -6576,7 +6588,8 @@ mod tests {
 
     #[test]
     fn test_active_stake_merge() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let delegation_a = 4_242_424_242u64;
         let delegation_b = 6_200_000_000u64;
         let credits_a = 124_521_000u64;

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -16,6 +16,7 @@ use {
     },
     solana_sdk::{
         account::AccountSharedData, bpf_loader, instruction::AccountMeta, pubkey::Pubkey,
+        transaction_context::TransactionContext,
     },
     std::{
         fs::File,
@@ -210,7 +211,8 @@ native machine code before execting it in the virtual machine.",
     };
     let preparation = prepare_mock_invoke_context(transaction_accounts, instruction_accounts);
     let program_indices = [0, 1];
-    let mut invoke_context = InvokeContext::new_mock(&preparation.transaction_accounts, &[]);
+    let transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
+    let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
     invoke_context
         .push(&preparation.instruction_accounts, &program_indices)
         .unwrap();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -502,6 +502,7 @@ mod tests {
         system_instruction, system_program, sysvar,
         sysvar::recent_blockhashes::IterItem,
         transaction::TransactionError,
+        transaction_context::TransactionContext,
     };
     use {
         super::*,
@@ -674,7 +675,8 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";
         let to = Pubkey::new_unique();
@@ -688,7 +690,8 @@ mod tests {
 
     #[test]
     fn test_create_account_with_seed_missing_sig() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";
@@ -718,7 +721,8 @@ mod tests {
 
     #[test]
     fn test_create_with_zero_lamports() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // create account with zero lamports transferred
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -752,7 +756,8 @@ mod tests {
 
     #[test]
     fn test_create_negative_lamports() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Attempt to create account with more lamports than remaining in from_account
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -776,7 +781,8 @@ mod tests {
 
     #[test]
     fn test_request_more_than_allowed_data_length() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
         let from = Pubkey::new_unique();
         let to_account = RefCell::new(AccountSharedData::new(0, 0, &system_program::id()));
@@ -823,7 +829,8 @@ mod tests {
 
     #[test]
     fn test_create_already_in_use() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Attempt to create system account in account already owned by another program
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -891,7 +898,8 @@ mod tests {
 
     #[test]
     fn test_create_unsigned() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Attempt to create an account without signing the transfer
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -946,7 +954,8 @@ mod tests {
 
     #[test]
     fn test_create_sysvar_invalid_id_with_feature() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Attempt to create system account in account already owned by another program
         let from = Pubkey::new_unique();
         let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
@@ -980,7 +989,8 @@ mod tests {
         feature_set
             .inactive
             .insert(feature_set::rent_for_sysvars::id());
-        let mut invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.feature_set = Arc::new(feature_set);
         // Attempt to create system account in account already owned by another program
         let from = Pubkey::new_unique();
@@ -1007,7 +1017,8 @@ mod tests {
 
     #[test]
     fn test_create_data_populated() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         // Attempt to create system account in account with populated data
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -1040,7 +1051,8 @@ mod tests {
 
     #[test]
     fn test_create_from_account_is_nonce_fail() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let nonce = Pubkey::new_unique();
         let nonce_account = RefCell::new(
             AccountSharedData::new_data(
@@ -1078,7 +1090,8 @@ mod tests {
 
     #[test]
     fn test_assign() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let new_owner = Pubkey::new(&[9; 32]);
         let pubkey = Pubkey::new_unique();
         let mut account = AccountSharedData::new(100, 0, &system_program::id());
@@ -1120,7 +1133,8 @@ mod tests {
 
     #[test]
     fn test_assign_to_sysvar_with_feature() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let new_owner = sysvar::id();
         let from = Pubkey::new_unique();
         let mut from_account = AccountSharedData::new(100, 0, &system_program::id());
@@ -1146,7 +1160,8 @@ mod tests {
         feature_set
             .inactive
             .insert(feature_set::rent_for_sysvars::id());
-        let mut invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context.feature_set = Arc::new(feature_set);
         let new_owner = sysvar::id();
         let from = Pubkey::new_unique();
@@ -1197,7 +1212,8 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let from = Pubkey::new_unique();
         let from_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
         let to = Pubkey::new(&[3; 32]);
@@ -1235,7 +1251,8 @@ mod tests {
 
     #[test]
     fn test_transfer_with_seed() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let base = Pubkey::new_unique();
         let base_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
         let from_base_keyed_account = KeyedAccount::new(&base, true, &base_account);
@@ -1295,7 +1312,8 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports_from_nonce_account_fail() {
-        let invoke_context = InvokeContext::new_mock(&[], &[]);
+        let transaction_context = TransactionContext::new(Vec::new(), 1);
+        let invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         let from = Pubkey::new_unique();
         let from_account = RefCell::new(
             AccountSharedData::new_data(

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -46,6 +46,7 @@ pub mod signer;
 pub mod system_transaction;
 pub mod timing;
 pub mod transaction;
+pub mod transaction_context;
 pub mod transport;
 pub mod wasm;
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -1,0 +1,342 @@
+//! Successors of instruction_context_context::StackFrame, KeyedAccount and AccountInfo
+
+use crate::{
+    account::{AccountSharedData, ReadableAccount, WritableAccount},
+    instruction::InstructionError,
+    pubkey::Pubkey,
+};
+use std::cell::{RefCell, RefMut};
+
+pub type TransactionAccount = (Pubkey, AccountSharedData);
+
+#[derive(Clone, Debug)]
+pub struct InstructionAccount {
+    pub index: usize,
+    pub is_signer: bool,
+    pub is_writable: bool,
+}
+
+/// Loaded transaction shared between runtime and programs.
+///
+/// This context is valid for the entire duration of a transaction being processed.
+pub struct TransactionContext {
+    account_keys: Vec<Pubkey>,
+    accounts: Vec<RefCell<AccountSharedData>>,
+    instruction_context_capacity: usize,
+    instruction_context_stack: Vec<InstructionContext>,
+    return_data: (Pubkey, Vec<u8>),
+}
+
+impl TransactionContext {
+    /// Constructs a new TransactionContext
+    pub fn new(
+        transaction_accounts: Vec<TransactionAccount>,
+        instruction_context_capacity: usize,
+    ) -> Self {
+        let (account_keys, accounts) = transaction_accounts
+            .into_iter()
+            .map(|(key, account)| (key, RefCell::new(account)))
+            .unzip();
+        Self {
+            account_keys,
+            accounts,
+            instruction_context_capacity,
+            instruction_context_stack: Vec::with_capacity(instruction_context_capacity),
+            return_data: (Pubkey::default(), Vec::new()),
+        }
+    }
+
+    /// Used by the bank in the runtime to write back the processed accounts
+    pub fn deconstruct(self) -> Vec<TransactionAccount> {
+        self.account_keys
+            .into_iter()
+            .zip(
+                self.accounts
+                    .into_iter()
+                    .map(|account| account.into_inner()),
+            )
+            .collect()
+    }
+
+    /// Used in mock_process_instruction
+    pub fn deconstruct_without_keys(self) -> Result<Vec<AccountSharedData>, InstructionError> {
+        if !self.instruction_context_stack.is_empty() {
+            return Err(InstructionError::CallDepth);
+        }
+        Ok(self
+            .accounts
+            .into_iter()
+            .map(|account| account.into_inner())
+            .collect())
+    }
+
+    /// Returns the total number of accounts loaded in this Transaction
+    pub fn get_number_of_accounts(&self) -> usize {
+        self.accounts.len()
+    }
+
+    /// Searches for an account by its key
+    pub fn get_key_of_account_at_index(&self, index_in_transaction: usize) -> &Pubkey {
+        &self.account_keys[index_in_transaction]
+    }
+
+    /// Searches for an account by its key
+    pub fn get_account_at_index(&self, index_in_transaction: usize) -> &RefCell<AccountSharedData> {
+        &self.accounts[index_in_transaction]
+    }
+
+    /// Searches for an account by its key
+    pub fn find_index_of_account(&self, pubkey: &Pubkey) -> Option<usize> {
+        self.account_keys.iter().position(|key| key == pubkey)
+    }
+
+    /// Searches for a program account by its key
+    pub fn find_index_of_program_account(&self, pubkey: &Pubkey) -> Option<usize> {
+        self.account_keys.iter().rposition(|key| key == pubkey)
+    }
+
+    /// Gets an InstructionContext by its height in the stack
+    pub fn get_instruction_context_at(
+        &self,
+        instruction_context_height: usize,
+    ) -> Result<&InstructionContext, InstructionError> {
+        if instruction_context_height >= self.instruction_context_stack.len() {
+            return Err(InstructionError::CallDepth);
+        }
+        Ok(&self.instruction_context_stack[instruction_context_height])
+    }
+
+    /// Gets the max height of the InstructionContext stack
+    pub fn get_instruction_context_capacity(&self) -> usize {
+        self.instruction_context_capacity
+    }
+
+    /// Gets the height of the current InstructionContext
+    pub fn get_instruction_context_height(&self) -> usize {
+        self.instruction_context_stack.len().saturating_sub(1)
+    }
+
+    /// Returns the current InstructionContext
+    pub fn get_current_instruction_context(&self) -> Result<&InstructionContext, InstructionError> {
+        self.get_instruction_context_at(self.get_instruction_context_height())
+    }
+
+    /// Gets the last program account of the current InstructionContext
+    pub fn try_borrow_program_account(&self) -> Result<BorrowedAccount, InstructionError> {
+        let instruction_context = self.get_current_instruction_context()?;
+        instruction_context.try_borrow_account(
+            self,
+            instruction_context
+                .number_of_program_accounts
+                .saturating_sub(1),
+        )
+    }
+
+    /// Gets an instruction account of the current InstructionContext
+    pub fn try_borrow_instruction_account(
+        &self,
+        index_in_instruction: usize,
+    ) -> Result<BorrowedAccount, InstructionError> {
+        let instruction_context = self.get_current_instruction_context()?;
+        instruction_context.try_borrow_account(
+            self,
+            instruction_context
+                .number_of_program_accounts
+                .saturating_add(index_in_instruction),
+        )
+    }
+
+    /// Pushes a new InstructionContext
+    pub fn push(
+        &mut self,
+        number_of_program_accounts: usize,
+        instruction_accounts: &[InstructionAccount],
+        instruction_data: Vec<u8>,
+    ) -> Result<(), InstructionError> {
+        if self.instruction_context_stack.len() >= self.instruction_context_capacity {
+            return Err(InstructionError::CallDepth);
+        }
+        let mut result = InstructionContext {
+            instruction_data,
+            number_of_program_accounts,
+            account_indices: Vec::with_capacity(instruction_accounts.len()),
+            account_is_signer: Vec::with_capacity(instruction_accounts.len()),
+            account_is_writable: Vec::with_capacity(instruction_accounts.len()),
+        };
+        for instruction_account in instruction_accounts.iter() {
+            result.account_indices.push(instruction_account.index);
+            result.account_is_signer.push(instruction_account.is_signer);
+            result
+                .account_is_writable
+                .push(instruction_account.is_writable);
+        }
+        self.instruction_context_stack.push(result);
+        Ok(())
+    }
+
+    /// Pops the current InstructionContext
+    pub fn pop(&mut self) -> Result<(), InstructionError> {
+        if self.instruction_context_stack.is_empty() {
+            return Err(InstructionError::CallDepth);
+        }
+        self.instruction_context_stack.pop();
+        Ok(())
+    }
+
+    /// Gets the return data of the current InstructionContext or any above
+    pub fn get_return_data(&self) -> (&Pubkey, &[u8]) {
+        (&self.return_data.0, &self.return_data.1)
+    }
+
+    /// Set the return data of the current InstructionContext
+    pub fn set_return_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
+        let pubkey = *self.try_borrow_program_account()?.get_key();
+        self.return_data = (pubkey, data);
+        Ok(())
+    }
+}
+
+/// Loaded instruction shared between runtime and programs.
+///
+/// This context is valid for the entire duration of a (possibly cross program) instruction being processed.
+pub struct InstructionContext {
+    number_of_program_accounts: usize,
+    account_indices: Vec<usize>,
+    account_is_signer: Vec<bool>,
+    account_is_writable: Vec<bool>,
+    instruction_data: Vec<u8>,
+}
+
+impl InstructionContext {
+    /// Number of program accounts
+    pub fn get_number_of_program_accounts(&self) -> usize {
+        self.number_of_program_accounts
+    }
+
+    /// Number of accounts in this Instruction (without program accounts)
+    pub fn get_number_of_instruction_accounts(&self) -> usize {
+        self.account_indices
+            .len()
+            .saturating_sub(self.number_of_program_accounts)
+    }
+
+    /// Total number of accounts in this Instruction (with program accounts)
+    pub fn get_total_number_of_accounts(&self) -> usize {
+        self.account_indices.len()
+    }
+
+    /// Data parameter for the programs `process_instruction` handler
+    pub fn get_instruction_data(&self) -> &[u8] {
+        &self.instruction_data
+    }
+
+    /// Tries to borrow an account from this Instruction
+    pub fn try_borrow_account<'a, 'b: 'a>(
+        &'a self,
+        transaction_context: &'b TransactionContext,
+        index_in_instruction: usize,
+    ) -> Result<BorrowedAccount<'a>, InstructionError> {
+        if index_in_instruction >= self.account_indices.len() {
+            return Err(InstructionError::NotEnoughAccountKeys);
+        }
+        let index_in_transaction = self.account_indices[index_in_instruction];
+        if index_in_transaction >= transaction_context.accounts.len() {
+            return Err(InstructionError::MissingAccount);
+        }
+        let account = transaction_context.accounts[index_in_transaction]
+            .try_borrow_mut()
+            .map_err(|_| InstructionError::AccountBorrowFailed)?;
+        Ok(BorrowedAccount {
+            transaction_context,
+            instruction_context: self,
+            index_in_transaction,
+            index_in_instruction,
+            account,
+        })
+    }
+}
+
+/// Shared account borrowed from the TransactionContext and an InstructionContext.
+pub struct BorrowedAccount<'a> {
+    transaction_context: &'a TransactionContext,
+    instruction_context: &'a InstructionContext,
+    index_in_transaction: usize,
+    index_in_instruction: usize,
+    account: RefMut<'a, AccountSharedData>,
+}
+
+impl<'a> BorrowedAccount<'a> {
+    /// Returns the public key of this account (transaction wide)
+    pub fn get_key(&self) -> &Pubkey {
+        &self.transaction_context.account_keys[self.index_in_transaction]
+    }
+
+    /// Returns the owner of this account (transaction wide)
+    pub fn get_owner(&self) -> &Pubkey {
+        self.account.owner()
+    }
+
+    /// Assignes the owner of this account (transaction wide)
+    pub fn set_owner(&mut self, pubkey: Pubkey) -> Result<(), InstructionError> {
+        if !self.is_writable() {
+            return Err(InstructionError::Immutable);
+        }
+        self.account.set_owner(pubkey);
+        Ok(())
+    }
+
+    /// Returns the number of lamports of this account (transaction wide)
+    pub fn get_lamports(&self) -> u64 {
+        self.account.lamports()
+    }
+
+    /// Overwrites the number of lamports of this account (transaction wide)
+    pub fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
+        if !self.is_writable() {
+            return Err(InstructionError::Immutable);
+        }
+        self.account.set_lamports(lamports);
+        Ok(())
+    }
+
+    /// Returns a read-only slice of the account data (transaction wide)
+    pub fn get_data(&self) -> &[u8] {
+        self.account.data()
+    }
+
+    /// Returns a writable slice of the account data (transaction wide)
+    pub fn get_data_mut(&mut self) -> Result<&mut [u8], InstructionError> {
+        if !self.is_writable() {
+            return Err(InstructionError::Immutable);
+        }
+        Ok(self.account.data_as_mut_slice())
+    }
+
+    /*pub fn realloc(&self, new_len: usize, zero_init: bool) {
+        // TODO
+    }*/
+
+    /// Returns whether this account is executable (transaction wide)
+    pub fn is_executable(&self) -> bool {
+        self.account.executable()
+    }
+
+    /// Configures whether this account is executable (transaction wide)
+    pub fn set_executable(&mut self, is_executable: bool) -> Result<(), InstructionError> {
+        if !self.is_writable() {
+            return Err(InstructionError::Immutable);
+        }
+        self.account.set_executable(is_executable);
+        Ok(())
+    }
+
+    /// Returns whether this account is a signer (instruction wide)
+    pub fn is_signer(&self) -> bool {
+        self.instruction_context.account_is_signer[self.index_in_instruction]
+    }
+
+    /// Returns whether this account is writable (instruction wide)
+    pub fn is_writable(&self) -> bool {
+        self.instruction_context.account_is_writable[self.index_in_instruction]
+    }
+}


### PR DESCRIPTION
#21882 and #21927 are preparations for this PR to remove the `Rc` from `Refcell<AccountSharedData>` in the program-runtime because `Rc` can not be serialized.

#### Problem
- `KeyedAccount` does not validate `self.is_writable()` before modification
- As the name suggests, `KeyedAccount` works by using `Pubkey` instead of an index (in instruction and in transaction)
- `KeyedAccount` and `AccountInfo` are two redundant implementations of nearly the same interface

#### Summary of Changes
As proposed for ABIv2 (https://github.com/solana-labs/solana/pull/19191):
- Adds `TransactionContext` to outsource the `accounts`, `invoke_stack` and `return_data` properties of `InvokeContext`
- Adds `InstructionContext` which will replace `invoke_context::StackFrame`
- Adds `BorrowedAccount` which will replace only `KeyedAccount` at first and later also `AccountInfo`
- Redirects the usage of `accounts` in `InvokeContext` through `TransactionContext`.
- Moves the types `TransactionAccount` and `InstructionAccount` into `transaction_context.rs`.

Replacement of other runtime structs and the encoding and the new BPF loader will come later.
This is only about the interfaces for the runtime and program tests for now, so that we can start migrating them.

Open issues / up to discussion:
- `BorrowedAccount` is a `RefMut`, so the user won't be able to borrow the same account multiple times even if they don't want to modify any. But of course, the user can have multiple references to one `BorrowedAccount` and also wrap it in a `RefCell`. I don't think that introducing a `BorrowedAccountReadonly` is necessary.
- Account reallocation interface: Copy the one from `AccountInfo`?

Fixes #
