### PR TITLE
Remove per program timings from blockstore processor ledger replay

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1128,6 +1128,7 @@ fn load_frozen_forks(
     let dev_halt_at_slot = opts.dev_halt_at_slot.unwrap_or(std::u64::MAX);
     if root_bank.slot() != dev_halt_at_slot {
         while !pending_slots.is_empty() {
+            timing.details.per_program_timings.clear();
             let (meta, bank, last_entry_hash) = pending_slots.pop().unwrap();
             let slot = bank.slot();
             if last_status_report.elapsed() > Duration::from_secs(2) {


### PR DESCRIPTION
#### Problem
New vector of error timings grows unboundedly large during ledger replay because they are never coalesced.

#### Summary of Changes
The cost model is never updated in ledger replay anyways, so just clear the per program timings
Fixes #
