### PR TITLE
Refactor: move sysvar cache to new module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,6 +5514,8 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
+ "solana-frozen-abi 1.10.0",
+ "solana-frozen-abi-macro 1.10.0",
  "solana-logger 1.10.0",
  "solana-measure",
  "solana-sdk",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -19,6 +19,8 @@ log = "0.4.14"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 serde = { version = "1.0.129", features = ["derive", "rc"] }
+solana-frozen-abi = { path = "../frozen-abi", version = "=1.10.0" }
+solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "=1.10.0" }
 solana-measure = { path = "../measure", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 thiserror = "1.0"

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -8,4 +8,5 @@ pub mod native_loader;
 pub mod neon_evm_program;
 pub mod pre_account;
 pub mod stable_log;
+pub mod sysvar_cache;
 pub mod timings;

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -1,0 +1,39 @@
+use {
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        pubkey::Pubkey,
+    },
+    std::ops::Deref,
+};
+
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
+    fn example() -> Self {
+        // SysvarCache is not Serialize so just rely on Default.
+        SysvarCache::default()
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct SysvarCache(Vec<(Pubkey, Vec<u8>)>);
+
+impl Deref for SysvarCache {
+    type Target = Vec<(Pubkey, Vec<u8>)>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl SysvarCache {
+    pub fn push_entry(&mut self, pubkey: Pubkey, data: Vec<u8>) {
+        self.0.push((pubkey, data));
+    }
+
+    pub fn update_entry(&mut self, pubkey: &Pubkey, new_account: &AccountSharedData) {
+        if let Some(position) = self.iter().position(|(id, _data)| id == pubkey) {
+            self.0[position].1 = new_account.data().to_vec();
+        } else {
+            self.0.push((*pubkey, new_account.data().to_vec()));
+        }
+    }
+}

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3405,6 +3405,8 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
+ "solana-frozen-abi 1.10.0",
+ "solana-frozen-abi-macro 1.10.0",
  "solana-measure",
  "solana-sdk",
  "thiserror",

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -1,0 +1,33 @@
+use {
+    super::Bank,
+    solana_sdk::{
+        account::ReadableAccount,
+        pubkey::Pubkey,
+        sysvar::{self, Sysvar},
+    },
+};
+
+impl Bank {
+    pub(crate) fn fill_sysvar_cache(&mut self) {
+        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        for id in sysvar::ALL_IDS.iter() {
+            if !sysvar_cache.iter().any(|(key, _data)| key == id) {
+                if let Some(account) = self.get_account_with_fixed_root(id) {
+                    sysvar_cache.push_entry(*id, account.data().to_vec());
+                }
+            }
+        }
+    }
+
+    /// Get the value of a cached sysvar by its id
+    pub fn get_cached_sysvar<T: Sysvar>(&self, id: &Pubkey) -> Option<T> {
+        let sysvar_cache = self.sysvar_cache.read().unwrap();
+        sysvar_cache.iter().find_map(|(key, data)| {
+            if id == key {
+                bincode::deserialize(data).ok()
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -5,6 +5,7 @@ use {
         instruction_recorder::InstructionRecorder,
         invoke_context::{BuiltinProgram, Executors, InvokeContext},
         log_collector::LogCollector,
+        sysvar_cache::SysvarCache,
         timings::ExecuteTimings,
     },
     solana_sdk::{
@@ -14,14 +15,13 @@ use {
         hash::Hash,
         message::SanitizedMessage,
         precompiles::is_precompile,
-        pubkey::Pubkey,
         rent::Rent,
         saturating_add_assign,
         sysvar::instructions,
         transaction::TransactionError,
         transaction_context::{InstructionAccount, TransactionContext},
     },
-    std::{cell::RefCell, rc::Rc, sync::Arc},
+    std::{borrow::Cow, cell::RefCell, rc::Rc, sync::Arc},
 };
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -62,7 +62,7 @@ impl MessageProcessor {
         feature_set: Arc<FeatureSet>,
         compute_budget: ComputeBudget,
         timings: &mut ExecuteTimings,
-        sysvars: &[(Pubkey, Vec<u8>)],
+        sysvar_cache: &SysvarCache,
         blockhash: Hash,
         lamports_per_signature: u64,
         current_accounts_data_len: u64,
@@ -71,7 +71,7 @@ impl MessageProcessor {
             transaction_context,
             rent,
             builtin_programs,
-            sysvars,
+            Cow::Borrowed(sysvar_cache),
             log_collector,
             compute_budget,
             executors,
@@ -166,6 +166,7 @@ mod tests {
             instruction::{AccountMeta, Instruction, InstructionError},
             message::Message,
             native_loader::{self, create_loadable_account_for_test},
+            pubkey::Pubkey,
             secp256k1_instruction::new_secp256k1_instruction,
             secp256k1_program,
         },
@@ -257,6 +258,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0)),
         ));
+        let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -269,7 +271,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -310,7 +312,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -343,7 +345,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -457,6 +459,7 @@ mod tests {
             )],
             Some(transaction_context.get_key_of_account_at_index(0)),
         ));
+        let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -469,7 +472,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -503,7 +506,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -534,7 +537,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,
@@ -595,6 +598,7 @@ mod tests {
             ],
             None,
         ));
+        let sysvar_cache = SysvarCache::default();
         let result = MessageProcessor::process_message(
             builtin_programs,
             &message,
@@ -607,7 +611,7 @@ mod tests {
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
-            &[],
+            &sysvar_cache,
             Hash::default(),
             0,
             0,


### PR DESCRIPTION
#### Summary of Changes
- Add `SysvarCache` type to the program runtime for use in the invoke context
- Move sysvar cache methods from `bank.rs` to `bank/sysvar_cache.rs` for better visibility
