### PR TITLE
cli: Improve nonce-related error messages

### DIFF
--- a/client/src/nonce_utils.rs
+++ b/client/src/nonce_utils.rs
@@ -4,6 +4,7 @@ use {
         account::{Account, ReadableAccount},
         account_utils::StateMut,
         commitment_config::CommitmentConfig,
+        hash::Hash,
         nonce::{
             state::{Data, Versions},
             State,
@@ -21,10 +22,10 @@ pub enum Error {
     InvalidAccountData,
     #[error("unexpected account data size")]
     UnexpectedDataSize,
-    #[error("query hash does not match stored hash")]
-    InvalidHash,
-    #[error("query authority does not match account authority")]
-    InvalidAuthority,
+    #[error("provided hash ({provided}) does not match nonce hash ({expected})")]
+    InvalidHash { provided: Hash, expected: Hash },
+    #[error("provided authority ({provided}) does not match nonce authority ({expected})")]
+    InvalidAuthority { provided: Pubkey, expected: Pubkey },
     #[error("invalid state for requested operation")]
     InvalidStateForOperation,
     #[error("client error: {0}")]


### PR DESCRIPTION
When working with nonces in the cli sometimes you'll get a terse error like `"query authority does not match account authority"`, forcing you to dive into the cli source to figure out what went wrong.

Instead report `"provided authority (xxx...) does not match nonce authority (yyy...)"` and the user error becomes obvious