### PR TITLE
Load account from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /solana-metrics/
 /solana-metrics.tar.bz2
 /target/
+/test-ledger/
 
 **/*.rs.bk
 .cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5981,6 +5981,9 @@ version = "1.10.0"
 dependencies = [
  "base64 0.12.3",
  "log 0.4.14",
+ "serde_derive",
+ "serde_json",
+ "solana-cli-output",
  "solana-client",
  "solana-core",
  "solana-gossip",

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -99,7 +99,7 @@ impl OutputFormat {
 pub struct CliAccount {
     #[serde(flatten)]
     pub keyed_account: RpcKeyedAccount,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, skip_deserializing)]
     pub use_lamports_unit: bool,
 }
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -462,18 +462,27 @@ pub fn process_show_account(
 
     let mut account_string = config.output_format.formatted_string(&cli_account);
 
-    if config.output_format == OutputFormat::Display
-        || config.output_format == OutputFormat::DisplayVerbose
-    {
-        if let Some(output_file) = output_file {
-            let mut f = File::create(output_file)?;
-            f.write_all(&data)?;
-            writeln!(&mut account_string)?;
-            writeln!(&mut account_string, "Wrote account data to {}", output_file)?;
-        } else if !data.is_empty() {
-            use pretty_hex::*;
-            writeln!(&mut account_string, "{:?}", data.hex_dump())?;
+    match config.output_format {
+        OutputFormat::Json | OutputFormat::JsonCompact => {
+            if let Some(output_file) = output_file {
+                let mut f = File::create(output_file)?;
+                f.write_all(account_string.as_bytes())?;
+                writeln!(&mut account_string)?;
+                writeln!(&mut account_string, "Wrote account to {}", output_file)?;
+            }
         }
+        OutputFormat::Display | OutputFormat::DisplayVerbose => {
+            if let Some(output_file) = output_file {
+                let mut f = File::create(output_file)?;
+                f.write_all(&data)?;
+                writeln!(&mut account_string)?;
+                writeln!(&mut account_string, "Wrote account data to {}", output_file)?;
+            } else if !data.is_empty() {
+                use pretty_hex::*;
+                writeln!(&mut account_string, "{:?}", data.hex_dump())?;
+            }
+        }
+        OutputFormat::DisplayQuiet => (),
     }
 
     Ok(account_string)

--- a/docs/src/developing/test-validator.md
+++ b/docs/src/developing/test-validator.md
@@ -14,6 +14,7 @@ starts a full-featured, single-node cluster on the developer's workstation.
 - Direct [on-chain program](on-chain-programs/overview) deployment
   (`--bpf-program ...`)
 - Clone accounts from a public cluster, including programs (`--clone ...`)
+- Load accounts from files
 - Configurable transaction history retention (`--limit-ledger-size ...`)
 - Configurable epoch length (`--slots-per-epoch ...`)
 - Jump to an arbitrary slot (`--warp-slot ...`)

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 [dependencies]
 base64 = "0.12.3"
 log = "0.4.14"
+serde_derive = "1.0.103"
+serde_json = "1.0.72"
+solana-cli-output = { path = "../cli-output", version = "=1.10.0" }
 solana-client = { path = "../client", version = "=1.10.0" }
 solana-core = { path = "../core", version = "=1.10.0" }
 solana-gossip = { path = "../gossip", version = "=1.10.0" }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -531,7 +531,7 @@ fn main() {
         for (name, long) in &[
             ("bpf_program", "--bpf-program"),
             ("clone_account", "--clone"),
-            ("clone_account_from_file", "--clone-from-file"),
+            ("account", "--account"),
             ("mint_address", "--mint"),
             ("slots_per_epoch", "--slots-per-epoch"),
             ("faucet_sol", "--faucet-sol"),


### PR DESCRIPTION
#### Problem

Programs can be dumped to file, and seamlessly loaded from file at genesis into the test validator. There is no similar feature for accounts (only dumping *data* of an account is supported, and no loading). This would ease testing on localnet when several accounts are necessary to run tests (manual and automated both), and for repeatability purposes (cloning leads to changing states per test run). 

#### Summary of Changes

* Add complete account dump to file (not only data)
* Add `solana-test-validator` option to load accounts from file

#### Notes

* Serialization/deserialization is done using the formats available in the `--output` option of `solana-test-validator`, i.e. `json` and `json-compact`
* Behavior is unchanged when dumping account to file without the `--output` option (only data gets written)

Fixes #20279
