### PR TITLE
Switch from arm64-apple-darwin to aarch64-apple-darwin to align with Rust's target names

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -39,7 +39,11 @@ fi
 
 case "$CI_OS_NAME" in
 osx)
-  TARGET=$(uname -m)-apple-darwin
+  _cputype="$(uname -m)"
+  if [[ $_cputype = arm64 ]]; then
+    _cputype=aarch64
+  fi
+  TARGET=${_cputype}-apple-darwin
   ;;
 linux)
   TARGET=x86_64-unknown-linux-gnu

--- a/install/solana-install-init.sh
+++ b/install/solana-install-init.sh
@@ -62,17 +62,24 @@ main() {
       esac
     done
 
-    case "$(uname)" in
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+
+    case "$_ostype" in
     Linux)
-      TARGET=x86_64-unknown-linux-gnu
+      _ostype=unknown-linux-gnu
       ;;
     Darwin)
-      TARGET=$(uname -m)-apple-darwin
+      if [[ $_cputype = arm64 ]]; then
+        _cputype=aarch64
+      fi
+      _ostype=apple-darwin
       ;;
     *)
       err "machine architecture is currently unsupported"
       ;;
     esac
+    TARGET="${_cputype}-${_ostype}"
 
     temp_dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t solana-install-init)"
     ensure mkdir -p "$temp_dir"

--- a/scripts/solana-install-deploy.sh
+++ b/scripts/solana-install-deploy.sh
@@ -31,7 +31,7 @@ fi
 
 case "$OS" in
 osx)
-  TARGET=$(uname -m)-apple-darwin
+  TARGET=x86_64-apple-darwin
   ;;
 linux)
   TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
Arguably less correct but not worth bucking the rest of the Rust world
