### PR TITLE
ci: Add Anchor and Anchor projects to the downstream build

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -227,6 +227,31 @@ EOF
       "downstream-projects skipped as no relevant files were modified"
   fi
 
+  # Downstream Anchor projects backwards compatibility
+  if affects \
+             .rs$ \
+             Cargo.lock$ \
+             Cargo.toml$ \
+             ^ci/rust-version.sh \
+             ^ci/test-stable-perf.sh \
+             ^ci/test-stable.sh \
+             ^ci/test-local-cluster.sh \
+             ^core/build.rs \
+             ^fetch-perf-libs.sh \
+             ^programs/ \
+             ^sdk/ \
+             ^scripts/build-downstream-anchor-projects.sh \
+      ; then
+    cat >> "$output_file" <<"EOF"
+  - command: "scripts/build-downstream-anchor-projects.sh"
+    name: "downstream-anchor-projects"
+    timeout_in_minutes: 30
+EOF
+  else
+    annotate --style info \
+      "downstream-anchor-projects skipped as no relevant files were modified"
+  fi
+
   # Wasm support
   if affects \
              ^ci/test-wasm.sh \

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -245,7 +245,7 @@ EOF
     cat >> "$output_file" <<"EOF"
   - command: "scripts/build-downstream-anchor-projects.sh"
     name: "downstream-anchor-projects"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
 EOF
   else
     annotate --style info \

--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Builds known downstream projects against local solana source
+#
+
+set -e
+cd "$(dirname "$0")"/..
+source ci/_
+source scripts/patch-crates.sh
+source scripts/read-cargo-variable.sh
+
+solana_ver=$(readCargoVariable version sdk/Cargo.toml)
+solana_dir=$PWD
+cargo="$solana_dir"/cargo
+cargo_build_bpf="$solana_dir"/cargo-build-bpf
+cargo_test_bpf="$solana_dir"/cargo-test-bpf
+
+mkdir -p target/downstream-projects-anchor
+cd target/downstream-projects-anchor
+
+update_anchor_dependencies() {
+  declare project_root="$1"
+  declare anchor_ver="$2"
+  declare tomls=()
+  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$project_root" -name Cargo.toml)
+
+  sed -i -e "s#\(anchor-lang = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-spl = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-lang = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-spl = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+}
+
+patch_crates_io_anchor() {
+  declare Cargo_toml="$1"
+  declare anchor_dir="$2"
+  cat >> "$Cargo_toml" <<EOF
+anchor-lang = { path = "$anchor_dir/lang" }
+anchor-spl = { path = "$anchor_dir/spl" }
+EOF
+}
+
+# NOTE This isn't run in a subshell to get $anchor_dir and $anchor_ver
+anchor() {
+  set -x
+  rm -rf anchor
+  git clone https://github.com/project-serum/anchor.git
+  cd anchor
+
+  update_solana_dependencies . "$solana_ver"
+  patch_crates_io_solana Cargo.toml "$solana_dir"
+
+  $cargo build
+  $cargo test
+
+  anchor_dir=$PWD
+  anchor_ver=$(readCargoVariable version "$anchor_dir"/lang/Cargo.toml)
+
+  cd "$solana_dir"/target/downstream-projects-anchor
+}
+
+mango() {
+  (
+    set -x
+    rm -rf mango-v3
+    git clone https://github.com/blockworks-foundation/mango-v3
+    cd mango-v3
+
+    update_solana_dependencies . "$solana_ver"
+    update_anchor_dependencies . "$anchor_ver"
+    patch_crates_io_solana Cargo.toml "$solana_dir"
+    patch_crates_io_anchor Cargo.toml "$anchor_dir"
+
+    $cargo build
+    $cargo test
+    $cargo_build_bpf
+    $cargo_test_bpf
+  )
+}
+
+metaplex() {
+  (
+    set -x
+    rm -rf metaplex-program-library
+    git clone https://github.com/metaplex-foundation/metaplex-program-library
+    cd metaplex-program-library
+
+    update_solana_dependencies . "$solana_ver"
+    update_anchor_dependencies . "$anchor_ver"
+    patch_crates_io_solana Cargo.toml "$solana_dir"
+    patch_crates_io_anchor Cargo.toml "$anchor_dir"
+
+    $cargo build
+    $cargo test
+    $cargo_build_bpf
+    $cargo_test_bpf
+  )
+}
+
+_ anchor
+#_ metaplex
+#_ mango

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -27,15 +27,35 @@ update_solana_dependencies() {
   sed -i -e "s#\(solana-sdk = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-client = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-client = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-clap-utils = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-clap-utils = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
 }
 
-patch_crates_io() {
+update_anchor_dependencies() {
+  declare tomls=()
+  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$1" -name Cargo.toml)
+
+  sed -i -e "s#\(anchor-lang = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-spl = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-lang = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(anchor-spl = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
+}
+
+patch_crates_io_solana() {
   cat >> "$1" <<EOF
 [patch.crates-io]
+solana-clap-utils = { path = "$solana_dir/clap-utils" }
 solana-client = { path = "$solana_dir/client" }
 solana-program = { path = "$solana_dir/sdk/program" }
 solana-program-test = { path = "$solana_dir/program-test" }
 solana-sdk = { path = "$solana_dir/sdk" }
+EOF
+}
+
+patch_crates_io_anchor() {
+  cat >> "$1" <<EOF
+anchor-lang = { path = "$anchor_dir/lang" }
+anchor-spl = { path = "$anchor_dir/spl" }
 EOF
 }
 
@@ -47,7 +67,7 @@ example_helloworld() {
     cd example-helloworld
 
     update_solana_dependencies src/program-rust
-    patch_crates_io src/program-rust/Cargo.toml
+    patch_crates_io_solana src/program-rust/Cargo.toml
     echo "[workspace]" >> src/program-rust/Cargo.toml
 
     $cargo_build_bpf \
@@ -81,8 +101,8 @@ serum_dex() {
     cd serum-dex
 
     update_solana_dependencies .
-    patch_crates_io Cargo.toml
-    patch_crates_io dex/Cargo.toml
+    patch_crates_io_solana Cargo.toml
+    patch_crates_io_solana dex/Cargo.toml
     cat >> dex/Cargo.toml <<EOF
 [workspace]
 exclude = [
@@ -100,7 +120,66 @@ EOF
   )
 }
 
+# NOTE This isn't run in a subshell to get $anchor_dir and $anchor_ver
+anchor() {
+  set -x
+  rm -rf anchor
+  git clone https://github.com/project-serum/anchor.git
+  cd anchor
 
+  update_solana_dependencies .
+  patch_crates_io_solana Cargo.toml
+
+  $cargo build
+  $cargo test
+
+  anchor_dir=$PWD
+  anchor_ver=$(readCargoVariable version "$anchor_dir"/lang/Cargo.toml)
+
+  cd "$solana_dir"/target/downstream-projects
+}
+
+mango() {
+  (
+    set -x
+    rm -rf mango-v3
+    git clone https://github.com/blockworks-foundation/mango-v3
+    cd mango-v3
+
+    update_solana_dependencies .
+    update_anchor_dependencies .
+    patch_crates_io_solana Cargo.toml
+    patch_crates_io_anchor Cargo.toml
+
+    $cargo build
+    $cargo test
+    $cargo_build_bpf
+    $cargo_test_bpf
+  )
+}
+
+metaplex() {
+  (
+    set -x
+    rm -rf metaplex
+    git clone https://github.com/metaplex-foundation/metaplex
+    cd metaplex/rust
+
+    update_solana_dependencies .
+    update_anchor_dependencies .
+    patch_crates_io_solana Cargo.toml
+    patch_crates_io_anchor Cargo.toml
+
+    $cargo build
+    $cargo test
+    $cargo_build_bpf
+    $cargo_test_bpf
+  )
+}
+
+_ anchor
 _ example_helloworld
 _ spl
 _ serum_dex
+#_ metaplex
+_ mango

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -6,6 +6,7 @@
 set -e
 cd "$(dirname "$0")"/..
 source ci/_
+source scripts/patch-crates.sh
 source scripts/read-cargo-variable.sh
 
 solana_ver=$(readCargoVariable version sdk/Cargo.toml)
@@ -17,48 +18,6 @@ cargo_test_bpf="$solana_dir"/cargo-test-bpf
 mkdir -p target/downstream-projects
 cd target/downstream-projects
 
-update_solana_dependencies() {
-  declare tomls=()
-  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$1" -name Cargo.toml)
-
-  sed -i -e "s#\(solana-program = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-program-test = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-sdk = \"\).*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-sdk = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-client = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-client = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-clap-utils = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(solana-clap-utils = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
-}
-
-update_anchor_dependencies() {
-  declare tomls=()
-  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$1" -name Cargo.toml)
-
-  sed -i -e "s#\(anchor-lang = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(anchor-spl = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(anchor-lang = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
-  sed -i -e "s#\(anchor-spl = { version = \"\)[^\"]*\(\"\)#\1=$anchor_ver\2#g" "${tomls[@]}" || return $?
-}
-
-patch_crates_io_solana() {
-  cat >> "$1" <<EOF
-[patch.crates-io]
-solana-clap-utils = { path = "$solana_dir/clap-utils" }
-solana-client = { path = "$solana_dir/client" }
-solana-program = { path = "$solana_dir/sdk/program" }
-solana-program-test = { path = "$solana_dir/program-test" }
-solana-sdk = { path = "$solana_dir/sdk" }
-EOF
-}
-
-patch_crates_io_anchor() {
-  cat >> "$1" <<EOF
-anchor-lang = { path = "$anchor_dir/lang" }
-anchor-spl = { path = "$anchor_dir/spl" }
-EOF
-}
-
 example_helloworld() {
   (
     set -x
@@ -66,8 +25,8 @@ example_helloworld() {
     git clone https://github.com/solana-labs/example-helloworld.git
     cd example-helloworld
 
-    update_solana_dependencies src/program-rust
-    patch_crates_io_solana src/program-rust/Cargo.toml
+    update_solana_dependencies src/program-rust "$solana_ver"
+    patch_crates_io_solana src/program-rust/Cargo.toml "$solana_dir"
     echo "[workspace]" >> src/program-rust/Cargo.toml
 
     $cargo_build_bpf \
@@ -100,9 +59,9 @@ serum_dex() {
     git clone https://github.com/project-serum/serum-dex.git
     cd serum-dex
 
-    update_solana_dependencies .
-    patch_crates_io_solana Cargo.toml
-    patch_crates_io_solana dex/Cargo.toml
+    update_solana_dependencies . "$solana_ver"
+    patch_crates_io_solana Cargo.toml "$solana_dir"
+    patch_crates_io_solana dex/Cargo.toml "$solana_dir"
     cat >> dex/Cargo.toml <<EOF
 [workspace]
 exclude = [
@@ -120,66 +79,6 @@ EOF
   )
 }
 
-# NOTE This isn't run in a subshell to get $anchor_dir and $anchor_ver
-anchor() {
-  set -x
-  rm -rf anchor
-  git clone https://github.com/project-serum/anchor.git
-  cd anchor
-
-  update_solana_dependencies .
-  patch_crates_io_solana Cargo.toml
-
-  $cargo build
-  $cargo test
-
-  anchor_dir=$PWD
-  anchor_ver=$(readCargoVariable version "$anchor_dir"/lang/Cargo.toml)
-
-  cd "$solana_dir"/target/downstream-projects
-}
-
-mango() {
-  (
-    set -x
-    rm -rf mango-v3
-    git clone https://github.com/blockworks-foundation/mango-v3
-    cd mango-v3
-
-    update_solana_dependencies .
-    update_anchor_dependencies .
-    patch_crates_io_solana Cargo.toml
-    patch_crates_io_anchor Cargo.toml
-
-    $cargo build
-    $cargo test
-    $cargo_build_bpf
-    $cargo_test_bpf
-  )
-}
-
-metaplex() {
-  (
-    set -x
-    rm -rf metaplex
-    git clone https://github.com/metaplex-foundation/metaplex
-    cd metaplex/rust
-
-    update_solana_dependencies .
-    update_anchor_dependencies .
-    patch_crates_io_solana Cargo.toml
-    patch_crates_io_anchor Cargo.toml
-
-    $cargo build
-    $cargo test
-    $cargo_build_bpf
-    $cargo_test_bpf
-  )
-}
-
-_ anchor
 _ example_helloworld
 _ spl
 _ serum_dex
-#_ metaplex
-_ mango

--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -1,0 +1,30 @@
+# source this file
+
+update_solana_dependencies() {
+  declare project_root="$1"
+  declare solana_ver="$2"
+  declare tomls=()
+  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$project_root" -name Cargo.toml)
+
+  sed -i -e "s#\(solana-program = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-program-test = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-sdk = \"\).*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-sdk = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-client = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-client = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-clap-utils = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-clap-utils = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+}
+
+patch_crates_io_solana() {
+  declare Cargo_toml="$1"
+  declare solana_dir="$2"
+  cat >> "$Cargo_toml" <<EOF
+[patch.crates-io]
+solana-clap-utils = { path = "$solana_dir/clap-utils" }
+solana-client = { path = "$solana_dir/client" }
+solana-program = { path = "$solana_dir/sdk/program" }
+solana-program-test = { path = "$solana_dir/program-test" }
+solana-sdk = { path = "$solana_dir/sdk" }
+EOF
+}


### PR DESCRIPTION
#### Problem

The downstream build only tests a couple of programs, and only against the monorepo changes.  A lot of the biggest programs on Solana rely on Anchor, so we need to create an environment with patched crates from both repos in order to run tests.

#### Summary of Changes

Add Anchor as a downstream build, and also patch the Anchor crates when running tests for Anchor-based programs.

Note: we don't need to merge this, since it could make CI even tougher to pass.  Either way, it's useful to be able to run these tests easily against any branch in the monorepo.

Also note: not all of the Metaplex tests pass currently, so it's disabled.

Fixes #

cc @dmakarov @jackcmay @CriesofCarrots 