### PR TITLE
`Bank::get_fee_for_message` is now nonce aware

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3073,9 +3073,17 @@ impl Bank {
     }
 
     pub fn get_fee_for_message(&self, message: &SanitizedMessage) -> Option<u64> {
-        let blockhash_queue = self.blockhash_queue.read().unwrap();
-        let lamports_per_signature =
-            blockhash_queue.get_lamports_per_signature(message.recent_blockhash())?;
+        let lamports_per_signature = {
+            let blockhash_queue = self.blockhash_queue.read().unwrap();
+            blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
+        }
+        .or_else(|| {
+            self.check_message_for_nonce(message)
+                .and_then(|(address, account)| {
+                    NoncePartial::new(address, account).lamports_per_signature()
+                })
+        })?;
+
         Some(Self::calculate_fee(message, lamports_per_signature))
     }
 
@@ -3438,18 +3446,23 @@ impl Bank {
             .check_hash_age(hash, max_age)
     }
 
-    pub fn check_transaction_for_nonce(
-        &self,
-        tx: &SanitizedTransaction,
-    ) -> Option<TransactionAccount> {
-        tx.get_durable_nonce(self.feature_set.is_active(&nonce_must_be_writable::id()))
+    fn check_message_for_nonce(&self, message: &SanitizedMessage) -> Option<TransactionAccount> {
+        message
+            .get_durable_nonce(self.feature_set.is_active(&nonce_must_be_writable::id()))
             .and_then(|nonce_address| {
                 self.get_account_with_fixed_root(nonce_address)
                     .map(|nonce_account| (*nonce_address, nonce_account))
             })
             .filter(|(_, nonce_account)| {
-                nonce_account::verify_nonce_account(nonce_account, tx.message().recent_blockhash())
+                nonce_account::verify_nonce_account(nonce_account, message.recent_blockhash())
             })
+    }
+
+    pub fn check_transaction_for_nonce(
+        &self,
+        tx: &SanitizedTransaction,
+    ) -> Option<TransactionAccount> {
+        self.check_message_for_nonce(tx.message())
     }
 
     pub fn check_transactions(

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -38,6 +38,7 @@ pub mod program_memory;
 pub mod program_option;
 pub mod program_pack;
 pub mod program_stubs;
+pub mod program_utils;
 pub mod pubkey;
 pub mod rent;
 pub mod sanitize;

--- a/sdk/program/src/program_utils.rs
+++ b/sdk/program/src/program_utils.rs
@@ -1,0 +1,38 @@
+use {crate::instruction::InstructionError, bincode::config::Options};
+
+/// Deserialize with a limit based the maximum amount of data a program can expect to get.
+/// This function should be used in place of direct deserialization to help prevent OOM errors
+pub fn limited_deserialize<T>(instruction_data: &[u8], limit: u64) -> Result<T, InstructionError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    bincode::options()
+        .with_limit(limit)
+        .with_fixint_encoding() // As per https://github.com/servo/bincode/issues/333, these two options are needed
+        .allow_trailing_bytes() // to retain the behavior of bincode::deserialize with the new `options()` method
+        .deserialize_from(instruction_data)
+        .map_err(|_| InstructionError::InvalidInstructionData)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use {super::*, solana_program::system_instruction::SystemInstruction};
+
+    #[test]
+    fn test_limited_deserialize_advance_nonce_account() {
+        let item = SystemInstruction::AdvanceNonceAccount;
+        let serialized = bincode::serialize(&item).unwrap();
+
+        assert_eq!(
+            serialized.len(),
+            4,
+            "`SanitizedMessage::get_durable_nonce()` may need a change"
+        );
+
+        assert_eq!(
+            limited_deserialize::<SystemInstruction>(&serialized, 4).as_ref(),
+            Ok(&item)
+        );
+        assert!(limited_deserialize::<SystemInstruction>(&serialized, 3).is_err());
+    }
+}

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -1,4 +1,4 @@
-use {crate::instruction::InstructionError, bincode::config::Options};
+use crate::instruction::InstructionError;
 
 /// Deserialize with a limit based the maximum amount of data a program can expect to get.
 /// This function should be used in place of direct deserialization to help prevent OOM errors
@@ -6,13 +6,10 @@ pub fn limited_deserialize<T>(instruction_data: &[u8]) -> Result<T, InstructionE
 where
     T: serde::de::DeserializeOwned,
 {
-    let limit = crate::packet::PACKET_DATA_SIZE as u64;
-    bincode::options()
-        .with_limit(limit)
-        .with_fixint_encoding() // As per https://github.com/servo/bincode/issues/333, these two options are needed
-        .allow_trailing_bytes() // to retain the behavior of bincode::deserialize with the new `options()` method
-        .deserialize_from(instruction_data)
-        .map_err(|_| InstructionError::InvalidInstructionData)
+    solana_program::program_utils::limited_deserialize(
+        instruction_data,
+        crate::packet::PACKET_DATA_SIZE as u64,
+    )
 }
 
 #[cfg(test)]

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -6,16 +6,13 @@ use {
             v0::{self, LoadedAddresses, MessageAddressTableLookup},
             SanitizedMessage, VersionedMessage,
         },
-        nonce::NONCED_TX_MARKER_IX_INDEX,
         precompiles::verify_if_precompile,
-        program_utils::limited_deserialize,
         pubkey::Pubkey,
         sanitize::Sanitize,
         signature::Signature,
         solana_sdk::feature_set,
         transaction::{Result, Transaction, TransactionError, VersionedTransaction},
     },
-    solana_program::{system_instruction::SystemInstruction, system_program},
     std::sync::Arc,
 };
 
@@ -181,31 +178,7 @@ impl SanitizedTransaction {
 
     /// If the transaction uses a durable nonce, return the pubkey of the nonce account
     pub fn get_durable_nonce(&self, nonce_must_be_writable: bool) -> Option<&Pubkey> {
-        self.message
-            .instructions()
-            .get(NONCED_TX_MARKER_IX_INDEX as usize)
-            .filter(
-                |ix| match self.message.get_account_key(ix.program_id_index as usize) {
-                    Some(program_id) => system_program::check_id(program_id),
-                    _ => false,
-                },
-            )
-            .filter(|ix| {
-                matches!(
-                    limited_deserialize(&ix.data),
-                    Ok(SystemInstruction::AdvanceNonceAccount)
-                )
-            })
-            .and_then(|ix| {
-                ix.accounts.get(0).and_then(|idx| {
-                    let idx = *idx as usize;
-                    if nonce_must_be_writable && !self.message.is_writable(idx) {
-                        None
-                    } else {
-                        self.message.get_account_key(idx)
-                    }
-                })
-            })
+        self.message.get_durable_nonce(nonce_must_be_writable)
     }
 
     /// Return the serialized message data to sign.


### PR DESCRIPTION
Nonce-based transactions fail from the cli due to the `getFeeForMesssage` RPC API not being nonce aware.  An example is:
```
$ solana transfer --allow-unfunded-recipient 1nc1nerator11111111111111111111111111111111 0 \
  --blockhash $(solana nonce nonce.json) --nonce $(solana-keygen pubkey nonce.json)
```
