### PR TITLE
Use lazy_rent_collection directly

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4333,7 +4333,7 @@ impl Bank {
     }
 
     fn collect_rent_eagerly(&self) {
-        if !self.enable_eager_rent_collection() {
+        if self.lazy_rent_collection.load(Relaxed) {
             return;
         }
 
@@ -4356,14 +4356,6 @@ impl Bank {
     #[cfg(test)]
     fn restore_old_behavior_for_fragile_tests(&self) {
         self.lazy_rent_collection.store(true, Relaxed);
-    }
-
-    fn enable_eager_rent_collection(&self) -> bool {
-        if self.lazy_rent_collection.load(Relaxed) {
-            return false;
-        }
-
-        true
     }
 
     fn rent_collection_partitions(&self) -> Vec<Partition> {


### PR DESCRIPTION
#### Problem

`Bank::enable_eager_rent_collection()` could be simplified, since it was doing `if (true) { false } else { true }` (sort of). However, since only one place calls this function, just inline the body since its a one-liner.

#### Summary of Changes

Inline and remove `enable_eager_rent_collection()`.