### PR TITLE
wrap create executor timings datapoint in a module

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -82,6 +82,28 @@ fn map_ebpf_error(invoke_context: &InvokeContext, e: EbpfError<BpfError>) -> Ins
     InstructionError::InvalidAccountData
 }
 
+mod executor_metrics {
+    #[derive(Debug, Default)]
+    pub struct CreateMetrics {
+        pub program_id: String,
+        pub load_elf_us: u64,
+        pub verify_code_us: u64,
+        pub jit_compile_us: u64,
+    }
+
+    impl CreateMetrics {
+        pub fn submit_datapoint(&self) {
+            datapoint_trace!(
+                "create_executor_trace",
+                ("program_id", self.program_id, String),
+                ("load_elf_us", self.load_elf_us, i64),
+                ("verify_code_us", self.verify_code_us, i64),
+                ("jit_compile_us", self.jit_compile_us, i64),
+            );
+        }
+    }
+}
+
 pub fn create_executor(
     programdata_account_index: usize,
     programdata_offset: usize,
@@ -124,14 +146,11 @@ pub fn create_executor(
             .is_active(&reject_all_elf_rw::id()),
         ..Config::default()
     };
-    let program_id;
-    let load_elf_us: u64;
-    let verify_elf_us: u64;
-    let mut jit_compile_us = 0u64;
+    let mut create_executor_metrics = executor_metrics::CreateMetrics::default();
     let mut executable = {
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
         let programdata = keyed_account_at_index(keyed_accounts, programdata_account_index)?;
-        program_id = *programdata.unsigned_key();
+        create_executor_metrics.program_id = programdata.unsigned_key().to_string();
         let mut load_elf_time = Measure::start("load_elf_time");
         let executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(
             &programdata.try_account_ref()?.data()[programdata_offset..],
@@ -140,11 +159,11 @@ pub fn create_executor(
             syscall_registry,
         );
         load_elf_time.stop();
-        load_elf_us = load_elf_time.as_us();
+        create_executor_metrics.load_elf_us = load_elf_time.as_us();
         invoke_context.timings.create_executor_load_elf_us = invoke_context
             .timings
             .create_executor_load_elf_us
-            .saturating_add(load_elf_us);
+            .saturating_add(create_executor_metrics.load_elf_us);
         executable
     }
     .map_err(|e| map_ebpf_error(invoke_context, e))?;
@@ -153,33 +172,27 @@ pub fn create_executor(
     verifier::check(text_bytes, &config)
         .map_err(|e| map_ebpf_error(invoke_context, EbpfError::UserError(e.into())))?;
     verify_code_time.stop();
-    verify_elf_us = verify_code_time.as_us();
+    create_executor_metrics.verify_code_us = verify_code_time.as_us();
     invoke_context.timings.create_executor_verify_code_us = invoke_context
         .timings
         .create_executor_verify_code_us
-        .saturating_add(verify_elf_us);
+        .saturating_add(create_executor_metrics.verify_code_us);
     if use_jit {
         let mut jit_compile_time = Measure::start("jit_compile_time");
         let jit_compile_result =
             Executable::<BpfError, ThisInstructionMeter>::jit_compile(&mut executable);
         jit_compile_time.stop();
-        jit_compile_us = jit_compile_time.as_us();
+        create_executor_metrics.jit_compile_us = jit_compile_time.as_us();
         invoke_context.timings.create_executor_jit_compile_us = invoke_context
             .timings
             .create_executor_jit_compile_us
-            .saturating_add(jit_compile_us);
+            .saturating_add(create_executor_metrics.jit_compile_us);
         if let Err(err) = jit_compile_result {
             ic_msg!(invoke_context, "Failed to compile program {:?}", err);
             return Err(InstructionError::ProgramFailedToCompile);
         }
     }
-    datapoint_trace!(
-        "create_executor_trace",
-        ("program_id", program_id.to_string(), String),
-        ("load_elf_us", load_elf_us, i64),
-        ("verify_elf_us", verify_elf_us, i64),
-        ("jit_compile_us", jit_compile_us, i64),
-    );
+    create_executor_metrics.submit_datapoint();
     Ok(Arc::new(BpfExecutor { executable }))
 }
 


### PR DESCRIPTION
#### Problem

Create executor timing trace datapoint is in the same module as a trace log that dumps program disassemblies, making it... less useful.

#### Summary of Changes

Encapsulate datapoint components in their own type and wrap it with a module to allow it to be isolated with a `RUST_LOG` filter