### PR TITLE
get_signatures_for_address does not correctly account for result sets that span local and Bigtable sources

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1472,6 +1472,17 @@ impl JsonRpcRequestProcessor {
                         before = results.last().map(|x| x.signature);
                     }
 
+                    if before.is_some()
+                        && bigtable_ledger_storage
+                            .get_confirmed_transaction(&before.unwrap())
+                            .await
+                            .ok()
+                            .flatten()
+                            .is_none()
+                    {
+                        before = None
+                    }
+
                     let bigtable_results = bigtable_ledger_storage
                         .get_confirmed_signatures_for_address(
                             &address,


### PR DESCRIPTION
#### Problem

When an account has tx history both in the Blockstore and Bigtable, but the tx hasn't been uploaded to Bigtable yet, there is no way for Bigtable to know which txs precede the tx passed in as `before`.

This causes Bigtable to return `RowNotFound` until the new tx is uploaded.

#### Proposed Solution

Check that `before` exists in Bigtable, and if not, set it to `None` to return the full data set.

References #21442 
Fixes #22110