### PR TITLE
Restore solana_validator::test_validator export

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -24,9 +24,10 @@ use {
         system_program,
     },
     solana_streamer::socket::SocketAddrSpace,
+    solana_test_validator::*,
     solana_validator::{
         admin_rpc_service, dashboard::Dashboard, ledger_lockfile, lock_ledger, println_name_value,
-        redirect_stderr_to_file, solana_test_validator::*,
+        redirect_stderr_to_file,
     },
     std::{
         collections::HashSet,

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -13,7 +13,10 @@ use {
         thread::JoinHandle,
     },
 };
-pub use {solana_gossip::cluster_info::MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, solana_test_validator};
+pub use {
+    solana_gossip::cluster_info::MINIMUM_VALIDATOR_PORT_RANGE_WIDTH,
+    solana_test_validator as test_validator,
+};
 
 pub mod admin_rpc_service;
 pub mod bootstrap;


### PR DESCRIPTION
#20658 renamed the `solana_validator::test_validator` export that downstream code expects:
https://github.com/mvines/solana-bpf-program-template/blob/9a57b67a37047d2e6f7b80189e4cdf29b0ef96cc/tests/integration.rs#L10
Restore it.