### PR TITLE
discards serialized gossip crds votes if cannot parse tx

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -983,7 +983,7 @@ impl ClusterInfo {
         assert!((vote_index as usize) < MAX_LOCKOUT_HISTORY);
         let self_pubkey = self.id();
         let now = timestamp();
-        let vote = Vote::new(self_pubkey, vote, now);
+        let vote = Vote::new(self_pubkey, vote, now).unwrap();
         let vote = CrdsData::Vote(vote_index, vote);
         let vote = CrdsValue::new_signed(vote, &self.keypair());
         let mut gossip_crds = self.gossip.crds.write().unwrap();
@@ -4219,7 +4219,8 @@ mod tests {
             keypair.pubkey(),
             vote_tx,
             0, // wallclock
-        );
+        )
+        .unwrap();
         let vote = CrdsValue::new_signed(CrdsData::Vote(1, vote), &Keypair::new());
         assert!(bincode::serialized_size(&vote).unwrap() <= PUSH_MESSAGE_MAX_PAYLOAD_SIZE as u64);
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -675,7 +675,7 @@ pub(crate) mod tests {
         rand::{seq::SliceRandom, thread_rng, SeedableRng},
         rand_chacha::ChaChaRng,
         rayon::ThreadPoolBuilder,
-        solana_perf::test_tx::test_tx,
+        solana_perf::test_tx::new_test_vote_tx,
         solana_sdk::{
             hash::{hash, HASH_BYTES},
             packet::PACKET_DATA_SIZE,
@@ -1623,6 +1623,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_process_pull_response() {
+        let mut rng = rand::thread_rng();
         let node_crds = RwLock::<Crds>::default();
         let node = CrdsGossipPull::default();
 
@@ -1678,8 +1679,8 @@ pub(crate) mod tests {
         );
 
         // construct something that's not a contact info
-        let peer_vote =
-            CrdsValue::new_unsigned(CrdsData::Vote(0, Vote::new(peer_pubkey, test_tx(), 0)));
+        let peer_vote = Vote::new(peer_pubkey, new_test_vote_tx(&mut rng), 0).unwrap();
+        let peer_vote = CrdsValue::new_unsigned(CrdsData::Vote(0, peer_vote));
         // check that older CrdsValues (non-ContactInfos) infos pass even if are too old,
         // but a recent contact info (inserted above) exists
         assert_eq!(

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -441,7 +441,7 @@ pub fn submit_vote_to_cluster_gossip(
         vec![CrdsValue::new_signed(
             CrdsData::Vote(
                 0,
-                crds_value::Vote::new(node_keypair.pubkey(), vote_tx, timestamp()),
+                crds_value::Vote::new(node_keypair.pubkey(), vote_tx, timestamp()).unwrap(),
             ),
             node_keypair,
         )],

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -599,7 +599,7 @@ mod tests {
         crate::{
             packet::{Packet, PacketBatch},
             sigverify::{self, PacketOffsets},
-            test_tx::{test_multisig_tx, test_tx, vote_tx},
+            test_tx::{new_test_vote_tx, test_multisig_tx, test_tx},
         },
         bincode::{deserialize, serialize},
         solana_sdk::{
@@ -1187,6 +1187,7 @@ mod tests {
     #[test]
     fn test_is_simple_vote_transaction() {
         solana_logger::setup();
+        let mut rng = rand::thread_rng();
 
         // tansfer tx is not
         {
@@ -1200,7 +1201,7 @@ mod tests {
 
         // single vote tx is
         {
-            let mut tx = vote_tx();
+            let mut tx = new_test_vote_tx(&mut rng);
             tx.message.instructions[0].data = vec![1, 2, 3];
             let mut packet = sigverify::make_packet_from_transaction(tx);
             let packet_offsets = do_get_packet_offsets(&packet, 0).unwrap();
@@ -1233,15 +1234,17 @@ mod tests {
     #[test]
     fn test_is_simple_vote_transaction_with_offsets() {
         solana_logger::setup();
+        let mut rng = rand::thread_rng();
 
         let mut current_offset = 0usize;
         let mut batch = PacketBatch::default();
         batch
             .packets
             .push(sigverify::make_packet_from_transaction(test_tx()));
+        let tx = new_test_vote_tx(&mut rng);
         batch
             .packets
-            .push(sigverify::make_packet_from_transaction(vote_tx()));
+            .push(sigverify::make_packet_from_transaction(tx));
         batch
             .packets
             .iter_mut()


### PR DESCRIPTION
#### Problem
The crds value is invalid if cannot parse tx into a vote.

#### Summary of Changes
Discard serialized gossip crds votes if cannot parse tx.
