### PR TITLE
(Ledger Store Benchmark) Display storage size of all data shreds

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -70,6 +70,7 @@ use {
 pub mod blockstore_purge;
 
 pub const BLOCKSTORE_DIRECTORY: &str = "rocksdb";
+pub const ROCKSDB_TOTAL_SST_FILES_SIZE: &str = "rocksdb.total-sst-files-size";
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -3175,6 +3176,24 @@ impl Blockstore {
 
     pub fn storage_size(&self) -> Result<u64> {
         self.db.storage_size()
+    }
+
+    /// Returns the total physical storage size contributed by all data shreds.
+    ///
+    /// Note that the reported size does not include those recently inserted
+    /// shreds that are still in memory.
+    pub fn total_data_shred_storage_size(&self) -> Result<u64> {
+        let shred_data_cf = self.db.column::<cf::ShredData>();
+        shred_data_cf.get_int_property(ROCKSDB_TOTAL_SST_FILES_SIZE)
+    }
+
+    /// Returns the total physical storage size contributed by all coding shreds.
+    ///
+    /// Note that the reported size does not include those recently inserted
+    /// shreds that are still in memory.
+    pub fn total_coding_shred_storage_size(&self) -> Result<u64> {
+        let shred_code_cf = self.db.column::<cf::ShredCode>();
+        shred_code_cf.get_int_property(ROCKSDB_TOTAL_SST_FILES_SIZE)
     }
 
     pub fn is_primary_access(&self) -> bool {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -501,6 +501,19 @@ impl Rocks {
     fn is_primary_access(&self) -> bool {
         self.1 == ActualAccessType::Primary
     }
+
+    /// Retrieves the specified RocksDB integer property of the current
+    /// column family.
+    ///
+    /// Full list of properties that return int values could be found
+    /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
+    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &str) -> Result<u64> {
+        match self.0.property_int_value_cf(cf, name) {
+            Ok(Some(value)) => Ok(value),
+            Ok(None) => Ok(0),
+            Err(e) => Err(BlockstoreError::RocksDb(e)),
+        }
+    }
 }
 
 pub trait Column {
@@ -1137,6 +1150,15 @@ where
 
     pub fn put_bytes(&self, key: C::Index, value: &[u8]) -> Result<()> {
         self.backend.put_cf(self.handle(), &C::key(key), value)
+    }
+
+    /// Retrieves the specified RocksDB integer property of the current
+    /// column family.
+    ///
+    /// Full list of properties that return int values could be found
+    /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
+    pub fn get_int_property(&self, name: &str) -> Result<u64> {
+        self.backend.get_int_property_cf(self.handle(), name)
     }
 }
 


### PR DESCRIPTION
#### Summary of Changes
Display the storage size of all data shreds in the ledger store benchmark.

This allows the benchmark to track whether the compactions are triggered at the right time.

This PR is based on top of #22443 (APIs for obtaining physical size of all data and coding shreds)

#### Test Plan / Results
Run the ledger cleanup benchmark and observe the shred storage size and its delta are correctly reported.
(The last two numbers before the three 0.00)

```
[2022-01-12T03:09:01.890862000Z INFO  ledger_cleanup::tests] Bench info num_batches: 500000, batch size (slots): 2, shreds_per_slot: 5, num_shreds_total: 5000000
TIME_MS,DELTA_MS,START_SLOT,BATCH_SIZE,SHREDS,MAX,SIZE,DELTA_SIZE,DATA_SHRED_SIZE,DATA_SHRED_SIZE_DELTA,CPU_USER,CPU_SYSTEM,CPU_IDLE
[2022-01-12T03:09:01.890938000Z INFO  ledger_cleanup::tests] 0,0,0,0,0,0,404598,404598,0,0,0.00,0.00,0.00
[2022-01-12T03:09:01.890943000Z INFO  ledger_cleanup::tests] Begin inserting shreds ...
[2022-01-12T03:09:01.891170000Z INFO  ledger_cleanup::tests] 0,0,1,2,5,50,404598,0,0,0,0.00,0.00,0.00
[2022-01-12T03:09:02.396330000Z INFO  ledger_cleanup::tests] 505,505,30049,2,5,50,183170142,182765544,0,0,0.00,0.00,0.00
[2022-01-12T03:09:02.901472000Z INFO  ledger_cleanup::tests] 1010,505,58883,2,5,50,615911082,432740940,257467805,257467805,0.00,0.00,0.00
[2022-01-12T03:09:03.406592000Z INFO  ledger_cleanup::tests] 1515,505,86843,2,5,50,785865258,169954176,257467805,0,0.00,0.00,0.00
[2022-01-12T03:09:03.911731000Z INFO  ledger_cleanup::tests] 2020,505,115631,2,5,50,1218091867,432226609,514935956,257468151,0.00,0.00,0.00
[2022-01-12T03:09:04.416920000Z INFO  ledger_cleanup::tests] 2525,505,144013,2,5,50,1648143847,430051980,772403758,257467802,0.00,0.00,0.00
...
```