### PR TITLE
Add (preflight) simulation to BanksClient

### DIFF
--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -19,6 +19,13 @@ pub enum BanksClientError {
 
     #[error("transport transaction error: {0}")]
     TransactionError(#[from] TransactionError),
+
+    #[error("simulation error: {err:?}, logs: {logs:?}, units_consumed: {units_consumed:?}")]
+    SimulationError {
+        err: TransactionError,
+        logs: Vec<String>,
+        units_consumed: u64,
+    },
 }
 
 impl BanksClientError {
@@ -40,6 +47,9 @@ impl From<BanksClientError> for io::Error {
             BanksClientError::TransactionError(err) => {
                 Self::new(io::ErrorKind::Other, err.to_string())
             }
+            BanksClientError::SimulationError { err, .. } => {
+                Self::new(io::ErrorKind::Other, err.to_string())
+            }
         }
     }
 }
@@ -57,6 +67,7 @@ impl From<BanksClientError> for TransportError {
                 Self::IoError(io::Error::new(io::ErrorKind::Other, err.to_string()))
             }
             BanksClientError::TransactionError(err) => Self::TransactionError(err),
+            BanksClientError::SimulationError { err, .. } => Self::TransactionError(err),
         }
     }
 }

--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -30,10 +30,10 @@ pub enum BanksClientError {
 
 impl BanksClientError {
     pub fn unwrap(&self) -> TransactionError {
-        if let BanksClientError::TransactionError(err) = self {
-            err.clone()
-        } else {
-            panic!("unexpected transport error")
+        match self {
+            BanksClientError::TransactionError(err)
+            | BanksClientError::SimulationError { err, .. } => err.clone(),
+            _ => panic!("unexpected transport error"),
         }
     }
 }

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -218,7 +218,7 @@ impl BanksClient {
 
     /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
     /// after the transaction has been rejected or reached the given level of commitment.
-    pub fn process_transaction_with_preflight(
+    pub fn process_transaction_with_preflight_and_commitment(
         &mut self,
         transaction: Transaction,
         commitment: CommitmentLevel,
@@ -250,6 +250,18 @@ impl BanksClient {
                 simulation_details: _,
             } => result.map_err(Into::into),
         })
+    }
+
+    /// Send a transaction and return any preflight (sanitization or simulation) errors, or return
+    /// after the transaction has been finalized or rejected.
+    pub fn process_transaction_with_preflight(
+        &mut self,
+        transaction: Transaction,
+    ) -> impl Future<Output = Result<(), BanksClientError>> + '_ {
+        self.process_transaction_with_preflight_and_commitment(
+            transaction,
+            CommitmentLevel::default(),
+        )
     }
 
     /// Send a transaction and return until the transaction has been finalized or rejected.

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -38,7 +38,7 @@ pub struct TransactionSimulationDetails {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct BanksTransactionResult {
+pub struct BanksTransactionResultWithSimulation {
     pub result: Option<transaction::Result<()>>,
     pub simulation_details: Option<TransactionSimulationDetails>,
 }
@@ -60,7 +60,7 @@ pub trait Banks {
     async fn process_transaction_with_preflight_and_commitment_and_context(
         transaction: Transaction,
         commitment: CommitmentLevel,
-    ) -> BanksTransactionResult;
+    ) -> BanksTransactionResultWithSimulation;
     async fn process_transaction_with_commitment_and_context(
         transaction: Transaction,
         commitment: CommitmentLevel,

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -30,6 +30,19 @@ pub struct TransactionStatus {
     pub confirmation_status: Option<TransactionConfirmationStatus>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionSimulationDetails {
+    pub logs: Vec<String>,
+    pub units_consumed: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BanksTransactionResult {
+    pub result: Option<transaction::Result<()>>,
+    pub simulation_details: Option<TransactionSimulationDetails>,
+}
+
 #[tarpc::service]
 pub trait Banks {
     async fn send_transaction_with_context(transaction: Transaction);
@@ -44,6 +57,10 @@ pub trait Banks {
         -> Option<TransactionStatus>;
     async fn get_slot_with_context(commitment: CommitmentLevel) -> Slot;
     async fn get_block_height_with_context(commitment: CommitmentLevel) -> u64;
+    async fn process_transaction_with_preflight_and_commitment_and_context(
+        transaction: Transaction,
+        commitment: CommitmentLevel,
+    ) -> BanksTransactionResult;
     async fn process_transaction_with_commitment_and_context(
         transaction: Transaction,
         commitment: CommitmentLevel,

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -2,9 +2,14 @@ use {
     bincode::{deserialize, serialize},
     futures::{future, prelude::stream::StreamExt},
     solana_banks_interface::{
-        Banks, BanksRequest, BanksResponse, TransactionConfirmationStatus, TransactionStatus,
+        Banks, BanksRequest, BanksResponse, BanksTransactionResult, TransactionConfirmationStatus,
+        TransactionSimulationDetails, TransactionStatus,
     },
-    solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache},
+    solana_runtime::{
+        bank::{Bank, TransactionSimulationResult},
+        bank_forks::BankForks,
+        commitment::BlockCommitmentCache,
+    },
     solana_sdk::{
         account::Account,
         clock::Slot,
@@ -15,7 +20,7 @@ use {
         message::{Message, SanitizedMessage},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, Transaction},
+        transaction::{self, SanitizedTransaction, Transaction},
     },
     solana_send_transaction_service::{
         send_transaction_service::{SendTransactionService, TransactionInfo},
@@ -240,6 +245,47 @@ impl Banks for BanksServer {
 
     async fn get_block_height_with_context(self, _: Context, commitment: CommitmentLevel) -> u64 {
         self.bank(commitment).block_height()
+    }
+
+    async fn process_transaction_with_preflight_and_commitment_and_context(
+        self,
+        ctx: Context,
+        transaction: Transaction,
+        commitment: CommitmentLevel,
+    ) -> BanksTransactionResult {
+        let sanitized_transaction =
+            match SanitizedTransaction::try_from_legacy_transaction(transaction.clone()) {
+                Err(err) => {
+                    return BanksTransactionResult {
+                        result: Some(Err(err)),
+                        simulation_details: None,
+                    };
+                }
+                Ok(tx) => tx,
+            };
+        if let TransactionSimulationResult {
+            result: Err(err),
+            logs,
+            post_simulation_accounts: _,
+            units_consumed,
+        } = self
+            .bank(commitment)
+            .simulate_transaction(sanitized_transaction)
+        {
+            return BanksTransactionResult {
+                result: Some(Err(err)),
+                simulation_details: Some(TransactionSimulationDetails {
+                    logs,
+                    units_consumed,
+                }),
+            };
+        }
+        BanksTransactionResult {
+            result: self
+                .process_transaction_with_commitment_and_context(ctx, transaction, commitment)
+                .await,
+            simulation_details: None,
+        }
     }
 
     async fn process_transaction_with_commitment_and_context(

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -270,7 +270,7 @@ impl Banks for BanksServer {
             units_consumed,
         } = self
             .bank(commitment)
-            .simulate_transaction(sanitized_transaction)
+            .simulate_transaction_unchecked(sanitized_transaction)
         {
             return BanksTransactionResult {
                 result: Some(Err(err)),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3134,6 +3134,15 @@ impl Bank {
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
 
+        self.simulate_transaction_unchecked(transaction)
+    }
+
+    /// Run transactions against a bank without committing the results; does not check if the bank
+    /// is frozen, enabling use in single-Bank test frameworks
+    pub fn simulate_transaction_unchecked(
+        &self,
+        transaction: SanitizedTransaction,
+    ) -> TransactionSimulationResult {
         let number_of_accounts = transaction.message().account_keys_len();
         let batch = self.prepare_simulation_batch(transaction);
         let mut timings = ExecuteTimings::default();

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -76,20 +76,24 @@ impl SanitizedTransaction {
         })
     }
 
-    /// Create a sanitized transaction from a legacy transaction. Used for tests only.
-    pub fn from_transaction_for_tests(tx: Transaction) -> Self {
-        tx.sanitize().unwrap();
+    pub fn try_from_legacy_transaction(tx: Transaction) -> Result<Self> {
+        tx.sanitize()?;
 
         if tx.message.has_duplicates() {
-            Result::<Self>::Err(TransactionError::AccountLoadedTwice).unwrap();
+            return Err(TransactionError::AccountLoadedTwice);
         }
 
-        Self {
+        Ok(Self {
             message_hash: tx.message.hash(),
             message: SanitizedMessage::Legacy(tx.message),
             is_simple_vote_tx: false,
             signatures: tx.signatures,
-        }
+        })
+    }
+
+    /// Create a sanitized transaction from a legacy transaction. Used for tests only.
+    pub fn from_transaction_for_tests(tx: Transaction) -> Self {
+        Self::try_from_legacy_transaction(tx).unwrap()
     }
 
     /// Return the first signature for this transaction.


### PR DESCRIPTION
#### Problem
BanksServer operation is confusing or clunky for cases where a transaction does not land (successfully or with InstructionError). See #22029 for more details and examples.

#### Summary of Changes
Add Banks method with preflight checks, and expose via the BanksClient::process_transaction_with_preflight() method.
Consider adding stronger comments recommending this api.

Fixes #22029

cc @joncinque 