### PR TITLE
Remove "msg <Recent Blockhash>" spam from deploying

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -99,7 +99,6 @@ pub fn get_fee_for_messages(
     Ok(messages
         .iter()
         .map(|message| {
-            println!("msg {:?}", message.recent_blockhash);
             rpc_client.get_fee_for_message(message)
         })
         .collect::<Result<Vec<_>, _>>()?

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -98,9 +98,7 @@ pub fn get_fee_for_messages(
 ) -> Result<u64, CliError> {
     Ok(messages
         .iter()
-        .map(|message| {
-            rpc_client.get_fee_for_message(message)
-        })
+        .map(|message| rpc_client.get_fee_for_message(message))
         .collect::<Result<Vec<_>, _>>()?
         .iter()
         .sum())


### PR DESCRIPTION
#### Problem

Deploying fills terminal with repeated "msg <Recent Blockhash>\n"

#### Summary of Changes

Deleted a single `println!`
