### PR TITLE
Remove the 5 integer msg! form

### DIFF
--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[macro_use]
 extern crate alloc;
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
+use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64, msg};
 use std::{alloc::Layout, mem};
 
 #[no_mangle]
@@ -46,7 +46,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
         for i in 0..ITERS {
             assert_eq!(*ptr.add(i as usize), i as u8);
         }
-        msg!(0x3, 0, 0, 0, u64::from(*ptr.add(42)));
+        sol_log_64(0x3, 0, 0, 0, u64::from(*ptr.add(42)));
         assert_eq!(*ptr.add(42), 42);
         alloc::alloc::dealloc(ptr, layout);
     }
@@ -61,7 +61,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
         for v in ones.iter() {
             sum += ones[*v];
         }
-        msg!(0x0, 0, 0, 0, sum as u64);
+        sol_log_64(0x0, 0, 0, 0, sum as u64);
         assert_eq!(sum, ITERS);
     }
 
@@ -74,7 +74,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
         for i in 0..ITERS {
             v.push(i);
         }
-        msg!(0x4, 0, 0, 0, v.len() as u64);
+        sol_log_64(0x4, 0, 0, 0, v.len() as u64);
         assert_eq!(v.len(), ITERS);
     }
 

--- a/programs/bpf/rust/call_depth/src/lib.rs
+++ b/programs/bpf/rust/call_depth/src/lib.rs
@@ -1,6 +1,6 @@
 //! Example Rust-based BPF program that tests call depth and stack usage
 
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
+use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64, msg};
 
 #[inline(never)]
 pub fn recurse(data: &mut [u8]) {
@@ -8,7 +8,7 @@ pub fn recurse(data: &mut [u8]) {
         return;
     }
     recurse(&mut data[1..]);
-    msg!(line!(), 0, 0, 0, data[0]);
+    sol_log_64(line!() as u64, 0, 0, 0, data[0] as u64);
 }
 
 /// # Safety
@@ -17,7 +17,7 @@ pub fn recurse(data: &mut [u8]) {
 pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
     msg!("Call depth");
     let depth = *(input.add(16) as *mut u8);
-    msg!(line!(), 0, 0, 0, depth);
+    sol_log_64(line!() as u64, 0, 0, 0, depth as u64);
     let mut data = Vec::with_capacity(depth as usize);
     for i in 0_u8..depth {
         data.push(i);

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -7,6 +7,7 @@ use solana_program::{
     account_info::AccountInfo,
     bpf_loader, entrypoint,
     entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
+    log::sol_log_64,
     msg,
     program::{get_return_data, invoke, invoke_signed, set_return_data},
     program_error::ProgramError,
@@ -105,7 +106,7 @@ fn process_instruction(
                 assert!(accounts[INVOKED_PROGRAM_DUP_INDEX]
                     .try_borrow_mut_data()
                     .is_err());
-                msg!(data[0], 0, 0, 0, 0);
+                sol_log_64(data[0] as u64, 0, 0, 0, 0);
             }
         }
         RETURN_OK => {

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -1,7 +1,7 @@
 //! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
+use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
@@ -12,7 +12,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     for v in ones.iter() {
         sum += *v;
     }
-    msg!(0xff, 0, 0, 0, sum);
+    sol_log_64(0xff, 0, 0, 0, sum);
     assert_eq!(sum, ITERS as u64);
 
     SUCCESS

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -1,7 +1,7 @@
 //! Solana Rust-based BPF program utility functions and types
 
 extern crate solana_program;
-use solana_program::msg;
+use solana_program::{log::sol_log_64, msg};
 
 pub fn many_args(
     arg1: u64,
@@ -15,8 +15,8 @@ pub fn many_args(
     arg9: u64,
 ) -> u64 {
     msg!("Another package - many_args");
-    msg!(arg1, arg2, arg3, arg4, arg5);
-    msg!(arg6, arg7, arg8, arg9, 0);
+    sol_log_64(arg1, arg2, arg3, arg4, arg5);
+    sol_log_64(arg6, arg7, arg8, arg9, 0);
     arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9
 }
 
@@ -39,8 +39,8 @@ pub fn many_args_sret(
     arg9: u64,
 ) -> Ret {
     msg!("Another package - many_args_sret");
-    msg!(arg1, arg2, arg3, arg4, arg5);
-    msg!(arg6, arg7, arg8, arg9, 0);
+    sol_log_64(arg1, arg2, arg3, arg4, arg5);
+    sol_log_64(arg6, arg7, arg8, arg9, 0);
     Ret {
         group1: u128::from(arg1) + u128::from(arg2) + u128::from(arg3),
         group2: u128::from(arg4) + u128::from(arg5) + u128::from(arg6),

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate solana_program;
 use solana_bpf_rust_param_passing_dep::{Data, TestDep};
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, msg};
+use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
@@ -17,7 +17,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
     };
 
     let test_dep = TestDep::new(&data, 1, 2, 3, 4, 5);
-    msg!(0, 0, 0, 0, test_dep.thirty);
+    sol_log_64(0, 0, 0, 0, test_dep.thirty as u64);
     assert!(test_dep.thirty == 30);
 
     SUCCESS

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -21,27 +21,16 @@ macro_rules! info {
 
 /// Print a message to the log
 ///
-/// There are two fast forms:
+/// Fast form:
 /// 1. Single string: `msg!("hi")`
-/// 2. 5 integers: `msg!(1, 2, 3, 4, 5)`
 ///
-/// The third form is more generic and incurs a very large runtime overhead so it should be used
-/// with care:
+/// The generic form incurs a very large runtime overhead so it should be used with care:
 /// 3. Generalized format string: `msg!("Hello {}: 1, 2, {}", "World", 3)`
 ///
 #[macro_export]
 macro_rules! msg {
     ($msg:expr) => {
         $crate::log::sol_log($msg)
-    };
-    ($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
-        $crate::log::sol_log_64(
-            $arg1 as u64,
-            $arg2 as u64,
-            $arg3 as u64,
-            $arg4 as u64,
-            $arg5 as u64,
-        )
     };
     ($($arg:tt)*) => ($crate::log::sol_log(&format!($($arg)*)));
 }
@@ -108,7 +97,7 @@ pub fn sol_log_data(data: &[&[u8]]) {
 #[allow(dead_code)]
 pub fn sol_log_slice(slice: &[u8]) {
     for (i, s) in slice.iter().enumerate() {
-        msg!(0, 0, 0, i, *s);
+        sol_log_64(0, 0, 0, i as u64, *s as u64);
     }
 }
 
@@ -120,15 +109,15 @@ pub fn sol_log_slice(slice: &[u8]) {
 pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
     for (i, account) in accounts.iter().enumerate() {
         msg!("AccountInfo");
-        msg!(0, 0, 0, 0, i);
+        sol_log_64(0, 0, 0, 0, i as u64);
         msg!("- Is signer");
-        msg!(0, 0, 0, 0, account.is_signer);
+        sol_log_64(0, 0, 0, 0, account.is_signer as u64);
         msg!("- Key");
         account.key.log();
         msg!("- Lamports");
-        msg!(0, 0, 0, 0, account.lamports());
+        sol_log_64(0, 0, 0, 0, account.lamports());
         msg!("- Account data length");
-        msg!(0, 0, 0, 0, account.data_len());
+        sol_log_64(0, 0, 0, 0, account.data_len() as u64);
         msg!("- Owner");
         account.owner.log();
     }

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -11,13 +11,4 @@ macro_rules! info {
     ($msg:expr) => {
         $crate::log::sol_log($msg)
     };
-    ($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
-        $crate::log::sol_log_64(
-            $arg1 as u64,
-            $arg2 as u64,
-            $arg3 as u64,
-            $arg4 as u64,
-            $arg5 as u64,
-        )
-    };
 }


### PR DESCRIPTION
The 5 integers form of `msg!` (`msg!(1, 2, 3, 4, 5)`) conflicts with the more useful generic form of wanting to emit a msg with 4 values