### PR TITLE
Limit accounts data size

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -115,7 +115,9 @@ pub const DEFAULT_MAX_ACCOUNTS_DATA_LEN: usize = 128_000_000_000;
 /// bprumo TODO: doc, and/or move
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct AccountsDataBudget {
+    /// The global maximum size for accounts data (i.e. DEFAULT_MAX_ACCOUNTS_DATA_LEN)
     maximum: usize,
+    /// The current accounts data size (for a Bank)
     current: usize,
 }
 impl AccountsDataBudget {
@@ -136,7 +138,10 @@ impl AccountsDataBudget {
 /// bprumo TODO: doc, and/or move
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct AccountsDataMeter {
+    /// The amount of available accounts data space (i.e. AccountsDataBudget::remaining())
     capacity: usize,
+    /// The amount available of accounts data space consumed.  This value is used to update the
+    /// Bank after transactions are successfully processed.
     consumed: usize,
 }
 impl AccountsDataMeter {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6997,7 +6997,7 @@ impl AccountsDb {
 
             if pass == 0 {
                 // subtract data.len() from accounts_data_len for all old accounts which are in the index twice
-                let mut timer = Measure::start("get accounts data len");
+                let mut timer = Measure::start("handle accounts data len duplicates");
                 let mut unique_pubkeys = HashSet::<Pubkey>::default();
                 self.uncleaned_pubkeys.iter().for_each(|entry| {
                     entry.value().iter().for_each(|pubkey| {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6697,7 +6697,9 @@ impl AccountsDb {
                         &self.account_indexes,
                     );
                 }
-                accounts_data_len += stored_account.data().len();
+                if !stored_account.is_zero_lamport() {
+                    accounts_data_len += stored_account.data().len();
+                }
 
                 if !rent_collector.should_collect_rent(&pubkey, &stored_account, false) || {
                     let (_rent_due, exempt) = rent_collector.get_rent_due(&stored_account);
@@ -7033,7 +7035,10 @@ impl AccountsDb {
                                         let loaded_account =
                                             accessor.check_and_get_loaded_account();
                                         let account = loaded_account.take_account();
-                                        accounts_data_len_from_duplicates += account.data().len();
+                                        if !account.is_zero_lamport() {
+                                            accounts_data_len_from_duplicates +=
+                                                account.data().len();
+                                        }
                                     });
                             }
                         });

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7046,6 +7046,11 @@ impl AccountsDb {
                     accounts_data_len.load(Ordering::Relaxed),
                     timer
                 );
+                error!(
+                    "bprumo DEBUG: generate_index(), accounts data len: {}, {:?}",
+                    accounts_data_len.load(Ordering::Relaxed),
+                    timer
+                );
             }
 
             let storage_info_timings = storage_info_timings.into_inner().unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7042,12 +7042,12 @@ impl AccountsDb {
                     });
                 timer.stop();
                 info!(
-                    "accounts data len: {}, {:?}",
+                    "accounts data len: {}, {}",
                     accounts_data_len.load(Ordering::Relaxed),
                     timer
                 );
                 error!(
-                    "bprumo DEBUG: generate_index(), accounts data len: {}, {:?}",
+                    "bprumo DEBUG: generate_index(), accounts data len: {}, {}",
                     accounts_data_len.load(Ordering::Relaxed),
                     timer
                 );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -738,7 +738,7 @@ pub(crate) struct BankFieldsToDeserialize {
     pub(crate) stakes: Stakes,
     pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
-    pub(crate) accounts_data_len: usize,
+    // bprumo TODO: pub(crate) accounts_data_len: usize,
 }
 
 // Bank's common fields shared by all supported snapshot versions for serialization.
@@ -778,7 +778,7 @@ pub(crate) struct BankFieldsToSerialize<'a> {
     pub(crate) stakes: &'a RwLock<Stakes>,
     pub(crate) epoch_stakes: &'a HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
-    pub(crate) accounts_data_len: usize,
+    // bprumo TODO: pub(crate) accounts_data_len: usize,
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
@@ -1445,6 +1445,7 @@ impl Bank {
 
         // bprumo TODO: move this somewhere else, like bank deserialization (from snapshot)
         if new.accounts_data_len.load(Acquire) == 0 {
+            error!("bprumo DEBUG: Bank::new_from_parent(), parent accounts_data_len == 0!");
             let total_account_stats = new.get_total_accounts_stats().unwrap();
             new.accounts_data_len
                 .store(total_account_stats.data_len, Release);
@@ -1709,7 +1710,7 @@ impl Bank {
             stakes: &self.stakes,
             epoch_stakes: &self.epoch_stakes,
             is_delta: self.is_delta.load(Relaxed),
-            accounts_data_len: self.accounts_data_len.load(Acquire),
+            // bprumo TODO: accounts_data_len: self.accounts_data_len.load(Acquire),
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1563,6 +1563,7 @@ impl Bank {
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         additional_builtins: Option<&Builtins>,
         debug_do_not_add_builtins: bool,
+        accounts_data_len: usize,
     ) -> Self {
         fn new<T: Default>() -> T {
             T::default()
@@ -1625,14 +1626,8 @@ impl Bank {
             vote_only_bank: false,
             cost_tracker: RwLock::new(CostTracker::default()),
             sysvar_cache: RwLock::new(Vec::new()),
-            accounts_data_len: AtomicUsize::default(),
+            accounts_data_len: AtomicUsize::new(accounts_data_len),
         };
-
-        // bprumo TODO: get this from fields instead
-        let total_account_stats = bank.get_total_accounts_stats().unwrap();
-        bank.accounts_data_len
-            .store(total_account_stats.data_len, Release);
-
         bank.finish_init(
             genesis_config,
             additional_builtins,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3584,7 +3584,6 @@ impl Bank {
 
                         if let Some(legacy_message) = tx.message().legacy_message() {
                             // bprumo NOTE: Here's where the message/transaction starts getting processed
-                            // bprumo TODO: Update self (Bank) with the new accounts data len
                             process_result = MessageProcessor::process_message(
                                 &self.builtin_programs.vec,
                                 legacy_message,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -130,8 +130,6 @@ impl MessageProcessor {
             );
             timings.accumulate(&invoke_context.timings);
         }
-        // bprumo NOTE: likely need to return the amount of new/changed account data size here too,
-        // so the bank can update its total
         Ok(ProcessMessageResult {
             accounts_data_meter: invoke_context.accounts_data_meter().take(),
         })

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -334,7 +334,7 @@ fn reconstruct_bank_from_fields<E>(
 where
     E: SerializableStorage + std::marker::Sync,
 {
-    let accounts_db = reconstruct_accountsdb_from_fields(
+    let (accounts_db, accounts_data_len) = reconstruct_accountsdb_from_fields(
         snapshot_accounts_db_fields,
         account_paths,
         unpacked_append_vec_map,
@@ -359,6 +359,7 @@ where
         debug_keys,
         additional_builtins,
         debug_do_not_add_builtins,
+        accounts_data_len,
     );
 
     info!("rent_collector: {:?}", bank.rent_collector());
@@ -399,7 +400,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     verify_index: bool,
     accounts_db_config: Option<AccountsDbConfig>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
-) -> Result<AccountsDb, Error>
+) -> Result<(AccountsDb, usize), Error>
 where
     E: SerializableStorage + std::marker::Sync,
 {
@@ -536,7 +537,7 @@ where
         })
         .unwrap();
 
-    accounts_db.generate_index(
+    let accounts_data_len = accounts_db.generate_index(
         limit_load_slot_count_from_snapshot,
         verify_index,
         genesis_config,
@@ -557,5 +558,5 @@ where
         ("accountsdb-notify-at-start-us", measure_notify.as_us(), i64),
     );
 
-    Ok(Arc::try_unwrap(accounts_db).unwrap())
+    Ok((Arc::try_unwrap(accounts_db).unwrap(), accounts_data_len))
 }

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -81,7 +81,7 @@ pub(crate) struct DeserializableVersionedBank {
     pub(crate) unused_accounts: UnusedAccounts,
     pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
-    pub(crate) accounts_data_len: usize,
+    // bprumo TODO: pub(crate) accounts_data_len: usize,
 }
 
 impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
@@ -118,7 +118,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             stakes: dvb.stakes,
             epoch_stakes: dvb.epoch_stakes,
             is_delta: dvb.is_delta,
-            accounts_data_len: dvb.accounts_data_len,
+            // bprumo TODO: accounts_data_len: dvb.accounts_data_len,
         }
     }
 }
@@ -159,7 +159,7 @@ pub(crate) struct SerializableVersionedBank<'a> {
     pub(crate) unused_accounts: UnusedAccounts,
     pub(crate) epoch_stakes: &'a HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
-    pub(crate) accounts_data_len: usize,
+    // bprumo TODO: pub(crate) accounts_data_len: usize,
 }
 
 impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedBank<'a> {
@@ -200,7 +200,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
             unused_accounts: new(),
             epoch_stakes: rhs.epoch_stakes,
             is_delta: rhs.is_delta,
-            accounts_data_len: rhs.accounts_data_len,
+            // bprumo TODO: accounts_data_len: rhs.accounts_data_len,
         }
     }
 }

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -81,6 +81,7 @@ pub(crate) struct DeserializableVersionedBank {
     pub(crate) unused_accounts: UnusedAccounts,
     pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
+    pub(crate) accounts_data_len: usize,
 }
 
 impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
@@ -117,6 +118,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             stakes: dvb.stakes,
             epoch_stakes: dvb.epoch_stakes,
             is_delta: dvb.is_delta,
+            accounts_data_len: dvb.accounts_data_len,
         }
     }
 }
@@ -157,6 +159,7 @@ pub(crate) struct SerializableVersionedBank<'a> {
     pub(crate) unused_accounts: UnusedAccounts,
     pub(crate) epoch_stakes: &'a HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
+    pub(crate) accounts_data_len: usize,
 }
 
 impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedBank<'a> {
@@ -197,6 +200,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
             unused_accounts: new(),
             epoch_stakes: rhs.epoch_stakes,
             is_delta: rhs.is_delta,
+            accounts_data_len: rhs.accounts_data_len,
         }
     }
 }

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -236,6 +236,10 @@ pub enum InstructionError {
     /// Illegal account owner
     #[error("Provided owner is not allowed")]
     IllegalOwner,
+
+    /// bprumo TODO: doc here, and add equivalent ProgramError
+    #[error("Accounts data budget exceeded")]
+    AccountsDataBudgetExceeded,
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 }

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -104,6 +104,7 @@ enum InstructionErrorType {
     ARITHMETIC_OVERFLOW = 47;
     UNSUPPORTED_SYSVAR = 48;
     ILLEGAL_OWNER = 49;
+    ACCOUNTS_DATA_BUDGET_EXCEEDED = 50;
 }
 
 message UnixTimestamp {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -791,6 +791,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             InstructionError::IllegalOwner => {
                                 tx_by_addr::InstructionErrorType::IllegalOwner
                             }
+                            InstructionError::AccountsDataBudgetExceeded => {
+                                tx_by_addr::InstructionErrorType::IllegalOwner
+                            }
                         } as i32,
                         custom: match instruction_error {
                             InstructionError::Custom(custom) => {


### PR DESCRIPTION
_Work in progress!_

This PR is aiming to put a cap on the accounts data size—128 GB, in particular—by keeping track of the current accounts data size, and then checking instructions/transactions/messages against the amount of remaining space.

Some questions:
- Should `accounts_data_len`, and all related variables, be tracked in a `u64` or a `usize`
- Can I add a field to `BankFieldsToSerialize/Deserialize`?
    - or would that break compatibility with the existing snapshot archives?
    - I would be adding the bank's `accounts_data_len`, because otherwise that value needs to be calculated at runtime
- Where should the `AccountsDataBudget` and `AccountsDataMeter` types live (i.e. which file(s))?

Related to issue #21604 