### PR TITLE
Add get_processed_inner_instruction syscall

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2837,6 +2837,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-inner-instructions"
+version = "1.10.0"
+dependencies = [
+ "solana-program 1.10.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-instruction-introspection"
 version = "1.10.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "rust/log_data",
     "rust/external_spend",
     "rust/finalize",
+    "rust/inner_instruction",
     "rust/instruction_introspection",
     "rust/invoke",
     "rust/invoke_and_error",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -70,6 +70,7 @@ fn main() {
             "log_data",
             "external_spend",
             "finalize",
+            "inner_instruction",
             "instruction_introspection",
             "invoke",
             "invoke_and_error",

--- a/programs/bpf/rust/inner_instruction/Cargo.toml
+++ b/programs/bpf/rust/inner_instruction/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-bpf-rust-inner-instructions"
+version = "1.10.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-log-data"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.10.0" }
+
+[features]
+default = ["program"]
+program = []
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/inner_instruction/src/lib.rs
+++ b/programs/bpf/rust/inner_instruction/src/lib.rs
@@ -6,7 +6,7 @@ use solana_program::{
     account_info::AccountInfo,
     entrypoint,
     entrypoint::ProgramResult,
-    instruction::{get_processed_inner_instruction, AccountMeta, Instruction},
+    instruction::{get_invoke_depth, get_processed_inner_instruction, AccountMeta, Instruction},
     msg,
     program::invoke,
     pubkey::Pubkey,
@@ -51,6 +51,7 @@ fn process_instruction(
     invoke(&instruction1, accounts)?;
     invoke(&instruction0, accounts)?;
 
+    assert_eq!(1, get_invoke_depth());
     assert_eq!(Some((1, instruction0)), get_processed_inner_instruction(0));
     assert_eq!(Some((1, instruction1)), get_processed_inner_instruction(1));
     assert_eq!(Some((1, instruction2)), get_processed_inner_instruction(2));

--- a/programs/bpf/rust/inner_instruction/src/lib.rs
+++ b/programs/bpf/rust/inner_instruction/src/lib.rs
@@ -1,0 +1,61 @@
+//! Example Rust-based BPF program that uses sol_get_processed_inner_instruction syscall
+
+#![cfg(feature = "program")]
+
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    instruction::{get_processed_inner_instruction, AccountMeta, Instruction},
+    msg,
+    program::invoke,
+    pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("inner");
+
+    // account 0 is mint
+    // account 1 is noop
+    // account 2 is invoke_and_return
+
+    let instruction3 = Instruction::new_with_bytes(*accounts[1].key, instruction_data, vec![]);
+    let instruction2 = Instruction::new_with_bytes(
+        *accounts[2].key,
+        instruction_data,
+        vec![AccountMeta::new_readonly(*accounts[1].key, false)],
+    );
+    let instruction1 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        instruction_data,
+        vec![
+            AccountMeta::new_readonly(*accounts[0].key, true),
+            AccountMeta::new_readonly(*accounts[1].key, false),
+        ],
+    );
+    let instruction0 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        instruction_data,
+        vec![
+            AccountMeta::new_readonly(*accounts[1].key, false),
+            AccountMeta::new_readonly(*accounts[0].key, true),
+        ],
+    );
+
+    invoke(&instruction2, accounts)?;
+    invoke(&instruction1, accounts)?;
+    invoke(&instruction0, accounts)?;
+
+    assert_eq!(Some((1, instruction0)), get_processed_inner_instruction(0));
+    assert_eq!(Some((1, instruction1)), get_processed_inner_instruction(1));
+    assert_eq!(Some((1, instruction2)), get_processed_inner_instruction(2));
+    assert_eq!(Some((2, instruction3)), get_processed_inner_instruction(3));
+    assert!(get_processed_inner_instruction(4).is_none());
+
+    Ok(())
+}

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -29,7 +29,7 @@ use {
             sol_log_data_syscall_enabled, update_syscall_base_costs,
         },
         hash::{Hasher, HASH_BYTES},
-        instruction::{AccountMeta, InnerMeta, Instruction, InstructionError},
+        instruction::{AccountMeta, Instruction, InstructionError, ProcessedInnerInstruction},
         keccak, native_loader,
         precompiles::is_precompile,
         program::MAX_RETURN_DATA,
@@ -3034,12 +3034,16 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedInnerInstruction<'a,
         if let Some((stack_depth, instruction)) =
             invoke_context.get_processed_inner_instruction(index as usize)
         {
-            let InnerMeta {
+            let ProcessedInnerInstruction {
                 data_len,
                 accounts_len,
                 depth,
             } = question_mark!(
-                translate_type_mut::<InnerMeta>(memory_mapping, meta_addr, &loader_id),
+                translate_type_mut::<ProcessedInnerInstruction>(
+                    memory_mapping,
+                    meta_addr,
+                    &loader_id
+                ),
                 result
             );
             if *data_len >= instruction.data.len() && *accounts_len >= instruction.accounts.len() {

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -650,7 +650,7 @@ impl CompiledInstruction {
 /// when calling the `sol_get_processed_inner_instruction` syscall.
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
-pub struct InnerMeta {
+pub struct ProcessedInnerInstruction {
     pub data_len: usize,
     pub accounts_len: usize,
     pub depth: usize,
@@ -673,14 +673,14 @@ pub fn get_processed_inner_instruction(index: usize) -> Option<(usize, Instructi
         extern "C" {
             fn sol_get_processed_inner_instruction(
                 index: u64,
-                meta: *mut InnerMeta,
+                meta: *mut ProcessedInnerInstruction,
                 program_id: *mut Pubkey,
                 data: *mut u8,
                 accounts: *mut AccountMeta,
             ) -> u64;
         }
 
-        let mut meta = InnerMeta::default();
+        let mut meta = ProcessedInnerInstruction::default();
         let mut program_id = Pubkey::default();
 
         if 1 == unsafe {

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -707,14 +707,35 @@ pub fn get_processed_inner_instruction(index: usize) -> Option<(usize, Instructi
                 )
             };
 
-            Some((meta.depth, Instruction::new_with_bytes(program_id, &data, accounts)))
+            Some((
+                meta.depth,
+                Instruction::new_with_bytes(program_id, &data, accounts),
+            ))
         } else {
             None
         }
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    crate::program_stubs::get_processed_inner_instruction(index)
+    crate::program_stubs::sol_get_processed_inner_instruction(index)
+}
+
+/// Get the current invocation depth, transaction-level instructions are depth
+/// 0, fist invoked inner instruction is depth 1, etc...
+pub fn get_invoke_depth() -> usize {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_get_invoke_depth() -> u64;
+        }
+
+        unsafe { sol_get_invoke_depth() as usize }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        crate::program_stubs::sol_get_invoke_depth() as usize
+    }
 }
 
 #[test]

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -91,8 +91,11 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         println!("data: {}", fields.iter().map(base64::encode).join(" "));
     }
-    fn get_processed_inner_instruction(&self, _index: usize) -> Option<(usize, Instruction)> {
+    fn sol_get_processed_inner_instruction(&self, _index: usize) -> Option<(usize, Instruction)> {
         None
+    }
+    fn sol_get_invoke_depth(&self) -> u64 {
+        0
     }
 }
 
@@ -180,11 +183,15 @@ pub(crate) fn sol_log_data(data: &[&[u8]]) {
     SYSCALL_STUBS.read().unwrap().sol_log_data(data)
 }
 
-pub(crate) fn get_processed_inner_instruction(index: usize) -> Option<(usize, Instruction)> {
+pub(crate) fn sol_get_processed_inner_instruction(index: usize) -> Option<(usize, Instruction)> {
     SYSCALL_STUBS
         .read()
         .unwrap()
-        .get_processed_inner_instruction(index)
+        .sol_get_processed_inner_instruction(index)
+}
+
+pub(crate) fn sol_get_invoke_depth() -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_invoke_depth()
 }
 
 /// Check that two regions do not overlap.

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -91,6 +91,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         println!("data: {}", fields.iter().map(base64::encode).join(" "));
     }
+    fn get_processed_inner_instruction(&self, _index: usize) -> Option<(usize, Instruction)> {
+        None
+    }
 }
 
 struct DefaultSyscallStubs {}
@@ -175,6 +178,13 @@ pub(crate) fn sol_set_return_data(data: &[u8]) {
 
 pub(crate) fn sol_log_data(data: &[&[u8]]) {
     SYSCALL_STUBS.read().unwrap().sol_log_data(data)
+}
+
+pub(crate) fn get_processed_inner_instruction(index: usize) -> Option<(usize, Instruction)> {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .get_processed_inner_instruction(index)
 }
 
 /// Check that two regions do not overlap.

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -311,6 +311,10 @@ pub mod vote_withdraw_authority_may_change_authorized_voter {
     solana_sdk::declare_id!("AVZS3ZsN4gi6Rkx2QUibYuSJG3S6QHib7xCYhG6vGJxU");
 }
 
+pub mod add_get_processed_inner_instruction_syscall {
+    solana_sdk::declare_id!("CFK1hRCNy8JJuAAY8Pb2GjLFNdCThS2qwZNe3izzBMgn");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -383,6 +387,7 @@ lazy_static! {
         (filter_votes_outside_slot_hashes::id(), "filter vote slots older than the slot hashes history"),
         (update_syscall_base_costs::id(), "Update syscall base costs"),
         (vote_withdraw_authority_may_change_authorized_voter::id(), "vote account withdraw authority may change the authorized voter #22521"),
+        (add_get_processed_inner_instruction_syscall::id(), "add add_get_processed_inner_instruction_syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

There are scenarios where instructions (top-level or via CPI) would like to know what the last instruction processed was. Some examples are verification of assert instructions or to check for memo instructions.  Programs can already check tx level instructions via the `Sysvar1nstructions1111111111111111111111111` but there is no way to get information about what inner instructions have been processed.

#### Summary of Changes

Add a syscall that allows a program to query what inner instructions have been successfully processed.

Fixes #22437
