### PR TITLE
web3.js: fix file reference in package.json

### DIFF
--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "browser": {
-    "./lib/index.cjs.js": "./lib/index.browser.esm.js",
+    "./lib/index.cjs.js": "./lib/index.browser.cjs.js",
     "./lib/index.esm.js": "./lib/index.browser.esm.js"
   },
   "main": "lib/index.cjs.js",


### PR DESCRIPTION
#### Problem
Seems like the CJS package should reference the CJS file?
