### PR TITLE
Cleanup AccountStorage struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,13 +1059,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b799062aaf67eb976af3bdca031ee6f846d2f0a5710ddbb0d2efee33f3cc4760"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot 0.11.2",
  "rayon",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.5"
-dashmap = { version = "5.0.0", features = ["rayon", "raw-api"] }
+dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 etcd-client = { version = "0.8.3", features = ["tls"]}
 fs_extra = "1.2.0"
 histogram = "0.6.9"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -14,7 +14,7 @@ bs58 = "0.4.0"
 clap = "2.33.1"
 crossbeam-channel = "0.5"
 csv = "1.1.6"
-dashmap = "5.0.0"
+dashmap = "4.0.2"
 histogram = "*"
 itertools = "0.10.3"
 log = { version = "0.4.14" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -666,13 +666,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b799062aaf67eb976af3bdca031ee6f846d2f0a5710ddbb0d2efee33f3cc4760"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot",
  "rayon",
 ]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.12.3"
 bincode = "1.3.3"
 bs58 = "0.4.0"
 crossbeam-channel = "0.5"
-dashmap = "5.0.0"
+dashmap = "4.0.2"
 itertools = "0.10.3"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0", features = ["ipc", "ws"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,7 @@ blake3 = "1.3.0"
 bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.4.3"
 bzip2 = "0.4.3"
-dashmap = { version = "5.0.0", features = ["rayon", "raw-api"] }
+dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 crossbeam-channel = "0.5"
 dir-diff = "0.3.2"
 enum-iterator = "0.7.0"

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -515,7 +515,7 @@ where
         .write()
         .unwrap()
         .insert(snapshot_slot, snapshot_bank_hash_info);
-    accounts_db.storage.0.extend(
+    accounts_db.storage.map.extend(
         storage
             .into_iter()
             .map(|(slot, slot_storage_entry)| (slot, Arc::new(RwLock::new(slot_storage_entry)))),


### PR DESCRIPTION
#### Problem
The previous 'tuple of 1 element' implementation resulted in the odd `storage.0` which has confused me for a year. If you are in code and you don't know what the type of `storage` is and you are trying to figure out what you're operating on, the `0` is confusing and not as helpful as it could be.

#### Summary of Changes
Name the field `map` and replace `.0` with `.map`
Fixes #
