### PR TITLE
move AccountInfo to its own file

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -5,7 +5,7 @@ extern crate test;
 use {
     rand::{thread_rng, Rng},
     solana_runtime::{
-        accounts_db::AccountInfo,
+        account_info::AccountInfo,
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         },

--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -1,0 +1,24 @@
+use crate::{accounts_db::AppendVecId, accounts_index::ZeroLamport};
+
+#[derive(Default, Debug, PartialEq, Clone, Copy)]
+pub struct AccountInfo {
+    /// index identifying the append storage
+    pub store_id: AppendVecId,
+
+    /// offset into the storage
+    pub offset: usize,
+
+    /// needed to track shrink candidacy in bytes. Used to update the number
+    /// of alive bytes in an AppendVec as newer slots purge outdated entries
+    pub stored_size: usize,
+
+    /// lamports in the account used when squashing kept for optimization
+    /// purposes to remove accounts with zero balance.
+    pub lamports: u64,
+}
+
+impl ZeroLamport for AccountInfo {
+    fn is_zero_lamport(&self) -> bool {
+        self.lamports == 0
+    }
+}

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -22,6 +22,7 @@
 use std::{thread::sleep, time::Duration};
 use {
     crate::{
+        account_info::AccountInfo,
         accounts_background_service::{DroppedSlotsSender, SendDroppedBankCallback},
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_hash::{AccountsHash, CalculateHashIntermediate, HashStats, PreviousPass},
@@ -284,22 +285,6 @@ impl GenerateIndexTimings {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Clone, Copy)]
-pub struct AccountInfo {
-    /// index identifying the append storage
-    store_id: AppendVecId,
-
-    /// offset into the storage
-    offset: usize,
-
-    /// needed to track shrink candidacy in bytes. Used to update the number
-    /// of alive bytes in an AppendVec as newer slots purge outdated entries
-    stored_size: usize,
-
-    /// lamports in the account used when squashing kept for optimization
-    /// purposes to remove accounts with zero balance.
-    lamports: u64,
-}
 impl IsCached for AccountInfo {
     fn is_cached(&self) -> bool {
         self.store_id == CACHE_VIRTUAL_STORAGE_ID
@@ -307,12 +292,6 @@ impl IsCached for AccountInfo {
 }
 
 impl IndexValue for AccountInfo {}
-
-impl ZeroLamport for AccountInfo {
-    fn is_zero_lamport(&self) -> bool {
-        self.lamports == 0
-    }
-}
 
 impl ZeroLamport for AccountSharedData {
     fn is_zero_lamport(&self) -> bool {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
+pub mod account_info;
 pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;


### PR DESCRIPTION
#### Problem
Refactoring of AccountInfo and AccountsIndex going on. Moving this to its own file allows me to hide struct members and move to accessors or traits.
#### Summary of Changes

Fixes #
