### PR TITLE
Add option `accountsdb-plugin-config` to test-validator

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -94,6 +94,7 @@ pub struct TestValidatorGenesis {
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub max_ledger_shreds: Option<u64>,
     pub max_genesis_archive_unpacked_size: Option<u64>,
+    pub accountsdb_plugin_config_files: Option<Vec<PathBuf>>,
 }
 
 impl TestValidatorGenesis {
@@ -510,6 +511,7 @@ impl TestValidator {
         }
 
         let mut validator_config = ValidatorConfig {
+            accountsdb_plugin_config_files: config.accountsdb_plugin_config_files.clone(),
             rpc_addrs: Some((
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
                 SocketAddr::new(

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -1,5 +1,5 @@
 use {
-    clap::{crate_name, value_t, value_t_or_exit, App, Arg},
+    clap::{crate_name, value_t, value_t_or_exit, values_t_or_exit, App, Arg},
     log::*,
     solana_clap_utils::{
         input_parsers::{pubkey_of, pubkeys_of, value_of},
@@ -281,6 +281,15 @@ fn main() {
                     "Give the faucet address this much SOL in genesis. \
                      If the ledger already exists then this parameter is silently ignored",
                 ),
+        )
+        .arg(
+            Arg::with_name("accountsdb_plugin_config")
+                .long("accountsdb-plugin-config")
+                .value_name("FILE")
+                .takes_value(true)
+                .multiple(true)
+                .hidden(true)
+                .help("Specify the configuration file for the AccountsDb plugin."),
         )
         .get_matches();
 
@@ -594,6 +603,15 @@ fn main() {
 
     if let Some(bind_address) = bind_address {
         genesis.bind_ip_addr(bind_address);
+    }
+
+    if matches.is_present("accountsdb_plugin_config") {
+        genesis.accountsdb_plugin_config_files = Some(
+            values_t_or_exit!(matches, "accountsdb_plugin_config", String)
+                .into_iter()
+                .map(PathBuf::from)
+                .collect(),
+        );
     }
 
     match genesis.start_with_mint_address(mint_address, socket_addr_space) {


### PR DESCRIPTION
Accountsdb plugins need to be tested somehow. This PR allows load plugins in the test validator.