### PR TITLE
Update jsonrpc-api.md to document 'owner' property

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -589,6 +589,7 @@ The JSON structure of token balances is defined as a list of objects in the foll
 
 - `accountIndex: <number>` - Index of the account in which the token balance is provided for.
 - `mint: <string>` - Pubkey of the token's mint.
+- `owner: <string>` - Pubkey of token balance's owner. 
 - `uiTokenAmount: <object>` -
   - `amount: <string>` - Raw amount of tokens as a string, ignoring decimals.
   - `decimals: <number>` - Number of decimals configured for token's mint.

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -589,7 +589,7 @@ The JSON structure of token balances is defined as a list of objects in the foll
 
 - `accountIndex: <number>` - Index of the account in which the token balance is provided for.
 - `mint: <string>` - Pubkey of the token's mint.
-- `owner: <string>` - Pubkey of token balance's owner. 
+- `owner: <string>` - Pubkey of token balance's owner.
 - `uiTokenAmount: <object>` -
   - `amount: <string>` - Raw amount of tokens as a string, ignoring decimals.
   - `decimals: <number>` - Number of decimals configured for token's mint.


### PR DESCRIPTION
Documents 'owner' property on the token balances struct.

#### Problem
Property 'owner' on token balances struct is returned from rpc api but is not documented anywhere.
#### Summary of Changes
Added the property to the rpc documentation.
