### PR TITLE
assert on AcctInfo.store_id with cached store

### DIFF
--- a/runtime/src/account_info.rs
+++ b/runtime/src/account_info.rs
@@ -130,6 +130,8 @@ impl AccountInfo {
     }
 
     pub fn store_id(&self) -> AppendVecId {
+        // if the account is in a cached store, the store_id is meaningless
+        assert!(!self.is_cached());
         self.store_id
     }
 


### PR DESCRIPTION
#### Problem
This assert was submitted previously. It was triggered. I removed the assert and then fixed the problem that triggered it. I'm now re-enabling the assert since this is expected behavior and we have time in 1.10 to gain confidence this never triggers.

#### Summary of Changes

Fixes #
