### PR TITLE
Remove active features stake program v3 and v4

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -3120,12 +3120,11 @@ mod tests {
         let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
-        // Withdrawing account down to only rent-exempt reserve should succeed before feature, and
-        // fail after
+        // Withdrawing account down to minimum balance should succeed
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
         assert_eq!(
             stake_keyed_account.withdraw(
-                stake,
+                stake - 1,
                 &to_keyed_account,
                 &clock,
                 &StakeHistory::default(),
@@ -3134,9 +3133,11 @@ mod tests {
             ),
             Ok(())
         );
+
+        // Withdrawing account down to only rent-exempt reserve should fail
         stake_account
             .borrow_mut()
-            .checked_add_lamports(stake)
+            .checked_add_lamports(stake - 1)
             .unwrap(); // top up account
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
         assert_eq!(
@@ -6230,7 +6231,7 @@ mod tests {
     fn test_merge_kind_merge() {
         let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        let clock = invoke_context.get_sysvar_cache().get_clock().unwrap();
+        let clock = Clock::default();
         let lamports = 424242;
         let meta = Meta {
             rent_exempt_reserve: 42,
@@ -6310,7 +6311,7 @@ mod tests {
     fn test_active_stake_merge() {
         let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        let clock = invoke_context.get_sysvar_cache().get_clock().unwrap();
+        let clock = Clock::default();
         let delegation_a = 4_242_424_242u64;
         let delegation_b = 6_200_000_000u64;
         let credits_a = 124_521_000u64;

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -94,7 +94,6 @@ fn redelegate(
     clock: &Clock,
     stake_history: &StakeHistory,
     config: &Config,
-    can_reverse_deactivation: bool,
 ) -> Result<(), StakeError> {
     // If stake is currently active:
     if stake.stake(clock.epoch, Some(stake_history)) != 0 {
@@ -103,7 +102,6 @@ fn redelegate(
         // we rescind deactivation
         if stake.delegation.voter_pubkey == *voter_pubkey
             && clock.epoch == stake.delegation.deactivation_epoch
-            && can_reverse_deactivation
         {
             stake.delegation.deactivation_epoch = std::u64::MAX;
             return Ok(());
@@ -377,14 +375,13 @@ pub trait StakeAccount {
         stake_history: &StakeHistory,
         config: &Config,
         signers: &HashSet<Pubkey>,
-        can_reverse_deactivation: bool,
     ) -> Result<(), InstructionError>;
     fn deactivate(&self, clock: &Clock, signers: &HashSet<Pubkey>) -> Result<(), InstructionError>;
     fn set_lockup(
         &self,
         lockup: &LockupArgs,
         signers: &HashSet<Pubkey>,
-        clock: Option<&Clock>,
+        clock: &Clock,
     ) -> Result<(), InstructionError>;
     fn split(
         &self,
@@ -399,7 +396,6 @@ pub trait StakeAccount {
         clock: &Clock,
         stake_history: &StakeHistory,
         signers: &HashSet<Pubkey>,
-        can_merge_expired_lockups: bool,
     ) -> Result<(), InstructionError>;
     fn withdraw(
         &self,
@@ -409,7 +405,6 @@ pub trait StakeAccount {
         stake_history: &StakeHistory,
         withdraw_authority: &KeyedAccount,
         custodian: Option<&KeyedAccount>,
-        prevent_withdraw_to_zero: bool,
     ) -> Result<(), InstructionError>;
 }
 
@@ -517,7 +512,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         stake_history: &StakeHistory,
         config: &Config,
         signers: &HashSet<Pubkey>,
-        can_reverse_deactivation: bool,
     ) -> Result<(), InstructionError> {
         if vote_account.owner()? != solana_vote_program::id() {
             return Err(InstructionError::IncorrectProgramId);
@@ -545,7 +539,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                     clock,
                     stake_history,
                     config,
-                    can_reverse_deactivation,
                 )?;
                 self.set_state(&StakeState::Stake(meta, stake))
             }
@@ -566,7 +559,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         &self,
         lockup: &LockupArgs,
         signers: &HashSet<Pubkey>,
-        clock: Option<&Clock>,
+        clock: &Clock,
     ) -> Result<(), InstructionError> {
         match self.state()? {
             StakeState::Initialized(mut meta) => {
@@ -705,7 +698,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         clock: &Clock,
         stake_history: &StakeHistory,
         signers: &HashSet<Pubkey>,
-        can_merge_expired_lockups: bool,
     ) -> Result<(), InstructionError> {
         // Ensure source isn't spoofed
         if source_account.owner()? != id() {
@@ -727,12 +719,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         ic_msg!(invoke_context, "Checking if source stake is mergeable");
         let source_merge_kind =
             MergeKind::get_if_mergeable(invoke_context, source_account, clock, stake_history)?;
-
-        let clock = if can_merge_expired_lockups {
-            Some(clock)
-        } else {
-            None
-        };
 
         ic_msg!(invoke_context, "Merging stake accounts");
         if let Some(merged_state) =
@@ -761,7 +747,6 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         stake_history: &StakeHistory,
         withdraw_authority: &KeyedAccount,
         custodian: Option<&KeyedAccount>,
-        prevent_withdraw_to_zero: bool,
     ) -> Result<(), InstructionError> {
         let mut signers = HashSet::new();
         let withdraw_authority_pubkey = withdraw_authority
@@ -789,11 +774,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
             StakeState::Initialized(meta) => {
                 meta.authorized
                     .check(&signers, StakeAuthorize::Withdrawer)?;
-                let reserve = if prevent_withdraw_to_zero {
-                    checked_add(meta.rent_exempt_reserve, 1)? // stake accounts must have a balance > rent_exempt_reserve
-                } else {
-                    meta.rent_exempt_reserve
-                };
+                let reserve = checked_add(meta.rent_exempt_reserve, 1)?; // stake accounts must have a balance > rent_exempt_reserve
 
                 (meta.lockup, reserve, false)
             }
@@ -899,18 +880,11 @@ impl MergeKind {
         invoke_context: &InvokeContext,
         stake: &Meta,
         source: &Meta,
-        clock: Option<&Clock>,
+        clock: &Clock,
     ) -> Result<(), InstructionError> {
-        let can_merge_lockups = match clock {
-            // pre-v4 behavior. lockups must match, even when expired
-            None => stake.lockup == source.lockup,
-            // v4 behavior. lockups may mismatch so long as both have expired
-            Some(clock) => {
-                stake.lockup == source.lockup
-                    || (!stake.lockup.is_in_force(clock, None)
-                        && !source.lockup.is_in_force(clock, None))
-            }
-        };
+        // lockups may mismatch so long as both have expired
+        let can_merge_lockups = stake.lockup == source.lockup
+            || (!stake.lockup.is_in_force(clock, None) && !source.lockup.is_in_force(clock, None));
         // `rent_exempt_reserve` has no bearing on the mergeability of accounts,
         // as the source account will be culled by runtime once the operation
         // succeeds. Considering it here would needlessly prevent merging stake
@@ -970,7 +944,7 @@ impl MergeKind {
         self,
         invoke_context: &InvokeContext,
         source: Self,
-        clock: Option<&Clock>,
+        clock: &Clock,
     ) -> Result<Option<StakeState>, InstructionError> {
         Self::metas_can_merge(invoke_context, self.meta(), source.meta(), clock)?;
         self.active_stake()
@@ -1547,7 +1521,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -1562,7 +1535,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             )
             .is_ok());
 
@@ -1592,7 +1564,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true
             ),
             Err(StakeError::TooSoonToRedelegate.into())
         );
@@ -1609,7 +1580,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Err(StakeError::TooSoonToRedelegate.into())
         );
@@ -1623,7 +1593,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             )
             .unwrap();
 
@@ -1640,7 +1609,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Err(StakeError::TooSoonToRedelegate.into())
         );
@@ -1659,7 +1627,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             )
             .is_ok());
 
@@ -1677,7 +1644,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Err(solana_sdk::instruction::InstructionError::IncorrectProgramId)
         );
@@ -1709,7 +1675,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             )
             .is_err());
     }
@@ -2434,7 +2399,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Ok(())
         );
@@ -2468,11 +2432,12 @@ mod tests {
             &id(),
         )
         .expect("stake_account");
+        let clock = Clock::default();
 
         // wrong state, should fail
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
         assert_eq!(
-            stake_keyed_account.set_lockup(&LockupArgs::default(), &HashSet::default(), None),
+            stake_keyed_account.set_lockup(&LockupArgs::default(), &HashSet::default(), &clock),
             Err(InstructionError::InvalidAccountData)
         );
 
@@ -2491,7 +2456,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            stake_keyed_account.set_lockup(&LockupArgs::default(), &HashSet::default(), None),
+            stake_keyed_account.set_lockup(&LockupArgs::default(), &HashSet::default(), &clock),
             Err(InstructionError::MissingRequiredSignature)
         );
 
@@ -2503,7 +2468,7 @@ mod tests {
                     custodian: Some(custodian),
                 },
                 &vec![custodian].into_iter().collect(),
-                None
+                &clock
             ),
             Ok(())
         );
@@ -2528,7 +2493,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &vec![stake_pubkey].into_iter().collect(),
-                true,
             )
             .unwrap();
 
@@ -2540,7 +2504,7 @@ mod tests {
                     custodian: Some(custodian),
                 },
                 &HashSet::default(),
-                None
+                &clock
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -2552,133 +2516,14 @@ mod tests {
                     custodian: Some(custodian),
                 },
                 &vec![custodian].into_iter().collect(),
-                None
+                &clock
             ),
             Ok(())
         );
     }
 
     #[test]
-    fn test_optional_lockup_for_stake_program_v3_and_earlier() {
-        let stake_pubkey = solana_sdk::pubkey::new_rand();
-        let stake_lamports = 42;
-        let stake_account = AccountSharedData::new_ref_data_with_space(
-            stake_lamports,
-            &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
-            &id(),
-        )
-        .expect("stake_account");
-        let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
-
-        let custodian = solana_sdk::pubkey::new_rand();
-        stake_keyed_account
-            .initialize(
-                &Authorized::auto(&stake_pubkey),
-                &Lockup {
-                    unix_timestamp: 1,
-                    epoch: 1,
-                    custodian,
-                },
-                &Rent::free(),
-            )
-            .unwrap();
-
-        assert_eq!(
-            stake_keyed_account.set_lockup(
-                &LockupArgs {
-                    unix_timestamp: None,
-                    epoch: None,
-                    custodian: None,
-                },
-                &vec![custodian].into_iter().collect(),
-                None
-            ),
-            Ok(())
-        );
-
-        assert_eq!(
-            stake_keyed_account.set_lockup(
-                &LockupArgs {
-                    unix_timestamp: Some(2),
-                    epoch: None,
-                    custodian: None,
-                },
-                &vec![custodian].into_iter().collect(),
-                None
-            ),
-            Ok(())
-        );
-
-        if let StakeState::Initialized(Meta { lockup, .. }) =
-            from(&stake_keyed_account.account.borrow()).unwrap()
-        {
-            assert_eq!(lockup.unix_timestamp, 2);
-            assert_eq!(lockup.epoch, 1);
-            assert_eq!(lockup.custodian, custodian);
-        } else {
-            panic!();
-        }
-
-        assert_eq!(
-            stake_keyed_account.set_lockup(
-                &LockupArgs {
-                    unix_timestamp: None,
-                    epoch: Some(3),
-                    custodian: None,
-                },
-                &vec![custodian].into_iter().collect(),
-                None
-            ),
-            Ok(())
-        );
-
-        if let StakeState::Initialized(Meta { lockup, .. }) =
-            from(&stake_keyed_account.account.borrow()).unwrap()
-        {
-            assert_eq!(lockup.unix_timestamp, 2);
-            assert_eq!(lockup.epoch, 3);
-            assert_eq!(lockup.custodian, custodian);
-        } else {
-            panic!();
-        }
-
-        let new_custodian = solana_sdk::pubkey::new_rand();
-        assert_eq!(
-            stake_keyed_account.set_lockup(
-                &LockupArgs {
-                    unix_timestamp: None,
-                    epoch: None,
-                    custodian: Some(new_custodian),
-                },
-                &vec![custodian].into_iter().collect(),
-                None
-            ),
-            Ok(())
-        );
-
-        if let StakeState::Initialized(Meta { lockup, .. }) =
-            from(&stake_keyed_account.account.borrow()).unwrap()
-        {
-            assert_eq!(lockup.unix_timestamp, 2);
-            assert_eq!(lockup.epoch, 3);
-            assert_eq!(lockup.custodian, new_custodian);
-        } else {
-            panic!();
-        }
-
-        assert_eq!(
-            stake_keyed_account.set_lockup(
-                &LockupArgs::default(),
-                &vec![custodian].into_iter().collect(),
-                None
-            ),
-            Err(InstructionError::MissingRequiredSignature)
-        );
-    }
-
-    #[test]
-    fn test_optional_lockup_for_stake_program_v4() {
+    fn test_optional_lockup_for_stake_program() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = AccountSharedData::new_ref_data_with_space(
@@ -2712,7 +2557,7 @@ mod tests {
                     custodian: None
                 },
                 &vec![stake_pubkey].into_iter().collect(),
-                Some(&Clock::default())
+                &Clock::default()
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -2726,7 +2571,7 @@ mod tests {
                     custodian: None
                 },
                 &vec![custodian].into_iter().collect(),
-                Some(&Clock::default())
+                &Clock::default()
             ),
             Ok(())
         );
@@ -2736,11 +2581,11 @@ mod tests {
             stake_keyed_account.set_lockup(
                 &LockupArgs::default(),
                 &vec![custodian].into_iter().collect(),
-                Some(&Clock {
+                &Clock {
                     unix_timestamp: UnixTimestamp::MAX,
                     epoch: Epoch::MAX,
                     ..Clock::default()
-                })
+                }
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -2750,11 +2595,11 @@ mod tests {
             stake_keyed_account.set_lockup(
                 &LockupArgs::default(),
                 &vec![stake_pubkey].into_iter().collect(),
-                Some(&Clock {
+                &Clock {
                     unix_timestamp: UnixTimestamp::MAX,
                     epoch: Epoch::MAX,
                     ..Clock::default()
-                })
+                }
             ),
             Ok(())
         );
@@ -2778,11 +2623,11 @@ mod tests {
             stake_keyed_account.set_lockup(
                 &LockupArgs::default(),
                 &vec![stake_pubkey].into_iter().collect(),
-                Some(&Clock {
+                &Clock {
                     unix_timestamp: UnixTimestamp::MAX,
                     epoch: Epoch::MAX,
                     ..Clock::default()
-                })
+                }
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -2816,7 +2661,6 @@ mod tests {
                 &StakeHistory::default(),
                 &to_keyed_account, // unsigned account as withdraw authority
                 None,
-                true,
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -2832,7 +2676,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -2868,7 +2711,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -2893,7 +2735,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Ok(())
         );
@@ -2911,7 +2752,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -2929,7 +2769,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -2949,7 +2788,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -2964,7 +2802,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -3021,7 +2858,6 @@ mod tests {
                 &StakeHistory::default(),
                 &authority_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds),
         );
@@ -3070,7 +2906,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             ),
             Ok(())
         );
@@ -3092,7 +2927,6 @@ mod tests {
                 &stake_history,
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -3122,7 +2956,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InvalidAccountData)
         );
@@ -3165,7 +2998,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(StakeError::LockupInForce.into())
         );
@@ -3181,7 +3013,6 @@ mod tests {
                     &StakeHistory::default(),
                     &stake_keyed_account,
                     Some(&custodian_keyed_account),
-                    true,
                 ),
                 Ok(())
             );
@@ -3203,7 +3034,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -3247,7 +3077,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(StakeError::LockupInForce.into())
         );
@@ -3262,7 +3091,6 @@ mod tests {
                     &StakeHistory::default(),
                     &stake_keyed_account,
                     Some(&custodian_keyed_account),
-                    true,
                 ),
                 Ok(())
             );
@@ -3303,7 +3131,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                false,
             ),
             Ok(())
         );
@@ -3320,7 +3147,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -3335,7 +3161,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                false,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -3348,7 +3173,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Err(InstructionError::InsufficientFunds)
         );
@@ -3363,7 +3187,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -3871,7 +3694,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account, // old signer
                 None,
-                true,
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -3888,7 +3710,6 @@ mod tests {
                 &StakeHistory::default(),
                 &stake_keyed_account2,
                 None,
-                true,
             ),
             Ok(())
         );
@@ -5043,7 +4864,6 @@ mod tests {
                         &Clock::default(),
                         &StakeHistory::default(),
                         &HashSet::new(),
-                        false,
                     ),
                     Err(InstructionError::MissingRequiredSignature)
                 );
@@ -5055,7 +4875,6 @@ mod tests {
                         &Clock::default(),
                         &StakeHistory::default(),
                         &signers,
-                        false,
                     ),
                     Ok(())
                 );
@@ -5148,7 +4967,6 @@ mod tests {
                 &Clock::default(),
                 &StakeHistory::default(),
                 &signers,
-                false,
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -5204,7 +5022,6 @@ mod tests {
                         &Clock::default(),
                         &StakeHistory::default(),
                         &wrong_signers,
-                        false,
                     ),
                     Err(InstructionError::MissingRequiredSignature)
                 );
@@ -5216,7 +5033,6 @@ mod tests {
                         &Clock::default(),
                         &StakeHistory::default(),
                         &signers,
-                        false,
                     ),
                     Err(StakeError::MergeMismatch.into())
                 );
@@ -5267,7 +5083,6 @@ mod tests {
                         &Clock::default(),
                         &StakeHistory::default(),
                         &signers,
-                        false,
                     ),
                     Err(InstructionError::InvalidAccountData)
                 );
@@ -5312,7 +5127,6 @@ mod tests {
                 &Clock::default(),
                 &StakeHistory::default(),
                 &signers,
-                false,
             ),
             Err(InstructionError::IncorrectProgramId)
         );
@@ -5410,7 +5224,6 @@ mod tests {
                 clock,
                 stake_history,
                 signers,
-                false,
             );
             if result.is_ok() {
                 assert_eq!(test_source_keyed.state(), Ok(StakeState::Uninitialized),);
@@ -5684,7 +5497,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &signers,
-                true,
             )
             .unwrap();
 
@@ -5731,7 +5543,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &other_signers,
-                true,
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -5745,7 +5556,6 @@ mod tests {
                 &StakeHistory::default(),
                 &Config::default(),
                 &new_signers,
-                true,
             ),
             Ok(())
         );
@@ -5797,7 +5607,6 @@ mod tests {
                 &stake_history,
                 &config,
                 &signers,
-                true,
             )
             .unwrap();
 
@@ -5818,7 +5627,6 @@ mod tests {
                 &stake_history,
                 &stake_keyed_account,
                 None,
-                true,
             )
             .unwrap();
         let expected_balance = rent_exempt_reserve + initial_lamports - withdraw_lamports;
@@ -5832,7 +5640,6 @@ mod tests {
                 &stake_history,
                 &config,
                 &signers,
-                true,
             )
             .unwrap();
         let stake = stake_from(&stake_account.borrow()).unwrap();
@@ -5859,7 +5666,6 @@ mod tests {
                 &stake_history,
                 &config,
                 &signers,
-                true,
             )
             .unwrap();
         let stake = stake_from(&stake_account.borrow()).unwrap();
@@ -6041,7 +5847,7 @@ mod tests {
     }
 
     #[test]
-    fn test_metas_can_merge_pre_v4() {
+    fn test_metas_can_merge() {
         let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
@@ -6049,94 +5855,7 @@ mod tests {
             &invoke_context,
             &Meta::default(),
             &Meta::default(),
-            None,
-        )
-        .is_ok());
-
-        let mismatched_rent_exempt_reserve_ok = Meta {
-            rent_exempt_reserve: 42,
-            ..Meta::default()
-        };
-        assert_ne!(
-            mismatched_rent_exempt_reserve_ok.rent_exempt_reserve,
-            Meta::default().rent_exempt_reserve
-        );
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &Meta::default(),
-            &mismatched_rent_exempt_reserve_ok,
-            None,
-        )
-        .is_ok());
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &mismatched_rent_exempt_reserve_ok,
-            &Meta::default(),
-            None,
-        )
-        .is_ok());
-
-        let mismatched_authorized_fails = Meta {
-            authorized: Authorized {
-                staker: Pubkey::new_unique(),
-                withdrawer: Pubkey::new_unique(),
-            },
-            ..Meta::default()
-        };
-        assert_ne!(
-            mismatched_authorized_fails.authorized,
-            Meta::default().authorized
-        );
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &Meta::default(),
-            &mismatched_authorized_fails,
-            None,
-        )
-        .is_err());
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &mismatched_authorized_fails,
-            &Meta::default(),
-            None,
-        )
-        .is_err());
-
-        let mismatched_lockup_fails = Meta {
-            lockup: Lockup {
-                unix_timestamp: 424242424,
-                epoch: 42,
-                custodian: Pubkey::new_unique(),
-            },
-            ..Meta::default()
-        };
-        assert_ne!(mismatched_lockup_fails.lockup, Meta::default().lockup);
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &Meta::default(),
-            &mismatched_lockup_fails,
-            None,
-        )
-        .is_err());
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &mismatched_lockup_fails,
-            &Meta::default(),
-            None,
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_metas_can_merge_v4() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
-        let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        // Identical Metas can merge
-        assert!(MergeKind::metas_can_merge(
-            &invoke_context,
-            &Meta::default(),
-            &Meta::default(),
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_ok());
 
@@ -6152,14 +5871,14 @@ mod tests {
             &invoke_context,
             &Meta::default(),
             &mismatched_rent_exempt_reserve_ok,
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_ok());
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
             &mismatched_rent_exempt_reserve_ok,
             &Meta::default(),
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_ok());
 
@@ -6178,14 +5897,14 @@ mod tests {
             &invoke_context,
             &Meta::default(),
             &mismatched_authorized_fails,
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_err());
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
             &mismatched_authorized_fails,
             &Meta::default(),
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_err());
 
@@ -6216,14 +5935,14 @@ mod tests {
             &invoke_context,
             &metas_with_lockup1,
             &metas_with_lockup2,
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_err());
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
             &metas_with_lockup2,
             &metas_with_lockup1,
-            Some(&Clock::default())
+            &Clock::default()
         )
         .is_err());
 
@@ -6239,14 +5958,14 @@ mod tests {
             &invoke_context,
             &metas_with_lockup1,
             &metas_with_lockup2,
-            Some(&clock)
+            &clock
         )
         .is_err());
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
             &metas_with_lockup2,
             &metas_with_lockup1,
-            Some(&clock)
+            &clock
         )
         .is_err());
 
@@ -6262,14 +5981,14 @@ mod tests {
             &invoke_context,
             &metas_with_lockup1,
             &metas_with_lockup2,
-            Some(&clock)
+            &clock
         )
         .is_ok());
         assert!(MergeKind::metas_can_merge(
             &invoke_context,
             &metas_with_lockup2,
             &metas_with_lockup1,
-            Some(&clock)
+            &clock
         )
         .is_ok());
     }
@@ -6511,6 +6230,7 @@ mod tests {
     fn test_merge_kind_merge() {
         let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+        let clock = invoke_context.get_sysvar_cache().get_clock().unwrap();
         let lamports = 424242;
         let meta = Meta {
             rent_exempt_reserve: 42,
@@ -6530,37 +6250,37 @@ mod tests {
         assert_eq!(
             inactive
                 .clone()
-                .merge(&invoke_context, inactive.clone(), None)
+                .merge(&invoke_context, inactive.clone(), &clock)
                 .unwrap(),
             None
         );
         assert_eq!(
             inactive
                 .clone()
-                .merge(&invoke_context, activation_epoch.clone(), None)
+                .merge(&invoke_context, activation_epoch.clone(), &clock)
                 .unwrap(),
             None
         );
         assert!(inactive
             .clone()
-            .merge(&invoke_context, fully_active.clone(), None)
+            .merge(&invoke_context, fully_active.clone(), &clock)
             .is_err());
         assert!(activation_epoch
             .clone()
-            .merge(&invoke_context, fully_active.clone(), None)
+            .merge(&invoke_context, fully_active.clone(), &clock)
             .is_err());
         assert!(fully_active
             .clone()
-            .merge(&invoke_context, inactive.clone(), None)
+            .merge(&invoke_context, inactive.clone(), &clock)
             .is_err());
         assert!(fully_active
             .clone()
-            .merge(&invoke_context, activation_epoch.clone(), None)
+            .merge(&invoke_context, activation_epoch.clone(), &clock)
             .is_err());
 
         let new_state = activation_epoch
             .clone()
-            .merge(&invoke_context, inactive, None)
+            .merge(&invoke_context, inactive, &clock)
             .unwrap()
             .unwrap();
         let delegation = new_state.delegation().unwrap();
@@ -6568,7 +6288,7 @@ mod tests {
 
         let new_state = activation_epoch
             .clone()
-            .merge(&invoke_context, activation_epoch, None)
+            .merge(&invoke_context, activation_epoch, &clock)
             .unwrap()
             .unwrap();
         let delegation = new_state.delegation().unwrap();
@@ -6579,7 +6299,7 @@ mod tests {
 
         let new_state = fully_active
             .clone()
-            .merge(&invoke_context, fully_active, None)
+            .merge(&invoke_context, fully_active, &clock)
             .unwrap()
             .unwrap();
         let delegation = new_state.delegation().unwrap();
@@ -6590,6 +6310,7 @@ mod tests {
     fn test_active_stake_merge() {
         let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+        let clock = invoke_context.get_sysvar_cache().get_clock().unwrap();
         let delegation_a = 4_242_424_242u64;
         let delegation_b = 6_200_000_000u64;
         let credits_a = 124_521_000u64;
@@ -6617,7 +6338,7 @@ mod tests {
         let activation_epoch_a = MergeKind::ActivationEpoch(meta, stake_a);
         let activation_epoch_b = MergeKind::ActivationEpoch(meta, stake_b);
         let new_stake = activation_epoch_a
-            .merge(&invoke_context, activation_epoch_b, None)
+            .merge(&invoke_context, activation_epoch_b, &clock)
             .unwrap()
             .unwrap()
             .stake()
@@ -6632,7 +6353,7 @@ mod tests {
         let fully_active_a = MergeKind::FullyActive(meta, stake_a);
         let fully_active_b = MergeKind::FullyActive(meta, stake_b);
         let new_stake = fully_active_a
-            .merge(&invoke_context, fully_active_b, None)
+            .merge(&invoke_context, fully_active_b, &clock)
             .unwrap()
             .unwrap()
             .stake()
@@ -6652,7 +6373,7 @@ mod tests {
         let activation_epoch_a = MergeKind::ActivationEpoch(meta, stake_a);
         let activation_epoch_b = MergeKind::ActivationEpoch(meta, stake_b);
         let new_stake = activation_epoch_a
-            .merge(&invoke_context, activation_epoch_b, None)
+            .merge(&invoke_context, activation_epoch_b, &clock)
             .unwrap()
             .unwrap()
             .stake()
@@ -6672,7 +6393,7 @@ mod tests {
         let fully_active_a = MergeKind::FullyActive(meta, stake_a);
         let fully_active_b = MergeKind::FullyActive(meta, stake_b);
         let new_stake = fully_active_a
-            .merge(&invoke_context, fully_active_b, None)
+            .merge(&invoke_context, fully_active_b, &clock)
             .unwrap()
             .unwrap()
             .stake()
@@ -6710,7 +6431,7 @@ mod tests {
         let fully_active_a = MergeKind::FullyActive(meta, stake_a);
         let fully_active_b = MergeKind::FullyActive(meta, stake_b);
         let new_stake = fully_active_a
-            .merge(&invoke_context, fully_active_b, None)
+            .merge(&invoke_context, fully_active_b, &clock)
             .unwrap()
             .unwrap()
             .stake()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -65,10 +65,6 @@ pub mod filter_stake_delegation_accounts {
     solana_sdk::declare_id!("GE7fRxmW46K6EmCD9AMZSbnaJ2e3LfqCZzdHi9hmYAgi");
 }
 
-pub mod stake_program_v3 {
-    solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
-}
-
 pub mod require_custodian_for_locked_stake_authorize {
     solana_sdk::declare_id!("D4jsDcXaqdW8tDAWn8H4R25Cdns2YwLneujSL1zvjW6R");
 }
@@ -83,10 +79,6 @@ pub mod warp_timestamp_again {
 
 pub mod check_init_vote_data {
     solana_sdk::declare_id!("3ccR6QpxGYsAbWyfevEtBNGfWV4xBffxRj2tD6A9i39F");
-}
-
-pub mod stake_program_v4 {
-    solana_sdk::declare_id!("Dc7djyhP9aLfdq2zktpvskeAjpG56msCU1yexpxXiWZb");
 }
 
 pub mod secp256k1_recover_syscall_enabled {
@@ -320,14 +312,12 @@ lazy_static! {
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
-        (stake_program_v3::id(), "solana_stake_program v3"),
         (require_custodian_for_locked_stake_authorize::id(), "require custodian to authorize withdrawer change for locked stake"),
         (spl_token_v2_self_transfer_fix::id(), "spl-token self-transfer fix"),
         (full_inflation::mainnet::certusone::enable::id(), "full inflation enabled by Certus One"),
         (full_inflation::mainnet::certusone::vote::id(), "community vote allowing Certus One to enable full inflation"),
         (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
         (check_init_vote_data::id(), "check initialized Vote data"),
-        (stake_program_v4::id(), "solana_stake_program v4"),
         (secp256k1_recover_syscall_enabled::id(), "secp256k1_recover syscall"),
         (system_transfer_zero_check::id(), "perform all checks for transfers of 0 lamports"),
         (blake3_syscall_enabled::id(), "blake3 syscall"),

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -464,13 +464,16 @@ mod tests {
         let custodian_keypair = Keypair::new();
         let custodian_pubkey = custodian_keypair.pubkey();
 
+        let withdrawer_keypair = Keypair::new();
+        let withdrawer_pubkey = withdrawer_keypair.pubkey();
+
         let message = new_stake_account(
             &fee_payer_pubkey,
             &funding_pubkey,
             &base_pubkey,
             lamports,
             &Pubkey::default(),
-            &Pubkey::default(),
+            &withdrawer_pubkey,
             &custodian_pubkey,
             0,
         );
@@ -483,16 +486,17 @@ mod tests {
         let lockups = get_lockups(&bank_client, &base_pubkey, 1);
         let messages = lockup_stake_accounts(
             &fee_payer_pubkey,
-            &custodian_pubkey,
+            &withdrawer_pubkey,
             &LockupArgs {
                 unix_timestamp: Some(1),
+                custodian: Some(custodian_pubkey),
                 ..LockupArgs::default()
             },
             &lockups,
             None,
         );
 
-        let signers = [&fee_payer_keypair, &custodian_keypair];
+        let signers = [&fee_payer_keypair, &withdrawer_keypair];
         for message in messages {
             bank_client
                 .send_and_confirm_message(&signers, message)
@@ -501,6 +505,7 @@ mod tests {
 
         let account = get_account_at(&bank_client, &base_pubkey, 0);
         let lockup = stake_state::lockup_from(&account).unwrap();
+        assert_eq!(lockup.custodian, custodian_pubkey);
         assert_eq!(lockup.unix_timestamp, 1);
         assert_eq!(lockup.epoch, 0);
 


### PR DESCRIPTION
Removing features for stake program v3 and v4. The v4 feature was activated back in June 2021 (slot [83376000](https://explorer.solana.com/block/83376000)), so I think they are safe to remove now.

By removing these feature, I was able to clean up some of the staking code paths, which I intend to be working on in subsequent PRs.
