### PR TITLE
Fix program log filtering

### DIFF
--- a/program-runtime/src/log_collector.rs
+++ b/program-runtime/src/log_collector.rs
@@ -69,7 +69,11 @@ impl From<LogCollector> for Vec<String> {
 #[macro_export]
 macro_rules! ic_logger_msg {
     ($log_collector:expr, $message:expr) => {
-        $crate::log_collector::log::debug!("{}", $message);
+        $crate::log_collector::log::debug!(
+            target: "solana_runtime::message_processor::stable_log",
+            "{}",
+            $message
+        );
         if let Some(log_collector) = $log_collector.as_ref() {
             if let Ok(mut log_collector) = log_collector.try_borrow_mut() {
                 log_collector.log($message);
@@ -77,7 +81,11 @@ macro_rules! ic_logger_msg {
         }
     };
     ($log_collector:expr, $fmt:expr, $($arg:tt)*) => {
-        $crate::log_collector::log::debug!($fmt, $($arg)*);
+        $crate::log_collector::log::debug!(
+            target: "solana_runtime::message_processor::stable_log",
+            $fmt,
+            $($arg)*
+        );
         if let Some(log_collector) = $log_collector.as_ref() {
             if let Ok(mut log_collector) = log_collector.try_borrow_mut() {
                 log_collector.log(&format!($fmt, $($arg)*));


### PR DESCRIPTION
#### Problem

The program log collector was moved from `solana_runtime` to `solana_program_runtime` which breaks existing clients' log filters.  This move is purely an internal refactoring and should not disrupt existing client behavior.

#### Summary of Changes

Revert to using `solana_runtime::message_processor=debug` as the log filter for program messages

Fixes #
