### PR TITLE
Add RPC support for versioned transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,6 +5504,7 @@ dependencies = [
  "serial_test",
  "soketto",
  "solana-account-decoder",
+ "solana-address-lookup-table-program",
  "solana-client",
  "solana-entry",
  "solana-faucet",

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2019,6 +2019,7 @@ pub fn process_transaction_history(
                     RpcTransactionConfig {
                         encoding: Some(UiTransactionEncoding::Base64),
                         commitment: Some(CommitmentConfig::confirmed()),
+                        max_supported_transaction_version: None,
                     },
                 ) {
                     Ok(confirmed_transaction) => {

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -559,6 +559,7 @@ pub fn process_confirm(
                         RpcTransactionConfig {
                             encoding: Some(UiTransactionEncoding::Base64),
                             commitment: Some(CommitmentConfig::confirmed()),
+                            max_supported_transaction_version: None,
                         },
                     ) {
                         Ok(confirmed_transaction) => {

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -15,7 +15,7 @@ use {
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
     solana_rpc::{
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-        rpc::create_test_transactions_and_populate_blockstore,
+        rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
         rpc_pubsub_service::{PubSubConfig, PubSubService},
         rpc_subscriptions::RpcSubscriptions,
     },
@@ -232,9 +232,12 @@ fn test_block_subscription() {
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
     bank.transfer(rent_exempt_amount, &alice, &keypair2.pubkey())
         .unwrap();
-    let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-        vec![&alice, &keypair1, &keypair2, &keypair3],
-        0,
+    populate_blockstore_for_tests(
+        create_test_transaction_entries(
+            vec![&alice, &keypair1, &keypair2, &keypair3],
+            bank.clone(),
+        )
+        .0,
         bank,
         blockstore.clone(),
         max_complete_transaction_status_slot,

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -36,7 +36,9 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
-    solana_transaction_status::{ConfirmedBlock, TransactionDetails, UiTransactionEncoding},
+    solana_transaction_status::{
+        BlockEncodingOptions, ConfirmedBlock, TransactionDetails, UiTransactionEncoding,
+    },
     std::{
         collections::HashSet,
         net::{IpAddr, SocketAddr},
@@ -270,6 +272,7 @@ fn test_block_subscription() {
             encoding: Some(UiTransactionEncoding::Json),
             transaction_details: Some(TransactionDetails::Signatures),
             show_rewards: None,
+            max_supported_transaction_version: None,
         }),
     )
     .unwrap();
@@ -281,14 +284,17 @@ fn test_block_subscription() {
     match maybe_actual {
         Ok(actual) => {
             let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-            let legacy_block = ConfirmedBlock::from(versioned_block)
-                .into_legacy_block()
+            let confirmed_block = ConfirmedBlock::from(versioned_block);
+            let block = confirmed_block
+                .encode_with_options(
+                    UiTransactionEncoding::Json,
+                    BlockEncodingOptions {
+                        transaction_details: TransactionDetails::Signatures,
+                        show_rewards: false,
+                        max_supported_transaction_version: None,
+                    },
+                )
                 .unwrap();
-            let block = legacy_block.configure(
-                UiTransactionEncoding::Json,
-                TransactionDetails::Signatures,
-                false,
-            );
             assert_eq!(actual.value.slot, slot);
             assert!(block.eq(&actual.value.block.unwrap()));
         }

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -192,7 +192,7 @@ impl RpcSender for MockSender {
             "getTransaction" => serde_json::to_value(EncodedConfirmedTransactionWithStatusMeta {
                 slot: 2,
                 transaction: EncodedTransactionWithStatusMeta {
-                    version: Some(TransactionVersion::Legacy),
+                    version: Some(TransactionVersion::LEGACY),
                     transaction: EncodedTransaction::Json(
                         UiTransaction {
                             signatures: vec!["3AsdoALgZFuq2oUVWrDYhg2pNeaLJKPLf8hU2mQ6U8qJxeJ6hsrPVpMn9ma39DtfYCrDQSvngWRP8NnTpEhezJpE".to_string()],
@@ -384,7 +384,7 @@ impl RpcSender for MockSender {
                         UiTransactionEncoding::Base58,
                     ),
                     meta: None,
-                    version: Some(TransactionVersion::Legacy),
+                    version: Some(TransactionVersion::LEGACY),
                 }],
                 rewards: Rewards::new(),
                 block_time: None,

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -28,7 +28,7 @@ use {
         pubkey::Pubkey,
         signature::Signature,
         sysvar::epoch_schedule::EpochSchedule,
-        transaction::{self, Transaction, TransactionError},
+        transaction::{self, Transaction, TransactionError, TransactionVersion},
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
@@ -192,6 +192,7 @@ impl RpcSender for MockSender {
             "getTransaction" => serde_json::to_value(EncodedConfirmedTransactionWithStatusMeta {
                 slot: 2,
                 transaction: EncodedTransactionWithStatusMeta {
+                    version: Some(TransactionVersion::Legacy),
                     transaction: EncodedTransaction::Json(
                         UiTransaction {
                             signatures: vec!["3AsdoALgZFuq2oUVWrDYhg2pNeaLJKPLf8hU2mQ6U8qJxeJ6hsrPVpMn9ma39DtfYCrDQSvngWRP8NnTpEhezJpE".to_string()],
@@ -213,6 +214,7 @@ impl RpcSender for MockSender {
                                         accounts: vec![0, 1],
                                         data: "3Bxs49DitAvXtoDR".to_string(),
                                     }],
+                                    address_table_lookups: None,
                                 })
                         }),
                     meta: Some(UiTransactionStatusMeta {
@@ -226,6 +228,7 @@ impl RpcSender for MockSender {
                             pre_token_balances: None,
                             post_token_balances: None,
                             rewards: None,
+                            loaded_addresses: None,
                         }),
                 },
                 block_time: Some(1628633791),
@@ -381,6 +384,7 @@ impl RpcSender for MockSender {
                         UiTransactionEncoding::Base58,
                     ),
                     meta: None,
+                    version: Some(TransactionVersion::Legacy),
                 }],
                 rewards: Rewards::new(),
                 block_time: None,

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -2411,6 +2411,7 @@ impl RpcClient {
     ///     transaction_details: Some(TransactionDetails::None),
     ///     rewards: Some(true),
     ///     commitment: None,
+    ///     max_supported_transaction_version: Some(0),
     /// };
     /// let block = rpc_client.get_block_with_config(
     ///     slot,
@@ -3051,6 +3052,7 @@ impl RpcClient {
     /// let config = RpcTransactionConfig {
     ///     encoding: Some(UiTransactionEncoding::Json),
     ///     commitment: Some(CommitmentConfig::confirmed()),
+    ///     max_supported_transaction_version: Some(0),
     /// };
     /// let transaction = rpc_client.get_transaction_with_config(
     ///     &signature,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -2034,6 +2034,7 @@ impl RpcClient {
     ///     transaction_details: Some(TransactionDetails::None),
     ///     rewards: Some(true),
     ///     commitment: None,
+    ///     max_supported_transaction_version: Some(0),
     /// };
     /// let block = rpc_client.get_block_with_config(
     ///     slot,
@@ -2596,6 +2597,7 @@ impl RpcClient {
     /// let config = RpcTransactionConfig {
     ///     encoding: Some(UiTransactionEncoding::Json),
     ///     commitment: Some(CommitmentConfig::confirmed()),
+    ///     max_supported_transaction_version: Some(0),
     /// };
     /// let transaction = rpc_client.get_transaction_with_config(
     ///     &signature,

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -197,6 +197,7 @@ pub struct RpcBlockSubscribeConfig {
     pub encoding: Option<UiTransactionEncoding>,
     pub transaction_details: Option<TransactionDetails>,
     pub show_rewards: Option<bool>,
+    pub max_supported_transaction_version: Option<u8>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -248,6 +249,7 @@ pub struct RpcBlockConfig {
     pub rewards: Option<bool>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
+    pub max_supported_transaction_version: Option<u8>,
 }
 
 impl EncodingConfig for RpcBlockConfig {
@@ -288,6 +290,7 @@ pub struct RpcTransactionConfig {
     pub encoding: Option<UiTransactionEncoding>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
+    pub max_supported_transaction_version: Option<u8>,
 }
 
 impl EncodingConfig for RpcTransactionConfig {

--- a/client/src/rpc_deprecated_config.rs
+++ b/client/src/rpc_deprecated_config.rs
@@ -71,6 +71,7 @@ impl From<RpcConfirmedBlockConfig> for RpcBlockConfig {
             transaction_details: config.transaction_details,
             rewards: config.rewards,
             commitment: config.commitment,
+            max_supported_transaction_version: None,
         }
     }
 }
@@ -98,6 +99,7 @@ impl From<RpcConfirmedTransactionConfig> for RpcTransactionConfig {
         Self {
             encoding: config.encoding,
             commitment: config.commitment,
+            max_supported_transaction_version: None,
         }
     }
 }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -432,8 +432,8 @@ pub enum RpcBlockUpdateError {
     #[error("block store error")]
     BlockStoreError,
 
-    #[error("unsupported transaction version")]
-    UnsupportedTransactionVersion,
+    #[error("unsupported transaction version ({0})")]
+    UnsupportedTransactionVersion(u8),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3384,9 +3384,7 @@ mod tests {
         account_address: Pubkey,
         address_lookup_table: AddressLookupTable<'static>,
     ) -> AccountSharedData {
-        let mut data = Vec::new();
-        address_lookup_table.serialize_for_tests(&mut data).unwrap();
-
+        let data = address_lookup_table.serialize_for_tests().unwrap();
         let mut account =
             AccountSharedData::new(1, data.len(), &solana_address_lookup_table_program::id());
         account.set_data(data);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3129,7 +3129,7 @@ pub mod tests {
         },
         solana_rpc::{
             optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-            rpc::create_test_transactions_and_populate_blockstore,
+            rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
         },
         solana_runtime::{
             accounts_background_service::AbsRequestSender,
@@ -3998,15 +3998,18 @@ pub mod tests {
             let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
             let slot = bank1.slot();
 
-            let mut test_signatures_iter = create_test_transactions_and_populate_blockstore(
+            let (entries, test_signatures) = create_test_transaction_entries(
                 vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
-                bank0.slot(),
+                bank1.clone(),
+            );
+            populate_blockstore_for_tests(
+                entries,
                 bank1,
                 blockstore.clone(),
                 Arc::new(AtomicU64::default()),
-            )
-            .into_iter();
+            );
 
+            let mut test_signatures_iter = test_signatures.into_iter();
             let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
             let actual_tx_results: Vec<_> = confirmed_block
                 .transactions

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -389,6 +389,7 @@ Returns identity and transaction information about a confirmed block in the ledg
   - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
   - (optional) `rewards: bool` - whether to populate the `rewards` array. If parameter not provided, the default includes rewards.
   - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `maxSupportedTransactionVersion: <number>` - set the max transaction version to return in responses. If the requested block contains a transaction with a higher version, an error will be returned.
 
 #### Results:
 
@@ -413,6 +414,10 @@ The result field will be an object with the following fields:
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
+      - `loadedAddresses: <object|undefined>` - Transaction addresses loaded from address lookup tables. Undefined if `maxSupportedTransactionVersion` is not set in request params.
+        - `writable: <array[string]>` - Ordered list of base-58 encoded addresses for writable loaded accounts
+        - `readonly: <array[string]>` - Ordered list of base-58 encoded addresses for readonly loaded accounts
+    - `version: <"legacy"|number|undefined>` - Transaction version. Undefined if `maxSupportedTransactionVersion` is not set in request params.
   - `signatures: <array>` - present if "signatures" are requested for transaction details; an array of signatures strings, corresponding to the transaction order in the block
   - `rewards: <array>` - present if rewards are requested; an array of JSON objects containing:
     - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
@@ -559,6 +564,10 @@ The JSON structure of a transaction is defined as follows:
     - `programIdIndex: <number>` - Index into the `message.accountKeys` array indicating the program account that executes this instruction.
     - `accounts: <array[number]>` - List of ordered indices into the `message.accountKeys` array indicating which accounts to pass to the program.
     - `data: <string>` - The program input data encoded in a base-58 string.
+  - `addressTableLookups: <array[object]|undefined>` - List of address table lookups used by a transaction to dynamically load addresses from on-chain address lookup tables. Undefined if `maxSupportedTransactionVersion` is not set.
+    - `accountKey: <string>` - base-58 encoded public key for an address lookup table account.
+    - `writableIndexes: <array[number]>` - List of indices used to load addresses of writable accounts from a lookup table.
+    - `readonlyIndexes: <array[number]>` - List of indices used to load addresses of readonly accounts from a lookup table.
 
 #### Inner Instructions Structure
 
@@ -2313,7 +2322,7 @@ Returns the slot leaders for a given slot range
 
 #### Results:
 
-- `<array<string>>` - Node identity public keys as base-58 encoded strings
+- `<array[string]>` - Node identity public keys as base-58 encoded strings
 
 #### Example:
 
@@ -2847,6 +2856,7 @@ Returns transaction details for a confirmed transaction
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (_slow_), "base64". If parameter not provided, the default encoding is "json".
     "jsonParsed" encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
   - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
+  - (optional) `maxSupportedTransactionVersion: <number>` - set the max transaction version to return in responses. If the requested transaction is a higher version, an error will be returned.
 
 #### Results:
 
@@ -2873,6 +2883,10 @@ Returns transaction details for a confirmed transaction
       - `postBalance: <u64>` - account balance in lamports after the reward was applied
       - `rewardType: <string>` - type of reward: currently only "rent", other types may be added in the future
       - `commission: <u8|undefined>` - vote account commission when the reward was credited, only present for voting and staking rewards
+    - `loadedAddresses: <object|undefined>` - Transaction addresses loaded from address lookup tables. Undefined if `maxSupportedTransactionVersion` is not set in request params.
+      - `writable: <array[string]>` - Ordered list of base-58 encoded addresses for writable loaded accounts
+      - `readonly: <array[string]>` - Ordered list of base-58 encoded addresses for readonly loaded accounts
+  - `version: <"legacy"|number|undefined>` - Transaction version. Undefined if `maxSupportedTransactionVersion` is not set in request params.
 
 #### Example:
 

--- a/programs/address-lookup-table-tests/tests/common.rs
+++ b/programs/address-lookup-table-tests/tests/common.rs
@@ -76,9 +76,7 @@ pub async fn add_lookup_table_account(
     account_address: Pubkey,
     address_lookup_table: AddressLookupTable<'static>,
 ) -> AccountSharedData {
-    let mut data = Vec::new();
-    address_lookup_table.serialize_for_tests(&mut data).unwrap();
-
+    let data = address_lookup_table.serialize_for_tests().unwrap();
     let rent = context.banks_client.get_rent().await.unwrap();
     let rent_exempt_balance = rent.minimum_balance(data.len());
 

--- a/programs/address-lookup-table/src/state.rs
+++ b/programs/address-lookup-table/src/state.rs
@@ -178,13 +178,13 @@ impl<'a> AddressLookupTable<'a> {
     }
 
     /// Serialize an address table including its addresses
-    pub fn serialize_for_tests(self, data: &mut Vec<u8>) -> Result<(), InstructionError> {
-        data.resize(LOOKUP_TABLE_META_SIZE, 0);
-        Self::overwrite_meta_data(data, self.meta)?;
+    pub fn serialize_for_tests(self) -> Result<Vec<u8>, InstructionError> {
+        let mut data = vec![0; LOOKUP_TABLE_META_SIZE];
+        Self::overwrite_meta_data(&mut data, self.meta)?;
         self.addresses.iter().for_each(|address| {
             data.extend_from_slice(address.as_ref());
         });
-        Ok(())
+        Ok(data)
     }
 
     /// Efficiently deserialize an address table without allocating
@@ -352,9 +352,8 @@ mod tests {
         fn test_case(num_addresses: usize) {
             let lookup_table_meta = LookupTableMeta::new_for_tests();
             let address_table = AddressLookupTable::new_for_tests(lookup_table_meta, num_addresses);
-            let mut address_table_data = Vec::new();
-            AddressLookupTable::serialize_for_tests(address_table.clone(), &mut address_table_data)
-                .unwrap();
+            let address_table_data =
+                AddressLookupTable::serialize_for_tests(address_table.clone()).unwrap();
             assert_eq!(
                 AddressLookupTable::deserialize(&address_table_data).unwrap(),
                 address_table,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -56,6 +56,7 @@ tokio-util = { version = "0.6", features = ["codec", "compat"] }
 
 [dev-dependencies]
 serial_test = "0.6.0"
+solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.10.1" }
 solana-net-utils = { path = "../net-utils", version = "=1.10.1" }
 solana-stake-program = { path = "../programs/stake", version = "=1.10.1" }
 symlink = "0.1.0"

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3476,8 +3476,7 @@ pub mod rpc_full {
                 .preflight_commitment
                 .map(|commitment| CommitmentConfig { commitment });
             let preflight_bank = &*meta.bank(preflight_commitment);
-            let finalized_bank = &*meta.bank(Some(CommitmentConfig::finalized()));
-            let transaction = sanitize_transaction(unsanitized_tx, finalized_bank)?;
+            let transaction = sanitize_transaction(unsanitized_tx, preflight_bank)?;
             let signature = *transaction.signature();
 
             let mut last_valid_block_height = preflight_bank
@@ -3585,8 +3584,7 @@ pub mod rpc_full {
                     .set_recent_blockhash(bank.last_blockhash());
             }
 
-            let finalized_bank = &*meta.bank(Some(CommitmentConfig::finalized()));
-            let transaction = sanitize_transaction(unsanitized_tx, finalized_bank)?;
+            let transaction = sanitize_transaction(unsanitized_tx, bank)?;
             if config.sig_verify {
                 verify_transaction(&transaction, &bank.feature_set)?;
             }

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -538,6 +538,7 @@ impl RpcSolPubSubInternal for RpcSolPubSubImpl {
             },
             transaction_details: config.transaction_details.unwrap_or_default(),
             show_rewards: config.show_rewards.unwrap_or_default(),
+            max_supported_transaction_version: config.max_supported_transaction_version,
         };
         self.subscribe(SubscriptionParams::Block(params))
     }

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -140,6 +140,7 @@ pub struct BlockSubscriptionParams {
     pub kind: BlockSubscriptionKind,
     pub transaction_details: TransactionDetails,
     pub show_rewards: bool,
+    pub max_supported_transaction_version: Option<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1192,7 +1192,7 @@ pub(crate) mod tests {
             optimistically_confirmed_bank_tracker::{
                 BankNotification, OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
             },
-            rpc::create_test_transactions_and_populate_blockstore,
+            rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
             rpc_pubsub::RpcSolPubSubInternal,
             rpc_pubsub_service,
         },
@@ -1411,9 +1411,12 @@ pub(crate) mod tests {
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
             .unwrap();
-        let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
-            0,
+        populate_blockstore_for_tests(
+            create_test_transaction_entries(
+                vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
+                bank.clone(),
+            )
+            .0,
             bank,
             blockstore.clone(),
             max_complete_transaction_status_slot,
@@ -1527,9 +1530,12 @@ pub(crate) mod tests {
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
             .unwrap();
-        let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
-            0,
+        populate_blockstore_for_tests(
+            create_test_transaction_entries(
+                vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
+                bank.clone(),
+            )
+            .0,
             bank,
             blockstore.clone(),
             max_complete_transaction_status_slot,
@@ -1638,9 +1644,12 @@ pub(crate) mod tests {
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
             .unwrap();
-        let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
-            0,
+        populate_blockstore_for_tests(
+            create_test_transaction_entries(
+                vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
+                bank.clone(),
+            )
+            .0,
             bank,
             blockstore.clone(),
             max_complete_transaction_status_slot,

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -40,7 +40,9 @@ use {
         timing::timestamp,
         transaction,
     },
-    solana_transaction_status::{ConfirmedBlock, LegacyConfirmedBlock},
+    solana_transaction_status::{
+        BlockEncodingOptions, ConfirmedBlock, EncodeError, VersionedConfirmedBlock,
+    },
     std::{
         cell::RefCell,
         collections::{HashMap, VecDeque},
@@ -278,39 +280,48 @@ impl RpcNotifier {
 }
 
 fn filter_block_result_txs(
-    mut block: LegacyConfirmedBlock,
+    mut block: VersionedConfirmedBlock,
     last_modified_slot: Slot,
     params: &BlockSubscriptionParams,
-) -> Option<RpcBlockUpdate> {
+) -> Result<Option<RpcBlockUpdate>, RpcBlockUpdateError> {
     block.transactions = match params.kind {
         BlockSubscriptionKind::All => block.transactions,
         BlockSubscriptionKind::MentionsAccountOrProgram(pk) => block
             .transactions
             .into_iter()
-            .filter(|tx_with_meta| tx_with_meta.transaction.message.account_keys.contains(&pk))
+            .filter(|tx| tx.account_keys().iter().any(|key| key == &pk))
             .collect(),
     };
 
     if block.transactions.is_empty() {
         if let BlockSubscriptionKind::MentionsAccountOrProgram(_) = params.kind {
-            return None;
+            return Ok(None);
         }
     }
 
-    let block = block.configure(
-        params.encoding,
-        params.transaction_details,
-        params.show_rewards,
-    );
+    let block = ConfirmedBlock::from(block)
+        .encode_with_options(
+            params.encoding,
+            BlockEncodingOptions {
+                transaction_details: params.transaction_details,
+                show_rewards: params.show_rewards,
+                max_supported_transaction_version: params.max_supported_transaction_version,
+            },
+        )
+        .map_err(|err| match err {
+            EncodeError::UnsupportedTransactionVersion(version) => {
+                RpcBlockUpdateError::UnsupportedTransactionVersion(version)
+            }
+        })?;
 
     // If last_modified_slot < last_notified_slot, then the last notif was for a fork.
     // That's the risk clients take when subscribing to non-finalized commitments.
     // This code lets the logic for dealing with forks live on the client side.
-    Some(RpcBlockUpdate {
+    Ok(Some(RpcBlockUpdate {
         slot: last_modified_slot,
         block: Some(block),
         err: None,
-    })
+    }))
 }
 
 fn filter_account_result(
@@ -964,19 +975,11 @@ impl RpcSubscriptions {
                                         error!("get_complete_block error: {}", e);
                                         RpcBlockUpdateError::BlockStoreError
                                     })
-                                    .and_then(|versioned_block| {
-                                        ConfirmedBlock::from(versioned_block)
-                                            .into_legacy_block()
-                                            .ok_or(
-                                                RpcBlockUpdateError::UnsupportedTransactionVersion,
-                                            )
-                                    });
+                                    .and_then(|block| filter_block_result_txs(block, s, params));
 
                                 match block_update_result {
                                     Ok(block_update) => {
-                                        if let Some(block_update) =
-                                            filter_block_result_txs(block_update, s, params)
-                                        {
+                                        if let Some(block_update) = block_update {
                                             notifier.notify(
                                                 Response {
                                                     context: RpcResponseContext { slot: s },
@@ -1385,6 +1388,7 @@ pub(crate) mod tests {
             encoding: Some(UiTransactionEncoding::Json),
             transaction_details: Some(TransactionDetails::Signatures),
             show_rewards: None,
+            max_supported_transaction_version: None,
         };
         let params = BlockSubscriptionParams {
             kind: BlockSubscriptionKind::All,
@@ -1392,6 +1396,7 @@ pub(crate) mod tests {
             encoding: config.encoding.unwrap(),
             transaction_details: config.transaction_details.unwrap(),
             show_rewards: config.show_rewards.unwrap_or_default(),
+            max_supported_transaction_version: config.max_supported_transaction_version,
         };
         let sub_id = rpc.block_subscribe(filter, Some(config)).unwrap();
 
@@ -1421,8 +1426,16 @@ pub(crate) mod tests {
 
         let confirmed_block =
             ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let legacy_block = confirmed_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let block = confirmed_block
+            .encode_with_options(
+                params.encoding,
+                BlockEncodingOptions {
+                    transaction_details: params.transaction_details,
+                    show_rewards: false,
+                    max_supported_transaction_version: None,
+                },
+            )
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1492,6 +1505,7 @@ pub(crate) mod tests {
             encoding: Some(UiTransactionEncoding::Json),
             transaction_details: Some(TransactionDetails::Signatures),
             show_rewards: None,
+            max_supported_transaction_version: None,
         };
         let params = BlockSubscriptionParams {
             kind: BlockSubscriptionKind::MentionsAccountOrProgram(keypair1.pubkey()),
@@ -1499,6 +1513,7 @@ pub(crate) mod tests {
             encoding: config.encoding.unwrap(),
             transaction_details: config.transaction_details.unwrap(),
             show_rewards: config.show_rewards.unwrap_or_default(),
+            max_supported_transaction_version: config.max_supported_transaction_version,
         };
         let sub_id = rpc.block_subscribe(filter, Some(config)).unwrap();
 
@@ -1526,17 +1541,24 @@ pub(crate) mod tests {
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
         // make sure it filtered out the other keypairs
-        let confirmed_block =
+        let mut confirmed_block =
             ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let mut legacy_block = confirmed_block.into_legacy_block().unwrap();
-        legacy_block.transactions.retain(|tx_with_meta| {
+        confirmed_block.transactions.retain(|tx_with_meta| {
             tx_with_meta
-                .transaction
-                .message
-                .account_keys
-                .contains(&keypair1.pubkey())
+                .account_keys()
+                .iter()
+                .any(|key| key == &keypair1.pubkey())
         });
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let block = confirmed_block
+            .encode_with_options(
+                params.encoding,
+                BlockEncodingOptions {
+                    transaction_details: params.transaction_details,
+                    show_rewards: false,
+                    max_supported_transaction_version: None,
+                },
+            )
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1594,6 +1616,7 @@ pub(crate) mod tests {
             encoding: Some(UiTransactionEncoding::Json),
             transaction_details: Some(TransactionDetails::Signatures),
             show_rewards: None,
+            max_supported_transaction_version: None,
         };
         let params = BlockSubscriptionParams {
             kind: BlockSubscriptionKind::All,
@@ -1601,6 +1624,7 @@ pub(crate) mod tests {
             encoding: config.encoding.unwrap(),
             transaction_details: config.transaction_details.unwrap(),
             show_rewards: config.show_rewards.unwrap_or_default(),
+            max_supported_transaction_version: config.max_supported_transaction_version,
         };
         let sub_id = rpc.block_subscribe(filter, Some(config)).unwrap();
         subscriptions
@@ -1634,8 +1658,16 @@ pub(crate) mod tests {
 
         let confirmed_block =
             ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let legacy_block = confirmed_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let block = confirmed_block
+            .encode_with_options(
+                params.encoding,
+                BlockEncodingOptions {
+                    transaction_details: params.transaction_details,
+                    show_rewards: false,
+                    max_supported_transaction_version: None,
+                },
+            )
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2057,14 +2057,9 @@ mod tests {
                 meta: LookupTableMeta::default(),
                 addresses: Cow::Owned(table_addresses.clone()),
             };
-            let table_data = {
-                let mut data = vec![];
-                table_state.serialize_for_tests(&mut data).unwrap();
-                data
-            };
             AccountSharedData::create(
                 1,
-                table_data,
+                table_state.serialize_for_tests().unwrap(),
                 solana_address_lookup_table_program::id(),
                 false,
                 0,

--- a/sdk/src/transaction/versioned.rs
+++ b/sdk/src/transaction/versioned.rs
@@ -17,11 +17,22 @@ use {
     std::cmp::Ordering,
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// Type that serializes to the string "legacy"
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Legacy {
+    Legacy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum TransactionVersion {
-    Legacy,
+    Legacy(Legacy),
     Number(u8),
+}
+
+impl TransactionVersion {
+    pub const LEGACY: Self = Self::Legacy(Legacy::Legacy);
 }
 
 // NOTE: Serialization-related changes must be paired with the direct read at sigverify.
@@ -103,7 +114,7 @@ impl VersionedTransaction {
     /// Returns the version of the transaction
     pub fn version(&self) -> TransactionVersion {
         match self.message {
-            VersionedMessage::Legacy(_) => TransactionVersion::Legacy,
+            VersionedMessage::Legacy(_) => TransactionVersion::LEGACY,
             VersionedMessage::V0(_) => TransactionVersion::Number(0),
         }
     }

--- a/sdk/src/transaction/versioned.rs
+++ b/sdk/src/transaction/versioned.rs
@@ -17,6 +17,13 @@ use {
     std::cmp::Ordering,
 };
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum TransactionVersion {
+    Legacy,
+    Number(u8),
+}
+
 // NOTE: Serialization-related changes must be paired with the direct read at sigverify.
 /// An atomic transaction
 #[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize, AbiExample)]
@@ -91,6 +98,14 @@ impl VersionedTransaction {
             signatures,
             message,
         })
+    }
+
+    /// Returns the version of the transaction
+    pub fn version(&self) -> TransactionVersion {
+        match self.message {
+            VersionedMessage::Legacy(_) => TransactionVersion::Legacy,
+            VersionedMessage::V0(_) => TransactionVersion::Number(0),
+        }
     }
 
     /// Returns a legacy transaction if the transaction message is legacy.

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -689,11 +689,11 @@ impl VersionedTransactionWithStatusMeta {
             self.transaction.version(),
         ) {
             // Set to none because old clients can't handle this field
-            (None, TransactionVersion::Legacy) => Ok(None),
+            (None, TransactionVersion::LEGACY) => Ok(None),
             (None, TransactionVersion::Number(version)) => {
                 Err(EncodeError::UnsupportedTransactionVersion(version))
             }
-            (Some(_), TransactionVersion::Legacy) => Ok(Some(TransactionVersion::Legacy)),
+            (Some(_), TransactionVersion::LEGACY) => Ok(Some(TransactionVersion::LEGACY)),
             (Some(max_version), TransactionVersion::Number(version)) => {
                 if version <= max_version {
                     Ok(Some(TransactionVersion::Number(version)))

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -18,7 +18,7 @@ pub mod token_balances;
 pub use {crate::extract_memos::extract_and_fmt_memos, solana_runtime::bank::RewardType};
 use {
     crate::{
-        parse_accounts::{parse_accounts, ParsedAccount},
+        parse_accounts::{parse_accounts, parse_static_accounts, ParsedAccount},
         parse_instruction::{parse, ParsedInstruction},
     },
     solana_account_decoder::parse_token::UiTokenAmount,
@@ -26,18 +26,48 @@ use {
         clock::{Slot, UnixTimestamp},
         commitment_config::CommitmentConfig,
         instruction::CompiledInstruction,
-        message::{v0::LoadedAddresses, AccountKeys, Message, MessageHeader},
+        message::{
+            v0::{self, LoadedAddresses, LoadedMessage, MessageAddressTableLookup},
+            AccountKeys, Message, MessageHeader, VersionedMessage,
+        },
+        pubkey::Pubkey,
         sanitize::Sanitize,
         signature::Signature,
-        transaction::{Result, Transaction, TransactionError, VersionedTransaction},
+        transaction::{
+            Result as TransactionResult, Transaction, TransactionError, TransactionVersion,
+            VersionedTransaction,
+        },
     },
     std::fmt,
+    thiserror::Error,
 };
+
+pub struct BlockEncodingOptions {
+    pub transaction_details: TransactionDetails,
+    pub show_rewards: bool,
+    pub max_supported_transaction_version: Option<u8>,
+}
+
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum EncodeError {
+    #[error("Encoding does not support transaction version {0}")]
+    UnsupportedTransactionVersion(u8),
+}
 
 /// Represents types that can be encoded into one of several encoding formats
 pub trait Encodable {
     type Encoded;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded;
+    fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded;
+}
+
+/// Represents types that can be encoded into one of several encoding formats
+pub trait EncodableWithMeta {
+    type Encoded;
+    fn encode_with_meta(
+        &self,
+        encoding: UiTransactionEncoding,
+        meta: &TransactionStatusMeta,
+    ) -> Self::Encoded;
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -160,14 +190,13 @@ pub struct UiInnerInstructions {
 }
 
 impl UiInnerInstructions {
-    fn parse(inner_instructions: InnerInstructions, message: &Message) -> Self {
-        let account_keys = AccountKeys::new(&message.account_keys, None);
+    fn parse(inner_instructions: InnerInstructions, account_keys: &AccountKeys) -> Self {
         Self {
             index: inner_instructions.index,
             instructions: inner_instructions
                 .instructions
                 .iter()
-                .map(|ix| UiInstruction::parse(ix, &account_keys))
+                .map(|ix| UiInstruction::parse(ix, account_keys))
                 .collect(),
         }
     }
@@ -221,7 +250,7 @@ impl From<TransactionTokenBalance> for UiTransactionTokenBalance {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TransactionStatusMeta {
-    pub status: Result<()>,
+    pub status: TransactionResult<()>,
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
@@ -255,7 +284,7 @@ impl Default for TransactionStatusMeta {
 #[serde(rename_all = "camelCase")]
 pub struct UiTransactionStatusMeta {
     pub err: Option<TransactionError>,
-    pub status: Result<()>, // This field is deprecated.  See https://github.com/solana-labs/solana/issues/9302
+    pub status: TransactionResult<()>, // This field is deprecated.  See https://github.com/solana-labs/solana/issues/9302
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
@@ -264,10 +293,38 @@ pub struct UiTransactionStatusMeta {
     pub pre_token_balances: Option<Vec<UiTransactionTokenBalance>>,
     pub post_token_balances: Option<Vec<UiTransactionTokenBalance>>,
     pub rewards: Option<Rewards>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loaded_addresses: Option<UiLoadedAddresses>,
+}
+
+/// A duplicate representation of LoadedAddresses
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiLoadedAddresses {
+    pub writable: Vec<String>,
+    pub readonly: Vec<String>,
+}
+
+impl From<&LoadedAddresses> for UiLoadedAddresses {
+    fn from(loaded_addresses: &LoadedAddresses) -> Self {
+        Self {
+            writable: loaded_addresses
+                .writable
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            readonly: loaded_addresses
+                .readonly
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        }
+    }
 }
 
 impl UiTransactionStatusMeta {
-    fn parse(meta: TransactionStatusMeta, message: &Message) -> Self {
+    fn parse(meta: TransactionStatusMeta, static_keys: &[Pubkey]) -> Self {
+        let account_keys = AccountKeys::new(static_keys, Some(&meta.loaded_addresses));
         Self {
             err: meta.status.clone().err(),
             status: meta.status,
@@ -276,7 +333,7 @@ impl UiTransactionStatusMeta {
             post_balances: meta.post_balances,
             inner_instructions: meta.inner_instructions.map(|ixs| {
                 ixs.into_iter()
-                    .map(|ix| UiInnerInstructions::parse(ix, message))
+                    .map(|ix| UiInnerInstructions::parse(ix, &account_keys))
                     .collect()
             }),
             log_messages: meta.log_messages,
@@ -287,6 +344,7 @@ impl UiTransactionStatusMeta {
                 .post_token_balances
                 .map(|balance| balance.into_iter().map(Into::into).collect()),
             rewards: meta.rewards,
+            loaded_addresses: Some(UiLoadedAddresses::from(&meta.loaded_addresses)),
         }
     }
 }
@@ -310,6 +368,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
                 .post_token_balances
                 .map(|balance| balance.into_iter().map(Into::into).collect()),
             rewards: meta.rewards,
+            loaded_addresses: Some(UiLoadedAddresses::from(&meta.loaded_addresses)),
         }
     }
 }
@@ -326,8 +385,8 @@ pub enum TransactionConfirmationStatus {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionStatus {
     pub slot: Slot,
-    pub confirmations: Option<usize>, // None = rooted
-    pub status: Result<()>,           // legacy field
+    pub confirmations: Option<usize>,  // None = rooted
+    pub status: TransactionResult<()>, // legacy field
     pub err: Option<TransactionError>,
     pub confirmation_status: Option<TransactionConfirmationStatus>,
 }
@@ -462,39 +521,21 @@ impl From<VersionedConfirmedBlock> for ConfirmedBlock {
     }
 }
 
-impl Encodable for LegacyConfirmedBlock {
-    type Encoded = EncodedConfirmedBlock;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
-        Self::Encoded {
-            previous_blockhash: self.previous_blockhash,
-            blockhash: self.blockhash,
-            parent_slot: self.parent_slot,
-            transactions: self
-                .transactions
-                .into_iter()
-                .map(|tx| tx.encode(encoding))
-                .collect(),
-            rewards: self.rewards,
-            block_time: self.block_time,
-            block_height: self.block_height,
-        }
-    }
-}
-
-impl LegacyConfirmedBlock {
-    pub fn configure(
+impl ConfirmedBlock {
+    pub fn encode_with_options(
         self,
         encoding: UiTransactionEncoding,
-        transaction_details: TransactionDetails,
-        show_rewards: bool,
-    ) -> UiConfirmedBlock {
-        let (transactions, signatures) = match transaction_details {
+        options: BlockEncodingOptions,
+    ) -> Result<UiConfirmedBlock, EncodeError> {
+        let (transactions, signatures) = match options.transaction_details {
             TransactionDetails::Full => (
                 Some(
                     self.transactions
                         .into_iter()
-                        .map(|tx_with_meta| tx_with_meta.encode(encoding))
-                        .collect(),
+                        .map(|tx_with_meta| {
+                            tx_with_meta.encode(encoding, options.max_supported_transaction_version)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
                 ),
                 None,
             ),
@@ -503,26 +544,26 @@ impl LegacyConfirmedBlock {
                 Some(
                     self.transactions
                         .into_iter()
-                        .map(|tx| tx.transaction.signatures[0].to_string())
+                        .map(|tx_with_meta| tx_with_meta.transaction_signature().to_string())
                         .collect(),
                 ),
             ),
             TransactionDetails::None => (None, None),
         };
-        UiConfirmedBlock {
+        Ok(UiConfirmedBlock {
             previous_blockhash: self.previous_blockhash,
             blockhash: self.blockhash,
             parent_slot: self.parent_slot,
             transactions,
             signatures,
-            rewards: if show_rewards {
+            rewards: if options.show_rewards {
                 Some(self.rewards)
             } else {
                 None
             },
             block_time: self.block_time,
             block_height: self.block_height,
-        }
+        })
     }
 }
 
@@ -568,21 +609,6 @@ pub struct UiConfirmedBlock {
     pub block_height: Option<u64>,
 }
 
-impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
-    fn from(block: EncodedConfirmedBlock) -> Self {
-        Self {
-            previous_blockhash: block.previous_blockhash,
-            blockhash: block.blockhash,
-            parent_slot: block.parent_slot,
-            transactions: Some(block.transactions),
-            signatures: None,
-            rewards: Some(block.rewards),
-            block_time: block.block_time,
-            block_height: block.block_height,
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum TransactionWithStatusMeta {
@@ -613,6 +639,23 @@ impl TransactionWithStatusMeta {
         }
     }
 
+    pub fn encode(
+        self,
+        encoding: UiTransactionEncoding,
+        max_supported_transaction_version: Option<u8>,
+    ) -> Result<EncodedTransactionWithStatusMeta, EncodeError> {
+        match self {
+            Self::MissingMetadata(ref transaction) => Ok(EncodedTransactionWithStatusMeta {
+                version: None,
+                transaction: transaction.encode(encoding),
+                meta: None,
+            }),
+            Self::Complete(tx_with_meta) => {
+                tx_with_meta.encode(encoding, max_supported_transaction_version)
+            }
+        }
+    }
+
     pub fn into_legacy_transaction_with_meta(self) -> Option<LegacyTransactionWithStatusMeta> {
         match self {
             TransactionWithStatusMeta::MissingMetadata(transaction) => {
@@ -626,9 +669,53 @@ impl TransactionWithStatusMeta {
             }
         }
     }
+
+    pub fn account_keys(&self) -> AccountKeys {
+        match self {
+            Self::MissingMetadata(tx) => AccountKeys::new(&tx.message.account_keys, None),
+            Self::Complete(tx_with_meta) => tx_with_meta.account_keys(),
+        }
+    }
 }
 
 impl VersionedTransactionWithStatusMeta {
+    pub fn encode(
+        self,
+        encoding: UiTransactionEncoding,
+        max_supported_transaction_version: Option<u8>,
+    ) -> Result<EncodedTransactionWithStatusMeta, EncodeError> {
+        let version = match (
+            max_supported_transaction_version,
+            self.transaction.version(),
+        ) {
+            // Set to none because old clients can't handle this field
+            (None, TransactionVersion::Legacy) => Ok(None),
+            (None, TransactionVersion::Number(version)) => {
+                Err(EncodeError::UnsupportedTransactionVersion(version))
+            }
+            (Some(_), TransactionVersion::Legacy) => Ok(Some(TransactionVersion::Legacy)),
+            (Some(max_version), TransactionVersion::Number(version)) => {
+                if version <= max_version {
+                    Ok(Some(TransactionVersion::Number(version)))
+                } else {
+                    Err(EncodeError::UnsupportedTransactionVersion(version))
+                }
+            }
+        }?;
+
+        Ok(EncodedTransactionWithStatusMeta {
+            transaction: self.transaction.encode_with_meta(encoding, &self.meta),
+            meta: Some(match encoding {
+                UiTransactionEncoding::JsonParsed => UiTransactionStatusMeta::parse(
+                    self.meta,
+                    self.transaction.message.static_account_keys(),
+                ),
+                _ => UiTransactionStatusMeta::from(self.meta),
+            }),
+            version,
+        })
+    }
+
     pub fn account_keys(&self) -> AccountKeys {
         AccountKeys::new(
             self.transaction.message.static_account_keys(),
@@ -636,26 +723,11 @@ impl VersionedTransactionWithStatusMeta {
         )
     }
 
-    pub fn into_legacy_transaction_with_meta(self) -> Option<LegacyTransactionWithStatusMeta> {
+    fn into_legacy_transaction_with_meta(self) -> Option<LegacyTransactionWithStatusMeta> {
         Some(LegacyTransactionWithStatusMeta {
             transaction: self.transaction.into_legacy_transaction()?,
             meta: Some(self.meta),
         })
-    }
-}
-
-impl Encodable for LegacyTransactionWithStatusMeta {
-    type Encoded = EncodedTransactionWithStatusMeta;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
-        Self::Encoded {
-            transaction: self.transaction.encode(encoding),
-            meta: self.meta.map(|meta| match encoding {
-                UiTransactionEncoding::JsonParsed => {
-                    UiTransactionStatusMeta::parse(meta, &self.transaction.message)
-                }
-                _ => UiTransactionStatusMeta::from(meta),
-            }),
-        }
     }
 }
 
@@ -664,6 +736,8 @@ impl Encodable for LegacyTransactionWithStatusMeta {
 pub struct EncodedTransactionWithStatusMeta {
     pub transaction: EncodedTransaction,
     pub meta: Option<UiTransactionStatusMeta>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<TransactionVersion>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -686,17 +760,6 @@ pub struct LegacyConfirmedTransactionWithStatusMeta {
     pub block_time: Option<UnixTimestamp>,
 }
 
-impl Encodable for LegacyConfirmedTransactionWithStatusMeta {
-    type Encoded = EncodedConfirmedTransactionWithStatusMeta;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
-        Self::Encoded {
-            slot: self.slot,
-            transaction: self.tx_with_meta.encode(encoding),
-            block_time: self.block_time,
-        }
-    }
-}
-
 impl ConfirmedTransactionWithStatusMeta {
     /// Downgrades a versioned confirmed transaction into a legacy
     /// confirmed transaction if it contains a legacy transaction.
@@ -707,6 +770,20 @@ impl ConfirmedTransactionWithStatusMeta {
             tx_with_meta: self.tx_with_meta.into_legacy_transaction_with_meta()?,
             block_time: self.block_time,
             slot: self.slot,
+        })
+    }
+
+    pub fn encode(
+        self,
+        encoding: UiTransactionEncoding,
+        max_supported_transaction_version: Option<u8>,
+    ) -> Result<EncodedConfirmedTransactionWithStatusMeta, EncodeError> {
+        Ok(EncodedConfirmedTransactionWithStatusMeta {
+            slot: self.slot,
+            transaction: self
+                .tx_with_meta
+                .encode(encoding, max_supported_transaction_version)?,
+            block_time: self.block_time,
         })
     }
 }
@@ -728,9 +805,41 @@ pub enum EncodedTransaction {
     Json(UiTransaction),
 }
 
-impl Encodable for &Transaction {
+impl EncodableWithMeta for VersionedTransaction {
     type Encoded = EncodedTransaction;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
+    fn encode_with_meta(
+        &self,
+        encoding: UiTransactionEncoding,
+        meta: &TransactionStatusMeta,
+    ) -> Self::Encoded {
+        match encoding {
+            UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
+                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+            ),
+            UiTransactionEncoding::Base58 => EncodedTransaction::Binary(
+                bs58::encode(bincode::serialize(self).unwrap()).into_string(),
+                encoding,
+            ),
+            UiTransactionEncoding::Base64 => EncodedTransaction::Binary(
+                base64::encode(bincode::serialize(self).unwrap()),
+                encoding,
+            ),
+            UiTransactionEncoding::Json | UiTransactionEncoding::JsonParsed => {
+                EncodedTransaction::Json(UiTransaction {
+                    signatures: self.signatures.iter().map(ToString::to_string).collect(),
+                    message: match &self.message {
+                        VersionedMessage::Legacy(message) => message.encode(encoding),
+                        VersionedMessage::V0(message) => message.encode_with_meta(encoding, meta),
+                    },
+                })
+            }
+        }
+    }
+}
+
+impl Encodable for Transaction {
+    type Encoded = EncodedTransaction;
+    fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
         match encoding {
             UiTransactionEncoding::Binary => EncodedTransaction::LegacyBinary(
                 bs58::encode(bincode::serialize(self).unwrap()).into_string(),
@@ -793,9 +902,9 @@ pub enum UiMessage {
     Raw(UiRawMessage),
 }
 
-impl Encodable for &Message {
+impl Encodable for Message {
     type Encoded = UiMessage;
-    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
+    fn encode(&self, encoding: UiTransactionEncoding) -> Self::Encoded {
         if encoding == UiTransactionEncoding::JsonParsed {
             let account_keys = AccountKeys::new(&self.account_keys, None);
             UiMessage::Parsed(UiParsedMessage {
@@ -806,6 +915,7 @@ impl Encodable for &Message {
                     .iter()
                     .map(|instruction| UiInstruction::parse(instruction, &account_keys))
                     .collect(),
+                address_table_lookups: None,
             })
         } else {
             UiMessage::Raw(UiRawMessage {
@@ -813,6 +923,43 @@ impl Encodable for &Message {
                 account_keys: self.account_keys.iter().map(ToString::to_string).collect(),
                 recent_blockhash: self.recent_blockhash.to_string(),
                 instructions: self.instructions.iter().map(Into::into).collect(),
+                address_table_lookups: None,
+            })
+        }
+    }
+}
+
+impl EncodableWithMeta for v0::Message {
+    type Encoded = UiMessage;
+    fn encode_with_meta(
+        &self,
+        encoding: UiTransactionEncoding,
+        meta: &TransactionStatusMeta,
+    ) -> Self::Encoded {
+        if encoding == UiTransactionEncoding::JsonParsed {
+            let account_keys = AccountKeys::new(&self.account_keys, Some(&meta.loaded_addresses));
+            let loaded_message = LoadedMessage::new_borrowed(self, &meta.loaded_addresses);
+            UiMessage::Parsed(UiParsedMessage {
+                account_keys: parse_static_accounts(&loaded_message),
+                recent_blockhash: self.recent_blockhash.to_string(),
+                instructions: self
+                    .instructions
+                    .iter()
+                    .map(|instruction| UiInstruction::parse(instruction, &account_keys))
+                    .collect(),
+                address_table_lookups: Some(
+                    self.address_table_lookups.iter().map(Into::into).collect(),
+                ),
+            })
+        } else {
+            UiMessage::Raw(UiRawMessage {
+                header: self.header,
+                account_keys: self.account_keys.iter().map(ToString::to_string).collect(),
+                recent_blockhash: self.recent_blockhash.to_string(),
+                instructions: self.instructions.iter().map(Into::into).collect(),
+                address_table_lookups: Some(
+                    self.address_table_lookups.iter().map(Into::into).collect(),
+                ),
             })
         }
     }
@@ -826,6 +973,27 @@ pub struct UiRawMessage {
     pub account_keys: Vec<String>,
     pub recent_blockhash: String,
     pub instructions: Vec<UiCompiledInstruction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address_table_lookups: Option<Vec<UiAddressTableLookup>>,
+}
+
+/// A duplicate representation of a MessageAddressTableLookup, in raw format, for pretty JSON serialization
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAddressTableLookup {
+    pub account_key: String,
+    pub writable_indexes: Vec<u8>,
+    pub readonly_indexes: Vec<u8>,
+}
+
+impl From<&MessageAddressTableLookup> for UiAddressTableLookup {
+    fn from(lookup: &MessageAddressTableLookup) -> Self {
+        Self {
+            account_key: lookup.account_key.to_string(),
+            writable_indexes: lookup.writable_indexes.clone(),
+            readonly_indexes: lookup.readonly_indexes.clone(),
+        }
+    }
 }
 
 /// A duplicate representation of a Message, in parsed format, for pretty JSON serialization
@@ -835,6 +1003,7 @@ pub struct UiParsedMessage {
     pub account_keys: Vec<ParsedAccount>,
     pub recent_blockhash: String,
     pub instructions: Vec<UiInstruction>,
+    pub address_table_lookups: Option<Vec<UiAddressTableLookup>>,
 }
 
 // A serialized `Vec<TransactionByAddrInfo>` is stored in the `tx-by-addr` table.  The row keys are

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -1,4 +1,4 @@
-use solana_sdk::message::Message;
+use solana_sdk::message::{v0::LoadedMessage, Message};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -20,16 +20,34 @@ pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
     accounts
 }
 
+pub fn parse_static_accounts(message: &LoadedMessage) -> Vec<ParsedAccount> {
+    let mut accounts: Vec<ParsedAccount> = vec![];
+    for (i, account_key) in message.static_account_keys().iter().enumerate() {
+        accounts.push(ParsedAccount {
+            pubkey: account_key.to_string(),
+            writable: message.is_writable(i),
+            signer: message.is_signer(i),
+        });
+    }
+    accounts
+}
+
 #[cfg(test)]
 mod test {
-    use {super::*, solana_sdk::message::MessageHeader};
+    use {
+        super::*,
+        solana_sdk::{
+            message::{v0, v0::LoadedAddresses, MessageHeader},
+            pubkey::Pubkey,
+        },
+    };
 
     #[test]
     fn test_parse_accounts() {
-        let pubkey0 = solana_sdk::pubkey::new_rand();
-        let pubkey1 = solana_sdk::pubkey::new_rand();
-        let pubkey2 = solana_sdk::pubkey::new_rand();
-        let pubkey3 = solana_sdk::pubkey::new_rand();
+        let pubkey0 = Pubkey::new_unique();
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let pubkey3 = Pubkey::new_unique();
         let message = Message {
             header: MessageHeader {
                 num_required_signatures: 2,
@@ -42,6 +60,55 @@ mod test {
 
         assert_eq!(
             parse_accounts(&message),
+            vec![
+                ParsedAccount {
+                    pubkey: pubkey0.to_string(),
+                    writable: true,
+                    signer: true,
+                },
+                ParsedAccount {
+                    pubkey: pubkey1.to_string(),
+                    writable: false,
+                    signer: true,
+                },
+                ParsedAccount {
+                    pubkey: pubkey2.to_string(),
+                    writable: true,
+                    signer: false,
+                },
+                ParsedAccount {
+                    pubkey: pubkey3.to_string(),
+                    writable: false,
+                    signer: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_static_accounts() {
+        let pubkey0 = Pubkey::new_unique();
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let pubkey3 = Pubkey::new_unique();
+        let message = LoadedMessage::new(
+            v0::Message {
+                header: MessageHeader {
+                    num_required_signatures: 2,
+                    num_readonly_signed_accounts: 1,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                account_keys: vec![pubkey0, pubkey1, pubkey2, pubkey3],
+                ..v0::Message::default()
+            },
+            LoadedAddresses {
+                writable: vec![Pubkey::new_unique()],
+                readonly: vec![Pubkey::new_unique()],
+            },
+        );
+
+        assert_eq!(
+            parse_static_accounts(&message),
             vec![
                 ParsedAccount {
                     pubkey: pubkey0.to_string(),


### PR DESCRIPTION
#### Problem
- Clients have no way to tell RPC which transaction versions they support receiving
- RPC doesn't support sending transactions which use address lookup tables

#### Summary of Changes
- Added `max_supported_transaction_version` request parameter to enable receiving versioned transactions in RPC responses and pubsub notifications. This ensures that older clients will get an "unsupported version error" instead of a response for a transaction version they can't parse.
- Added RPC support for sending and simulating transactions which load addresses from on-chain lookup tables
- Added `version` field to transaction responses when the `max_supported_transaction_version` is used whose value is "legacy" string for legacy transactions and a number (ie 0) for versioned transactions.
- Added `loaded_addresses` field to transaction metadata responses for transactions with version 0
- Added `address_table_lookups` field to transaction message responses for transactions with version 0

Fixes #
