### PR TITLE
Add return types to generate_index()

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -221,9 +221,6 @@ pub struct ErrorCounters {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct IndexGenerationInfo {}
-
-#[derive(Debug, Default, Clone, Copy)]
 struct SlotIndexGenerationInfo {
     insert_time_us: u64,
     num_accounts: u64,
@@ -6868,7 +6865,7 @@ impl AccountsDb {
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
         genesis_config: &GenesisConfig,
-    ) -> IndexGenerationInfo {
+    ) {
         let mut slots = self.storage.all_slots();
         #[allow(clippy::stable_sort_primitive)]
         slots.sort();
@@ -7025,8 +7022,6 @@ impl AccountsDb {
             }
             timings.report();
         }
-
-        IndexGenerationInfo::default()
     }
 
     fn update_storage_info(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -221,10 +221,10 @@ pub struct ErrorCounters {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct GenerateIndexInfo {}
+pub struct IndexGenerationInfo {}
 
 #[derive(Debug, Default, Clone, Copy)]
-struct GenerateIndexForSlotInfo {
+struct SlotIndexGenerationInfo {
     insert_time_us: u64,
     num_accounts: u64,
     num_accounts_rent_exempt: u64,
@@ -6672,9 +6672,9 @@ impl AccountsDb {
         accounts_map: GenerateIndexAccountsMap<'a>,
         slot: &Slot,
         rent_collector: &RentCollector,
-    ) -> GenerateIndexForSlotInfo {
+    ) -> SlotIndexGenerationInfo {
         if accounts_map.is_empty() {
-            return GenerateIndexForSlotInfo::default();
+            return SlotIndexGenerationInfo::default();
         }
 
         let secondary = !self.account_indexes.is_empty();
@@ -6728,7 +6728,7 @@ impl AccountsDb {
         if !dirty_pubkeys.is_empty() {
             self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
         }
-        GenerateIndexForSlotInfo {
+        SlotIndexGenerationInfo {
             insert_time_us,
             num_accounts: num_accounts as u64,
             num_accounts_rent_exempt,
@@ -6868,7 +6868,7 @@ impl AccountsDb {
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
         genesis_config: &GenesisConfig,
-    ) -> GenerateIndexInfo {
+    ) -> IndexGenerationInfo {
         let mut slots = self.storage.all_slots();
         #[allow(clippy::stable_sort_primitive)]
         slots.sort();
@@ -6928,7 +6928,7 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            let GenerateIndexForSlotInfo {
+                            let SlotIndexGenerationInfo {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,
                                 num_accounts_rent_exempt: rent_exempt_this_slot,
@@ -7026,7 +7026,7 @@ impl AccountsDb {
             timings.report();
         }
 
-        GenerateIndexInfo::default()
+        IndexGenerationInfo::default()
     }
 
     fn update_storage_info(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -220,6 +220,16 @@ pub struct ErrorCounters {
     pub invalid_writable_account: usize,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GenerateIndexResult {}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct GenerateIndexForSlotResult {
+    insert_time_us: u64,
+    num_accounts: u64,
+    num_accounts_rent_exempt: u64,
+}
+
 #[derive(Default, Debug)]
 struct GenerateIndexTimings {
     pub index_time: u64,
@@ -6657,21 +6667,20 @@ impl AccountsDb {
         accounts_map
     }
 
-    /// return time_us, # accts rent exempt, total # accts
     fn generate_index_for_slot<'a>(
         &self,
         accounts_map: GenerateIndexAccountsMap<'a>,
         slot: &Slot,
         rent_collector: &RentCollector,
-    ) -> (u64, u64, u64) {
+    ) -> GenerateIndexForSlotResult {
         if accounts_map.is_empty() {
-            return (0, 0, 0);
+            return GenerateIndexForSlotResult::default();
         }
 
         let secondary = !self.account_indexes.is_empty();
 
-        let mut rent_exempt = 0;
-        let len = accounts_map.len();
+        let mut num_accounts_rent_exempt = 0;
+        let num_accounts = accounts_map.len();
         let items = accounts_map.into_iter().map(
             |(
                 pubkey,
@@ -6694,7 +6703,7 @@ impl AccountsDb {
                     let (_rent_due, exempt) = rent_collector.get_rent_due(&stored_account);
                     exempt
                 } {
-                    rent_exempt += 1;
+                    num_accounts_rent_exempt += 1;
                 }
 
                 (
@@ -6709,9 +6718,9 @@ impl AccountsDb {
             },
         );
 
-        let (dirty_pubkeys, insert_us) = self
+        let (dirty_pubkeys, insert_time_us) = self
             .accounts_index
-            .insert_new_if_missing_into_primary_index(*slot, len, items);
+            .insert_new_if_missing_into_primary_index(*slot, num_accounts, items);
 
         // dirty_pubkeys will contain a pubkey if an item has multiple rooted entries for
         // a given pubkey. If there is just a single item, there is no cleaning to
@@ -6719,7 +6728,11 @@ impl AccountsDb {
         if !dirty_pubkeys.is_empty() {
             self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
         }
-        (insert_us, rent_exempt, len as u64)
+        GenerateIndexForSlotResult {
+            insert_time_us,
+            num_accounts: num_accounts as u64,
+            num_accounts_rent_exempt,
+        }
     }
 
     fn filler_unique_id_bytes() -> usize {
@@ -6855,7 +6868,7 @@ impl AccountsDb {
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
         genesis_config: &GenesisConfig,
-    ) {
+    ) -> GenerateIndexResult {
         let mut slots = self.storage.all_slots();
         #[allow(clippy::stable_sort_primitive)]
         slots.sort();
@@ -6915,8 +6928,11 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            let (insert_us, rent_exempt_this_slot, total_this_slot) =
-                                self.generate_index_for_slot(accounts_map, slot, &rent_collector);
+                            let GenerateIndexForSlotResult {
+                                insert_time_us: insert_us,
+                                num_accounts: total_this_slot,
+                                num_accounts_rent_exempt: rent_exempt_this_slot,
+                            } = self.generate_index_for_slot(accounts_map, slot, &rent_collector);
                             rent_exempt.fetch_add(rent_exempt_this_slot, Ordering::Relaxed);
                             total_duplicates.fetch_add(total_this_slot, Ordering::Relaxed);
                             insert_us
@@ -7009,6 +7025,8 @@ impl AccountsDb {
             }
             timings.report();
         }
+
+        GenerateIndexResult::default()
     }
 
     fn update_storage_info(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -221,10 +221,10 @@ pub struct ErrorCounters {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct GenerateIndexResult {}
+pub struct GenerateIndexInfo {}
 
 #[derive(Debug, Default, Clone, Copy)]
-struct GenerateIndexForSlotResult {
+struct GenerateIndexForSlotInfo {
     insert_time_us: u64,
     num_accounts: u64,
     num_accounts_rent_exempt: u64,
@@ -6672,9 +6672,9 @@ impl AccountsDb {
         accounts_map: GenerateIndexAccountsMap<'a>,
         slot: &Slot,
         rent_collector: &RentCollector,
-    ) -> GenerateIndexForSlotResult {
+    ) -> GenerateIndexForSlotInfo {
         if accounts_map.is_empty() {
-            return GenerateIndexForSlotResult::default();
+            return GenerateIndexForSlotInfo::default();
         }
 
         let secondary = !self.account_indexes.is_empty();
@@ -6728,7 +6728,7 @@ impl AccountsDb {
         if !dirty_pubkeys.is_empty() {
             self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
         }
-        GenerateIndexForSlotResult {
+        GenerateIndexForSlotInfo {
             insert_time_us,
             num_accounts: num_accounts as u64,
             num_accounts_rent_exempt,
@@ -6868,7 +6868,7 @@ impl AccountsDb {
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
         genesis_config: &GenesisConfig,
-    ) -> GenerateIndexResult {
+    ) -> GenerateIndexInfo {
         let mut slots = self.storage.all_slots();
         #[allow(clippy::stable_sort_primitive)]
         slots.sort();
@@ -6928,7 +6928,7 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            let GenerateIndexForSlotResult {
+                            let GenerateIndexForSlotInfo {
                                 insert_time_us: insert_us,
                                 num_accounts: total_this_slot,
                                 num_accounts_rent_exempt: rent_exempt_this_slot,
@@ -7026,7 +7026,7 @@ impl AccountsDb {
             timings.report();
         }
 
-        GenerateIndexResult::default()
+        GenerateIndexInfo::default()
     }
 
     fn update_storage_info(

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -536,7 +536,7 @@ where
         })
         .unwrap();
 
-    accounts_db.generate_index(
+    let _ = accounts_db.generate_index(
         limit_load_slot_count_from_snapshot,
         verify_index,
         genesis_config,


### PR DESCRIPTION
In preparation to get (and return) the total accounts data len during generate index, I'm adding structs to `generate_index()` and `generate_index_for_slot()`. This makes the return values self-documenting.

I personally find this way to be helpful for functions that return non-obvious values. I.e. I wouldn't expect `generate_index()`'s return value to be the the accounts data len. IMO, having a struct with the named fields does help with that.
