### PR TITLE
Rename open_with_access_type() to open_with_options() in Blockstore

### DIFF
--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -8,6 +8,7 @@ mod tests {
         solana_core::ledger_cleanup_service::LedgerCleanupService,
         solana_ledger::{
             blockstore::{make_many_slot_shreds, Blockstore},
+            blockstore_db::BlockstoreOptions,
             get_tmp_ledger_path,
         },
         solana_measure::measure::Measure,
@@ -283,7 +284,8 @@ mod tests {
         solana_logger::setup_with("error,ledger_cleanup::tests=info");
 
         let ledger_path = get_tmp_ledger_path!();
-        let mut blockstore = Blockstore::open(&ledger_path).unwrap();
+        let mut blockstore =
+            Blockstore::open_with_options(&ledger_path, BlockstoreOptions::default()).unwrap();
         let config = get_benchmark_config();
         if config.no_compaction {
             blockstore.set_no_compaction(true);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -670,7 +670,7 @@ fn open_blockstore(
     access_type: AccessType,
     wal_recovery_mode: Option<BlockstoreRecoveryMode>,
 ) -> Blockstore {
-    match Blockstore::open_with_access_type(
+    match Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
             access_type,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -344,10 +344,7 @@ impl Blockstore {
         Self::do_open(ledger_path, BlockstoreOptions::default())
     }
 
-    pub fn open_with_access_type(
-        ledger_path: &Path,
-        options: BlockstoreOptions,
-    ) -> Result<Blockstore> {
+    pub fn open_with_options(ledger_path: &Path, options: BlockstoreOptions) -> Result<Blockstore> {
         Self::do_open(ledger_path, options)
     }
 
@@ -457,7 +454,7 @@ impl Blockstore {
         ledger_path: &Path,
         options: BlockstoreOptions,
     ) -> Result<BlockstoreSignals> {
-        let mut blockstore = Self::open_with_access_type(ledger_path, options)?;
+        let mut blockstore = Self::open_with_options(ledger_path, options)?;
         let (ledger_signal_sender, ledger_signal_receiver) = sync_channel(1);
         let (completed_slots_sender, completed_slots_receiver) =
             sync_channel(MAX_COMPLETED_SLOTS_IN_CHANNEL);
@@ -3755,7 +3752,7 @@ pub fn create_new_ledger(
     genesis_config.write(ledger_path)?;
 
     // Fill slot 0 with ticks that link back to the genesis_config to bootstrap the ledger.
-    let blockstore = Blockstore::open_with_access_type(
+    let blockstore = Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
             access_type,

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -70,7 +70,7 @@ pub fn remove_tower(tower_path: &Path, node_pubkey: &Pubkey) {
 }
 
 pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
-    Blockstore::open_with_access_type(
+    Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
             access_type: AccessType::TryPrimaryThenSecondary,

--- a/local-cluster/tests/local_cluster_flakey.rs
+++ b/local-cluster/tests/local_cluster_flakey.rs
@@ -325,7 +325,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
 
         if let Some((last_vote, _)) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
             a_votes.push(last_vote);
-            let blockstore = Blockstore::open_with_access_type(
+            let blockstore = Blockstore::open_with_options(
                 &val_a_ledger_path,
                 BlockstoreOptions {
                     access_type: AccessType::TryPrimaryThenSecondary,

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -175,7 +175,7 @@ fn start_client_rpc_services(
         block_commitment_cache,
     } = bank_info;
     let blockstore = Arc::new(
-        Blockstore::open_with_access_type(
+        Blockstore::open_with_options(
             &replica_config.ledger_path,
             BlockstoreOptions {
                 enforce_ulimit_nofile: false,


### PR DESCRIPTION
#### Summary of Changes
This PR is based on #22121 which unifies blockstore options to a struct
called BlockstoreOptions.  This PR renames `open_with_access_type()`
to `open_with_options()` as the function now accepts BlockstoreOptions
instead.

This PR also makes test_ledger_cleanup_compaction open the db with
`open_with_options` instead of open to allow specifying different options
for benchmark purposes.

