### PR TITLE
(Ledger Store) Periodically report RocksDB column family properties

### DIFF
--- a/core/src/ledger_metric_report_service.rs
+++ b/core/src/ledger_metric_report_service.rs
@@ -1,0 +1,44 @@
+//! The `ledger_metric_report_service` periodically reports ledger store metrics.
+
+use {
+    solana_ledger::blockstore::Blockstore,
+    std::{
+        string::ToString,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::Duration,
+    },
+};
+
+// Determines how often we report blockstore metrics.
+const BLOCKSTORE_METRICS_REPORT_PERIOD_MILLIS: u64 = 10000;
+
+pub struct LedgerMetricReportService {
+    t_cf_metric: JoinHandle<()>,
+}
+
+impl LedgerMetricReportService {
+    pub fn new(blockstore: Arc<Blockstore>, exit: &Arc<AtomicBool>) -> Self {
+        let exit_signal = exit.clone();
+        let t_cf_metric = Builder::new()
+            .name("metric_report_rocksdb_cf_metrics".to_string())
+            .spawn(move || loop {
+                if exit_signal.load(Ordering::Relaxed) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(
+                    BLOCKSTORE_METRICS_REPORT_PERIOD_MILLIS,
+                ));
+                blockstore.submit_rocksdb_cf_metrics_for_all_cfs();
+            })
+            .unwrap();
+        Self { t_cf_metric }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.t_cf_metric.join()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod latest_validator_votes_for_frozen_banks;
 pub mod leader_slot_banking_stage_metrics;
 pub mod leader_slot_banking_stage_timing_metrics;
 pub mod ledger_cleanup_service;
+pub mod ledger_metric_report_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
 pub mod packet_hasher;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -16,6 +16,7 @@ use {
         cost_update_service::CostUpdateService,
         drop_bank_service::DropBankService,
         ledger_cleanup_service::LedgerCleanupService,
+        ledger_metric_report_service::LedgerMetricReportService,
         replay_stage::{ReplayStage, ReplayStageConfig},
         retransmit_stage::RetransmitStage,
         rewards_recorder_service::RewardsRecorderSender,
@@ -70,6 +71,7 @@ pub struct Tvu {
     retransmit_stage: RetransmitStage,
     replay_stage: ReplayStage,
     ledger_cleanup_service: Option<LedgerCleanupService>,
+    ledger_metric_report_service: LedgerMetricReportService,
     accounts_background_service: AccountsBackgroundService,
     accounts_hash_verifier: AccountsHashVerifier,
     cost_update_service: CostUpdateService,
@@ -357,6 +359,8 @@ impl Tvu {
             )
         });
 
+        let ledger_metric_report_service = LedgerMetricReportService::new(blockstore, exit);
+
         let accounts_background_service = AccountsBackgroundService::new(
             bank_forks.clone(),
             exit,
@@ -373,6 +377,7 @@ impl Tvu {
             retransmit_stage,
             replay_stage,
             ledger_cleanup_service,
+            ledger_metric_report_service,
             accounts_background_service,
             accounts_hash_verifier,
             cost_update_service,
@@ -389,6 +394,7 @@ impl Tvu {
         if self.ledger_cleanup_service.is_some() {
             self.ledger_cleanup_service.unwrap().join()?;
         }
+        self.ledger_metric_report_service.join()?;
         self.accounts_background_service.join()?;
         self.replay_stage.join()?;
         self.accounts_hash_verifier.join()?;

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -294,7 +294,7 @@ mod tests {
 
         *time_previous = time_now;
         *storage_previous = storage_now;
-        *data_shred_storage_previous = data_shred_storage_now;
+        *data_shred_storage_previous = data_shred_storage_now.try_into().unwrap();
     }
 
     /// Helper function of the benchmark `test_ledger_cleanup_compaction` which

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -528,9 +528,9 @@ impl Rocks {
     ///
     /// Full list of properties that return int values could be found
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
-    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &str) -> Result<u64> {
+    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &str) -> Result<i64> {
         match self.0.property_int_value_cf(cf, name) {
-            Ok(Some(value)) => Ok(value),
+            Ok(Some(value)) => Ok(value.try_into().unwrap()),
             Ok(None) => Ok(0),
             Err(e) => Err(BlockstoreError::RocksDb(e)),
         }
@@ -1233,7 +1233,7 @@ where
     ///
     /// Full list of properties that return int values could be found
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
-    pub fn get_int_property(&self, name: &str) -> Result<u64> {
+    pub fn get_int_property(&self, name: &str) -> Result<i64> {
         self.backend.get_int_property_cf(self.handle(), name)
     }
 }


### PR DESCRIPTION
This PR enables blockstore to periodically report RocksDB column family properties.
The reported properties are under `blockstore_rocksdb_cfs`, and the properties also
support group by operation on cf_name.