### PR TITLE
v1.8: Soften vote account identity mismatch from panic to runtime error

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1157,10 +1157,6 @@ impl Tower {
                 self.node_pubkey,
                 bank.slot(),
             );
-            assert_eq!(
-                self.vote_state.node_pubkey, self.node_pubkey,
-                "vote account's node_pubkey doesn't match",
-            );
         } else {
             self.initialize_root(root);
             info!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1454,6 +1454,14 @@ impl ReplayStage {
             }
             Ok(vote_state) => vote_state,
         };
+        if vote_state.node_pubkey != node_keypair.pubkey() {
+            info!(
+                "Vote account node_pubkey mismatch: {} (expected: {}).  Unable to vote",
+                vote_state.node_pubkey,
+                node_keypair.pubkey()
+            );
+            return None;
+        }
         let authorized_voter_pubkey =
             if let Some(authorized_voter_pubkey) = vote_state.get_authorized_voter(bank.epoch()) {
                 authorized_voter_pubkey


### PR DESCRIPTION
A vote account identity mismatch can be intentional during the migration of a vote account from one validator to another, with carefully configured `solana-validator` command-line arguments.  There's no reason to panic in this case, instead log a message whenever a vote cannot be cast due to this mismatch.  This change has been on v1.9 since July :-/