### PR TITLE
Lower vote-only-mode to 400 slots

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1520,7 +1520,7 @@ impl ReplayStage {
             );
 
             let root_distance = poh_slot - root_slot;
-            const MAX_ROOT_DISTANCE_FOR_VOTE_ONLY: Slot = 500;
+            const MAX_ROOT_DISTANCE_FOR_VOTE_ONLY: Slot = 400;
             let vote_only_bank = if root_distance > MAX_ROOT_DISTANCE_FOR_VOTE_ONLY {
                 datapoint_info!("vote-only-bank", ("slot", poh_slot, i64));
                 true


### PR DESCRIPTION
#### Problem

500 slots is a bit close and allows for 800-1000 slot root distance

#### Summary of Changes

Reduce to 400 slot height difference to trigger vote-mode to keep the cluster in check.

Fixes #
