### PR TITLE
patches bug in recv_mmsg when npkts != nrecv

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2818,8 +2818,7 @@ mod tests {
                     .unwrap();
 
                 let mut packets = vec![Packet::default(); 2];
-                let (_, num_received) =
-                    recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
+                let num_received = recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
                 assert_eq!(num_received, expected_num_forwarded, "{}", name);
             }
 
@@ -2918,8 +2917,7 @@ mod tests {
                     .unwrap();
 
                 let mut packets = vec![Packet::default(); 2];
-                let (_, num_received) =
-                    recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
+                let num_received = recv_mmsg(recv_socket, &mut packets[..]).unwrap_or_default();
                 assert_eq!(num_received, expected_ids.len(), "{}", name);
                 for (i, expected_id) in expected_ids.iter().enumerate() {
                     assert_eq!(packets[i].meta.size, 1);

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -41,7 +41,7 @@ pub fn recv_from(batch: &mut PacketBatch, socket: &UdpSocket, max_wait_ms: u64) 
                 trace!("recv_from err {:?}", e);
                 return Err(e);
             }
-            Ok((_, npkts)) => {
+            Ok(npkts) => {
                 if i == 0 {
                     socket.set_nonblocking(true)?;
                 }

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -112,6 +112,10 @@ mod tests {
         }
         send_to(&batch, &send_socket, &SocketAddrSpace::Unspecified).unwrap();
 
+        batch
+            .packets
+            .iter_mut()
+            .for_each(|pkt| pkt.meta = Meta::default());
         let recvd = recv_from(&mut batch, &recv_socket, 1).unwrap();
 
         assert_eq!(recvd, batch.packets.len());

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(sent, Some(()));
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(32, recv);
     }
 
@@ -206,11 +206,11 @@ mod tests {
         assert_eq!(sent, Some(()));
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(16, recv);
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap();
         assert_eq!(16, recv);
     }
 
@@ -241,19 +241,19 @@ mod tests {
         assert_eq!(sent, Some(()));
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         assert_eq!(1, recv);
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader2, &mut packets[..]).unwrap();
         assert_eq!(1, recv);
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader3, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader3, &mut packets[..]).unwrap();
         assert_eq!(1, recv);
 
         let mut packets = vec![Packet::default(); 32];
-        let recv = recv_mmsg(&reader4, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader4, &mut packets[..]).unwrap();
         assert_eq!(1, recv);
     }
 

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -2,7 +2,7 @@
 
 use {
     solana_streamer::{
-        packet::{Packet, PACKET_DATA_SIZE},
+        packet::{Meta, Packet, PACKET_DATA_SIZE},
         recvmmsg::*,
     },
     std::{net::UdpSocket, time::Instant},
@@ -44,6 +44,9 @@ pub fn test_recv_mmsg_batch_size() {
             if recv >= TEST_BATCH_SIZE {
                 break;
             }
+            packets
+                .iter_mut()
+                .for_each(|pkt| pkt.meta = Meta::default());
         }
         elapsed_in_small_batch += now.elapsed().as_nanos();
         assert_eq!(TEST_BATCH_SIZE, recv);

--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -25,7 +25,7 @@ pub fn test_recv_mmsg_batch_size() {
         }
         let mut packets = vec![Packet::default(); TEST_BATCH_SIZE];
         let now = Instant::now();
-        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap().1;
+        let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         elapsed_in_max_batch += now.elapsed().as_nanos();
         assert_eq!(TEST_BATCH_SIZE, recv);
     });
@@ -40,7 +40,7 @@ pub fn test_recv_mmsg_batch_size() {
         let mut recv = 0;
         let now = Instant::now();
         while let Ok(num) = recv_mmsg(&reader, &mut packets[..]) {
-            recv += num.1;
+            recv += num;
             if recv >= TEST_BATCH_SIZE {
                 break;
             }


### PR DESCRIPTION
#### Problem
If `recv_mmsg` receives 2 packets where the first one is filtered out,
then it returns `npkts == 1`:
https://github.com/solana-labs/solana/blob/01a096adc/streamer/src/recvmmsg.rs#L104-L115

But then `streamer::packet::recv_from` will erroneously keep the 1st
packet and drop the 2nd one:
https://github.com/solana-labs/solana/blob/01a096adc/streamer/src/packet.rs#L34-L49


#### Summary of Changes
To avoid this bug, this commit updates `recv_mmsg` to always return total
number of received packets. If socket address cannot be correctly
obtained, it is left as the default value which is `UNSPECIFIED`:
https://github.com/solana-labs/solana/blob/01a096adc/sdk/src/packet.rs#L145

Also removing `total_size` from return value since it is unused.