### PR TITLE
replay stats report time since last new root

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -34,7 +34,13 @@ impl std::ops::DerefMut for ReplaySlotStats {
 }
 
 impl ReplaySlotStats {
-    pub fn report_stats(&self, slot: Slot, num_entries: usize, num_shreds: u64) {
+    pub fn report_stats(
+        &self,
+        slot: Slot,
+        num_entries: usize,
+        num_shreds: u64,
+        root_elapsed_ms: u64,
+    ) {
         datapoint_info!(
             "replay-slot-stats",
             ("slot", slot as i64, i64),
@@ -121,6 +127,7 @@ impl ReplaySlotStats {
                 self.execute_timings.details.data_size_changed,
                 i64
             ),
+            ("root_elapsed_ms", root_elapsed_ms, i64),
         );
 
         let mut per_pubkey_timings: Vec<_> = self

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2129,6 +2129,7 @@ impl ReplayStage {
                     bank.slot(),
                     bank_progress.replay_progress.num_entries,
                     bank_progress.replay_progress.num_shreds,
+                    bank.new_root_elapsed_ms(),
                 );
                 did_complete_bank = true;
                 info!("bank frozen: {}", bank.slot());

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1063,6 +1063,9 @@ pub struct AccountsDb {
     // lower passes = faster total time, higher dynamic memory usage
     // passes=2 cuts dynamic memory usage in approximately half.
     pub num_hash_scan_passes: Option<usize>,
+
+    /// keep track of when last root was made
+    pub(crate) root_last_time: AtomicInterval,
 }
 
 #[derive(Debug, Default)]
@@ -1598,6 +1601,7 @@ impl AccountsDb {
             filler_account_count: 0,
             filler_account_suffix: None,
             num_hash_scan_passes,
+            root_last_time: AtomicInterval::default(),
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2644,6 +2644,19 @@ impl Bank {
         }
     }
 
+    /// return ms since last time this function was called
+    /// Designed to report time per root in metrics
+    pub fn new_root_elapsed_ms(&self) -> u64 {
+        let interval = &self.accounts().accounts_db.root_last_time;
+        let result = interval.elapsed_ms();
+        if interval.should_update(result.saturating_sub(1)) {
+            result
+        } else {
+            // we have no meaningful value initially. This number is at least in the ball park to not skew the metrics.
+            solana_sdk::clock::DEFAULT_MS_PER_SLOT
+        }
+    }
+
     // Should not be called outside of startup, will race with
     // concurrent cleaning logic in AccountsBackgroundService
     pub fn exhaustively_free_unused_resource(&self, last_full_snapshot_slot: Option<Slot>) {


### PR DESCRIPTION
#### Problem
log ms since last root. useful to get an idea of how quickly a validator is making roots.
#### Summary of Changes

Fixes #
