### PR TITLE
fix: ensure program loader is ratelimited on solana.com

### DIFF
--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -170,16 +170,23 @@ export class Loader {
         programId,
         data,
       });
-      transactions.push(
-        sendAndConfirmTransaction(connection, transaction, [payer, program], {
+
+      const tx = sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [payer, program],
+        {
           commitment: 'confirmed',
-        }),
+        },
       );
 
       // Delay between sends in an attempt to reduce rate limit errors
       if (connection._rpcEndpoint.includes('solana.com')) {
+        await tx;
         const REQUESTS_PER_SECOND = 4;
         await sleep(1000 / REQUESTS_PER_SECOND);
+      } else {
+        transactions.push(tx);
       }
 
       offset += chunkSize;


### PR DESCRIPTION
Without this fix, this happens often:
-snip-
Server responded with 429 Too Many Requests.  Retrying after 4000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 500ms delay...
Server responded with 429 Too Many Requests.  Retrying after 1000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 2000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 4000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 4000ms delay...
/home/sean/git/solang/tmp/node_modules/@solana/web3.js/lib/index.cjs.js:4423
        callback(new Error(`${res.status} ${res.statusText}: ${text}`));
                 ^

Error: 429 Too Many Requests:  {"jsonrpc":"2.0","error":{"code": 429, "message":"Too requests from your IP, contact your app developer or support@rpcpool.com."}, "id": "5fd7d98e-454d-4917-9d3d-4ce86c57f218" }

    at ClientBrowser.callServer (/home/sean/git/solang/tmp/node_modules/@solana/web3.js/lib/index.cjs.js:4423:18)

#### Problem

#### Summary of Changes

Fixes #
