### PR TITLE
new net-stats require a new table

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -15,7 +15,7 @@ use {
 };
 
 const MS_PER_S: u64 = 1_000;
-const SAMPLE_INTERVAL_UDP_MS: u64 = MS_PER_S;
+const SAMPLE_INTERVAL_UDP_MS: u64 = 2 * MS_PER_S;
 const SAMPLE_INTERVAL_MEM_MS: u64 = MS_PER_S;
 const SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -15,7 +15,7 @@ use {
 };
 
 const MS_PER_S: u64 = 1_000;
-const SAMPLE_INTERVAL_UDP_MS: u64 = 60 * MS_PER_S;
+const SAMPLE_INTERVAL_UDP_MS: u64 = MS_PER_S;
 const SAMPLE_INTERVAL_MEM_MS: u64 = MS_PER_S;
 const SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -130,7 +130,7 @@ impl SystemMonitorService {
     #[cfg(target_os = "linux")]
     fn report_udp_stats(old_stats: &UdpStats, new_stats: &UdpStats) {
         datapoint_info!(
-            "net-stats",
+            "net-stats-validator",
             (
                 "in_datagrams_delta",
                 new_stats.in_datagrams - old_stats.in_datagrams,


### PR DESCRIPTION
#### Problem
net-stats table is used by net-stats.sh, addition of new net stats values are silently dropped

#### Summary of Changes
- log to new "net-stats-validator" table
- increase logging frequency to 2s

Fixes #
