### PR TITLE
Only sum accounts data len from non-zero lamport accounts

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6676,7 +6676,9 @@ impl AccountsDb {
                         &self.account_indexes,
                     );
                 }
-                accounts_data_len += stored_account.data().len() as u64;
+                if !stored_account.is_zero_lamport() {
+                    accounts_data_len += stored_account.data().len() as u64;
+                }
 
                 if !rent_collector.should_collect_rent(&pubkey, &stored_account, false) || {
                     let (_rent_due, exempt) = rent_collector.get_rent_due(&stored_account);


### PR DESCRIPTION
#### Problem

`generate_index()` is including zero-lamport accounts in its summation of the total accounts data size. However, zero-lamport accounts just haven't been cleaned yet, and should not count towards the total accounts data size.

#### Summary of Changes

Only sum non-zero-lamport accounts' data len.