### PR TITLE
Handle accounts data size changes due to rent-collected accounts

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -275,12 +275,14 @@ impl Accounts {
                             .load_with_fixed_root(ancestors, key)
                             .map(|(mut account, _)| {
                                 if message.is_writable(i) {
-                                    let rent_due = rent_collector.collect_from_existing_account(
-                                        key,
-                                        &mut account,
-                                        rent_for_sysvars,
-                                        self.accounts_db.filler_account_suffix.as_ref(),
-                                    );
+                                    let rent_due = rent_collector
+                                        .collect_from_existing_account(
+                                            key,
+                                            &mut account,
+                                            rent_for_sysvars,
+                                            self.accounts_db.filler_account_suffix.as_ref(),
+                                        )
+                                        .rent_amount;
                                     (account, rent_due)
                                 } else {
                                     (account, 0)
@@ -1199,11 +1201,9 @@ impl Accounts {
 
                     if execution_status.is_ok() || is_nonce_account || is_fee_payer {
                         if account.rent_epoch() == INITIAL_RENT_EPOCH {
-                            let rent = rent_collector.collect_from_created_account(
-                                address,
-                                account,
-                                rent_for_sysvars,
-                            );
+                            let rent = rent_collector
+                                .collect_from_created_account(address, account, rent_for_sysvars)
+                                .rent_amount;
                             loaded_transaction.rent += rent;
                             loaded_transaction.rent_debits.insert(
                                 address,


### PR DESCRIPTION
#### Problem

Accounts that are reclaimed during rent collection (i.e. lamports go to zero) are not factored into the Bank's `accounts_data_len`.

#### Summary of Changes

Track reclaimed accounts data len during rent collection, then return that information to the bank so it can update its accounts data len.

* Return `CollectedInfo` from `collect_from_existing_account()` to track both the rent amount and account data len
* In `collect_rent_in_partition()`, sum all the collected-infos then use that final value to update the bank's accounts data len