### PR TITLE
bpf_loader: introduce disable_deprecated_load_instructions feature

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -38,8 +38,9 @@ use {
         clock::Clock,
         entrypoint::{HEAP_LENGTH, SUCCESS},
         feature_set::{
-            cap_accounts_data_len, do_support_realloc, reduce_required_deploy_balance,
-            reject_all_elf_rw, reject_deployment_of_unresolved_syscalls,
+            cap_accounts_data_len, disable_deprecated_load_instructions, do_support_realloc,
+            reduce_required_deploy_balance, reject_all_elf_rw,
+            reject_deployment_of_unresolved_syscalls,
             reject_section_virtual_address_file_offset_mismatch, requestable_heap_size,
             start_verify_shift32_imm, stop_verify_mul64_imm_nonzero,
         },
@@ -119,6 +120,9 @@ pub fn create_executor(
         reject_all_writable_sections: invoke_context
             .feature_set
             .is_active(&reject_all_elf_rw::id()),
+        disable_deprecated_load_instructions: invoke_context
+            .feature_set
+            .is_active(&disable_deprecated_load_instructions::id()),
         ..Config::default()
     };
     let mut executable = {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -295,6 +295,10 @@ pub mod max_tx_account_locks {
     solana_sdk::declare_id!("CBkDroRDqm8HwHe6ak9cguPjUomrASEkfmxEaZ5CNNxz");
 }
 
+pub mod disable_deprecated_load_instructions {
+    solana_sdk::declare_id!("5hvf5YRyWVNtQsCdQHiNGkw2o1QC6AA6q39rjGJxGQFx");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [


### PR DESCRIPTION
#### Problem

As part of the move to SBFv2 we want to disable "input buffer" load instructions that don't really make sense in our execution environment.

#### Summary of Changes

Add the disable_deprecated_load_instructions feature gate that turns on the corresponding rbpf feature https://github.com/solana-labs/rbpf/pull/251 

