### PR TITLE
Profile Picture Support

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -19,6 +19,7 @@
         "@sentry/react": "^6.16.1",
         "@solana/spl-token-registry": "^0.2.1143",
         "@solana/web3.js": "^1.31.0",
+        "@solflare-wallet/pfp": "^0.0.5",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -4534,9 +4535,9 @@
       "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="
     },
     "node_modules/@project-serum/borsh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.2.tgz",
-      "integrity": "sha512-Ms+aWmGVW6bWd3b0+MWwoaYig2QD0F90h0uhr7AzY3dpCb5e2S6RsRW02vFTfa085pY2VLB7nTZNbFECQ1liTg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.3.tgz",
+      "integrity": "sha512-lH9zEYADZE3cxrgiFym8+jbUE3NM/LH+WOKYcUjs65CT10Q64Hv45bcAAa/phwYk4Tpz0uQ1x+ergFaAoGt67Q==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -4989,6 +4990,43 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+    },
+    "node_modules/@solflare-wallet/pfp": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@solflare-wallet/pfp/-/pfp-0.0.5.tgz",
+      "integrity": "sha512-3gtRPR+PssRhhXVPdO7dStRF1T9jys0e9hGGbrBLaYkkmoGmHh/Vv57KQq6vFI5GrAXUOClikHQ7oTT4Dqq6Mw==",
+      "dependencies": {
+        "@metaplex-foundation/mpl-token-metadata": "0.0.2",
+        "@project-serum/borsh": "^0.2.3",
+        "@solana/web3.js": "^1.31.0",
+        "btoa": "^1.2.1",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^3.1.4",
+        "jdenticon": "^3.1.1"
+      }
+    },
+    "node_modules/@solflare-wallet/pfp/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "1.4.2",
@@ -8036,6 +8074,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
@@ -8277,6 +8326,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/canvas-renderer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.0.tgz",
+      "integrity": "sha512-Itdq9pwXcs4IbbkRCXc7reeGBk6i6tlDtZTjE1yc+KvYkx1Mt3WLf6tidZ/Ixbm7Vmi+jpWKG0dRBor67x9yGw==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/capture-exit": {
@@ -14077,6 +14134,20 @@
       "version": "12.20.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
       "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+    },
+    "node_modules/jdenticon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.1.1.tgz",
+      "integrity": "sha512-/m0Kk5ou7tPHjW6YovCysRETqPlFcTabWG96r8NbbSsEK+eQ3jHiGULaGOtp4XBqkRxWS1XMopLRGwdhet5ezw==",
+      "dependencies": {
+        "canvas-renderer": "~2.2.0"
+      },
+      "bin": {
+        "jdenticon": "bin/jdenticon.js"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/jest": {
       "version": "26.6.0",
@@ -30515,9 +30586,9 @@
       }
     },
     "@project-serum/borsh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.2.tgz",
-      "integrity": "sha512-Ms+aWmGVW6bWd3b0+MWwoaYig2QD0F90h0uhr7AzY3dpCb5e2S6RsRW02vFTfa085pY2VLB7nTZNbFECQ1liTg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.3.tgz",
+      "integrity": "sha512-lH9zEYADZE3cxrgiFym8+jbUE3NM/LH+WOKYcUjs65CT10Q64Hv45bcAAa/phwYk4Tpz0uQ1x+ergFaAoGt67Q==",
       "requires": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -30850,6 +30921,31 @@
           "version": "0.14.2",
           "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
           "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+        }
+      }
+    },
+    "@solflare-wallet/pfp": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@solflare-wallet/pfp/-/pfp-0.0.5.tgz",
+      "integrity": "sha512-3gtRPR+PssRhhXVPdO7dStRF1T9jys0e9hGGbrBLaYkkmoGmHh/Vv57KQq6vFI5GrAXUOClikHQ7oTT4Dqq6Mw==",
+      "requires": {
+        "@metaplex-foundation/mpl-token-metadata": "0.0.2",
+        "@project-serum/borsh": "^0.2.3",
+        "@solana/web3.js": "^1.31.0",
+        "btoa": "^1.2.1",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^3.1.4",
+        "jdenticon": "^3.1.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
         }
       }
     },
@@ -33259,6 +33355,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
@@ -33440,6 +33541,14 @@
       "version": "1.0.30001283",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
       "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
+    },
+    "canvas-renderer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.0.tgz",
+      "integrity": "sha512-Itdq9pwXcs4IbbkRCXc7reeGBk6i6tlDtZTjE1yc+KvYkx1Mt3WLf6tidZ/Ixbm7Vmi+jpWKG0dRBor67x9yGw==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -37987,6 +38096,14 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
           "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
         }
+      }
+    },
+    "jdenticon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.1.1.tgz",
+      "integrity": "sha512-/m0Kk5ou7tPHjW6YovCysRETqPlFcTabWG96r8NbbSsEK+eQ3jHiGULaGOtp4XBqkRxWS1XMopLRGwdhet5ezw==",
+      "requires": {
+        "canvas-renderer": "~2.2.0"
       }
     },
     "jest": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -14,6 +14,7 @@
     "@sentry/react": "^6.16.1",
     "@solana/spl-token-registry": "^0.2.1143",
     "@solana/web3.js": "^1.31.0",
+    "@solflare-wallet/pfp": "^0.0.5",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { PublicKey } from "@solana/web3.js";
 import { CacheEntry, FetchStatus } from "providers/cache";
 import {
@@ -201,6 +202,29 @@ export function AccountHeader({
           <h2 className="header-title">
             {tokenDetails?.name || "Unknown Token"}
           </h2>
+        </div>
+      </div>
+    );
+  }
+
+  if (account?.details?.space === 0) {
+    return (
+      <div className="row align-items-end">
+        <div className="col-auto">
+          <div className="avatar avatar-lg header-avatar-top">
+            <Link to={clusterPath(`/address/${account.details.pfpData?.mintAccount?.toBase58()}`)}>              
+              <img
+                src={account?.details?.pfpData?.url}
+                alt="token logo"
+                className="avatar-img rounded-circle border border-4 border-body"
+              />
+            </Link>
+
+          </div>
+        </div>
+        <div className="col mb-3 ms-n3 ms-md-n2">
+          <h6 className="header-pretitle">Details</h6>
+          <h2 className="header-title">Account</h2>
         </div>
       </div>
     );

--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "validators/accounts/upgradeable-program";
 import { RewardsProvider } from "./rewards";
 import { programs, MetadataJson } from "@metaplex/js";
+import { getProfilePicture } from "@solflare-wallet/pfp"
 import getEditionInfo, { EditionInfo } from "./utils/getEditionInfo";
 export { useAccountHistory } from "./history";
 
@@ -76,6 +77,15 @@ export type ConfigProgramData = {
   parsed: ConfigAccount;
 };
 
+export type PfpData = {
+  isAvailable: boolean;
+  url: string;
+  name?: string;
+  metadata?: any;
+  tokenAccount?: PublicKey;
+  mintAccount?: PublicKey;
+}
+
 export type ProgramData =
   | UpgradeableLoaderAccountData
   | StakeProgramData
@@ -89,6 +99,7 @@ export interface Details {
   executable: boolean;
   owner: PublicKey;
   space: number;
+  pfpData?: PfpData;
   data?: ProgramData;
 }
 
@@ -288,6 +299,7 @@ async function fetchAccountInfo(
         space,
         executable: result.executable,
         owner: result.owner,
+        pfpData: await getProfilePicture(connection, pubkey),
         data,
       };
     }


### PR DESCRIPTION
#### Problem

This PR is an implementation of the Profile Picture Protocol with the goal to introduce a social aspect for users to be able to set their Solana-wide profile pictures.

The protocol allows Solana users to set a single Metaplex-standard NFT as a universal PFP for the Solana blockchain.

Individual Solana protocols can use the documentation below both to show SPP PFPs in their FE, and to provide functionality within their own FE to allow users to set a new PFP.

Relevant open-source repositories can be found here:
- Solana program: https://github.com/solflare-wallet/solana-pfp-program
- NPM module: https://github.com/solflare-wallet/solana-pfp

#### Summary of Changes

Fetching and rendering system accounts now also fetches relevant NFT information, displays it and links to it. 

#### example
![image](https://user-images.githubusercontent.com/989725/149563075-f4fd2589-1a71-4d74-a328-e77f23fa1809.png)
