### PR TITLE
Add timestamp zone toggle to Explorer

### DIFF
--- a/explorer/src/components/common/TimestampToggle.tsx
+++ b/explorer/src/components/common/TimestampToggle.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { displayTimestampUtc, displayTimestamp } from "utils/date";
+
+type State = "hide" | "show";
+
+function Tooltip({
+  state
+}: {
+  state: State
+}) {
+  const tooltip = {
+    maxWidth: "20rem"
+  }
+
+  if (state === "hide") return null;
+  return(
+    <div
+      className="popover bs-popover-bottom show"
+      style={tooltip}
+    >
+      <div className="arrow" />
+      <div className="popover-body">(Click to toggle between local and UTC)</div>
+    </div>
+  )
+}
+
+export function TimestampToggle({
+  unixTimestamp
+}: {
+  unixTimestamp: number
+}) {
+  const [isTimestampTypeUtc, toggleTimestampType] = useState(true)
+  const [showTooltip, toggleTooltip] = useState<State>("hide")
+
+  const toggle = () => {
+    toggleTimestampType(!isTimestampTypeUtc)
+  }
+
+  const tooltipContainer = {
+    cursor: "pointer"
+  }
+
+  return (
+    <div className="popover-container w-100" style={tooltipContainer}>
+      <span
+        onClick={toggle}
+        onMouseOver={() => toggleTooltip("show")}
+        onMouseOut={() => toggleTooltip("hide")}
+      >
+        {isTimestampTypeUtc === true ? displayTimestampUtc(unixTimestamp) : displayTimestamp(unixTimestamp)}
+      </span>
+      <Tooltip state={showTooltip} />
+    </div>
+  )
+}

--- a/explorer/src/components/common/TimestampToggle.tsx
+++ b/explorer/src/components/common/TimestampToggle.tsx
@@ -3,42 +3,33 @@ import { displayTimestampUtc, displayTimestamp } from "utils/date";
 
 type State = "hide" | "show";
 
-function Tooltip({
-  state
-}: {
-  state: State
-}) {
+function Tooltip({ state }: { state: State }) {
   const tooltip = {
-    maxWidth: "20rem"
-  }
+    maxWidth: "20rem",
+  };
 
   if (state === "hide") return null;
-  return(
-    <div
-      className="popover bs-popover-bottom show"
-      style={tooltip}
-    >
+  return (
+    <div className="popover bs-popover-bottom show" style={tooltip}>
       <div className="arrow" />
-      <div className="popover-body">(Click to toggle between local and UTC)</div>
+      <div className="popover-body">
+        (Click to toggle between local and UTC)
+      </div>
     </div>
-  )
+  );
 }
 
-export function TimestampToggle({
-  unixTimestamp
-}: {
-  unixTimestamp: number
-}) {
-  const [isTimestampTypeUtc, toggleTimestampType] = useState(true)
-  const [showTooltip, toggleTooltip] = useState<State>("hide")
+export function TimestampToggle({ unixTimestamp }: { unixTimestamp: number }) {
+  const [isTimestampTypeUtc, toggleTimestampType] = useState(true);
+  const [showTooltip, toggleTooltip] = useState<State>("hide");
 
   const toggle = () => {
-    toggleTimestampType(!isTimestampTypeUtc)
-  }
+    toggleTimestampType(!isTimestampTypeUtc);
+  };
 
   const tooltipContainer = {
-    cursor: "pointer"
-  }
+    cursor: "pointer",
+  };
 
   return (
     <div className="popover-container w-100" style={tooltipContainer}>
@@ -47,9 +38,11 @@ export function TimestampToggle({
         onMouseOver={() => toggleTooltip("show")}
         onMouseOut={() => toggleTooltip("hide")}
       >
-        {isTimestampTypeUtc === true ? displayTimestampUtc(unixTimestamp) : displayTimestamp(unixTimestamp)}
+        {isTimestampTypeUtc === true
+          ? displayTimestampUtc(unixTimestamp)
+          : displayTimestamp(unixTimestamp)}
       </span>
       <Tooltip state={showTooltip} />
     </div>
-  )
+  );
 }

--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -10,13 +10,14 @@ import {
 import { abbreviatedNumber, lamportsToSol, slotsToHumanString } from "utils";
 import { ClusterStatus, useCluster } from "providers/cluster";
 import { TpsCard } from "components/TpsCard";
-import { displayTimestampWithoutDate, displayTimestampUtc } from "utils/date";
+import { displayTimestampWithoutDate } from "utils/date";
 import { Status, useFetchSupply, useSupply } from "providers/supply";
 import { ErrorCard } from "components/common/ErrorCard";
 import { LoadingCard } from "components/common/LoadingCard";
 import { useVoteAccounts } from "providers/accounts/vote-accounts";
 import { CoingeckoStatus, useCoinGecko } from "utils/coingecko";
 import { Epoch } from "components/common/Epoch";
+import { TimestampToggle } from "components/common/TimestampToggle";
 
 const CLUSTER_STATS_TIMEOUT = 5000;
 
@@ -253,7 +254,7 @@ function StatsCardBody() {
         <tr>
           <td className="w-100">Cluster time</td>
           <td className="text-lg-end font-monospace">
-            {displayTimestampUtc(blockTime)}
+            <TimestampToggle unixTimestamp={blockTime}></TimestampToggle>
           </td>
         </tr>
       )}


### PR DESCRIPTION
#### Problem
Timestamps in the explorer are displayed in UTC zone, which isn't the right tool for all jobs
#### Summary of Changes
Added a component (`explorer/src/components/common/TimestampToggle.tsx`) that allows the toggle between UTC and local, and shows an informative tooltip
Currently only added it on the Cluster stats page but it can be re-used on any component 
```js
import { TimestampToggle } from "components/common/TimestampToggle";
...
<TimestampToggle unixTimestamp={blockTime}></TimestampToggle>
```

Fixes #21642
