### PR TITLE
Ignore spl downstream build

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -102,5 +102,5 @@ EOF
 
 
 _ example_helloworld
-_ spl
+# _ spl
 _ serum_dex


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana-program-library/pull/2674 bumps the SPL library to v1.9, which uses some new client apis, breaking the spl downstream build on monorepo v1.8

#### Summary of Changes
Ignore broken build
