### PR TITLE
AcctIdx: items() uses held ranges

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7164,10 +7164,10 @@ impl AccountsDb {
         #[allow(clippy::stable_sort_primitive)]
         roots.sort();
         info!("{}: accounts_index roots: {:?}", label, roots,);
+        let full_pubkey_range = Pubkey::new(&[0; 32])..=Pubkey::new(&[0xff; 32]);
+
         self.accounts_index.account_maps.iter().for_each(|map| {
-            for (pubkey, account_entry) in
-                map.read().unwrap().items(&None::<&std::ops::Range<Pubkey>>)
-            {
+            for (pubkey, account_entry) in map.read().unwrap().items(&full_pubkey_range) {
                 info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
                 info!(
                     "      slots: {:?}",

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -668,7 +668,7 @@ impl<'a, T: IndexValue> AccountsIndexIterator<'a, T> {
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
-        let mut result = map.items(&Some(&range));
+        let mut result = map.items(&range);
         if !collect_all_unsorted {
             result.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         }

--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -28,6 +28,7 @@ pub struct BucketMapHolderStats {
     pub load_disk_missing_us: AtomicU64,
     pub updates_in_mem: AtomicU64,
     pub items: AtomicU64,
+    pub items_us: AtomicU64,
     pub keys: AtomicU64,
     pub deletes: AtomicU64,
     pub inserts: AtomicU64,
@@ -517,6 +518,7 @@ impl BucketMapHolderStats {
                     i64
                 ),
                 ("items", self.items.swap(0, Ordering::Relaxed), i64),
+                ("items_us", self.items_us.swap(0, Ordering::Relaxed), i64),
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
             );
         }

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -116,21 +116,22 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
     }
 
-    pub fn items<R>(&self, range: &Option<&R>) -> Vec<(K, AccountMapEntry<T>)>
+    pub fn items<R>(&self, range: &R) -> Vec<(K, AccountMapEntry<T>)>
     where
         R: RangeBounds<Pubkey> + std::fmt::Debug,
     {
-        self.start_stop_flush(true);
-        self.put_range_in_cache(range); // check range here to see if our items are already held in the cache
-        Self::update_stat(&self.stats().items, 1);
+        let m = Measure::start("items");
+        self.hold_range_in_memory(range, true);
         let map = self.map().read().unwrap();
         let mut result = Vec::with_capacity(map.len());
         map.iter().for_each(|(k, v)| {
-            if range.map(|range| range.contains(k)).unwrap_or(true) {
+            if range.contains(k) {
                 result.push((*k, Arc::clone(v)));
             }
         });
-        self.start_stop_flush(false);
+        self.hold_range_in_memory(range, false);
+        Self::update_stat(&self.stats().items, 1);
+        Self::update_time_stat(&self.stats().items_us, m);
         result
     }
 


### PR DESCRIPTION
#### Problem
items uses held ranges to load make sure items are in memory. Held ranges can return early and skip loading from disk if the range is already being held.
#### Summary of Changes

Fixes #
