### PR TITLE
MessageProcessor::process_message() returns the accounts data len delta, and the bank uses the value to update its accounts_data_len field

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3625,11 +3625,11 @@ impl Bank {
                                 blockhash,
                                 lamports_per_signature,
                             )
-                            .and_then(|process_result| {
+                            .map(|process_result| {
                                 self.update_accounts_data_len(
                                     process_result.accounts_data_len_delta,
                                 );
-                                Ok(())
+                                ()
                             });
                         } else {
                             // TODO: support versioned messages

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -148,7 +148,7 @@ use {
         sync::{
             atomic::{
                 AtomicBool, AtomicU64,
-                Ordering::{Acquire, Relaxed, Release},
+                Ordering::{AcqRel, Acquire, Relaxed, Release},
             },
             Arc, LockResult, RwLock, RwLockReadGuard, RwLockWriteGuard,
         },
@@ -3624,7 +3624,13 @@ impl Bank {
                                 &*self.sysvar_cache.read().unwrap(),
                                 blockhash,
                                 lamports_per_signature,
-                            );
+                            )
+                            .and_then(|process_result| {
+                                self.update_accounts_data_len(
+                                    process_result.accounts_data_len_delta,
+                                );
+                                Ok(())
+                            });
                         } else {
                             // TODO: support versioned messages
                             process_result = Err(TransactionError::UnsupportedVersion);
@@ -3783,6 +3789,18 @@ impl Bank {
             tx_count,
             signature_count,
         )
+    }
+
+    /// Update the bank's accounts_data_len field based on the `delta`.
+    fn update_accounts_data_len(&self, delta: i64) {
+        if delta == 0 {
+            return;
+        }
+        if delta > 0 {
+            self.accounts_data_len.fetch_add(delta as u64, AcqRel);
+        } else {
+            self.accounts_data_len.fetch_sub(delta.abs() as u64, AcqRel);
+        }
     }
 
     /// Calculate fee for `SanitizedMessage`

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3628,8 +3628,7 @@ impl Bank {
                             .map(|process_result| {
                                 self.update_accounts_data_len(
                                     process_result.accounts_data_len_delta,
-                                );
-                                ()
+                                )
                             });
                         } else {
                             // TODO: support versioned messages

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -34,6 +34,13 @@ impl ::solana_frozen_abi::abi_example::AbiExample for MessageProcessor {
     }
 }
 
+/// Resultant information gathered from calling process_message()
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessedMessageInfo {
+    /// The amount that the accounts data len has changed
+    pub accounts_data_len_delta: i64,
+}
+
 impl MessageProcessor {
     /// Process a message.
     /// This method calls each instruction in the message over the set of loaded accounts.
@@ -56,7 +63,7 @@ impl MessageProcessor {
         sysvars: &[(Pubkey, Vec<u8>)],
         blockhash: Hash,
         lamports_per_signature: u64,
-    ) -> Result<(), TransactionError> {
+    ) -> Result<ProcessedMessageInfo, TransactionError> {
         let mut invoke_context = InvokeContext::new(
             rent,
             accounts,
@@ -118,7 +125,7 @@ impl MessageProcessor {
             );
             timings.accumulate(&invoke_context.timings);
         }
-        Ok(())
+        Ok(ProcessedMessageInfo::default())
     }
 }
 
@@ -244,7 +251,7 @@ mod tests {
             Hash::default(),
             0,
         );
-        assert_eq!(result, Ok(()));
+        assert!(result.is_ok());
         assert_eq!(accounts[0].1.borrow().lamports(), 100);
         assert_eq!(accounts[1].1.borrow().lamports(), 0);
 
@@ -483,7 +490,7 @@ mod tests {
             Hash::default(),
             0,
         );
-        assert_eq!(result, Ok(()));
+        assert!(result.is_ok());
 
         // Do work on the same account but at different location in keyed_accounts[]
         let message = Message::new(
@@ -513,7 +520,7 @@ mod tests {
             Hash::default(),
             0,
         );
-        assert_eq!(result, Ok(()));
+        assert!(result.is_ok());
         assert_eq!(accounts[0].1.borrow().lamports(), 80);
         assert_eq!(accounts[1].1.borrow().lamports(), 20);
         assert_eq!(accounts[0].1.borrow().data(), &vec![42]);


### PR DESCRIPTION
#### Problem

The bank doesn't get accounts data len changes from MessageProcessor, so it cannot account for any changes.

For more context see the main issue #21604 

#### Summary of Changes

MessageProcessor::process_message() returns the accounts data len delta, and the bank uses the value to update its accounts_data_len field