### PR TITLE
De-dupe all packets before processing in banking stage

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -5,7 +5,10 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     rayon::prelude::*,
-    solana_core::banking_stage::BankingStage,
+    solana_core::{
+        banking_stage::BankingStage,
+        packet_deduper::PacketDeduper,
+    },
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
         blockstore::Blockstore,
@@ -235,6 +238,7 @@ fn main() {
             None,
             replay_vote_sender,
             Arc::new(RwLock::new(CostModel::default())),
+            PacketDeduper::default(),
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -5,10 +5,7 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     rayon::prelude::*,
-    solana_core::{
-        banking_stage::BankingStage,
-        packet_deduper::PacketDeduper,
-    },
+    solana_core::{banking_stage::BankingStage, packet_deduper::PacketDeduper},
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
         blockstore::Blockstore,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -10,6 +10,7 @@ use {
     rayon::prelude::*,
     solana_core::{
         banking_stage::{BankingStage, BankingStageStats},
+        packet_deduper::PacketDeduper,
         qos_service::QosService,
     },
     solana_entry::entry::{next_hash, Entry},
@@ -221,6 +222,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
         );
         let cluster_info = Arc::new(cluster_info);
         let (s, _r) = unbounded();
+        let packet_deduper = PacketDeduper::default();
         let _banking_stage = BankingStage::new(
             &cluster_info,
             &poh_recorder,
@@ -230,6 +232,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             None,
             s,
             Arc::new(RwLock::new(CostModel::default())),
+            packet_deduper.clone(),
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 
@@ -264,6 +267,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             // in this chunk, but since we rotate between CHUNKS then
             // we should clear them by the time we come around again to re-use that chunk.
             bank.clear_signatures();
+            packet_deduper.reset();
             trace!(
                 "time: {} checked: {} sent: {}",
                 duration_as_us(&now.elapsed()),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -257,6 +257,7 @@ impl BankingStage {
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
         cost_model: Arc<RwLock<CostModel>>,
+        packet_deduper: PacketDeduper,
     ) -> Self {
         Self::new_num_threads(
             cluster_info,
@@ -268,6 +269,7 @@ impl BankingStage {
             transaction_status_sender,
             gossip_vote_sender,
             cost_model,
+            packet_deduper,
         )
     }
 
@@ -281,12 +283,12 @@ impl BankingStage {
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
         cost_model: Arc<RwLock<CostModel>>,
+        packet_deduper: PacketDeduper,
     ) -> Self {
         let batch_limit = TOTAL_BUFFERED_PACKETS / ((num_threads - 1) as usize * PACKETS_PER_BATCH);
         // Single thread to generate entries from many banks.
         // This thread talks to poh_service and broadcasts the entries once they have been recorded.
         // Once an entry has been recorded, its blockhash is registered with the bank.
-        let packet_deduper = PacketDeduper::default();
         let data_budget = Arc::new(DataBudget::default());
         let qos_service = Arc::new(QosService::new(cost_model));
         // Many banks that process transactions in parallel.
@@ -1606,6 +1608,7 @@ mod tests {
                 None,
                 gossip_vote_sender,
                 Arc::new(RwLock::new(CostModel::default())),
+                PacketDeduper::default(),
             );
             drop(verified_sender);
             drop(gossip_verified_vote_sender);
@@ -1655,6 +1658,7 @@ mod tests {
                 None,
                 gossip_vote_sender,
                 Arc::new(RwLock::new(CostModel::default())),
+                PacketDeduper::default(),
             );
             trace!("sending bank");
             drop(verified_sender);
@@ -1730,6 +1734,7 @@ mod tests {
                 None,
                 gossip_vote_sender,
                 Arc::new(RwLock::new(CostModel::default())),
+                PacketDeduper::default(),
             );
 
             // fund another account so we can send 2 good transactions in a single batch.
@@ -1881,6 +1886,7 @@ mod tests {
                     None,
                     gossip_vote_sender,
                     Arc::new(RwLock::new(CostModel::default())),
+                    PacketDeduper::default(),
                 );
 
                 // wait for banking_stage to eat the packets

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -273,6 +273,7 @@ impl BankingStage {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_num_threads(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod latest_validator_votes_for_frozen_banks;
 pub mod ledger_cleanup_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
+pub mod packet_deduper;
 pub mod packet_hasher;
 pub mod progress_map;
 pub mod qos_service;

--- a/core/src/packet_deduper.rs
+++ b/core/src/packet_deduper.rs
@@ -1,0 +1,58 @@
+use {
+    crate::{banking_stage::BankingStageStats, packet_hasher::PacketHasher},
+    lru::LruCache,
+    solana_measure::measure::Measure,
+    solana_perf::packet::PacketBatch,
+    std::{
+        ops::DerefMut,
+        sync::{atomic::Ordering, Arc, Mutex},
+    },
+};
+
+const DEFAULT_LRU_SIZE: usize = 200_000;
+
+#[derive(Clone)]
+pub struct PacketDeduper(Arc<Mutex<(LruCache<u64, ()>, PacketHasher)>>);
+
+impl Default for PacketDeduper {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new((
+            LruCache::new(DEFAULT_LRU_SIZE),
+            PacketHasher::default(),
+        ))))
+    }
+}
+
+impl PacketDeduper {
+    pub fn dedupe_packets(
+        &self,
+        packet_batch: &PacketBatch,
+        packet_indexes: &mut Vec<usize>,
+        banking_stage_stats: &BankingStageStats,
+    ) {
+        let original_packets_count = packet_indexes.len();
+        let mut packet_duplicate_check_time = Measure::start("packet_duplicate_check");
+        let mut duplicates = self.0.lock().unwrap();
+        let (cache, hasher) = duplicates.deref_mut();
+        packet_indexes.retain(|i| {
+            let packet_hash = hasher.hash_packet(&packet_batch.packets[*i]);
+            match cache.get_mut(&packet_hash) {
+                Some(_hash) => false,
+                None => {
+                    cache.put(packet_hash, ());
+                    true
+                }
+            }
+        });
+        packet_duplicate_check_time.stop();
+        banking_stage_stats
+            .packet_duplicate_check_elapsed
+            .fetch_add(packet_duplicate_check_time.as_us(), Ordering::Relaxed);
+        banking_stage_stats
+            .dropped_duplicated_packets_count
+            .fetch_add(
+                original_packets_count.saturating_sub(packet_indexes.len()),
+                Ordering::Relaxed,
+            );
+    }
+}

--- a/core/src/packet_deduper.rs
+++ b/core/src/packet_deduper.rs
@@ -55,4 +55,9 @@ impl PacketDeduper {
                 Ordering::Relaxed,
             );
     }
+
+    pub fn reset(&self) {
+        let mut duplicates = self.0.lock().unwrap();
+        duplicates.0.clear();
+    }
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -10,6 +10,7 @@ use {
             GossipVerifiedVoteHashSender, VerifiedVoteSender, VoteTracker,
         },
         fetch_stage::FetchStage,
+        packet_deduper::PacketDeduper,
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
     },
@@ -133,6 +134,7 @@ impl Tpu {
             transaction_status_sender,
             replay_vote_sender,
             cost_model.clone(),
+            PacketDeduper::default(),
         );
 
         let broadcast_stage = broadcast_type.new_broadcast_stage(


### PR DESCRIPTION
#### Problem
Packets aren't de-duped if they skip the buffer in banking stage

#### Summary of Changes
De-dupe new packets before processing in banking stage but skip de-duping packets that were de-duped before being buffered

Fixes #
