### PR TITLE
chore: add PublicKey toJSON

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -87,6 +87,10 @@ export class PublicKey extends Struct {
     return bs58.encode(this.toBytes());
   }
 
+  toJSON(): string {
+    return this.toBase58();
+  }
+
   /**
    * Return the byte array representation of the public key
    */

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -71,6 +71,17 @@ describe('PublicKey', function () {
     expect(key4.toBase58()).to.eq('11111111111111111111111111111111');
   });
 
+  it('toJSON', () => {
+    const key = new PublicKey('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
+    expect(key.toJSON()).to.eq('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
+    expect(JSON.stringify(key)).to.eq(
+      '"CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3"',
+    );
+    expect(JSON.stringify({key})).to.eq(
+      '{"key":"CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3"}',
+    );
+  });
+
   it('toBuffer', () => {
     const key = new PublicKey('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
     expect(key.toBuffer()).to.have.length(32);


### PR DESCRIPTION
#### Problem

When we run `JSON.stringify` on an object that has nested public keys, we get a `{"_bn": "...."}` string which isn't too useful. 

#### Summary of Changes

This adds `PublicKey#toJSON` which `JSON.stringify` uses [under the hood](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior).
