### PR TITLE
Change lto and codegen-units for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[profile.release]
+lto = true
+codegen-units = 1
+
 [workspace]
 members = [
     "accountsdb-plugin-interface",


### PR DESCRIPTION
Was surprised that the default release profile has not changed.
https://doc.rust-lang.org/cargo/reference/profiles.html#release

`solana-validator` size is better on 29% (22% gziped):
```bash
v1.9.1 GitHub
size: solana-validator 63998976 (gzip: 22705731, 35.47%)

$ cargo +stable --version
cargo 1.57.0 (b2e52d7ca 2021-10-21)
// v1.9.1 default release profile
$ time cargo +stable build --release
real  9m47.005s
// size: solana-validator 64112080 (gzip: 23133840, 36.08%)
// v1.9.1 changed release profile
$ time cargo +stable build --release
real  15m35.551s
// size: solana-validator 45296184 (gzip: 18043632, 39.83%)
```

Any suggestion for benchmark with a changed release profile?