### PR TITLE
Update tx-wide compute budget

### DIFF
--- a/runtime/src/compute_budget_whitelist.rs
+++ b/runtime/src/compute_budget_whitelist.rs
@@ -1,0 +1,103 @@
+use {
+    lazy_static::lazy_static,
+    solana_sdk::{pubkey::Pubkey, transaction::SanitizedTransaction},
+    std::{collections::HashMap, str::FromStr},
+};
+
+#[macro_export]
+macro_rules! to_pubkey {
+    ($id_string:expr) => {{
+        Pubkey::from_str($id_string).unwrap()
+    }};
+}
+
+lazy_static! {
+    pub static ref COMPUTE_BUDGET_WHITELIST: HashMap<Pubkey, u64> = [
+        (to_pubkey!("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"), 1_300_000),
+        (to_pubkey!("2WG3bYHtVuuVQFKvRSnbYYf6TzxcjU2A5tzgridDTnFd"), 1_400_000)
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}
+
+pub fn is_whitelisted(tx: &SanitizedTransaction) -> Option<u64> {
+    tx.message()
+        .program_ids()
+        .iter()
+        .find_map(|program_id| COMPUTE_BUDGET_WHITELIST.get(program_id).copied())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use solana_sdk::{
+        hash::Hash, instruction::CompiledInstruction, signature::Keypair, transaction::Transaction,
+    };
+
+    #[test]
+    fn test_compute_budget_is_whitelisted() {
+        let signer = Keypair::new();
+        let program_id = to_pubkey!("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8");
+
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![])];
+        let tx = SanitizedTransaction::from_transaction_for_tests(
+            Transaction::new_with_compiled_instructions(
+                &[&signer],
+                &[],
+                Hash::default(),
+                vec![program_id, Pubkey::new_unique(), Pubkey::new_unique()],
+                instructions,
+            ),
+        );
+        assert_eq!(is_whitelisted(&tx), Some(1_300_000));
+
+        let instructions = vec![CompiledInstruction::new(2, &(), vec![])];
+        let tx = SanitizedTransaction::from_transaction_for_tests(
+            Transaction::new_with_compiled_instructions(
+                &[&signer],
+                &[],
+                Hash::default(),
+                vec![Pubkey::new_unique(), program_id, Pubkey::new_unique()],
+                instructions,
+            ),
+        );
+        assert_eq!(is_whitelisted(&tx), Some(1_300_000));
+
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![])];
+        let tx = SanitizedTransaction::from_transaction_for_tests(
+            Transaction::new_with_compiled_instructions(
+                &[&signer],
+                &[],
+                Hash::default(),
+                vec![Pubkey::new_unique(), program_id, Pubkey::new_unique()],
+                instructions,
+            ),
+        );
+        assert_eq!(is_whitelisted(&tx), None);
+    }
+
+    #[test]
+    fn test_compute_budget_whitelist() {
+        let signer = Keypair::new();
+        let instructions = vec![CompiledInstruction::new(1, &(), vec![])];
+
+        let ids = &[
+            ("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8", 1_300_000),
+            ("2WG3bYHtVuuVQFKvRSnbYYf6TzxcjU2A5tzgridDTnFd", 1_400_000),
+        ];
+        for (id, cap) in ids.iter() {
+            let program_id = to_pubkey!(id);
+            let tx = SanitizedTransaction::from_transaction_for_tests(
+                Transaction::new_with_compiled_instructions(
+                    &[&signer],
+                    &[],
+                    Hash::default(),
+                    vec![program_id],
+                    instructions.clone(),
+                ),
+            );
+            assert_eq!(is_whitelisted(&tx), Some(*cap));
+        }
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod builtins;
 pub mod cache_hash_data;
 pub mod cache_hash_data_stats;
 pub mod commitment;
+pub mod compute_budget_whitelist;
 pub mod contains;
 pub mod cost_model;
 pub mod cost_tracker;

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -134,6 +134,13 @@ impl SanitizedMessage {
         })
     }
 
+    pub fn program_ids(&self) -> Vec<&Pubkey> {
+        self.instructions()
+            .iter()
+            .filter_map(|ix| self.get_account_key(ix.program_id_index as usize))
+            .collect()
+    }
+
     /// Iterator of all account keys referenced in this message, included mapped keys.
     pub fn account_keys_iter(&self) -> Box<dyn Iterator<Item = &Pubkey> + '_> {
         match self {

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -14,7 +14,7 @@ use {
 
 crate::declare_id!("ComputeBudget111111111111111111111111111111");
 
-const MAX_UNITS: u32 = 1_000_000;
+const MAX_UNITS: u32 = 1_400_000;
 const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
 
 /// Compute Budget Instructions


### PR DESCRIPTION
#### Problem

Some existing programs exceed the default tx-wide cap and would be blocked when the tx-wide cap feature is enabled

#### Summary of Changes

- Whitelist existing programs to give them a window of time to modify their client to request more units
- Adjust the caps based on mainnet measurements
- Add docs on how clients should request units

Fixes #
