### PR TITLE
Add missing word "that"

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -108,7 +108,7 @@ The time, i.e. number of [slots](#slot), for which a [leader schedule](#leader-s
 
 ## fee account
 
-The fee account in the transaction is the account pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Read-Write (writable) in the transaction since paying for the transaction reduces the account balance.
+The fee account in the transaction is the account that pays for the cost of including the transaction in the ledger. This is the first account in the transaction. This account must be declared as Read-Write (writable) in the transaction since paying for the transaction reduces the account balance.
 
 ## finality
 


### PR DESCRIPTION
#### Problem
The definition of "fee account" on the Terminology page is missing a word. This PR adds it in.

#### Summary of Changes
Changed 

> The fee account in the transaction is the account pays for the cost of including the transaction in the ledger.

to 

> The fee account in the transaction is the account **that** pays for the cost of including the transaction in the ledger.

