### PR TITLE
chore: add owner to token balance type

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -498,6 +498,7 @@ export type ParsedInnerInstruction = {
 export type TokenBalance = {
   accountIndex: number;
   mint: string;
+  owner?: string;
   uiTokenAmount: TokenAmount;
 };
 
@@ -1437,6 +1438,7 @@ const ParsedConfirmedTransactionResult = pick({
 const TokenBalanceResult = pick({
   accountIndex: number(),
   mint: string(),
+  owner: optional(string()),
   uiTokenAmount: TokenAmountResult,
 });
 


### PR DESCRIPTION
This adds the `owner` type to the `TokenBalance` in web3.js — this seems like it should be valid since it's in the Rust types — https://github.com/solana-labs/solana/blob/76098dd42a71d0acc5c5b9c4af22c93b19faab25/transaction-status/src/lib.rs#L130