### PR TITLE
estimate a program cost as 2 standard deviation above mean

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2812,6 +2812,10 @@ mod tests {
             ..
         } = create_slow_genesis_config(lamports);
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        // set cost tracker limits to MAX so it will not filter out TXs
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
 
         // Transfer more than the balance of the mint keypair, should cause a
         // InstructionError::InsufficientFunds that is then committed. Needs to be
@@ -2868,6 +2872,10 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        // set cost tracker limits to MAX so it will not filter out TXs
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
 
         // Make all repetitive transactions that conflict on the `mint_keypair`, so only 1 should be executed
         let mut transactions = vec![

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -9,17 +9,15 @@ use {
     solana_measure::measure::Measure,
     solana_program_runtime::timings::ExecuteTimings,
     solana_runtime::{bank::Bank, cost_model::CostModel},
-    solana_sdk::{pubkey::Pubkey, timing::timestamp},
+    solana_sdk::timing::timestamp,
     std::{
-        collections::HashMap,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc, RwLock,
-        },
+        sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
-        time::Duration,
     },
 };
+
+// Update blockstore persistence storage when accumulated cost_table updates count exceeds the threshold
+const PERSIST_THRESHOLD: u64 = 1_000;
 
 #[derive(Default)]
 pub struct CostUpdateServiceTiming {
@@ -32,20 +30,25 @@ pub struct CostUpdateServiceTiming {
 impl CostUpdateServiceTiming {
     fn update(
         &mut self,
-        update_cost_model_count: u64,
-        update_cost_model_elapsed: u64,
-        persist_cost_table_elapsed: u64,
+        update_cost_model_count: Option<u64>,
+        update_cost_model_elapsed: Option<u64>,
+        persist_cost_table_elapsed: Option<u64>,
     ) {
-        self.update_cost_model_count += update_cost_model_count;
-        self.update_cost_model_elapsed += update_cost_model_elapsed;
-        self.persist_cost_table_elapsed += persist_cost_table_elapsed;
+        if let Some(update_cost_model_count) = update_cost_model_count {
+            self.update_cost_model_count += update_cost_model_count;
+        }
+        if let Some(update_cost_model_elapsed) = update_cost_model_elapsed {
+            self.update_cost_model_elapsed += update_cost_model_elapsed;
+        }
+        if let Some(persist_cost_table_elapsed) = persist_cost_table_elapsed {
+            self.persist_cost_table_elapsed += persist_cost_table_elapsed;
+        }
 
         let now = timestamp();
         let elapsed_ms = now - self.last_print;
         if elapsed_ms > 1000 {
             datapoint_info!(
                 "cost-update-service-stats",
-                ("total_elapsed_us", elapsed_ms * 1000, i64),
                 (
                     "update_cost_model_count",
                     self.update_cost_model_count as i64,
@@ -87,7 +90,6 @@ pub struct CostUpdateService {
 impl CostUpdateService {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         cost_model: Arc<RwLock<CostModel>>,
         cost_update_receiver: CostUpdateReceiver,
@@ -95,7 +97,7 @@ impl CostUpdateService {
         let thread_hdl = Builder::new()
             .name("solana-cost-update-service".to_string())
             .spawn(move || {
-                Self::service_loop(exit, blockstore, cost_model, cost_update_receiver);
+                Self::service_loop(blockstore, cost_model, cost_update_receiver);
             })
             .unwrap();
 
@@ -107,58 +109,53 @@ impl CostUpdateService {
     }
 
     fn service_loop(
-        exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         cost_model: Arc<RwLock<CostModel>>,
         cost_update_receiver: CostUpdateReceiver,
     ) {
         let mut cost_update_service_timing = CostUpdateServiceTiming::default();
-        let mut update_count: u64;
-        let mut updated_program_costs = HashMap::<Pubkey, u64>::new();
-        let wait_timer = Duration::from_millis(100);
+        let mut update_count = 0_u64;
 
-        loop {
-            if exit.load(Ordering::Relaxed) {
-                break;
-            }
+        for cost_update in cost_update_receiver.iter() {
+            match cost_update {
+                CostUpdate::FrozenBank { bank } => {
+                    bank.read_cost_tracker().unwrap().report_stats(bank.slot());
+                }
+                CostUpdate::ExecuteTiming {
+                    mut execute_timings,
+                } => {
+                    let mut update_cost_model_time = Measure::start("update_cost_model_time");
+                    update_count += Self::update_cost_model(&cost_model, &mut execute_timings);
+                    update_cost_model_time.stop();
+                    cost_update_service_timing.update(
+                        Some(update_count),
+                        Some(update_cost_model_time.as_us()),
+                        None,
+                    );
 
-            update_count = 0_u64;
-            let mut update_cost_model_time = Measure::start("update_cost_model_time");
-            for cost_update in cost_update_receiver.try_iter() {
-                match cost_update {
-                    CostUpdate::FrozenBank { bank } => {
-                        bank.read_cost_tracker().unwrap().report_stats(bank.slot());
-                    }
-                    CostUpdate::ExecuteTiming {
-                        mut execute_timings,
-                    } => {
-                        updated_program_costs =
-                            Self::update_cost_model(&cost_model, &mut execute_timings);
-                        update_count += 1;
+                    if update_count > PERSIST_THRESHOLD {
+                        let mut persist_cost_table_time = Measure::start("persist_cost_table_time");
+                        Self::persist_cost_table(&blockstore, &cost_model);
+                        update_count = 0_u64;
+                        persist_cost_table_time.stop();
+                        cost_update_service_timing.update(
+                            None,
+                            None,
+                            Some(persist_cost_table_time.as_us()),
+                        );
                     }
                 }
             }
-            update_cost_model_time.stop();
-
-            let mut persist_cost_table_time = Measure::start("persist_cost_table_time");
-            Self::persist_cost_table(&blockstore, &updated_program_costs);
-            persist_cost_table_time.stop();
-
-            cost_update_service_timing.update(
-                update_count,
-                update_cost_model_time.as_us(),
-                persist_cost_table_time.as_us(),
-            );
-
-            thread::sleep(wait_timer);
         }
     }
 
+    // Normalize `program_timings` with current estimated cost, update instruction_cost table
+    // Returns number of updates applied
     fn update_cost_model(
         cost_model: &RwLock<CostModel>,
         execute_timings: &mut ExecuteTimings,
-    ) -> HashMap<Pubkey, u64> {
-        let mut updated_program_costs = HashMap::<Pubkey, u64>::new();
+    ) -> u64 {
+        let mut update_count = 0_u64;
         for (program_id, program_timings) in &mut execute_timings.details.per_program_timings {
             let current_estimated_program_cost =
                 cost_model.read().unwrap().find_instruction_cost(program_id);
@@ -169,50 +166,42 @@ impl CostUpdateService {
             }
 
             let units = program_timings.accumulated_units / program_timings.count as u64;
-            match cost_model
+            cost_model
                 .write()
                 .unwrap()
-                .upsert_instruction_cost(program_id, units)
-            {
-                Ok(cost) => {
-                    debug!(
-                        "after replayed into bank, instruction {:?} has averaged cost {}",
-                        program_id, cost
-                    );
-                    updated_program_costs.insert(*program_id, cost);
-                }
-                Err(err) => {
-                    debug!(
-                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
-                        program_id, err
-                    );
-                }
-            }
+                .upsert_instruction_cost(program_id, units);
+            update_count += 1;
+            debug!(
+                "After replayed into bank, updated cost for instruction {:?}, update_value {}, pre_aggregated_value {}",
+                program_id, units, current_estimated_program_cost
+            );
         }
-        updated_program_costs
+        update_count
     }
 
-    fn persist_cost_table(blockstore: &Blockstore, updated_program_costs: &HashMap<Pubkey, u64>) {
-        if updated_program_costs.is_empty() {
-            return;
-        }
-
+    // 1. Remove obsolete program entries from persisted table to limit its size
+    // 2. Update persisted program cost. This involves EMA cost calculation at
+    //    execute_cost_table.get_cost()
+    fn persist_cost_table(blockstore: &Blockstore, cost_model: &RwLock<CostModel>) {
         let db_records = blockstore.read_program_costs().expect("read programs");
+        let cost_model = cost_model.read().unwrap();
+        let active_program_keys = cost_model.get_program_keys();
 
         // delete records from blockstore if they are no longer in cost_table
         db_records.iter().for_each(|(pubkey, _)| {
-            if !updated_program_costs.contains_key(pubkey) {
+            if !active_program_keys.contains(&pubkey) {
                 blockstore
                     .delete_program_cost(pubkey)
                     .expect("delete old program");
             }
         });
 
-        for (key, cost) in updated_program_costs.iter() {
+        active_program_keys.iter().for_each(|program_id| {
+            let cost = cost_model.find_instruction_cost(program_id);
             blockstore
-                .write_program_cost(key, cost)
+                .write_program_cost(program_id, &cost)
                 .expect("persist program costs to blockstore");
-        }
+        });
     }
 }
 
@@ -224,9 +213,9 @@ mod tests {
     fn test_update_cost_model_with_empty_execute_timings() {
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
         let mut empty_execute_timings = ExecuteTimings::default();
-        assert!(
-            CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings)
-                .is_empty()
+        assert_eq!(
+            CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings),
+            0
         );
     }
 
@@ -256,12 +245,15 @@ mod tests {
                     total_errored_units,
                 },
             );
-            let updated_program_costs =
+            let update_count =
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
-            assert_eq!(1, updated_program_costs.len());
+            assert_eq!(1, update_count);
             assert_eq!(
-                Some(&expected_cost),
-                updated_program_costs.get(&program_key_1)
+                expected_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -270,8 +262,8 @@ mod tests {
             let accumulated_us: u64 = 2000;
             let accumulated_units: u64 = 200;
             let count: u32 = 10;
-            // to expect new cost = (mean + 2 * std)
-            expected_cost = 24;
+            // to expect new cost = (mean + 2 * std) of [10, 20]
+            expected_cost = 13;
 
             execute_timings.details.per_program_timings.insert(
                 program_key_1,
@@ -283,12 +275,15 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            let updated_program_costs =
+            let update_count =
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
-            assert_eq!(1, updated_program_costs.len());
+            assert_eq!(1, update_count);
             assert_eq!(
-                Some(&expected_cost),
-                updated_program_costs.get(&program_key_1)
+                expected_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }
@@ -314,8 +309,9 @@ mod tests {
             );
             // If both the `errored_txs_compute_consumed` is empty and `count == 0`, then
             // nothing should be inserted into the cost model
-            assert!(
-                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings).is_empty()
+            assert_eq!(
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                0
             );
         }
 
@@ -332,12 +328,15 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            let updated_program_costs =
+            let update_count =
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
-            assert_eq!(1, updated_program_costs.len());
+            assert_eq!(1, update_count);
             assert_eq!(
-                Some(&current_program_cost),
-                updated_program_costs.get(&program_key_1)
+                current_program_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -345,6 +344,12 @@ mod tests {
         // greater than the current instruction cost for the program. Should update with the
         // new erroring compute costs
         let cost_per_error = 1000;
+        // expected_cost = (mean + 2*std) of data points:
+        // [
+        //  100,  // original program_cost
+        //  1000, // cost_per_error
+        // ]
+        let expected_cost = 289u64;
         {
             let errored_txs_compute_consumed = vec![cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -358,26 +363,23 @@ mod tests {
                     total_errored_units,
                 },
             );
-            let updated_program_costs =
+            let update_count =
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
 
-            // expected_cost = (mean + 2*std) of data points:
-            // [
-            //  100,  // original program_cost
-            //  1000, // cost_per_error
-            // ]
-            let expected_cost = 1342u64;
-            assert_eq!(1, updated_program_costs.len());
+            assert_eq!(1, update_count);
             assert_eq!(
-                Some(&expected_cost),
-                updated_program_costs.get(&program_key_1)
+                expected_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
         // Test updating cost model with only erroring compute costs where the error cost is
         // `smaller_cost_per_error`, less than the current instruction cost for the program.
         // The cost should not decrease for these new lesser errors
-        let smaller_cost_per_error = cost_per_error - 10;
+        let smaller_cost_per_error = expected_cost - 10;
         {
             let errored_txs_compute_consumed = vec![smaller_cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -391,20 +393,23 @@ mod tests {
                     total_errored_units,
                 },
             );
-            let updated_program_costs =
+            let update_count =
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
 
             // expected_cost = (mean = 2*std) of data points:
             // [
             //  100,  // original program cost,
             //  1000, // cost_per_error from above test
-            //  1450, // the smaller_cost_per_error will be coalesced to prev cost
+            //  289, // the smaller_cost_per_error will be coalesced to prev cost
             // ]
-            let expected_cost = 1915u64;
-            assert_eq!(1, updated_program_costs.len());
+            let expected_cost = 293u64;
+            assert_eq!(1, update_count);
             assert_eq!(
-                Some(&expected_cost),
-                updated_program_costs.get(&program_key_1)
+                expected_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -270,9 +270,8 @@ mod tests {
             let accumulated_us: u64 = 2000;
             let accumulated_units: u64 = 200;
             let count: u32 = 10;
-            // to expect new cost = (mean + 2 * std) of [10, 20] = 25, where
-            //   mean = (10+20)/2 = 15; std=5
-            expected_cost = 25;
+            // to expect new cost = (mean + 2 * std)
+            expected_cost = 24;
 
             execute_timings.details.per_program_timings.insert(
                 program_key_1,
@@ -367,7 +366,7 @@ mod tests {
             //  100,  // original program_cost
             //  1000, // cost_per_error
             // ]
-            let expected_cost = 1450u64;
+            let expected_cost = 1342u64;
             assert_eq!(1, updated_program_costs.len());
             assert_eq!(
                 Some(&expected_cost),
@@ -401,7 +400,7 @@ mod tests {
             //  1000, // cost_per_error from above test
             //  1450, // the smaller_cost_per_error will be coalesced to prev cost
             // ]
-            let expected_cost = 1973u64;
+            let expected_cost = 1915u64;
             assert_eq!(1, updated_program_costs.len());
             assert_eq!(
                 Some(&expected_cost),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -305,12 +305,8 @@ impl Tvu {
         );
 
         let (cost_update_sender, cost_update_receiver) = unbounded();
-        let cost_update_service = CostUpdateService::new(
-            exit.clone(),
-            blockstore.clone(),
-            cost_model.clone(),
-            cost_update_receiver,
-        );
+        let cost_update_service =
+            CostUpdateService::new(blockstore.clone(), cost_model.clone(), cost_update_receiver);
 
         let (drop_bank_sender, drop_bank_receiver) = unbounded();
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -498,8 +498,8 @@ mod tests {
         let key1 = Pubkey::new_unique();
         let cost1 = 100;
         let cost2 = 200;
-        // updated_cost = (mean + 2*std) = 150 + 2 * 50 = 250
-        let updated_cost = 250;
+        // updated_cost = (mean + 2*std)
+        let updated_cost = 238;
 
         let mut cost_model = CostModel::default();
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -11,7 +11,6 @@ use {
         instruction::CompiledInstruction, program_utils::limited_deserialize, pubkey::Pubkey,
         system_instruction::SystemInstruction, system_program, transaction::SanitizedTransaction,
     },
-    std::collections::HashMap,
 };
 
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
@@ -79,28 +78,9 @@ impl CostModel {
             .map(|(key, cost)| (key, cost))
             .chain(BUILT_IN_INSTRUCTION_COSTS.iter())
             .for_each(|(program_id, cost)| {
-                match self
-                    .instruction_execution_cost_table
-                    .upsert(program_id, *cost)
-                {
-                    Some(c) => {
-                        debug!(
-                            "initiating cost table, instruction {:?} has cost {}",
-                            program_id, c
-                        );
-                    }
-                    None => {
-                        debug!(
-                            "initiating cost table, failed for instruction {:?}",
-                            program_id
-                        );
-                    }
-                }
+                self.instruction_execution_cost_table
+                    .upsert(program_id, *cost);
             });
-        debug!(
-            "restored cost model instruction cost table from blockstore, current values: {:?}",
-            self.get_instruction_cost_table()
-        );
     }
 
     pub fn calculate_cost(&self, transaction: &SanitizedTransaction) -> TransactionCost {
@@ -124,22 +104,18 @@ impl CostModel {
         self.instruction_execution_cost_table
             .upsert(program_key, cost);
         match self.instruction_execution_cost_table.get_cost(program_key) {
-            Some(cost) => Ok(*cost),
+            Some(cost) => Ok(cost),
             None => Err("failed to upsert to ExecuteCostTable"),
         }
     }
 
-    pub fn get_instruction_cost_table(&self) -> &HashMap<Pubkey, u64> {
-        self.instruction_execution_cost_table.get_cost_table()
-    }
-
     pub fn find_instruction_cost(&self, program_key: &Pubkey) -> u64 {
         match self.instruction_execution_cost_table.get_cost(program_key) {
-            Some(cost) => *cost,
+            Some(cost) => cost,
             None => {
-                let default_value = self.instruction_execution_cost_table.get_mode();
+                let default_value = self.instruction_execution_cost_table.get_default();
                 debug!(
-                    "Program key {:?} does not have assigned cost, using mode {}",
+                    "Program key {:?} does not have assigned cost, using default value {}",
                     program_key, default_value
                 );
                 default_value
@@ -304,7 +280,7 @@ mod tests {
 
         // unknown program is assigned with default cost
         assert_eq!(
-            testee.instruction_execution_cost_table.get_mode(),
+            testee.instruction_execution_cost_table.get_default(),
             testee.find_instruction_cost(
                 &Pubkey::from_str("unknown111111111111111111111111111111111111").unwrap()
             )
@@ -439,7 +415,7 @@ mod tests {
         let result = testee.get_transaction_cost(&tx);
 
         // expected cost for two random/unknown program is
-        let expected_cost = testee.instruction_execution_cost_table.get_mode() * 2;
+        let expected_cost = testee.instruction_execution_cost_table.get_default() * 2;
         assert_eq!(expected_cost, result);
     }
 
@@ -483,7 +459,7 @@ mod tests {
         let mut cost_model = CostModel::default();
         // Using default cost for unknown instruction
         assert_eq!(
-            cost_model.instruction_execution_cost_table.get_mode(),
+            cost_model.instruction_execution_cost_table.get_default(),
             cost_model.find_instruction_cost(&key1)
         );
 
@@ -522,7 +498,8 @@ mod tests {
         let key1 = Pubkey::new_unique();
         let cost1 = 100;
         let cost2 = 200;
-        let updated_cost = (cost1 + cost2) / 2;
+        // updated_cost = (mean + 2*std) = 150 + 2 * 50 = 250
+        let updated_cost = 250;
 
         let mut cost_model = CostModel::default();
 

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -15,11 +15,15 @@ const OCCURRENCES_WEIGHT: i64 = 100;
 
 const DEFAULT_CAPACITY: usize = 1024;
 
+// The coefficient represents the degree of weighting decrease in EMA,
+// a constant smoothing factor between 0 and 1. A higher alpha
+// discounts older observations faster.
+const COEFFICIENT: f64 = 0.4;
+
 #[derive(Debug, Default)]
 struct AggregatedVarianceStats {
-    count: u64,
-    mean: f64,
-    squared_mean_distance: f64,
+    ema: f64,
+    ema_var: f64,
 }
 
 #[derive(Debug)]
@@ -57,18 +61,11 @@ impl ExecuteCostTable {
 
     // returns None if program doesn't exist in table. In this case,
     // it is advised to call `get_default()` for default program costdefault/
-    // using Welford's Algorithm to calculate mean and std:
-    // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
     // Program cost is estimated as 2 standard deviations above mean, eg
     // cost = (mean + 2 * std)
     pub fn get_cost(&self, key: &Pubkey) -> Option<u64> {
         let aggregated = self.table.get(key)?;
-        if aggregated.count < 1 {
-            None
-        } else {
-            let variance = aggregated.squared_mean_distance / aggregated.count as f64;
-            Some((aggregated.mean + 2.0 * variance.sqrt()).ceil() as u64)
-        }
+        Some((aggregated.ema + 2.0 * aggregated.ema_var.sqrt()).ceil() as u64)
     }
 
     pub fn upsert(&mut self, key: &Pubkey, value: u64) {
@@ -78,16 +75,24 @@ impl ExecuteCostTable {
             self.prune_to(&((current_size as f64 * PRUNE_RATIO) as usize));
         }
 
-        // Welford's algorithm
-        let aggregated = self
-            .table
-            .entry(*key)
-            .or_insert_with(AggregatedVarianceStats::default);
-        aggregated.count += 1;
-        let delta = value as f64 - aggregated.mean;
-        aggregated.mean += delta / aggregated.count as f64;
-        let delta_2 = value as f64 - aggregated.mean;
-        aggregated.squared_mean_distance += delta * delta_2;
+        // exponential moving average algorithm
+        // https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation
+        if self.table.contains_key(key) {
+            let aggregated = self.table.get_mut(key).unwrap();
+            let theta = value as f64 - aggregated.ema;
+            aggregated.ema += theta * COEFFICIENT;
+            aggregated.ema_var =
+                (1.0 - COEFFICIENT) * (aggregated.ema_var + COEFFICIENT * theta * theta)
+        } else {
+            // the starting values
+            self.table.insert(
+                *key,
+                AggregatedVarianceStats {
+                    ema: value as f64,
+                    ema_var: 0.0,
+                },
+            );
+        }
 
         let (count, timestamp) = self
             .occurrences
@@ -231,7 +236,7 @@ mod tests {
         testee.upsert(&key1, cost2);
         assert_eq!(2, testee.get_count());
         // expected key1 cost = (mean + 2*std) = (105 + 2*5) = 115
-        let expected_cost = 115;
+        let expected_cost = 114;
         assert_eq!(expected_cost, testee.get_cost(&key1).unwrap());
         assert_eq!(cost2, testee.get_cost(&key2).unwrap());
     }
@@ -276,7 +281,7 @@ mod tests {
         assert_eq!(2, testee.get_count());
         assert!(testee.get_cost(&key1).is_none());
         // expected key2 cost = (mean + 2*std) = (105 + 2*5) = 115
-        let expected_cost_2 = 115;
+        let expected_cost_2 = 116;
         assert_eq!(expected_cost_2, testee.get_cost(&key2).unwrap());
         assert!(testee.get_cost(&key3).is_none());
         assert_eq!(cost4, testee.get_cost(&key4).unwrap());

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -4,7 +4,10 @@
 /// When its capacity limit is reached, it prunes old and less-used programs
 /// to make room for new ones.
 use log::*;
-use {solana_sdk::pubkey::Pubkey, std::collections::HashMap};
+use {
+    solana_sdk::pubkey::Pubkey,
+    std::collections::{hash_map::Entry, HashMap},
+};
 
 // prune is rather expensive op, free up bulk space in each operation
 // would be more efficient. PRUNE_RATIO defines the after prune table
@@ -18,7 +21,8 @@ const DEFAULT_CAPACITY: usize = 1024;
 // The coefficient represents the degree of weighting decrease in EMA,
 // a constant smoothing factor between 0 and 1. A higher alpha
 // discounts older observations faster.
-const COEFFICIENT: f64 = 0.4;
+// Setting it using `2/(N+1)` where N is 200 samples
+const COEFFICIENT: f64 = 0.01;
 
 #[derive(Debug, Default)]
 struct AggregatedVarianceStats {
@@ -53,19 +57,27 @@ impl ExecuteCostTable {
         self.table.len()
     }
 
-    // default prorgam cost to max
+    // default program cost to max
     pub fn get_default(&self) -> u64 {
-        // default max comoute units per program
+        // default max compute units per program
         200_000u64
     }
 
     // returns None if program doesn't exist in table. In this case,
-    // it is advised to call `get_default()` for default program costdefault/
+    // it is advised to call `get_default()` for default program cost.
     // Program cost is estimated as 2 standard deviations above mean, eg
     // cost = (mean + 2 * std)
     pub fn get_cost(&self, key: &Pubkey) -> Option<u64> {
         let aggregated = self.table.get(key)?;
-        Some((aggregated.ema + 2.0 * aggregated.ema_var.sqrt()).ceil() as u64)
+        let cost_f64 = (aggregated.ema + 2.0 * aggregated.ema_var.sqrt()).ceil();
+
+        // check if cost:f64 can be losslessly convert to u64, otherwise return None
+        let cost_u64 = cost_f64 as u64;
+        if cost_f64 == cost_u64 as f64 {
+            Some(cost_u64)
+        } else {
+            None
+        }
     }
 
     pub fn upsert(&mut self, key: &Pubkey, value: u64) {
@@ -77,21 +89,21 @@ impl ExecuteCostTable {
 
         // exponential moving average algorithm
         // https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation
-        if self.table.contains_key(key) {
-            let aggregated = self.table.get_mut(key).unwrap();
-            let theta = value as f64 - aggregated.ema;
-            aggregated.ema += theta * COEFFICIENT;
-            aggregated.ema_var =
-                (1.0 - COEFFICIENT) * (aggregated.ema_var + COEFFICIENT * theta * theta)
-        } else {
-            // the starting values
-            self.table.insert(
-                *key,
-                AggregatedVarianceStats {
+        match self.table.entry(*key) {
+            Entry::Occupied(mut entry) => {
+                let aggregated = entry.get_mut();
+                let theta = value as f64 - aggregated.ema;
+                aggregated.ema += theta * COEFFICIENT;
+                aggregated.ema_var =
+                    (1.0 - COEFFICIENT) * (aggregated.ema_var + COEFFICIENT * theta * theta);
+            }
+            Entry::Vacant(entry) => {
+                // the starting values
+                entry.insert(AggregatedVarianceStats {
                     ema: value as f64,
                     ema_var: 0.0,
-                },
-            );
+                });
+            }
         }
 
         let (count, timestamp) = self
@@ -100,6 +112,10 @@ impl ExecuteCostTable {
             .or_insert((0, Self::micros_since_epoch()));
         *count += 1;
         *timestamp = Self::micros_since_epoch();
+    }
+
+    pub fn get_program_keys(&self) -> Vec<&Pubkey> {
+        self.table.keys().collect()
     }
 
     // prune the old programs so the table contains `new_size` of records,
@@ -189,9 +205,9 @@ mod tests {
         let key2 = Pubkey::new_unique();
         let key3 = Pubkey::new_unique();
 
-        // simulate a lot of occurences to key1, so even there're longer than
+        // simulate a lot of occurrences to key1, so even there're longer than
         // usual delay between upsert(key1..) and upsert(key2, ..), test
-        // would still satisfy as key1 has enough occurences to compensate
+        // would still satisfy as key1 has enough occurrences to compensate
         // its age.
         for i in 0..1000 {
             testee.upsert(&key1, i);
@@ -235,8 +251,8 @@ mod tests {
         // update 1st record
         testee.upsert(&key1, cost2);
         assert_eq!(2, testee.get_count());
-        // expected key1 cost = (mean + 2*std) = (105 + 2*5) = 115
-        let expected_cost = 114;
+        // expected key1 cost is EMA of [100, 110] with alpha=0.01 => 103
+        let expected_cost = 103;
         assert_eq!(expected_cost, testee.get_cost(&key1).unwrap());
         assert_eq!(cost2, testee.get_cost(&key2).unwrap());
     }
@@ -280,10 +296,29 @@ mod tests {
         testee.upsert(&key4, cost4);
         assert_eq!(2, testee.get_count());
         assert!(testee.get_cost(&key1).is_none());
-        // expected key2 cost = (mean + 2*std) = (105 + 2*5) = 115
-        let expected_cost_2 = 116;
+        // expected key2 cost = (mean + 2*std) of [110, 100] => 112
+        let expected_cost_2 = 112;
         assert_eq!(expected_cost_2, testee.get_cost(&key2).unwrap());
         assert!(testee.get_cost(&key3).is_none());
         assert_eq!(cost4, testee.get_cost(&key4).unwrap());
+    }
+
+    #[test]
+    fn test_get_cost_overflow_u64() {
+        solana_logger::setup();
+        let mut testee = ExecuteCostTable::default();
+
+        let key1 = Pubkey::new_unique();
+        let cost1: u64 = f64::MAX as u64;
+        let cost2: u64 = u64::MAX / 2; // create large variance so the final result will overflow
+
+        // insert one record
+        testee.upsert(&key1, cost1);
+        assert_eq!(1, testee.get_count());
+        assert_eq!(cost1, testee.get_cost(&key1).unwrap());
+
+        // update cost
+        testee.upsert(&key1, cost2);
+        assert!(testee.get_cost(&key1).is_none());
     }
 }


### PR DESCRIPTION
#### Problem
Simply averaging a program's execution cost isn't sufficient, as it can be easily skewed by lower/higher cost instances. Instead it should estimate program cost close to higher end to avoid underpricing. The proposed solution is to implement formula `cost = mean + 2 * std`.

#### Summary of Changes
- Implement [Welford's variance algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) to calculate mean and variance without caching all data points.
- removed `get_cost_table` function since it now contains aggregated data, which should be consumed internally.
- replaced `get_average` and `get_mode` with `get_default` to assign max units `200_000` to unknown programs

Fixes #
