### PR TITLE
Fix weird formatting of bullets in "Staking Rewards" docs

### DIFF
--- a/docs/src/implemented-proposals/staking-rewards.md
+++ b/docs/src/implemented-proposals/staking-rewards.md
@@ -4,17 +4,11 @@ title: Staking Rewards
 
 A Proof of Stake \(PoS\), \(i.e. using in-protocol asset, SOL, to provide secure consensus\) design is outlined here. Solana implements a proof of stake reward/security scheme for validator nodes in the cluster. The purpose is threefold:
 
-- Align validator incentives with that of the greater cluster through
+- Align validator incentives with that of the greater cluster through skin-in-the-game deposits at risk
 
-  skin-in-the-game deposits at risk
+- Avoid 'nothing at stake' fork voting issues by implementing slashing rules aimed at promoting fork convergence
 
-- Avoid 'nothing at stake' fork voting issues by implementing slashing rules
-
-  aimed at promoting fork convergence
-
-- Provide an avenue for validator rewards provided as a function of validator
-
-  participation in the cluster.
+- Provide an avenue for validator rewards provided as a function of validator participation in the cluster.
 
 While many of the details of the specific implementation are currently under consideration and are expected to come into focus through specific modeling studies and parameter exploration on the Solana testnet, we outline here our current thinking on the main components of the PoS system. Much of this thinking is based on the current status of Casper FFG, with optimizations and specific attributes to be modified as is allowed by Solana's Proof of History \(PoH\) blockchain data structure.
 
@@ -24,29 +18,11 @@ Solana's ledger validation design is based on a rotating, stake-weighted selecte
 
 To become a Solana validator, one must deposit/lock-up some amount of SOL in a contract. This SOL will not be accessible for a specific time period. The precise duration of the staking lockup period has not been determined. However we can consider three phases of this time for which specific parameters will be necessary:
 
-- _Warm-up period_: which SOL is deposited and inaccessible to the node,
+- _Warm-up period_: which SOL is deposited and inaccessible to the node, however PoH transaction validation has not begun. Most likely on the order of days to weeks
 
-  however PoH transaction validation has not begun. Most likely on the order of
+- _Validation period_: a minimum duration for which the deposited SOL will be inaccessible, at risk of slashing \(see slashing rules below\) and earning rewards for the validator participation. Likely duration of months to a year.
 
-  days to weeks
-
-- _Validation period_: a minimum duration for which the deposited SOL will be
-
-  inaccessible, at risk of slashing \(see slashing rules below\) and earning
-
-  rewards for the validator participation. Likely duration of months to a
-
-  year.
-
-- _Cool-down period_: a duration of time following the submission of a
-
-  'withdrawal' transaction. During this period validation responsibilities have
-
-  been removed and the funds continue to be inaccessible. Accumulated rewards
-
-  should be delivered at the end of this period, along with the return of the
-
-  initial deposit.
+- _Cool-down period_: a duration of time following the submission of a 'withdrawal' transaction. During this period validation responsibilities have been removed and the funds continue to be inaccessible. Accumulated rewards should be delivered at the end of this period, along with the return of the initial deposit.
 
 Solana's trustless sense of time and ordering provided by its PoH data structure, along with its [turbine](https://www.youtube.com/watch?v=qt_gDRXHrHQ&t=1s) data broadcast and transmission design, should provide sub-second transaction confirmation times that scale with the log of the number of nodes in the cluster. This means we shouldn't have to restrict the number of validating nodes with a prohibitive 'minimum deposits' and expect nodes to be able to become validators with nominal amounts of SOL staked. At the same time, Solana's focus on high-throughput should create incentive for validation clients to provide high-performant and reliable hardware. Combined with potential a minimum network speed threshold to join as a validation-client, we expect a healthy validation delegation market to emerge.
 


### PR DESCRIPTION
#### Problem

The bullets on the docs page for the Staking Rewards proposal are preemptively wrapped and look odd when rendered. This differs from the style of bulleted statements elsewhere in the docs.

<img width="848" alt="Screen Shot 2021-12-19 at 4 48 09 PM" src="https://user-images.githubusercontent.com/96332127/146697347-8ce33525-250c-4fe2-bcf6-80f42792557a.png">

#### Summary of Changes

I just got rid of the newlines that were breaking up the bulleted statements.
