### PR TITLE
Fix token-balance owner type in docs

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -589,7 +589,7 @@ The JSON structure of token balances is defined as a list of objects in the foll
 
 - `accountIndex: <number>` - Index of the account in which the token balance is provided for.
 - `mint: <string>` - Pubkey of the token's mint.
-- `owner: <string>` - Pubkey of token balance's owner.
+- `owner: <string | undefined>` - Pubkey of token balance's owner.
 - `uiTokenAmount: <object>` -
   - `amount: <string>` - Raw amount of tokens as a string, ignoring decimals.
   - `decimals: <number>` - Number of decimals configured for token's mint.


### PR DESCRIPTION
Token balance struct now documents `owner` field, but type doesn't account for old data that doesn't have this field.
