### PR TITLE
Add comment for clear_unconfirmed_slot() in blockstore.rs

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -970,6 +970,13 @@ impl Blockstore {
         Ok((newly_completed_data_sets, inserted_indices))
     }
 
+    /// Range-delete all entries which prefix matches the specified `slot` and
+    /// clear all the related `SlotMeta` except its next_slots.
+    ///
+    /// This function currently requires `insert_shreds_lock`, as both
+    /// `clear_unconfirmed_slot()` and `insert_shreds_handle_duplicate()`
+    /// try to perform read-modify-write operation on [`cf::SlotMeta`] column
+    /// family.
     pub fn clear_unconfirmed_slot(&self, slot: Slot) {
         let _lock = self.insert_shreds_lock.lock().unwrap();
         if let Some(mut slot_meta) = self


### PR DESCRIPTION
#### Summary of Changes
Add comment block for clear_unconfirmed_slot() in blockstore.rs
explaining what it does and which column family it modifies.

