### PR TITLE
ci: Patch solana-account-decoder for downstream builds

### DIFF
--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -14,6 +14,8 @@ update_solana_dependencies() {
   sed -i -e "s#\(solana-client = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-clap-utils = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-clap-utils = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-account-decoder = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-account-decoder = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
 }
 
 patch_crates_io_solana() {
@@ -21,6 +23,7 @@ patch_crates_io_solana() {
   declare solana_dir="$2"
   cat >> "$Cargo_toml" <<EOF
 [patch.crates-io]
+solana-account-decoder = { path = "$solana_dir/account-decoder" }
 solana-clap-utils = { path = "$solana_dir/clap-utils" }
 solana-client = { path = "$solana_dir/client" }
 solana-program = { path = "$solana_dir/sdk/program" }


### PR DESCRIPTION
#### Problem

The downstream anchor build broke because `solana-account-decoder` was added as a dependency on the client.

#### Summary of Changes

Patch `solana-account-decoder` too.

Fixes #
