### PR TITLE
Remove activated feature that checks tx signature len

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2037,10 +2037,6 @@ fn verify_transaction(
         return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
     }
 
-    if !transaction.verify_signatures_len() {
-        return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
-    }
-
     Ok(())
 }
 

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -299,11 +299,6 @@ impl Transaction {
         Signature::default()
     }
 
-    /// Verify the length of signatures matches the value in the message header
-    pub fn verify_signatures_len(&self) -> bool {
-        self.signatures.len() == self.message.header.num_required_signatures as usize
-    }
-
     /// Verify the transaction and hash its message
     pub fn verify_and_hash_message(&self) -> Result<Hash> {
         let message_bytes = self.message_data();

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -197,11 +197,6 @@ impl SanitizedTransaction {
         }
     }
 
-    /// Verify the length of signatures matches the value in the message header
-    pub fn verify_signatures_len(&self) -> bool {
-        self.signatures.len() == self.message.header().num_required_signatures as usize
-    }
-
     /// Verify the transaction signatures
     pub fn verify(&self) -> Result<()> {
         let message_bytes = self.message_data();


### PR DESCRIPTION
#### Problem
Now that the feature to check transaction signatures length is activated on all clusters, it can be removed and the length check can be moved into transaction sanitization checking.

#### Summary of Changes

Fixes #
