### PR TITLE
Update bench-tps.md

### DIFF
--- a/docs/src/cluster/bench-tps.md
+++ b/docs/src/cluster/bench-tps.md
@@ -18,7 +18,7 @@ cd solana
 The demo code is sometimes broken between releases as we add new low-level features, so if this is your first time running the demo, you'll improve your odds of success if you check out the [latest release](https://github.com/solana-labs/solana/releases) before proceeding:
 
 ```bash
-TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+$TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
 git checkout $TAG
 ```
 


### PR DESCRIPTION
Type in variable declaration in TAG bash script. Should be $TAG.

#### Problem
Typo in cluster benchmarking MD file

#### Summary of Changes
Fully declare TAG variable in bash script as $TAG

Fixes #
Fix variable declaration error.