### PR TITLE
Cleanup serde snapshot's "future" to "newer"

### DIFF
--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -1,5 +1,3 @@
-#[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
-use solana_frozen_abi::abi_example::IgnoreAsHelper;
 use {
     super::{common::UnusedAccounts, *},
     crate::{ancestors::AncestorsForSerialization, stakes::StakesCache},
@@ -33,7 +31,7 @@ impl SerializableStorage for SerializableAccountStorageEntry {
     }
 }
 
-#[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountStorageEntry {}
 
 impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
@@ -204,7 +202,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
 }
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl<'a> IgnoreAsHelper for SerializableVersionedBank<'a> {}
+impl<'a> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableVersionedBank<'a> {}
 
 pub(super) struct Context {}
 impl<'a> TypeContext<'a> for Context {


### PR DESCRIPTION
As part of #21604, I likely need to add a new Snapshot Version to add `accounts_data_len` to the snapshot. While starting on that, I found a few bits to cleanup/refactor (based on the original PR #9980).

In particular, I've renamed the "styles" so any mentions of "future" are now "newer" (more details [here](https://github.com/solana-labs/solana/pull/9980#discussion_r428462546)).