### PR TITLE
Refactoring: Moves `InvokeContext::return_data` to `TransactionContext`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -181,7 +181,6 @@ impl<'a> StackFrame<'a> {
 
 pub struct InvokeContext<'a> {
     pub transaction_context: &'a mut TransactionContext,
-    pub return_data: (Pubkey, Vec<u8>),
     invoke_stack: Vec<StackFrame<'a>>,
     rent: Rent,
     pre_accounts: Vec<PreAccount>,
@@ -218,7 +217,6 @@ impl<'a> InvokeContext<'a> {
     ) -> Self {
         Self {
             transaction_context,
-            return_data: (Pubkey::default(), Vec::new()),
             invoke_stack: Vec::with_capacity(compute_budget.max_invoke_depth),
             rent,
             pre_accounts: Vec::new(),
@@ -835,7 +833,8 @@ impl<'a> InvokeContext<'a> {
             .and_then(|_| {
                 let mut process_executable_chain_time =
                     Measure::start("process_executable_chain_time");
-                self.return_data = (program_id, Vec::new());
+                self.transaction_context
+                    .set_return_data(program_id, Vec::new())?;
                 let pre_remaining_units = self.compute_meter.borrow().get_remaining();
                 let execution_result = self.process_executable_chain(instruction_data);
                 let post_remaining_units = self.compute_meter.borrow().get_remaining();

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -226,13 +226,13 @@ fn run_program(name: &str) -> u64 {
         let mut instruction_count = 0;
         let mut tracer = None;
         for i in 0..2 {
-            invoke_context.return_data = (
+            invoke_context.transaction_context.set_return_data(
                 *invoke_context
                     .transaction_context
                     .get_program_key()
                     .unwrap(),
                 Vec::new(),
-            );
+            ).unwrap();
             let mut parameter_bytes = parameter_bytes.clone();
             {
                 let mut vm = create_vm(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1099,7 +1099,8 @@ impl Executor for BpfExecutor {
                 trace!("BPF Program Instruction Trace:\n{}", trace_string);
             }
             drop(vm);
-            let (_returned_from_program_id, return_data) = &invoke_context.return_data;
+            let (_returned_from_program_id, return_data) =
+                invoke_context.transaction_context.get_return_data();
             if !return_data.is_empty() {
                 stable_log::program_return(&log_collector, &program_id, return_data);
             }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -180,8 +180,12 @@ impl TransactionContext {
     }
 
     /// Set the return data of the current InstructionContext
-    pub fn set_return_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
-        self.return_data = (*self.get_program_key()?, data);
+    pub fn set_return_data(
+        &mut self,
+        program_id: Pubkey,
+        data: Vec<u8>,
+    ) -> Result<(), InstructionError> {
+        self.return_data = (program_id, data);
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem
In [ABIv2](https://github.com/solana-labs/solana/pull/19191) the return data will be shared between instruction directly.

#### Summary of Changes
Moves `InvokeContext::return_data` to `TransactionContext`.

Fixes #
