### PR TITLE
Prevent log spam by updating channel error type

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -460,7 +460,7 @@ impl ClusterInfoVoteListener {
             ) {
                 match e {
                     Error::CrossbeamRecvTimeout(RecvTimeoutError::Disconnected)
-                    | Error::ReadyTimeout => (),
+                    | Error::CrossbeamRecvTimeout(RecvTimeoutError::Timeout) => (),
                     _ => {
                         error!("thread {:?} error {:?}", thread::current().name(), e);
                     }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/21981 removed the `Select` channel logic in favor of `recv_timeout`, so receivers expecting error type for `Select` are no longer correct

#### Summary of Changes
Use `RecvTimeout` errors

Fixes #
