### PR TITLE
re-calibrate limit based on mainnet data

### DIFF
--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -38,7 +38,8 @@ lazy_static! {
         (solana_sdk::stake::program::id(), COMPUTE_UNIT_TO_US_RATIO * 25),
         (solana_config_program::id(), COMPUTE_UNIT_TO_US_RATIO * 15),
         (solana_vote_program::id(), COMPUTE_UNIT_TO_US_RATIO * 70),
-        (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 2),
+        // secp256k1 is executed in banking stage, it should cost similar to sigverify
+        (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
         (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
     ]
     .iter()

--- a/runtime/src/block_cost_limits.rs
+++ b/runtime/src/block_cost_limits.rs
@@ -11,22 +11,22 @@ use {
 /// Static configurations:
 ///
 /// Number of microseconds replaying a block should take, 400 millisecond block times
-/// is curerntly publicly communicated on solana.com
+/// is currently publicly communicated on solana.com
 pub const MAX_BLOCK_REPLAY_TIME_US: u64 = 400_000;
 /// number of concurrent processes,
-pub const MAX_CONCURRENCY: u64 = 10;
+pub const MAX_CONCURRENCY: u64 = 4;
 
 /// Cluster data, method of collecting at https://github.com/solana-labs/solana/issues/19627
 /// Dashboard: https://metrics.solana.com:8889/sources/0/dashboards/10?refresh=Paused&lower=now%28%29%20-%2012h
 ///
-/// cluster avergaed compute unit to microsec conversion rate
-pub const COMPUTE_UNIT_TO_US_RATIO: u64 = 40;
+/// cluster averaged compute unit to micro-sec conversion rate
+pub const COMPUTE_UNIT_TO_US_RATIO: u64 = 30;
 /// Number of compute units for one signature verification.
-pub const SIGNATURE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 130;
+pub const SIGNATURE_COST: u64 = COMPUTE_UNIT_TO_US_RATIO * 24;
 /// Number of compute units for one write lock
 pub const WRITE_LOCK_UNITS: u64 = COMPUTE_UNIT_TO_US_RATIO * 10;
 /// Number of data bytes per compute units
-pub const DATA_BYTES_UNITS: u64 = 220 /*bytes per us*/ / COMPUTE_UNIT_TO_US_RATIO;
+pub const DATA_BYTES_UNITS: u64 = 550 /*bytes per us*/ / COMPUTE_UNIT_TO_US_RATIO;
 // Number of compute units for each built-in programs
 lazy_static! {
     /// Number of compute units for each built-in programs
@@ -37,9 +37,9 @@ lazy_static! {
         (solana_sdk::stake::config::id(), COMPUTE_UNIT_TO_US_RATIO * 2),
         (solana_sdk::stake::program::id(), COMPUTE_UNIT_TO_US_RATIO * 25),
         (solana_config_program::id(), COMPUTE_UNIT_TO_US_RATIO * 15),
-        (solana_vote_program::id(), COMPUTE_UNIT_TO_US_RATIO * 85),
-        (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 4),
-        (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 10),
+        (solana_vote_program::id(), COMPUTE_UNIT_TO_US_RATIO * 70),
+        (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 2),
+        (system_program::id(), COMPUTE_UNIT_TO_US_RATIO * 5),
     ]
     .iter()
     .cloned()
@@ -49,15 +49,15 @@ lazy_static! {
 /// Statically computed data:
 ///
 /// Number of compute units that a block is allowed. A block's compute units are
-/// accumualted by Transactions added to it; A transaction's compute units are
-/// calculated by cost_model, based on transaction's signarures, write locks,
-/// data size and built-in and BPF instructinos.
+/// accumulated by Transactions added to it; A transaction's compute units are
+/// calculated by cost_model, based on transaction's signatures, write locks,
+/// data size and built-in and BPF instructions.
 pub const MAX_BLOCK_UNITS: u64 =
     MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO * MAX_CONCURRENCY;
 /// Number of compute units that a writable account in a block is allowed. The
-/// limit is to prevent too many transactions write to same account, threrefore
-/// reduce block's paralellism.
+/// limit is to prevent too many transactions write to same account, therefore
+/// reduce block's parallelism.
 pub const MAX_WRITABLE_ACCOUNT_UNITS: u64 = MAX_BLOCK_REPLAY_TIME_US * COMPUTE_UNIT_TO_US_RATIO;
 
-/// max len of account data in a slot (bytes)
+/// max length of account data in a slot (bytes)
 pub const MAX_ACCOUNT_DATA_LEN: u64 = 100_000_000;


### PR DESCRIPTION
#### Problem
Adjust cost limit to better reflect mainnet data collected via [dashboard](https://metrics.solana.com:8889/sources/0/dashboards/14?refresh=Paused&tempVars%5Bdb%5D=%22mainnet-beta%22&tempVars%5Bprogram_id%5D=&tempVars%5Btime_threshold%5D=100000&lower=now%28%29%20-%201h)

#### Summary of Changes
numbers collected 

Fixes #
#21917