### PR TITLE
Fix transaction pk violation

### DIFF
--- a/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
@@ -492,7 +492,15 @@ impl SimplePostgresClient {
     ) -> Result<Statement, AccountsDbPluginError> {
         let stmt = "INSERT INTO transaction AS txn (signature, is_vote, slot, message_type, legacy_message, \
         v0_loaded_message, signatures, message_hash, meta, updated_on) \
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+        ON CONFLICT (transaction_pk) DO UPDATE SET is_vote=excluded.is_vote, \
+        message_type=excluded.message_type, \
+        legacy_message=excluded.legacy_message, \
+        v0_loaded_message=excluded.v0_loaded_message, \
+        signatures=excluded.signatures, \
+        message_hash=excluded.message_hash, \
+        meta=excluded.meta, \
+        updated_on=excluded.updated_on";
 
         let stmt = client.prepare(stmt);
 

--- a/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
@@ -493,7 +493,7 @@ impl SimplePostgresClient {
         let stmt = "INSERT INTO transaction AS txn (signature, is_vote, slot, message_type, legacy_message, \
         v0_loaded_message, signatures, message_hash, meta, updated_on) \
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
-        ON CONFLICT (transaction_pk) DO UPDATE SET is_vote=excluded.is_vote, \
+        ON CONFLICT (slot, signature) DO UPDATE SET is_vote=excluded.is_vote, \
         message_type=excluded.message_type, \
         legacy_message=excluded.legacy_message, \
         v0_loaded_message=excluded.v0_loaded_message, \


### PR DESCRIPTION
#### Problem
When the validator restarts some of the transaction earlier notified might be re-notified if it is restoring from an older snapshots. 
#### Summary of Changes
Handle the conflict on (slot, signature), on conflict, overwrites.

Fixes #22003