### PR TITLE
Bumps solana_rbpf to version v0.2.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6055,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4ea641d81290842c822f1348ce9f35ff3e11d09553e709c894af9765b7934c"
+checksum = "8a0379d2ea44628bd591f8db07de2db6432d95bac7dec3801f6e3d0d3406794c"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ solana-config-program = { path = "../programs/config", version = "=1.10.0" }
 solana-faucet = { path = "../faucet", version = "=1.10.0" }
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.10.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3550,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4ea641d81290842c822f1348ce9f35ff3e11d09553e709c894af9765b7934c"
+checksum = "8a0379d2ea44628bd591f8db07de2db6432d95bac7dec3801f6e3d0d3406794c"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.10.0" }
 solana-logger = { path = "../../logger", version = "=1.10.0" }
 solana-measure = { path = "../../measure", version = "=1.10.0" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 solana-runtime = { path = "../../runtime", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -17,7 +17,7 @@ libsecp256k1 = "0.6.0"
 solana-measure = { path = "../../measure", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,5 +17,5 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.10.
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 time = "0.3.5"


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.20](https://github.com/solana-labs/rbpf/releases/tag/v0.2.20) was released

#### Summary of Changes
Bumps solana_rbpf to version `v0.2.20`

Fixes #
