### PR TITLE
Display bpf-tools version in cargo-build-bpf version string

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -65,6 +65,9 @@ test-stable-bpf)
     fi
   done
 
+  # bpf-tools version
+  "$cargo_build_bpf" -V
+
   # BPF program instruction count assertion
   bpf_target_path=programs/bpf/target
   _ "$cargo" stable test \


### PR DESCRIPTION
#### Problem

bpf-tools version is unrelated to solana version, but sometimes it's useful to know which version is used in current installation of Solana SDK.

#### Summary of Changes

Add version of bpf-tools to the version string of cargo-build-bpf.
