### PR TITLE
AcctIdx: disable direct to disk for filler account upsert

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -360,7 +360,10 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                     }
                     Entry::Vacant(vacant) => {
                         // not in cache, look on disk
-                        let directly_to_disk = self.storage.get_startup();
+
+                        // desired to be this for filler accounts: self.storage.get_startup();
+                        // but, this has proven to be far too slow at high account counts
+                        let directly_to_disk = false;
                         if directly_to_disk {
                             // We may like this to always run, but it is unclear.
                             // If disk bucket needs to resize, then this call can stall for a long time.


### PR DESCRIPTION
#### Problem
Intention was to speed up the filler account insertion process. Works fine at lower acct #s. Currently performs poorly at higher #s. Will likely change this back once perf is better.
#### Summary of Changes

Fixes #
