### PR TITLE
Add feature for dynamically adjusting fees from block compute usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,6 +5764,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-vote-program",
+ "static_assertions",
  "symlink",
  "tar",
  "tempfile",

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -1002,7 +1002,7 @@ mod tests {
     #[test]
     fn test_bench_tps_fund_keys_with_fees() {
         let (mut genesis_config, id) = create_genesis_config(10_000);
-        let fee_rate_governor = FeeRateGovernor::new(11, 0);
+        let fee_rate_governor = FeeRateGovernor::new(11, 0, 0);
         genesis_config.fee_rate_governor = fee_rate_governor;
         let bank = Bank::new_for_tests(&genesis_config);
         let client = Arc::new(BankClient::new(bank));

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
         let (keypairs, _) = generate_keypairs(id, keypair_count as u64);
         let num_accounts = keypairs.len() as u64;
         let max_fee =
-            FeeRateGovernor::new(*target_lamports_per_signature, 0).max_lamports_per_signature;
+            FeeRateGovernor::new(*target_lamports_per_signature, 0, 0).max_lamports_per_signature;
         let num_lamports_per_account = (num_accounts - 1 + NUM_SIGNATURES_FOR_TXS * max_fee)
             / num_accounts
             + num_lamports_per_account;

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -107,11 +107,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let (
         default_target_lamports_per_signature,
         default_target_signatures_per_slot,
+        default_target_compute_units_per_slot,
         default_fee_burn_percentage,
     ) = {
         (
             &fee_rate_governor.target_lamports_per_signature.to_string(),
             &fee_rate_governor.target_signatures_per_slot.to_string(),
+            &fee_rate_governor.target_compute_units_per_slot.to_string(),
             &fee_rate_governor.burn_percent.to_string(),
         )
     };
@@ -296,6 +298,20 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 ),
         )
         .arg(
+            Arg::with_name("target_compute_units_per_slot")
+                .long("target-compute-units-per-slot")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .default_value(default_target_compute_units_per_slot)
+                .help(
+                    "Used to estimate the desired processing capacity of the cluster. \
+                    As the compute units consumed for recent slots are smaller/larger \
+                    than this value, lamports_per_signature will decrease/increase for \
+                    the next slot. A value of 0 disables lamports_per_signature fee \
+                    adjustments",
+                ),
+        )
+        .arg(
             Arg::with_name("target_tick_duration")
                 .long("target-tick-duration")
                 .value_name("MILLIS")
@@ -443,6 +459,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mut fee_rate_governor = FeeRateGovernor::new(
         value_t_or_exit!(matches, "target_lamports_per_signature", u64),
         value_t_or_exit!(matches, "target_signatures_per_slot", u64),
+        value_t_or_exit!(matches, "target_compute_units_per_slot", u64),
     );
     fee_rate_governor.burn_percent = value_t_or_exit!(matches, "fee_burn_percentage", u8);
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -323,6 +323,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
                 &account_indices,
                 &caller_privileges,
             )
+            .result
             .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2391,6 +2391,7 @@ fn call<'a, 'b: 'a>(
             &account_indices,
             &caller_write_privileges,
         )
+        .result
         .map_err(SyscallError::InstructionError)?;
 
     // Copy results back to caller

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,6 +62,7 @@ name = "solana_runtime"
 ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 assert_matches = "1.5.0"
+static_assertions = "1.1.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -46,16 +46,33 @@ lazy_static! {
     .collect();
 }
 
+// This assertion must not be changed because it is used to set the initial
+// target compute units per block for the fee rate governor. Once the feature
+// for dynamic fees from compute consumption is activated, this can be changed
+// if needed.
+#[cfg(test)]
+static_assertions::const_assert_eq!(MAX_BLOCK_UNITS, 160_000_000);
+
+// This assertion is just a loose check that the target compute unit consumption
+// per block for the fee governor is in line with the max block units constant
+// used by the qos service. They don't need to be equal but should be.
+#[cfg(test)]
+static_assertions::const_assert_eq!(
+    MAX_BLOCK_UNITS,
+    solana_sdk::fee_calculator::DEFAULT_TARGET_COMPUTE_UNITS_PER_SLOT
+);
+
 /// Statically computed data:
 ///
 /// Number of compute units that a block is allowed. A block's compute units are
-/// accumualted by Transactions added to it; A transaction's compute units are
-/// calculated by cost_model, based on transaction's signarures, write locks,
-/// data size and built-in and BPF instructinos.
+/// accumulated by Transactions added to it; A transaction's compute units are
+/// calculated by cost_model, based on transaction's signatures, write locks,
+/// data size and built-in and BPF instructions.
 pub const MAX_BLOCK_UNITS: u64 =
     MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO * MAX_CONCURRENCY;
+
 /// Number of compute units that a writable account in a block is allowed. The
-/// limit is to prevent too many transactions write to same account, threrefore
+/// limit is to prevent too many transactions write to same account, therefore
 /// reduce block's paralellism.
 pub const MAX_WRITABLE_ACCOUNT_UNITS: u64 = MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO;
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -92,8 +92,8 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
         &voting_keypairs[0].borrow().stake_keypair.pubkey(),
         stakes[0],
         VALIDATOR_LAMPORTS,
-        FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
-        Rent::free(),               // most tests don't expect rent
+        FeeRateGovernor::new(0, 0, 0), // most tests can't handle transaction fees
+        Rent::free(),                  // most tests don't expect rent
         cluster_type,
         vec![],
     );
@@ -149,8 +149,8 @@ pub fn create_genesis_config_with_leader(
         &solana_sdk::pubkey::new_rand(),
         validator_stake_lamports,
         VALIDATOR_LAMPORTS,
-        FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
-        Rent::free(),               // most tests don't expect rent
+        FeeRateGovernor::new(0, 0, 0), // most tests can't handle transaction fees
+        Rent::free(),                  // most tests don't expect rent
         ClusterType::Development,
         vec![],
     );

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -83,6 +83,7 @@ pub(crate) struct DeserializableVersionedBank {
     pub(crate) unused_accounts: UnusedAccounts,
     pub(crate) epoch_stakes: HashMap<Epoch, EpochStakes>,
     pub(crate) is_delta: bool,
+    pub(crate) consumed_compute_units: u64,
 }
 
 impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
@@ -104,7 +105,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             ns_per_slot: dvb.ns_per_slot,
             genesis_creation_time: dvb.genesis_creation_time,
             slots_per_year: dvb.slots_per_year,
-            unused: dvb.unused,
+            consumed_compute_units: dvb.consumed_compute_units,
             slot: dvb.slot,
             epoch: dvb.epoch,
             block_height: dvb.block_height,
@@ -143,7 +144,7 @@ pub(crate) struct SerializableVersionedBank<'a> {
     pub(crate) ns_per_slot: u128,
     pub(crate) genesis_creation_time: UnixTimestamp,
     pub(crate) slots_per_year: f64,
-    pub(crate) unused: u64,
+    pub(crate) consumed_compute_units: u64,
     pub(crate) slot: Slot,
     pub(crate) epoch: Epoch,
     pub(crate) block_height: u64,
@@ -183,7 +184,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
             ns_per_slot: rhs.ns_per_slot,
             genesis_creation_time: rhs.genesis_creation_time,
             slots_per_year: rhs.slots_per_year,
-            unused: rhs.unused,
+            consumed_compute_units: rhs.consumed_compute_units,
             slot: rhs.slot,
             epoch: rhs.epoch,
             block_height: rhs.block_height,

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -49,7 +49,7 @@ pub struct FeeRateGovernor {
     // The current cost of a signature  This amount may increase/decrease over time based on
     // cluster processing load.
     #[serde(skip)]
-    pub lamports_per_signature: u64,
+    lamports_per_signature: u64,
 
     // The target cost of a signature when the cluster is operating around target_signatures_per_slot
     // signatures
@@ -159,6 +159,16 @@ impl FeeRateGovernor {
             me.lamports_per_signature
         );
         me
+    }
+
+    #[deprecated(note = "Remove after `disable_fee_calculator` feature is activated")]
+    pub fn override_lamports_per_signature(&mut self, lamports_per_signature: u64) {
+        self.lamports_per_signature = lamports_per_signature;
+    }
+
+    /// get current lamports per signature
+    pub fn get_lamports_per_signature(&self) -> u64 {
+        self.lamports_per_signature
     }
 
     /// calculate unburned fee from a fee total, returns (unburned, burned)

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -283,6 +283,10 @@ pub mod reject_all_elf_rw {
     solana_sdk::declare_id!("DeMpxgMq51j3rZfNK2hQKZyXknQvqevPSFPJFNTbXxsS");
 }
 
+pub mod update_fees_by_block_compute_usage {
+    solana_sdk::declare_id!("E3nU1SNJDeMQwAc9UvDqtyRmDCwoeWnqhpZdTg4nBi7F");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -348,6 +352,7 @@ lazy_static! {
         (evict_invalid_stakes_cache_entries::id(), "evict invalid stakes cache entries on epoch boundaries"),
         (allow_votes_to_directly_update_vote_state::id(), "enable direct vote state update"),
         (reject_all_elf_rw::id(), "reject all read-write data in program elfs"),
+        (update_fees_by_block_compute_usage::id(), "dynamically update fees according to block compute usage"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -380,7 +380,7 @@ impl TestValidator {
         socket_addr_space: SocketAddrSpace,
     ) -> Self {
         TestValidatorGenesis::default()
-            .fee_rate_governor(FeeRateGovernor::new(0, 0))
+            .fee_rate_governor(FeeRateGovernor::new(0, 0, 0))
             .rent(Rent {
                 lamports_per_byte_year: 1,
                 exemption_threshold: 1.0,
@@ -402,7 +402,7 @@ impl TestValidator {
         socket_addr_space: SocketAddrSpace,
     ) -> Self {
         TestValidatorGenesis::default()
-            .fee_rate_governor(FeeRateGovernor::new(target_lamports_per_signature, 0))
+            .fee_rate_governor(FeeRateGovernor::new(target_lamports_per_signature, 0, 0))
             .rent(Rent {
                 lamports_per_byte_year: 1,
                 exemption_threshold: 1.0,


### PR DESCRIPTION
#### Problem
As demand for compute increases, we need a way to dynamically increase fees to get block compute consumption to a healthy level.

#### Summary of Changes
- Track `consumed_compute_units` per bank and compare with the target compute units per slot to increase or decrease fees.
- Add feature for enable dynamic fees based on compute usage
- Change `FeeRateGovernor` serialized fields to include target compute units
- Always record program timings if some compute units were consumed no matter if the instruction succeeded or failed.

Fixes https://github.com/solana-labs/solana/issues/21910
