### PR TITLE
Avoid cloning Vec<Entry> when calling entries_to_test_shreds()

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2564,7 +2564,7 @@ mod tests {
 
             poh_recorder.lock().unwrap().set_bank(&bank);
 
-            let shreds = entries_to_test_shreds(entries, bank.slot(), 0, true, 0);
+            let shreds = entries_to_test_shreds(&entries, bank.slot(), 0, true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
             blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
 

--- a/core/src/repair_generic_traversal.rs
+++ b/core/src/repair_generic_traversal.rs
@@ -302,7 +302,7 @@ pub mod test {
                 blockhashes.insert(slot, entries.last().unwrap().hash);
 
                 let mut shreds = solana_ledger::blockstore::entries_to_test_shreds(
-                    entries.clone(),
+                    &entries,
                     slot,
                     parent.unwrap_or(slot),
                     is_slot_complete,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3389,7 +3389,7 @@ pub mod tests {
                     ), // should cause AccountNotFound error
                 ],
             );
-            entries_to_test_shreds(vec![entry], slot, slot.saturating_sub(1), false, 0)
+            entries_to_test_shreds(&[entry], slot, slot.saturating_sub(1), false, 0)
         });
 
         assert_matches!(
@@ -3419,7 +3419,7 @@ pub mod tests {
                     blockhash,
                 )],
             );
-            entries_to_test_shreds(vec![entry], slot, slot.saturating_sub(1), false, 0)
+            entries_to_test_shreds(&[entry], slot, slot.saturating_sub(1), false, 0)
         });
 
         if let Err(BlockstoreProcessorError::InvalidBlock(block_error)) = res {
@@ -3439,7 +3439,7 @@ pub mod tests {
 
             let too_few_hashes_tick = Entry::new(&blockhash, hashes_per_tick - 1, vec![]);
             entries_to_test_shreds(
-                vec![too_few_hashes_tick],
+                &[too_few_hashes_tick],
                 slot,
                 slot.saturating_sub(1),
                 false,
@@ -3463,7 +3463,7 @@ pub mod tests {
             let slot = bank.slot();
             let hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
             entries_to_test_shreds(
-                entry::create_ticks(bank.ticks_per_slot() + 1, hashes_per_tick, blockhash),
+                &entry::create_ticks(bank.ticks_per_slot() + 1, hashes_per_tick, blockhash),
                 slot,
                 slot.saturating_sub(1),
                 false,
@@ -3483,7 +3483,7 @@ pub mod tests {
             let slot = bank.slot();
             let hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
             entries_to_test_shreds(
-                entry::create_ticks(bank.ticks_per_slot() - 1, hashes_per_tick, blockhash),
+                &entry::create_ticks(bank.ticks_per_slot() - 1, hashes_per_tick, blockhash),
                 slot,
                 slot.saturating_sub(1),
                 true,
@@ -3505,7 +3505,7 @@ pub mod tests {
             let slot = bank.slot();
             let hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
             entries_to_test_shreds(
-                entry::create_ticks(bank.ticks_per_slot(), hashes_per_tick, blockhash),
+                &entry::create_ticks(bank.ticks_per_slot(), hashes_per_tick, blockhash),
                 slot,
                 slot.saturating_sub(1),
                 false,
@@ -3533,7 +3533,7 @@ pub mod tests {
             let tx = system_transaction::transfer(funded_keypair, &keypair.pubkey(), 2, blockhash);
             let trailing_entry = entry::next_entry(&last_entry_hash, 1, vec![tx]);
             entries.push(trailing_entry);
-            entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0)
+            entries_to_test_shreds(&entries, slot, slot.saturating_sub(1), true, 0)
         });
 
         if let Err(BlockstoreProcessorError::InvalidBlock(block_error)) = res {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1819,7 +1819,7 @@ mod tests {
             info!("creating shreds");
             let mut last_print = Instant::now();
             for i in 1..10 {
-                let shreds = blockstore::entries_to_test_shreds(entries.clone(), i, i - 1, true, 1);
+                let shreds = blockstore::entries_to_test_shreds(&entries, i, i - 1, true, 1);
                 blockstore.insert_shreds(shreds, None, true).unwrap();
                 if last_print.elapsed().as_millis() > 5000 {
                     info!("inserted {}", i);

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -20,7 +20,7 @@ fn bench_write_shreds(bench: &mut Bencher, entries: Vec<Entry>, ledger_path: &Pa
     let blockstore =
         Blockstore::open(ledger_path).expect("Expected to be able to open database ledger");
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
 
@@ -42,7 +42,7 @@ fn setup_read_bench(
     );
 
     // Convert the entries to shreds, write the shreds to the ledger
-    let shreds = entries_to_test_shreds(entries, slot, slot.saturating_sub(1), true, 0);
+    let shreds = entries_to_test_shreds(&entries, slot, slot.saturating_sub(1), true, 0);
     blockstore
         .insert_shreds(shreds, None, false)
         .expect("Expectd successful insertion of shreds into ledger");
@@ -135,7 +135,7 @@ fn bench_insert_data_shred_small(bench: &mut Bencher) {
     let num_entries = 32 * 1024;
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
     Blockstore::destroy(&ledger_path).expect("Expected successful database destruction");
@@ -150,7 +150,7 @@ fn bench_insert_data_shred_big(bench: &mut Bencher) {
     let num_entries = 32 * 1024;
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
-        let shreds = entries_to_test_shreds(entries.clone(), 0, 0, true, 0);
+        let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
     });
     Blockstore::destroy(&ledger_path).expect("Expected successful database destruction");

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -777,7 +777,7 @@ pub mod tests {
 
         for x in 0..index0_max_slot + 1 {
             let entries = make_slot_entries_with_transactions(1);
-            let shreds = entries_to_test_shreds(entries.clone(), x, x.saturating_sub(1), true, 0);
+            let shreds = entries_to_test_shreds(&entries, x, x.saturating_sub(1), true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature = entries
                 .iter()
@@ -813,7 +813,7 @@ pub mod tests {
 
         for x in index0_max_slot + 1..index1_max_slot + 1 {
             let entries = make_slot_entries_with_transactions(1);
-            let shreds = entries_to_test_shreds(entries.clone(), x, x.saturating_sub(1), true, 0);
+            let shreds = entries_to_test_shreds(&entries, x, x.saturating_sub(1), true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
             let signature: Signature = entries
                 .iter()
@@ -1213,7 +1213,7 @@ pub mod tests {
             let mut tick = create_ticks(1, 0, hash(&serialize(&x).unwrap()));
             entries.append(&mut tick);
         }
-        let shreds = entries_to_test_shreds(entries, slot, slot - 1, true, 0);
+        let shreds = entries_to_test_shreds(&entries, slot, slot - 1, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         let mut write_batch = blockstore.db.batch().unwrap();

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -21,7 +21,7 @@ fn test_multiple_threads_insert_shred() {
         let threads: Vec<_> = (0..num_threads)
             .map(|i| {
                 let entries = entry::create_ticks(1, 0, Hash::default());
-                let shreds = blockstore::entries_to_test_shreds(entries, i + 1, 0, false, 0);
+                let shreds = blockstore::entries_to_test_shreds(&entries, i + 1, 0, false, 0);
                 let blockstore_ = blockstore.clone();
                 Builder::new()
                     .name("blockstore-writer".to_string())

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4251,13 +4251,8 @@ pub fn create_test_transactions_and_populate_blockstore(
     let entry_3 = solana_entry::entry::next_entry(&entry_2.hash, 1, vec![fail_tx]);
     let entries = vec![entry_1, entry_2, entry_3];
 
-    let shreds = solana_ledger::blockstore::entries_to_test_shreds(
-        entries.clone(),
-        slot,
-        previous_slot,
-        true,
-        0,
-    );
+    let shreds =
+        solana_ledger::blockstore::entries_to_test_shreds(&entries, slot, previous_slot, true, 0);
     blockstore.insert_shreds(shreds, None, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();
 


### PR DESCRIPTION
#### Problem
Parameter `entries` is always used as a reference inside `entries_to_test_shreds`.
https://github.com/solana-labs/solana/blob/65d59f4ef025410120e50129a4e97df2b6774f40/ledger/src/blockstore.rs#L3901

However, the function takes raw-instance instead of a reference, which yields
unnecessary cloning on the call site.

#### Summary of Changes
As `entries` is only used as a reference inside `entries_to_test_shreds`, this PR
makes it accept its reference and avoid unnecessary cloning on the call site.

