### PR TITLE
Refactor: Move `InstructionRecorder` into `TransactionContext`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1991,7 +1991,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod accounts_data_meter;
 pub mod compute_budget;
-pub mod instruction_recorder;
 pub mod invoke_context;
 pub mod log_collector;
 pub mod native_loader;

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -100,7 +100,7 @@ fn create_inputs() -> TransactionContext {
             },
         )
         .collect::<Vec<_>>();
-    let mut transaction_context = TransactionContext::new(transaction_accounts, 1);
+    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
         .push(&[0], &instruction_accounts, &instruction_data)

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -456,7 +456,8 @@ mod tests {
             instruction_accounts,
             &program_indices,
         );
-        let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
+        let mut transaction_context =
+            TransactionContext::new(preparation.transaction_accounts, 1, 1);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3285,6 +3285,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
             1,
+            1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.push(&[], &[0], &[]).unwrap();
@@ -3357,6 +3358,7 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
             1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
@@ -3458,6 +3460,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
             1,
+            1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.push(&[], &[0], &[]).unwrap();
@@ -3495,6 +3498,7 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
             1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
@@ -3707,6 +3711,7 @@ mod tests {
                 AccountSharedData::new(0, 0, &bpf_loader_deprecated::id()),
             )],
             1,
+            1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.push(&[], &[0], &[]).unwrap();
@@ -3863,6 +3868,7 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
             1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
@@ -4114,6 +4120,7 @@ mod tests {
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
             1,
+            1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.push(&[], &[0], &[]).unwrap();
@@ -4225,6 +4232,7 @@ mod tests {
         let program_id = Pubkey::new_unique();
         let mut transaction_context = TransactionContext::new(
             vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
+            1,
             1,
         );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -4999,7 +4999,7 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -5110,7 +5110,7 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
@@ -5156,7 +5156,7 @@ mod tests {
 
     #[test]
     fn test_merge_incorrect_authorized_staker() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -5226,7 +5226,7 @@ mod tests {
 
     #[test]
     fn test_merge_invalid_account_data() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -5277,7 +5277,7 @@ mod tests {
 
     #[test]
     fn test_merge_fake_stake_source() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -5320,7 +5320,7 @@ mod tests {
 
     #[test]
     fn test_merge_active_stake() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let base_lamports = 4242424242;
         let stake_address = Pubkey::new_unique();
@@ -5943,7 +5943,7 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let good_stake = Stake {
             credits_observed: 4242,
@@ -6042,7 +6042,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_pre_v4() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
@@ -6129,7 +6129,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge_v4() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
@@ -6276,7 +6276,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
@@ -6509,7 +6509,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let lamports = 424242;
         let meta = Meta {
@@ -6588,7 +6588,7 @@ mod tests {
 
     #[test]
     fn test_active_stake_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let delegation_a = 4_242_424_242u64;
         let delegation_b = 6_200_000_000u64;

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -139,6 +139,7 @@ fn do_bench(bencher: &mut Bencher, feature: Option<Pubkey>) {
                 (solana_vote_program::id(), AccountSharedData::default()),
             ],
             1,
+            1,
         );
 
         let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -212,7 +212,7 @@ native machine code before execting it in the virtual machine.",
     let program_indices = [0, 1];
     let preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
-    let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1);
+    let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1, 1);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     invoke_context
         .push(

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -3,7 +3,6 @@ use {
     solana_measure::measure::Measure,
     solana_program_runtime::{
         compute_budget::ComputeBudget,
-        instruction_recorder::InstructionRecorder,
         invoke_context::{BuiltinProgram, Executors, InvokeContext},
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
@@ -58,7 +57,6 @@ impl MessageProcessor {
         rent: Rent,
         log_collector: Option<Rc<RefCell<LogCollector>>>,
         executors: Rc<RefCell<Executors>>,
-        instruction_recorder: Option<Rc<RefCell<InstructionRecorder>>>,
         feature_set: Arc<FeatureSet>,
         compute_budget: ComputeBudget,
         timings: &mut ExecuteTimings,
@@ -75,7 +73,6 @@ impl MessageProcessor {
             log_collector,
             compute_budget,
             executors,
-            instruction_recorder,
             feature_set,
             blockhash,
             lamports_per_signature,
@@ -242,7 +239,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_metas = vec![
@@ -267,7 +264,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors.clone(),
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -308,7 +304,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors.clone(),
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -341,7 +336,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors,
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -441,7 +435,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_metas = vec![
@@ -468,7 +462,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors.clone(),
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -502,7 +495,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors.clone(),
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -533,7 +525,6 @@ mod tests {
             rent_collector.rent,
             None,
             executors,
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),
@@ -586,7 +577,7 @@ mod tests {
             (secp256k1_program::id(), secp256k1_account),
             (mock_program_id, mock_program_account),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 1);
 
         let message = SanitizedMessage::Legacy(Message::new(
             &[
@@ -607,7 +598,6 @@ mod tests {
             RentCollector::default().rent,
             None,
             Rc::new(RefCell::new(Executors::default())),
-            None,
             Arc::new(FeatureSet::all_enabled()),
             ComputeBudget::new(),
             &mut ExecuteTimings::default(),

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -334,7 +334,7 @@ mod test {
     where
         F: FnMut(&mut InvokeContext, &KeyedAccount),
     {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let pubkey = Pubkey::new_unique();
         let account = create_account(lamports);

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";
@@ -676,7 +676,7 @@ mod tests {
 
     #[test]
     fn test_create_account_with_seed_missing_sig() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let new_owner = Pubkey::new(&[9; 32]);
         let from = Pubkey::new_unique();
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn test_create_with_zero_lamports() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // create account with zero lamports transferred
         let new_owner = Pubkey::new(&[9; 32]);
@@ -742,7 +742,7 @@ mod tests {
 
     #[test]
     fn test_create_negative_lamports() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Attempt to create account with more lamports than remaining in from_account
         let new_owner = Pubkey::new(&[9; 32]);
@@ -767,7 +767,7 @@ mod tests {
 
     #[test]
     fn test_request_more_than_allowed_data_length() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from_account = RefCell::new(AccountSharedData::new(100, 0, &system_program::id()));
         let from = Pubkey::new_unique();
@@ -815,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_create_already_in_use() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Attempt to create system account in account already owned by another program
         let new_owner = Pubkey::new(&[9; 32]);
@@ -884,7 +884,7 @@ mod tests {
 
     #[test]
     fn test_create_unsigned() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Attempt to create an account without signing the transfer
         let new_owner = Pubkey::new(&[9; 32]);
@@ -940,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_create_sysvar_invalid_id_with_feature() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Attempt to create system account in account already owned by another program
         let from = Pubkey::new_unique();
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn test_create_data_populated() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Attempt to create system account in account with populated data
         let new_owner = Pubkey::new(&[9; 32]);
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn test_create_from_account_is_nonce_fail() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let nonce = Pubkey::new_unique();
         let nonce_account = RefCell::new(
@@ -1041,7 +1041,7 @@ mod tests {
 
     #[test]
     fn test_assign() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let new_owner = Pubkey::new(&[9; 32]);
         let pubkey = Pubkey::new_unique();
@@ -1084,7 +1084,7 @@ mod tests {
 
     #[test]
     fn test_assign_to_sysvar_with_feature() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let new_owner = sysvar::id();
         let from = Pubkey::new_unique();
@@ -1135,7 +1135,7 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let from_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
@@ -1174,7 +1174,7 @@ mod tests {
 
     #[test]
     fn test_transfer_with_seed() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let base = Pubkey::new_unique();
         let base_account = RefCell::new(AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32]))); // account owner should not matter
@@ -1235,7 +1235,7 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports_from_nonce_account_fail() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let from_account = RefCell::new(

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
-    instruction::InstructionError,
+    instruction::{CompiledInstruction, InstructionError},
     lamports::LamportsError,
     pubkey::Pubkey,
 };
@@ -31,6 +31,7 @@ pub struct TransactionContext {
     accounts: Pin<Box<[RefCell<AccountSharedData>]>>,
     instruction_context_capacity: usize,
     instruction_context_stack: Vec<InstructionContext>,
+    instruction_trace: Vec<Vec<CompiledInstruction>>,
     return_data: (Pubkey, Vec<u8>),
 }
 
@@ -39,6 +40,7 @@ impl TransactionContext {
     pub fn new(
         transaction_accounts: Vec<TransactionAccount>,
         instruction_context_capacity: usize,
+        number_of_instructions_at_transaction_level: usize,
     ) -> Self {
         let (account_keys, accounts): (Vec<Pubkey>, Vec<RefCell<AccountSharedData>>) =
             transaction_accounts
@@ -50,20 +52,24 @@ impl TransactionContext {
             accounts: Pin::new(accounts.into_boxed_slice()),
             instruction_context_capacity,
             instruction_context_stack: Vec::with_capacity(instruction_context_capacity),
+            instruction_trace: Vec::with_capacity(number_of_instructions_at_transaction_level),
             return_data: (Pubkey::default(), Vec::new()),
         }
     }
 
-    /// Used by the bank in the runtime to write back the processed accounts
-    pub fn deconstruct(self) -> Vec<TransactionAccount> {
-        Vec::from(Pin::into_inner(self.account_keys))
-            .into_iter()
-            .zip(
-                Vec::from(Pin::into_inner(self.accounts))
-                    .into_iter()
-                    .map(|account| account.into_inner()),
-            )
-            .collect()
+    /// Used by the bank in the runtime to write back the processed accounts and recorded instructions
+    pub fn deconstruct(self) -> (Vec<TransactionAccount>, Vec<Vec<CompiledInstruction>>) {
+        (
+            Vec::from(Pin::into_inner(self.account_keys))
+                .into_iter()
+                .zip(
+                    Vec::from(Pin::into_inner(self.accounts))
+                        .into_iter()
+                        .map(|account| account.into_inner()),
+                )
+                .collect(),
+            self.instruction_trace,
+        )
     }
 
     /// Used in mock_process_instruction
@@ -143,6 +149,9 @@ impl TransactionContext {
         if self.instruction_context_stack.len() >= self.instruction_context_capacity {
             return Err(InstructionError::CallDepth);
         }
+        if self.instruction_context_stack.is_empty() {
+            self.instruction_trace.push(Vec::new());
+        }
         self.instruction_context_stack.push(InstructionContext {
             program_accounts: program_accounts.to_vec(),
             instruction_accounts: instruction_accounts.to_vec(),
@@ -187,6 +196,13 @@ impl TransactionContext {
     ) -> Result<(), InstructionError> {
         self.return_data = (program_id, data);
         Ok(())
+    }
+
+    /// Used by the runtime when a new CPI instruction begins
+    pub fn record_compiled_instruction(&mut self, instruction: CompiledInstruction) {
+        if let Some(records) = self.instruction_trace.last_mut() {
+            records.push(instruction);
+        }
     }
 }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -31,6 +31,7 @@ pub struct TransactionContext {
     accounts: Pin<Box<[RefCell<AccountSharedData>]>>,
     instruction_context_capacity: usize,
     instruction_context_stack: Vec<InstructionContext>,
+    number_of_instructions_at_transaction_level: usize,
     instruction_trace: Vec<Vec<CompiledInstruction>>,
     return_data: (Pubkey, Vec<u8>),
 }
@@ -52,6 +53,7 @@ impl TransactionContext {
             accounts: Pin::new(accounts.into_boxed_slice()),
             instruction_context_capacity,
             instruction_context_stack: Vec::with_capacity(instruction_context_capacity),
+            number_of_instructions_at_transaction_level,
             instruction_trace: Vec::with_capacity(number_of_instructions_at_transaction_level),
             return_data: (Pubkey::default(), Vec::new()),
         }
@@ -150,6 +152,9 @@ impl TransactionContext {
             return Err(InstructionError::CallDepth);
         }
         if self.instruction_context_stack.is_empty() {
+            debug_assert!(
+                self.instruction_trace.len() < self.number_of_instructions_at_transaction_level
+            );
             self.instruction_trace.push(Vec::new());
         }
         self.instruction_context_stack.push(InstructionContext {


### PR DESCRIPTION
#### Problem
#22515 will expose a trace of recorded `Instruction`s in ABIv1 via syscalls.
The same should be supported in ABIv2 as well, but without syscalls, instead being directly accessible through the `TransactionContext`.

#### Summary of Changes
- Moves `InstructionRecorder` into `TransactionContext`.
- Always records instructions as if `enable_cpi_recording` was `true` and only discards the record in `TransactionExecutionResult`.

Fixes #
