### PR TITLE
Bump solana_rbpf to version v0.2.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4ea641d81290842c822f1348ce9f35ff3e11d09553e709c894af9765b7934c"
+checksum = "8a0379d2ea44628bd591f8db07de2db6432d95bac7dec3801f6e3d0d3406794c"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,7 +40,7 @@ solana-config-program = { path = "../programs/config", version = "=1.8.12" }
 solana-faucet = { path = "../faucet", version = "=1.8.12" }
 solana-logger = { path = "../logger", version = "=1.8.12" }
 solana-net-utils = { path = "../net-utils", version = "=1.8.12" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.8.12" }
 solana-sdk = { path = "../sdk", version = "=1.8.12" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.8.12" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3698,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4ea641d81290842c822f1348ce9f35ff3e11d09553e709c894af9765b7934c"
+checksum = "8a0379d2ea44628bd591f8db07de2db6432d95bac7dec3801f6e3d0d3406794c"
 dependencies = [
  "byteorder 1.3.4",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -30,7 +30,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.8.12" }
 solana-cli-output = { path = "../../cli-output", version = "=1.8.12" }
 solana-logger = { path = "../../logger", version = "=1.8.12" }
 solana-measure = { path = "../../measure", version = "=1.8.12" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 solana-runtime = { path = "../../runtime", version = "=1.8.12" }
 solana-sdk = { path = "../../sdk", version = "=1.8.12" }
 solana-transaction-status = { path = "../../transaction-status", version = "=1.8.12" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -21,7 +21,7 @@ sha3 = "0.9.1"
 solana-measure = { path = "../../measure", version = "=1.8.12" }
 solana-runtime = { path = "../../runtime", version = "=1.8.12" }
 solana-sdk = { path = "../../sdk", version = "=1.8.12" }
-solana_rbpf = "=0.2.19"
+solana_rbpf = "=0.2.20"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Manual backport of #22164 to `v1.8`.