### PR TITLE
Limit number of accounts that a transaction can lock

### DIFF
--- a/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
@@ -331,6 +331,7 @@ pub enum DbTransactionErrorCode {
     UnsupportedVersion,
     InvalidWritableAccount,
     WouldExceedMaxAccountDataCostLimit,
+    TooManyAccountLocks,
 }
 
 impl From<&TransactionError> for DbTransactionErrorCode {
@@ -362,6 +363,7 @@ impl From<&TransactionError> for DbTransactionErrorCode {
             TransactionError::WouldExceedMaxAccountDataCostLimit => {
                 Self::WouldExceedMaxAccountDataCostLimit
             }
+            TransactionError::TooManyAccountLocks => Self::TooManyAccountLocks,
         }
     }
 }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -123,7 +123,7 @@ impl TransactionStatusService {
                             transaction.message(),
                             lamports_per_signature,
                         );
-                        let tx_account_locks = transaction.get_account_locks();
+                        let tx_account_locks = transaction.get_account_locks_unchecked();
 
                         let inner_instructions = inner_instructions.map(|inner_instructions| {
                             inner_instructions

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -238,7 +238,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "2pPboTQ9ixNuR1hvRt7McJriam5EHfd3vpBWfxnVbmF3")]
+#[frozen_abi(digest = "6XG6H1FChrDdY39K62KFWj5XfDao4dd24WZgcJkdMu1E")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 // Eager rent collection repeats in cyclic manner.
@@ -3069,7 +3069,10 @@ impl Bank {
             .into_iter()
             .map(SanitizedTransaction::from_transaction_for_tests)
             .collect::<Vec<_>>();
-        let lock_results = self.rc.accounts.lock_accounts(sanitized_txs.iter());
+        let lock_results = self
+            .rc
+            .accounts
+            .lock_accounts(sanitized_txs.iter(), &FeatureSet::all_enabled());
         TransactionBatch::new(lock_results, self, Cow::Owned(sanitized_txs))
     }
 
@@ -3085,7 +3088,10 @@ impl Bank {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        let lock_results = self.rc.accounts.lock_accounts(sanitized_txs.iter());
+        let lock_results = self
+            .rc
+            .accounts
+            .lock_accounts(sanitized_txs.iter(), &FeatureSet::all_enabled());
         Ok(TransactionBatch::new(
             lock_results,
             self,
@@ -3098,7 +3104,10 @@ impl Bank {
         &'a self,
         txs: &'b [SanitizedTransaction],
     ) -> TransactionBatch<'a, 'b> {
-        let lock_results = self.rc.accounts.lock_accounts(txs.iter());
+        let lock_results = self
+            .rc
+            .accounts
+            .lock_accounts(txs.iter(), &self.feature_set);
         TransactionBatch::new(lock_results, self, Cow::Borrowed(txs))
     }
 
@@ -3110,10 +3119,11 @@ impl Bank {
         transaction_results: impl Iterator<Item = Result<()>>,
     ) -> TransactionBatch<'a, 'b> {
         // this lock_results could be: Ok, AccountInUse, WouldExceedBlockMaxLimit or WouldExceedAccountMaxLimit
-        let lock_results = self
-            .rc
-            .accounts
-            .lock_accounts_with_results(transactions.iter(), transaction_results);
+        let lock_results = self.rc.accounts.lock_accounts_with_results(
+            transactions.iter(),
+            transaction_results,
+            &self.feature_set,
+        );
         TransactionBatch::new(lock_results, self, Cow::Borrowed(transactions))
     }
 
@@ -3122,7 +3132,9 @@ impl Bank {
         &'a self,
         transaction: SanitizedTransaction,
     ) -> TransactionBatch<'a, '_> {
-        let mut batch = TransactionBatch::new(vec![Ok(())], self, Cow::Owned(vec![transaction]));
+        let lock_result = transaction.get_account_locks(&self.feature_set).map(|_| ());
+        let mut batch =
+            TransactionBatch::new(vec![lock_result], self, Cow::Owned(vec![transaction]));
         batch.needs_unlock = false;
         batch
     }
@@ -6218,6 +6230,7 @@ pub(crate) mod tests {
             system_program,
             sysvar::rewards::Rewards,
             timing::duration_as_s,
+            transaction::MAX_TX_ACCOUNT_LOCKS,
         },
         solana_vote_program::{
             vote_instruction,
@@ -11584,6 +11597,43 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_process_transaction_with_too_many_account_locks() {
+        solana_logger::setup();
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
+
+        let account_metas = vec![
+            AccountMeta::new(from_pubkey, false),
+            AccountMeta::new(to_pubkey, false),
+        ];
+
+        bank.add_builtin(
+            "mock_vote",
+            &solana_vote_program::id(),
+            mock_ok_vote_processor,
+        );
+
+        let instruction =
+            Instruction::new_with_bincode(solana_vote_program::id(), &10, account_metas);
+        let mut tx = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            bank.last_blockhash(),
+        );
+
+        while tx.message.account_keys.len() <= MAX_TX_ACCOUNT_LOCKS {
+            tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
+        }
+
+        let result = bank.process_transaction(&tx);
+        assert_eq!(result, Err(TransactionError::TooManyAccountLocks));
+    }
+
+    #[test]
     fn test_program_id_as_payer() {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(500);
@@ -14953,44 +15003,6 @@ pub(crate) mod tests {
                 bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
                     .err(),
                 Some(TransactionError::SanitizeFailure),
-            );
-        }
-    }
-
-    #[test]
-    fn test_verify_transactions_load_duplicate_account() {
-        let GenesisConfigInfo { genesis_config, .. } =
-            create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
-        let bank = Bank::new_for_tests(&genesis_config);
-
-        let mut rng = rand::thread_rng();
-        let recent_blockhash = hash::new_rand(&mut rng);
-        let from_keypair = Keypair::new();
-        let to_keypair = Keypair::new();
-        let from_pubkey = from_keypair.pubkey();
-        let to_pubkey = to_keypair.pubkey();
-
-        let make_transaction = || {
-            let mut message = Message::new(
-                &[system_instruction::transfer(&from_pubkey, &to_pubkey, 1)],
-                Some(&from_pubkey),
-            );
-            let to_index = message
-                .account_keys
-                .iter()
-                .position(|k| k == &to_pubkey)
-                .unwrap();
-            message.account_keys[to_index] = from_pubkey;
-            Transaction::new(&[&from_keypair], message, recent_blockhash)
-        };
-
-        // Duplicate account
-        {
-            let tx = make_transaction();
-            assert_eq!(
-                bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                    .err(),
-                Some(TransactionError::AccountLoadedTwice),
             );
         }
     }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -287,6 +287,10 @@ pub mod cap_accounts_data_len {
     solana_sdk::declare_id!("capRxUrBjNkkCpjrJxPGfPaWijB7q3JoDfsWXAnt46r");
 }
 
+pub mod max_tx_account_locks {
+    solana_sdk::declare_id!("CBkDroRDqm8HwHe6ak9cguPjUomrASEkfmxEaZ5CNNxz");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -353,6 +357,7 @@ lazy_static! {
         (allow_votes_to_directly_update_vote_state::id(), "enable direct vote state update"),
         (reject_all_elf_rw::id(), "reject all read-write data in program elfs"),
         (cap_accounts_data_len::id(), "cap the accounts data len"),
+        (max_tx_account_locks::id(), "enforce max number of locked accounts per transaction"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -105,6 +105,10 @@ pub enum TransactionError {
     /// Transaction would exceed max account data limit within the block
     #[error("Transaction would exceed max account data limit within the block")]
     WouldExceedMaxAccountDataCostLimit,
+
+    /// Transaction locked too many accounts
+    #[error("Transaction locked too many accounts")]
+    TooManyAccountLocks,
 }
 
 impl From<SanitizeError> for TransactionError {
@@ -114,12 +118,7 @@ impl From<SanitizeError> for TransactionError {
 }
 
 impl From<SanitizeMessageError> for TransactionError {
-    fn from(err: SanitizeMessageError) -> Self {
-        match err {
-            SanitizeMessageError::IndexOutOfBounds
-            | SanitizeMessageError::ValueOutOfBounds
-            | SanitizeMessageError::InvalidValue => Self::SanitizeFailure,
-            SanitizeMessageError::DuplicateAccountKey => Self::AccountLoadedTwice,
-        }
+    fn from(_err: SanitizeMessageError) -> Self {
+        Self::SanitizeFailure
     }
 }

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -46,6 +46,7 @@ enum TransactionErrorType {
     INVALID_WRITABLE_ACCOUNT = 19;
     WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT = 20;
     WOULD_EXCEED_MAX_ACCOUNT_DATA_COST_LIMIT = 21;
+    TOO_MANY_ACCOUNT_LOCKS = 22;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -569,6 +569,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             19 => TransactionError::InvalidWritableAccount,
             20 => TransactionError::WouldExceedMaxAccountCostLimit,
             21 => TransactionError::WouldExceedMaxAccountDataCostLimit,
+            22 => TransactionError::TooManyAccountLocks,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -641,6 +642,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::WouldExceedMaxAccountDataCostLimit => {
                     tx_by_addr::TransactionErrorType::WouldExceedMaxAccountDataCostLimit
+                }
+                TransactionError::TooManyAccountLocks => {
+                    tx_by_addr::TransactionErrorType::TooManyAccountLocks
                 }
             } as i32,
             instruction_error: match transaction_error {


### PR DESCRIPTION
#### Problem
No limit to the number of accounts that a transaction can lock

#### Summary of Changes
- Moved account key validation to `SanitizedTransaction::get_account_locks()`
- Added validation check to limit the number of locked accounts per transaction to 64
- Added feature switch to activate the new validation check

Fixes https://github.com/solana-labs/solana/issues/21748
