### PR TITLE
Flip iter operations to keep associated address/header/packets together

### DIFF
--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -100,16 +100,14 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<(usize,
     }
     let mut npkts = 0;
     let mut total_size = 0;
-    addrs
-        .iter()
-        .zip(hdrs)
-        .zip(packets.iter_mut())
+
+    izip!(addrs, hdrs, packets.iter_mut())
         .take(nrecv as usize)
-        .filter_map(|((addr, hdr), pkt)| {
-            let addr = cast_socket_addr(addr, &hdr)?.to_std();
-            Some(((addr, hdr), pkt))
+        .filter_map(|(addr, hdr, pkt)| {
+            let addr = cast_socket_addr(&addr, &hdr)?.to_std();
+            Some((addr, hdr, pkt))
         })
-        .for_each(|((addr, hdr), pkt)| {
+        .for_each(|(addr, hdr, pkt)| {
             pkt.meta.size = hdr.msg_len as usize;
             pkt.meta.set_addr(&addr);
             npkts += 1;

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -99,21 +99,22 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result<(usize,
         return Err(io::Error::last_os_error());
     }
     let mut npkts = 0;
+    let mut total_size = 0;
     addrs
         .iter()
         .zip(hdrs)
-        .take(nrecv as usize)
-        .filter_map(|(addr, hdr)| {
-            let addr = cast_socket_addr(addr, &hdr)?.to_std();
-            Some((addr, hdr))
-        })
         .zip(packets.iter_mut())
+        .take(nrecv as usize)
+        .filter_map(|((addr, hdr), pkt)| {
+            let addr = cast_socket_addr(addr, &hdr)?.to_std();
+            Some(((addr, hdr), pkt))
+        })
         .for_each(|((addr, hdr), pkt)| {
             pkt.meta.size = hdr.msg_len as usize;
             pkt.meta.set_addr(&addr);
             npkts += 1;
+            total_size += pkt.meta.size;
         });
-    let total_size = packets.iter().take(npkts).map(|pkt| pkt.meta.size).sum();
     Ok((total_size, npkts))
 }
 


### PR DESCRIPTION
#### Problem
Before this change, if cast_socket_addr() returned a None for any
address/header pair, the subsequent zip() would misalign the
address/header pair and packet.

#### Summary of Changes
So, this change zips all three together,
then does filter_map() so keep things aligned.

Additionally, compute `total_size` inline to avoid running through packets
a second time.
