### PR TITLE
Refactor cached vote account creation

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -191,7 +191,7 @@ impl AggregateCommitmentService {
             if *lamports == 0 {
                 continue;
             }
-            if let Ok(vote_state) = account.vote_state().as_ref() {
+            if let Some(vote_state) = account.vote_state() {
                 Self::aggregate_commitment_for_vote_account(
                     &mut commitment,
                     &mut rooted_stake,
@@ -493,12 +493,7 @@ mod tests {
     fn test_highest_confirmed_root_advance() {
         fn get_vote_account_root_slot(vote_pubkey: Pubkey, bank: &Arc<Bank>) -> Slot {
             let (_stake, vote_account) = bank.get_vote_account(&vote_pubkey).unwrap();
-            let slot = vote_account
-                .vote_state()
-                .as_ref()
-                .unwrap()
-                .root_slot
-                .unwrap();
+            let slot = vote_account.vote_state().unwrap().root_slot.unwrap();
             slot
         }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -222,8 +222,8 @@ impl Tower {
                 continue;
             }
             trace!("{} {} with stake {}", vote_account_pubkey, key, voted_stake);
-            let mut vote_state = match account.vote_state().as_ref() {
-                Err(_) => {
+            let mut vote_state = match account.vote_state() {
+                None => {
                     datapoint_warn!(
                         "tower_warn",
                         (
@@ -234,7 +234,7 @@ impl Tower {
                     );
                     continue;
                 }
-                Ok(vote_state) => vote_state.clone(),
+                Some(vote_state) => vote_state.clone(),
             };
             for vote in &vote_state.votes {
                 lockout_intervals
@@ -384,7 +384,7 @@ impl Tower {
 
     pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
         let (_stake, vote_account) = bank.get_vote_account(vote_account_pubkey)?;
-        let slot = vote_account.vote_state().as_ref().ok()?.last_voted_slot();
+        let slot = vote_account.vote_state()?.last_voted_slot();
         slot
     }
 
@@ -1138,7 +1138,6 @@ impl Tower {
         if let Some((_stake, vote_account)) = bank.get_vote_account(vote_account_pubkey) {
             self.vote_state = vote_account
                 .vote_state()
-                .as_ref()
                 .expect("vote_account isn't a VoteState?")
                 .clone();
             self.initialize_root(root);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1726,16 +1726,15 @@ impl ReplayStage {
             }
             Some((_stake, vote_account)) => vote_account,
         };
-        let vote_state = vote_account.vote_state();
-        let vote_state = match vote_state.as_ref() {
-            Err(_) => {
+        let vote_state = match vote_account.vote_state() {
+            None => {
                 warn!(
                     "Vote account {} is unreadable.  Unable to vote",
                     vote_account_pubkey,
                 );
                 return None;
             }
-            Ok(vote_state) => vote_state,
+            Some(vote_state) => vote_state,
         };
 
         if vote_state.node_pubkey != node_keypair.pubkey() {
@@ -5795,10 +5794,7 @@ pub mod tests {
         let (_stake, vote_account) = expired_bank_child
             .get_vote_account(&my_vote_pubkey)
             .unwrap();
-        assert_eq!(
-            vote_account.vote_state().as_ref().unwrap().tower(),
-            vec![0, 1]
-        );
+        assert_eq!(vote_account.vote_state().unwrap().tower(), vec![0, 1]);
         expired_bank_child.fill_bank_with_ticks();
         expired_bank_child.freeze();
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1639,7 +1639,6 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
         }
         let vote_state_node_pubkey = vote_account
             .vote_state()
-            .as_ref()
             .map(|vote_state| vote_state.node_pubkey)
             .unwrap_or_default();
 

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -90,7 +90,7 @@ impl<'a> Iterator for ValidatorGossipVotesIterator<'a> {
                         .vote_accounts()
                         .get(&vote_account_key)
                         .and_then(|(_stake, vote_account)| {
-                            vote_account.vote_state().as_ref().ok().map(|vote_state| {
+                            vote_account.vote_state().map(|vote_state| {
                                 let start_vote_slot =
                                     vote_state.last_voted_slot().map(|x| x + 1).unwrap_or(0);
                                 // Filter out the votes that are outdated

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -366,8 +366,7 @@ fn graph_forks(bank_forks: &BankForks, include_all_votes: bool) -> String {
             .map(|(_, (stake, _))| stake)
             .sum();
         for (stake, vote_account) in bank.vote_accounts().values() {
-            let vote_state = vote_account.vote_state();
-            let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
+            let vote_state = vote_account.vote_state().unwrap_or(&default_vote_state);
             if let Some(last_vote) = vote_state.votes.iter().last() {
                 let entry = last_votes.entry(vote_state.node_pubkey).or_insert((
                     last_vote.slot,
@@ -407,8 +406,7 @@ fn graph_forks(bank_forks: &BankForks, include_all_votes: bool) -> String {
         let mut first = true;
         loop {
             for (_, vote_account) in bank.vote_accounts().values() {
-                let vote_state = vote_account.vote_state();
-                let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
+                let vote_state = vote_account.vote_state().unwrap_or(&default_vote_state);
                 if let Some(last_vote) = vote_state.votes.iter().last() {
                     let validator_votes = all_votes.entry(vote_state.node_pubkey).or_default();
                     validator_votes

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1335,15 +1335,15 @@ fn supermajority_root_from_vote_accounts(
                 return None;
             }
 
-            match account.vote_state().as_ref() {
-                Err(_) => {
+            match account.vote_state() {
+                None => {
                     warn!(
                         "Unable to get vote_state from account {} in bank: {}",
                         key, bank_slot
                     );
                     None
                 }
-                Ok(vote_state) => Some((vote_state.root_slot?, *stake)),
+                Some(vote_state) => Some((vote_state.root_slot?, *stake)),
             }
         })
         .collect();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -840,8 +840,7 @@ impl JsonRpcRequestProcessor {
                     }
                 }
 
-                let vote_state = account.vote_state();
-                let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
+                let vote_state = account.vote_state().unwrap_or(&default_vote_state);
                 let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
                     vote.slot
                 } else {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -71,9 +71,8 @@ impl EpochStakes {
         let epoch_authorized_voters = epoch_vote_accounts
             .iter()
             .filter_map(|(key, (stake, account))| {
-                let vote_state = account.vote_state();
-                let vote_state = match vote_state.as_ref() {
-                    Err(_) => {
+                let vote_state = match account.vote_state() {
+                    None => {
                         datapoint_warn!(
                             "parse_epoch_vote_accounts",
                             (
@@ -84,7 +83,7 @@ impl EpochStakes {
                         );
                         return None;
                     }
-                    Ok(vote_state) => vote_state,
+                    Some(vote_state) => vote_state,
                 };
 
                 if *stake > 0 {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -247,7 +247,7 @@ impl Stakes {
             .vote_accounts
             .iter()
             .max_by(|(_ak, av), (_bk, bv)| av.0.cmp(&bv.0))?;
-        let node_pubkey = vote_account.vote_state().as_ref().ok()?.node_pubkey;
+        let node_pubkey = vote_account.vote_state().as_ref()?.node_pubkey;
         Some(node_pubkey)
     }
 }


### PR DESCRIPTION
#### Problem
When caching vote accounts in the stakes cache, account data is lazily deserialized into a `VoteState` struct when necessary. However, this deserialization is nearly always done immediately because when adding a vote account, the stakes cache needs to deserialize the vote state to retrieve the node pubkey to track any updates to the amount of stake delegated to validators.

#### Summary of Changes
- Remove lazy calculation
- Store vote state as an `Option` rather than `Result` since the err is never read anyways

Follow-up PR will eagerly deserialize vote accounts before taking a write lock on the stakes cache

Fixes #
