### PR TITLE
ci/buildkite-secondary.yml: Add aarch64-apple-darwin publish tarball step

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -19,3 +19,8 @@ steps:
     timeout_in_minutes: 240
     name: "publish crate"
     branches: "!master"
+  - command: "ci/publish-tarball.sh"
+    agents:
+      - "queue=release-build-aarch64-apple-darwin"
+    timeout_in_minutes: 60
+    name: "publish tarball (aarch64-apple-darwin)"


### PR DESCRIPTION
Once the m1 buildkite agent is up and running, this'll give us native m1 release and channel build artifacts