### PR TITLE
Store address table lookups in blockstore and bigtable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4849,6 +4849,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "solana-accountsdb-plugin-manager",
+ "solana-address-lookup-table-program",
  "solana-client",
  "solana-entry",
  "solana-frozen-abi 1.10.0",

--- a/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
+++ b/accountsdb-plugin-postgres/src/postgres_client/postgres_client_transaction.rs
@@ -1034,6 +1034,10 @@ pub(crate) mod tests {
                     commission: Some(11),
                 },
             ]),
+            loaded_addresses: LoadedAddresses {
+                writable: vec![Pubkey::new_unique()],
+                readonly: vec![Pubkey::new_unique()],
+            },
         }
     }
 

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -275,8 +275,9 @@ fn test_block_subscription() {
     let maybe_actual = receiver.recv_timeout(Duration::from_millis(400));
     match maybe_actual {
         Ok(actual) => {
-            let complete_block = blockstore.get_complete_block(slot, false).unwrap();
-            let block = complete_block.clone().configure(
+            let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
+            let legacy_block = versioned_block.into_legacy_block().unwrap();
+            let block = legacy_block.clone().configure(
                 UiTransactionEncoding::Json,
                 TransactionDetails::Signatures,
                 false,
@@ -286,7 +287,7 @@ fn test_block_subscription() {
                 block: Some(block),
                 err: None,
             };
-            let block = complete_block.configure(
+            let block = legacy_block.configure(
                 UiTransactionEncoding::Json,
                 TransactionDetails::Signatures,
                 false,

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -20,6 +20,7 @@ pub const JSON_RPC_SERVER_ERROR_TRANSACTION_HISTORY_NOT_AVAILABLE: i64 = -32011;
 pub const JSON_RPC_SCAN_ERROR: i64 = -32012;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_LEN_MISMATCH: i64 = -32013;
 pub const JSON_RPC_SERVER_ERROR_BLOCK_STATUS_NOT_AVAILABLE_YET: i64 = -32014;
+pub const JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION: i64 = -32015;
 
 #[derive(Error, Debug)]
 pub enum RpcCustomError {
@@ -57,6 +58,8 @@ pub enum RpcCustomError {
     TransactionSignatureLenMismatch,
     #[error("BlockStatusNotAvailableYet")]
     BlockStatusNotAvailableYet { slot: Slot },
+    #[error("UnsupportedTransactionVersion")]
+    UnsupportedTransactionVersion,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -167,6 +170,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::BlockStatusNotAvailableYet { slot } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BLOCK_STATUS_NOT_AVAILABLE_YET),
                 message: format!("Block status not yet available for slot {}", slot),
+                data: None,
+            },
+            RpcCustomError::UnsupportedTransactionVersion => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION),
+                message: "Versioned transactions are not supported".to_string(),
                 data: None,
             },
         }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -429,6 +429,9 @@ pub struct RpcInflationReward {
 pub enum RpcBlockUpdateError {
     #[error("block store error")]
     BlockStoreError,
+
+    #[error("unsupported transaction version")]
+    UnsupportedTransactionVersion,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ rayon = "1.5.1"
 retain_mut = "0.1.5"
 serde = "1.0.133"
 serde_derive = "1.0.103"
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.10.0" }
 solana-accountsdb-plugin-manager = { path = "../accountsdb-plugin-manager", version = "=1.10.0" }
 solana-client = { path = "../client", version = "=1.10.0" }
 solana-entry = { path = "../entry", version = "=1.10.0" }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3003,7 +3003,7 @@ pub mod tests {
             transaction::TransactionError,
         },
         solana_streamer::socket::SocketAddrSpace,
-        solana_transaction_status::TransactionWithStatusMeta,
+        solana_transaction_status::VersionedTransactionWithStatusMeta,
         solana_vote_program::{
             vote_state::{VoteState, VoteStateVersions},
             vote_transaction,
@@ -3860,7 +3860,7 @@ pub mod tests {
             let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
             assert_eq!(confirmed_block.transactions.len(), 3);
 
-            for TransactionWithStatusMeta { transaction, meta } in
+            for VersionedTransactionWithStatusMeta { transaction, meta } in
                 confirmed_block.transactions.into_iter()
             {
                 if transaction.signatures[0] == signatures[0] {

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -898,8 +898,17 @@ pub fn create_random_ticks(num_ticks: u64, max_hashes_per_tick: u64, mut hash: H
 
 /// Creates the next Tick or Transaction Entry `num_hashes` after `start_hash`.
 pub fn next_entry(prev_hash: &Hash, num_hashes: u64, transactions: Vec<Transaction>) -> Entry {
-    assert!(num_hashes > 0 || transactions.is_empty());
     let transactions = transactions.into_iter().map(Into::into).collect::<Vec<_>>();
+    next_versioned_entry(prev_hash, num_hashes, transactions)
+}
+
+/// Creates the next Tick or Transaction Entry `num_hashes` after `start_hash`.
+pub fn next_versioned_entry(
+    prev_hash: &Hash,
+    num_hashes: u64,
+    transactions: Vec<VersionedTransaction>,
+) -> Entry {
+    assert!(num_hashes > 0 || transactions.is_empty());
     Entry {
         num_hashes,
         hash: next_hash(prev_hash, num_hashes, &transactions),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -42,9 +42,9 @@ use {
     },
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
     solana_transaction_status::{
-        ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
-        ConfirmedTransactionWithStatusMeta, Rewards, TransactionStatusMeta,
-        TransactionWithStatusMeta,
+        ConfirmedTransactionStatusWithSignature, Rewards, TransactionStatusMeta,
+        VersionedConfirmedBlock, VersionedConfirmedTransactionWithStatusMeta,
+        VersionedTransactionWithStatusMeta,
     },
     std::{
         borrow::Cow,
@@ -1923,7 +1923,7 @@ impl Blockstore {
         &self,
         slot: Slot,
         require_previous_blockhash: bool,
-    ) -> Result<ConfirmedBlock> {
+    ) -> Result<VersionedConfirmedBlock> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_rooted_block".to_string(), String)
@@ -1940,7 +1940,7 @@ impl Blockstore {
         &self,
         slot: Slot,
         require_previous_blockhash: bool,
-    ) -> Result<ConfirmedBlock> {
+    ) -> Result<VersionedConfirmedBlock> {
         let slot_meta_cf = self.db.column::<cf::SlotMeta>();
         let slot_meta = match slot_meta_cf.get(slot)? {
             Some(slot_meta) => slot_meta,
@@ -1998,7 +1998,7 @@ impl Blockstore {
                 let block_time = self.blocktime_cf.get(slot)?;
                 let block_height = self.block_height_cf.get(slot)?;
 
-                let block = ConfirmedBlock {
+                let block = VersionedConfirmedBlock {
                     previous_blockhash: previous_blockhash.to_string(),
                     blockhash: blockhash.to_string(),
                     // If the slot is full it should have parent_slot populated
@@ -2020,22 +2020,17 @@ impl Blockstore {
         &self,
         slot: Slot,
         iterator: impl Iterator<Item = VersionedTransaction>,
-    ) -> Result<Vec<TransactionWithStatusMeta>> {
+    ) -> Result<Vec<VersionedTransactionWithStatusMeta>> {
         iterator
-            .map(|versioned_tx| {
-                // TODO: add support for versioned transactions
-                if let Some(transaction) = versioned_tx.into_legacy_transaction() {
-                    let signature = transaction.signatures[0];
-                    Ok(TransactionWithStatusMeta {
-                        transaction,
-                        meta: self
-                            .read_transaction_status((signature, slot))
-                            .ok()
-                            .flatten(),
-                    })
-                } else {
-                    Err(BlockstoreError::UnsupportedTransactionVersion)
-                }
+            .map(|transaction| {
+                let signature = transaction.signatures[0];
+                Ok(VersionedTransactionWithStatusMeta {
+                    transaction,
+                    meta: self
+                        .read_transaction_status((signature, slot))
+                        .ok()
+                        .flatten(),
+                })
             })
             .collect()
     }
@@ -2287,7 +2282,7 @@ impl Blockstore {
     pub fn get_rooted_transaction(
         &self,
         signature: Signature,
-    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_rooted_transaction".to_string(), String)
@@ -2300,7 +2295,7 @@ impl Blockstore {
         &self,
         signature: Signature,
         highest_confirmed_slot: Slot,
-    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_complete_transaction".to_string(), String)
@@ -2317,7 +2312,7 @@ impl Blockstore {
         &self,
         signature: Signature,
         confirmed_unrooted_slots: &[Slot],
-    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
         if let Some((slot, status)) =
             self.get_transaction_status(signature, confirmed_unrooted_slots)?
         {
@@ -2325,15 +2320,10 @@ impl Blockstore {
                 .find_transaction_in_slot(slot, signature)?
                 .ok_or(BlockstoreError::TransactionStatusSlotMismatch)?; // Should not happen
 
-            // TODO: support retrieving versioned transactions
-            let transaction = transaction
-                .into_legacy_transaction()
-                .ok_or(BlockstoreError::UnsupportedTransactionVersion)?;
-
             let block_time = self.get_block_time(slot)?;
-            Ok(Some(ConfirmedTransactionWithStatusMeta {
+            Ok(Some(VersionedConfirmedTransactionWithStatusMeta {
                 slot,
-                transaction: TransactionWithStatusMeta {
+                tx_with_meta: VersionedTransactionWithStatusMeta {
                     transaction,
                     meta: Some(status),
                 },
@@ -4146,6 +4136,7 @@ pub mod tests {
         solana_sdk::{
             hash::{self, hash, Hash},
             instruction::CompiledInstruction,
+            message::v0::LoadedAddresses,
             packet::PACKET_DATA_SIZE,
             pubkey::Pubkey,
             signature::Signature,
@@ -6237,20 +6228,15 @@ pub mod tests {
             .put_meta_bytes(slot - 1, &serialize(&parent_meta).unwrap())
             .unwrap();
 
-        let expected_transactions: Vec<TransactionWithStatusMeta> = entries
+        let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
             .flat_map(|entry| entry.transactions)
             .map(|transaction| {
-                transaction
-                    .into_legacy_transaction()
-                    .expect("versioned transactions not supported")
-            })
-            .map(|transaction| {
                 let mut pre_balances: Vec<u64> = vec![];
                 let mut post_balances: Vec<u64> = vec![];
-                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                for i in 0..transaction.message.total_account_keys_len() {
                     pre_balances.push(i as u64 * 10);
                     post_balances.push(i as u64 * 11);
                 }
@@ -6265,6 +6251,7 @@ pub mod tests {
                     pre_token_balances: Some(vec![]),
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
+                    loaded_addresses: LoadedAddresses::default(),
                 }
                 .into();
                 blockstore
@@ -6281,6 +6268,7 @@ pub mod tests {
                     pre_token_balances: Some(vec![]),
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
+                    loaded_addresses: LoadedAddresses::default(),
                 }
                 .into();
                 blockstore
@@ -6297,13 +6285,14 @@ pub mod tests {
                     pre_token_balances: Some(vec![]),
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
+                    loaded_addresses: LoadedAddresses::default(),
                 }
                 .into();
                 blockstore
                     .transaction_status_cf
                     .put_protobuf((0, signature, slot + 2), &status)
                     .unwrap();
-                TransactionWithStatusMeta {
+                VersionedTransactionWithStatusMeta {
                     transaction,
                     meta: Some(TransactionStatusMeta {
                         status: Ok(()),
@@ -6315,6 +6304,7 @@ pub mod tests {
                         pre_token_balances: Some(vec![]),
                         post_token_balances: Some(vec![]),
                         rewards: Some(vec![]),
+                        loaded_addresses: LoadedAddresses::default(),
                     }),
                 }
             })
@@ -6335,7 +6325,7 @@ pub mod tests {
         // Test if require_previous_blockhash is false
         let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
-        let expected_block = ConfirmedBlock {
+        let expected_block = VersionedConfirmedBlock {
             transactions: expected_transactions.clone(),
             parent_slot: slot - 1,
             blockhash: blockhash.to_string(),
@@ -6349,7 +6339,7 @@ pub mod tests {
         let confirmed_block = blockstore.get_rooted_block(slot + 1, true).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
 
-        let mut expected_block = ConfirmedBlock {
+        let mut expected_block = VersionedConfirmedBlock {
             transactions: expected_transactions.clone(),
             parent_slot: slot,
             blockhash: blockhash.to_string(),
@@ -6366,7 +6356,7 @@ pub mod tests {
         let complete_block = blockstore.get_complete_block(slot + 2, true).unwrap();
         assert_eq!(complete_block.transactions.len(), 100);
 
-        let mut expected_complete_block = ConfirmedBlock {
+        let mut expected_complete_block = VersionedConfirmedBlock {
             transactions: expected_transactions,
             parent_slot: slot + 1,
             blockhash: blockhash.to_string(),
@@ -6422,6 +6412,10 @@ pub mod tests {
         let pre_token_balances_vec = vec![];
         let post_token_balances_vec = vec![];
         let rewards_vec = vec![];
+        let test_loaded_addresses = LoadedAddresses {
+            writable: vec![Pubkey::new_unique()],
+            readonly: vec![Pubkey::new_unique()],
+        };
 
         // result not found
         assert!(transaction_status_cf
@@ -6440,6 +6434,7 @@ pub mod tests {
             pre_token_balances: Some(pre_token_balances_vec.clone()),
             post_token_balances: Some(post_token_balances_vec.clone()),
             rewards: Some(rewards_vec.clone()),
+            loaded_addresses: test_loaded_addresses.clone(),
         }
         .into();
         assert!(transaction_status_cf
@@ -6457,6 +6452,7 @@ pub mod tests {
             pre_token_balances,
             post_token_balances,
             rewards,
+            loaded_addresses,
         } = transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((0, Signature::default(), 0))
             .unwrap()
@@ -6472,6 +6468,7 @@ pub mod tests {
         assert_eq!(pre_token_balances.unwrap(), pre_token_balances_vec);
         assert_eq!(post_token_balances.unwrap(), post_token_balances_vec);
         assert_eq!(rewards.unwrap(), rewards_vec);
+        assert_eq!(loaded_addresses, test_loaded_addresses);
 
         // insert value
         let status = TransactionStatusMeta {
@@ -6484,6 +6481,7 @@ pub mod tests {
             pre_token_balances: Some(pre_token_balances_vec.clone()),
             post_token_balances: Some(post_token_balances_vec.clone()),
             rewards: Some(rewards_vec.clone()),
+            loaded_addresses: test_loaded_addresses.clone(),
         }
         .into();
         assert!(transaction_status_cf
@@ -6501,6 +6499,7 @@ pub mod tests {
             pre_token_balances,
             post_token_balances,
             rewards,
+            loaded_addresses,
         } = transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((
                 0,
@@ -6522,6 +6521,7 @@ pub mod tests {
         assert_eq!(pre_token_balances.unwrap(), pre_token_balances_vec);
         assert_eq!(post_token_balances.unwrap(), post_token_balances_vec);
         assert_eq!(rewards.unwrap(), rewards_vec);
+        assert_eq!(loaded_addresses, test_loaded_addresses);
     }
 
     #[test]
@@ -6749,6 +6749,7 @@ pub mod tests {
             pre_token_balances: Some(vec![]),
             post_token_balances: Some(vec![]),
             rewards: Some(vec![]),
+            loaded_addresses: LoadedAddresses::default(),
         }
         .into();
 
@@ -6943,6 +6944,7 @@ pub mod tests {
             pre_token_balances: Some(vec![]),
             post_token_balances: Some(vec![]),
             rewards: Some(vec![]),
+            loaded_addresses: LoadedAddresses::default(),
         }
         .into();
 
@@ -7093,19 +7095,15 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(vec![slot - 1, slot].iter()).unwrap();
 
-        let expected_transactions: Vec<TransactionWithStatusMeta> = entries
+        let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
             .flat_map(|entry| entry.transactions)
-            .map(|tx| {
-                tx.into_legacy_transaction()
-                    .expect("versioned transactions not supported")
-            })
             .map(|transaction| {
                 let mut pre_balances: Vec<u64> = vec![];
                 let mut post_balances: Vec<u64> = vec![];
-                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                for i in 0..transaction.message.total_account_keys_len() {
                     pre_balances.push(i as u64 * 10);
                     post_balances.push(i as u64 * 11);
                 }
@@ -7128,13 +7126,14 @@ pub mod tests {
                     pre_token_balances: pre_token_balances.clone(),
                     post_token_balances: post_token_balances.clone(),
                     rewards: rewards.clone(),
+                    loaded_addresses: LoadedAddresses::default(),
                 }
                 .into();
                 blockstore
                     .transaction_status_cf
                     .put_protobuf((0, signature, slot), &status)
                     .unwrap();
-                TransactionWithStatusMeta {
+                VersionedTransactionWithStatusMeta {
                     transaction,
                     meta: Some(TransactionStatusMeta {
                         status: Ok(()),
@@ -7146,18 +7145,19 @@ pub mod tests {
                         pre_token_balances,
                         post_token_balances,
                         rewards,
+                        loaded_addresses: LoadedAddresses::default(),
                     }),
                 }
             })
             .collect();
 
-        for transaction in expected_transactions.clone() {
-            let signature = transaction.transaction.signatures[0];
+        for tx_with_meta in expected_transactions.clone() {
+            let signature = tx_with_meta.transaction.signatures[0];
             assert_eq!(
                 blockstore.get_rooted_transaction(signature).unwrap(),
-                Some(ConfirmedTransactionWithStatusMeta {
+                Some(VersionedConfirmedTransactionWithStatusMeta {
                     slot,
-                    transaction: transaction.clone(),
+                    tx_with_meta: tx_with_meta.clone(),
                     block_time: None
                 })
             );
@@ -7165,9 +7165,9 @@ pub mod tests {
                 blockstore
                     .get_complete_transaction(signature, slot + 1)
                     .unwrap(),
-                Some(ConfirmedTransactionWithStatusMeta {
+                Some(VersionedConfirmedTransactionWithStatusMeta {
                     slot,
-                    transaction,
+                    tx_with_meta,
                     block_time: None
                 })
             );
@@ -7175,7 +7175,7 @@ pub mod tests {
 
         blockstore.run_purge(0, 2, PurgeType::PrimaryIndex).unwrap();
         *blockstore.lowest_cleanup_slot.write().unwrap() = slot;
-        for TransactionWithStatusMeta { transaction, .. } in expected_transactions {
+        for VersionedTransactionWithStatusMeta { transaction, .. } in expected_transactions {
             let signature = transaction.signatures[0];
             assert_eq!(blockstore.get_rooted_transaction(signature).unwrap(), None,);
             assert_eq!(
@@ -7197,19 +7197,15 @@ pub mod tests {
         let shreds = entries_to_test_shreds(&entries, slot, slot - 1, true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
-        let expected_transactions: Vec<TransactionWithStatusMeta> = entries
+        let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
             .flat_map(|entry| entry.transactions)
-            .map(|tx| {
-                tx.into_legacy_transaction()
-                    .expect("versioned transactions not supported")
-            })
             .map(|transaction| {
                 let mut pre_balances: Vec<u64> = vec![];
                 let mut post_balances: Vec<u64> = vec![];
-                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                for i in 0..transaction.message.total_account_keys_len() {
                     pre_balances.push(i as u64 * 10);
                     post_balances.push(i as u64 * 11);
                 }
@@ -7232,13 +7228,14 @@ pub mod tests {
                     pre_token_balances: pre_token_balances.clone(),
                     post_token_balances: post_token_balances.clone(),
                     rewards: rewards.clone(),
+                    loaded_addresses: LoadedAddresses::default(),
                 }
                 .into();
                 blockstore
                     .transaction_status_cf
                     .put_protobuf((0, signature, slot), &status)
                     .unwrap();
-                TransactionWithStatusMeta {
+                VersionedTransactionWithStatusMeta {
                     transaction,
                     meta: Some(TransactionStatusMeta {
                         status: Ok(()),
@@ -7250,20 +7247,21 @@ pub mod tests {
                         pre_token_balances,
                         post_token_balances,
                         rewards,
+                        loaded_addresses: LoadedAddresses::default(),
                     }),
                 }
             })
             .collect();
 
-        for transaction in expected_transactions.clone() {
-            let signature = transaction.transaction.signatures[0];
+        for tx_with_meta in expected_transactions.clone() {
+            let signature = tx_with_meta.transaction.signatures[0];
             assert_eq!(
                 blockstore
                     .get_complete_transaction(signature, slot)
                     .unwrap(),
-                Some(ConfirmedTransactionWithStatusMeta {
+                Some(VersionedConfirmedTransactionWithStatusMeta {
                     slot,
-                    transaction,
+                    tx_with_meta,
                     block_time: None
                 })
             );
@@ -7272,7 +7270,7 @@ pub mod tests {
 
         blockstore.run_purge(0, 2, PurgeType::PrimaryIndex).unwrap();
         *blockstore.lowest_cleanup_slot.write().unwrap() = slot;
-        for TransactionWithStatusMeta { transaction, .. } in expected_transactions {
+        for VersionedTransactionWithStatusMeta { transaction, .. } in expected_transactions {
             let signature = transaction.signatures[0];
             assert_eq!(
                 blockstore
@@ -7560,16 +7558,13 @@ pub mod tests {
                     // Purge to freeze index 0 and write address-signatures in new primary index
                     blockstore.run_purge(0, 1, PurgeType::PrimaryIndex).unwrap();
                 }
-                for tx in entry.transactions {
-                    let transaction = tx
-                        .into_legacy_transaction()
-                        .expect("versioned transactions not supported");
+                for transaction in entry.transactions {
                     assert_eq!(transaction.signatures.len(), 1);
                     blockstore
                         .write_transaction_status(
                             slot,
                             transaction.signatures[0],
-                            transaction.message.account_keys.iter().collect(),
+                            transaction.message.static_account_keys_iter().collect(),
                             vec![],
                             TransactionStatusMeta::default(),
                         )
@@ -7587,16 +7582,13 @@ pub mod tests {
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
             for entry in entries.into_iter() {
-                for tx in entry.transactions {
-                    let transaction = tx
-                        .into_legacy_transaction()
-                        .expect("versioned transactions not supported");
+                for transaction in entry.transactions {
                     assert_eq!(transaction.signatures.len(), 1);
                     blockstore
                         .write_transaction_status(
                             slot,
                             transaction.signatures[0],
-                            transaction.message.account_keys.iter().collect(),
+                            transaction.message.static_account_keys_iter().collect(),
                             vec![],
                             TransactionStatusMeta::default(),
                         )
@@ -8019,6 +8011,7 @@ pub mod tests {
                 pre_token_balances: Some(vec![]),
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
+                loaded_addresses: LoadedAddresses::default(),
             }
             .into();
             transaction_status_cf
@@ -8570,8 +8563,9 @@ pub mod tests {
                 reward_type: Some(RewardType::Rent),
                 commission: None,
             }]),
+            loaded_addresses: LoadedAddresses::default(),
         };
-        let deprecated_status: StoredTransactionStatusMeta = status.clone().into();
+        let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();
 
         for slot in 0..2 {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -45,7 +45,7 @@ use solana_sdk::{
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     loader_instruction,
-    message::{Message, SanitizedMessage},
+    message::{v0::LoadedAddresses, Message, SanitizedMessage},
     pubkey::Pubkey,
     signature::{keypair_from_seed, Keypair, Signer},
     system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
@@ -421,6 +421,7 @@ fn execute_transactions(
                         inner_instructions,
                         log_messages,
                         rewards: None,
+                        loaded_addresses: LoadedAddresses::default(),
                     };
 
                     Ok(ConfirmedTransactionWithStatusMeta {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -141,7 +141,7 @@ impl TransactionStatusService {
                                 })
                                 .collect(),
                         );
-
+                        let loaded_addresses = transaction.get_loaded_addresses();
                         let transaction_status_meta = TransactionStatusMeta {
                             status,
                             fee,
@@ -152,6 +152,7 @@ impl TransactionStatusService {
                             pre_token_balances,
                             post_token_balances,
                             rewards,
+                            loaded_addresses,
                         };
 
                         if let Some(transaction_notifier) = transaction_notifier.as_ref() {

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -71,6 +71,24 @@ impl VersionedMessage {
         }
     }
 
+    pub fn total_account_keys_len(&self) -> usize {
+        match self {
+            Self::Legacy(message) => message.account_keys.len(),
+            Self::V0(message) => message.account_keys.len().saturating_add(
+                message
+                    .address_table_lookups
+                    .iter()
+                    .map(|lookup| {
+                        lookup
+                            .writable_indexes
+                            .len()
+                            .saturating_add(lookup.readonly_indexes.len())
+                    })
+                    .sum(),
+            ),
+        }
+    }
+
     pub fn recent_blockhash(&self) -> &Hash {
         match self {
             Self::Legacy(message) => &message.recent_blockhash,
@@ -82,6 +100,13 @@ impl VersionedMessage {
         match self {
             Self::Legacy(message) => message.recent_blockhash = recent_blockhash,
             Self::V0(message) => message.recent_blockhash = recent_blockhash,
+        }
+    }
+
+    pub fn instructions(&self) -> &[CompiledInstruction] {
+        match self {
+            Self::Legacy(message) => &message.instructions,
+            Self::V0(message) => &message.instructions,
         }
     }
 

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -5,7 +5,7 @@ use {
         pubkey::Pubkey,
         sysvar,
     },
-    std::{collections::HashSet, convert::TryFrom, ops::Deref},
+    std::{collections::HashSet, ops::Deref},
 };
 
 /// Combination of a version #0 message and its loaded addresses
@@ -44,6 +44,30 @@ impl FromIterator<LoadedAddresses> for LoadedAddresses {
             writable: writable.into_iter().flatten().collect(),
             readonly: readonly.into_iter().flatten().collect(),
         }
+    }
+}
+
+impl LoadedAddresses {
+    /// Checks if there are no writable or readonly addresses
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Combined length of loaded writable and readonly addresses
+    pub fn len(&self) -> usize {
+        self.writable.len().saturating_add(self.readonly.len())
+    }
+
+    /// Iterate over loaded addresses in the order that they are used
+    /// as account indexes
+    pub fn ordered_iter(&self) -> impl Iterator<Item = &Pubkey> {
+        self.writable.iter().chain(self.readonly.iter())
+    }
+
+    /// Iterate over loaded addresses in the order that they are used
+    /// as account indexes
+    pub fn into_ordered_iter(self) -> impl Iterator<Item = Pubkey> {
+        self.writable.into_iter().chain(self.readonly.into_iter())
     }
 }
 

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -48,6 +48,9 @@ pub enum SignerError {
 
     #[error("{0}")]
     UserCancel(String),
+
+    #[error("too many signers")]
+    TooManySigners,
 }
 
 /// The `Signer` trait declares operations that all digital signature providers

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -179,6 +179,14 @@ impl SanitizedTransaction {
         account_locks
     }
 
+    /// Return the list of addresses loaded from on-chain address lookup tables
+    pub fn get_loaded_addresses(&self) -> LoadedAddresses {
+        match &self.message {
+            SanitizedMessage::Legacy(_) => LoadedAddresses::default(),
+            SanitizedMessage::V0(message) => message.loaded_addresses.clone(),
+        }
+    }
+
     /// If the transaction uses a durable nonce, return the pubkey of the nonce account
     pub fn get_durable_nonce(&self, nonce_must_be_writable: bool) -> Option<&Pubkey> {
         self.message

--- a/sdk/src/transaction/versioned.rs
+++ b/sdk/src/transaction/versioned.rs
@@ -9,6 +9,8 @@ use {
         sanitize::{Sanitize, SanitizeError},
         short_vec,
         signature::Signature,
+        signer::SignerError,
+        signers::Signers,
         transaction::{Result, Transaction, TransactionError},
     },
     serde::Serialize,
@@ -57,6 +59,40 @@ impl From<Transaction> for VersionedTransaction {
 }
 
 impl VersionedTransaction {
+    /// Signs a versioned message and if successful, returns a signed
+    /// transaction.
+    pub fn try_new<T: Signers>(
+        message: VersionedMessage,
+        keypairs: &T,
+    ) -> std::result::Result<Self, SignerError> {
+        let static_account_keys = message.static_account_keys();
+        if static_account_keys.len() < message.header().num_required_signatures as usize {
+            return Err(SignerError::InvalidInput("invalid message".to_string()));
+        }
+
+        let signer_keys = keypairs.pubkeys();
+        let expected_signer_keys =
+            &static_account_keys[0..message.header().num_required_signatures as usize];
+
+        match signer_keys.len().cmp(&expected_signer_keys.len()) {
+            Ordering::Greater => Err(SignerError::TooManySigners),
+            Ordering::Less => Err(SignerError::NotEnoughSigners),
+            Ordering::Equal => Ok(()),
+        }?;
+
+        if signer_keys != expected_signer_keys {
+            return Err(SignerError::KeypairPubkeyMismatch);
+        }
+
+        let message_data = message.serialize();
+        let signatures = keypairs.try_sign_message(&message_data)?;
+
+        Ok(Self {
+            signatures,
+            message,
+        })
+    }
+
     /// Returns a legacy transaction if the transaction message is legacy.
     pub fn into_legacy_transaction(self) -> Option<Transaction> {
         match self.message {

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -27,12 +27,20 @@ message Message {
     repeated bytes account_keys = 2;
     bytes recent_blockhash = 3;
     repeated CompiledInstruction instructions = 4;
+    bool versioned = 5;
+    repeated MessageAddressTableLookup address_table_lookups = 6;
 }
 
 message MessageHeader {
     uint32 num_required_signatures = 1;
     uint32 num_readonly_signed_accounts = 2;
     uint32 num_readonly_unsigned_accounts = 3;
+}
+
+message MessageAddressTableLookup {
+    bytes account_key = 1;
+    bytes writable_indexes = 2;
+    bytes readonly_indexes = 3;
 }
 
 message TransactionStatusMeta {
@@ -47,6 +55,8 @@ message TransactionStatusMeta {
     repeated TokenBalance pre_token_balances = 7;
     repeated TokenBalance post_token_balances = 8;
     repeated Reward rewards = 9;
+    repeated bytes loaded_writable_addresses = 12;
+    repeated bytes loaded_readonly_addresses = 13;
 }
 
 message TransactionError {

--- a/transaction-status/src/extract_memos.rs
+++ b/transaction-status/src/extract_memos.rs
@@ -1,5 +1,5 @@
 use {
-    crate::parse_instruction::parse_memo_data,
+    crate::{parse_instruction::parse_memo_data, VersionedTransactionWithStatusMeta},
     solana_sdk::{
         instruction::CompiledInstruction,
         message::{Message, SanitizedMessage},
@@ -52,6 +52,15 @@ impl ExtractMemos for Message {
 impl ExtractMemos for SanitizedMessage {
     fn extract_memos(&self) -> Vec<String> {
         extract_memos_inner(self.account_keys_iter(), self.instructions())
+    }
+}
+
+impl ExtractMemos for VersionedTransactionWithStatusMeta {
+    fn extract_memos(&self) -> Vec<String> {
+        extract_memos_inner(
+            self.account_keys_iter(),
+            self.transaction.message.instructions(),
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem
Dynamically loaded addresses from lookup tables need to be stored in transaction metadata for future reference since on-chain lookup table accounts may be closed.

#### Summary of Changes
- Updated `TransactionStatusMeta` to include dynamically loaded addresses
- Added support for uploading / fetching versioned transactions to bigtable
- Added support for retrieving versioned transactions to blockstore
- Improved error response for RPC methods that don't support versioned transactions
- RPC / CLI / Ledger-tool support for versioned transactions will come in follow up PR's and for now will return an error when handling versioned transactions.

Fixes #
