### PR TITLE
Refactor Rent::due() with RentDue enum

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2128,7 +2128,7 @@ pub fn process_calculate_rent(
         timing::years_as_slots(1.0, &seconds_per_tick, clock::DEFAULT_TICKS_PER_SLOT);
     let slots_per_epoch = epoch_schedule.slots_per_epoch as f64;
     let years_per_epoch = slots_per_epoch / slots_per_year;
-    let (lamports_per_epoch, _) = rent.due(0, data_length, years_per_epoch);
+    let lamports_per_epoch = rent.due(0, data_length, years_per_epoch).lamports();
     let cli_rent_calculation = CliRentCalculation {
         lamports_per_byte_year: rent.lamports_per_byte_year,
         lamports_per_epoch,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6680,10 +6680,9 @@ impl AccountsDb {
                     accounts_data_len += stored_account.data().len() as u64;
                 }
 
-                if !rent_collector.should_collect_rent(&pubkey, &stored_account, false) || {
-                    let (_rent_due, exempt) = rent_collector.get_rent_due(&stored_account);
-                    exempt
-                } {
+                if !rent_collector.should_collect_rent(&pubkey, &stored_account, false)
+                    || rent_collector.get_rent_due(&stored_account).is_exempt()
+                {
                     num_accounts_rent_exempt += 1;
                 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6174,7 +6174,7 @@ impl Bank {
             }
 
             if !rent_collector.should_collect_rent(pubkey, account, false)
-                || rent_collector.get_rent_due(account).1
+                || rent_collector.get_rent_due(account).is_exempt()
             {
                 total_accounts_stats.num_rent_exempt_accounts += 1;
             } else {
@@ -7342,11 +7342,15 @@ pub(crate) mod tests {
                     .get_slots_in_epoch(epoch + 1)
             })
             .sum();
-        let (generic_rent_due_for_system_account, _) = bank.rent_collector.rent.due(
-            bank.get_minimum_balance_for_rent_exemption(0) - 1,
-            0,
-            slots_elapsed as f64 / bank.rent_collector.slots_per_year,
-        );
+        let generic_rent_due_for_system_account = bank
+            .rent_collector
+            .rent
+            .due(
+                bank.get_minimum_balance_for_rent_exemption(0) - 1,
+                0,
+                slots_elapsed as f64 / bank.rent_collector.slots_per_year,
+            )
+            .lamports();
 
         store_accounts_for_rent_test(
             &bank,

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -93,20 +93,98 @@ impl RentCollector {
         rent_for_sysvars: bool,
         filler_account_suffix: Option<&Pubkey>,
     ) -> u64 {
-        if self.can_skip_rent_collection(address, account, rent_for_sysvars, filler_account_suffix)
-        {
+        if self.can_skip_rent_collection(address, account, rent_for_sysvars, filler_account_suffix) {
             return 0;
         }
 
         let begin_lamports = account.lamports();
         let rent_due = self.get_rent_due(account);
 
-        self.handle_rent_epoch(account, &rent_due);
-        self.handle_rent_amount(account, &rent_due);
-        self.handle_account_cleanup(account);
+        match rent_due {
+            RentDue::Exempt => {
+                let rent_due = rent_due.lamports();
+                if account.lamports() > rent_due {
+                    account.set_rent_epoch(
+                        self.epoch + 
+                                // Rent isn't collected for the next epoch
+                                // Make sure to check exempt status later in current epoch again
+                                0
+                    );
+                    account.checked_sub_lamports(rent_due).unwrap(); // will not fail. We check above.
+                    rent_due
+                } else {
+                    let rent_charged = account.lamports();
+                    *account = AccountSharedData::default();
+                    rent_charged
+                }
+            }
+            RentDue::Paying(x) if x != 0 => {
+                let rent_due = rent_due.lamports();
+                if account.lamports() > rent_due {
+                    account.set_rent_epoch(
+                        self.epoch + 
+                                // Rent is collected for next epoch
+                                1
+                    );
+                    account.checked_sub_lamports(rent_due).unwrap(); // will not fail. We check above.
+                    rent_due
+                } else {
+                    let rent_charged = account.lamports();
+                    *account = AccountSharedData::default();
+                    rent_charged
+                }
+            }
+            _ => {
+                // maybe collect rent later, leave account alone
+                0
+            }
+        }
 
-        let end_lamports = account.lamports();
-        begin_lamports - end_lamports
+        /*
+         *         // OLD
+         *
+         *             let (rent_due, exempt) = self.get_rent_due(account);
+         *
+         *             if exempt || rent_due != 0 {
+         *                 if account.lamports() > rent_due {
+         *                     account.set_rent_epoch(
+         *                         self.epoch
+         *                             + if exempt {
+         *                                 // Rent isn't collected for the next epoch
+         *                                 // Make sure to check exempt status later in current epoch again
+         *                                 0
+         *                             } else {
+         *                                 // Rent is collected for next epoch
+         *                                 1
+         *                             },
+         *                     );
+         *                     let _ = account.checked_sub_lamports(rent_due); // will not fail. We check above.
+         *                     rent_due
+         *                 } else {
+         *                     let rent_charged = account.lamports();
+         *                     *account = AccountSharedData::default();
+         *                     rent_charged
+         *                 }
+         *             } else {
+         *                 // maybe collect rent later, leave account alone
+         *                 0
+         *             }
+         */
+
+        /*
+         *             // NEW ish
+         *
+         *
+         *         let begin_lamports = account.lamports();
+         *         let rent_due = self.get_rent_due(account);
+         *
+         *         self.handle_rent_epoch(account, &rent_due);
+         *         self.handle_rent_amount(account, &rent_due);
+         *         self.handle_account_cleanup(account);
+         *
+         *         let end_lamports = account.lamports();
+         *         begin_lamports - end_lamports
+         */
     }
 
     #[must_use = "add to Bank::collected_rent"]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -158,8 +158,9 @@ impl RentCollector {
 
     /// Update the account for its next rent epoch
     fn handle_rent_epoch(&self, account: &mut AccountSharedData, rent_due: &RentDue) {
-        self.next_rent_epoch(rent_due)
-            .map(|epoch| account.set_rent_epoch(epoch));
+        if let Some(epoch) = self.next_rent_epoch(rent_due) {
+            account.set_rent_epoch(epoch)
+        }
     }
 
     /// Deduct the applicable rent amount from the account

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -99,11 +99,9 @@ impl RentCollector {
         }
 
         let rent_due = self.get_rent_due(account);
-        if let RentDue::Paying(rent_amount) = rent_due {
-            if rent_amount == 0 {
-                // maybe collect rent later, leave account alone
-                return 0;
-            }
+        if let RentDue::Paying(0) = rent_due {
+            // maybe collect rent later, leave account alone
+            return 0;
         }
 
         let epoch_increment = match rent_due {

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -64,16 +64,13 @@ impl Rent {
     }
 
     /// rent due on account's data_len with balance
-    pub fn due(&self, balance: u64, data_len: usize, years_elapsed: f64) -> (u64, bool) {
+    pub fn due(&self, balance: u64, data_len: usize, years_elapsed: f64) -> RentDue {
         if self.is_exempt(balance, data_len) {
-            (0, true)
+            RentDue::Exempt
         } else {
-            (
-                ((self.lamports_per_byte_year * (data_len as u64 + ACCOUNT_STORAGE_OVERHEAD))
-                    as f64
-                    * years_elapsed) as u64,
-                false,
-            )
+            let actual_data_len = data_len as u64 + ACCOUNT_STORAGE_OVERHEAD;
+            let lamports_per_year = self.lamports_per_byte_year * actual_data_len;
+            RentDue::Paying((lamports_per_year as f64 * years_elapsed) as u64)
         }
     }
 
@@ -96,6 +93,33 @@ impl Rent {
     }
 }
 
+/// Enumerate return values from `Rent::due()`
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RentDue {
+    /// Used to indicate the account is rent exempt
+    Exempt,
+    /// The account owes rent, and the amount is the field
+    Paying(u64),
+}
+
+impl RentDue {
+    /// Return the lamports due for rent
+    pub fn lamports(&self) -> u64 {
+        match self {
+            RentDue::Exempt => 0,
+            RentDue::Paying(x) => *x,
+        }
+    }
+
+    /// Return 'true' if rent exempt
+    pub fn is_exempt(&self) -> bool {
+        match self {
+            RentDue::Exempt => true,
+            RentDue::Paying(_) => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,11 +130,10 @@ mod tests {
 
         assert_eq!(
             default_rent.due(0, 2, 1.2),
-            (
+            RentDue::Paying(
                 (((2 + ACCOUNT_STORAGE_OVERHEAD) * DEFAULT_LAMPORTS_PER_BYTE_YEAR) as f64 * 1.2)
-                    as u64,
-                DEFAULT_LAMPORTS_PER_BYTE_YEAR == 0
-            )
+                    as u64
+            ),
         );
         assert_eq!(
             default_rent.due(
@@ -119,7 +142,7 @@ mod tests {
                 2,
                 1.2
             ),
-            (0, true)
+            RentDue::Exempt,
         );
 
         let custom_rent = Rent {
@@ -130,10 +153,9 @@ mod tests {
 
         assert_eq!(
             custom_rent.due(0, 2, 1.2),
-            (
+            RentDue::Paying(
                 (((2 + ACCOUNT_STORAGE_OVERHEAD) * custom_rent.lamports_per_byte_year) as f64 * 1.2)
                     as u64,
-                false
             )
         );
 
@@ -144,43 +166,21 @@ mod tests {
                 2,
                 1.2
             ),
-            (0, true)
+            RentDue::Exempt
         );
     }
 
-    #[ignore]
     #[test]
-    #[should_panic]
-    fn show_rent_model() {
-        use crate::{clock::*, sysvar::Sysvar};
+    fn test_rent_due_lamports() {
+        assert_eq!(RentDue::Exempt.lamports(), 0);
 
-        const SECONDS_PER_YEAR: f64 = 365.242_199 * 24.0 * 60.0 * 60.0;
-        const SLOTS_PER_YEAR: f64 = SECONDS_PER_YEAR / DEFAULT_S_PER_SLOT;
+        let amount = 123;
+        assert_eq!(RentDue::Paying(amount).lamports(), amount);
+    }
 
-        let rent = Rent::default();
-        panic!(
-            "\n\n\
-             ==================================================\n\
-             empty account, no data:\n\
-             \t{} lamports per epoch, {} lamports to be rent_exempt\n\n\
-             stake_history, which is {}kB of data:\n\
-             \t{} lamports per epoch, {} lamports to be rent_exempt\n\
-             ==================================================\n\n",
-            rent.due(
-                0,
-                0,
-                (1.0 / SLOTS_PER_YEAR) * DEFAULT_SLOTS_PER_EPOCH as f64,
-            )
-            .0,
-            rent.minimum_balance(0),
-            crate::sysvar::stake_history::StakeHistory::size_of() / 1024,
-            rent.due(
-                0,
-                crate::sysvar::stake_history::StakeHistory::size_of(),
-                (1.0 / SLOTS_PER_YEAR) * DEFAULT_SLOTS_PER_EPOCH as f64,
-            )
-            .0,
-            rent.minimum_balance(crate::sysvar::stake_history::StakeHistory::size_of()),
-        );
+    #[test]
+    fn test_rent_due_is_exempt() {
+        assert!(RentDue::Exempt.is_exempt());
+        assert!(!RentDue::Paying(0).is_exempt());
     }
 }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -103,6 +103,12 @@ pub trait WritableAccount: ReadableAccount {
         );
         Ok(())
     }
+    fn saturating_add_lamports(&mut self, lamports: u64) {
+        self.set_lamports(self.lamports().saturating_add(lamports))
+    }
+    fn saturating_sub_lamports(&mut self, lamports: u64) {
+        self.set_lamports(self.lamports().saturating_sub(lamports))
+    }
     fn data_mut(&mut self) -> &mut Vec<u8>;
     fn data_as_mut_slice(&mut self) -> &mut [u8];
     fn set_owner(&mut self, owner: Pubkey);
@@ -798,6 +804,28 @@ pub mod tests {
         let key = Pubkey::new_unique();
         let (_account1, mut account2) = make_two_accounts(&key);
         account2.checked_sub_lamports(u64::MAX).unwrap();
+    }
+
+    #[test]
+    fn test_account_saturating_add_lamports() {
+        let key = Pubkey::new_unique();
+        let (mut account, _) = make_two_accounts(&key);
+
+        let remaining = 22;
+        account.set_lamports(u64::MAX - remaining);
+        account.saturating_add_lamports(remaining * 2);
+        assert_eq!(account.lamports(), u64::MAX);
+    }
+
+    #[test]
+    fn test_account_saturating_sub_lamports() {
+        let key = Pubkey::new_unique();
+        let (mut account, _) = make_two_accounts(&key);
+
+        let remaining = 33;
+        account.set_lamports(remaining);
+        account.saturating_sub_lamports(remaining * 2);
+        assert_eq!(account.lamports(), 0);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

I found `RentCollector::collect_from_existing_account()` to be quite unwieldy. It boiled down to how `Rent::due()` returned its result (and conflates them).

For background, I started looking at this because I need to track accounts that get cleaned up during rent collection. So I've isolated just the rent refactoring to this PR. See #21604 for more information.

#### Summary of Changes

I've introduced an enum, `RentDue`, as the result from `Rent::due()`. This enabled me to simplify `RentCollector::collect_from_existing_account()`.

I've added a few people as reviewers; **since rent collection is very important to get right, please do add additional reviewers that should weigh in.**