### PR TITLE
Add solana-cli-config link to rust-api.md

### DIFF
--- a/docs/src/developing/clients/rust-api.md
+++ b/docs/src/developing/clients/rust-api.md
@@ -21,11 +21,16 @@ Some important crates:
 - [`solana-client`] &mdash; For interacting with a Solana node via the
   [JSON RPC API](jsonrpc-api).
 
+- [`solana-cli-config`] &mdash; Loading and saving the Solana CLI configuration
+  file.
+
 - [`solana-clap-utils`] &mdash; Routines for setting up a CLI, using [`clap`],
-  as used by the main Solana CLI.
+  as used by the main Solana CLI. Includes functions for loading all types of
+  signers supported by the CLI.
 
 [`solana-program`]: https://docs.rs/solana-program
 [`solana-sdk`]: https://docs.rs/solana-sdk
 [`solana-client`]: https://docs.rs/solana-client
+[`solana-cli-config`]: https://docs.rs/solana-cli-config
 [`solana-clap-utils`]: https://docs.rs/solana-clap-utils
 [`clap`]: https://docs.rs/clap


### PR DESCRIPTION
#### Problem

We all want Rust hackers to find the docs they seek, but sometimes the don't.

#### Summary of Changes

Add the solana-cli-config crate to the list / descriptions of Rust crates in the main docs.