### PR TITLE
uses enum instead of trait for VoteTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,16 +1001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
-dependencies = [
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,15 +1320,6 @@ dependencies = [
  "log 0.4.14",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "erased-serde"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1709,17 +1690,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "ghost"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
-dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
 ]
 
 [[package]]
@@ -2101,16 +2071,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367fed6750ff2a5bcb967a631528303bb85631f167a75eb1bf7762d57eb7678"
-dependencies = [
- "ctor",
- "ghost",
 ]
 
 [[package]]
@@ -6179,7 +6139,6 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
- "typetag",
 ]
 
 [[package]]
@@ -7121,30 +7080,6 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
-
-[[package]]
-name = "typetag"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4080564c5b2241b5bff53ab610082234e0c57b0417f4bd10596f183001505b8a"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
-dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
-]
 
 [[package]]
 name = "ucd-trie"

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -677,7 +677,7 @@ impl ClusterInfoVoteListener {
 
     #[allow(clippy::too_many_arguments)]
     fn track_new_votes_and_notify_confirmations(
-        vote: Box<dyn VoteTransaction>,
+        vote: VoteTransaction,
         vote_pubkey: &Pubkey,
         vote_tracker: &VoteTracker,
         root_bank: &Bank,
@@ -792,7 +792,7 @@ impl ClusterInfoVoteListener {
     fn filter_gossip_votes(
         vote_tracker: &VoteTracker,
         vote_pubkey: &Pubkey,
-        vote: &dyn VoteTransaction,
+        vote: &VoteTransaction,
         gossip_tx: &Transaction,
     ) -> bool {
         if vote.is_empty() {
@@ -842,7 +842,7 @@ impl ClusterInfoVoteListener {
             .filter_map(|gossip_tx| {
                 vote_transaction::parse_vote_transaction(gossip_tx)
                     .filter(|(vote_pubkey, vote, _)| {
-                        Self::filter_gossip_votes(vote_tracker, vote_pubkey, &**vote, gossip_tx)
+                        Self::filter_gossip_votes(vote_tracker, vote_pubkey, vote, gossip_tx)
                     })
                     .map(|v| (true, v))
             })
@@ -1249,7 +1249,7 @@ mod tests {
                 replay_votes_sender
                     .send((
                         vote_keypair.pubkey(),
-                        Box::new(replay_vote.clone()),
+                        VoteTransaction::from(replay_vote.clone()),
                         switch_proof_hash,
                     ))
                     .unwrap();
@@ -1537,7 +1537,7 @@ mod tests {
                     replay_votes_sender
                         .send((
                             vote_keypair.pubkey(),
-                            Box::new(Vote::new(vec![vote_slot], Hash::default())),
+                            VoteTransaction::from(Vote::new(vec![vote_slot], Hash::default())),
                             switch_proof_hash,
                         ))
                         .unwrap();
@@ -1685,7 +1685,7 @@ mod tests {
             // Add gossip vote for same slot, should not affect outcome
             vec![(
                 validator0_keypairs.vote_keypair.pubkey(),
-                Box::new(Vote::new(vec![voted_slot], Hash::default())),
+                VoteTransaction::from(Vote::new(vec![voted_slot], Hash::default())),
                 None,
             )],
             &bank,
@@ -1741,7 +1741,7 @@ mod tests {
             vote_txs,
             vec![(
                 validator_keypairs[1].vote_keypair.pubkey(),
-                Box::new(Vote::new(vec![first_slot_in_new_epoch], Hash::default())),
+                VoteTransaction::from(Vote::new(vec![first_slot_in_new_epoch], Hash::default())),
                 None,
             )],
             &new_root_bank,

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -18,7 +18,7 @@ const MAX_VOTES_PER_VALIDATOR: usize = 1000;
 
 pub struct VerifiedVoteMetadata {
     pub vote_account_key: Pubkey,
-    pub vote: Box<dyn VoteTransaction>,
+    pub vote: VoteTransaction,
     pub packet_batch: PacketBatch,
     pub signature: Signature,
 }
@@ -198,7 +198,7 @@ mod tests {
         let vote = Vote::new(vec![vote_slot], vote_hash);
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
-            vote: Box::new(vote.clone()),
+            vote: VoteTransaction::from(vote.clone()),
             packet_batch: PacketBatch::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
@@ -218,7 +218,7 @@ mod tests {
         // Same slot, same hash, should not be inserted
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
-            vote: Box::new(vote),
+            vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
@@ -240,7 +240,7 @@ mod tests {
         let vote = Vote::new(vec![vote_slot], new_vote_hash);
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
-            vote: Box::new(vote),
+            vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
             signature: Signature::new(&[1u8; 64]),
         }])
@@ -263,7 +263,7 @@ mod tests {
         let vote = Vote::new(vec![vote_slot], vote_hash);
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
-            vote: Box::new(vote),
+            vote: VoteTransaction::from(vote),
             packet_batch: PacketBatch::default(),
             signature: Signature::new(&[2u8; 64]),
         }])
@@ -302,7 +302,7 @@ mod tests {
             let vote = Vote::new(vec![vote_slot], vote_hash);
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
-                vote: Box::new(vote),
+                vote: VoteTransaction::from(vote),
                 packet_batch: PacketBatch::default(),
                 signature: Signature::new(&[1u8; 64]),
             }])
@@ -339,7 +339,7 @@ mod tests {
             let vote = Vote::new(vec![vote_slot], vote_hash);
             s.send(vec![VerifiedVoteMetadata {
                 vote_account_key,
-                vote: Box::new(vote),
+                vote: VoteTransaction::from(vote),
                 packet_batch: PacketBatch::default(),
                 signature: Signature::new_unique(),
             }])
@@ -393,7 +393,7 @@ mod tests {
                 let vote = Vote::new(vec![*vote_slot], *vote_hash);
                 s.send(vec![VerifiedVoteMetadata {
                     vote_account_key,
-                    vote: Box::new(vote),
+                    vote: VoteTransaction::from(vote),
                     packet_batch: PacketBatch::new(vec![Packet::default(); num_packets]),
                     signature: Signature::new_unique(),
                 }])
@@ -457,7 +457,7 @@ mod tests {
             my_leader_bank.slot() + 1,
         ));
         let vote_account_key = vote_simulator.vote_pubkeys[1];
-        let vote = Box::new(Vote::new(vec![vote_slot], vote_hash));
+        let vote = VoteTransaction::from(Vote::new(vec![vote_slot], vote_hash));
         s.send(vec![VerifiedVoteMetadata {
             vote_account_key,
             vote,

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -601,16 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
-dependencies = [
- "quote 1.0.6",
- "syn 1.0.67",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,15 +871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "erased-serde"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,17 +1105,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "ghost"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.6",
- "syn 1.0.67",
 ]
 
 [[package]]
@@ -1381,16 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367fed6750ff2a5bcb967a631528303bb85631f167a75eb1bf7762d57eb7678"
-dependencies = [
- "ctor",
- "ghost",
 ]
 
 [[package]]
@@ -3614,7 +3574,6 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
- "typetag",
 ]
 
 [[package]]
@@ -4086,30 +4045,6 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "typetag"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4080564c5b2241b5bff53ab610082234e0c57b0417f4bd10596f183001505b8a"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60147782cc30833c05fba3bab1d9b5771b2685a2557672ac96fa5d154099c0e"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.6",
- "syn 1.0.67",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -22,7 +22,6 @@ solana-logger = { path = "../../logger", version = "=1.10.0" }
 solana-metrics = { path = "../../metrics", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }
-typetag = "0.1"
 thiserror = "1.0"
 
 [build-dependencies]

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -19,7 +19,6 @@ use {
         sysvar::clock::Clock,
     },
     std::{
-        any::Any,
         boxed::Box,
         cmp::Ordering,
         collections::{HashSet, VecDeque},
@@ -41,63 +40,70 @@ pub const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
 // Offset of VoteState::prior_voters, for determining initialization status without deserialization
 const DEFAULT_PRIOR_VOTERS_OFFSET: usize = 82;
 
-// VoteTransactionClone hack is done so that we can derive clone on the tower that uses the
-// VoteTransaction trait object. Clone doesn't work here because it returns Self which is not
-// allowed for trait objects
-#[typetag::serde{tag = "type"}]
-pub trait VoteTransaction: VoteTransactionClone + Debug + Send {
-    fn slot(&self, i: usize) -> Slot;
-    fn len(&self) -> usize;
-    fn hash(&self) -> Hash;
-    fn timestamp(&self) -> Option<UnixTimestamp>;
-    fn last_voted_slot(&self) -> Option<Slot>;
-    fn last_voted_slot_hash(&self) -> Option<(Slot, Hash)>;
-    fn set_timestamp(&mut self, ts: Option<UnixTimestamp>);
-
-    fn slots(&self) -> Vec<Slot> {
-        (0..self.len()).map(|i| self.slot(i)).collect()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    // Have to manually implement because deriving PartialEq returns Self
-    fn eq(&self, other: &dyn VoteTransaction) -> bool;
-    fn as_any(&self) -> &dyn Any;
+#[derive(Debug, PartialEq)]
+pub enum VoteTransaction {
+    Vote(Vote),
+    VoteStateUpdate(VoteStateUpdate),
 }
 
-pub trait VoteTransactionClone {
-    fn clone_box(&self) -> Box<dyn VoteTransaction>;
-}
+impl VoteTransaction {
+    pub fn slots(&self) -> Vec<Slot> {
+        match self {
+            VoteTransaction::Vote(vote) => vote.slots.clone(),
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update
+                .lockouts
+                .iter()
+                .map(|lockout| lockout.slot)
+                .collect(),
+        }
+    }
 
-impl<T> VoteTransactionClone for T
-where
-    T: VoteTransaction + Clone + 'static,
-{
-    fn clone_box(&self) -> Box<dyn VoteTransaction> {
-        Box::new(self.clone())
+    pub fn is_empty(&self) -> bool {
+        match self {
+            VoteTransaction::Vote(vote) => vote.slots.is_empty(),
+            VoteTransaction::VoteStateUpdate(vote_state_update) => {
+                vote_state_update.lockouts.is_empty()
+            }
+        }
+    }
+
+    pub fn hash(&self) -> Hash {
+        match self {
+            VoteTransaction::Vote(vote) => vote.hash,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.hash,
+        }
+    }
+
+    pub fn timestamp(&self) -> Option<UnixTimestamp> {
+        match self {
+            VoteTransaction::Vote(vote) => vote.timestamp,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp,
+        }
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        match self {
+            VoteTransaction::Vote(vote) => vote.slots.last().copied(),
+            VoteTransaction::VoteStateUpdate(vote_state_update) => {
+                Some(vote_state_update.lockouts.back()?.slot)
+            }
+        }
+    }
+
+    pub fn last_voted_slot_hash(&self) -> Option<(Slot, Hash)> {
+        Some((self.last_voted_slot()?, self.hash()))
     }
 }
 
-impl Clone for Box<dyn VoteTransaction> {
-    fn clone(&self) -> Box<dyn VoteTransaction> {
-        self.clone_box()
+impl From<Vote> for VoteTransaction {
+    fn from(vote: Vote) -> Self {
+        VoteTransaction::Vote(vote)
     }
 }
 
-// Have to manually implement because derive returns Self
-impl<'a, 'b> PartialEq<dyn VoteTransaction + 'b> for dyn VoteTransaction + 'a {
-    fn eq(&self, other: &(dyn VoteTransaction + 'b)) -> bool {
-        VoteTransaction::eq(self, other)
-    }
-}
-
-// This is needed because of weirdness in the derive PartialEq macro
-// See rust issue #31740 for more info
-impl PartialEq<&Self> for Box<dyn VoteTransaction> {
-    fn eq(&self, other: &&Self) -> bool {
-        VoteTransaction::eq(self.as_ref(), other.as_ref())
+impl From<VoteStateUpdate> for VoteTransaction {
+    fn from(vote_state_update: VoteStateUpdate) -> Self {
+        VoteTransaction::VoteStateUpdate(vote_state_update)
     }
 }
 
@@ -119,48 +125,6 @@ impl Vote {
             hash,
             timestamp: None,
         }
-    }
-}
-
-#[typetag::serde]
-impl VoteTransaction for Vote {
-    fn slot(&self, i: usize) -> Slot {
-        self.slots[i]
-    }
-
-    fn len(&self) -> usize {
-        self.slots.len()
-    }
-
-    fn hash(&self) -> Hash {
-        self.hash
-    }
-
-    fn timestamp(&self) -> Option<UnixTimestamp> {
-        self.timestamp
-    }
-
-    fn last_voted_slot(&self) -> Option<Slot> {
-        self.slots.last().copied()
-    }
-
-    fn last_voted_slot_hash(&self) -> Option<(Slot, Hash)> {
-        self.slots.last().copied().map(|slot| (slot, self.hash))
-    }
-
-    fn set_timestamp(&mut self, ts: Option<UnixTimestamp>) {
-        self.timestamp = ts
-    }
-
-    fn eq(&self, other: &dyn VoteTransaction) -> bool {
-        other
-            .as_any()
-            .downcast_ref::<Self>()
-            .map_or(false, |x| x == self)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -215,51 +179,6 @@ impl VoteStateUpdate {
             hash,
             timestamp: None,
         }
-    }
-}
-
-#[typetag::serde]
-impl VoteTransaction for VoteStateUpdate {
-    fn slot(&self, i: usize) -> Slot {
-        self.lockouts[i].slot
-    }
-
-    fn len(&self) -> usize {
-        self.lockouts.len()
-    }
-
-    fn hash(&self) -> Hash {
-        self.hash
-    }
-
-    fn timestamp(&self) -> Option<UnixTimestamp> {
-        self.timestamp
-    }
-
-    fn last_voted_slot(&self) -> Option<Slot> {
-        self.lockouts.back().copied().map(|lockout| lockout.slot)
-    }
-
-    fn last_voted_slot_hash(&self) -> Option<(Slot, Hash)> {
-        self.lockouts
-            .back()
-            .copied()
-            .map(|lockout| (lockout.slot, self.hash))
-    }
-
-    fn set_timestamp(&mut self, ts: Option<UnixTimestamp>) {
-        self.timestamp = ts
-    }
-
-    fn eq(&self, other: &dyn VoteTransaction) -> bool {
-        other
-            .as_any()
-            .downcast_ref::<Self>()
-            .map_or(false, |x| x == self)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 
@@ -465,7 +384,7 @@ impl VoteState {
 
     fn check_slots_are_valid(
         &self,
-        vote: &(impl VoteTransaction + Debug),
+        vote: &Vote,
         slot_hashes: &[(Slot, Hash)],
     ) -> Result<(), VoteError> {
         // index into the vote's slots, sarting at the newest
@@ -484,19 +403,19 @@ impl VoteState {
         //
         // 2) Conversely, `slot_hashes` is sorted from newest/largest vote to
         // the oldest/smallest vote
-        while i < vote.len() && j > 0 {
+        while i < vote.slots.len() && j > 0 {
             // 1) increment `i` to find the smallest slot `s` in `vote.slots`
             // where `s` >= `last_voted_slot`
             if self
                 .last_voted_slot()
-                .map_or(false, |last_voted_slot| vote.slot(i) <= last_voted_slot)
+                .map_or(false, |last_voted_slot| vote.slots[i] <= last_voted_slot)
             {
                 i += 1;
                 continue;
             }
 
             // 2) Find the hash for this slot `s`.
-            if vote.slot(i) != slot_hashes[j - 1].0 {
+            if vote.slots[i] != slot_hashes[j - 1].0 {
                 // Decrement `j` to find newer slots
                 j -= 1;
                 continue;
@@ -518,7 +437,7 @@ impl VoteState {
             );
             return Err(VoteError::VoteTooOld);
         }
-        if i != vote.len() {
+        if i != vote.slots.len() {
             // This means there existed some slot for which we couldn't find
             // a matching slot hash in step 2)
             info!(
@@ -528,16 +447,13 @@ impl VoteState {
             inc_new_counter_info!("dropped-vote-slot", 1);
             return Err(VoteError::SlotsMismatch);
         }
-        if slot_hashes[j].1 != vote.hash() {
+        if slot_hashes[j].1 != vote.hash {
             // This means the newest vote in the slot has a match that
             // doesn't match the expected hash for that slot on this
             // fork
             warn!(
                 "{} dropped vote {:?} failed to match hash {} {}",
-                self.node_pubkey,
-                vote,
-                vote.hash(),
-                slot_hashes[j].1
+                self.node_pubkey, vote, vote.hash, slot_hashes[j].1
             );
             inc_new_counter_info!("dropped-vote-hash", 1);
             return Err(VoteError::SlotHashMismatch);
@@ -1160,8 +1076,18 @@ pub fn process_vote_state_update<S: std::hash::BuildHasher>(
     signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
     let mut vote_state = verify_and_get_vote_state(vote_account, clock, signers)?;
-
-    vote_state.check_slots_are_valid(&vote_state_update, slot_hashes)?;
+    {
+        let vote = Vote {
+            slots: vote_state_update
+                .lockouts
+                .iter()
+                .map(|lockout| lockout.slot)
+                .collect(),
+            hash: vote_state_update.hash,
+            timestamp: vote_state_update.timestamp,
+        };
+        vote_state.check_slots_are_valid(&vote, slot_hashes)?;
+    }
     vote_state.process_new_vote_state(
         vote_state_update.lockouts,
         vote_state_update.root,

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -611,7 +611,7 @@ mod tests {
             transaction::{self, Transaction},
         },
         solana_stake_program::stake_state,
-        solana_vote_program::vote_state::Vote,
+        solana_vote_program::vote_state::{Vote, VoteTransaction},
         std::{
             sync::{
                 atomic::{AtomicBool, AtomicU64},
@@ -1315,7 +1315,7 @@ mod tests {
             hash: Hash::default(),
             timestamp: None,
         };
-        subscriptions.notify_vote(Box::new(vote));
+        subscriptions.notify_vote(VoteTransaction::from(vote));
 
         let response = receiver.recv();
         assert_eq!(

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -93,7 +93,7 @@ impl From<NotificationEntry> for TimestampedNotificationEntry {
 pub enum NotificationEntry {
     Slot(SlotInfo),
     SlotUpdate(SlotUpdate),
-    Vote(Box<dyn VoteTransaction>),
+    Vote(VoteTransaction),
     Root(Slot),
     Bank(CommitmentSlots),
     Gossip(Slot),
@@ -677,8 +677,8 @@ impl RpcSubscriptions {
         self.enqueue_notification(NotificationEntry::SignaturesReceived(slot_signatures));
     }
 
-    pub fn notify_vote(&self, vote: Box<dyn VoteTransaction>) {
-        self.enqueue_notification(NotificationEntry::Vote(vote.clone()));
+    pub fn notify_vote(&self, vote: VoteTransaction) {
+        self.enqueue_notification(NotificationEntry::Vote(vote));
     }
 
     pub fn notify_roots(&self, mut rooted_slots: Vec<Slot>) {


### PR DESCRIPTION
#### Problem
`Box<dyn Trait>` involves runtime dispatch, has significant overhead and
is slow. It also requires hacky boilerplate code for implementing Clone
or other basic traits:
https://github.com/solana-labs/solana/blob/e92a81b74/programs/vote/src/vote_state/mod.rs#L70-L102

Only limited known types can be `VoteTransaction` and they are all defined
in the same crate. So using a trait here only adds overhead.
https://github.com/solana-labs/solana/blob/e92a81b74/programs/vote/src/vote_state/mod.rs#L125-L165
https://github.com/solana-labs/solana/blob/e92a81b74/programs/vote/src/vote_state/mod.rs#L221-L264

#### Summary of Changes
* use enum instead of trait for VoteTransaction.