### PR TITLE
read in number of iterations correctly from param

### DIFF
--- a/programs/bpf/c/src/tuner-variable-iterations/tuner-variable-iterations.c
+++ b/programs/bpf/c/src/tuner-variable-iterations/tuner-variable-iterations.c
@@ -20,7 +20,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
 
   size_t current = 1;
 
-  uint64_t iterations = params.data[0] * 18;
+  uint64_t iterations = 0;
+  uint64_t size = params.data_len > sizeof(uint64_t) ? (uint64_t)sizeof(uint64_t) : params.data_len;
+  sol_memcpy(&iterations, params.data, size);
   iterations = iterations == 0 ? UINT64_MAX : iterations;
   size_t rand = params.data[1];
   size_t account_index = rand % params.ka_num;


### PR DESCRIPTION
#### Problem
The tuner program only takes first byte of instruction data as customized number of iterations. If test program specifies `--iterations 500,000`, it'd only loop `500,000 % 256 * 18 = 576`. 

Thanks @Lichtso  for finding it out.

#### Summary of Changes
- reads entire data_len for iterations. 
- removed `* 18` part, not sure if that's necessary.

Fixes #
