### PR TITLE
Remove erroneous `dbg!()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1600,7 +1600,6 @@ mod tests {
         // Test 1: Resize the account to use up all the space; this must succeed
         {
             let new_len = user_account_data_len + remaining_account_data_len;
-            dbg!(new_len);
             let instruction_data =
                 bincode::serialize(&MockInstruction::Resize { new_len }).unwrap();
 
@@ -1618,7 +1617,6 @@ mod tests {
         // Test 2: Resize the account to *the same size*, so not consuming any additional size; this must succeed
         {
             let new_len = user_account_data_len + remaining_account_data_len;
-            dbg!(new_len);
             let instruction_data =
                 bincode::serialize(&MockInstruction::Resize { new_len }).unwrap();
 
@@ -1636,7 +1634,6 @@ mod tests {
         // Test 3: Resize the account to exceed the budget; this must fail
         {
             let new_len = user_account_data_len + remaining_account_data_len + 1;
-            dbg!(new_len);
             let instruction_data =
                 bincode::serialize(&MockInstruction::Resize { new_len }).unwrap();
 


### PR DESCRIPTION
Remove the erroneous `dbg!()` calls that I accidentally left in InvokeContext.