### PR TITLE
Don't panic if SubscriptionTokenInner::upgrade is_none

### DIFF
--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -221,7 +221,7 @@ impl SubscriptionControl {
                 entry
                     .get()
                     .upgrade()
-                    .expect("dead subscription encountered in SubscriptionControl"),
+                    .ok_or(Error::EmptySubscriptionTokenInnerFound)?,
                 self.0.counter.create_token(),
             )),
             DashEntry::Vacant(entry) => {
@@ -320,6 +320,8 @@ impl SubscriptionInfo {
 pub enum Error {
     #[error("node subscription limit reached")]
     TooManySubscriptions,
+    #[error("empty subscription token inner")]
+    EmptySubscriptionTokenInnerFound,
 }
 
 struct LogsSubscriptionsIndex {


### PR DESCRIPTION
#### Problem
A new subscription can cause RPC node to panic if it hits this case: https://github.com/solana-labs/solana/blob/005592998dd107b3d54d9203babe24da681834f5/rpc/src/rpc_subscription_tracker.rs#L224
There seems to be a race condition in dropping SubscriptionTokenInner

#### Summary of Changes
Return an error instead of panicking in these cases

The race still needs to be addressed, but this is an immediate fix for #21948
