### PR TITLE
Bump local cluster timeout

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -287,7 +287,7 @@ pub fn check_for_new_roots(num_new_roots: usize, contact_infos: &[ContactInfo], 
     let mut done = false;
     let mut last_print = Instant::now();
     let loop_start = Instant::now();
-    let loop_timeout = Duration::from_secs(60);
+    let loop_timeout = Duration::from_secs(180);
     let mut num_roots_map = HashMap::new();
     while !done {
         assert!(loop_start.elapsed() < loop_timeout);

--- a/sdk/bpf/syscalls.txt
+++ b/sdk/bpf/syscalls.txt
@@ -9,7 +9,6 @@ sol_try_find_program_address
 sol_sha256
 sol_keccak256
 sol_secp256k1_recover
-sol_blake3
 sol_get_clock_sysvar
 sol_get_epoch_schedule_sysvar
 sol_get_fees_sysvar


### PR DESCRIPTION
#### Problem
Local cluster timing out because current 60 second timeout is not enough in many cases to resolve a 128 long lockout from being on a minor fork

#### Summary of Changes
Bump to 180 second timeout, consistent with master and 1.9

Fixes #
