### PR TITLE
(Ledger Store) APIs for obtaining physical size of all data and coding shreds

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -70,6 +70,7 @@ use {
 pub mod blockstore_purge;
 
 pub const BLOCKSTORE_DIRECTORY: &str = "rocksdb";
+pub const ROCKSDB_TOTAL_SST_FILES_SIZE: &str = "rocksdb.total-sst-files-size";
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -3175,6 +3176,24 @@ impl Blockstore {
 
     pub fn storage_size(&self) -> Result<u64> {
         self.db.storage_size()
+    }
+
+    /// Returns the total physical storage size contributed by all data shreds.
+    ///
+    /// Note that the reported size does not include those recently inserted
+    /// shreds that are still in memory.
+    pub fn total_data_shred_storage_size(&self) -> Result<u64> {
+        let shred_data_cf = self.db.column::<cf::ShredData>();
+        shred_data_cf.get_int_property(ROCKSDB_TOTAL_SST_FILES_SIZE)
+    }
+
+    /// Returns the total physical storage size contributed by all coding shreds.
+    ///
+    /// Note that the reported size does not include those recently inserted
+    /// shreds that are still in memory.
+    pub fn total_coding_shred_storage_size(&self) -> Result<u64> {
+        let shred_code_cf = self.db.column::<cf::ShredCode>();
+        shred_code_cf.get_int_property(ROCKSDB_TOTAL_SST_FILES_SIZE)
     }
 
     pub fn is_primary_access(&self) -> bool {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -501,6 +501,19 @@ impl Rocks {
     fn is_primary_access(&self) -> bool {
         self.1 == ActualAccessType::Primary
     }
+
+    /// Retrieves the specified RocksDB integer property of the current
+    /// column family.
+    ///
+    /// Full list of properties that return int values could be found
+    /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
+    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &str) -> Result<u64> {
+        match self.0.property_int_value_cf(cf, name) {
+            Ok(Some(value)) => Ok(value),
+            Ok(None) => Ok(0),
+            Err(e) => Err(BlockstoreError::RocksDb(e)),
+        }
+    }
 }
 
 pub trait Column {
@@ -1137,6 +1150,15 @@ where
 
     pub fn put_bytes(&self, key: C::Index, value: &[u8]) -> Result<()> {
         self.backend.put_cf(self.handle(), &C::key(key), value)
+    }
+
+    /// Retrieves the specified RocksDB integer property of the current
+    /// column family.
+    ///
+    /// Full list of properties that return int values could be found
+    /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
+    pub fn get_int_property(&self, name: &str) -> Result<u64> {
+        self.backend.get_int_property_cf(self.handle(), name)
     }
 }
 


### PR DESCRIPTION
#### Problem
The current blockstore only offers an API for the total DB size, but sometimes it is
desirable to understand how much storage is occupied by data shreds and coding
shreds to know whether the compaction is triggered in time. 

#### Summary of Changes
This PR adds two functions: `total_data_shred_size` and `total_coding_shred_size`.
The former returns the physical storage size of all data shreds, while the latter returns
the physical size of all coding shreds.

