### PR TITLE
Perf: Store deserialized sysvars in the sysvars cache

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -26,7 +26,6 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         saturating_add_assign,
-        sysvar::Sysvar,
         transaction_context::{InstructionAccount, TransactionAccount, TransactionContext},
     },
     std::{borrow::Cow, cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc, sync::Arc},
@@ -988,21 +987,9 @@ impl<'a> InvokeContext<'a> {
         &self.current_compute_budget
     }
 
-    /// Get the value of a sysvar by its id
-    pub fn get_sysvar<T: Sysvar>(&self, id: &Pubkey) -> Result<T, InstructionError> {
-        self.sysvar_cache
-            .iter()
-            .find_map(|(key, data)| {
-                if id == key {
-                    bincode::deserialize(data).ok()
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| {
-                ic_msg!(self, "Unable to get sysvar {}", id);
-                InstructionError::UnsupportedSysvar
-            })
+    /// Get cached sysvars
+    pub fn get_sysvar_cache(&self) -> &SysvarCache {
+        &self.sysvar_cache
     }
 }
 

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -1,9 +1,13 @@
+#[allow(deprecated)]
+use solana_sdk::sysvar::fees::Fees;
 use {
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
-        pubkey::Pubkey,
+        instruction::InstructionError,
+        sysvar::{
+            clock::Clock, epoch_schedule::EpochSchedule, rent::Rent, slot_hashes::SlotHashes,
+        },
     },
-    std::ops::Deref,
+    std::sync::Arc,
 };
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
@@ -15,25 +19,63 @@ impl ::solana_frozen_abi::abi_example::AbiExample for SysvarCache {
 }
 
 #[derive(Default, Clone, Debug)]
-pub struct SysvarCache(Vec<(Pubkey, Vec<u8>)>);
-
-impl Deref for SysvarCache {
-    type Target = Vec<(Pubkey, Vec<u8>)>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+pub struct SysvarCache {
+    clock: Option<Arc<Clock>>,
+    epoch_schedule: Option<Arc<EpochSchedule>>,
+    #[allow(deprecated)]
+    fees: Option<Arc<Fees>>,
+    rent: Option<Arc<Rent>>,
+    slot_hashes: Option<Arc<SlotHashes>>,
 }
 
 impl SysvarCache {
-    pub fn push_entry(&mut self, pubkey: Pubkey, data: Vec<u8>) {
-        self.0.push((pubkey, data));
+    pub fn get_clock(&self) -> Result<Arc<Clock>, InstructionError> {
+        self.clock
+            .clone()
+            .ok_or(InstructionError::UnsupportedSysvar)
     }
 
-    pub fn update_entry(&mut self, pubkey: &Pubkey, new_account: &AccountSharedData) {
-        if let Some(position) = self.iter().position(|(id, _data)| id == pubkey) {
-            self.0[position].1 = new_account.data().to_vec();
-        } else {
-            self.0.push((*pubkey, new_account.data().to_vec()));
-        }
+    pub fn set_clock(&mut self, clock: Clock) {
+        self.clock = Some(Arc::new(clock));
+    }
+
+    pub fn get_epoch_schedule(&self) -> Result<Arc<EpochSchedule>, InstructionError> {
+        self.epoch_schedule
+            .clone()
+            .ok_or(InstructionError::UnsupportedSysvar)
+    }
+
+    pub fn set_epoch_schedule(&mut self, epoch_schedule: EpochSchedule) {
+        self.epoch_schedule = Some(Arc::new(epoch_schedule));
+    }
+
+    #[deprecated]
+    #[allow(deprecated)]
+    pub fn get_fees(&self) -> Result<Arc<Fees>, InstructionError> {
+        self.fees.clone().ok_or(InstructionError::UnsupportedSysvar)
+    }
+
+    #[deprecated]
+    #[allow(deprecated)]
+    pub fn set_fees(&mut self, fees: Fees) {
+        self.fees = Some(Arc::new(fees));
+    }
+
+    pub fn get_rent(&self) -> Result<Arc<Rent>, InstructionError> {
+        self.rent.clone().ok_or(InstructionError::UnsupportedSysvar)
+    }
+
+    pub fn set_rent(&mut self, rent: Rent) {
+        self.rent = Some(Arc::new(rent));
+    }
+
+    pub fn get_slot_hashes(&self) -> Result<Arc<SlotHashes>, InstructionError> {
+        self.slot_hashes
+            .clone()
+            .ok_or(InstructionError::UnsupportedSysvar)
+    }
+
+    pub fn set_slot_hashes(&mut self, slot_hashes: SlotHashes) {
+        self.slot_hashes = Some(Arc::new(slot_hashes));
     }
 }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -973,7 +973,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
     lamports: u64,
     to_account: &KeyedAccount,
     signers: &HashSet<Pubkey, S>,
-    rent_sysvar: Option<Rent>,
+    rent_sysvar: Option<&Rent>,
 ) -> Result<(), InstructionError> {
     let vote_state: VoteState =
         State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
@@ -2072,7 +2072,7 @@ mod tests {
                     &RefCell::new(AccountSharedData::default()),
                 ),
                 &signers,
-                Some(rent_sysvar),
+                Some(&rent_sysvar),
             );
             assert_eq!(res, Err(InstructionError::InsufficientFunds));
         }
@@ -2095,7 +2095,7 @@ mod tests {
                 withdraw_lamports,
                 &KeyedAccount::new(&solana_sdk::pubkey::new_rand(), false, &to_account),
                 &signers,
-                Some(rent_sysvar),
+                Some(&rent_sysvar),
             );
             assert_eq!(res, Ok(()));
             assert_eq!(
@@ -2108,7 +2108,7 @@ mod tests {
         // full withdraw, before/after activation
         {
             let rent_sysvar = Rent::default();
-            for rent_sysvar in [None, Some(rent_sysvar)] {
+            for rent_sysvar in [None, Some(&rent_sysvar)] {
                 let to_account = RefCell::new(AccountSharedData::default());
                 let (vote_pubkey, vote_account) = create_test_account();
                 let lamports = vote_account.borrow().lamports();

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -1,33 +1,149 @@
 use {
     super::Bank,
-    solana_sdk::{
-        account::ReadableAccount,
-        pubkey::Pubkey,
-        sysvar::{self, Sysvar},
-    },
+    solana_program_runtime::sysvar_cache::SysvarCache,
+    solana_sdk::{account::ReadableAccount, sysvar::Sysvar},
 };
 
 impl Bank {
-    pub(crate) fn fill_sysvar_cache(&mut self) {
+    pub(crate) fn fill_missing_sysvar_cache_entries(&self) {
         let mut sysvar_cache = self.sysvar_cache.write().unwrap();
-        for id in sysvar::ALL_IDS.iter() {
-            if !sysvar_cache.iter().any(|(key, _data)| key == id) {
-                if let Some(account) = self.get_account_with_fixed_root(id) {
-                    sysvar_cache.push_entry(*id, account.data().to_vec());
-                }
+        if sysvar_cache.get_clock().is_err() {
+            if let Some(clock) = self.load_sysvar_account() {
+                sysvar_cache.set_clock(clock);
+            }
+        }
+        if sysvar_cache.get_epoch_schedule().is_err() {
+            if let Some(epoch_schedule) = self.load_sysvar_account() {
+                sysvar_cache.set_epoch_schedule(epoch_schedule);
+            }
+        }
+        #[allow(deprecated)]
+        if sysvar_cache.get_fees().is_err() {
+            if let Some(fees) = self.load_sysvar_account() {
+                sysvar_cache.set_fees(fees);
+            }
+        }
+        if sysvar_cache.get_rent().is_err() {
+            if let Some(rent) = self.load_sysvar_account() {
+                sysvar_cache.set_rent(rent);
+            }
+        }
+        if sysvar_cache.get_slot_hashes().is_err() {
+            if let Some(slot_hashes) = self.load_sysvar_account() {
+                sysvar_cache.set_slot_hashes(slot_hashes);
             }
         }
     }
 
-    /// Get the value of a cached sysvar by its id
-    pub fn get_cached_sysvar<T: Sysvar>(&self, id: &Pubkey) -> Option<T> {
-        let sysvar_cache = self.sysvar_cache.read().unwrap();
-        sysvar_cache.iter().find_map(|(key, data)| {
-            if id == key {
-                bincode::deserialize(data).ok()
-            } else {
-                None
-            }
-        })
+    pub(crate) fn reset_sysvar_cache(&self) {
+        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        *sysvar_cache = SysvarCache::default();
+    }
+
+    fn load_sysvar_account<T: Sysvar>(&self) -> Option<T> {
+        if let Some(account) = self.get_account_with_fixed_root(&T::id()) {
+            bincode::deserialize(account.data()).ok()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{genesis_config::create_genesis_config, pubkey::Pubkey},
+        std::sync::Arc,
+    };
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_sysvar_cache_initialization() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let bank0_sysvar_cache = bank0.sysvar_cache.read().unwrap();
+        let bank0_cached_clock = bank0_sysvar_cache.get_clock();
+        let bank0_cached_epoch_schedule = bank0_sysvar_cache.get_epoch_schedule();
+        let bank0_cached_fees = bank0_sysvar_cache.get_fees();
+        let bank0_cached_rent = bank0_sysvar_cache.get_rent();
+
+        assert!(bank0_cached_clock.is_ok());
+        assert!(bank0_cached_epoch_schedule.is_ok());
+        assert!(bank0_cached_fees.is_ok());
+        assert!(bank0_cached_rent.is_ok());
+        assert!(bank0
+            .sysvar_cache
+            .read()
+            .unwrap()
+            .get_slot_hashes()
+            .is_err());
+
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), bank0.slot() + 1);
+
+        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_cached_clock = bank1_sysvar_cache.get_clock();
+        let bank1_cached_epoch_schedule = bank0_sysvar_cache.get_epoch_schedule();
+        let bank1_cached_fees = bank0_sysvar_cache.get_fees();
+        let bank1_cached_rent = bank0_sysvar_cache.get_rent();
+
+        assert!(bank1_cached_clock.is_ok());
+        assert!(bank1_cached_epoch_schedule.is_ok());
+        assert!(bank1_cached_fees.is_ok());
+        assert!(bank1_cached_rent.is_ok());
+        assert!(bank1.sysvar_cache.read().unwrap().get_slot_hashes().is_ok());
+
+        assert_ne!(bank0_cached_clock, bank1_cached_clock);
+        assert_eq!(bank0_cached_epoch_schedule, bank1_cached_epoch_schedule);
+        assert_eq!(bank0_cached_fees, bank1_cached_fees);
+        assert_eq!(bank0_cached_rent, bank1_cached_rent);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_reset_and_fill_sysvar_cache() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), bank0.slot() + 1);
+
+        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_cached_clock = bank1_sysvar_cache.get_clock();
+        let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
+        let bank1_cached_fees = bank1_sysvar_cache.get_fees();
+        let bank1_cached_rent = bank1_sysvar_cache.get_rent();
+        let bank1_cached_slot_hashes = bank1_sysvar_cache.get_slot_hashes();
+
+        assert!(bank1_cached_clock.is_ok());
+        assert!(bank1_cached_epoch_schedule.is_ok());
+        assert!(bank1_cached_fees.is_ok());
+        assert!(bank1_cached_rent.is_ok());
+        assert!(bank1_cached_slot_hashes.is_ok());
+
+        drop(bank1_sysvar_cache);
+        bank1.reset_sysvar_cache();
+
+        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        assert!(bank1_sysvar_cache.get_clock().is_err());
+        assert!(bank1_sysvar_cache.get_epoch_schedule().is_err());
+        assert!(bank1_sysvar_cache.get_fees().is_err());
+        assert!(bank1_sysvar_cache.get_rent().is_err());
+        assert!(bank1_sysvar_cache.get_slot_hashes().is_err());
+
+        drop(bank1_sysvar_cache);
+        bank1.fill_missing_sysvar_cache_entries();
+
+        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        assert_eq!(bank1_sysvar_cache.get_clock(), bank1_cached_clock);
+        assert_eq!(
+            bank1_sysvar_cache.get_epoch_schedule(),
+            bank1_cached_epoch_schedule
+        );
+        assert_eq!(bank1_sysvar_cache.get_fees(), bank1_cached_fees);
+        assert_eq!(bank1_sysvar_cache.get_rent(), bank1_cached_rent);
+        assert_eq!(
+            bank1_sysvar_cache.get_slot_hashes(),
+            bank1_cached_slot_hashes
+        );
     }
 }


### PR DESCRIPTION
#### Problem
Deserializing sysvars is slow

#### Summary of Changes
- Store deserialized sysvars in the cache

Fixes #
