### PR TITLE
docs: fix get fee for message docs

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -999,13 +999,12 @@ Get the fee the network will charge for a particular Message
 
 #### Parameters:
 
-- `blockhash: <string>` - The blockhash of this block, as base-58 encoded string
 - `message: <string>` - Base-64 encoded Message
 - `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash)
 
 #### Results:
 
-- `<u64>` - Fee corresponding to the message at the specified blockhash
+- `<u64 | null>` - Fee corresponding to the message at the specified blockhash
 
 #### Example:
 
@@ -1017,7 +1016,7 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
   "jsonrpc":"2.0",
   "method":"getFeeForMessage",
   "params":[
-    "FxVKTksYShgKjnFG3RQUEo2AEesDb4ZHGY3NGJ7KHd7F","AQABAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAA",
+    "AQABAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBAQAA",
     {
       "commitment":"processed"
     }


### PR DESCRIPTION
#### Problem

I opened an issue #22500 
if I'm correct at the issue, here is the PR.

#### Summary of Changes

update getFeeForMessage docs
1. remove incorrect input, `blockhash`
2. add nullable type for return value

Closes #22500