### PR TITLE
downgrade individual per-program-timing to trace to reduce writes to influx

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -145,7 +145,7 @@ impl ReplaySlotStats {
             );
 
         for (pubkey, time) in per_pubkey_timings.iter().take(5) {
-            datapoint_info!(
+            datapoint_trace!(
                 "per_program_timings",
                 ("slot", slot as i64, i64),
                 ("pubkey", pubkey.to_string(), String),
@@ -168,7 +168,7 @@ impl ReplaySlotStats {
             ("accumulated_units", total_units, i64),
             ("count", total_count, i64),
             ("errored_units", total_errored_units, i64),
-            ("count", total_errored_count, i64)
+            ("errored_count", total_errored_count, i64)
         );
     }
 }


### PR DESCRIPTION
#### Problem
per-program-timing writes 20% bytes to influx, with 7.7% of total writing. Largely due to pubkey. 

#### Summary of Changes
- downgrade from `info` to `trace` for top 5 pre-program-timing. Keep the aggregated `all` as info to allow us get overall avergaed CU/us ratio 
- We will configured some of our notes to trace to capture top 5 program timing.

Fixes #
