### PR TITLE
Fix check failure in test_process_instruction_compute_budget

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1674,7 +1674,8 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(account_index, account_meta)| InstructionAccount {
-                index: account_index,
+                index_in_transaction: account_index,
+                index_in_caller: 1 + account_index,
                 is_signer: account_meta.is_signer,
                 is_writable: account_meta.is_writable,
             })


### PR DESCRIPTION
#### Problem
Looks like the master is failing the follow check in test_process_instruction_compute_budget:

```
error[E0560]: struct `solana_sdk::transaction_context::InstructionAccount` has no field named `index`
--
  | --> program-runtime/src/invoke_context.rs:1677:17
  | \|
  | 1677 \|                 index: account_index,
  | \|                 ^^^^^ `solana_sdk::transaction_context::InstructionAccount` does not have this field
  | \|
  | = note: available fields are: `index_in_transaction`, `index_in_caller`, `is_signer`, `is_writable`

```

#### Summary of Changes
This PR fixes the check failure by assigning account_index to the right field.
