### PR TITLE
Add accounts_data_len to Bank

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -347,10 +347,6 @@ where
         accounts_db_config,
         accounts_update_notifier,
     )?;
-    debug!(
-        "accounts data len: {}",
-        reconstructed_accounts_db_info.accounts_data_len
-    );
 
     let bank_rc = BankRc::new(Accounts::new_empty(accounts_db), bank_fields.slot);
 
@@ -363,6 +359,7 @@ where
         debug_keys,
         additional_builtins,
         debug_do_not_add_builtins,
+        reconstructed_accounts_db_info.accounts_data_len,
     );
 
     info!("rent_collector: {:?}", bank.rent_collector());


### PR DESCRIPTION
#### Problem

To set a cap on the accounts data size, transaction processing needs to know about the current size of the accounts data. This falls to the bank, which doesn't currently know about the size of the accounts data.

#### Summary of Changes

Add a field to Bank for storing the current accounts data size.

Build on PR #21757
Related to Issue #21604 
