### PR TITLE
tracks erasure coding shreds indices explicitly

### DIFF
--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -100,7 +100,11 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     let slot = 0;
     let parent = 0;
     let shredder = Shredder::new(slot, parent, 0, 0).unwrap();
-    let mut data_shreds = shredder.entries_to_shreds(&keypair, &entries, true, 0).0;
+    let (mut data_shreds, _) = shredder.entries_to_shreds(
+        &keypair, &entries, true, // is_last_in_slot
+        0,    // next_shred_index
+        0,    // next_code_index
+    );
 
     let num_packets = data_shreds.len();
 

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -74,7 +74,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     let entries = create_ticks(num_ticks, 0, Hash::default());
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-        shredder.entries_to_shreds(&kp, &entries, true, 0);
+        shredder.entries_to_shreds(&kp, &entries, true, 0, 0);
     })
 }
 
@@ -93,7 +93,7 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
     // 1Mb
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-        shredder.entries_to_shreds(&kp, &entries, true, 0);
+        shredder.entries_to_shreds(&kp, &entries, true, 0, 0);
     })
 }
 
@@ -106,7 +106,7 @@ fn bench_deshredder(bencher: &mut Bencher) {
     let num_ticks = max_ticks_per_n_shreds(1, Some(shred_size)) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-    let data_shreds = shredder.entries_to_shreds(&kp, &entries, true, 0).0;
+    let (data_shreds, _) = shredder.entries_to_shreds(&kp, &entries, true, 0, 0);
     bencher.iter(|| {
         let raw = &mut Shredder::deshred(&data_shreds).unwrap();
         assert_ne!(raw.len(), 0);
@@ -133,6 +133,7 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
         Shredder::generate_coding_shreds(
             &data_shreds[..symbol_count],
             true, // is_last_in_slot
+            0,    // next_code_index
         )
         .len();
     })
@@ -145,6 +146,7 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
     let coding_shreds = Shredder::generate_coding_shreds(
         &data_shreds[..symbol_count],
         true, // is_last_in_slot
+        0,    // next_code_index
     );
     bencher.iter(|| {
         Shredder::try_recovery(coding_shreds[..].to_vec()).unwrap();

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -497,6 +497,7 @@ pub mod test {
             &keypair,
             &data_shreds[0..],
             true, // is_last_in_slot
+            0,    // next_code_index
             &mut ProcessShredsStats::default(),
         )
         .unwrap();

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -10,6 +10,7 @@ pub(super) struct BroadcastFakeShredsRun {
     last_blockhash: Hash,
     partition: usize,
     shred_version: u16,
+    next_code_index: u32,
 }
 
 impl BroadcastFakeShredsRun {
@@ -18,6 +19,7 @@ impl BroadcastFakeShredsRun {
             last_blockhash: Hash::default(),
             partition,
             shred_version,
+            next_code_index: 0,
         }
     }
 }
@@ -57,6 +59,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             &receive_results.entries,
             last_tick_height == bank.max_tick_height(),
             next_shred_index,
+            self.next_code_index,
         );
 
         // If the last blockhash is default, a new block is being created
@@ -74,7 +77,17 @@ impl BroadcastRun for BroadcastFakeShredsRun {
             &fake_entries,
             last_tick_height == bank.max_tick_height(),
             next_shred_index,
+            self.next_code_index,
         );
+
+        if let Some(index) = coding_shreds
+            .iter()
+            .chain(&fake_coding_shreds)
+            .map(Shred::index)
+            .max()
+        {
+            self.next_code_index = index + 1;
+        }
 
         // If it's the last tick, reset the last block hash to default
         // this will cause next run to grab last bank's blockhash

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -21,6 +21,7 @@ pub(super) struct ReceiveResults {
 #[derive(Clone)]
 pub struct UnfinishedSlotInfo {
     pub next_shred_index: u32,
+    pub(crate) next_code_index: u32,
     pub slot: Slot,
     pub parent: Slot,
     // Data shreds buffered to make a batch of size

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -270,6 +270,7 @@ mod tests {
         let coding = solana_ledger::shred::Shredder::generate_coding_shreds(
             &[shred],
             false, // is_last_in_slot
+            3,     // next_code_index
         );
         coding[0].copy_to_packet(&mut packet);
         ShredFetchStage::process_packet(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -740,7 +740,12 @@ mod test {
         keypair: &Keypair,
     ) -> Vec<Shred> {
         let shredder = Shredder::new(slot, parent, 0, 0).unwrap();
-        shredder.entries_to_shreds(keypair, entries, true, 0).0
+        let (data_shreds, _) = shredder.entries_to_shreds(
+            keypair, entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
+        data_shreds
     }
 
     #[test]

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -341,6 +341,7 @@ pub(crate) mod tests {
             &entries,
             true, // is_last_in_slot
             next_shred_index,
+            next_shred_index, // next_code_index
         );
         data_shreds.swap_remove(0)
     }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -69,11 +69,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
     },
-    std::{
-        cell::RefCell,
-        convert::{TryFrom, TryInto},
-        mem::size_of,
-    },
+    std::{cell::RefCell, convert::TryInto, mem::size_of},
     thiserror::Error,
 };
 
@@ -759,6 +755,7 @@ impl Shredder {
         entries: &[Entry],
         is_last_in_slot: bool,
         next_shred_index: u32,
+        next_code_index: u32,
     ) -> (
         Vec<Shred>, // data shreds
         Vec<Shred>, // coding shreds
@@ -772,9 +769,14 @@ impl Shredder {
             next_shred_index, // fec_set_offset
             &mut stats,
         );
-        let coding_shreds =
-            Self::data_shreds_to_coding_shreds(keypair, &data_shreds, is_last_in_slot, &mut stats)
-                .unwrap();
+        let coding_shreds = Self::data_shreds_to_coding_shreds(
+            keypair,
+            &data_shreds,
+            is_last_in_slot,
+            next_code_index,
+            &mut stats,
+        )
+        .unwrap();
         (data_shreds, coding_shreds)
     }
 
@@ -852,6 +854,7 @@ impl Shredder {
         keypair: &Keypair,
         data_shreds: &[Shred],
         is_last_in_slot: bool,
+        next_code_index: u32,
         process_stats: &mut ProcessShredsStats,
     ) -> Result<Vec<Shred>> {
         if data_shreds.is_empty() {
@@ -863,8 +866,26 @@ impl Shredder {
             thread_pool.borrow().install(|| {
                 data_shreds
                     .par_chunks(MAX_DATA_SHREDS_PER_FEC_BLOCK as usize)
-                    .flat_map(|shred_data_batch| {
-                        Shredder::generate_coding_shreds(shred_data_batch, is_last_in_slot)
+                    .enumerate()
+                    .flat_map(|(i, shred_data_batch)| {
+                        // Assumption here is that, for now, each fec block has
+                        // as many coding shreds as data shreds (except for the
+                        // last one in the slot).
+                        // TODO: tie this more closely with
+                        // generate_coding_shreds.
+                        let next_code_index = next_code_index
+                            .checked_add(
+                                u32::try_from(i)
+                                    .unwrap()
+                                    .checked_mul(MAX_DATA_SHREDS_PER_FEC_BLOCK)
+                                    .unwrap(),
+                            )
+                            .unwrap();
+                        Shredder::generate_coding_shreds(
+                            shred_data_batch,
+                            is_last_in_slot,
+                            next_code_index,
+                        )
                     })
                     .collect()
             })
@@ -922,7 +943,11 @@ impl Shredder {
     }
 
     /// Generates coding shreds for the data shreds in the current FEC set
-    pub fn generate_coding_shreds(data: &[Shred], is_last_in_slot: bool) -> Vec<Shred> {
+    pub fn generate_coding_shreds(
+        data: &[Shred],
+        is_last_in_slot: bool,
+        next_code_index: u32,
+    ) -> Vec<Shred> {
         const PAYLOAD_ENCODE_SIZE: usize = SHRED_PAYLOAD_SIZE - SIZE_OF_CODING_SHRED_HEADERS;
         let ShredCommonHeader {
             slot,
@@ -958,9 +983,10 @@ impl Shredder {
             .iter()
             .enumerate()
             .map(|(i, parity)| {
+                let index = next_code_index + u32::try_from(i).unwrap();
                 let mut shred = Shred::new_empty_coding(
                     slot,
-                    fec_set_index + i as u32, // shred index
+                    index,
                     fec_set_index,
                     num_data,
                     num_coding,
@@ -1308,8 +1334,13 @@ pub mod tests {
             .saturating_sub(num_expected_data_shreds as usize)
             .max(num_expected_data_shreds as usize);
         let start_index = 0;
-        let (data_shreds, coding_shreds) =
-            shredder.entries_to_shreds(&keypair, &entries, true, start_index);
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair,
+            &entries,
+            true,        // is_last_in_slot
+            start_index, // next_shred_index
+            start_index, // next_code_index
+        );
         let next_index = data_shreds.last().unwrap().index() + 1;
         assert_eq!(next_index as u64, num_expected_data_shreds);
 
@@ -1379,8 +1410,11 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&keypair, &entries, true, 0).0;
-
+        let (data_shreds, _) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
         let deserialized_shred =
             Shred::new_from_serialized_shred(data_shreds.last().unwrap().payload.clone()).unwrap();
         assert_eq!(deserialized_shred, *data_shreds.last().unwrap());
@@ -1402,7 +1436,11 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&keypair, &entries, true, 0).0;
+        let (data_shreds, _) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), 5);
             assert_eq!(Shred::reference_tick_from_data(&s.payload), 5);
@@ -1429,7 +1467,11 @@ pub mod tests {
             })
             .collect();
 
-        let data_shreds = shredder.entries_to_shreds(&keypair, &entries, true, 0).0;
+        let (data_shreds, _) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), SHRED_TICK_REFERENCE_MASK);
             assert_eq!(
@@ -1462,8 +1504,11 @@ pub mod tests {
             })
             .collect();
 
-        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(&keypair, &entries, true, 0);
-
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
         for (i, s) in data_shreds.iter().enumerate() {
             verify_test_data_shred(
                 s,
@@ -1515,6 +1560,7 @@ pub mod tests {
             &entries,
             is_last_in_slot,
             0, // next_shred_index
+            0, // next_code_index
         );
         let num_coding_shreds = coding_shreds.len();
 
@@ -1641,7 +1687,11 @@ pub mod tests {
         // Test5: Try recovery/reassembly with non zero index full slot with 3 missing data shreds
         // and 2 missing coding shreds. Hint: should work
         let serialized_entries = bincode::serialize(&entries).unwrap();
-        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(&keypair, &entries, true, 25);
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            25,   // next_shred_index,
+            25,   // next_code_index
+        );
         // We should have 10 shreds now
         assert_eq!(data_shreds.len(), num_data_shreds);
 
@@ -1725,8 +1775,13 @@ pub mod tests {
         )
         .unwrap();
         let next_shred_index = rng.gen_range(1, 1024);
-        let (data_shreds, coding_shreds) =
-            shredder.entries_to_shreds(&keypair, &[entry], is_last_in_slot, next_shred_index);
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair,
+            &[entry],
+            is_last_in_slot,
+            next_shred_index,
+            next_shred_index, // next_code_index
+        );
         let num_data_shreds = data_shreds.len();
         let mut shreds = coding_shreds;
         shreds.extend(data_shreds.iter().cloned());
@@ -1779,7 +1834,11 @@ pub mod tests {
             })
             .collect();
 
-        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(&keypair, &entries, true, 0);
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair, &entries, true, // is_last_in_slot
+            0,    // next_shred_index
+            0,    // next_code_index
+        );
         assert!(!data_shreds
             .iter()
             .chain(coding_shreds.iter())
@@ -1827,9 +1886,13 @@ pub mod tests {
             .collect();
 
         let start_index = 0x12;
-        let (data_shreds, coding_shreds) =
-            shredder.entries_to_shreds(&keypair, &entries, true, start_index);
-
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair,
+            &entries,
+            true,        // is_last_in_slot
+            start_index, // next_shred_index
+            start_index, // next_code_index
+        );
         let max_per_block = MAX_DATA_SHREDS_PER_FEC_BLOCK as usize;
         data_shreds.iter().enumerate().for_each(|(i, s)| {
             let expected_fec_set_index = start_index + ((i / max_per_block) * max_per_block) as u32;
@@ -1874,12 +1937,14 @@ pub mod tests {
         );
 
         assert!(data_shreds.len() > MAX_DATA_SHREDS_PER_FEC_BLOCK as usize);
+        let next_code_index = data_shreds[0].index();
 
         (1..=MAX_DATA_SHREDS_PER_FEC_BLOCK as usize).for_each(|count| {
             let coding_shreds = Shredder::data_shreds_to_coding_shreds(
                 &keypair,
                 &data_shreds[..count],
                 false, // is_last_in_slot
+                next_code_index,
                 &mut stats,
             )
             .unwrap();
@@ -1888,6 +1953,7 @@ pub mod tests {
                 &keypair,
                 &data_shreds[..count],
                 true, // is_last_in_slot
+                next_code_index,
                 &mut stats,
             )
             .unwrap();
@@ -1901,6 +1967,7 @@ pub mod tests {
             &keypair,
             &data_shreds[..MAX_DATA_SHREDS_PER_FEC_BLOCK as usize + 1],
             false, // is_last_in_slot
+            next_code_index,
             &mut stats,
         )
         .unwrap();
@@ -1912,6 +1979,7 @@ pub mod tests {
             &keypair,
             &data_shreds[..MAX_DATA_SHREDS_PER_FEC_BLOCK as usize + 1],
             true, // is_last_in_slot
+            next_code_index,
             &mut stats,
         )
         .unwrap();

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -48,7 +48,11 @@ fn test_multi_fec_block_coding() {
         .collect();
 
     let serialized_entries = bincode::serialize(&entries).unwrap();
-    let (data_shreds, coding_shreds) = shredder.entries_to_shreds(&keypair, &entries, true, 0);
+    let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+        &keypair, &entries, true, // is_last_in_slot
+        0,    // next_shred_index
+        0,    // next_code_index
+    );
     let next_index = data_shreds.last().unwrap().index() + 1;
     assert_eq!(next_index as usize, num_data_shreds);
     assert_eq!(data_shreds.len(), num_data_shreds);
@@ -218,8 +222,10 @@ fn setup_different_sized_fec_blocks(
     let total_num_data_shreds: usize = 2 * num_shreds_per_iter;
     for i in 0..2 {
         let is_last = i == 1;
-        let (data_shreds, coding_shreds) =
-            shredder.entries_to_shreds(&keypair, &entries, is_last, next_index);
+        let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
+            &keypair, &entries, is_last, next_index, // next_shred_index
+            next_index, // next_code_index
+        );
         for shred in &data_shreds {
             if (shred.index() as usize) == total_num_data_shreds - 1 {
                 assert!(shred.data_complete());


### PR DESCRIPTION
#### Problem
The indices for erasure coding shreds are tied to data shreds:
https://github.com/solana-labs/solana/blob/90f41fd9b/ledger/src/shred.rs#L921

However with upcoming changes to erasure schema there will be more erasure coding shreds than data shreds and we can no longer infer coding shreds indices from data shreds.

#### Summary of Changes
* The commit adds constructs to track coding shreds indices explicitly.
