### PR TITLE
Add sigverify options

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -143,7 +143,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = unbounded();
     let verifier = TransactionSigVerifier::default();
-    let stage = SigVerifyStage::new(packet_r, verified_s, verifier);
+    let stage = SigVerifyStage::new(packet_r, verified_s, verifier, 10_000, None);
 
     let use_same_tx = true;
     bencher.iter(move || {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -54,6 +54,13 @@ pub struct Tpu {
     tpu_quic_t: thread::JoinHandle<()>,
 }
 
+pub struct TpuConfig {
+    pub tpu_coalesce_ms: u64,
+    pub shred_version: u16,
+    pub tpu_sigverify_batch_size: usize,
+    pub tpu_packet_rate_per_second: Option<usize>,
+}
+
 impl Tpu {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -67,7 +74,6 @@ impl Tpu {
         blockstore: &Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
         exit: &Arc<AtomicBool>,
-        shred_version: u16,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         verified_vote_sender: VerifiedVoteSender,
@@ -75,10 +81,10 @@ impl Tpu {
         replay_vote_receiver: ReplayVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
         bank_notification_sender: Option<BankNotificationSender>,
-        tpu_coalesce_ms: u64,
         cluster_confirmed_slot_sender: GossipDuplicateConfirmedSlotsSender,
         cost_model: &Arc<RwLock<CostModel>>,
         keypair: &Keypair,
+        tpu_config: TpuConfig,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -87,6 +93,13 @@ impl Tpu {
             broadcast: broadcast_sockets,
             transactions_quic: transactions_quic_sockets,
         } = sockets;
+
+        let TpuConfig {
+            tpu_coalesce_ms,
+            shred_version,
+            tpu_sigverify_batch_size,
+            tpu_packet_rate_per_second,
+        } = tpu_config;
 
         let (packet_sender, packet_receiver) = unbounded();
         let (vote_packet_sender, vote_packet_receiver) = unbounded();
@@ -113,7 +126,13 @@ impl Tpu {
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::default();
-            SigVerifyStage::new(packet_receiver, verified_sender, verifier)
+            SigVerifyStage::new(
+                packet_receiver,
+                verified_sender,
+                verifier,
+                tpu_sigverify_batch_size,
+                tpu_packet_rate_per_second,
+            )
         };
 
         let (verified_tpu_vote_packets_sender, verified_tpu_vote_packets_receiver) = unbounded();
@@ -124,6 +143,8 @@ impl Tpu {
                 vote_packet_receiver,
                 verified_tpu_vote_packets_sender,
                 verifier,
+                tpu_sigverify_batch_size,
+                tpu_packet_rate_per_second,
             )
         };
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -21,7 +21,7 @@ use {
         rewards_recorder_service::RewardsRecorderSender,
         shred_fetch_stage::ShredFetchStage,
         sigverify_shreds::ShredSigVerifier,
-        sigverify_stage::SigVerifyStage,
+        sigverify_stage::{SigVerifyStage, MAX_SIGVERIFY_BATCH},
         tower_storage::TowerStorage,
         voting_service::VotingService,
     },
@@ -176,6 +176,8 @@ impl Tvu {
             fetch_receiver,
             verified_sender,
             ShredSigVerifier::new(bank_forks.clone(), leader_schedule_cache.clone()),
+            MAX_SIGVERIFY_BATCH,
+            None,
         );
 
         let cluster_slots = Arc::new(ClusterSlots::default());

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -13,11 +13,12 @@ use {
         serve_repair::ServeRepair,
         serve_repair_service::ServeRepairService,
         sigverify,
+        sigverify_stage::MAX_SIGVERIFY_BATCH,
         snapshot_packager_service::SnapshotPackagerService,
         stats_reporter_service::StatsReporterService,
         system_monitor_service::{verify_udp_stats_access, SystemMonitorService},
         tower_storage::TowerStorage,
-        tpu::{Tpu, TpuSockets, DEFAULT_TPU_COALESCE_MS},
+        tpu::{Tpu, TpuConfig, TpuSockets, DEFAULT_TPU_COALESCE_MS},
         tvu::{Tvu, TvuConfig, TvuSockets},
     },
     crossbeam_channel::{bounded, unbounded, Receiver},
@@ -165,6 +166,8 @@ pub struct ValidatorConfig {
     pub no_wait_for_vote_to_start_leader: bool,
     pub accounts_shrink_ratio: AccountShrinkThreshold,
     pub wait_to_vote_slot: Option<Slot>,
+    pub tpu_sigverify_batch_size: usize,
+    pub tpu_packet_rate_per_second: Option<usize>,
 }
 
 impl Default for ValidatorConfig {
@@ -225,6 +228,8 @@ impl Default for ValidatorConfig {
             accounts_shrink_ratio: AccountShrinkThreshold::default(),
             accounts_db_config: None,
             wait_to_vote_slot: None,
+            tpu_packet_rate_per_second: None,
+            tpu_sigverify_batch_size: MAX_SIGVERIFY_BATCH,
         }
     }
 }
@@ -879,6 +884,12 @@ impl Validator {
             config.wait_to_vote_slot,
         );
 
+        let tpu_config = TpuConfig {
+            tpu_coalesce_ms: config.tpu_coalesce_ms,
+            tpu_packet_rate_per_second: config.tpu_packet_rate_per_second,
+            tpu_sigverify_batch_size: config.tpu_sigverify_batch_size,
+            shred_version: node.info.shred_version,
+        };
         let tpu = Tpu::new(
             &cluster_info,
             &poh_recorder,
@@ -896,7 +907,6 @@ impl Validator {
             &blockstore,
             &config.broadcast_stage_type,
             &exit,
-            node.info.shred_version,
             vote_tracker,
             bank_forks.clone(),
             verified_vote_sender,
@@ -904,10 +914,10 @@ impl Validator {
             replay_vote_receiver,
             replay_vote_sender,
             bank_notification_sender,
-            config.tpu_coalesce_ms,
             cluster_confirmed_slot_sender,
             &cost_model,
             &identity_keypair,
+            tpu_config,
         );
 
         datapoint_info!("validator-new", ("id", id.to_string(), String));

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -62,6 +62,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_config: config.accounts_db_config.clone(),
         wait_to_vote_slot: config.wait_to_vote_slot,
+        tpu_packet_rate_per_second: config.tpu_packet_rate_per_second,
+        tpu_sigverify_batch_size: config.tpu_sigverify_batch_size,
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -23,6 +23,7 @@ use {
     },
     solana_core::{
         ledger_cleanup_service::{DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS},
+        sigverify_stage::MAX_SIGVERIFY_BATCH,
         system_monitor_service::SystemMonitorService,
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
@@ -419,6 +420,8 @@ pub fn main() {
         &format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1);
     let default_genesis_archive_unpacked_size = &MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string();
     let default_rpc_max_multiple_accounts = &MAX_MULTIPLE_ACCOUNTS.to_string();
+
+    let default_sigverify_batch_size = &MAX_SIGVERIFY_BATCH.to_string();
 
     let default_rpc_pubsub_max_active_subscriptions =
         PubSubConfig::default().max_active_subscriptions.to_string();
@@ -1375,6 +1378,27 @@ pub fn main() {
                 ),
         )
         .arg(
+            Arg::with_name("tpu_sigverify_batch_size")
+                .long("tpu-sigverify-batch-size")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .default_value(default_sigverify_batch_size)
+                .hidden(true)
+                .help(
+                    "Number of packets to sigverify at a time",
+                ),
+        )
+        .arg(
+            Arg::with_name("tpu_packet_rate_per_second")
+                .long("tpu-packet-rate-per-second")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .hidden(true)
+                .help(
+                    "Limit the TPU throughput by this many packets per second.",
+                ),
+        )
+        .arg(
             Arg::with_name("wal_recovery_mode")
                 .long("wal-recovery-mode")
                 .value_name("MODE")
@@ -1991,6 +2015,22 @@ pub fn main() {
         incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
     };
 
+    let tpu_packet_rate_per_second = value_t!(matches, "tpu_packet_rate_per_second", usize).ok();
+    if let Some(rate) = tpu_packet_rate_per_second {
+        const MIN_TPU_PACKET_RATE: usize = 2000;
+        if rate < MIN_TPU_PACKET_RATE {
+            eprintln!(
+                "TPU packet rate too low: {} minimum of {}",
+                rate, MIN_TPU_PACKET_RATE
+            );
+            exit(1);
+        }
+    }
+    let tpu_sigverify_batch_size = value_t_or_exit!(matches, "tpu_sigverify_batch_size", usize);
+    if !(2..=10_000_000).contains(&tpu_sigverify_batch_size) {
+        eprintln!("TPU batch size not in valid range of {{2, 10_000_000}}");
+        exit(1);
+    }
     let private_rpc = matches.is_present("private_rpc");
     let do_port_check = !matches.is_present("no_port_check");
     let no_rocksdb_compaction = true;
@@ -2338,6 +2378,8 @@ pub fn main() {
         tpu_coalesce_ms,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         accounts_shrink_ratio,
+        tpu_sigverify_batch_size,
+        tpu_packet_rate_per_second,
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

Options to control the sigverify batch size (and thus latency into banking-stage) and overall throughput could be handy.

#### Summary of Changes

Add options to control sigverify batch and throughput.

Fixes #
