### PR TITLE
removes Select in favor of recv_timeout/try_iter

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -97,11 +97,8 @@ impl AggregateCommitmentService {
                 return Ok(());
             }
 
-            let mut aggregation_data = receiver.recv_timeout(Duration::from_secs(1))?;
-
-            while let Ok(new_data) = receiver.try_recv() {
-                aggregation_data = new_data;
-            }
+            let aggregation_data = receiver.recv_timeout(Duration::from_secs(1))?;
+            let aggregation_data = receiver.try_iter().last().unwrap_or(aggregation_data);
 
             let ancestors = aggregation_data.bank.status_cache_ancestors();
             if ancestors.is_empty() {

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -164,12 +164,9 @@ impl LedgerCleanupService {
     }
 
     fn receive_new_roots(new_root_receiver: &Receiver<Slot>) -> Result<Slot, RecvTimeoutError> {
-        let mut root = new_root_receiver.recv_timeout(Duration::from_secs(1))?;
+        let root = new_root_receiver.recv_timeout(Duration::from_secs(1))?;
         // Get the newest root
-        while let Ok(new_root) = new_root_receiver.try_recv() {
-            root = new_root;
-        }
-        Ok(root)
+        Ok(new_root_receiver.try_iter().last().unwrap_or(root))
     }
 
     pub fn cleanup_ledger(

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -233,14 +233,10 @@ fn run_check_duplicate(
 
         Ok(())
     };
-    let timer = Duration::from_millis(200);
-    let shred = shred_receiver.recv_timeout(timer)?;
-    check_duplicate(shred)?;
-    while let Ok(shred) = shred_receiver.try_recv() {
-        check_duplicate(shred)?;
-    }
-
-    Ok(())
+    const RECV_TIMEOUT: Duration = Duration::from_millis(200);
+    std::iter::once(shred_receiver.recv_timeout(RECV_TIMEOUT)?)
+        .chain(shred_receiver.try_iter())
+        .try_for_each(check_duplicate)
 }
 
 fn verify_repair(


### PR DESCRIPTION

#### Problem
`crossbeam_channel::Select::ready_timeout` might return with success spuriously.

#### Summary of Changes
removed `Select` in favor of `recv_timeout`/`try_iter`.