### PR TITLE
Add reject_all_writable_sections feature gate

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2001,6 +2001,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
             verify_mul64_imm_nonzero: false,
             verify_shift32_imm: true,
             reject_section_virtual_address_file_offset_mismatch: true,
+            reject_all_writable_sections: true,
             ..Config::default()
         },
         register_syscalls(&mut invoke_context).unwrap(),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -211,6 +211,7 @@ fn run_program(name: &str) -> u64 {
             enable_instruction_tracing: true,
             reject_unresolved_syscalls: true,
             reject_section_virtual_address_file_offset_mismatch: true,
+            reject_all_writable_sections: true,
             verify_mul64_imm_nonzero: false,
             verify_shift32_imm: true,
             ..Config::default()

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -38,7 +38,7 @@ use {
         clock::Clock,
         entrypoint::{HEAP_LENGTH, SUCCESS},
         feature_set::{
-            do_support_realloc, reduce_required_deploy_balance,
+            do_support_realloc, reduce_required_deploy_balance, reject_all_writable_sections,
             reject_deployment_of_unresolved_syscalls,
             reject_section_virtual_address_file_offset_mismatch, requestable_heap_size,
             start_verify_shift32_imm, stop_verify_mul64_imm_nonzero,
@@ -101,6 +101,10 @@ pub fn create_executor(
             && invoke_context
                 .feature_set
                 .is_active(&reject_section_virtual_address_file_offset_mismatch::id()),
+        reject_all_writable_sections: reject_deployment_of_broken_elfs
+            && invoke_context
+                .feature_set
+                .is_active(&reject_all_writable_sections::id()),
         verify_mul64_imm_nonzero: !invoke_context
             .feature_set
             .is_active(&stop_verify_mul64_imm_nonzero::id()),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -247,6 +247,10 @@ pub mod reject_section_virtual_address_file_offset_mismatch {
     solana_sdk::declare_id!("5N4NikcJLEiZNqwndhNyvZw15LvFXp1oF7AJQTNTZY5k");
 }
 
+pub mod reject_all_writable_sections {
+    solana_sdk::declare_id!("Dz1Ln7oRyVsyZBirceufeAfFTpHvNrmZtFZkSmqyMGcU");
+}
+
 pub mod nonce_must_be_writable {
     solana_sdk::declare_id!("BiCU7M5w8ZCMykVSyhZ7Q3m2SWoR2qrEQ86ERcDX77ME");
 }
@@ -335,6 +339,7 @@ lazy_static! {
         (add_compute_budget_program::id(), "Add compute_budget_program"),
         (reject_deployment_of_unresolved_syscalls::id(), "Reject deployment of programs with unresolved syscall symbols"),
         (reject_section_virtual_address_file_offset_mismatch::id(), "enforce section virtual addresses and file offsets in ELF to be equal"),
+        (reject_all_writable_sections::id(), "reject deployment of programs with writable data sections"),
         (nonce_must_be_writable::id(), "nonce must be writable"),
         (spl_token_v3_3_0_release::id(), "spl-token v3.3.0 release"),
         (leave_nonce_on_success::id(), "leave nonce as is on success"),


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/rbpf/pull/240 adds a config option to reject programs with global mutable state.

#### Summary of Changes

This PR adds a `reject_writable_data_sections` feature gate, which once turned on rejects programs with global mutable state.
