### PR TITLE
Add AccountsDataMeter to InvokeContext

### DIFF
--- a/program-runtime/src/accounts_data_meter.rs
+++ b/program-runtime/src/accounts_data_meter.rs
@@ -1,0 +1,145 @@
+//! The accounts data space has a maximum size it is permitted to grow to.  This module contains
+//! the constants and types for tracking and metering the accounts data space during program
+//! runtime.
+use solana_sdk::instruction::InstructionError;
+
+/// The maximum allowed size, in bytes, of the accounts data
+/// 128 GB was chosen because it is the RAM amount listed under Hardware Recommendations on
+/// [Validator Requirements](https://docs.solana.com/running-validator/validator-reqs), and
+/// validators often put the ledger on a RAM disk (i.e. tmpfs).
+pub const MAX_ACCOUNTS_DATA_LEN: u64 = 128_000_000_000; // 128 GB
+
+/// Meter and track the amount of available accounts data space
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct AccountsDataMeter {
+    /// The maximum amount of accounts data space that can be used (in bytes)
+    maximum: u64,
+
+    /// The current amount of accounts data space used (in bytes)
+    current: u64,
+}
+
+impl AccountsDataMeter {
+    /// Make a new AccountsDataMeter
+    pub fn new(current_accounts_data_len: u64) -> Self {
+        let accounts_data_meter = Self {
+            maximum: MAX_ACCOUNTS_DATA_LEN,
+            current: current_accounts_data_len,
+        };
+        debug_assert!(accounts_data_meter.current <= accounts_data_meter.maximum);
+        accounts_data_meter
+    }
+
+    /// Return the maximum amount of accounts data space that can be used (in bytes)
+    pub fn maximum(&self) -> u64 {
+        self.maximum
+    }
+
+    /// Return the current amount of accounts data space used (in bytes)
+    pub fn current(&self) -> u64 {
+        self.current
+    }
+
+    /// Get the remaining amount of accounts data space (in bytes)
+    pub fn remaining(&self) -> u64 {
+        self.maximum.saturating_sub(self.current)
+    }
+
+    /// Consume accounts data space, in bytes.  If `amount` is positive, we are *increasing* the
+    /// amount of accounts data space used.  If `amount` is negative, we are *decreasing* the
+    /// amount of accounts data space used.
+    pub fn consume(&mut self, amount: i64) -> Result<(), InstructionError> {
+        if amount == 0 {
+            // nothing to do here; lets us skip doing unnecessary work in the 'else' case
+            return Ok(());
+        }
+
+        if amount.is_positive() {
+            let amount = amount as u64;
+            if amount > self.remaining() {
+                return Err(InstructionError::AccountsDataBudgetExceeded);
+            }
+            self.current = self.current.saturating_add(amount);
+        } else {
+            let amount = amount.abs() as u64;
+            self.current = self.current.saturating_sub(amount);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let current = 1234;
+        let accounts_data_meter = AccountsDataMeter::new(current);
+        assert_eq!(accounts_data_meter.maximum, MAX_ACCOUNTS_DATA_LEN);
+        assert_eq!(accounts_data_meter.current, current);
+    }
+
+    #[test]
+    fn test_new_can_use_max_len() {
+        let _ = AccountsDataMeter::new(MAX_ACCOUNTS_DATA_LEN);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_new_panics_if_current_len_too_big() {
+        let _ = AccountsDataMeter::new(MAX_ACCOUNTS_DATA_LEN + 1);
+    }
+
+    #[test]
+    fn test_remaining() {
+        let current_accounts_data_len = 0;
+        let accounts_data_meter = AccountsDataMeter::new(current_accounts_data_len);
+        assert_eq!(accounts_data_meter.remaining(), MAX_ACCOUNTS_DATA_LEN);
+    }
+
+    #[test]
+    fn test_remaining_saturates() {
+        let current_accounts_data_len = 0;
+        let mut accounts_data_meter = AccountsDataMeter::new(current_accounts_data_len);
+        // To test that remaining() saturates, need to break the invariant that current <= maximum
+        accounts_data_meter.current = MAX_ACCOUNTS_DATA_LEN + 1;
+        assert_eq!(accounts_data_meter.remaining(), 0);
+    }
+
+    #[test]
+    fn test_consume() {
+        let current_accounts_data_len = 0;
+        let mut accounts_data_meter = AccountsDataMeter::new(current_accounts_data_len);
+
+        // Test: simple, positive numbers
+        let result = accounts_data_meter.consume(0);
+        assert!(result.is_ok());
+        let result = accounts_data_meter.consume(1);
+        assert!(result.is_ok());
+        let result = accounts_data_meter.consume(4);
+        assert!(result.is_ok());
+        let result = accounts_data_meter.consume(9);
+        assert!(result.is_ok());
+
+        // Test: can consume the remaining amount
+        let remaining = accounts_data_meter.remaining() as i64;
+        let result = accounts_data_meter.consume(remaining);
+        assert!(result.is_ok());
+        assert_eq!(accounts_data_meter.remaining(), 0);
+    }
+
+    #[test]
+    fn test_consume_deallocate() {
+        let current_accounts_data_len = 10_000;
+        let mut accounts_data_meter = AccountsDataMeter::new(current_accounts_data_len);
+        let remaining_before = accounts_data_meter.remaining();
+
+        let amount = (current_accounts_data_len / 2) as i64;
+        let amount = -amount;
+        let result = accounts_data_meter.consume(amount);
+        assert!(result.is_ok());
+        let remaining_after = accounts_data_meter.remaining();
+        assert_eq!(remaining_after, remaining_before + amount.abs() as u64);
+    }
+}

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -23,8 +23,6 @@ use {
     },
     std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc},
 };
-/// The maximum allowed size, in bytes, of the accounts data
-pub const MAX_ACCOUNTS_DATA_LEN: u64 = 128_000_000_000; // 128 GB
 
 pub type TransactionAccountRefCell = (Pubkey, RefCell<AccountSharedData>);
 pub type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 
+pub mod accounts_data_meter;
 pub mod instruction_recorder;
 pub mod invoke_context;
 pub mod log_collector;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -240,7 +240,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "GcfJc94Hb3s7gzF7Uh4YxLSiQf1MvUtMmtU45BvinkVT")]
+#[frozen_abi(digest = "2pPboTQ9ixNuR1hvRt7McJriam5EHfd3vpBWfxnVbmF3")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 // Eager rent collection repeats in cyclic manner.
@@ -3609,6 +3609,7 @@ impl Bank {
                                 &*self.sysvar_cache.read().unwrap(),
                                 blockhash,
                                 lamports_per_signature,
+                                self.accounts_data_len.load(Acquire),
                             )
                             .map(|process_result| {
                                 self.update_accounts_data_len(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -148,7 +148,7 @@ use {
         sync::{
             atomic::{
                 AtomicBool, AtomicU64,
-                Ordering::{AcqRel, Acquire, Relaxed, Release},
+                Ordering::{Acquire, Relaxed, Release},
             },
             Arc, LockResult, RwLock, RwLockReadGuard, RwLockWriteGuard,
         },
@@ -1194,8 +1194,7 @@ impl Bank {
         };
 
         let total_accounts_stats = bank.get_total_accounts_stats().unwrap();
-        bank.accounts_data_len
-            .store(total_accounts_stats.data_len as u64, Release);
+        bank.store_accounts_data_len(total_accounts_stats.data_len as u64);
 
         bank
     }
@@ -1443,7 +1442,7 @@ impl Bank {
             freeze_started: AtomicBool::new(false),
             cost_tracker: RwLock::new(CostTracker::default()),
             sysvar_cache: RwLock::new(Vec::new()),
-            accounts_data_len: AtomicU64::new(parent.accounts_data_len.load(Acquire)),
+            accounts_data_len: AtomicU64::new(parent.load_accounts_data_len()),
         };
 
         let mut ancestors = Vec::with_capacity(1 + new.parents().len());
@@ -3612,9 +3611,7 @@ impl Bank {
                                 self.accounts_data_len.load(Acquire),
                             )
                             .map(|process_result| {
-                                self.update_accounts_data_len(
-                                    process_result.accounts_data_len_delta,
-                                )
+                                self.store_accounts_data_len(process_result.accounts_data_len)
                             });
                         } else {
                             // TODO: support versioned messages
@@ -3774,16 +3771,14 @@ impl Bank {
         )
     }
 
-    /// Update the bank's accounts_data_len field based on the `delta`.
-    fn update_accounts_data_len(&self, delta: i64) {
-        if delta == 0 {
-            return;
-        }
-        if delta > 0 {
-            self.accounts_data_len.fetch_add(delta as u64, AcqRel);
-        } else {
-            self.accounts_data_len.fetch_sub(delta.abs() as u64, AcqRel);
-        }
+    /// Load the accounts data len
+    fn load_accounts_data_len(&self) -> u64 {
+        self.accounts_data_len.load(Acquire)
+    }
+
+    /// Store a new value to the accounts data len
+    fn store_accounts_data_len(&self, accounts_data_len: u64) {
+        self.accounts_data_len.store(accounts_data_len, Release)
     }
 
     /// Calculate fee for `SanitizedMessage`

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -39,8 +39,8 @@ impl ::solana_frozen_abi::abi_example::AbiExample for MessageProcessor {
 /// Resultant information gathered from calling process_message()
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ProcessedMessageInfo {
-    /// The amount that the accounts data len has changed
-    pub accounts_data_len_delta: i64,
+    /// The new accounts data len
+    pub accounts_data_len: u64,
 }
 
 impl MessageProcessor {
@@ -142,7 +142,7 @@ impl MessageProcessor {
             timings.accumulate(&invoke_context.timings);
         }
         Ok(ProcessedMessageInfo {
-            accounts_data_len_delta: invoke_context.get_accounts_data_meter().take().consumed(),
+            accounts_data_len: invoke_context.get_accounts_data_meter().take().finalize(),
         })
     }
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -65,6 +65,7 @@ impl MessageProcessor {
         sysvars: &[(Pubkey, Vec<u8>)],
         blockhash: Hash,
         lamports_per_signature: u64,
+        current_accounts_data_len: u64,
     ) -> Result<ProcessedMessageInfo, TransactionError> {
         let mut invoke_context = InvokeContext::new(
             rent,
@@ -78,6 +79,7 @@ impl MessageProcessor {
             feature_set,
             blockhash,
             lamports_per_signature,
+            current_accounts_data_len,
         );
 
         debug_assert_eq!(program_indices.len(), message.instructions.len());
@@ -139,7 +141,9 @@ impl MessageProcessor {
             );
             timings.accumulate(&invoke_context.timings);
         }
-        Ok(ProcessedMessageInfo::default())
+        Ok(ProcessedMessageInfo {
+            accounts_data_len_delta: invoke_context.get_accounts_data_meter().take().consumed(),
+        })
     }
 }
 
@@ -264,6 +268,7 @@ mod tests {
             &[],
             Hash::default(),
             0,
+            0,
         );
         assert!(result.is_ok());
         assert_eq!(accounts[0].1.borrow().lamports(), 100);
@@ -292,6 +297,7 @@ mod tests {
             &mut ExecuteDetailsTimings::default(),
             &[],
             Hash::default(),
+            0,
             0,
         );
         assert_eq!(
@@ -325,6 +331,7 @@ mod tests {
             &mut ExecuteDetailsTimings::default(),
             &[],
             Hash::default(),
+            0,
             0,
         );
         assert_eq!(
@@ -470,6 +477,7 @@ mod tests {
             &[],
             Hash::default(),
             0,
+            0,
         );
         assert_eq!(
             result,
@@ -503,6 +511,7 @@ mod tests {
             &[],
             Hash::default(),
             0,
+            0,
         );
         assert!(result.is_ok());
 
@@ -532,6 +541,7 @@ mod tests {
             &mut ExecuteDetailsTimings::default(),
             &[],
             Hash::default(),
+            0,
             0,
         );
         assert!(result.is_ok());
@@ -589,6 +599,7 @@ mod tests {
             &mut ExecuteDetailsTimings::default(),
             &[],
             Hash::default(),
+            0,
             0,
         );
         assert_eq!(

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -142,7 +142,7 @@ impl MessageProcessor {
             timings.accumulate(&invoke_context.timings);
         }
         Ok(ProcessedMessageInfo {
-            accounts_data_len: invoke_context.get_accounts_data_meter().take().finalize(),
+            accounts_data_len: invoke_context.get_accounts_data_meter().current(),
         })
     }
 }

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -248,6 +248,10 @@ pub enum InstructionError {
     /// Illegal account owner
     #[error("Provided owner is not allowed")]
     IllegalOwner,
+
+    /// Accounts data budget exceeded
+    #[error("Requested account data allocation exceeded the accounts data budget")]
+    AccountsDataBudgetExceeded,
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 }

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -49,6 +49,8 @@ pub enum ProgramError {
     UnsupportedSysvar,
     #[error("Provided owner is not allowed")]
     IllegalOwner,
+    #[error("Requested account data allocation exceeded the accounts data budget")]
+    AccountsDataBudgetExceeded,
 }
 
 pub trait PrintProgramError {
@@ -87,6 +89,7 @@ impl PrintProgramError for ProgramError {
             Self::AccountNotRentExempt => msg!("Error: AccountNotRentExempt"),
             Self::UnsupportedSysvar => msg!("Error: UnsupportedSysvar"),
             Self::IllegalOwner => msg!("Error: IllegalOwner"),
+            Self::AccountsDataBudgetExceeded => msg!("Error: AccountsDataBudgetExceeded"),
         }
     }
 }
@@ -117,6 +120,7 @@ pub const BORSH_IO_ERROR: u64 = to_builtin!(15);
 pub const ACCOUNT_NOT_RENT_EXEMPT: u64 = to_builtin!(16);
 pub const UNSUPPORTED_SYSVAR: u64 = to_builtin!(17);
 pub const ILLEGAL_OWNER: u64 = to_builtin!(18);
+pub const ACCOUNTS_DATA_BUDGET_EXCEEDED: u64 = to_builtin!(19);
 // Warning: Any new program errors added here must also be:
 // - Added to the below conversions
 // - Added as an equivilent to InstructionError
@@ -143,6 +147,7 @@ impl From<ProgramError> for u64 {
             ProgramError::AccountNotRentExempt => ACCOUNT_NOT_RENT_EXEMPT,
             ProgramError::UnsupportedSysvar => UNSUPPORTED_SYSVAR,
             ProgramError::IllegalOwner => ILLEGAL_OWNER,
+            ProgramError::AccountsDataBudgetExceeded => ACCOUNTS_DATA_BUDGET_EXCEEDED,
             ProgramError::Custom(error) => {
                 if error == 0 {
                     CUSTOM_ZERO
@@ -175,6 +180,7 @@ impl From<u64> for ProgramError {
             ACCOUNT_NOT_RENT_EXEMPT => Self::AccountNotRentExempt,
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
             ILLEGAL_OWNER => Self::IllegalOwner,
+            ACCOUNTS_DATA_BUDGET_EXCEEDED => Self::AccountsDataBudgetExceeded,
             _ => Self::Custom(error as u32),
         }
     }
@@ -203,6 +209,7 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::AccountNotRentExempt => Ok(Self::AccountNotRentExempt),
             Self::Error::UnsupportedSysvar => Ok(Self::UnsupportedSysvar),
             Self::Error::IllegalOwner => Ok(Self::IllegalOwner),
+            Self::Error::AccountsDataBudgetExceeded => Ok(Self::AccountsDataBudgetExceeded),
             _ => Err(error),
         }
     }
@@ -233,6 +240,7 @@ where
             ACCOUNT_NOT_RENT_EXEMPT => Self::AccountNotRentExempt,
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
             ILLEGAL_OWNER => Self::IllegalOwner,
+            ACCOUNTS_DATA_BUDGET_EXCEEDED => Self::AccountsDataBudgetExceeded,
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -283,6 +283,10 @@ pub mod reject_all_elf_rw {
     solana_sdk::declare_id!("DeMpxgMq51j3rZfNK2hQKZyXknQvqevPSFPJFNTbXxsS");
 }
 
+pub mod cap_accounts_data_len {
+    solana_sdk::declare_id!("capRxUrBjNkkCpjrJxPGfPaWijB7q3JoDfsWXAnt46r");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -348,6 +352,7 @@ lazy_static! {
         (evict_invalid_stakes_cache_entries::id(), "evict invalid stakes cache entries on epoch boundaries"),
         (allow_votes_to_directly_update_vote_state::id(), "enable direct vote state update"),
         (reject_all_elf_rw::id(), "reject all read-write data in program elfs"),
+        (cap_accounts_data_len::id(), "cap the accounts data len"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -105,6 +105,7 @@ enum InstructionErrorType {
     ARITHMETIC_OVERFLOW = 47;
     UNSUPPORTED_SYSVAR = 48;
     ILLEGAL_OWNER = 49;
+    ACCOUNTS_DATA_BUDGET_EXCEEDED = 50;
 }
 
 message UnixTimestamp {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -536,6 +536,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
                     47 => InstructionError::ArithmeticOverflow,
                     48 => InstructionError::UnsupportedSysvar,
                     49 => InstructionError::IllegalOwner,
+                    50 => InstructionError::AccountsDataBudgetExceeded,
                     _ => return Err("Invalid InstructionError"),
                 };
 
@@ -794,6 +795,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             }
                             InstructionError::IllegalOwner => {
                                 tx_by_addr::InstructionErrorType::IllegalOwner
+                            }
+                            InstructionError::AccountsDataBudgetExceeded => {
+                                tx_by_addr::InstructionErrorType::AccountsDataBudgetExceeded
                             }
                         } as i32,
                         custom: match instruction_error {


### PR DESCRIPTION
#### Problem

Bank does not know how much the accounts data len changes after processing messages.

For more context see the main issue #21604 

#### Summary of Changes

Add AccountsDataMeter to InvokeContext, and return the new accounts_data_len from MessageProcessor::process_message() so that Bank can update its accounts_data_len.

**Does not track accounts_data_len yet.** That will be part of a subsequent PR.
(Subsequent PR will likely be—or look like—this one: https://github.com/solana-labs/solana/pull/21994)