### PR TITLE
getParsedTokenAccountsByOwner: explain where to find mint addresses

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2296,7 +2296,8 @@ export class Connection {
   }
 
   /**
-   * Fetch all the token accounts owned by the specified account
+   * Fetch all the token accounts owned by the specified account.
+   * For parsed account data, see {@link getParsedTokenAccountsByOwner}.
    *
    * @return {Promise<RpcResponseAndContext<Array<{pubkey: PublicKey, account: AccountInfo<Buffer>}>>>}
    */
@@ -2334,6 +2335,10 @@ export class Connection {
    * Fetch parsed token accounts owned by the specified account
    *
    * @return {Promise<RpcResponseAndContext<Array<{pubkey: PublicKey, account: AccountInfo<ParsedAccountData>}>>>}
+   * @param {TokenAccountsFilter} filter - you can find `mint` addresses for SPL tokens via the `@solana/spl-token-registry`
+   *   package, which published its [token list](https://raw.githubusercontent.com/solana-labs/token-list/main/src/tokens/solana.tokenlist.json)
+   *   on [JSDelivr](https://cdn.jsdelivr.net/gh/solana-labs/token-list@main/src/tokens/solana.tokenlist.json).
+   *   Alternatively, you can look up the token's address by typing its name in the [Solana Explorer](https://explorer.solana.com).
    */
   async getParsedTokenAccountsByOwner(
     ownerAddress: PublicKey,


### PR DESCRIPTION
#### Problem

For newcomers, the documentation is rather cryptic. One of the most common tasks, finding the token balance of an account, should have a simple example, and `getParsedTokenAccountsByOwner` should document where to find token addresses.

#### Summary of Changes

Documented where to find mint addresses, for now. Happy to contribute an example if it would help, e.g.

```ts
async function getUsdcBalance(publicKey: solana.PublicKey) {
  const usdcAddress = new solanaWeb3.PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
  const parsedAccountInfo = await connection.getParsedTokenAccountsByOwner(publicKey, { mint: usdcAddress });
  return parsedAccountInfo.value[0].account.data.parsed.info.tokenAmount.uiAmountString;
}
```

