### PR TITLE
 Compute accounts data len during generate_index()

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -220,6 +220,16 @@ pub struct ErrorCounters {
     pub invalid_writable_account: usize,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GenerateIndexResult {}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct GenerateIndexForSlotResult {
+    insert_time_us: u64,
+    num_accounts: u64,
+    num_accounts_rent_exempt: u64,
+}
+
 #[derive(Default, Debug)]
 struct GenerateIndexTimings {
     pub index_time: u64,
@@ -6657,21 +6667,20 @@ impl AccountsDb {
         accounts_map
     }
 
-    /// return time_us, # accts rent exempt, total # accts
     fn generate_index_for_slot<'a>(
         &self,
         accounts_map: GenerateIndexAccountsMap<'a>,
         slot: &Slot,
         rent_collector: &RentCollector,
-    ) -> (u64, u64, u64) {
+    ) -> GenerateIndexForSlotResult {
         if accounts_map.is_empty() {
-            return (0, 0, 0);
+            return GenerateIndexForSlotResult::default();
         }
 
         let secondary = !self.account_indexes.is_empty();
 
-        let mut rent_exempt = 0;
-        let len = accounts_map.len();
+        let mut num_accounts_rent_exempt = 0;
+        let num_accounts = accounts_map.len();
         let items = accounts_map.into_iter().map(
             |(
                 pubkey,
@@ -6694,7 +6703,7 @@ impl AccountsDb {
                     let (_rent_due, exempt) = rent_collector.get_rent_due(&stored_account);
                     exempt
                 } {
-                    rent_exempt += 1;
+                    num_accounts_rent_exempt += 1;
                 }
 
                 (
@@ -6709,9 +6718,9 @@ impl AccountsDb {
             },
         );
 
-        let (dirty_pubkeys, insert_us) = self
+        let (dirty_pubkeys, insert_time_us) = self
             .accounts_index
-            .insert_new_if_missing_into_primary_index(*slot, len, items);
+            .insert_new_if_missing_into_primary_index(*slot, num_accounts, items);
 
         // dirty_pubkeys will contain a pubkey if an item has multiple rooted entries for
         // a given pubkey. If there is just a single item, there is no cleaning to
@@ -6719,7 +6728,11 @@ impl AccountsDb {
         if !dirty_pubkeys.is_empty() {
             self.uncleaned_pubkeys.insert(*slot, dirty_pubkeys);
         }
-        (insert_us, rent_exempt, len as u64)
+        GenerateIndexForSlotResult {
+            insert_time_us,
+            num_accounts: num_accounts as u64,
+            num_accounts_rent_exempt,
+        }
     }
 
     fn filler_unique_id_bytes() -> usize {
@@ -6855,7 +6868,7 @@ impl AccountsDb {
         limit_load_slot_count_from_snapshot: Option<usize>,
         verify: bool,
         genesis_config: &GenesisConfig,
-    ) {
+    ) -> GenerateIndexResult {
         let mut slots = self.storage.all_slots();
         #[allow(clippy::stable_sort_primitive)]
         slots.sort();
@@ -6915,8 +6928,11 @@ impl AccountsDb {
 
                         let insert_us = if pass == 0 {
                             // generate index
-                            let (insert_us, rent_exempt_this_slot, total_this_slot) =
-                                self.generate_index_for_slot(accounts_map, slot, &rent_collector);
+                            let GenerateIndexForSlotResult {
+                                insert_time_us: insert_us,
+                                num_accounts: total_this_slot,
+                                num_accounts_rent_exempt: rent_exempt_this_slot,
+                            } = self.generate_index_for_slot(accounts_map, slot, &rent_collector);
                             rent_exempt.fetch_add(rent_exempt_this_slot, Ordering::Relaxed);
                             total_duplicates.fetch_add(total_this_slot, Ordering::Relaxed);
                             insert_us
@@ -7009,6 +7025,8 @@ impl AccountsDb {
             }
             timings.report();
         }
+
+        GenerateIndexResult::default()
     }
 
     fn update_storage_info(

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -536,7 +536,7 @@ where
         })
         .unwrap();
 
-    accounts_db.generate_index(
+    let _ = accounts_db.generate_index(
         limit_load_slot_count_from_snapshot,
         verify_index,
         genesis_config,


### PR DESCRIPTION
- Add Result types to generate_index()
- Compute accounts data len during generate_index()

#### Problem

#### Summary of Changes

Fixes #
