### PR TITLE
Refactor: Removes `Rc` from `Refcell<AccountSharedData>` in the program-runtime

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -25,7 +25,7 @@ use {
     std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc},
 };
 
-pub type TransactionAccountRefCell = (Pubkey, Rc<RefCell<AccountSharedData>>);
+pub type TransactionAccountRefCell = (Pubkey, RefCell<AccountSharedData>);
 pub type TransactionAccountRefCells = Vec<TransactionAccountRefCell>;
 
 pub type ProcessInstructionWithContext =
@@ -847,35 +847,23 @@ pub struct MockInvokeContextPreparation {
 pub fn prepare_mock_invoke_context(
     program_indices: &[usize],
     instruction_data: &[u8],
-    keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
 ) -> MockInvokeContextPreparation {
-    #[allow(clippy::type_complexity)]
-    let (accounts, mut metas): (TransactionAccountRefCells, Vec<AccountMeta>) = keyed_accounts
-        .iter()
-        .map(|(is_signer, is_writable, pubkey, account)| {
-            (
-                (*pubkey, account.clone()),
-                AccountMeta {
-                    pubkey: *pubkey,
-                    is_signer: *is_signer,
-                    is_writable: *is_writable,
-                },
-            )
-        })
-        .unzip();
+    let transaction_accounts: TransactionAccountRefCells = transaction_accounts
+        .into_iter()
+        .map(|(pubkey, account)| (pubkey, RefCell::new(account)))
+        .collect();
     let program_id = if let Some(program_index) = program_indices.last() {
-        accounts[*program_index].0
+        transaction_accounts[*program_index].0
     } else {
         Pubkey::default()
     };
-    for program_index in program_indices.iter().rev() {
-        metas.remove(*program_index);
-    }
     let message = Message::new(
         &[Instruction::new_with_bytes(
             program_id,
             instruction_data,
-            metas,
+            instruction_accounts,
         )],
         None,
     );
@@ -883,14 +871,14 @@ pub fn prepare_mock_invoke_context(
         .account_keys
         .iter()
         .map(|search_key| {
-            accounts
+            transaction_accounts
                 .iter()
                 .position(|(key, _account)| key == search_key)
-                .unwrap_or(accounts.len())
+                .unwrap_or(transaction_accounts.len())
         })
         .collect();
     MockInvokeContextPreparation {
-        accounts,
+        accounts: transaction_accounts,
         message,
         account_indices,
     }
@@ -902,27 +890,31 @@ pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
     mut callback: F,
 ) -> R {
     let program_indices = vec![0, 1];
-    let keyed_accounts = [
+    let transaction_accounts = vec![
         (
-            false,
-            false,
             loader_id,
-            AccountSharedData::new_ref(0, 0, &solana_sdk::native_loader::id()),
+            AccountSharedData::new(0, 0, &solana_sdk::native_loader::id()),
         ),
         (
-            false,
-            false,
             Pubkey::new_unique(),
-            AccountSharedData::new_ref(1, 0, &loader_id),
+            AccountSharedData::new(1, 0, &loader_id),
         ),
         (
-            false,
-            false,
             Pubkey::new_unique(),
-            AccountSharedData::new_ref(2, account_size, &Pubkey::new_unique()),
+            AccountSharedData::new(2, account_size, &Pubkey::new_unique()),
         ),
     ];
-    let preparation = prepare_mock_invoke_context(&program_indices, &[], &keyed_accounts);
+    let instruction_accounts = vec![AccountMeta {
+        pubkey: transaction_accounts[2].0,
+        is_signer: false,
+        is_writable: false,
+    }];
+    let preparation = prepare_mock_invoke_context(
+        &program_indices,
+        &[],
+        transaction_accounts,
+        instruction_accounts,
+    );
     let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
     invoke_context
         .push(
@@ -939,38 +931,60 @@ pub fn mock_process_instruction_with_sysvars(
     loader_id: &Pubkey,
     mut program_indices: Vec<usize>,
     instruction_data: &[u8],
-    keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+    expected_result: Result<(), InstructionError>,
     sysvars: &[(Pubkey, Vec<u8>)],
     process_instruction: ProcessInstructionWithContext,
-) -> Result<(), InstructionError> {
-    let mut preparation =
-        prepare_mock_invoke_context(&program_indices, instruction_data, keyed_accounts);
-    let processor_account = AccountSharedData::new_ref(0, 0, &solana_sdk::native_loader::id());
+) -> Vec<AccountSharedData> {
+    let mut preparation = prepare_mock_invoke_context(
+        &program_indices,
+        instruction_data,
+        transaction_accounts,
+        instruction_accounts,
+    );
+    let processor_account = RefCell::new(AccountSharedData::new(
+        0,
+        0,
+        &solana_sdk::native_loader::id(),
+    ));
     program_indices.insert(0, preparation.accounts.len());
     preparation.accounts.push((*loader_id, processor_account));
     let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
     invoke_context.sysvars = sysvars;
-    invoke_context.push(
-        &preparation.message,
-        &preparation.message.instructions[0],
-        &program_indices,
-        &preparation.account_indices,
-    )?;
-    process_instruction(1, instruction_data, &mut invoke_context)
+    let result = invoke_context
+        .push(
+            &preparation.message,
+            &preparation.message.instructions[0],
+            &program_indices,
+            &preparation.account_indices,
+        )
+        .and_then(|_| process_instruction(1, instruction_data, &mut invoke_context));
+    preparation.accounts.pop();
+    assert_eq!(result, expected_result);
+    preparation
+        .accounts
+        .into_iter()
+        .map(|(_key, account)| account.into_inner())
+        .collect()
 }
 
 pub fn mock_process_instruction(
     loader_id: &Pubkey,
     program_indices: Vec<usize>,
     instruction_data: &[u8],
-    keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
+    transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+    instruction_accounts: Vec<AccountMeta>,
+    expected_result: Result<(), InstructionError>,
     process_instruction: ProcessInstructionWithContext,
-) -> Result<(), InstructionError> {
+) -> Vec<AccountSharedData> {
     mock_process_instruction_with_sysvars(
         loader_id,
         program_indices,
         instruction_data,
-        keyed_accounts,
+        transaction_accounts,
+        instruction_accounts,
+        expected_result,
         &[],
         process_instruction,
     )
@@ -1082,22 +1096,18 @@ mod tests {
             invoke_stack.push(solana_sdk::pubkey::new_rand());
             accounts.push((
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::new(
-                    i as u64,
-                    1,
-                    &invoke_stack[i],
-                ))),
+                RefCell::new(AccountSharedData::new(i as u64, 1, &invoke_stack[i])),
             ));
             metas.push(AccountMeta::new(accounts[i].0, false));
         }
         for program_id in invoke_stack.iter() {
             accounts.push((
                 *program_id,
-                Rc::new(RefCell::new(AccountSharedData::new(
+                RefCell::new(AccountSharedData::new(
                     1,
                     1,
                     &solana_sdk::pubkey::Pubkey::default(),
-                ))),
+                )),
             ));
             metas.push(AccountMeta::new(*program_id, false));
         }
@@ -1184,7 +1194,7 @@ mod tests {
     fn test_invoke_context_verify() {
         let accounts = vec![(
             solana_sdk::pubkey::new_rand(),
-            Rc::new(RefCell::new(AccountSharedData::default())),
+            RefCell::new(AccountSharedData::default()),
         )];
         let message = Message::new(
             &[Instruction::new_with_bincode(
@@ -1222,20 +1232,17 @@ mod tests {
         program_account.set_executable(true);
 
         let accounts = vec![
+            (solana_sdk::pubkey::new_rand(), RefCell::new(owned_account)),
             (
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(owned_account)),
+                RefCell::new(not_owned_account),
             ),
             (
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(not_owned_account)),
+                RefCell::new(readonly_account),
             ),
-            (
-                solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(readonly_account)),
-            ),
-            (caller_program_id, Rc::new(RefCell::new(loader_account))),
-            (callee_program_id, Rc::new(RefCell::new(program_account))),
+            (caller_program_id, RefCell::new(loader_account)),
+            (callee_program_id, RefCell::new(program_account)),
         ];
         let account_indices = [0, 1, 2];
         let program_indices = [3, 4];
@@ -1355,20 +1362,17 @@ mod tests {
         program_account.set_executable(true);
 
         let accounts = vec![
+            (solana_sdk::pubkey::new_rand(), RefCell::new(owned_account)),
             (
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(owned_account)),
+                RefCell::new(not_owned_account),
             ),
             (
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(not_owned_account)),
+                RefCell::new(readonly_account),
             ),
-            (
-                solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(readonly_account)),
-            ),
-            (caller_program_id, Rc::new(RefCell::new(loader_account))),
-            (callee_program_id, Rc::new(RefCell::new(program_account))),
+            (caller_program_id, RefCell::new(loader_account)),
+            (callee_program_id, RefCell::new(program_account)),
         ];
         let program_indices = [3];
         let metas = vec![
@@ -1450,11 +1454,11 @@ mod tests {
         let accounts = vec![
             (
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::default())),
+                RefCell::new(AccountSharedData::default()),
             ),
             (
                 crate::neon_evm_program::id(),
-                Rc::new(RefCell::new(AccountSharedData::default())),
+                RefCell::new(AccountSharedData::default()),
             ),
         ];
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -322,6 +322,7 @@ mod tests {
             account_info::AccountInfo,
             bpf_loader,
             entrypoint::deserialize,
+            instruction::AccountMeta,
         },
         std::{
             cell::RefCell,
@@ -333,122 +334,128 @@ mod tests {
     #[test]
     fn test_serialize_parameters() {
         let program_id = solana_sdk::pubkey::new_rand();
-        let dup_key = solana_sdk::pubkey::new_rand();
-        let dup_key2 = solana_sdk::pubkey::new_rand();
-        let keyed_accounts = [
+        let transaction_accounts = vec![
             (
-                false,
-                false,
                 program_id,
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
+                AccountSharedData::from(Account {
                     lamports: 0,
                     data: vec![],
                     owner: bpf_loader::id(),
                     executable: true,
                     rent_epoch: 0,
-                }))),
+                }),
             ),
             (
-                false,
-                false,
-                dup_key,
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
-                    lamports: 1,
-                    data: vec![1u8, 2, 3, 4, 5],
-                    owner: bpf_loader::id(),
-                    executable: false,
-                    rent_epoch: 100,
-                }))),
-            ),
-            (
-                false,
-                false,
-                dup_key,
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
-                    lamports: 1,
-                    data: vec![1u8, 2, 3, 4, 5],
-                    owner: bpf_loader::id(),
-                    executable: false,
-                    rent_epoch: 100,
-                }))),
-            ),
-            (
-                false,
-                false,
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
+                AccountSharedData::from(Account {
+                    lamports: 1,
+                    data: vec![1u8, 2, 3, 4, 5],
+                    owner: bpf_loader::id(),
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::from(Account {
                     lamports: 2,
                     data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
                     owner: bpf_loader::id(),
                     executable: true,
                     rent_epoch: 200,
-                }))),
+                }),
             ),
             (
-                false,
-                false,
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
+                AccountSharedData::from(Account {
                     lamports: 3,
                     data: vec![],
                     owner: bpf_loader::id(),
                     executable: false,
                     rent_epoch: 3100,
-                }))),
+                }),
             ),
             (
-                false,
-                true,
-                dup_key2,
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
-                    lamports: 4,
-                    data: vec![1u8, 2, 3, 4, 5],
-                    owner: bpf_loader::id(),
-                    executable: false,
-                    rent_epoch: 100,
-                }))),
-            ),
-            (
-                false,
-                true,
-                dup_key2,
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
-                    lamports: 4,
-                    data: vec![1u8, 2, 3, 4, 5],
-                    owner: bpf_loader::id(),
-                    executable: false,
-                    rent_epoch: 100,
-                }))),
-            ),
-            (
-                false,
-                true,
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
+                AccountSharedData::from(Account {
+                    lamports: 4,
+                    data: vec![1u8, 2, 3, 4, 5],
+                    owner: bpf_loader::id(),
+                    executable: false,
+                    rent_epoch: 100,
+                }),
+            ),
+            (
+                solana_sdk::pubkey::new_rand(),
+                AccountSharedData::from(Account {
                     lamports: 5,
                     data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
                     owner: bpf_loader::id(),
                     executable: true,
                     rent_epoch: 200,
-                }))),
+                }),
             ),
             (
-                false,
-                true,
                 solana_sdk::pubkey::new_rand(),
-                Rc::new(RefCell::new(AccountSharedData::from(Account {
+                AccountSharedData::from(Account {
                     lamports: 6,
                     data: vec![],
                     owner: bpf_loader::id(),
                     executable: false,
                     rent_epoch: 3100,
-                }))),
+                }),
             ),
+        ];
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: transaction_accounts[1].0,
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[1].0,
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[2].0,
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[3].0,
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[4].0,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[4].0,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[5].0,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: transaction_accounts[6].0,
+                is_signer: false,
+                is_writable: true,
+            },
         ];
         let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         let program_indices = [0];
-        let preparation =
-            prepare_mock_invoke_context(&program_indices, &instruction_data, &keyed_accounts);
+        let preparation = prepare_mock_invoke_context(
+            &program_indices,
+            &instruction_data,
+            transaction_accounts.clone(),
+            instruction_accounts,
+        );
         let mut invoke_context = InvokeContext::new_mock(&preparation.accounts, &[]);
         invoke_context
             .push(
@@ -479,9 +486,12 @@ mod tests {
             (&de_instruction_data[0] as *const u8).align_offset(BPF_ALIGN_OF_U128),
             0
         );
-        for ((_, _, key, account), account_info) in keyed_accounts.iter().skip(1).zip(de_accounts) {
-            assert_eq!(key, account_info.key);
-            let account = account.borrow();
+        for account_info in de_accounts {
+            let account = &transaction_accounts
+                .iter()
+                .find(|(key, _account)| key == account_info.key)
+                .unwrap()
+                .1;
             assert_eq!(account.lamports(), account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
@@ -511,12 +521,14 @@ mod tests {
             true,
         )
         .unwrap();
-        for ((_, _, key, account), de_keyed_account) in keyed_accounts.iter().zip(de_keyed_accounts)
-        {
-            assert_eq!(key, de_keyed_account.unsigned_key());
-            let account = account.borrow();
-            assert_eq!(account.executable(), de_keyed_account.executable().unwrap());
-            assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
+        for keyed_account in de_keyed_accounts {
+            let account = &transaction_accounts
+                .iter()
+                .find(|(key, _account)| key == keyed_account.unsigned_key())
+                .unwrap()
+                .1;
+            assert_eq!(account.executable(), keyed_account.executable().unwrap());
+            assert_eq!(account.rent_epoch(), keyed_account.rent_epoch().unwrap());
         }
 
         // check serialize_parameters_unaligned
@@ -534,9 +546,12 @@ mod tests {
             unsafe { deserialize_unaligned(&mut serialized.as_slice_mut()[0] as *mut u8) };
         assert_eq!(&program_id, de_program_id);
         assert_eq!(instruction_data, de_instruction_data);
-        for ((_, _, key, account), account_info) in keyed_accounts.iter().skip(1).zip(de_accounts) {
-            assert_eq!(key, account_info.key);
-            let account = account.borrow();
+        for account_info in de_accounts {
+            let account = &transaction_accounts
+                .iter()
+                .find(|(key, _account)| key == account_info.key)
+                .unwrap()
+                .1;
             assert_eq!(account.lamports(), account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
@@ -553,18 +568,20 @@ mod tests {
             true,
         )
         .unwrap();
-        for ((_, _, key, account), de_keyed_account) in keyed_accounts.iter().zip(de_keyed_accounts)
-        {
-            assert_eq!(key, de_keyed_account.unsigned_key());
-            let account = account.borrow();
-            assert_eq!(account.lamports(), de_keyed_account.lamports().unwrap());
+        for keyed_account in de_keyed_accounts {
+            let account = &transaction_accounts
+                .iter()
+                .find(|(key, _account)| key == keyed_account.unsigned_key())
+                .unwrap()
+                .1;
+            assert_eq!(account.lamports(), keyed_account.lamports().unwrap());
             assert_eq!(
                 account.data(),
-                de_keyed_account.try_account_ref().unwrap().data()
+                keyed_account.try_account_ref().unwrap().data()
             );
-            assert_eq!(*account.owner(), de_keyed_account.owner().unwrap());
-            assert_eq!(account.executable(), de_keyed_account.executable().unwrap());
-            assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
+            assert_eq!(*account.owner(), keyed_account.owner().unwrap());
+            assert_eq!(account.executable(), keyed_account.executable().unwrap());
+            assert_eq!(account.rent_epoch(), keyed_account.rent_epoch().unwrap());
         }
     }
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2984,7 +2984,7 @@ mod tests {
     #[should_panic(expected = "UserError(SyscallError(Panic(\"Gaggablaghblagh!\", 42, 84)))")]
     fn test_syscall_sol_panic() {
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3061,7 +3061,7 @@ mod tests {
     #[test]
     fn test_syscall_sol_log() {
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3165,7 +3165,7 @@ mod tests {
     #[test]
     fn test_syscall_sol_log_u64() {
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3207,7 +3207,7 @@ mod tests {
     #[test]
     fn test_syscall_sol_pubkey() {
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3419,7 +3419,8 @@ mod tests {
     fn test_syscall_sha256() {
         let config = Config::default();
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader_deprecated::id());
+        let program_account =
+            RefCell::new(AccountSharedData::new(0, 0, &bpf_loader_deprecated::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3548,7 +3549,7 @@ mod tests {
     fn test_syscall_get_sysvar() {
         let config = Config::default();
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3858,7 +3859,7 @@ mod tests {
         // These tests duplicate the direct tests in solana_program::pubkey
 
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],
@@ -3974,7 +3975,7 @@ mod tests {
     #[test]
     fn test_find_program_address() {
         let program_id = Pubkey::new_unique();
-        let program_account = AccountSharedData::new_ref(0, 0, &bpf_loader::id());
+        let program_account = RefCell::new(AccountSharedData::new(0, 0, &bpf_loader::id()));
         let accounts = [(program_id, program_account)];
         let message = Message::new(
             &[Instruction::new_with_bytes(program_id, &[], vec![])],

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -147,22 +147,26 @@ mod tests {
         solana_program_runtime::invoke_context::mock_process_instruction,
         solana_sdk::{
             account::AccountSharedData,
+            instruction::AccountMeta,
             pubkey::Pubkey,
             signature::{Keypair, Signer},
             system_instruction::SystemInstruction,
         },
-        std::{cell::RefCell, rc::Rc},
     };
 
     fn process_instruction(
         instruction_data: &[u8],
-        keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
-    ) -> Result<(), InstructionError> {
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: Vec<AccountMeta>,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
         mock_process_instruction(
             &id(),
             Vec::new(),
             instruction_data,
-            keyed_accounts,
+            transaction_accounts,
+            instruction_accounts,
+            expected_result,
             super::process_instruction,
         )
     }
@@ -191,16 +195,12 @@ mod tests {
         }
     }
 
-    fn create_config_account(
-        keys: Vec<(Pubkey, bool)>,
-    ) -> (Keypair, Rc<RefCell<AccountSharedData>>) {
+    fn create_config_account(keys: Vec<(Pubkey, bool)>) -> (Keypair, AccountSharedData) {
         let from_pubkey = Pubkey::new_unique();
         let config_keypair = Keypair::new();
         let config_pubkey = config_keypair.pubkey();
-
         let instructions =
             config_instruction::create_account::<MyConfig>(&from_pubkey, &config_pubkey, 1, keys);
-
         let system_instruction = limited_deserialize(&instructions[0].data).unwrap();
         let space = match system_instruction {
             SystemInstruction::CreateAccount {
@@ -210,14 +210,18 @@ mod tests {
             } => space,
             _ => panic!("Not a CreateAccount system instruction"),
         };
-        let config_account = AccountSharedData::new_ref(0, space as usize, &id());
-        let keyed_accounts = [(true, false, config_pubkey, config_account.clone())];
-        assert_eq!(
-            process_instruction(&instructions[1].data, &keyed_accounts),
-            Ok(())
+        let config_account = AccountSharedData::new(0, space as usize, &id());
+        let accounts = process_instruction(
+            &instructions[1].data,
+            vec![(config_pubkey, config_account)],
+            vec![AccountMeta {
+                pubkey: config_pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Ok(()),
         );
-
-        (config_keypair, config_account)
+        (config_keypair, accounts[0].clone())
     }
 
     #[test]
@@ -226,7 +230,7 @@ mod tests {
         let (_, config_account) = create_config_account(vec![]);
         assert_eq!(
             Some(MyConfig::default()),
-            deserialize(get_config_data(config_account.borrow().data()).unwrap()).ok()
+            deserialize(get_config_data(config_account.data()).unwrap()).ok()
         );
     }
 
@@ -239,14 +243,19 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        let keyed_accounts = [(true, false, config_pubkey, config_account.clone())];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![(config_pubkey, config_account)],
+            vec![AccountMeta {
+                pubkey: config_pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Ok(()),
         );
         assert_eq!(
             Some(my_config),
-            deserialize(get_config_data(config_account.borrow().data()).unwrap()).ok()
+            deserialize(get_config_data(accounts[0].data()).unwrap()).ok()
         );
     }
 
@@ -260,10 +269,15 @@ mod tests {
 
         let mut instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
         instruction.data = vec![0; 123]; // <-- Replace data with a vector that's too large
-        let keyed_accounts = [(true, false, config_pubkey, config_account)];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::InvalidInstructionData)
+        process_instruction(
+            &instruction.data,
+            vec![(config_pubkey, config_account)],
+            vec![AccountMeta {
+                pubkey: config_pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Err(InstructionError::InvalidInstructionData),
         );
     }
 
@@ -277,10 +291,15 @@ mod tests {
 
         let mut instruction = config_instruction::store(&config_pubkey, true, vec![], &my_config);
         instruction.accounts[0].is_signer = false; // <----- not a signer
-        let keyed_accounts = [(false, false, config_pubkey, config_account)];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::MissingRequiredSignature)
+        process_instruction(
+            &instruction.data,
+            vec![(config_pubkey, config_account)],
+            vec![AccountMeta {
+                pubkey: config_pubkey,
+                is_signer: false,
+                is_writable: false,
+            }],
+            Err(InstructionError::MissingRequiredSignature),
         );
     }
 
@@ -298,24 +317,41 @@ mod tests {
         let (config_keypair, config_account) = create_config_account(keys.clone());
         let config_pubkey = config_keypair.pubkey();
         let my_config = MyConfig::new(42);
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let signer1_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let signer1_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let keyed_accounts = [
-            (true, false, config_pubkey, config_account.clone()),
-            (true, false, signer0_pubkey, signer0_account),
-            (true, false, signer1_pubkey, signer1_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account),
+                (signer1_pubkey, signer1_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        let meta_data: ConfigKeys = deserialize(config_account.borrow().data()).unwrap();
+        let meta_data: ConfigKeys = deserialize(accounts[0].data()).unwrap();
         assert_eq!(meta_data.keys, keys);
         assert_eq!(
             Some(my_config),
-            deserialize(get_config_data(config_account.borrow().data()).unwrap()).ok()
+            deserialize(get_config_data(accounts[0].data()).unwrap()).ok()
         );
     }
 
@@ -328,13 +364,18 @@ mod tests {
         let (config_keypair, _) = create_config_account(keys.clone());
         let config_pubkey = config_keypair.pubkey();
         let my_config = MyConfig::new(42);
+        let signer0_account = AccountSharedData::new(0, 0, &id());
 
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
-        let signer0_account = AccountSharedData::new_ref(0, 0, &id());
-        let keyed_accounts = [(true, false, signer0_pubkey, signer0_account)];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::InvalidAccountData)
+        process_instruction(
+            &instruction.data,
+            vec![(signer0_pubkey, signer0_account)],
+            vec![AccountMeta {
+                pubkey: signer0_pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Err(InstructionError::InvalidAccountData),
         );
     }
 
@@ -343,30 +384,56 @@ mod tests {
         solana_logger::setup();
         let signer0_pubkey = Pubkey::new_unique();
         let signer1_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let signer1_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let signer1_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let keys = vec![(signer0_pubkey, true)];
         let (config_keypair, config_account) = create_config_account(keys.clone());
         let config_pubkey = config_keypair.pubkey();
         let my_config = MyConfig::new(42);
 
-        let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-
         // Config-data pubkey doesn't match signer
-        let mut keyed_accounts = [
-            (true, false, config_pubkey, config_account),
-            (true, false, signer1_pubkey, signer1_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::MissingRequiredSignature)
+        let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account.clone()),
+                (signer1_pubkey, signer1_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
         );
 
         // Config-data pubkey not a signer
-        keyed_accounts[1] = (false, false, signer0_pubkey, signer0_account);
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::MissingRequiredSignature)
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
         );
     }
 
@@ -377,9 +444,9 @@ mod tests {
         let signer0_pubkey = Pubkey::new_unique();
         let signer1_pubkey = Pubkey::new_unique();
         let signer2_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let signer1_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let signer2_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let signer1_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let signer2_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -390,40 +457,98 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
-        let mut keyed_accounts = [
-            (true, false, config_pubkey, config_account.clone()),
-            (true, false, signer0_pubkey, signer0_account),
-            (true, false, signer1_pubkey, signer1_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account.clone()),
+                (signer1_pubkey, signer1_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
 
         // Update with expected signatures
         let new_config = MyConfig::new(84);
         let instruction =
             config_instruction::store(&config_pubkey, false, keys.clone(), &new_config);
-        keyed_accounts[0].0 = false;
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, accounts[0].clone()),
+                (signer0_pubkey, signer0_account.clone()),
+                (signer1_pubkey, signer1_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        let meta_data: ConfigKeys = deserialize(config_account.borrow().data()).unwrap();
+        let meta_data: ConfigKeys = deserialize(accounts[0].data()).unwrap();
         assert_eq!(meta_data.keys, keys);
         assert_eq!(
             new_config,
-            MyConfig::deserialize(get_config_data(config_account.borrow().data()).unwrap())
-                .unwrap()
+            MyConfig::deserialize(get_config_data(accounts[0].data()).unwrap()).unwrap()
         );
 
         // Attempt update with incomplete signatures
         let keys = vec![(pubkey, false), (signer0_pubkey, true)];
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
-        keyed_accounts[2].0 = false;
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::MissingRequiredSignature)
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, accounts[0].clone()),
+                (signer0_pubkey, signer0_account.clone()),
+                (signer1_pubkey, signer1_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
         );
 
         // Attempt update with incorrect signatures
@@ -433,10 +558,31 @@ mod tests {
             (signer2_pubkey, true),
         ];
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
-        keyed_accounts[2] = (true, false, signer2_pubkey, signer2_account);
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::MissingRequiredSignature)
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, accounts[0].clone()),
+                (signer0_pubkey, signer0_account),
+                (signer2_pubkey, signer2_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer2_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::MissingRequiredSignature),
         );
     }
 
@@ -445,7 +591,7 @@ mod tests {
         solana_logger::setup();
         let config_address = Pubkey::new_unique();
         let signer0_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let keys = vec![
             (config_address, false),
             (signer0_pubkey, true),
@@ -457,13 +603,29 @@ mod tests {
 
         // Attempt initialization with duplicate signer inputs
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        let keyed_accounts = [
-            (true, false, config_pubkey, config_account),
-            (true, false, signer0_pubkey, signer0_account.clone()),
-            (true, false, signer0_pubkey, signer0_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
@@ -474,8 +636,8 @@ mod tests {
         let config_address = Pubkey::new_unique();
         let signer0_pubkey = Pubkey::new_unique();
         let signer1_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let signer1_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let signer1_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let keys = vec![
             (config_address, false),
             (signer0_pubkey, true),
@@ -486,13 +648,30 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        let mut keyed_accounts = [
-            (true, false, config_pubkey, config_account),
-            (true, false, signer0_pubkey, signer0_account),
-            (true, false, signer1_pubkey, signer1_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account.clone()),
+                (signer1_pubkey, signer1_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer1_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
             Ok(()),
         );
 
@@ -504,9 +683,29 @@ mod tests {
             (signer0_pubkey, true),
         ];
         let instruction = config_instruction::store(&config_pubkey, false, dupe_keys, &new_config);
-        keyed_accounts[2] = keyed_accounts[1].clone();
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, accounts[0].clone()),
+                (signer0_pubkey, signer0_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
@@ -516,7 +715,7 @@ mod tests {
         solana_logger::setup();
         let pubkey = Pubkey::new_unique();
         let signer0_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -525,7 +724,6 @@ mod tests {
         let (config_keypair, config_account) = create_config_account(keys);
         let config_pubkey = config_keypair.pubkey();
         let my_config = MyConfig::new(42);
-
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -533,37 +731,70 @@ mod tests {
         ];
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
-        let keyed_accounts = [
-            (true, false, config_pubkey, config_account.clone()),
-            (true, false, signer0_pubkey, signer0_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
 
         // Update with expected signatures
         let new_config = MyConfig::new(84);
         let instruction =
             config_instruction::store(&config_pubkey, true, keys.clone(), &new_config);
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Ok(())
+        let accounts = process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, accounts[0].clone()),
+                (signer0_pubkey, signer0_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        let meta_data: ConfigKeys = deserialize(config_account.borrow().data()).unwrap();
+        let meta_data: ConfigKeys = deserialize(accounts[0].data()).unwrap();
         assert_eq!(meta_data.keys, keys);
         assert_eq!(
             new_config,
-            MyConfig::deserialize(get_config_data(config_account.borrow().data()).unwrap())
-                .unwrap()
+            MyConfig::deserialize(get_config_data(accounts[0].data()).unwrap()).unwrap()
         );
 
         // Attempt update with incomplete signatures
         let keys = vec![(pubkey, false), (config_keypair.pubkey(), true)];
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts[0..1]),
-            Err(InstructionError::MissingRequiredSignature)
+        process_instruction(
+            &instruction.data,
+            vec![(config_pubkey, accounts[0].clone())],
+            vec![AccountMeta {
+                pubkey: config_pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Err(InstructionError::MissingRequiredSignature),
         );
     }
 
@@ -574,9 +805,11 @@ mod tests {
         let (_, _config_account) = create_config_account(vec![]);
         let instructions =
             config_instruction::create_account::<MyConfig>(&from_pubkey, &config_pubkey, 1, vec![]);
-        assert_eq!(
-            process_instruction(&instructions[1].data, &[]),
-            Err(InstructionError::NotEnoughAccountKeys)
+        process_instruction(
+            &instructions[1].data,
+            Vec::new(),
+            Vec::new(),
+            Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
@@ -586,8 +819,8 @@ mod tests {
         let config_pubkey = Pubkey::new_unique();
         let new_config = MyConfig::new(84);
         let signer0_pubkey = Pubkey::new_unique();
-        let signer0_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
-        let config_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
+        let signer0_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+        let config_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let (_, _config_account) = create_config_account(vec![]);
         let keys = vec![
             (from_pubkey, false),
@@ -596,13 +829,25 @@ mod tests {
         ];
 
         let instruction = config_instruction::store(&config_pubkey, true, keys, &new_config);
-        let keyed_accounts = [
-            (true, false, config_pubkey, config_account),
-            (true, false, signer0_pubkey, signer0_account),
-        ];
-        assert_eq!(
-            process_instruction(&instruction.data, &keyed_accounts),
-            Err(InstructionError::InvalidAccountOwner)
+        process_instruction(
+            &instruction.data,
+            vec![
+                (config_pubkey, config_account),
+                (signer0_pubkey, signer0_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: config_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: signer0_pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::InvalidAccountOwner),
         );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3415,11 +3415,10 @@ impl Bank {
     /// Converts Accounts into RefCell<AccountSharedData>, this involves moving
     /// ownership by draining the source
     fn accounts_to_refcells(accounts: &mut TransactionAccounts) -> TransactionAccountRefCells {
-        let account_refcells: Vec<_> = accounts
+        accounts
             .drain(..)
-            .map(|(pubkey, account)| (pubkey, Rc::new(RefCell::new(account))))
-            .collect();
-        account_refcells
+            .map(|(pubkey, account)| (pubkey, RefCell::new(account)))
+            .collect()
     }
 
     /// Converts back from RefCell<AccountSharedData> to AccountSharedData, this involves moving
@@ -3427,17 +3426,10 @@ impl Bank {
     fn refcells_to_accounts(
         accounts: &mut TransactionAccounts,
         mut account_refcells: TransactionAccountRefCells,
-    ) -> std::result::Result<(), TransactionError> {
+    ) {
         for (pubkey, account_refcell) in account_refcells.drain(..) {
-            accounts.push((
-                pubkey,
-                Rc::try_unwrap(account_refcell)
-                    .map_err(|_| TransactionError::AccountBorrowOutstanding)?
-                    .into_inner(),
-            ))
+            accounts.push((pubkey, account_refcell.into_inner()))
         }
-
-        Ok(())
     }
 
     /// Get any cached executors needed by the transaction
@@ -3648,13 +3640,10 @@ impl Bank {
                             });
                         inner_instructions.push(inner_instruction_list);
 
-                        if let Err(e) = Self::refcells_to_accounts(
+                        Self::refcells_to_accounts(
                             &mut loaded_transaction.accounts,
                             account_refcells,
-                        ) {
-                            warn!("Account lifetime mismanagement");
-                            process_result = Err(e);
-                        }
+                        );
 
                         if process_result.is_ok() {
                             self.update_executors(executors);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -197,19 +197,19 @@ mod tests {
             process_instruction: mock_system_process_instruction,
         }];
 
-        let program_account = Rc::new(RefCell::new(create_loadable_account_for_test(
-            "mock_system_program",
-        )));
         let accounts = vec![
             (
                 solana_sdk::pubkey::new_rand(),
-                AccountSharedData::new_ref(100, 1, &mock_system_program_id),
+                RefCell::new(AccountSharedData::new(100, 1, &mock_system_program_id)),
             ),
             (
                 solana_sdk::pubkey::new_rand(),
-                AccountSharedData::new_ref(0, 1, &mock_system_program_id),
+                RefCell::new(AccountSharedData::new(0, 1, &mock_system_program_id)),
             ),
-            (mock_system_program_id, program_account),
+            (
+                mock_system_program_id,
+                RefCell::new(create_loadable_account_for_test("mock_system_program")),
+            ),
         ];
         let program_indices = vec![vec![2]];
 
@@ -401,19 +401,19 @@ mod tests {
             process_instruction: mock_system_process_instruction,
         }];
 
-        let program_account = Rc::new(RefCell::new(create_loadable_account_for_test(
-            "mock_system_program",
-        )));
         let accounts = vec![
             (
                 solana_sdk::pubkey::new_rand(),
-                AccountSharedData::new_ref(100, 1, &mock_program_id),
+                RefCell::new(AccountSharedData::new(100, 1, &mock_program_id)),
             ),
             (
                 solana_sdk::pubkey::new_rand(),
-                AccountSharedData::new_ref(0, 1, &mock_program_id),
+                RefCell::new(AccountSharedData::new(0, 1, &mock_program_id)),
             ),
-            (mock_program_id, program_account),
+            (
+                mock_program_id,
+                RefCell::new(create_loadable_account_for_test("mock_system_program")),
+            ),
         ];
         let program_indices = vec![vec![2]];
 
@@ -534,13 +534,13 @@ mod tests {
             process_instruction: mock_process_instruction,
         }];
 
-        let secp256k1_account = AccountSharedData::new_ref(1, 0, &native_loader::id());
-        secp256k1_account.borrow_mut().set_executable(true);
-        let mock_program_account = AccountSharedData::new_ref(1, 0, &native_loader::id());
-        mock_program_account.borrow_mut().set_executable(true);
+        let mut secp256k1_account = AccountSharedData::new(1, 0, &native_loader::id());
+        secp256k1_account.set_executable(true);
+        let mut mock_program_account = AccountSharedData::new(1, 0, &native_loader::id());
+        mock_program_account.set_executable(true);
         let accounts = vec![
-            (secp256k1_program::id(), secp256k1_account),
-            (mock_program_id, mock_program_account),
+            (secp256k1_program::id(), RefCell::new(secp256k1_account)),
+            (mock_program_id, RefCell::new(mock_program_account)),
         ];
 
         let message = Message::new(

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -508,7 +508,7 @@ mod tests {
         crate::{bank::Bank, bank_client::BankClient},
         bincode::serialize,
         solana_program_runtime::invoke_context::{mock_process_instruction, InvokeContext},
-        std::{cell::RefCell, rc::Rc, sync::Arc},
+        std::{cell::RefCell, sync::Arc},
     };
 
     impl From<Pubkey> for Address {
@@ -522,33 +522,33 @@ mod tests {
 
     fn process_instruction(
         instruction_data: &[u8],
-        keyed_accounts: &[(bool, bool, Pubkey, Rc<RefCell<AccountSharedData>>)],
-    ) -> Result<(), InstructionError> {
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: Vec<AccountMeta>,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
         mock_process_instruction(
             &system_program::id(),
             Vec::new(),
             instruction_data,
-            keyed_accounts,
+            transaction_accounts,
+            instruction_accounts,
+            expected_result,
             super::process_instruction,
         )
     }
 
-    fn create_default_account() -> Rc<RefCell<AccountSharedData>> {
-        AccountSharedData::new_ref(0, 0, &Pubkey::new_unique())
+    fn create_default_account() -> AccountSharedData {
+        AccountSharedData::new(0, 0, &Pubkey::new_unique())
     }
-    fn create_default_recent_blockhashes_account() -> Rc<RefCell<AccountSharedData>> {
-        Rc::new(RefCell::new(
-            #[allow(deprecated)]
-            recent_blockhashes_account::create_account_with_data_for_test(
-                vec![IterItem(0u64, &Hash::default(), 0); sysvar::recent_blockhashes::MAX_ENTRIES]
-                    .into_iter(),
-            ),
-        ))
+    fn create_default_recent_blockhashes_account() -> AccountSharedData {
+        #[allow(deprecated)]
+        recent_blockhashes_account::create_account_with_data_for_test(
+            vec![IterItem(0u64, &Hash::default(), 0); sysvar::recent_blockhashes::MAX_ENTRIES]
+                .into_iter(),
+        )
     }
-    fn create_default_rent_account() -> Rc<RefCell<AccountSharedData>> {
-        Rc::new(RefCell::new(account::create_account_shared_data_for_test(
-            &Rent::free(),
-        )))
+    fn create_default_rent_account() -> AccountSharedData {
+        account::create_account_shared_data_for_test(&Rent::free())
     }
 
     #[test]
@@ -556,28 +556,35 @@ mod tests {
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
         let to = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
+        let to_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
-        assert_eq!(
-            process_instruction(
-                &bincode::serialize(&SystemInstruction::CreateAccount {
-                    lamports: 50,
-                    space: 2,
-                    owner: new_owner
-                })
-                .unwrap(),
-                &[
-                    (true, false, from, from_account.clone()),
-                    (true, false, to, to_account.clone()),
-                ],
-            ),
-            Ok(())
+        let accounts = process_instruction(
+            &bincode::serialize(&SystemInstruction::CreateAccount {
+                lamports: 50,
+                space: 2,
+                owner: new_owner,
+            })
+            .unwrap(),
+            vec![(from, from_account), (to, to_account)],
+            vec![
+                AccountMeta {
+                    pubkey: from,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: to,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        assert_eq!(from_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().owner(), &new_owner);
-        assert_eq!(to_account.borrow().data(), &[0, 0]);
+        assert_eq!(accounts[0].lamports(), 50);
+        assert_eq!(accounts[1].lamports(), 50);
+        assert_eq!(accounts[1].owner(), &new_owner);
+        assert_eq!(accounts[1].data(), &[0, 0]);
     }
 
     #[test]
@@ -586,30 +593,37 @@ mod tests {
         let from = Pubkey::new_unique();
         let seed = "shiny pepper";
         let to = Pubkey::create_with_seed(&from, seed, &new_owner).unwrap();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
+        let to_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
-        assert_eq!(
-            process_instruction(
-                &bincode::serialize(&SystemInstruction::CreateAccountWithSeed {
-                    base: from,
-                    seed: seed.to_string(),
-                    lamports: 50,
-                    space: 2,
-                    owner: new_owner
-                })
-                .unwrap(),
-                &[
-                    (true, false, from, from_account.clone()),
-                    (false, false, to, to_account.clone()),
-                ],
-            ),
-            Ok(())
+        let accounts = process_instruction(
+            &bincode::serialize(&SystemInstruction::CreateAccountWithSeed {
+                base: from,
+                seed: seed.to_string(),
+                lamports: 50,
+                space: 2,
+                owner: new_owner,
+            })
+            .unwrap(),
+            vec![(from, from_account), (to, to_account)],
+            vec![
+                AccountMeta {
+                    pubkey: from,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: to,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        assert_eq!(from_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().owner(), &new_owner);
-        assert_eq!(to_account.borrow().data(), &[0, 0]);
+        assert_eq!(accounts[0].lamports(), 50);
+        assert_eq!(accounts[1].lamports(), 50);
+        assert_eq!(accounts[1].owner(), &new_owner);
+        assert_eq!(accounts[1].data(), &[0, 0]);
     }
 
     #[test]
@@ -619,32 +633,43 @@ mod tests {
         let base = Pubkey::new_unique();
         let seed = "shiny pepper";
         let to = Pubkey::create_with_seed(&base, seed, &new_owner).unwrap();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
-        let base_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
+        let to_account = AccountSharedData::new(0, 0, &Pubkey::default());
+        let base_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
-        assert_eq!(
-            process_instruction(
-                &bincode::serialize(&SystemInstruction::CreateAccountWithSeed {
-                    base,
-                    seed: seed.to_string(),
-                    lamports: 50,
-                    space: 2,
-                    owner: new_owner
-                })
-                .unwrap(),
-                &[
-                    (true, false, from, from_account.clone()),
-                    (false, false, to, to_account.clone()),
-                    (true, false, base, base_account),
-                ],
-            ),
-            Ok(())
+        let accounts = process_instruction(
+            &bincode::serialize(&SystemInstruction::CreateAccountWithSeed {
+                base,
+                seed: seed.to_string(),
+                lamports: 50,
+                space: 2,
+                owner: new_owner,
+            })
+            .unwrap(),
+            vec![(from, from_account), (to, to_account), (base, base_account)],
+            vec![
+                AccountMeta {
+                    pubkey: from,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: to,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: base,
+                    is_signer: true,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
         );
-        assert_eq!(from_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().lamports(), 50);
-        assert_eq!(to_account.borrow().owner(), &new_owner);
-        assert_eq!(to_account.borrow().data(), &[0, 0]);
+        assert_eq!(accounts[0].lamports(), 50);
+        assert_eq!(accounts[1].lamports(), 50);
+        assert_eq!(accounts[1].owner(), &new_owner);
+        assert_eq!(accounts[1].data(), &[0, 0]);
     }
 
     #[test]
@@ -669,8 +694,8 @@ mod tests {
         let seed = "dull boy";
         let to = Pubkey::create_with_seed(&from, seed, &new_owner).unwrap();
 
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
         let to_address =
             Address::create(&to, Some((&from, seed, &new_owner)), &invoke_context).unwrap();
 
@@ -697,10 +722,10 @@ mod tests {
         // create account with zero lamports transferred
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &Pubkey::new_unique()); // not from system account
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new_unique())); // not from system account
 
         let to = Pubkey::new_unique();
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
 
         assert_eq!(
             create_account(
@@ -731,10 +756,10 @@ mod tests {
         // Attempt to create account with more lamports than remaining in from_account
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let to = Pubkey::new_unique();
-        let to_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
 
         let result = create_account(
             &KeyedAccount::new(&from, true, &from_account),
@@ -752,9 +777,9 @@ mod tests {
     #[test]
     fn test_request_more_than_allowed_data_length() {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
         let from = Pubkey::new_unique();
-        let to_account = AccountSharedData::new_ref(0, 0, &system_program::id());
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &system_program::id()));
         let to = Pubkey::new_unique();
 
         let signers = &[from, to].iter().cloned().collect::<HashSet<_>>();
@@ -802,11 +827,11 @@ mod tests {
         // Attempt to create system account in account already owned by another program
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let original_program_owner = Pubkey::new(&[5; 32]);
         let owned_key = Pubkey::new_unique();
-        let owned_account = AccountSharedData::new_ref(0, 0, &original_program_owner);
+        let owned_account = RefCell::new(AccountSharedData::new(0, 0, &original_program_owner));
         let unchanged_account = owned_account.clone();
 
         let signers = &[from, owned_key].iter().cloned().collect::<HashSet<_>>();
@@ -829,7 +854,7 @@ mod tests {
         assert_eq!(owned_account, unchanged_account);
 
         // Attempt to create system account in account that already has data
-        let owned_account = AccountSharedData::new_ref(0, 1, &Pubkey::default());
+        let owned_account = RefCell::new(AccountSharedData::new(0, 1, &Pubkey::default()));
         let unchanged_account = owned_account.borrow().clone();
         let result = create_account(
             &KeyedAccount::new(&from, true, &from_account),
@@ -847,7 +872,7 @@ mod tests {
         assert_eq!(*owned_account.borrow(), unchanged_account);
 
         // Attempt to create an account that already has lamports
-        let owned_account = AccountSharedData::new_ref(1, 0, &Pubkey::default());
+        let owned_account = RefCell::new(AccountSharedData::new(1, 0, &Pubkey::default()));
         let unchanged_account = owned_account.borrow().clone();
         let result = create_account(
             &KeyedAccount::new(&from, true, &from_account),
@@ -870,10 +895,10 @@ mod tests {
         // Attempt to create an account without signing the transfer
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let owned_key = Pubkey::new_unique();
-        let owned_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let owned_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
 
         let owned_address = owned_key.into();
 
@@ -891,7 +916,7 @@ mod tests {
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
         // Haven't signed to account
-        let owned_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let owned_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
         let result = create_account(
             &KeyedAccount::new(&from, true, &from_account),
             &KeyedAccount::new(&owned_key, true, &owned_account),
@@ -905,7 +930,7 @@ mod tests {
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
         // Don't support unsigned creation with zero lamports (ephemeral account)
-        let owned_account = AccountSharedData::new_ref(0, 0, &Pubkey::default());
+        let owned_account = RefCell::new(AccountSharedData::new(0, 0, &Pubkey::default()));
         let result = create_account(
             &KeyedAccount::new(&from, false, &from_account),
             &KeyedAccount::new(&owned_key, true, &owned_account),
@@ -924,10 +949,10 @@ mod tests {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
         // Attempt to create system account in account already owned by another program
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let to = Pubkey::new_unique();
-        let to_account = AccountSharedData::new_ref(0, 0, &system_program::id());
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &system_program::id()));
 
         let signers = [from, to].iter().cloned().collect::<HashSet<_>>();
         let to_address = to.into();
@@ -959,10 +984,10 @@ mod tests {
         invoke_context.feature_set = Arc::new(feature_set);
         // Attempt to create system account in account already owned by another program
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let to = Pubkey::new_unique();
-        let to_account = AccountSharedData::new_ref(0, 0, &system_program::id());
+        let to_account = RefCell::new(AccountSharedData::new(0, 0, &system_program::id()));
 
         let signers = [from, to].iter().cloned().collect::<HashSet<_>>();
         let to_address = to.into();
@@ -986,14 +1011,13 @@ mod tests {
         // Attempt to create system account in account with populated data
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
 
         let populated_key = Pubkey::new_unique();
-        let populated_account = AccountSharedData::from(Account {
+        let populated_account = RefCell::new(AccountSharedData::from(Account {
             data: vec![0, 1, 2, 3],
             ..Account::default()
-        })
-        .into();
+        }));
 
         let signers = [from, populated_key]
             .iter()
@@ -1018,18 +1042,20 @@ mod tests {
     fn test_create_from_account_is_nonce_fail() {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
         let nonce = Pubkey::new_unique();
-        let nonce_account = AccountSharedData::new_ref_data(
-            42,
-            &nonce::state::Versions::new_current(nonce::State::Initialized(
-                nonce::state::Data::default(),
-            )),
-            &system_program::id(),
-        )
-        .unwrap();
+        let nonce_account = RefCell::new(
+            AccountSharedData::new_data(
+                42,
+                &nonce::state::Versions::new_current(nonce::State::Initialized(
+                    nonce::state::Data::default(),
+                )),
+                &system_program::id(),
+            )
+            .unwrap(),
+        );
         let from = KeyedAccount::new(&nonce, true, &nonce_account);
         let new = Pubkey::new_unique();
 
-        let new_account = AccountSharedData::new_ref(0, 0, &system_program::id());
+        let new_account = RefCell::new(AccountSharedData::new(0, 0, &system_program::id()));
 
         let signers = [nonce, new].iter().cloned().collect::<HashSet<_>>();
         let new_address = new.into();
@@ -1080,13 +1106,15 @@ mod tests {
             Ok(())
         );
 
-        let account = Rc::new(RefCell::new(account));
-        assert_eq!(
-            process_instruction(
-                &bincode::serialize(&SystemInstruction::Assign { owner: new_owner }).unwrap(),
-                &[(true, false, pubkey, account)],
-            ),
-            Ok(())
+        process_instruction(
+            &bincode::serialize(&SystemInstruction::Assign { owner: new_owner }).unwrap(),
+            vec![(pubkey, account)],
+            vec![AccountMeta {
+                pubkey,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Ok(()),
         );
     }
 
@@ -1143,25 +1171,37 @@ mod tests {
             owner: Pubkey::new_unique(),
         };
         let data = serialize(&instruction).unwrap();
-        let result = process_instruction(&data, &[]);
-        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
+        process_instruction(
+            &data,
+            Vec::new(),
+            Vec::new(),
+            Err(InstructionError::NotEnoughAccountKeys),
+        );
 
         // Attempt to transfer with no destination
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
         let instruction = SystemInstruction::Transfer { lamports: 0 };
         let data = serialize(&instruction).unwrap();
-        let result = process_instruction(&data, &[(true, false, from, from_account)]);
-        assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
+        process_instruction(
+            &data,
+            vec![(from, from_account)],
+            vec![AccountMeta {
+                pubkey: from,
+                is_signer: true,
+                is_writable: false,
+            }],
+            Err(InstructionError::NotEnoughAccountKeys),
+        );
     }
 
     #[test]
     fn test_transfer_lamports() {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
         let to = Pubkey::new(&[3; 32]);
-        let to_account = AccountSharedData::new_ref(1, 0, &to); // account owner should not matter
+        let to_account = RefCell::new(AccountSharedData::new(1, 0, &to)); // account owner should not matter
         let from_keyed_account = KeyedAccount::new(&from, true, &from_account);
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
         transfer(&from_keyed_account, &to_keyed_account, 50, &invoke_context).unwrap();
@@ -1197,14 +1237,14 @@ mod tests {
     fn test_transfer_with_seed() {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
         let base = Pubkey::new_unique();
-        let base_account = AccountSharedData::new_ref(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let base_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
         let from_base_keyed_account = KeyedAccount::new(&base, true, &base_account);
         let from_seed = "42";
         let from_owner = system_program::id();
         let from = Pubkey::create_with_seed(&base, from_seed, &from_owner).unwrap();
-        let from_account = AccountSharedData::new_ref(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let from_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
         let to = Pubkey::new(&[3; 32]);
-        let to_account = AccountSharedData::new_ref(1, 0, &to); // account owner should not matter
+        let to_account = RefCell::new(AccountSharedData::new(1, 0, &to)); // account owner should not matter
         let from_keyed_account = KeyedAccount::new(&from, true, &from_account);
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
         transfer_with_seed(
@@ -1257,22 +1297,26 @@ mod tests {
     fn test_transfer_lamports_from_nonce_account_fail() {
         let invoke_context = InvokeContext::new_mock(&[], &[]);
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new_ref_data(
-            100,
-            &nonce::state::Versions::new_current(nonce::State::Initialized(nonce::state::Data {
-                authority: from,
-                ..nonce::state::Data::default()
-            })),
-            &system_program::id(),
-        )
-        .unwrap();
+        let from_account = RefCell::new(
+            AccountSharedData::new_data(
+                100,
+                &nonce::state::Versions::new_current(nonce::State::Initialized(
+                    nonce::state::Data {
+                        authority: from,
+                        ..nonce::state::Data::default()
+                    },
+                )),
+                &system_program::id(),
+            )
+            .unwrap(),
+        );
         assert_eq!(
             get_system_account_kind(&from_account.borrow()),
             Some(SystemAccountKind::Nonce)
         );
 
         let to = Pubkey::new(&[3; 32]);
-        let to_account = AccountSharedData::new_ref(1, 0, &to); // account owner should not matter
+        let to_account = RefCell::new(AccountSharedData::new(1, 0, &to)); // account owner should not matter
         assert_eq!(
             transfer(
                 &KeyedAccount::new(&from, true, &from_account),
@@ -1463,78 +1507,92 @@ mod tests {
         assert_eq!(bank_client.get_balance(&mallory_pubkey).unwrap(), 50);
     }
 
-    fn process_nonce_instruction(instruction: &Instruction) -> Result<(), InstructionError> {
-        let accounts = instruction.accounts.iter().map(|meta| {
-            #[allow(deprecated)]
-            if sysvar::recent_blockhashes::check_id(&meta.pubkey) {
-                create_default_recent_blockhashes_account()
-            } else if sysvar::rent::check_id(&meta.pubkey) {
-                Rc::new(RefCell::new(account::create_account_shared_data_for_test(
-                    &Rent::free(),
-                )))
-            } else {
-                AccountSharedData::new_ref(0, 0, &Pubkey::new_unique())
-            }
-        });
-        let keyed_accounts: Vec<_> = instruction
+    fn process_nonce_instruction(
+        instruction: Instruction,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
+        let transaction_accounts = instruction
             .accounts
             .iter()
-            .zip(accounts)
-            .map(|(meta, account)| (meta.is_signer, meta.is_writable, meta.pubkey, account))
+            .map(|meta| {
+                #[allow(deprecated)]
+                (
+                    meta.pubkey,
+                    if sysvar::recent_blockhashes::check_id(&meta.pubkey) {
+                        create_default_recent_blockhashes_account()
+                    } else if sysvar::rent::check_id(&meta.pubkey) {
+                        account::create_account_shared_data_for_test(&Rent::free())
+                    } else {
+                        AccountSharedData::new(0, 0, &Pubkey::new_unique())
+                    },
+                )
+            })
             .collect();
-        process_instruction(&instruction.data, &keyed_accounts)
+        process_instruction(
+            &instruction.data,
+            transaction_accounts,
+            instruction.accounts,
+            expected_result,
+        )
     }
 
     #[test]
     fn test_process_nonce_ix_no_acc_data_fail() {
         let none_address = Pubkey::new_unique();
-        assert_eq!(
-            process_nonce_instruction(&system_instruction::advance_nonce_account(
-                &none_address,
-                &none_address
-            )),
+        process_nonce_instruction(
+            system_instruction::advance_nonce_account(&none_address, &none_address),
             Err(InstructionError::InvalidAccountData),
         );
     }
 
     #[test]
     fn test_process_nonce_ix_no_keyed_accs_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
-                &[],
-            ),
+        process_instruction(
+            &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+            Vec::new(),
+            Vec::new(),
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_nonce_ix_only_nonce_acc_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
-                &[(true, true, Pubkey::new_unique(), create_default_account())],
-            ),
+        let pubkey = Pubkey::new_unique();
+        process_instruction(
+            &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+            vec![(pubkey, create_default_account())],
+            vec![AccountMeta {
+                pubkey,
+                is_signer: true,
+                is_writable: true,
+            }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_nonce_ix_bad_recent_blockhash_state_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
-                &[
-                    (true, true, Pubkey::new_unique(), create_default_account()),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_account(),
-                    ),
-                ],
-            ),
+        let pubkey = Pubkey::new_unique();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+            vec![
+                (pubkey, create_default_account()),
+                (blockhash_id, create_default_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
@@ -1542,252 +1600,315 @@ mod tests {
     #[test]
     fn test_process_nonce_ix_ok() {
         let nonce_address = Pubkey::new_unique();
-        let nonce_account = Rc::new(nonce_account::create_account(1_000_000));
-        process_instruction(
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        let accounts = process_instruction(
             &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
-            &[
-                (true, true, nonce_address, nonce_account.clone()),
-                (
-                    false,
-                    false,
-                    #[allow(deprecated)]
-                    sysvar::recent_blockhashes::id(),
-                    create_default_recent_blockhashes_account(),
-                ),
-                (
-                    false,
-                    false,
-                    sysvar::rent::id(),
-                    create_default_rent_account(),
-                ),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
             ],
-        )
-        .unwrap();
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
+        );
         let blockhash = hash(&serialize(&0).unwrap());
         #[allow(deprecated)]
-        let new_recent_blockhashes_account = Rc::new(RefCell::new(
+        let new_recent_blockhashes_account =
             solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
                 vec![IterItem(0u64, &blockhash, 0); sysvar::recent_blockhashes::MAX_ENTRIES]
                     .into_iter(),
-            ),
-        ));
-        #[allow(deprecated)]
-        let blockhash_id = sysvar::recent_blockhashes::id();
-        let keyed_accounts = [
-            (true, true, nonce_address, nonce_account),
-            (false, false, blockhash_id, new_recent_blockhashes_account),
-        ];
-        assert_eq!(
-            mock_process_instruction(
-                &system_program::id(),
-                Vec::new(),
-                &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
-                &keyed_accounts,
-                |first_instruction_account: usize,
-                 instruction_data: &[u8],
-                 invoke_context: &mut InvokeContext| {
-                    invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                    super::process_instruction(
-                        first_instruction_account,
-                        instruction_data,
-                        invoke_context,
-                    )
+            );
+        mock_process_instruction(
+            &system_program::id(),
+            Vec::new(),
+            &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+            vec![
+                (nonce_address, accounts[0].clone()),
+                (blockhash_id, new_recent_blockhashes_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
                 },
-            ),
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Ok(()),
+            |first_instruction_account: usize,
+             instruction_data: &[u8],
+             invoke_context: &mut InvokeContext| {
+                invoke_context.blockhash = hash(&serialize(&0).unwrap());
+                super::process_instruction(
+                    first_instruction_account,
+                    instruction_data,
+                    invoke_context,
+                )
+            },
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_no_acc_data_fail() {
         let nonce_address = Pubkey::new_unique();
-        assert_eq!(
-            process_nonce_instruction(&system_instruction::withdraw_nonce_account(
+        process_nonce_instruction(
+            system_instruction::withdraw_nonce_account(
                 &nonce_address,
                 &Pubkey::new_unique(),
                 &nonce_address,
                 1,
-            )),
+            ),
             Err(InstructionError::InvalidAccountData),
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_no_keyed_accs_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
-                &[],
-            ),
+        process_instruction(
+            &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
+            Vec::new(),
+            Vec::new(),
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_only_nonce_acc_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
-                &[(true, false, Pubkey::default(), create_default_account())],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        process_instruction(
+            &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
+            vec![(nonce_address, create_default_account())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: true,
+                is_writable: true,
+            }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_bad_recent_blockhash_state_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
-                &[
-                    (true, false, Pubkey::default(), create_default_account()),
-                    (false, false, Pubkey::default(), create_default_account()),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_account()
-                    ),
-                ],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let pubkey = Pubkey::new_unique();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
+            vec![
+                (nonce_address, create_default_account()),
+                (pubkey, create_default_account()),
+                (blockhash_id, create_default_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_bad_rent_state_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
-                &[
-                    (
-                        true,
-                        false,
-                        Pubkey::default(),
-                        Rc::new(nonce_account::create_account(1_000_000)),
-                    ),
-                    (true, false, Pubkey::default(), create_default_account()),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_recent_blockhashes_account(),
-                    ),
-                    (false, false, sysvar::rent::id(), create_default_account()),
-                ],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        let pubkey = Pubkey::new_unique();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (pubkey, create_default_account()),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
 
     #[test]
     fn test_process_withdraw_ix_ok() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
-                &[
-                    (
-                        true,
-                        true,
-                        Pubkey::new_unique(),
-                        Rc::new(nonce_account::create_account(1_000_000)),
-                    ),
-                    (true, false, Pubkey::default(), create_default_account()),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_recent_blockhashes_account(),
-                    ),
-                    (
-                        false,
-                        false,
-                        sysvar::rent::id(),
-                        create_default_rent_account()
-                    ),
-                ],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        let pubkey = Pubkey::new_unique();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (pubkey, create_default_account()),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey,
+                    is_signer: true,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Ok(()),
         );
     }
 
     #[test]
     fn test_process_initialize_ix_no_keyed_accs_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
-                &[],
-            ),
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
+            Vec::new(),
+            Vec::new(),
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_initialize_ix_only_nonce_acc_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
-                &[(
-                    true,
-                    false,
-                    Pubkey::default(),
-                    Rc::new(nonce_account::create_account(1_000_000)),
-                )],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![(nonce_address, nonce_account)],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: true,
+                is_writable: true,
+            }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
 
     #[test]
     fn test_process_initialize_bad_recent_blockhash_state_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
-                &[
-                    (
-                        true,
-                        false,
-                        Pubkey::default(),
-                        Rc::new(nonce_account::create_account(1_000_000)),
-                    ),
-                    (
-                        true,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_account()
-                    ),
-                ],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
 
     #[test]
     fn test_process_initialize_ix_bad_rent_state_fail() {
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
-                &[
-                    (
-                        true,
-                        false,
-                        Pubkey::default(),
-                        Rc::new(nonce_account::create_account(1_000_000)),
-                    ),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_recent_blockhashes_account(),
-                    ),
-                    (false, false, sysvar::rent::id(), create_default_account()),
-                ],
-            ),
+        let nonce_address = Pubkey::new_unique();
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(InstructionError::InvalidArgument),
         );
     }
@@ -1795,31 +1916,33 @@ mod tests {
     #[test]
     fn test_process_initialize_ix_ok() {
         let nonce_address = Pubkey::new_unique();
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
-                &[
-                    (
-                        true,
-                        true,
-                        nonce_address,
-                        Rc::new(nonce_account::create_account(1_000_000)),
-                    ),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        create_default_recent_blockhashes_account(),
-                    ),
-                    (
-                        false,
-                        false,
-                        sysvar::rent::id(),
-                        create_default_rent_account()
-                    ),
-                ],
-            ),
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Ok(()),
         );
     }
@@ -1827,32 +1950,43 @@ mod tests {
     #[test]
     fn test_process_authorize_ix_ok() {
         let nonce_address = Pubkey::new_unique();
-        let nonce_account = Rc::new(nonce_account::create_account(1_000_000));
-        process_instruction(
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
+        #[allow(deprecated)]
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        let accounts = process_instruction(
             &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
-            &[
-                (true, true, nonce_address, nonce_account.clone()),
-                (
-                    false,
-                    false,
-                    #[allow(deprecated)]
-                    sysvar::recent_blockhashes::id(),
-                    create_default_recent_blockhashes_account(),
-                ),
-                (
-                    false,
-                    false,
-                    sysvar::rent::id(),
-                    create_default_rent_account(),
-                ),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
             ],
-        )
-        .unwrap();
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::AuthorizeNonceAccount(nonce_address)).unwrap(),
-                &[(true, true, nonce_address, nonce_account)],
-            ),
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
+        );
+        process_instruction(
+            &serialize(&SystemInstruction::AuthorizeNonceAccount(nonce_address)).unwrap(),
+            vec![(nonce_address, accounts[0].clone())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: true,
+                is_writable: true,
+            }],
             Ok(()),
         );
     }
@@ -1860,12 +1994,12 @@ mod tests {
     #[test]
     fn test_process_authorize_bad_account_data_fail() {
         let nonce_address = Pubkey::new_unique();
-        assert_eq!(
-            process_nonce_instruction(&system_instruction::authorize_nonce_account(
+        process_nonce_instruction(
+            system_instruction::authorize_nonce_account(
                 &nonce_address,
                 &Pubkey::new_unique(),
                 &nonce_address,
-            )),
+            ),
             Err(InstructionError::InvalidAccountData),
         );
     }
@@ -1926,91 +2060,110 @@ mod tests {
     #[test]
     fn test_nonce_initialize_with_empty_recent_blockhashes_fail() {
         let nonce_address = Pubkey::new_unique();
-        let nonce_account = Rc::new(nonce_account::create_account(1_000_000));
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
         #[allow(deprecated)]
-        let new_recent_blockhashes_account = Rc::new(RefCell::new(
+        let blockhash_id = sysvar::recent_blockhashes::id();
+        #[allow(deprecated)]
+        let new_recent_blockhashes_account =
             solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
                 vec![].into_iter(),
-            ),
-        ));
-        assert_eq!(
-            process_instruction(
-                &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
-                &[
-                    (true, true, nonce_address, nonce_account),
-                    (
-                        false,
-                        false,
-                        #[allow(deprecated)]
-                        sysvar::recent_blockhashes::id(),
-                        new_recent_blockhashes_account,
-                    ),
-                    (
-                        false,
-                        false,
-                        sysvar::rent::id(),
-                        create_default_rent_account()
-                    ),
-                ],
-            ),
-            Err(NonceError::NoRecentBlockhashes.into())
+            );
+        process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, new_recent_blockhashes_account),
+                (sysvar::rent::id(), create_default_rent_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(NonceError::NoRecentBlockhashes.into()),
         );
     }
 
     #[test]
     fn test_nonce_advance_with_empty_recent_blockhashes_fail() {
         let nonce_address = Pubkey::new_unique();
-        let nonce_account = Rc::new(nonce_account::create_account(1_000_000));
-        process_instruction(
-            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
-            &[
-                (true, true, nonce_address, nonce_account.clone()),
-                (
-                    false,
-                    false,
-                    #[allow(deprecated)]
-                    sysvar::recent_blockhashes::id(),
-                    create_default_recent_blockhashes_account(),
-                ),
-                (
-                    false,
-                    false,
-                    sysvar::rent::id(),
-                    create_default_rent_account(),
-                ),
-            ],
-        )
-        .unwrap();
-        #[allow(deprecated)]
-        let new_recent_blockhashes_account = Rc::new(RefCell::new(
-            solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
-                vec![].into_iter(),
-            ),
-        ));
+        let nonce_account = nonce_account::create_account(1_000_000).into_inner();
         #[allow(deprecated)]
         let blockhash_id = sysvar::recent_blockhashes::id();
-        let keyed_accounts = [
-            (true, false, nonce_address, nonce_account),
-            (false, false, blockhash_id, new_recent_blockhashes_account),
-        ];
-        assert_eq!(
-            mock_process_instruction(
-                &system_program::id(),
-                Vec::new(),
-                &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
-                &keyed_accounts,
-                |first_instruction_account: usize,
-                 instruction_data: &[u8],
-                 invoke_context: &mut InvokeContext| {
-                    invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                    super::process_instruction(
-                        first_instruction_account,
-                        instruction_data,
-                        invoke_context,
-                    )
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::InitializeNonceAccount(nonce_address)).unwrap(),
+            vec![
+                (nonce_address, nonce_account),
+                (blockhash_id, create_default_recent_blockhashes_account()),
+                (sysvar::rent::id(), create_default_rent_account()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
                 },
-            ),
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+                AccountMeta {
+                    pubkey: sysvar::rent::id(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Ok(()),
+        );
+        #[allow(deprecated)]
+        let new_recent_blockhashes_account =
+            solana_sdk::recent_blockhashes_account::create_account_with_data_for_test(
+                vec![].into_iter(),
+            );
+        mock_process_instruction(
+            &system_program::id(),
+            Vec::new(),
+            &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
+            vec![
+                (nonce_address, accounts[0].clone()),
+                (blockhash_id, new_recent_blockhashes_account),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: nonce_address,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: blockhash_id,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
             Err(NonceError::NoRecentBlockhashes.into()),
+            |first_instruction_account: usize,
+             instruction_data: &[u8],
+             invoke_context: &mut InvokeContext| {
+                invoke_context.blockhash = hash(&serialize(&0).unwrap());
+                super::process_instruction(
+                    first_instruction_account,
+                    instruction_data,
+                    invoke_context,
+                )
+            },
         );
     }
 }


### PR DESCRIPTION
#### Problem
Continuation of #21882.

- #21706 will require the `keyed_accounts` parameter of `mock_process_instruction()` to be split in `transaction_accounts` and `instruction_accounts`.
- The tuple of the `keyed_account` parameter should be replaced by the struct `AccountMeta` and `instruction_accounts` (see [discussion in #20448](https://github.com/solana-labs/solana/pull/20448#discussion_r723746908)).
- Individual test cases should be isolated and the accounts generated by one and consumed by another explicitly routes through an `accounts` variable.
- Tests currently can mock impossible transactions, which have two different accounts for the same key or two different keys for the same account. The `transaction_accounts` mapping should always be bijective.

#### Summary of Changes
- Removes `Rc` from `Refcell<AccountSharedData>` in the program-runtime
- Makes `TransactionError::AccountBorrowOutstanding` obsolete, but does not remove it yet
- Adjust all program tests accordingly

Fixes #
