### PR TITLE
docs: Update default --dynamic-port-range values to include some room for additional ports that may be added in the future

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -51,7 +51,7 @@ $ solana-validator \
     --only-known-rpc \
     --ledger ledger \
     --rpc-port 8899 \
-    --dynamic-port-range 8000-8010 \
+    --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.devnet.solana.com:8001 \
     --entrypoint entrypoint2.devnet.solana.com:8001 \
     --entrypoint entrypoint3.devnet.solana.com:8001 \
@@ -103,7 +103,7 @@ $ solana-validator \
     --only-known-rpc \
     --ledger ledger \
     --rpc-port 8899 \
-    --dynamic-port-range 8000-8010 \
+    --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.testnet.solana.com:8001 \
     --entrypoint entrypoint2.testnet.solana.com:8001 \
     --entrypoint entrypoint3.testnet.solana.com:8001 \
@@ -158,7 +158,7 @@ $ solana-validator \
     --ledger ledger \
     --rpc-port 8899 \
     --private-rpc \
-    --dynamic-port-range 8000-8010 \
+    --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint2.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint3.mainnet-beta.solana.com:8001 \

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -321,8 +321,8 @@ If your validator is connected, its public key and IP address will appear in the
 
 By default the validator will dynamically select available network ports in the
 8000-10000 range, and may be overridden with `--dynamic-port-range`. For
-example, `solana-validator --dynamic-port-range 11000-11010 ...` will restrict
-the validator to ports 11000-11010.
+example, `solana-validator --dynamic-port-range 11000-11020 ...` will restrict
+the validator to ports 11000-11020.
 
 ### Limiting ledger size to conserve disk space
 


### PR DESCRIPTION
v1.9.3 adds an additional port causing the previous advertised value of `--dynamic-port-range 11000-11010` to cause `solana-validator` to abort on startup.  

Update the docs to include a range of 20 ports to avoid operator pain the next time a new port is added.