### PR TITLE
Change cost tracker to handle chained batch cost

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -755,7 +755,7 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
         for transaction in &entry.transactions {
             programs += transaction.message().instructions.len();
             let tx_cost = cost_model.calculate_cost(transaction, true);
-            let result = cost_tracker.try_add(transaction, &tx_cost);
+            let result = cost_tracker.try_add(&tx_cost);
             if result.is_err() {
                 println!(
                     "Slot: {}, CostModel rejected transaction {:?}, reason {:?}",

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -16,6 +16,7 @@ const MAX_WRITABLE_ACCOUNTS: usize = 256;
 // costs are stored in number of 'compute unit's
 #[derive(AbiExample, Default, Debug)]
 pub struct TransactionCost {
+    pub readable_accounts: Vec<Pubkey>,
     pub writable_accounts: Vec<Pubkey>,
     pub signature_cost: u64,
     pub write_lock_cost: u64,
@@ -136,6 +137,8 @@ impl CostModel {
             if is_writable {
                 tx_cost.writable_accounts.push(*k);
                 tx_cost.write_lock_cost += WRITE_LOCK_UNITS;
+            } else {
+                tx_cost.readable_accounts.push(*k);
             }
         });
     }

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -5,11 +5,9 @@
 //!
 use {
     crate::{block_cost_limits::*, cost_model::TransactionCost},
-    solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::Transaction},
-    std::collections::HashMap,
+    solana_sdk::{clock::Slot, pubkey::Pubkey},
+    std::collections::HashSet,
 };
-
-const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 512;
 
 #[derive(Debug, Clone)]
 pub enum CostTrackerError {
@@ -20,11 +18,51 @@ pub enum CostTrackerError {
     WouldExceedAccountMaxLimit,
 }
 
+#[derive(Debug, Default)]
+struct ChainedCost {
+    read_keys: HashSet<Pubkey>,
+    write_keys: HashSet<Pubkey>,
+    current_batch_cost: u64,
+    total_chained_cost: u64,
+}
+
+impl ChainedCost {
+    fn has_conflicts(&self, read_keys: &[Pubkey], write_keys: &[Pubkey]) -> bool {
+        for account_key in read_keys.iter() {
+            if self.write_keys.contains(account_key) {
+                return true;
+            }
+        }
+        for account_key in write_keys.iter() {
+            if self.read_keys.contains(account_key) || self.write_keys.contains(account_key) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn add_new_batch(&mut self, read_keys: &[Pubkey], write_keys: &[Pubkey], cost: u64) {
+        if self.has_conflicts(read_keys, write_keys) {
+            self.total_chained_cost += self.current_batch_cost;
+            self.current_batch_cost = cost;
+            self.read_keys.clear();
+            self.write_keys.clear();
+        }
+        self.current_batch_cost = std::cmp::max(self.current_batch_cost, cost);
+        for key in read_keys.iter() {
+            self.read_keys.insert(*key);
+        }
+        for key in write_keys.iter() {
+            self.write_keys.insert(*key);
+        }
+    }
+}
+
 #[derive(AbiExample, Debug)]
 pub struct CostTracker {
     account_cost_limit: u64,
     block_cost_limit: u64,
-    cost_by_writable_accounts: HashMap<Pubkey, u64>,
+    chained_cost: ChainedCost,
     block_cost: u64,
     transaction_count: u64,
 }
@@ -41,9 +79,9 @@ impl CostTracker {
         Self {
             account_cost_limit,
             block_cost_limit,
-            cost_by_writable_accounts: HashMap::with_capacity(WRITABLE_ACCOUNTS_PER_BLOCK),
             block_cost: 0,
             transaction_count: 0,
+            chained_cost: ChainedCost::default(),
         }
     }
 
@@ -53,26 +91,26 @@ impl CostTracker {
         self.block_cost_limit = block_cost_limit;
     }
 
-    pub fn would_transaction_fit(
-        &self,
-        _transaction: &Transaction,
-        tx_cost: &TransactionCost,
-    ) -> Result<(), CostTrackerError> {
-        self.would_fit(&tx_cost.writable_accounts, &tx_cost.sum())
+    pub fn would_transaction_fit(&self, tx_cost: &TransactionCost) -> Result<(), CostTrackerError> {
+        self.would_fit(
+            &tx_cost.readable_accounts,
+            &tx_cost.writable_accounts,
+            tx_cost.sum(),
+        )
     }
 
-    pub fn add_transaction_cost(&mut self, _transaction: &Transaction, tx_cost: &TransactionCost) {
-        self.add_transaction(&tx_cost.writable_accounts, &tx_cost.sum());
+    pub fn add_transaction_cost(&mut self, tx_cost: &TransactionCost) {
+        self.add_transaction(
+            &tx_cost.readable_accounts,
+            &tx_cost.writable_accounts,
+            tx_cost.sum(),
+        );
     }
 
-    pub fn try_add(
-        &mut self,
-        _transaction: &Transaction,
-        tx_cost: &TransactionCost,
-    ) -> Result<u64, CostTrackerError> {
+    pub fn try_add(&mut self, tx_cost: &TransactionCost) -> Result<u64, CostTrackerError> {
         let cost = tx_cost.sum();
-        self.would_fit(&tx_cost.writable_accounts, &cost)?;
-        self.add_transaction(&tx_cost.writable_accounts, &cost);
+        self.would_fit(&tx_cost.readable_accounts, &tx_cost.writable_accounts, cost)?;
+        self.add_transaction(&tx_cost.readable_accounts, &tx_cost.writable_accounts, cost);
         Ok(self.block_cost)
     }
 
@@ -82,71 +120,38 @@ impl CostTracker {
             return;
         }
 
-        let (costliest_account, costliest_account_cost) = self.find_costliest_account();
-
         datapoint_info!(
             "cost_tracker_stats",
             ("bank_slot", bank_slot as i64, i64),
             ("block_cost", self.block_cost as i64, i64),
             ("transaction_count", self.transaction_count as i64, i64),
-            (
-                "number_of_accounts",
-                self.cost_by_writable_accounts.len() as i64,
-                i64
-            ),
-            ("costliest_account", costliest_account.to_string(), String),
-            ("costliest_account_cost", costliest_account_cost as i64, i64),
         );
     }
 
-    fn find_costliest_account(&self) -> (Pubkey, u64) {
-        let mut costliest_account = Pubkey::default();
-        let mut costliest_account_cost = 0;
-        for (key, cost) in self.cost_by_writable_accounts.iter() {
-            if *cost > costliest_account_cost {
-                costliest_account = *key;
-                costliest_account_cost = *cost;
-            }
-        }
-
-        (costliest_account, costliest_account_cost)
-    }
-
-    fn would_fit(&self, keys: &[Pubkey], cost: &u64) -> Result<(), CostTrackerError> {
+    fn would_fit(
+        &self,
+        read_keys: &[Pubkey],
+        write_keys: &[Pubkey],
+        cost: u64,
+    ) -> Result<(), CostTrackerError> {
         // check against the total package cost
         if self.block_cost + cost > self.block_cost_limit {
             return Err(CostTrackerError::WouldExceedBlockMaxLimit);
         }
 
-        // check if the transaction itself is more costly than the account_cost_limit
-        if *cost > self.account_cost_limit {
+        // Check that the chained cost if a new batch is
+        // made doesn't increase above the max
+        if self.account_cost_limit <= self.chained_cost.total_chained_cost.saturating_add(cost)
+            && self.chained_cost.has_conflicts(read_keys, write_keys)
+        {
             return Err(CostTrackerError::WouldExceedAccountMaxLimit);
-        }
-
-        // check each account against account_cost_limit,
-        for account_key in keys.iter() {
-            match self.cost_by_writable_accounts.get(&account_key) {
-                Some(chained_cost) => {
-                    if chained_cost + cost > self.account_cost_limit {
-                        return Err(CostTrackerError::WouldExceedAccountMaxLimit);
-                    } else {
-                        continue;
-                    }
-                }
-                None => continue,
-            }
         }
 
         Ok(())
     }
 
-    fn add_transaction(&mut self, keys: &[Pubkey], cost: &u64) {
-        for account_key in keys.iter() {
-            *self
-                .cost_by_writable_accounts
-                .entry(*account_key)
-                .or_insert(0) += cost;
-        }
+    fn add_transaction(&mut self, read_keys: &[Pubkey], write_keys: &[Pubkey], cost: u64) {
+        self.chained_cost.add_new_batch(read_keys, write_keys, cost);
         self.block_cost += cost;
         self.transaction_count += 1;
     }
@@ -184,12 +189,17 @@ mod tests {
     fn build_simple_transaction(
         mint_keypair: &Keypair,
         start_hash: &Hash,
-    ) -> (Transaction, Vec<Pubkey>, u64) {
+    ) -> (Transaction, Vec<Pubkey>, Vec<Pubkey>, u64) {
         let keypair = Keypair::new();
         let simple_transaction =
             system_transaction::transfer(&mint_keypair, &keypair.pubkey(), 2, *start_hash);
 
-        (simple_transaction, vec![mint_keypair.pubkey()], 5)
+        let (write_keys, read_keys) = simple_transaction
+            .message()
+            .get_account_keys_by_lock_type(true);
+        let write_keys = write_keys.into_iter().cloned().collect();
+        let read_keys = read_keys.into_iter().cloned().collect();
+        (simple_transaction, read_keys, write_keys, 5)
     }
 
     #[test]
@@ -197,19 +207,19 @@ mod tests {
         let testee = CostTracker::new(10, 11);
         assert_eq!(10, testee.account_cost_limit);
         assert_eq!(11, testee.block_cost_limit);
-        assert_eq!(0, testee.cost_by_writable_accounts.len());
         assert_eq!(0, testee.block_cost);
     }
 
     #[test]
     fn test_cost_tracker_ok_add_one() {
         let (mint_keypair, start_hash) = test_setup();
-        let (_tx, keys, cost) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx, read_keys, write_keys, cost) =
+            build_simple_transaction(&mint_keypair, &start_hash);
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.would_fit(&keys, &cost).is_ok());
-        testee.add_transaction(&keys, &cost);
+        assert!(testee.would_fit(&read_keys, &write_keys, cost).is_ok());
+        testee.add_transaction(&read_keys, &write_keys, cost);
         assert_eq!(cost, testee.block_cost);
     }
 
@@ -217,62 +227,66 @@ mod tests {
     fn test_cost_tracker_ok_add_two_same_accounts() {
         let (mint_keypair, start_hash) = test_setup();
         // build two transactions with same signed account
-        let (_tx1, keys1, cost1) = build_simple_transaction(&mint_keypair, &start_hash);
-        let (_tx2, keys2, cost2) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx1, read_keys1, write_keys1, cost1) =
+            build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx2, read_keys2, write_keys2, cost2) =
+            build_simple_transaction(&mint_keypair, &start_hash);
 
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2);
         {
-            assert!(testee.would_fit(&keys1, &cost1).is_ok());
-            testee.add_transaction(&keys1, &cost1);
+            assert!(testee.would_fit(&read_keys1, &write_keys1, cost1).is_ok());
+            testee.add_transaction(&read_keys1, &write_keys1, cost1);
         }
         {
-            assert!(testee.would_fit(&keys2, &cost2).is_ok());
-            testee.add_transaction(&keys2, &cost2);
+            assert!(testee.would_fit(&read_keys2, &write_keys2, cost2).is_ok());
+            testee.add_transaction(&read_keys2, &write_keys2, cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost);
-        assert_eq!(1, testee.cost_by_writable_accounts.len());
     }
 
     #[test]
     fn test_cost_tracker_ok_add_two_diff_accounts() {
         let (mint_keypair, start_hash) = test_setup();
         // build two transactions with diff accounts
-        let (_tx1, keys1, cost1) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx1, read_keys1, write_keys1, cost1) =
+            build_simple_transaction(&mint_keypair, &start_hash);
         let second_account = Keypair::new();
-        let (_tx2, keys2, cost2) = build_simple_transaction(&second_account, &start_hash);
+        let (_tx2, read_keys2, write_keys2, cost2) =
+            build_simple_transaction(&second_account, &start_hash);
 
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
         {
-            assert!(testee.would_fit(&keys1, &cost1).is_ok());
-            testee.add_transaction(&keys1, &cost1);
+            assert!(testee.would_fit(&read_keys1, &write_keys1, cost1).is_ok());
+            testee.add_transaction(&read_keys1, &write_keys1, cost1);
         }
         {
-            assert!(testee.would_fit(&keys2, &cost2).is_ok());
-            testee.add_transaction(&keys2, &cost2);
+            assert!(testee.would_fit(&read_keys2, &write_keys2, cost2).is_ok());
+            testee.add_transaction(&read_keys2, &write_keys2, cost2);
         }
         assert_eq!(cost1 + cost2, testee.block_cost);
-        assert_eq!(2, testee.cost_by_writable_accounts.len());
     }
 
     #[test]
     fn test_cost_tracker_chain_reach_limit() {
         let (mint_keypair, start_hash) = test_setup();
         // build two transactions with same signed account
-        let (_tx1, keys1, cost1) = build_simple_transaction(&mint_keypair, &start_hash);
-        let (_tx2, keys2, cost2) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx1, read_keys1, write_keys1, cost1) =
+            build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx2, read_keys2, write_keys2, cost2) =
+            build_simple_transaction(&mint_keypair, &start_hash);
 
         // build testee to have capacity for two simple transactions, but not for same accounts
         let mut testee = CostTracker::new(cmp::min(cost1, cost2), cost1 + cost2);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&keys1, &cost1).is_ok());
-            testee.add_transaction(&keys1, &cost1);
+            assert!(testee.would_fit(&read_keys1, &write_keys1, cost1).is_ok());
+            testee.add_transaction(&read_keys1, &write_keys1, cost1);
         }
         // but no more sapce on the same chain (same signer account)
         {
-            assert!(testee.would_fit(&keys2, &cost2).is_err());
+            assert!(testee.would_fit(&read_keys2, &write_keys2, cost2).is_err());
         }
     }
 
@@ -280,27 +294,30 @@ mod tests {
     fn test_cost_tracker_reach_limit() {
         let (mint_keypair, start_hash) = test_setup();
         // build two transactions with diff accounts
-        let (_tx1, keys1, cost1) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx1, read_keys1, write_keys1, cost1) =
+            build_simple_transaction(&mint_keypair, &start_hash);
         let second_account = Keypair::new();
-        let (_tx2, keys2, cost2) = build_simple_transaction(&second_account, &start_hash);
+        let (_tx2, read_keys2, write_keys2, cost2) =
+            build_simple_transaction(&second_account, &start_hash);
 
         // build testee to have capacity for each chain, but not enough room for both transactions
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&keys1, &cost1).is_ok());
-            testee.add_transaction(&keys1, &cost1);
+            assert!(testee.would_fit(&read_keys1, &write_keys1, cost1).is_ok());
+            testee.add_transaction(&read_keys1, &write_keys1, cost1);
         }
         // but no more room for package as whole
         {
-            assert!(testee.would_fit(&keys2, &cost2).is_err());
+            assert!(testee.would_fit(&read_keys2, &write_keys2, cost2).is_err());
         }
     }
 
     #[test]
     fn test_cost_tracker_try_add_is_atomic() {
         let (mint_keypair, start_hash) = test_setup();
-        let (tx, _keys, _cost) = build_simple_transaction(&mint_keypair, &start_hash);
+        let (_tx, _read_keys, _write_keys, _cost) =
+            build_simple_transaction(&mint_keypair, &start_hash);
 
         let acct1 = Pubkey::new_unique();
         let acct2 = Pubkey::new_unique();
@@ -322,11 +339,8 @@ mod tests {
                 execution_cost: cost,
                 ..TransactionCost::default()
             };
-            assert!(testee.try_add(&tx, &tx_cost).is_ok());
-            let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
+            assert!(testee.try_add(&tx_cost).is_ok());
             assert_eq!(cost, testee.block_cost);
-            assert_eq!(3, testee.cost_by_writable_accounts.len());
-            assert_eq!(cost, costliest_account_cost);
         }
 
         // case 2: add tx writes to acct2 with $cost, should succeed, result to
@@ -340,12 +354,8 @@ mod tests {
                 execution_cost: cost,
                 ..TransactionCost::default()
             };
-            assert!(testee.try_add(&tx, &tx_cost).is_ok());
-            let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
+            assert!(testee.try_add(&tx_cost).is_ok());
             assert_eq!(cost * 2, testee.block_cost);
-            assert_eq!(3, testee.cost_by_writable_accounts.len());
-            assert_eq!(cost * 2, costliest_account_cost);
-            assert_eq!(acct2, costliest_account);
         }
 
         // case 3: add tx writes to [acct1, acct2], acct2 exceeds limit, should failed atomically,
@@ -360,12 +370,8 @@ mod tests {
                 execution_cost: cost,
                 ..TransactionCost::default()
             };
-            assert!(testee.try_add(&tx, &tx_cost).is_err());
-            let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
+            assert!(testee.try_add(&tx_cost).is_err());
             assert_eq!(cost * 2, testee.block_cost);
-            assert_eq!(3, testee.cost_by_writable_accounts.len());
-            assert_eq!(cost * 2, costliest_account_cost);
-            assert_eq!(acct2, costliest_account);
         }
     }
 }


### PR DESCRIPTION
#### Problem

Cost tracker doesn't accurately track when there are account dependencies that increase the overall single-threaded chain performance of the batch.

#### Summary of Changes

Accumulate locked keys into batches of transactions
where each batch has the cost of the highest of the batch.
Once a conflicting key comes, then create a new batch and add
the current to the total chained cost.

Fixes #
