### PR TITLE
bypass time based retransmission for slots without propagated stats

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -854,7 +854,11 @@ impl ReplayStage {
     ) {
         let start_slot = poh_recorder.lock().unwrap().start_slot();
         if let Some(latest_leader_slot) = progress.get_latest_leader_slot(start_slot) {
-            if !progress.is_propagated(latest_leader_slot) {
+            if !progress
+                .get_propagated_stats(latest_leader_slot)
+                .map(|stats| stats.is_propagated)
+                .unwrap_or(true)
+            {
                 warn!("Slot not propagated: slot={}", latest_leader_slot);
                 let retransmit_info = progress.get_retransmit_info(latest_leader_slot).unwrap();
                 if retransmit_info.reached_retransmit_threshold() {


### PR DESCRIPTION
#### Problem
```
thread 'solana-replay-stage' panicked at 'All frozen banks must exist in the Progress map', core/src/progress_map.rs:481:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::panicking::panic_display
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:64:5
   3: core::option::expect_failed
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/option.rs:1638:5
   4: solana_core::progress_map::ProgressMap::is_propagated
   5: solana_core::replay_stage::ReplayStage::retransmit_latest_unpropagated_leader_slot
   6: solana_core::replay_stage::ReplayStage::new::{{closure}}
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: IoError(Custom { kind: Other, error: "retry_transfer failed in 10 retries" })', /solana/local-cluster/src/cluster_tests.rs:79:14
stack backtrace:
```

https://buildkite.com/solana-labs/solana/builds/62281#65a507b6-ef34-4eb5-a87d-8b664c0dd0e3

#### Summary of Changes
Only consider retransmission of slots for which we have propagated stats.

Fixes #
