### PR TITLE
Handle already discarded packets in discard_excess_packets

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -195,6 +195,7 @@ impl SigVerifyStage {
             .iter_mut()
             .rev()
             .flat_map(|batch| batch.packets.iter_mut().rev())
+            .filter(|packet| !packet.meta.discard())
             .map(|packet| (packet.meta.addr, packet))
             .into_group_map();
         // Allocate max_packets evenly across addresses.
@@ -372,11 +373,14 @@ mod tests {
         let mut batch = PacketBatch::default();
         batch.packets.resize(10, Packet::default());
         batch.packets[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
+        batch.packets[3].meta.set_discard(true);
+        batch.packets[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
         let mut batches = vec![batch];
         let max = 3;
         SigVerifyStage::discard_excess_packets(&mut batches, max);
         assert_eq!(count_non_discard(&batches), max);
         assert!(!batches[0].packets[0].meta.discard());
-        assert!(!batches[0].packets[3].meta.discard());
+        assert!(batches[0].packets[3].meta.discard());
+        assert!(!batches[0].packets[4].meta.discard());
     }
 }


### PR DESCRIPTION
#### Problem

Packets with .discard() == true are considered as valid by discard_excess_packets, but they have already been dropped as dupes.

#### Summary of Changes

Don't consider discarded packets

Fixes #
