### PR TITLE
Fix #21986

### DIFF
--- a/docs/src/developing/programming-model/calling-between-programs.md
+++ b/docs/src/developing/programming-model/calling-between-programs.md
@@ -54,8 +54,12 @@ mod acme {
 
 `invoke()` is built into Solana's runtime and is responsible for routing the
 given instruction to the `token` program via the instruction's `program_id`
-field. The caller has to pass all the accounts required by the instruction
-being invoked, except for the executable account (with the key `program_id`).
+field.
+
+Note that `invoke` requires the caller to pass all the accounts required by the
+instruction being invoked. This means that both the executable account (the
+ones that matches the instruction's program id) and the accounts passed to the
+instruction processor.
 
 Before invoking `pay()`, the runtime must ensure that `acme` didn't modify any
 accounts owned by `token`. It does this by applying the runtime's policy to the

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -24,19 +24,19 @@ fn process_instruction(
     }
 
     let secp_instruction_index = instruction_data[0];
-    let instruction_accounts = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
-    assert_eq!(*instruction_accounts.key, instructions::id());
-    let data_len = instruction_accounts.try_borrow_data()?.len();
+    let instructions_account = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
+    assert_eq!(*instructions_account.key, instructions::id());
+    let data_len = instructions_account.try_borrow_data()?.len();
     if data_len < 2 {
         return Err(ProgramError::InvalidAccountData);
     }
 
     let instruction = instructions::load_instruction_at_checked(
         secp_instruction_index as usize,
-        instruction_accounts,
+        instructions_account,
     )?;
 
-    let current_instruction = instructions::load_current_index_checked(instruction_accounts)?;
+    let current_instruction = instructions::load_current_index_checked(instructions_account)?;
     let my_index = instruction_data[1] as u16;
     assert_eq!(current_instruction, my_index);
 

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::next_account_info,
     account_info::AccountInfo,
     entrypoint,
     entrypoint::ProgramResult,
@@ -25,8 +24,7 @@ fn process_instruction(
     }
 
     let secp_instruction_index = instruction_data[0];
-    let account_info_iter = &mut accounts.iter();
-    let instruction_accounts = next_account_info(account_info_iter)?;
+    let instruction_accounts = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
     assert_eq!(*instruction_accounts.key, instructions::id());
     let data_len = instruction_accounts.try_borrow_data()?.len();
     if data_len < 2 {
@@ -56,7 +54,7 @@ fn process_instruction(
                 &[instruction_data[0], instruction_data[1], 1],
                 vec![AccountMeta::new_readonly(instructions::id(), false)],
             ),
-            &[instruction_accounts.clone()],
+            accounts,
         )?;
     }
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1449,7 +1449,10 @@ fn test_program_bpf_instruction_introspection() {
     );
 
     // Passing transaction
-    let account_metas = vec![AccountMeta::new_readonly(sysvar::instructions::id(), false)];
+    let account_metas = vec![
+        AccountMeta::new(program_id, false),
+        AccountMeta::new(sysvar::instructions::id(), false),
+    ];
     let instruction0 = Instruction::new_with_bytes(program_id, &[0u8, 0u8], account_metas.clone());
     let instruction1 = Instruction::new_with_bytes(program_id, &[0u8, 1u8], account_metas.clone());
     let instruction2 = Instruction::new_with_bytes(program_id, &[0u8, 2u8], account_metas);

--- a/sdk/program/src/program.rs
+++ b/sdk/program/src/program.rs
@@ -7,6 +7,8 @@ use crate::{
 /// Notes:
 /// - RefCell checking can be compute unit expensive, to avoid that expense use
 ///   `invoke_unchecked` instead, but at your own risk.
+/// - The program id of the instruction being issued must also be included in
+///   `account_infos`.
 pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {
     invoke_signed(instruction, account_infos, &[])
 }
@@ -17,6 +19,8 @@ pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> Progr
 /// - The missing checks ensured that the invocation doesn't violate the borrow
 ///   rules of the `AccountInfo` fields that are wrapped in `RefCell`s.  To
 ///   include the checks call `invoke` instead.
+/// - The program id of the instruction being issued must also be included in
+///   `account_infos`.
 pub fn invoke_unchecked(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {
     invoke_signed_unchecked(instruction, account_infos, &[])
 }
@@ -26,6 +30,8 @@ pub fn invoke_unchecked(instruction: &Instruction, account_infos: &[AccountInfo]
 /// Notes:
 /// - RefCell checking can be compute unit expensive, to avoid that expense use
 ///   `invoke_signed_unchecked` instead, but at your own risk.
+/// - The program id of the instruction being issued must also be included in
+///   `account_infos`.
 pub fn invoke_signed(
     instruction: &Instruction,
     account_infos: &[AccountInfo],
@@ -57,6 +63,8 @@ pub fn invoke_signed(
 /// - The missing checks ensured that the invocation doesn't violate the borrow
 ///   rules of the `AccountInfo` fields that are wrapped in `RefCell`s.  To
 ///   include the checks call `invoke_signed` instead.
+/// - The program id of the instruction being issued must also be included in
+///   `account_infos`.
 pub fn invoke_signed_unchecked(
     instruction: &Instruction,
     account_infos: &[AccountInfo],


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/21986#issuecomment-998236208

It turns out that we can not remove the necessity of having `program_id` in the `account_metas` and `account_infos` for CPI just yet (as #20448 accidentally did). That is because ABIv1 still needs it to resolve the permissions of `keyed_accounts` correctly in cases where multiple `keyed_accounts` of `program_id` are being passed with different permissions.

#### Summary of Changes
- Reverts some doc changes from #21633
- Fixes the test from #20604 which was not passing the `program_id`, a thing that would not have worked before #20448
- Extends the patch from #21535

Fixes #21986
