### PR TITLE
Added TooManyAccountLocks to the PostgreSQL enum types

### DIFF
--- a/accountsdb-plugin-postgres/scripts/create_schema.sql
+++ b/accountsdb-plugin-postgres/scripts/create_schema.sql
@@ -48,7 +48,8 @@ Create TYPE "TransactionErrorCode" AS ENUM (
     'WouldExceedMaxBlockCostLimit',
     'UnsupportedVersion',
     'InvalidWritableAccount',
-    'WouldExceedMaxAccountDataCostLimit'
+    'WouldExceedMaxAccountDataCostLimit',
+    'TooManyAccountLocks'
 );
 
 CREATE TYPE "TransactionError" AS (


### PR DESCRIPTION
#### Problem
Failed to persist the update of transaction info to the PostgreSQL database due to Rust and PostgreSQL type mist matches

#### Summary of Changes
Added TooManyAccountLocks to the PostgreSQL enum types
Fixes #
