### PR TITLE
Update getSignaturesForAddress and getConfirmedSignaturesForAddress2 RPC call description

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -4368,7 +4368,9 @@ Result:
 **DEPRECATED: Please use [getSignaturesForAddress](jsonrpc-api.md#getsignaturesforaddress) instead**
 This method is expected to be removed in solana-core v2.0
 
-Returns confirmed signatures for transactions when the address is present in the compact-array of account addresses of a transaction. Returns signatures backwards in time from the provided signature or most recent confirmed block
+Returns signatures for confirmed transactions that include the given address in
+their `accountKeys` list. Returns signatures backwards in time from the
+provided signature or most recent confirmed block
 
 
 #### Parameters:

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1971,7 +1971,7 @@ Result:
 ### getSignaturesForAddress
 
 
-Returns confirmed signatures for transactions when the address is present in the compact-array of account addresses of a transaction. Returns signatures backwards in time from the provided signature or most recent confirmed block
+Returns signatures for confirmed transactions that include the given address in their `accountKeys` list. Returns signatures backwards in time from the provided signature or most recent confirmed block
 
 #### Parameters:
 * `<string>` - account address as base-58 encoded string

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1971,8 +1971,7 @@ Result:
 ### getSignaturesForAddress
 
 
-Returns confirmed signatures for transactions involving an
-address backwards in time from the provided signature or most recent confirmed block
+Returns confirmed signatures for transactions when the address is present in the compact-array of account addresses of a transaction. Returns signatures backwards in time from the provided signature or most recent confirmed block
 
 #### Parameters:
 * `<string>` - account address as base-58 encoded string
@@ -4367,8 +4366,7 @@ Result:
 **DEPRECATED: Please use [getSignaturesForAddress](jsonrpc-api.md#getsignaturesforaddress) instead**
 This method is expected to be removed in solana-core v2.0
 
-Returns confirmed signatures for transactions involving an
-address backwards in time from the provided signature or most recent confirmed block
+Returns confirmed signatures for transactions when the address is present in the compact-array of account addresses of a transaction. Returns signatures backwards in time from the provided signature or most recent confirmed block
 
 #### Parameters:
 * `<string>` - account address as base-58 encoded string

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1971,7 +1971,9 @@ Result:
 ### getSignaturesForAddress
 
 
-Returns signatures for confirmed transactions that include the given address in their `accountKeys` list. Returns signatures backwards in time from the provided signature or most recent confirmed block
+Returns signatures for confirmed transactions that include the given address in
+their `accountKeys` list. Returns signatures backwards in time from the
+provided signature or most recent confirmed block
 
 #### Parameters:
 * `<string>` - account address as base-58 encoded string
@@ -4367,6 +4369,7 @@ Result:
 This method is expected to be removed in solana-core v2.0
 
 Returns confirmed signatures for transactions when the address is present in the compact-array of account addresses of a transaction. Returns signatures backwards in time from the provided signature or most recent confirmed block
+
 
 #### Parameters:
 * `<string>` - account address as base-58 encoded string


### PR DESCRIPTION
#### Problem
The description doesn't fully match the functionality of the call. Take for instance [this transaction](https://explorer.solana.com/tx/2ScmUjDCfyDgvDhdn2w2fHzZ4BaaQ3Vmx8fgvrR7DmcgTuM2gC9qp1F9ZBJiEUrY6YLHi68cDVfiu1ADdbWthKBn). The transfer in the transaction is never reported for the [mint involved](https://explorer.solana.com/address/6eAaYYYXexov1xSc9uizvgk6DY8eYVQiwxkXPvkVjGj4) . i.e the transaction never gets returned since the mint is not passed but the two ATAs thus misleading.


#### Summary of Changes

Modification suggestion

