### PR TITLE
Point to getParsedAccountInfo from getAccountInfo

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2458,7 +2458,8 @@ export class Connection {
   }
 
   /**
-   * Fetch all the account info for the specified public key
+   * Fetch account information for the specified public key. `data` will be a `Buffer`.
+   * To get program-specific deserialized data, use {@link getParsedAccountInfo}.
    */
   async getAccountInfo(
     publicKey: PublicKey,


### PR DESCRIPTION
#### Problem

No newcomer-friendly documentation for parsing stake accounts.

#### Summary of Changes

Add comment pointing to `getParsedAccountInfo`.
