### PR TITLE
AcctIdx: StoredSize is u32

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -11,7 +11,8 @@ use crate::{
 pub type Offset = usize;
 
 /// bytes used to store this account in append vec
-pub type StoredSize = usize;
+/// Note this max needs to be big enough to handle max data len of 10MB, which is a const
+pub type StoredSize = u32;
 
 /// specify where account data is located
 #[derive(Debug)]


### PR DESCRIPTION
#### Problem
max acct data len is 10M. So, max acct size in append vec is not much bigger than that. We don't need a usize to store 0-~10M. u32 works great.
#### Summary of Changes
Reduce in-mem AccountInfo.stored_size to u32 to reduce memory use (and disk-bucket disk use) of AcctIdx.
Fixes #
