### PR TITLE
Only examine explicit tx accounts for rent state

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -15863,6 +15863,51 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_rent_state_list_len() {
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(sol_to_lamports(100.), &Pubkey::new_unique(), 42);
+        genesis_config.rent = Rent::default();
+        // Activate features, including require_rent_exempt_accounts
+        activate_all_features(&mut genesis_config);
+
+        let bank = Bank::new_for_tests(&genesis_config);
+        let recipient = Pubkey::new_unique();
+        let tx = system_transaction::transfer(
+            &mint_keypair,
+            &recipient,
+            sol_to_lamports(1.),
+            bank.last_blockhash(),
+        );
+        let num_accounts = tx.message().account_keys.len();
+        let sanitized_tx = SanitizedTransaction::try_from_legacy_transaction(tx).unwrap();
+        let mut error_counters = ErrorCounters::default();
+        let loaded_txs = bank.rc.accounts.load_accounts(
+            &bank.ancestors,
+            &[sanitized_tx.clone()],
+            vec![(Ok(()), None)],
+            &bank.blockhash_queue.read().unwrap(),
+            &mut error_counters,
+            &bank.rent_collector,
+            &bank.feature_set,
+        );
+
+        let compute_budget = bank.compute_budget.unwrap_or_else(ComputeBudget::new);
+        let transaction_context = TransactionContext::new(
+            loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
+            compute_budget.max_invoke_depth.saturating_add(1),
+        );
+
+        assert_eq!(
+            bank.get_transaction_account_state_info(&transaction_context, sanitized_tx.message())
+                .len(),
+            num_accounts,
+        );
+    }
+
+    #[test]
     fn test_update_accounts_data_len() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);

--- a/runtime/src/bank/transaction_account_state_info.rs
+++ b/runtime/src/bank/transaction_account_state_info.rs
@@ -19,7 +19,7 @@ impl Bank {
         transaction_context: &TransactionContext,
         message: &SanitizedMessage,
     ) -> Vec<TransactionAccountStateInfo> {
-        (0..transaction_context.get_number_of_accounts())
+        (0..message.account_keys_len())
             .map(|i| {
                 let rent_state = if message.is_writable(i) {
                     let account = transaction_context.get_account_at_index(i).borrow();


### PR DESCRIPTION
#### Problem
#22292 examines all accounts in the TransactionContext unnecessarily. Only (writable) accounts listed explicitly in a transaction can see state changes during processing.

#### Summary of Changes
- Add test to demonstrate
- Use `SanitizedMessage::account_keys_len()` in `Bank::get_transaction_account_state_info()`
