### PR TITLE
uses Option<u64> for SlotMeta.last_index

### DIFF
--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -57,7 +57,7 @@ pub fn get_unknown_last_index(
             .entry(slot)
             .or_insert_with(|| blockstore.meta(slot).unwrap());
         if let Some(slot_meta) = slot_meta {
-            if slot_meta.known_last_index().is_none() {
+            if slot_meta.last_index.is_none() {
                 let shred_index = blockstore.get_index(slot).unwrap();
                 let num_processed_shreds = if let Some(shred_index) = shred_index {
                     shred_index.data().num_shreds() as u64
@@ -123,7 +123,7 @@ pub fn get_closest_completion(
             if slot_meta.is_full() {
                 continue;
             }
-            if let Some(last_index) = slot_meta.known_last_index() {
+            if let Some(last_index) = slot_meta.last_index {
                 let shred_index = blockstore.get_index(slot).unwrap();
                 let dist = if let Some(shred_index) = shred_index {
                     let shred_count = shred_index.data().num_shreds() as u64;


### PR DESCRIPTION

#### Problem
`SlotMeta.last_index` may be unknown and current code is using `u64::MAX`
to indicate that:
https://github.com/solana-labs/solana/blob/6c108c8fc/ledger/src/blockstore_meta.rs#L169-L174

This lacks type-safety and can introduce bugs if not always checked for
Several instances of `slot_meta.last_index + 1` are also subject to
overflow.


#### Summary of Changes
This commit updates the type to Option<u64>. Backward compatibility is
maintained by customizing serde serialize/deserialize implementations.
