### PR TITLE
optionally skip clean on startup, too

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5332,9 +5332,9 @@ impl Bank {
         accounts_db_skip_shrink: bool,
         last_full_snapshot_slot: Option<Slot>,
     ) -> bool {
-        info!("cleaning..");
         let mut clean_time = Measure::start("clean");
-        if self.slot() > 0 {
+        if !accounts_db_skip_shrink && self.slot() > 0 {
+            info!("cleaning..");
             self.clean_accounts(true, true, last_full_snapshot_slot);
         }
         clean_time.stop();


### PR DESCRIPTION
#### Problem
Startup with large # accts can take a very long time. Clean and shrink are two of the biggest offenders. There is value in skipping shrink to allow validators to catch up faster. With larger account #s, we need to skip clean, too, to allow validators to catch up. This option facilitates testing at large account sizes. It also puts pressure on shrink and clean in the bg.
#### Summary of Changes

Fixes #
