### PR TITLE
validator: add contact-info query to admin port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5970,6 +5970,8 @@ dependencies = [
  "log 0.4.14",
  "num_cpus",
  "rand 0.7.3",
+ "serde",
+ "serde_json",
  "signal-hook",
  "solana-clap-utils",
  "solana-cli-config",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -25,6 +25,8 @@ jsonrpc-server-utils= "18.0.0"
 log = "0.4.14"
 num_cpus = "1.13.1"
 rand = "0.7.0"
+serde = "1.0.132"
+serde_json = "1.0.73"
 solana-clap-utils = { path = "../clap-utils", version = "=1.10.0" }
 solana-cli-config = { path = "../cli-config", version = "=1.10.0" }
 solana-client = { path = "../client", version = "=1.10.0" }

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -5,15 +5,17 @@ use {
     jsonrpc_ipc_server::{RequestContext, ServerBuilder},
     jsonrpc_server_utils::tokio,
     log::*,
+    serde::{Deserialize, Serialize},
     solana_core::{
         consensus::Tower, tower_storage::TowerStorage, validator::ValidatorStartProgress,
     },
-    solana_gossip::cluster_info::ClusterInfo,
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_sdk::{
         exit::Exit,
         signature::{read_keypair_file, Keypair, Signer},
     },
     std::{
+        fmt::{self, Display},
         net::SocketAddr,
         path::{Path, PathBuf},
         sync::{Arc, RwLock},
@@ -33,6 +35,76 @@ pub struct AdminRpcRequestMetadata {
     pub tower_storage: Arc<dyn TowerStorage>,
 }
 impl Metadata for AdminRpcRequestMetadata {}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AdminRpcContactInfo {
+    pub id: String,
+    pub gossip: SocketAddr,
+    pub tvu: SocketAddr,
+    pub tvu_forwards: SocketAddr,
+    pub repair: SocketAddr,
+    pub tpu: SocketAddr,
+    pub tpu_forwards: SocketAddr,
+    pub tpu_vote: SocketAddr,
+    pub rpc: SocketAddr,
+    pub rpc_pubsub: SocketAddr,
+    pub serve_repair: SocketAddr,
+    pub last_updated_timestamp: u64,
+    pub shred_version: u16,
+}
+
+impl From<ContactInfo> for AdminRpcContactInfo {
+    fn from(contact_info: ContactInfo) -> Self {
+        let ContactInfo {
+            id,
+            gossip,
+            tvu,
+            tvu_forwards,
+            repair,
+            tpu,
+            tpu_forwards,
+            tpu_vote,
+            rpc,
+            rpc_pubsub,
+            serve_repair,
+            wallclock,
+            shred_version,
+        } = contact_info;
+        Self {
+            id: id.to_string(),
+            last_updated_timestamp: wallclock,
+            gossip,
+            tvu,
+            tvu_forwards,
+            repair,
+            tpu,
+            tpu_forwards,
+            tpu_vote,
+            rpc,
+            rpc_pubsub,
+            serve_repair,
+            shred_version,
+        }
+    }
+}
+
+impl Display for AdminRpcContactInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Identity: {}", self.id)?;
+        writeln!(f, "Gossip: {}", self.gossip)?;
+        writeln!(f, "TVU: {}", self.tvu)?;
+        writeln!(f, "TVU Forwards: {}", self.tvu_forwards)?;
+        writeln!(f, "Repair: {}", self.repair)?;
+        writeln!(f, "TPU: {}", self.tpu)?;
+        writeln!(f, "TPU Forwards: {}", self.tpu_forwards)?;
+        writeln!(f, "TPU Votes: {}", self.tpu_vote)?;
+        writeln!(f, "RPC: {}", self.rpc)?;
+        writeln!(f, "RPC Pubsub: {}", self.rpc_pubsub)?;
+        writeln!(f, "Serve Repair: {}", self.serve_repair)?;
+        writeln!(f, "Last Updated Timestamp: {}", self.last_updated_timestamp)?;
+        writeln!(f, "Shred Version: {}", self.shred_version)
+    }
+}
 
 #[rpc]
 pub trait AdminRpc {
@@ -61,6 +133,9 @@ pub trait AdminRpc {
 
     #[rpc(meta, name = "setIdentity")]
     fn set_identity(&self, meta: Self::Metadata, keypair_file: String) -> Result<()>;
+
+    #[rpc(meta, name = "contactInfo")]
+    fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo>;
 }
 
 pub struct AdminRpcImpl;
@@ -161,6 +236,16 @@ impl AdminRpc for AdminRpcImpl {
             cluster_info.set_keypair(Arc::new(identity_keypair));
             warn!("Identity set to {}", cluster_info.id());
             Ok(())
+        } else {
+            Err(jsonrpc_core::error::Error::invalid_params(
+                "Retry once validator start up is complete",
+            ))
+        }
+    }
+
+    fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo> {
+        if let Some(cluster_info) = meta.cluster_info.read().unwrap().as_ref() {
+            Ok(cluster_info.my_contact_info().into())
         } else {
             Err(jsonrpc_core::error::Error::invalid_params(
                 "Retry once validator start up is complete",


### PR DESCRIPTION
#### Problem

No easy way to query all validator port assignments

#### Summary of Changes

Add `contactInfo` method to validator admin port
Add `contact-info` subcommand to `solana-validator`