### PR TITLE
Use VecDeque instead of Vec in sigverify stage

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(clippy::integer_arithmetic)]
 
 extern crate solana_core;
 extern crate test;
@@ -19,8 +20,7 @@ use {
     test::Bencher,
 };
 
-#[bench]
-fn bench_packet_discard(bencher: &mut Bencher) {
+fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
     solana_logger::setup();
     let len = 30 * 1000;
     let chunk_size = 1024;
@@ -29,7 +29,7 @@ fn bench_packet_discard(bencher: &mut Bencher) {
 
     let mut total = 0;
 
-    let ips: Vec<_> = (0..10_000)
+    let ips: Vec<_> = (0..num_ips)
         .into_iter()
         .map(|_| {
             let mut addr = [0u16; 8];
@@ -55,6 +55,16 @@ fn bench_packet_discard(bencher: &mut Bencher) {
             }
         }
     });
+}
+
+#[bench]
+fn bench_packet_discard_many_senders(bencher: &mut Bencher) {
+    run_bench_packet_discard(1000, bencher);
+}
+
+#[bench]
+fn bench_packet_discard_single_sender(bencher: &mut Bencher) {
+    run_bench_packet_discard(1, bencher);
 }
 
 #[bench]


### PR DESCRIPTION
#### Problem

Vec has bad remove(0) performance.

#### Summary of Changes

Avoid bad performance of remove(0) for a single sender and use VecDeque instead.

Before:
```
test bench_packet_discard_many_senders  ... bench:   1,943,585 ns/iter (+/- 3,441)
test bench_packet_discard_single_sender ... bench:  55,018,780 ns/iter (+/- 326,300)
```

After:
```
test bench_packet_discard_many_senders  ... bench:   1,894,268 ns/iter (+/- 12,025)
test bench_packet_discard_single_sender ... bench:   1,361,563 ns/iter (+/- 8,583)
```

Fixes #
