### PR TITLE
Bugfix/block subscribe

### DIFF
--- a/client/src/pubsub_client.rs
+++ b/client/src/pubsub_client.rs
@@ -305,7 +305,7 @@ impl PubsubClient {
 
         let result = PubsubClientSubscription {
             message_type: PhantomData,
-            operation: "blocks",
+            operation: "block",
             socket,
             subscription_id,
             t_cleanup: Some(t_cleanup),

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -49,6 +49,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --rpc-pubsub-enable-block-subscription ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --enable-cpi-and-log-storage ]]; then
       args+=("$1")
       shift

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1206,6 +1206,7 @@ pub fn main() {
         .arg(
             Arg::with_name("rpc_pubsub_enable_block_subscription")
                 .long("rpc-pubsub-enable-block-subscription")
+                .requires("enable_rpc_transaction_history")
                 .takes_value(false)
                 .help("Enable the unstable RPC PubSub `blockSubscribe` subscription"),
         )


### PR DESCRIPTION
#### Problem
Without `enable_rpc_transaction_history` being set to true, up the chain from [here](https://github.com/solana-labs/solana/blob/cddab635ffc6db8d7f2e8c31016bdb52e394d048/core/src/replay_stage.rs#L2165), `transaction_status_sender` is none. `transaction_status_receiver` is what sets `max_complete_transaction_status_slot`, which is dependent upon [here](https://github.com/solana-labs/solana/blob/cddab635ffc6db8d7f2e8c31016bdb52e394d048/rpc/src/rpc_subscriptions.rs#L957). In short, without that flag `max_complete_transaction_status_slot` is always 0 which means no `block_subscribe` notifications are sent out.

#### Summary of Changes
Requires `enable_rpc_transaction_history` to be true when `rpc_pubsub_enable_block_subscription` is passed in.
