### PR TITLE
AcctIdx: share bucket map size for perf

### DIFF
--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -79,21 +79,14 @@ impl<T: Clone + Copy + Debug> BucketMap<T> {
         });
         let drives = Arc::new(drives);
 
-        let mut per_bucket_count = Vec::with_capacity(config.max_buckets);
-        per_bucket_count.resize_with(config.max_buckets, Arc::default);
-        let stats = Arc::new(BucketMapStats {
-            per_bucket_count,
-            ..BucketMapStats::default()
-        });
-        let buckets = stats
-            .per_bucket_count
-            .iter()
-            .map(|per_bucket_count| {
+        let stats = Arc::default();
+        let buckets = (0..config.max_buckets)
+            .into_iter()
+            .map(|_| {
                 Arc::new(BucketApi::new(
                     Arc::clone(&drives),
                     max_search,
                     Arc::clone(&stats),
-                    Arc::clone(per_bucket_count),
                 ))
             })
             .collect();

--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -14,5 +14,4 @@ pub struct BucketStats {
 pub struct BucketMapStats {
     pub index: Arc<BucketStats>,
     pub data: Arc<BucketStats>,
-    pub per_bucket_count: Vec<Arc<AtomicU64>>,
 }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -170,10 +170,9 @@ impl BucketMapHolderStats {
         let disk = storage.disk.as_ref();
         let disk_per_bucket_counts = disk
             .map(|disk| {
-                disk.stats
-                    .per_bucket_count
-                    .iter()
-                    .map(|count| count.load(Ordering::Relaxed) as usize)
+                (0..self.bins)
+                    .into_iter()
+                    .map(|i| disk.get_bucket_from_index(i as usize).bucket_len() as usize)
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();


### PR DESCRIPTION
#### Problem
Streamline access to bucket len and allow it to be read outside a lock. Also avoid having to update a second copy of it on every write lock.
#### Summary of Changes

Fixes #
