### PR TITLE
Add PacketBatch packet_indexes stat

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3236,7 +3236,7 @@ mod tests {
         let mut dropped_packet_batches_count = 0;
         let mut dropped_packets_count = 0;
         let mut newly_buffered_packets_count = 0;
-        let banking_stage_stats = BankingStageStats::default();
+        let mut banking_stage_stats = BankingStageStats::default();
         // Because the set of unprocessed `packet_indexes` is empty, the
         // packets are not added to the unprocessed queue
         BankingStage::push_unprocessed(
@@ -3248,7 +3248,7 @@ mod tests {
             &mut newly_buffered_packets_count,
             batch_limit,
             &packet_deduper,
-            &banking_stage_stats,
+            &mut banking_stage_stats,
         );
         assert_eq!(unprocessed_packets.len(), 1);
         assert_eq!(dropped_packet_batches_count, 0);
@@ -3267,7 +3267,7 @@ mod tests {
             &mut newly_buffered_packets_count,
             batch_limit,
             &packet_deduper,
-            &banking_stage_stats,
+            &mut banking_stage_stats,
         );
         assert_eq!(unprocessed_packets.len(), 2);
         assert_eq!(dropped_packet_batches_count, 0);
@@ -3291,7 +3291,7 @@ mod tests {
             &mut newly_buffered_packets_count,
             batch_limit,
             &packet_deduper,
-            &banking_stage_stats,
+            &mut banking_stage_stats,
         );
         assert_eq!(unprocessed_packets.len(), 2);
         assert_eq!(
@@ -3312,7 +3312,7 @@ mod tests {
             &mut newly_buffered_packets_count,
             3,
             &packet_deduper,
-            &banking_stage_stats,
+            &mut banking_stage_stats,
         );
         assert_eq!(unprocessed_packets.len(), 2);
         assert_eq!(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1,10 +1,10 @@
 //! The `banking_stage` processes Transaction messages. It is intended to be used
 //! to contruct a software pipeline. The stage uses all available CPU cores and
 //! can do its processing in parallel with signature verification on the GPU.
-use histogram::Histogram;
 use {
     crate::{packet_deduper::PacketDeduper, qos_service::QosService},
     crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError},
+    histogram::Histogram,
     itertools::Itertools,
     retain_mut::RetainMut,
     solana_entry::entry::hash_transactions,
@@ -96,7 +96,7 @@ pub struct BankingStageStats {
     current_buffered_packet_batches_count: AtomicUsize,
     rebuffered_packets_count: AtomicUsize,
     consumed_buffered_packets_count: AtomicUsize,
-    pub(crate) packet_batch_indices_len: Histogram,
+    packet_batch_indices_len: Histogram,
 
     // Timing
     consume_buffered_packets_elapsed: AtomicU64,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -113,7 +113,10 @@ impl BankingStageStats {
     pub fn new(id: u32) -> Self {
         BankingStageStats {
             id,
-            packet_batch_indices_len: Histogram::configure().max_value(PACKETS_PER_BATCH as u64).build().unwrap(),
+            packet_batch_indices_len: Histogram::configure()
+                .max_value(PACKETS_PER_BATCH as u64)
+                .build()
+                .unwrap(),
             ..BankingStageStats::default()
         }
     }
@@ -1503,7 +1506,9 @@ impl BankingStage {
                     *dropped_packets_count += dropped_batch.1.len();
                 }
             }
-            let _ = banking_stage_stats.packet_batch_indices_len.increment(packet_indexes.len() as u64);
+            let _ = banking_stage_stats
+                .packet_batch_indices_len
+                .increment(packet_indexes.len() as u64);
 
             *newly_buffered_packets_count += packet_indexes.len();
             unprocessed_packet_batches.push_back((packet_batch, packet_indexes, false));

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -96,7 +96,7 @@ pub struct BankingStageStats {
     current_buffered_packet_batches_count: AtomicUsize,
     rebuffered_packets_count: AtomicUsize,
     consumed_buffered_packets_count: AtomicUsize,
-    packet_batch_indices_len: Histogram,
+    batch_packet_indexes_len: Histogram,
 
     // Timing
     consume_buffered_packets_elapsed: AtomicU64,
@@ -113,7 +113,7 @@ impl BankingStageStats {
     pub fn new(id: u32) -> Self {
         BankingStageStats {
             id,
-            packet_batch_indices_len: Histogram::configure()
+            batch_packet_indexes_len: Histogram::configure()
                 .max_value(PACKETS_PER_BATCH as u64)
                 .build()
                 .unwrap(),
@@ -153,7 +153,7 @@ impl BankingStageStats {
                 .unprocessed_packet_conversion_elapsed
                 .load(Ordering::Relaxed)
             + self.transaction_processing_elapsed.load(Ordering::Relaxed)
-            + self.packet_batch_indices_len.entries()
+            + self.batch_packet_indexes_len.entries()
     }
 
     fn report(&mut self, report_interval_ms: u64) {
@@ -264,26 +264,26 @@ impl BankingStageStats {
                 ),
                 (
                     "packet_batch_indices_len_min",
-                    self.packet_batch_indices_len.minimum().unwrap_or(0) as i64,
+                    self.batch_packet_indexes_len.minimum().unwrap_or(0) as i64,
                     i64
                 ),
                 (
                     "packet_batch_indices_len_max",
-                    self.packet_batch_indices_len.maximum().unwrap_or(0) as i64,
+                    self.batch_packet_indexes_len.maximum().unwrap_or(0) as i64,
                     i64
                 ),
                 (
                     "packet_batch_indices_len_mean",
-                    self.packet_batch_indices_len.mean().unwrap_or(0) as i64,
+                    self.batch_packet_indexes_len.mean().unwrap_or(0) as i64,
                     i64
                 ),
                 (
                     "packet_batch_indices_len_90pct",
-                    self.packet_batch_indices_len.percentile(90.0).unwrap_or(0) as i64,
+                    self.batch_packet_indexes_len.percentile(90.0).unwrap_or(0) as i64,
                     i64
                 )
             );
-            self.packet_batch_indices_len.clear();
+            self.batch_packet_indexes_len.clear();
         }
     }
 }
@@ -1507,7 +1507,7 @@ impl BankingStage {
                 }
             }
             let _ = banking_stage_stats
-                .packet_batch_indices_len
+                .batch_packet_indexes_len
                 .increment(packet_indexes.len() as u64);
 
             *newly_buffered_packets_count += packet_indexes.len();


### PR DESCRIPTION
#### Questions

#### Problem
Suspect duplicates are screwing with max batch size for parallel execution.

#### Summary of Changes
Add metrics to collect data on packet_indexes.

Fixes #
