### PR TITLE
Add option `no-accounts-db-caching` to test-validator

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -95,6 +95,7 @@ pub struct TestValidatorGenesis {
     pub max_ledger_shreds: Option<u64>,
     pub max_genesis_archive_unpacked_size: Option<u64>,
     pub accountsdb_plugin_config_files: Option<Vec<PathBuf>>,
+    pub accounts_db_caching_enabled: bool,
 }
 
 impl TestValidatorGenesis {
@@ -512,6 +513,7 @@ impl TestValidator {
 
         let mut validator_config = ValidatorConfig {
             accountsdb_plugin_config_files: config.accountsdb_plugin_config_files.clone(),
+            accounts_db_caching_enabled: config.accounts_db_caching_enabled,
             rpc_addrs: Some((
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
                 SocketAddr::new(

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -292,6 +292,11 @@ fn main() {
                 .hidden(true)
                 .help("Specify the configuration file for the AccountsDb plugin."),
         )
+        .arg(
+            Arg::with_name("no_accounts_db_caching")
+                .long("no-accounts-db-caching")
+                .help("Disables accounts caching"),
+        )
         .get_matches();
 
     let output = if matches.is_present("quiet") {
@@ -518,6 +523,7 @@ fn main() {
     let mut genesis = TestValidatorGenesis::default();
     genesis.max_ledger_shreds = value_of(&matches, "limit_ledger_size");
     genesis.max_genesis_archive_unpacked_size = Some(u64::MAX);
+    genesis.accounts_db_caching_enabled = !matches.is_present("no_accounts_db_caching");
 
     let tower_storage = Arc::new(FileTowerStorage::new(ledger_path.clone()));
 


### PR DESCRIPTION
#### Problem

Currently, `accountsdb` plugins don't receive accounts notifications in test-validator

#### Summary of Changes

I'm not sure that add option for the cache is the correct solution. PR introduced cache requirements is https://github.com/solana-labs/solana/pull/20948

cc @lijunwangs 