### PR TITLE
Refactor: `InstructionAccount` indices

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -451,8 +451,11 @@ mod tests {
         ];
         let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         let program_indices = [0];
-        let preparation =
-            prepare_mock_invoke_context(transaction_accounts.clone(), instruction_accounts);
+        let preparation = prepare_mock_invoke_context(
+            transaction_accounts.clone(),
+            instruction_accounts,
+            &program_indices,
+        );
         let transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
         let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
         invoke_context

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -209,8 +209,9 @@ native machine code before execting it in the virtual machine.",
             input.instruction_data
         }
     };
-    let preparation = prepare_mock_invoke_context(transaction_accounts, instruction_accounts);
     let program_indices = [0, 1];
+    let preparation =
+        prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
     let transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
     let mut invoke_context = InvokeContext::new_mock(&transaction_context, &[]);
     invoke_context

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -117,12 +117,13 @@ impl MessageProcessor {
             let instruction_accounts = instruction
                 .accounts
                 .iter()
-                .map(|account_index| {
-                    let account_index = *account_index as usize;
+                .map(|index_in_transaction| {
+                    let index_in_transaction = *index_in_transaction as usize;
                     InstructionAccount {
-                        index: account_index,
-                        is_signer: message.is_signer(account_index),
-                        is_writable: message.is_writable(account_index),
+                        index_in_transaction,
+                        index_in_caller: program_indices.len().saturating_add(index_in_transaction),
+                        is_signer: message.is_signer(index_in_transaction),
+                        is_writable: message.is_writable(index_in_transaction),
                     }
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
#### Problem
The property `index` of `InstructionAccount` should be called `index_in_transaction`.
Also, we currently search for the `index_in_caller` in the program runtime multiple times and could be reusing them.
Thus it makes sense to introduce an `index_in_caller` property as well.

#### Summary of Changes
- Splits `index` of `InstructionAccount` into `index_in_transaction` and `index_in_caller`.
- Adds more helpers and convenience methods to `transaction_context.rs`

Fixes #
