### PR TITLE
Add deactivation cooldown before address lookup tables can be closed

### DIFF
--- a/programs/address-lookup-table-tests/tests/create_lookup_table_ix.rs
+++ b/programs/address-lookup-table-tests/tests/create_lookup_table_ix.rs
@@ -52,7 +52,7 @@ async fn test_create_lookup_table() {
             Rent::default().minimum_balance(LOOKUP_TABLE_META_SIZE)
         );
         let lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data).unwrap();
-        assert_eq!(lookup_table.meta.derivation_slot, test_recent_slot);
+        assert_eq!(lookup_table.meta.deactivation_slot, Slot::MAX);
         assert_eq!(lookup_table.meta.authority, Some(authority_address));
         assert_eq!(lookup_table.meta.last_extended_slot, 0);
         assert_eq!(lookup_table.meta.last_extended_slot_start_index, 0);

--- a/programs/address-lookup-table/src/instruction.rs
+++ b/programs/address-lookup-table/src/instruction.rs
@@ -31,7 +31,7 @@ pub enum ProgramInstruction {
         bump_seed: u8,
     },
 
-    /// Permanently freeze a address lookup table, making it immutable.
+    /// Permanently freeze an address lookup table, making it immutable.
     ///
     /// # Account references
     ///   0. `[WRITE]` Address lookup table account to freeze
@@ -46,6 +46,14 @@ pub enum ProgramInstruction {
     ///   2. `[SIGNER, WRITE]` Account that will fund the table reallocation
     ///   3. `[]` System program for CPI.
     ExtendLookupTable { new_addresses: Vec<Pubkey> },
+
+    /// Deactivate an address lookup table, making it unusable and
+    /// eligible for closure after a short period of time.
+    ///
+    /// # Account references
+    ///   0. `[WRITE]` Address lookup table account to deactivate
+    ///   1. `[SIGNER]` Current authority
+    DeactivateLookupTable,
 
     /// Close an address lookup table account
     ///
@@ -123,6 +131,23 @@ pub fn extend_lookup_table(
             AccountMeta::new_readonly(authority_address, true),
             AccountMeta::new(payer_address, true),
             AccountMeta::new_readonly(system_program::id(), false),
+        ],
+    )
+}
+
+/// Constructs an instruction that deactivates an address lookup
+/// table so that it cannot be extended again and will be unusable
+/// and eligible for closure after a short amount of time.
+pub fn deactivate_lookup_table(
+    lookup_table_address: Pubkey,
+    authority_address: Pubkey,
+) -> Instruction {
+    Instruction::new_with_bincode(
+        id(),
+        &ProgramInstruction::DeactivateLookupTable,
+        vec![
+            AccountMeta::new(lookup_table_address, false),
+            AccountMeta::new_readonly(authority_address, true),
         ],
     )
 }

--- a/programs/address-lookup-table/src/state.rs
+++ b/programs/address-lookup-table/src/state.rs
@@ -22,12 +22,11 @@ pub enum ProgramState {
 }
 
 /// Address lookup table metadata
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, AbiExample)]
 pub struct LookupTableMeta {
-    /// The slot used to derive the table's address. The table cannot
-    /// be closed until the derivation slot is no longer "recent"
-    /// (not accessible in the `SlotHashes` sysvar).
-    pub derivation_slot: Slot,
+    /// Lookup tables cannot be closed until the deactivation slot is
+    /// no longer "recent" (not accessible in the `SlotHashes` sysvar).
+    pub deactivation_slot: Slot,
     /// The slot that the table was last extended. Address tables may
     /// only be used to lookup addresses that were extended before
     /// the current bank's slot.
@@ -43,10 +42,21 @@ pub struct LookupTableMeta {
     // the account's data, starting from `LOOKUP_TABLE_META_SIZE`.
 }
 
+impl Default for LookupTableMeta {
+    fn default() -> Self {
+        Self {
+            deactivation_slot: Slot::MAX,
+            last_extended_slot: 0,
+            last_extended_slot_start_index: 0,
+            authority: None,
+            _padding: 0,
+        }
+    }
+}
+
 impl LookupTableMeta {
-    pub fn new(authority: Pubkey, derivation_slot: Slot) -> Self {
+    pub fn new(authority: Pubkey) -> Self {
         LookupTableMeta {
-            derivation_slot,
             authority: Some(authority),
             ..LookupTableMeta::default()
         }


### PR DESCRIPTION
#### Problem
Address lookup tables will be used to load transaction addresses without taking a read lock on the address lookup table account so they cannot be closed in a way that would affect in-progress address loading.

#### Summary of Changes
- Change `derivation_slot` field to `deactivation_slot` to track when an address table has been deactivated long enough that it can be closed.
- Don't allow changes to an address lookup table account if it has been deactivated.

Fixes #
