### PR TITLE
Perf: Only check executors cache for executable bpf program ids

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3552,11 +3552,7 @@ impl Bank {
         let executable_keys: Vec<_> = accounts
             .iter()
             .filter_map(|(key, account)| {
-                if account.executable()
-                    && (account.owner() == &bpf_loader_upgradeable::id()
-                        || account.owner() == &bpf_loader_deprecated::id()
-                        || account.owner() == &bpf_loader::id())
-                {
+                if account.executable() && account.owner() != &native_loader::id() {
                     Some(key)
                 } else {
                     None

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13102,7 +13102,7 @@ pub(crate) mod tests {
 
         let accounts = &[
             (key1, executable_account.clone()),
-            (key2, executable_account.clone()),
+            (key2, executable_account),
         ];
 
         // add one to root bank


### PR DESCRIPTION
#### Problem
Metrics for executors cache misses are misleading because check every single transaction key against the cache

#### Summary of Changes
- Only check executable bpf program ids used in a given transaction against the executors cache
- Only grab a read lock executors cache read lock when a bpf program is being used (votes no longer grab the read lock for example)

Fixes #
