### PR TITLE
cargo-build-bpf: don't set -C linker on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -676,7 +676,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -7170,7 +7170,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -451,7 +451,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -4193,7 +4193,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.5",
  "subtle",
 ]
 

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -516,17 +516,11 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     env::set_var("OBJDUMP", llvm_bin.join("llvm-objdump"));
     env::set_var("OBJCOPY", llvm_bin.join("llvm-objcopy"));
 
-    if let Ok(mut rustflags) = env::var("RUSTFLAGS") {
-        if cfg!(windows) && !rustflags.contains("-C linker=") {
-            let ld_path = llvm_bin.join("ld.lld");
-            rustflags = format!("{} -C linker={}", rustflags, ld_path.display());
-        }
-
-        if config.verbose {
-            println!("RUSTFLAGS={}", rustflags);
-        }
-
-        env::set_var("RUSTFLAGS", rustflags);
+    if config.verbose {
+        println!(
+            "RUSTFLAGS={}",
+            env::var("RUSTFLAGS").ok().as_deref().unwrap_or("")
+        );
     };
 
     let cargo_build = PathBuf::from("cargo");


### PR DESCRIPTION
#### Problem

cargo-build-bpf hardcodes `-C linker` when building for windows

#### Summary of Changes

Since we're now linking using rust-lld
(https://github.com/solana-labs/rust/commit/87ba5c61a5fe7f6fc5b74298127592dd0bc38389)
which is guaranteed to always be in the sysroot, hardcoding the linker path
shouldn't be needed anymore.