### PR TITLE
Leader QoS service metrics

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -97,7 +97,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
-                &Arc::new(QosService::new(Arc::new(RwLock::new(CostModel::default())))),
+                &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
             );
         });
 


### PR DESCRIPTION
#### Problem
It'd be better if TPU transaction counters are aggregated by slots, would make QoS investigation easier. 

#### Summary of Changes
- qos_service metrics tagged with leader thread ids to separate gossip/tpu votes and transactions;
- qos_service metrics is reported with bank slot;
- replaced timer-based reporting with signal via channel; removed async report test as qos_service now lives within a thread
- add tpu live packets (eg, not buffered packets) states to qos metrics reporting

Fixes #
