### PR TITLE
impl better debug for Ancestors

### DIFF
--- a/runtime/src/ancestors.rs
+++ b/runtime/src/ancestors.rs
@@ -1,10 +1,21 @@
-use {crate::accounts_index::RollingBitField, solana_sdk::clock::Slot, std::collections::HashMap};
+use {
+    crate::accounts_index::RollingBitField,
+    core::fmt::{Debug, Formatter},
+    solana_sdk::clock::Slot,
+    std::collections::HashMap,
+};
 
 pub type AncestorsForSerialization = HashMap<Slot, usize>;
 
-#[derive(Debug, Clone, PartialEq, AbiExample)]
+#[derive(Clone, PartialEq, AbiExample)]
 pub struct Ancestors {
     ancestors: RollingBitField,
+}
+
+impl Debug for Ancestors {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.keys())
+    }
 }
 
 // some tests produce ancestors ranges that are too large such


### PR DESCRIPTION
#### Problem
default implementation prints out a giant bitfield, which is not ideal. Listing the keys is far more useful and what would be expected.
This only affects tests which may log ancestors.
#### Summary of Changes

Fixes #
