### PR TITLE
Improved flexibility of FetchMiddleware for Web3.js

### DIFF
--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3,7 +3,7 @@ import {Buffer} from 'buffer';
 import {Token, u64} from '@solana/spl-token';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-
+import fetch from 'cross-fetch';
 import {
   Account,
   Authorized,
@@ -112,11 +112,11 @@ describe('Connection', () => {
 
     it('should allow middleware to augment request', async () => {
       let connection = new Connection(url, {
-        fetchMiddleware: (url, options, fetch) => {
+        fetchMiddleware: async (url, options) => {
           options.headers = Object.assign(options.headers, {
             Authorization: 'Bearer 123',
           });
-          fetch(url, options);
+          return await fetch(url, options);
         },
       });
 
@@ -136,7 +136,7 @@ describe('Connection', () => {
   it('should attribute middleware fatals to the middleware', async () => {
     let connection = new Connection(url, {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      fetchMiddleware: (_url, _options, _fetch) => {
+      fetchMiddleware: (_url, _options) => {
         throw new Error('This middleware experienced a fatal error');
       },
     });
@@ -151,8 +151,8 @@ describe('Connection', () => {
 
   it('should not attribute fetch errors to the middleware', async () => {
     let connection = new Connection(url, {
-      fetchMiddleware: (url, _options, fetch) => {
-        fetch(url, 'An `Object` was expected here; this is a `TypeError`.');
+      fetchMiddleware: async (url, _options) => {
+        return await fetch(url, 'An `Object` was expected here; this is a `TypeError`.' as RequestInit);
       },
     });
     const error = await expect(connection.getVersion()).to.be.rejected;


### PR DESCRIPTION
#### Problem
Currently, the fetch client is `cross-fetch` which is fine in most situations, but in some cases, it can be **very** problematic. Personally, I'm trying to use web3.js on Cloudflare Workers which has a custom fetch client. In other cases, like React Native, the library may also not work, see: https://github.com/solana-labs/solana/issues/22421

My point is that there should be an option to use another fetch function. 


#### Proposed Solution
Currently, there is a Middleware option in the Connection constructor. The issue with this middleware is that it's very limited as we have to use the provided `fetch` function as a callback. I propose to have a `FetchMiddleware` function like that:
```js
const fetchMiddleware = async (url, options): Promise<Response> => {
    // Your code, but here's how you would use it:
   return await fetch(url, options)
}
```

It really shouldn't be hard to implement it. I can probably do it, but I prefer to wait for feedback.

#### Summary of changes
- Updated `connection.ts`
- Updated tests (may need help to fix one test)

Fixes #22429 
