### PR TITLE
ci/upload-ci-artifact.sh: Use experimential docker virtualization framework for arm64

### DIFF
--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -19,13 +19,24 @@ upload-ci-artifact() {
 upload-s3-artifact() {
   echo "--- artifact: $1 to $2"
   (
-    set -x
-    docker run \
-      --rm \
-      --env AWS_ACCESS_KEY_ID \
-      --env AWS_SECRET_ACCESS_KEY \
-      --volume "$PWD:/solana" \
-      eremite/aws-cli:2018.12.18 \
+    args=(
+      --rm
+      --env AWS_ACCESS_KEY_ID
+      --env AWS_SECRET_ACCESS_KEY
+      --volume "$PWD:/solana"
+
+    )
+    if [[ $(uname -m) = arm64 ]]; then
+      # Ref: https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/#tldr
+      args+=(
+        --platform linux/amd64
+      )
+    fi
+    args+=(
+      eremite/aws-cli:2018.12.18
       /usr/bin/s3cmd --acl-public put "$1" "$2"
+    )
+    set -x
+    docker run "${args[@]}"
   )
 }


### PR DESCRIPTION
`docker` by default on m1 runs `linux/arm64` but there's no `eremite/aws-cli` image for that platform currently, so run as `linux/amd64` instead