### PR TITLE
(Draft) Make RocksFifo as the default shred storage type to run full tests.

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1040,7 +1040,7 @@ impl Default for BlockstoreOptions {
             access_type: AccessType::PrimaryOnly,
             recovery_mode: None,
             enforce_ulimit_nofile: true,
-            shred_storage_type: ShredStorageType::RocksLevel,
+            shred_storage_type: ShredStorageType::RocksFifo,
             // Maximum size of cf::DataShred.  Used when `shred_storage_type`
             // is set to ShredStorageType::RocksFifo.
             shred_data_cf_size: DEFAULT_FIFO_COMPACTION_DATA_CF_SIZE,


### PR DESCRIPTION
#### Summary of Changes
This experimental draft PR is used for monitoring test results when RocksFifo
is set as the default shred storage type.
