### PR TITLE
Speed up packet dedup and fix benches

### DIFF
--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -331,7 +331,9 @@ mod test {
         assert_eq!(bloom.keys.len(), 3);
         assert_eq!(bloom.num_bits, 6168);
         assert_eq!(bloom.bits.len(), 97);
-        hash_values.par_iter().for_each(|v| bloom.add(v));
+        hash_values.par_iter().for_each(|v| {
+            bloom.add(v);
+        });
         let bloom: Bloom<Hash> = bloom.into();
         assert_eq!(bloom.keys.len(), 3);
         assert_eq!(bloom.bits.len(), 6168);
@@ -373,7 +375,9 @@ mod test {
         }
         // Round trip, re-inserting the same hash values.
         let bloom: AtomicBloom<_> = bloom.into();
-        hash_values.par_iter().for_each(|v| bloom.add(v));
+        hash_values.par_iter().for_each(|v| {
+            bloom.add(v);
+        });
         for hash_value in &hash_values {
             assert!(bloom.contains(hash_value));
         }
@@ -391,7 +395,9 @@ mod test {
         let bloom: AtomicBloom<_> = bloom.into();
         assert_eq!(bloom.num_bits, 9731);
         assert_eq!(bloom.bits.len(), (9731 + 63) / 64);
-        more_hash_values.par_iter().for_each(|v| bloom.add(v));
+        more_hash_values.par_iter().for_each(|v| {
+            bloom.add(v);
+        });
         for hash_value in &hash_values {
             assert!(bloom.contains(hash_value));
         }

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![feature(test)]
 
 extern crate test;

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -3,43 +3,96 @@
 extern crate test;
 
 use {
+    rand::prelude::*,
     solana_bloom::bloom::{AtomicBloom, Bloom},
-    solana_perf::{packet::to_packet_batches, sigverify, test_tx::test_tx},
+    solana_perf::{
+        packet::{to_packet_batches, PacketBatch},
+        sigverify,
+    },
     test::Bencher,
 };
 
-#[bench]
-fn bench_dedup_same(bencher: &mut Bencher) {
-    let tx = test_tx();
+fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
+    // subtract 8 bytes because the length will get serialized as well
+    (0..size.checked_sub(8).unwrap())
+        .map(|_| rng.gen())
+        .collect()
+}
 
-    // generate packet vector
-    let mut batches = to_packet_batches(
-        &std::iter::repeat(tx).take(64 * 1024).collect::<Vec<_>>(),
-        128,
-    );
-    let packet_count = sigverify::count_packets_in_batches(&batches);
-    let bloom: AtomicBloom<&[u8]> = Bloom::random(1_000_000, 0.0001, 8 << 22).into();
-
-    println!("packet_count {} {}", packet_count, batches.len());
-
+fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) {
     // verify packets
+    let mut bloom: AtomicBloom<&[u8]> = Bloom::random(1_000_000, 0.0001, 8 << 22).into();
     bencher.iter(|| {
-        let _ans = sigverify::dedup_packets(&bloom, &mut batches);
+        // bench
+        sigverify::dedup_packets(&bloom, &mut batches);
+
+        // reset
+        bloom.clear_for_tests();
+        batches.iter_mut().for_each(|batch| {
+            batch
+                .packets
+                .iter_mut()
+                .for_each(|p| p.meta.set_discard(false))
+        });
     })
 }
 
 #[bench]
-fn bench_dedup_diff(bencher: &mut Bencher) {
-    // generate packet vector
-    let mut batches =
-        to_packet_batches(&(0..64 * 1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
-    let packet_count = sigverify::count_packets_in_batches(&batches);
-    let bloom: AtomicBloom<&[u8]> = Bloom::random(1_000_000, 0.0001, 8 << 22).into();
+#[ignore]
+fn bench_dedup_same_small_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let small_packet = test_packet_with_size(128, &mut rng);
 
-    println!("packet_count {} {}", packet_count, batches.len());
+    let batches = to_packet_batches(
+        &std::iter::repeat(small_packet)
+            .take(4096)
+            .collect::<Vec<_>>(),
+        128,
+    );
 
-    // verify packets
-    bencher.iter(|| {
-        let _ans = sigverify::dedup_packets(&bloom, &mut batches);
-    })
+    do_bench_dedup_packets(bencher, batches);
+}
+
+#[bench]
+#[ignore]
+fn bench_dedup_same_big_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let big_packet = test_packet_with_size(1024, &mut rng);
+
+    let batches = to_packet_batches(
+        &std::iter::repeat(big_packet).take(4096).collect::<Vec<_>>(),
+        128,
+    );
+
+    do_bench_dedup_packets(bencher, batches);
+}
+
+#[bench]
+#[ignore]
+fn bench_dedup_diff_small_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+
+    let batches = to_packet_batches(
+        &(0..4096)
+            .map(|_| test_packet_with_size(128, &mut rng))
+            .collect::<Vec<_>>(),
+        128,
+    );
+
+    do_bench_dedup_packets(bencher, batches);
+}
+
+#[bench]
+#[ignore]
+fn bench_dedup_diff_big_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+
+    let batches = to_packet_batches(
+        &(0..4096)
+            .map(|_| test_packet_with_size(1024, &mut rng))
+            .collect::<Vec<_>>(),
+        128,
+    );
+
+    do_bench_dedup_packets(bencher, batches);
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -426,12 +426,11 @@ fn dedup_packet(count: &AtomicU64, packet: &mut Packet, bloom: &AtomicBloom<&[u8
         return;
     }
 
-    if bloom.contains(&packet.data.as_slice()) {
+    // If this packet was not newly added, it's a dup and should be discarded
+    if !bloom.add(&&packet.data.as_slice()[0..packet.meta.size]) {
         packet.meta.set_discard(true);
         count.fetch_add(1, Ordering::Relaxed);
-        return;
     }
-    bloom.add(&packet.data.as_slice());
 }
 
 pub fn dedup_packets(bloom: &AtomicBloom<&[u8]>, batches: &mut [PacketBatch]) -> u64 {


### PR DESCRIPTION
#### Problems
- Packet deduping is slow for larger packets but we always add the full 1232 data buffer to the bloom filter
- It's slow to iterate over the bloom filter keys twice (once for `contains` and once for `add`)

#### Summary of Changes
- Only add the used data buffer portion of a packet to the bloom filter
- Modify `AtomicBloom:add` to return whether the item was newly added or not

Before
```
test bench_dedup_diff_big_packets   ... bench:  20,010,316 ns/iter (+/- 1,623,356)
test bench_dedup_diff_small_packets ... bench:  19,772,433 ns/iter (+/- 1,470,336)
test bench_dedup_same_big_packets   ... bench:  17,869,979 ns/iter (+/- 1,158,488)
test bench_dedup_same_small_packets ... bench:  18,181,612 ns/iter (+/- 2,449,875)
```

After
```
test bench_dedup_diff_big_packets   ... bench:  15,266,433 ns/iter (+/- 1,096,914)
test bench_dedup_diff_small_packets ... bench:   1,943,839 ns/iter (+/- 239,305)
test bench_dedup_same_big_packets   ... bench:  16,299,237 ns/iter (+/- 570,619)
test bench_dedup_same_small_packets ... bench:   3,363,462 ns/iter (+/- 2,007,400)
```

Fixes #
