### PR TITLE
Bump solana_rbpf to version v0.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6150,9 +6150,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd409d0fba8427ef41b5c1ef79dcabb592f1cff144b77e07094b66c010c2d52"
+checksum = "5c7a237a92714db63de655e20af29a3b59c007881f2dfbdc2d3838ca3675f45f"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ solana-config-program = { path = "../programs/config", version = "=1.10.0" }
 solana-faucet = { path = "../faucet", version = "=1.10.0" }
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
-solana_rbpf = "=0.2.17"
+solana_rbpf = "=0.2.18"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.10.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3600,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd409d0fba8427ef41b5c1ef79dcabb592f1cff144b77e07094b66c010c2d52"
+checksum = "5c7a237a92714db63de655e20af29a3b59c007881f2dfbdc2d3838ca3675f45f"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.10.0" }
 solana-logger = { path = "../../logger", version = "=1.10.0" }
 solana-measure = { path = "../../measure", version = "=1.10.0" }
-solana_rbpf = "=0.2.17"
+solana_rbpf = "=0.2.18"
 solana-runtime = { path = "../../runtime", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -20,7 +20,7 @@ libsecp256k1 = "0.6.0"
 solana-measure = { path = "../../measure", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.17"
+solana_rbpf = "=0.2.18"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -16,5 +16,5 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.10.
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.17"
+solana_rbpf = "=0.2.18"
 time = "0.3.5"

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1147,4 +1147,4 @@ mod tests {
         assert!(test.get_should_age(test.storage.current_age()));
         assert_eq!(test.storage.count_ages_flushed(), 0);
     }
-} 
+}


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.18](https://github.com/solana-labs/rbpf/releases/tag/v0.2.18) was released.

#### Summary of Changes
Rejects programs with overlapping ELF read-only sections.

Fixes #
