### PR TITLE
generate index goes to mem not disk

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -520,9 +520,39 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
             }
             Entry::Vacant(vacant) => {
                 // not in cache, look on disk
-                let already_existed =
-                    self.upsert_on_disk(vacant, new_entry, &mut Vec::default(), false);
-                (false, already_existed)
+                let initial_insert_directly_to_disk = false;
+                if initial_insert_directly_to_disk {
+                    // This is more direct, but becomes too slow with very large acct #.
+                    // disk buckets will be improved to make them more performant. Tuning the disks may also help.
+                    // This may become a config tuning option.
+                    let already_existed =
+                        self.upsert_on_disk(vacant, new_entry, &mut Vec::default(), false);
+                    (false, already_existed)
+                } else {
+                    let disk_entry = self.load_account_entry_from_disk(vacant.key());
+                    self.stats().insert_or_delete_mem(true, self.bin);
+                    if let Some(disk_entry) = disk_entry {
+                        let (slot, account_info) = new_entry.into();
+                        InMemAccountsIndex::lock_and_update_slot_list(
+                            &disk_entry,
+                            (slot, account_info),
+                            &mut Vec::default(),
+                            false,
+                        );
+                        vacant.insert(disk_entry);
+                        (
+                            false, /* found in mem */
+                            true,  /* already existed */
+                        )
+                    } else {
+                        // not on disk, so insert new thing and we're done
+                        let new_entry: AccountMapEntry<T> =
+                            new_entry.into_account_map_entry(&self.storage);
+                        assert!(new_entry.dirty());
+                        vacant.insert(new_entry);
+                        (false, false)
+                    }
+                }
             }
         };
         drop(map);


### PR DESCRIPTION
#### Problem
Going straight to disk doesn't work well at high acct#s yet. We may soon work to improve straight to disk index. In the meantime, it hampers perf at high accounts to go direct to disk.
#### Summary of Changes

Fixes #
