### PR TITLE
explorer: fix missing logs error for old transactions

### DIFF
--- a/explorer/src/components/transaction/ProgramLogSection.tsx
+++ b/explorer/src/components/transaction/ProgramLogSection.tsx
@@ -15,7 +15,11 @@ export function ProgramLogSection({ signature }: SignatureProps) {
 
   const logMessages = transaction.meta?.logMessages || null;
   const err = transaction.meta?.err || null;
-  const prettyLogs = prettyProgramLogs(logMessages, err, cluster);
+
+  let prettyLogs = null;
+  if (logMessages !== null) {
+    prettyLogs = prettyProgramLogs(logMessages, err, cluster);
+  }
 
   return (
     <>
@@ -23,11 +27,17 @@ export function ProgramLogSection({ signature }: SignatureProps) {
         <div className="card-header">
           <h3 className="card-header-title">Program Logs</h3>
         </div>
-        <ProgramLogsCardBody
-          message={message}
-          logs={prettyLogs}
-          cluster={cluster}
-        />
+        {prettyLogs !== null ? (
+          <ProgramLogsCardBody
+            message={message}
+            logs={prettyLogs}
+            cluster={cluster}
+          />
+        ) : (
+          <div className="card-body">
+            Logs not supported for this transaction
+          </div>
+        )}
       </div>
     </>
   );

--- a/explorer/src/pages/inspector/SimulatorCard.tsx
+++ b/explorer/src/pages/inspector/SimulatorCard.tsx
@@ -101,6 +101,9 @@ function useSimulator(message: Message) {
 
         // Simulate without signers to skip signer verification
         const resp = await connection.simulateTransaction(tx);
+        if (resp.value.logs === null) {
+          throw new Error("Expected to receive logs from simulation");
+        }
 
         // Prettify logs
         setLogs(prettyProgramLogs(resp.value.logs, resp.value.err, cluster));

--- a/explorer/src/utils/program-logs.ts
+++ b/explorer/src/utils/program-logs.ts
@@ -15,7 +15,7 @@ export type InstructionLogs = {
 };
 
 export function prettyProgramLogs(
-  logs: string[] | null,
+  logs: string[],
   error: TransactionError | null,
   cluster: Cluster
 ): InstructionLogs[] {
@@ -27,10 +27,7 @@ export function prettyProgramLogs(
   };
 
   let prettyError;
-  if (!logs) {
-    if (error) throw new Error(JSON.stringify(error));
-    throw new Error("No logs detected");
-  } else if (error) {
+  if (error) {
     prettyError = getTransactionInstructionError(error);
   }
 


### PR DESCRIPTION
#### Problem
Explorer crashes when trying to display old transactions which don't have logs

#### Summary of Changes

Fixes #
