### PR TITLE
Re-enable LTO

### DIFF
--- a/sdk/bpf/env.sh
+++ b/sdk/bpf/env.sh
@@ -14,5 +14,3 @@ export CC="$bpf_sdk/dependencies/bpf-tools/llvm/bin/clang"
 export AR="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-ar"
 export OBJDUMP="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-objdump"
 export OBJCOPY="$bpf_sdk/dependencies/bpf-tools/llvm/bin/llvm-objcopy"
-
-export RUSTFLAGS="${RUSTFLAGS} -C lto=no"

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -515,25 +515,20 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     env::set_var("AR", llvm_bin.join("llvm-ar"));
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
-    const RF_LTO: &str = "-C lto=no";
-    let mut rustflags = match env::var("RUSTFLAGS") {
-        Ok(rf) => {
-            if rf.contains(&RF_LTO) {
-                rf
-            } else {
-                format!("{} {}", rf, RF_LTO)
-            }
+
+    if let Ok(mut rustflags) = env::var("RUSTFLAGS") {
+        if cfg!(windows) && !rustflags.contains("-C linker=") {
+            let ld_path = llvm_bin.join("ld.lld");
+            rustflags = format!("{} -C linker={}", rustflags, ld_path.display());
         }
-        _ => RF_LTO.to_string(),
+
+        if config.verbose {
+            println!("RUSTFLAGS={}", rustflags);
+        }
+
+        env::set_var("RUSTFLAGS", rustflags);
     };
-    if cfg!(windows) && !rustflags.contains("-C linker=") {
-        let ld_path = llvm_bin.join("ld.lld");
-        rustflags = format!("{} -C linker={}", rustflags, ld_path.display());
-    }
-    if config.verbose {
-        println!("RUSTFLAGS={}", rustflags);
-    }
-    env::set_var("RUSTFLAGS", rustflags);
+
     let cargo_build = PathBuf::from("cargo");
     let mut cargo_build_args = vec![
         "+bpf",


### PR DESCRIPTION
#### Problem

LTO is currently disabled by cargo-build-bpf. It was disabled a few months back to workaround a possible miscompilation bug.

#### Summary of Changes

Re-enable LTO as it seems to work fine now. It was possibly fixed by either the LLVM13 upgrade or by our recent rustc fixes, which did fix one LTO issue when compiling tests.