### PR TITLE
Fix build: s/vote_instruction/vote_processor/

### DIFF
--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -153,7 +153,7 @@ fn do_bench(bencher: &mut Bencher, feature: Option<Pubkey>) {
 
         let first_instruction_account = 1;
         assert_eq!(
-            solana_vote_program::vote_instruction::process_instruction(
+            solana_vote_program::vote_processor::process_instruction(
                 first_instruction_account,
                 &instruction.data,
                 &mut invoke_context


### PR DESCRIPTION
Looks like #22486 broke the build (see [here](https://buildkite.com/solana-labs/solana/builds/63443#a07e39fb-f507-4517-afd8-0086cd8c715d) for build error). I think it is just a FQN issue.