### PR TITLE
Move type alias and use it more broadly

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,10 @@ use {
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
     solana_program_runtime::{
         instruction_recorder::InstructionRecorder,
-        invoke_context::{BuiltinProgram, Executor, Executors, ProcessInstructionWithContext},
+        invoke_context::{
+            BuiltinProgram, Executor, Executors, ProcessInstructionWithContext,
+            TransactionAccountRefCells,
+        },
         log_collector::LogCollector,
         timings::ExecuteDetailsTimings,
     },
@@ -238,8 +241,6 @@ impl ExecuteTimings {
 type BankStatusCache = StatusCache<Result<()>>;
 #[frozen_abi(digest = "32EjVUc6shHHVPpsnBAVfyBziMgyFzH8qxisLwmwwdS1")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
-pub(crate) type TransactionAccountRefCell = (Pubkey, Rc<RefCell<AccountSharedData>>);
-type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;
 
 // Eager rent collection repeats in cyclic manner.
 // Each cycle is composed of <partition_count> number of tiny pubkey subranges

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1,10 +1,9 @@
 use {
-    crate::bank::TransactionAccountRefCell,
     serde::{Deserialize, Serialize},
     solana_measure::measure::Measure,
     solana_program_runtime::{
         instruction_recorder::InstructionRecorder,
-        invoke_context::{BuiltinProgram, Executors, InvokeContext},
+        invoke_context::{BuiltinProgram, Executors, InvokeContext, TransactionAccountRefCell},
         log_collector::LogCollector,
         timings::ExecuteDetailsTimings,
     },


### PR DESCRIPTION
#### Problem
A lot of things have moved to program-runtime recently, including a lot of uses of the `(Pubkey, Rc<RefCell<AccountSharedData>>)` type, which I missed in #21755

#### Summary of Changes
Move type alias and use in program-runtime
