### PR TITLE
AcctIdx: appendvecid: u32

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -16,7 +16,7 @@ use {
         epoch_stakes::EpochStakes,
         hardened_unpack::UnpackedAppendVecMap,
         rent_collector::RentCollector,
-        serde_snapshot::future::SerializableStorage,
+        serde_snapshot::future::{AppendVecIdSerialized, SerializableStorage},
         stakes::Stakes,
     },
     bincode::{self, config::Options, Error},
@@ -468,7 +468,7 @@ where
                     //    rename the file to this new path.
                     //    **DEVELOPER NOTE:**  Keep this check last so that it can short-circuit if
                     //    possible.
-                    if storage_entry.id() == remapped_append_vec_id
+                    if storage_entry.id() == remapped_append_vec_id as AppendVecIdSerialized
                         || std::fs::metadata(&remapped_append_vec_path).is_err()
                     {
                         break (remapped_append_vec_id, remapped_append_vec_path);
@@ -479,7 +479,7 @@ where
                     num_collisions.fetch_add(1, Ordering::Relaxed);
                 };
                 // Only rename the file if the new ID is actually different from the original.
-                if storage_entry.id() != remapped_append_vec_id {
+                if storage_entry.id() != remapped_append_vec_id as AppendVecIdSerialized {
                     std::fs::rename(append_vec_path, &remapped_append_vec_path)?;
                 }
 


### PR DESCRIPTION
#### Problem
AccountInfo has unnecessarily large data types. AccountInfo is held once per account data instance at runtime, which is > # accounts. When using disk buckets, we aim to provide space for sizeof(AccountInfo) X 2 X # account data instances. There is value in using smaller data types for AccountInfo as it makes sense.
One instance of a data type that is too large is AppendVecId = usize (u64).
ids are reset to 0..n when loading from a snapshot.
recycling appendvecs result in next_id++.
next_id is currently AtomicUsize.
next_id is prevented from rolling over by an assert checking for AppendVecId::MAX. The max value is used as a sentinel for storage in the cache.

The goal is change AppendVecId to u32. Range of 0..4B.
The ids will now assert at u32::max. The goal was to allow the ids to wrap from Max to 0 and keep going. However, there are maps where we key off of id alone. Most are (slot, id) tuples, which are fine with rolled over ids. To reduce risk, we can keep an assert such that ew don't have to worry about the roll over case.
The special 'cache' id state will be stored separately in an AccountInfo instance.
So, all AppendVecId values can be valid ids.
The risk here is that at runtime we end up trying to create a new (or recycle) an appendvec with an id that is still in use.
This scenario would require us to create ~4B new append vecs or recycle them before a single 'old' append vec was destroyed.

At 432k slots per epoch, I calculate ~10k epochs before we have used 4B unique append vec IDs. Sometimes we could have multiple appendvecs per slot. We could also shrink append vecs during execution, incrementing the next_id counter at faster than 1 per slot. 

#### Summary of Changes

Fixes #
