### PR TITLE
Revert "Count compute units even when transaction errors (#22059)"

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -25,7 +25,7 @@ use {
             TransactionExecutionResult,
         },
         bank_utils,
-        cost_model::{CostModel, ExecutionCost},
+        cost_model::CostModel,
         transaction_batch::TransactionBatch,
         vote_sender_types::ReplayVoteSender,
     },
@@ -974,20 +974,14 @@ impl BankingStage {
         let tx_costs = qos_service.compute_transaction_costs(txs.iter());
 
         let transactions_qos_results =
-            qos_service.select_transactions_per_cost(txs.iter(), tx_costs.into_iter(), bank);
+            qos_service.select_transactions_per_cost(txs.iter(), tx_costs.iter(), bank);
 
         // Only lock accounts for those transactions are selected for the block;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
         // same account state
         let mut lock_time = Measure::start("lock_time");
-        let batch = bank.prepare_sanitized_batch_with_results(
-            txs,
-            transactions_qos_results
-                .into_iter()
-                .map(|transaction_cost_result| {
-                    transaction_cost_result.map(|transaction_cost| transaction_cost.execution_cost)
-                }),
-        );
+        let batch =
+            bank.prepare_sanitized_batch_with_results(txs, transactions_qos_results.into_iter());
         lock_time.stop();
 
         // retryable_txs includes AccountInUse, WouldExceedMaxBlockCostLimit
@@ -1087,9 +1081,9 @@ impl BankingStage {
     fn prepare_filter_for_pending_transactions(
         transactions_len: usize,
         pending_tx_indexes: &[usize],
-    ) -> Vec<transaction::Result<ExecutionCost>> {
+    ) -> Vec<transaction::Result<()>> {
         let mut mask = vec![Err(TransactionError::BlockhashNotFound); transactions_len];
-        pending_tx_indexes.iter().for_each(|x| mask[*x] = Ok(0));
+        pending_tx_indexes.iter().for_each(|x| mask[*x] = Ok(()));
         mask
     }
 
@@ -1180,7 +1174,7 @@ impl BankingStage {
 
         let results = bank.check_transactions(
             transactions,
-            filter.into_iter(),
+            &filter,
             (MAX_PROCESSING_AGE)
                 .saturating_sub(max_tx_fwd_delay)
                 .saturating_sub(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET as usize),
@@ -1985,20 +1979,20 @@ mod tests {
             vec![
                 Err(TransactionError::BlockhashNotFound),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(0),
+                Ok(()),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(0),
-                Ok(0)
+                Ok(()),
+                Ok(())
             ]
         );
 
         assert_eq!(
             BankingStage::prepare_filter_for_pending_transactions(6, &[0, 2, 3]),
             vec![
-                Ok(0),
+                Ok(()),
                 Err(TransactionError::BlockhashNotFound),
-                Ok(0),
-                Ok(0),
+                Ok(()),
+                Ok(()),
                 Err(TransactionError::BlockhashNotFound),
                 Err(TransactionError::BlockhashNotFound),
             ]
@@ -2012,10 +2006,10 @@ mod tests {
                 &[
                     (Err(TransactionError::BlockhashNotFound), None),
                     (Err(TransactionError::BlockhashNotFound), None),
-                    (Ok(0), None),
+                    (Ok(()), None),
                     (Err(TransactionError::BlockhashNotFound), None),
-                    (Ok(0), None),
-                    (Ok(0), None),
+                    (Ok(()), None),
+                    (Ok(()), None),
                 ],
                 &[2, 4, 5, 9, 11, 13]
             ),
@@ -2025,12 +2019,12 @@ mod tests {
         assert_eq!(
             BankingStage::filter_valid_transaction_indexes(
                 &[
-                    (Ok(0), None),
+                    (Ok(()), None),
                     (Err(TransactionError::BlockhashNotFound), None),
                     (Err(TransactionError::BlockhashNotFound), None),
-                    (Ok(0), None),
-                    (Ok(0), None),
-                    (Ok(0), None),
+                    (Ok(()), None),
+                    (Ok(()), None),
+                    (Ok(()), None),
                 ],
                 &[1, 6, 7, 9, 31, 43]
             ),

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -246,7 +246,6 @@ mod tests {
                 ProgramTiming {
                     accumulated_us,
                     accumulated_units,
-                    current_cost_model_estimated_units: 0,
                     count,
                 },
             );
@@ -282,7 +281,6 @@ mod tests {
                 ProgramTiming {
                     accumulated_us,
                     accumulated_units,
-                    current_cost_model_estimated_units: 0,
                     count,
                 },
             );

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -117,18 +117,18 @@ impl QosService {
     pub fn select_transactions_per_cost<'a>(
         &self,
         transactions: impl Iterator<Item = &'a SanitizedTransaction>,
-        transactions_costs: impl Iterator<Item = TransactionCost>,
+        transactions_costs: impl Iterator<Item = &'a TransactionCost>,
         bank: &Arc<Bank>,
-    ) -> Vec<transaction::Result<TransactionCost>> {
+    ) -> Vec<transaction::Result<()>> {
         let mut cost_tracking_time = Measure::start("cost_tracking_time");
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let select_results = transactions
             .zip(transactions_costs)
-            .map(|(tx, cost)| match cost_tracker.try_add(tx, &cost) {
+            .map(|(tx, cost)| match cost_tracker.try_add(tx, cost) {
                 Ok(current_block_cost) => {
                     debug!("slot {:?}, transaction {:?}, cost {:?}, fit into current block, current block cost {}", bank.slot(), tx, cost, current_block_cost);
                     self.metrics.selected_txs_count.fetch_add(1, Ordering::Relaxed);
-                    Ok(cost)
+                    Ok(())
                 },
                 Err(e) => {
                     debug!("slot {:?}, transaction {:?}, cost {:?}, not fit into current block, '{:?}'", bank.slot(), tx, cost, e);
@@ -441,8 +441,7 @@ mod tests {
         bank.write_cost_tracker()
             .unwrap()
             .set_limits(cost_limit, cost_limit);
-        let results =
-            qos_service.select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
+        let results = qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
 
         // verify that first transfer tx and all votes are allowed
         assert_eq!(results.len(), txs.len());

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -102,10 +102,10 @@ thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::
                     .unwrap())
 );
 
-fn first_err<T>(results: &[Result<T>]) -> Result<()> {
+fn first_err(results: &[Result<()>]) -> Result<()> {
     for r in results {
-        if let Err(e) = r {
-            return Err(e.clone());
+        if r.is_err() {
+            return r.clone();
         }
     }
     Ok(())

--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -4,7 +4,6 @@ use {solana_sdk::pubkey::Pubkey, std::collections::HashMap};
 pub struct ProgramTiming {
     pub accumulated_us: u64,
     pub accumulated_units: u64,
-    pub current_cost_model_estimated_units: u64,
     pub count: u32,
 }
 
@@ -47,24 +46,10 @@ impl ExecuteDetailsTimings {
             program_timing.count = program_timing.count.saturating_add(other.count);
         }
     }
-    pub fn accumulate_program(
-        &mut self,
-        program_id: &Pubkey,
-        us: u64,
-        actual_compute_units_consumed: u64,
-        estimated_execution_cost: u64,
-        is_error: bool,
-    ) {
+    pub fn accumulate_program(&mut self, program_id: &Pubkey, us: u64, units: u64) {
         let program_timing = self.per_program_timings.entry(*program_id).or_default();
         program_timing.accumulated_us = program_timing.accumulated_us.saturating_add(us);
-        let compute_units_update = if is_error {
-            std::cmp::max(actual_compute_units_consumed, estimated_execution_cost)
-        } else {
-            actual_compute_units_consumed
-        };
-        program_timing.accumulated_units = program_timing
-            .accumulated_units
-            .saturating_add(compute_units_update);
+        program_timing.accumulated_units = program_timing.accumulated_units.saturating_add(units);
         program_timing.count = program_timing.count.saturating_add(1);
     }
 }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -283,7 +283,6 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
                 Some(&caller_write_privileges),
                 &program_indices,
             )
-            .result
             .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2395,7 +2395,6 @@ fn call<'a, 'b: 'a>(
             Some(&caller_write_privileges),
             &program_indices,
         )
-        .result
         .map_err(SyscallError::InstructionError)?;
 
     // Copy results back to caller

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -18,7 +18,6 @@ use {
 };
 
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
-pub type ExecutionCost = u64;
 
 // costs are stored in number of 'compute unit's
 #[derive(Debug)]
@@ -27,7 +26,7 @@ pub struct TransactionCost {
     pub signature_cost: u64,
     pub write_lock_cost: u64,
     pub data_bytes_cost: u64,
-    pub execution_cost: ExecutionCost,
+    pub execution_cost: u64,
     // `cost_weight` is a multiplier could be applied to transaction cost,
     // if set to zero allows the transaction to bypass cost limit check.
     pub cost_weight: u32,

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -1,12 +1,12 @@
 use {
-    crate::{bank::Bank, cost_model::ExecutionCost},
+    crate::bank::Bank,
     solana_sdk::transaction::{Result, SanitizedTransaction},
     std::borrow::Cow,
 };
 
 // Represents the results of trying to lock a set of accounts
 pub struct TransactionBatch<'a, 'b> {
-    lock_results: Vec<Result<ExecutionCost>>,
+    lock_results: Vec<Result<()>>,
     bank: &'a Bank,
     sanitized_txs: Cow<'b, [SanitizedTransaction]>,
     pub(crate) needs_unlock: bool,
@@ -14,7 +14,7 @@ pub struct TransactionBatch<'a, 'b> {
 
 impl<'a, 'b> TransactionBatch<'a, 'b> {
     pub fn new(
-        lock_results: Vec<Result<ExecutionCost>>,
+        lock_results: Vec<Result<()>>,
         bank: &'a Bank,
         sanitized_txs: Cow<'b, [SanitizedTransaction]>,
     ) -> Self {
@@ -27,7 +27,7 @@ impl<'a, 'b> TransactionBatch<'a, 'b> {
         }
     }
 
-    pub fn lock_results(&self) -> &Vec<Result<ExecutionCost>> {
+    pub fn lock_results(&self) -> &Vec<Result<()>> {
         &self.lock_results
     }
 


### PR DESCRIPTION
#### Problem
Fix doesn't fix update cost model on replay side, and is complex

#### Summary of Changes
Revert
Fixes #
