### PR TITLE
Increment execution timings on errors as well

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -995,7 +995,7 @@ impl Executor for BpfExecutor {
         serialize_time.stop();
         let mut create_vm_time = Measure::start("create_vm");
         let mut execute_time;
-        {
+        let execuction_result = {
             let mut vm = match create_vm(
                 &self.executable,
                 parameter_bytes.as_slice_mut(),
@@ -1040,12 +1040,10 @@ impl Executor for BpfExecutor {
                 stable_log::program_return(&log_collector, &program_id, return_data);
             }
             match result {
-                Ok(status) => {
-                    if status != SUCCESS {
-                        let error: InstructionError = status.into();
-                        stable_log::program_failure(&log_collector, &program_id, &error);
-                        return Err(error);
-                    }
+                Ok(status) if status != SUCCESS => {
+                    let error: InstructionError = status.into();
+                    stable_log::program_failure(&log_collector, &program_id, &error);
+                    Err(error)
                 }
                 Err(error) => {
                     let error = match error {
@@ -1058,23 +1056,29 @@ impl Executor for BpfExecutor {
                         }
                     };
                     stable_log::program_failure(&log_collector, &program_id, &error);
-                    return Err(error);
+                    Err(error)
                 }
+                _ => Ok(()),
             }
-            execute_time.stop();
-        }
+        };
+        execute_time.stop();
+
         let mut deserialize_time = Measure::start("deserialize");
-        let keyed_accounts = invoke_context.get_keyed_accounts()?;
-        deserialize_parameters(
-            &loader_id,
-            &keyed_accounts[first_instruction_account + 1..],
-            parameter_bytes.as_slice(),
-            &account_lengths,
-            invoke_context
-                .feature_set
-                .is_active(&do_support_realloc::id()),
-        )?;
+        let execute_or_deserialize_result = execuction_result.and_then(|_| {
+            let keyed_accounts = invoke_context.get_keyed_accounts()?;
+            deserialize_parameters(
+                &loader_id,
+                &keyed_accounts[first_instruction_account + 1..],
+                parameter_bytes.as_slice(),
+                &account_lengths,
+                invoke_context
+                    .feature_set
+                    .is_active(&do_support_realloc::id()),
+            )
+        });
         deserialize_time.stop();
+
+        // Update the timings
         let timings = &mut invoke_context.timings;
         timings.serialize_us = timings.serialize_us.saturating_add(serialize_time.as_us());
         timings.create_vm_us = timings.create_vm_us.saturating_add(create_vm_time.as_us());
@@ -1082,6 +1086,8 @@ impl Executor for BpfExecutor {
         timings.deserialize_us = timings
             .deserialize_us
             .saturating_add(deserialize_time.as_us());
+
+        execute_or_deserialize_result?;
         stable_log::program_success(&log_collector, &program_id);
         Ok(())
     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -995,7 +995,7 @@ impl Executor for BpfExecutor {
         serialize_time.stop();
         let mut create_vm_time = Measure::start("create_vm");
         let mut execute_time;
-        let execuction_result = {
+        let execution_result = {
             let mut vm = match create_vm(
                 &self.executable,
                 parameter_bytes.as_slice_mut(),
@@ -1064,7 +1064,7 @@ impl Executor for BpfExecutor {
         execute_time.stop();
 
         let mut deserialize_time = Measure::start("deserialize");
-        let execute_or_deserialize_result = execuction_result.and_then(|_| {
+        let execute_or_deserialize_result = execution_result.and_then(|_| {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             deserialize_parameters(
                 &loader_id,
@@ -1087,9 +1087,10 @@ impl Executor for BpfExecutor {
             .deserialize_us
             .saturating_add(deserialize_time.as_us());
 
-        execute_or_deserialize_result?;
-        stable_log::program_success(&log_collector, &program_id);
-        Ok(())
+        if execute_or_deserialize_result.is_ok() {
+            stable_log::program_success(&log_collector, &program_id);
+        }
+        execute_or_deserialize_result
     }
 }
 


### PR DESCRIPTION
#### Problem
When execution timings spike, in `replay-slot-stats`, none of the constituent execution details timings go up the proportional amount. 

One contributor to this could be that early returns for execution failures aren't being counted towards the execution details timings

#### Summary of Changes
Increment execution details timings even when failures occur

Fixes #
