### PR TITLE
Add helper crate to generate syscalls.txt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-syscall-list"
+version = "1.10.0"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,7 +4606,6 @@ dependencies = [
  "libsecp256k1 0.6.0",
  "log 0.4.14",
  "rand 0.7.3",
- "regex",
  "solana-measure",
  "solana-program-runtime",
  "solana-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "programs/address-lookup-table",
     "programs/address-lookup-table-tests",
     "programs/bpf_loader",
+    "programs/bpf_loader/gen-syscall-list",
     "programs/compute-budget",
     "programs/config",
     "programs/stake",

--- a/cargo-build-bpf
+++ b/cargo-build-bpf
@@ -9,5 +9,8 @@ for a in "$@"; do
   fi
 done
 
-set -x
+set -ex
+if [[ ! -f sdk/bpf/syscalls.txt ]]; then
+  "$here"/cargo build --manifest-path "$here"/programs/bpf_loader/gen-syscall-list/Cargo.toml
+fi
 exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-build-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2637,7 +2637,6 @@ dependencies = [
  "byteorder 1.4.3",
  "libsecp256k1 0.6.0",
  "log",
- "regex",
  "solana-measure",
  "solana-program-runtime",
  "solana-sdk",

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -9,9 +9,6 @@ homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bpf-loader-program"
 edition = "2021"
 
-[build-dependencies]
-regex = "1.5.4"
-
 [dependencies]
 bincode = "1.3.3"
 byteorder = "1.4.3"

--- a/programs/bpf_loader/gen-syscall-list/Cargo.toml
+++ b/programs/bpf_loader/gen-syscall-list/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gen-syscall-list"
+version = "1.10.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[build-dependencies]
+regex = "1.5.4"

--- a/programs/bpf_loader/gen-syscall-list/build.rs
+++ b/programs/bpf_loader/gen-syscall-list/build.rs
@@ -4,7 +4,6 @@ use {
         fs::File,
         io::{prelude::*, BufWriter, Read},
         path::PathBuf,
-        process::exit,
         str,
     },
 };
@@ -15,18 +14,24 @@ use {
  * to verify undefined symbols in a .so module that cargo-build-bpf has built.
  */
 fn main() {
-    let path = PathBuf::from("src/syscalls.rs");
-    let mut file = match File::open(&path) {
+    let syscalls_rs_path = PathBuf::from("../src/syscalls.rs");
+    let syscalls_txt_path = PathBuf::from("../../../sdk/bpf/syscalls.txt");
+    println!(
+        "cargo:warning=(not a warning) Generating {1} from {0}",
+        syscalls_rs_path.display(),
+        syscalls_txt_path.display()
+    );
+
+    let mut file = match File::open(&syscalls_rs_path) {
         Ok(x) => x,
-        _ => exit(1),
+        Err(err) => panic!("Failed to open {}: {}", syscalls_rs_path.display(), err),
     };
     let mut text = vec![];
     file.read_to_end(&mut text).unwrap();
     let text = str::from_utf8(&text).unwrap();
-    let path = PathBuf::from("../../sdk/bpf/syscalls.txt");
-    let file = match File::create(&path) {
+    let file = match File::create(&syscalls_txt_path) {
         Ok(x) => x,
-        _ => exit(1),
+        Err(err) => panic!("Failed to create {}: {}", syscalls_txt_path.display(), err),
     };
     let mut out = BufWriter::new(file);
     let sysc_re = Regex::new(r#"register_syscall_by_name\([[:space:]]*b"([^"]+)","#).unwrap();

--- a/programs/bpf_loader/gen-syscall-list/src/main.rs
+++ b/programs/bpf_loader/gen-syscall-list/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    /* I do all my work in `../build.rs` */
+}

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -145,8 +145,12 @@ if [[ -d target/perf-libs ]]; then
   cp -a target/perf-libs "$installDir"/bin/perf-libs
 fi
 
-mkdir -p "$installDir"/bin/sdk/bpf
-cp -a sdk/bpf/* "$installDir"/bin/sdk/bpf
+if [[ -z "$validatorOnly" ]]; then
+  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+  "$cargo" $maybeRustVersion build --manifest-path programs/bpf_loader/gen-syscall-list/Cargo.toml
+  mkdir -p "$installDir"/bin/sdk/bpf
+  cp -a sdk/bpf/* "$installDir"/bin/sdk/bpf
+fi
 
 (
   set -x


### PR DESCRIPTION
1.9.0 crate publishing broke because the solana-bpf-loader-program's build.rs attempts to write the file "../../sdk/bpf/syscalls.txt", which doesn't work when the crate is not within the monorepo.  