### PR TITLE
Use load_accounts_data_len() instead of Atomic .load()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3590,7 +3590,7 @@ impl Bank {
                                 &*self.sysvar_cache.read().unwrap(),
                                 blockhash,
                                 lamports_per_signature,
-                                self.accounts_data_len.load(Acquire),
+                                self.load_accounts_data_len(),
                             )
                             .map(|process_result| {
                                 self.store_accounts_data_len(process_result.accounts_data_len)


### PR DESCRIPTION
#### Problem

An access to `Bank::accounts_data_len` was using the underlying Atomic `.load()` instruction instead of using `Bank::load_accounts_data_len()`, which enforces the correct Ordering.

#### Summary of Changes

Replace call to `Atomic::load()` with `Bank::load_accounts_data_len()`.