### PR TITLE
Elgamal pass

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4531,9 +4531,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -31,7 +31,7 @@ sha3 = "0.9"
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 subtle = "2"
 thiserror = "1"
-zeroize = { version = "1.2.0", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 time = "0.1.40"

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -593,7 +593,12 @@ mod tests {
         };
 
         assert_eq!(expected_instance, ElGamal::decrypt(&secret, &ciphertext));
-        assert_eq!(57_u32, secret.decrypt_u32_online(&ciphertext, &(*DECODE_U32_PRECOMPUTATION_FOR_G)).unwrap());
+        assert_eq!(
+            57_u32,
+            secret
+                .decrypt_u32_online(&ciphertext, &(*DECODE_U32_PRECOMPUTATION_FOR_G))
+                .unwrap()
+        );
     }
 
     #[test]

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -1,4 +1,17 @@
-//! TODO
+//! The twisted ElGamal encryption implementation.
+//!
+//! The message space consists of any number that is representable as a scalar (a.k.a. "exponent")
+//! for Curve25519. 
+//!
+//! A twisted ElGamal ciphertext consists of two components:
+//! - A Pedersen commitment that encodes a message to be encrypted
+//! - A "decryption handle" that binds the Pedersen opening to a specific public key
+//! In contrast to the traditional ElGamal encryption scheme, the twisted ElGamal encodes messages
+//! directly as a Pedersen commitment. Therefore, proof systems that are designed specifically for
+//! Pedersen commitments can be used on the twisted ElGamal ciphertexts.
+//!
+//! As the messages are encrypted as scalar elements (a.k.a. in the "exponent"), the encryption
+//! scheme requires solving discrete log to recover the original plaintext.
 
 use {
     crate::encryption::{

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -577,7 +577,7 @@ define_mul_variants!(LHS = DecryptHandle, RHS = Scalar, Output = DecryptHandle);
 mod tests {
     use {
         super::*,
-        crate::encryption::pedersen::Pedersen,
+        crate::encryption::{discrete_log::DECODE_U32_PRECOMPUTATION_FOR_G, pedersen::Pedersen},
         solana_sdk::{signature::Keypair, signer::null_signer::NullSigner},
     };
 
@@ -593,6 +593,7 @@ mod tests {
         };
 
         assert_eq!(expected_instance, ElGamal::decrypt(&secret, &ciphertext));
+        assert_eq!(57_u32, secret.decrypt_u32_online(&ciphertext, &(*DECODE_U32_PRECOMPUTATION_FOR_G)).unwrap());
     }
 
     #[test]

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -1,7 +1,7 @@
 //! The twisted ElGamal encryption implementation.
 //!
 //! The message space consists of any number that is representable as a scalar (a.k.a. "exponent")
-//! for Curve25519. 
+//! for Curve25519.
 //!
 //! A twisted ElGamal ciphertext consists of two components:
 //! - A Pedersen commitment that encodes a message to be encrypted

--- a/zk-token-sdk/src/encryption/mod.rs
+++ b/zk-token-sdk/src/encryption/mod.rs
@@ -1,3 +1,5 @@
+//! TODO: Description
+
 pub mod auth_encryption;
 pub mod discrete_log;
 pub mod elgamal;

--- a/zk-token-sdk/src/encryption/mod.rs
+++ b/zk-token-sdk/src/encryption/mod.rs
@@ -1,4 +1,14 @@
-//! TODO: Description
+//! Collection of encryption-related data structures and algorithms used in the Solana zk-token
+//! protocol.
+//!
+//! The module contains implementations of the following cryptographic objects:
+//! - Pedersen commitments that uses the prime-order Ristretto representation of Curve25519.
+//! [curve25519-dalek](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/ristretto/index.html)
+//! is used for the Ristretto group implementation.
+//! - The twisted ElGamal scheme, which converts Pedersen commitments into a public-key encryption
+//! scheme.
+//! - Basic type-wrapper around the AES-GCM-SIV symmetric authenticated encryption scheme
+//! implemented by [aes-gcm-siv](https://docs.rs/aes-gcm-siv/latest/aes_gcm_siv/) crate.
 
 pub mod auth_encryption;
 pub mod discrete_log;

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -15,13 +15,11 @@ use {
     zeroize::Zeroize,
 };
 
-/// Curve basepoints for which Pedersen commitment is defined over.
-///
-/// The point `G` should be used to encode the message to be committed.
-/// The point `H` should be used to encode the Pedersen opening value.
-pub static G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
-pub static H: RistrettoPoint =
-    RistrettoPoint::hash_from_bytes::<Sha3_512>(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+lazy_static::lazy_static!{
+    pub static ref G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
+    pub static ref H: RistrettoPoint =
+        RistrettoPoint::hash_from_bytes::<Sha3_512>(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+}
 
 /// Algorithm handle for the Pedersen commitment scheme.
 pub struct Pedersen;
@@ -48,7 +46,7 @@ impl Pedersen {
         let x: Scalar = amount.into();
         let r = open.get_scalar();
 
-        PedersenCommitment(RistrettoPoint::multiscalar_mul(&[x, *r], &[G, H]))
+        PedersenCommitment(RistrettoPoint::multiscalar_mul(&[x, *r], &[*G, *H]))
     }
 }
 
@@ -145,11 +143,6 @@ pub struct PedersenCommitment(pub(crate) RistrettoPoint);
 impl PedersenCommitment {
     pub fn get_point(&self) -> &RistrettoPoint {
         &self.0
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        self.0.compress().as_bytes()
     }
 
     #[allow(clippy::wrong_self_convention)]

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -55,7 +55,7 @@ impl Pedersen {
 /// Pedersen opening type.
 ///
 /// Instances of Pedersen openings are zeroized on drop.
-#[derive(Clone, Debug, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
 pub struct PedersenOpening(pub(crate) Scalar);
 impl PedersenOpening {

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -35,7 +35,7 @@ impl Pedersen {
     #[cfg(not(target_arch = "bpf"))]
     #[allow(clippy::new_ret_no_self)]
     pub fn new<T: Into<Scalar>>(message: T) -> (PedersenCommitment, PedersenOpening) {
-        let opening = PedersenOpening::random();
+        let opening = PedersenOpening::new_rand();
         let commitment = Pedersen::with(message, &opening);
 
         (commitment, opening)
@@ -66,7 +66,7 @@ impl PedersenOpening {
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    pub fn random() -> Self {
+    pub fn new_rand() -> Self {
         PedersenOpening(Scalar::random(&mut OsRng))
     }
 

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -16,7 +16,9 @@ use {
 };
 
 lazy_static::lazy_static!{
+    /// Pedersen base point for encoding messages to be committed.
     pub static ref G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
+    /// Pedersen base point for encoding the commitment openings.
     pub static ref H: RistrettoPoint =
         RistrettoPoint::hash_from_bytes::<Sha3_512>(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
 }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -1,3 +1,5 @@
+//! Pedersen commitment implementation using the Ristretto prime-order group.
+
 #[cfg(not(target_arch = "bpf"))]
 use rand::rngs::OsRng;
 use {

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -18,51 +18,34 @@ use {
 
 /// Curve basepoints for which Pedersen commitment is defined over.
 ///
-/// These points should be fixed for the entire system.
-/// TODO: Consider setting these points as constants?
-#[allow(non_snake_case)]
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PedersenBase {
-    pub G: RistrettoPoint,
-    pub H: RistrettoPoint,
-}
-/// Default PedersenBase. This is set arbitrarily for now, but it should be fixed
-/// for the entire system.
-///
-/// `G` is a constant point in the curve25519_dalek library
-/// `H` is the Sha3 hash of `G` interpretted as a RistrettoPoint
-impl Default for PedersenBase {
-    #[allow(non_snake_case)]
-    fn default() -> PedersenBase {
-        let G = RISTRETTO_BASEPOINT_POINT;
-        let H =
-            RistrettoPoint::hash_from_bytes::<Sha3_512>(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
+/// The point `G` should be used to encode the message to be committed.
+/// The point `H` should be used to encode the Pedersen opening value.
+pub static G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
+pub static H: RistrettoPoint =
+    RistrettoPoint::hash_from_bytes::<Sha3_512>(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
 
-        PedersenBase { G, H }
-    }
-}
-
-/// Handle for the Pedersen commitment scheme
+/// Algorithm handle for the Pedersen commitment scheme.
 pub struct Pedersen;
 impl Pedersen {
-    /// Given a number as input, the function returns a Pedersen commitment of
-    /// the number and its corresponding opening.
+    /// On input a message, the function returns a Pedersen commitment of the message and the
+    /// corresponding opening.
+    ///
+    /// This function is randomized. It internally samples a Pedersen opening using `OsRng`.
     #[cfg(not(target_arch = "bpf"))]
     #[allow(clippy::new_ret_no_self)]
-    pub fn new<T: Into<Scalar>>(amount: T) -> (PedersenCommitment, PedersenOpening) {
-        let open = PedersenOpening(Scalar::random(&mut OsRng));
-        let comm = Pedersen::with(amount, &open);
+    pub fn new<T: Into<Scalar>>(message: T) -> (PedersenCommitment, PedersenOpening) {
+        let opening = PedersenOpening::random();
+        let commitment = Pedersen::with(message, &opening);
 
-        (comm, open)
+        (commitment, opening)
     }
 
-    /// Given a number and an opening as inputs, the function returns their
-    /// Pedersen commitment.
+    /// On input a message and a Pedersen opening, the function returns the corresponding Pedersen
+    /// commitment.
+    ///
+    /// This function is deterministic.
     #[allow(non_snake_case)]
     pub fn with<T: Into<Scalar>>(amount: T, open: &PedersenOpening) -> PedersenCommitment {
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let x: Scalar = amount.into();
         let r = open.get_scalar();
 
@@ -70,7 +53,10 @@ impl Pedersen {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, Zeroize)]
+/// Pedersen opening type.
+///
+/// Instances of Pedersen openings are zeroized on drop.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
 pub struct PedersenOpening(pub(crate) Scalar);
 impl PedersenOpening {
@@ -79,8 +65,8 @@ impl PedersenOpening {
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    pub fn random<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        PedersenOpening(Scalar::random(rng))
+    pub fn random() -> Self {
+        PedersenOpening(Scalar::random(&mut OsRng))
     }
 
     #[allow(clippy::wrong_self_convention)]
@@ -111,7 +97,7 @@ impl<'a, 'b> Add<&'b PedersenOpening> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
     fn add(self, other: &'b PedersenOpening) -> PedersenOpening {
-        PedersenOpening(self.get_scalar() + other.get_scalar())
+        PedersenOpening(&self.0 + &other.0)
     }
 }
 
@@ -125,7 +111,7 @@ impl<'a, 'b> Sub<&'b PedersenOpening> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
     fn sub(self, other: &'b PedersenOpening) -> PedersenOpening {
-        PedersenOpening(self.get_scalar() - other.get_scalar())
+        PedersenOpening(&self.0 - &other.0)
     }
 }
 
@@ -139,7 +125,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
     fn mul(self, other: &'b Scalar) -> PedersenOpening {
-        PedersenOpening(self.get_scalar() * other)
+        PedersenOpening(&self.0 * other)
     }
 }
 
@@ -149,22 +135,8 @@ define_mul_variants!(
     Output = PedersenOpening
 );
 
-impl<'a, 'b> Div<&'b Scalar> for &'a PedersenOpening {
-    type Output = PedersenOpening;
-
-    #[allow(clippy::suspicious_arithmetic_impl)]
-    fn div(self, other: &'b Scalar) -> PedersenOpening {
-        PedersenOpening(self.get_scalar() * other.invert())
-    }
-}
-
-define_div_variants!(
-    LHS = PedersenOpening,
-    RHS = Scalar,
-    Output = PedersenOpening
-);
-
-#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, Eq, PartialEq)]
+/// Pedersen commitment type.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PedersenCommitment(pub(crate) RistrettoPoint);
 impl PedersenCommitment {
     pub fn get_point(&self) -> RistrettoPoint {
@@ -187,7 +159,7 @@ impl<'a, 'b> Add<&'b PedersenCommitment> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn add(self, other: &'b PedersenCommitment) -> PedersenCommitment {
-        PedersenCommitment(self.get_point() + other.get_point())
+        PedersenCommitment(&self.0 + &other.0)
     }
 }
 
@@ -201,7 +173,7 @@ impl<'a, 'b> Sub<&'b PedersenCommitment> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn sub(self, other: &'b PedersenCommitment) -> PedersenCommitment {
-        PedersenCommitment(self.get_point() - other.get_point())
+        PedersenCommitment(&self.0 - &other.0)
     }
 }
 
@@ -215,7 +187,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
     fn mul(self, other: &'b Scalar) -> PedersenCommitment {
-        PedersenCommitment(self.get_point() * other)
+        PedersenCommitment(&self.0 * other)
     }
 }
 
@@ -223,105 +195,6 @@ define_mul_variants!(
     LHS = PedersenCommitment,
     RHS = Scalar,
     Output = PedersenCommitment
-);
-
-impl<'a, 'b> Div<&'b Scalar> for &'a PedersenCommitment {
-    type Output = PedersenCommitment;
-
-    #[allow(clippy::suspicious_arithmetic_impl)]
-    fn div(self, other: &'b Scalar) -> PedersenCommitment {
-        PedersenCommitment(self.get_point() * other.invert())
-    }
-}
-
-define_div_variants!(
-    LHS = PedersenCommitment,
-    RHS = Scalar,
-    Output = PedersenCommitment
-);
-
-/// Decryption handle for Pedersen commitment.
-///
-/// A decryption handle can be combined with Pedersen commitments to form an
-/// ElGamal ciphertext.
-#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PedersenDecryptHandle(pub(crate) RistrettoPoint);
-impl PedersenDecryptHandle {
-    pub fn new(pk: &ElGamalPubkey, open: &PedersenOpening) -> Self {
-        Self(pk.get_point() * open.get_scalar())
-    }
-
-    pub fn get_point(&self) -> RistrettoPoint {
-        self.0
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_bytes(&self) -> [u8; 32] {
-        self.0.compress().to_bytes()
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Option<PedersenDecryptHandle> {
-        Some(PedersenDecryptHandle(
-            CompressedRistretto::from_slice(bytes).decompress()?,
-        ))
-    }
-}
-
-impl<'a, 'b> Add<&'b PedersenDecryptHandle> for &'a PedersenDecryptHandle {
-    type Output = PedersenDecryptHandle;
-
-    fn add(self, other: &'b PedersenDecryptHandle) -> PedersenDecryptHandle {
-        PedersenDecryptHandle(self.get_point() + other.get_point())
-    }
-}
-
-define_add_variants!(
-    LHS = PedersenDecryptHandle,
-    RHS = PedersenDecryptHandle,
-    Output = PedersenDecryptHandle
-);
-
-impl<'a, 'b> Sub<&'b PedersenDecryptHandle> for &'a PedersenDecryptHandle {
-    type Output = PedersenDecryptHandle;
-
-    fn sub(self, other: &'b PedersenDecryptHandle) -> PedersenDecryptHandle {
-        PedersenDecryptHandle(self.get_point() - other.get_point())
-    }
-}
-
-define_sub_variants!(
-    LHS = PedersenDecryptHandle,
-    RHS = PedersenDecryptHandle,
-    Output = PedersenDecryptHandle
-);
-
-impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenDecryptHandle {
-    type Output = PedersenDecryptHandle;
-
-    fn mul(self, other: &'b Scalar) -> PedersenDecryptHandle {
-        PedersenDecryptHandle(self.get_point() * other)
-    }
-}
-
-define_mul_variants!(
-    LHS = PedersenDecryptHandle,
-    RHS = Scalar,
-    Output = PedersenDecryptHandle
-);
-
-impl<'a, 'b> Div<&'b Scalar> for &'a PedersenDecryptHandle {
-    type Output = PedersenDecryptHandle;
-
-    #[allow(clippy::suspicious_arithmetic_impl)]
-    fn div(self, other: &'b Scalar) -> PedersenDecryptHandle {
-        PedersenDecryptHandle(self.get_point() * other.invert())
-    }
-}
-
-define_div_variants!(
-    LHS = PedersenDecryptHandle,
-    RHS = Scalar,
-    Output = PedersenDecryptHandle
 );
 
 #[cfg(test)]
@@ -329,7 +202,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_homomorphic_addition() {
+    fn test_pedersen_homomorphic_addition() {
         let amt_0: u64 = 77;
         let amt_1: u64 = 57;
 
@@ -345,7 +218,7 @@ mod tests {
     }
 
     #[test]
-    fn test_homomorphic_subtraction() {
+    fn test_pedersen_homomorphic_subtraction() {
         let amt_0: u64 = 77;
         let amt_1: u64 = 57;
 
@@ -361,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn test_homomorphic_multiplication() {
+    fn test_pedersen_homomorphic_multiplication() {
         let amt_0: u64 = 77;
         let amt_1: u64 = 57;
 
@@ -373,19 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn test_homomorphic_division() {
-        let amt_0: u64 = 77;
-        let amt_1: u64 = 7;
-
-        let (comm, open) = Pedersen::new(amt_0);
-        let scalar = Scalar::from(amt_1);
-        let comm_addition = Pedersen::with(amt_0 / amt_1, &(open / scalar));
-
-        assert_eq!(comm_addition, comm / scalar);
-    }
-
-    #[test]
-    fn test_commitment_bytes() {
+    fn test_pedersen_commitment_bytes() {
         let amt: u64 = 77;
         let (comm, _) = Pedersen::new(amt);
 
@@ -396,7 +257,7 @@ mod tests {
     }
 
     #[test]
-    fn test_opening_bytes() {
+    fn test_pedersen_opening_bytes() {
         let open = PedersenOpening(Scalar::random(&mut OsRng));
 
         let encoded = open.to_bytes();
@@ -406,17 +267,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decrypt_handle_bytes() {
-        let handle = PedersenDecryptHandle(RistrettoPoint::default());
-
-        let encoded = handle.to_bytes();
-        let decoded = PedersenDecryptHandle::from_bytes(&encoded).unwrap();
-
-        assert_eq!(handle, decoded);
-    }
-
-    #[test]
-    fn test_serde_commitment() {
+    fn test_serde_pedersen_commitment() {
         let amt: u64 = 77;
         let (comm, _) = Pedersen::new(amt);
 
@@ -427,22 +278,12 @@ mod tests {
     }
 
     #[test]
-    fn test_serde_opening() {
+    fn test_serde_pedersen_opening() {
         let open = PedersenOpening(Scalar::random(&mut OsRng));
 
         let encoded = bincode::serialize(&open).unwrap();
         let decoded: PedersenOpening = bincode::deserialize(&encoded).unwrap();
 
         assert_eq!(open, decoded);
-    }
-
-    #[test]
-    fn test_serde_decrypt_handle() {
-        let handle = PedersenDecryptHandle(RistrettoPoint::default());
-
-        let encoded = bincode::serialize(&handle).unwrap();
-        let decoded: PedersenDecryptHandle = bincode::deserialize(&encoded).unwrap();
-
-        assert_eq!(handle, decoded);
     }
 }

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -15,7 +15,7 @@ use {
     zeroize::Zeroize,
 };
 
-lazy_static::lazy_static!{
+lazy_static::lazy_static! {
     /// Pedersen base point for encoding messages to be committed.
     pub static ref G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
     /// Pedersen base point for encoding the commitment openings.

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -109,14 +109,14 @@ mod test {
     use {
         super::*,
         crate::encryption::{
-            elgamal::ElGamalKeypair,
-            pedersen::{Pedersen, PedersenDecryptHandle, PedersenOpening},
+            elgamal::{DecryptHandle, ElGamalKeypair},
+            pedersen::{Pedersen, PedersenOpening},
         },
     };
 
     #[test]
     fn test_close_account_correctness() {
-        let source_keypair = ElGamalKeypair::default();
+        let source_keypair = ElGamalKeypair::random();
 
         // general case: encryption of 0
         let balance = source_keypair.public.encrypt(0_u64);
@@ -135,11 +135,11 @@ mod test {
 
         // edge cases: only C or D is zero - such ciphertext is always invalid
         let zeroed_comm = Pedersen::with(0_u64, &PedersenOpening::default());
-        let handle = balance.decrypt_handle;
+        let handle = balance.handle;
 
         let zeroed_comm_ciphertext = ElGamalCiphertext {
-            message_comm: zeroed_comm,
-            decrypt_handle: handle,
+            commitment: zeroed_comm,
+            handle,
         };
 
         let proof = CloseAccountProof::new(&source_keypair, &zeroed_comm_ciphertext);
@@ -148,8 +148,8 @@ mod test {
             .is_err());
 
         let zeroed_handle_ciphertext = ElGamalCiphertext {
-            message_comm: balance.message_comm,
-            decrypt_handle: PedersenDecryptHandle::default(),
+            commitment: balance.commitment,
+            handle: DecryptHandle::default(),
         };
 
         let proof = CloseAccountProof::new(&source_keypair, &zeroed_handle_ciphertext);

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -116,7 +116,7 @@ mod test {
 
     #[test]
     fn test_close_account_correctness() {
-        let source_keypair = ElGamalKeypair::random();
+        let source_keypair = ElGamalKeypair::new_rand();
 
         // general case: encryption of 0
         let balance = source_keypair.public.encrypt(0_u64);

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -7,7 +7,9 @@ use {
     crate::{
         encryption::{
             discrete_log::*,
-            elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
+            elgamal::{
+                DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey,
+            },
             pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
         },
         errors::ProofError,
@@ -470,10 +472,7 @@ pub fn combine_u32_comms(
 }
 
 #[cfg(not(target_arch = "bpf"))]
-pub fn combine_u32_handles(
-    handle_lo: DecryptHandle,
-    handle_hi: DecryptHandle,
-) -> DecryptHandle {
+pub fn combine_u32_handles(handle_lo: DecryptHandle, handle_hi: DecryptHandle) -> DecryptHandle {
     handle_lo + handle_hi * Scalar::from(TWO_32)
 }
 

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -7,8 +7,8 @@ use {
     crate::{
         encryption::{
             discrete_log::*,
-            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
-            pedersen::{Pedersen, PedersenCommitment, PedersenDecryptHandle, PedersenOpening},
+            elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
+            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
         },
         errors::ProofError,
         instruction::{Role, Verifiable},
@@ -128,8 +128,8 @@ impl TransferData {
         };
 
         // subtract transfer amount from the spendable ciphertext
-        let spendable_comm = spendable_balance_ciphertext.message_comm;
-        let spendable_handle = spendable_balance_ciphertext.decrypt_handle;
+        let spendable_comm = spendable_balance_ciphertext.commitment;
+        let spendable_handle = spendable_balance_ciphertext.handle;
 
         let new_spendable_balance = spendable_balance - transfer_amount;
         let new_spendable_comm = spendable_comm - combine_u32_comms(comm_lo, comm_hi);
@@ -137,8 +137,8 @@ impl TransferData {
             spendable_handle - combine_u32_handles(handle_source_lo, handle_source_hi);
 
         let new_spendable_ct = ElGamalCiphertext {
-            message_comm: new_spendable_comm,
-            decrypt_handle: new_spendable_handle,
+            commitment: new_spendable_comm,
+            handle: new_spendable_handle,
         };
 
         // range_proof and validity_proof should be generated together
@@ -172,7 +172,10 @@ impl TransferData {
         }
         .try_into()?;
 
-        Ok((transfer_comm_lo, decryption_handle_lo).into())
+        Ok(ElGamalCiphertext {
+            commitment: transfer_comm_lo,
+            handle: decryption_handle_lo,
+        })
     }
 
     /// Extracts the lo ciphertexts associated with a transfer data
@@ -187,7 +190,10 @@ impl TransferData {
         }
         .try_into()?;
 
-        Ok((transfer_comm_hi, decryption_handle_hi).into())
+        Ok(ElGamalCiphertext {
+            commitment: transfer_comm_hi,
+            handle: decryption_handle_hi,
+        })
     }
 
     /// Decrypts transfer amount from transfer data
@@ -274,8 +280,8 @@ impl TransferProof {
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_EG = source_keypair.public.get_point();
-        let C_EG = source_new_balance_ct.message_comm.get_point();
-        let D_EG = source_new_balance_ct.decrypt_handle.get_point();
+        let C_EG = source_new_balance_ct.commitment.get_point();
+        let D_EG = source_new_balance_ct.handle.get_point();
         let C_Ped = source_commitment.get_point();
 
         // append all current state to the transcript
@@ -339,8 +345,8 @@ impl TransferProof {
         let new_spendable_ct: ElGamalCiphertext = (*new_spendable_ct).try_into()?;
 
         let P_EG = source_pk.get_point();
-        let C_EG = new_spendable_ct.message_comm.get_point();
-        let D_EG = new_spendable_ct.decrypt_handle.get_point();
+        let C_EG = new_spendable_ct.commitment.get_point();
+        let D_EG = new_spendable_ct.handle.get_point();
         let C_Ped = commitment.get_point();
 
         // append all current state to the transcript
@@ -361,11 +367,11 @@ impl TransferProof {
         let amount_comm_lo: PedersenCommitment = amount_comms.lo.try_into()?;
         let amount_comm_hi: PedersenCommitment = amount_comms.hi.try_into()?;
 
-        let handle_lo_dest: PedersenDecryptHandle = decryption_handles_lo.dest.try_into()?;
-        let handle_hi_dest: PedersenDecryptHandle = decryption_handles_hi.dest.try_into()?;
+        let handle_lo_dest: DecryptHandle = decryption_handles_lo.dest.try_into()?;
+        let handle_hi_dest: DecryptHandle = decryption_handles_hi.dest.try_into()?;
 
-        let handle_lo_auditor: PedersenDecryptHandle = decryption_handles_lo.auditor.try_into()?;
-        let handle_hi_auditor: PedersenDecryptHandle = decryption_handles_hi.auditor.try_into()?;
+        let handle_lo_auditor: DecryptHandle = decryption_handles_lo.auditor.try_into()?;
+        let handle_hi_auditor: DecryptHandle = decryption_handles_hi.auditor.try_into()?;
 
         // TODO: validity proof
         validity_proof.verify(
@@ -419,9 +425,9 @@ pub struct EncryptedTransferAmount {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferDecryptHandles {
-    pub source: pod::PedersenDecryptHandle,  // 32 bytes
-    pub dest: pod::PedersenDecryptHandle,    // 32 bytes
-    pub auditor: pod::PedersenDecryptHandle, // 32 bytes
+    pub source: pod::DecryptHandle,  // 32 bytes
+    pub dest: pod::DecryptHandle,    // 32 bytes
+    pub auditor: pod::DecryptHandle, // 32 bytes
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -437,9 +443,9 @@ pub struct EncryptedTransferFee {
     /// The transfer fee commitment
     pub fee_comm: pod::PedersenCommitment,
     /// The decryption handle for destination ElGamal pubkey
-    pub decrypt_handle_dest: pod::PedersenDecryptHandle,
+    pub decrypt_handle_dest: pod::DecryptHandle,
     /// The decryption handle for fee collector ElGamal pubkey
-    pub decrypt_handle_fee_collector: pod::PedersenDecryptHandle,
+    pub decrypt_handle_fee_collector: pod::DecryptHandle,
 }
 
 /// Split u64 number into two u32 numbers
@@ -465,9 +471,9 @@ pub fn combine_u32_comms(
 
 #[cfg(not(target_arch = "bpf"))]
 pub fn combine_u32_handles(
-    handle_lo: PedersenDecryptHandle,
-    handle_hi: PedersenDecryptHandle,
-) -> PedersenDecryptHandle {
+    handle_lo: DecryptHandle,
+    handle_hi: DecryptHandle,
+) -> DecryptHandle {
     handle_lo + handle_hi * Scalar::from(TWO_32)
 }
 
@@ -483,9 +489,9 @@ mod test {
     #[test]
     fn test_transfer_correctness() {
         // ElGamalKeypair keys for source, destination, and auditor accounts
-        let source_keypair = ElGamalKeypair::default();
-        let dest_pk = ElGamalKeypair::default().public;
-        let auditor_pk = ElGamalKeypair::default().public;
+        let source_keypair = ElGamalKeypair::random();
+        let dest_pk = ElGamalKeypair::random().public;
+        let auditor_pk = ElGamalKeypair::random().public;
 
         // create source account spendable ciphertext
         let spendable_balance: u64 = 77;
@@ -510,17 +516,17 @@ mod test {
     #[test]
     fn test_source_dest_ciphertext() {
         // ElGamalKeypair keys for source, destination, and auditor accounts
-        let source_keypair = ElGamalKeypair::default();
+        let source_keypair = ElGamalKeypair::random();
 
         let ElGamalKeypair {
             public: dest_pk,
             secret: dest_sk,
-        } = ElGamalKeypair::default();
+        } = ElGamalKeypair::random();
 
         let ElGamalKeypair {
             public: auditor_pk,
             secret: auditor_sk,
-        } = ElGamalKeypair::default();
+        } = ElGamalKeypair::random();
 
         // create source account spendable ciphertext
         let spendable_balance: u64 = 77;

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -488,9 +488,9 @@ mod test {
     #[test]
     fn test_transfer_correctness() {
         // ElGamalKeypair keys for source, destination, and auditor accounts
-        let source_keypair = ElGamalKeypair::random();
-        let dest_pk = ElGamalKeypair::random().public;
-        let auditor_pk = ElGamalKeypair::random().public;
+        let source_keypair = ElGamalKeypair::new_rand();
+        let dest_pk = ElGamalKeypair::new_rand().public;
+        let auditor_pk = ElGamalKeypair::new_rand().public;
 
         // create source account spendable ciphertext
         let spendable_balance: u64 = 77;
@@ -515,17 +515,17 @@ mod test {
     #[test]
     fn test_source_dest_ciphertext() {
         // ElGamalKeypair keys for source, destination, and auditor accounts
-        let source_keypair = ElGamalKeypair::random();
+        let source_keypair = ElGamalKeypair::new_rand();
 
         let ElGamalKeypair {
             public: dest_pk,
             secret: dest_sk,
-        } = ElGamalKeypair::random();
+        } = ElGamalKeypair::new_rand();
 
         let ElGamalKeypair {
             public: auditor_pk,
             secret: auditor_sk,
-        } = ElGamalKeypair::random();
+        } = ElGamalKeypair::new_rand();
 
         // create source account spendable ciphertext
         let spendable_balance: u64 = 77;

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -117,8 +117,8 @@ impl WithdrawProof {
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_EG = source_keypair.public.get_point();
-        let C_EG = final_balance_ct.message_comm.get_point();
-        let D_EG = final_balance_ct.decrypt_handle.get_point();
+        let C_EG = final_balance_ct.commitment.get_point();
+        let D_EG = final_balance_ct.handle.get_point();
         let C_Ped = commitment.get_point();
 
         // append all current state to the transcript
@@ -166,8 +166,8 @@ impl WithdrawProof {
 
         // extract the relevant scalar and Ristretto points from the inputs
         let P_EG = source_pk.get_point();
-        let C_EG = final_balance_ct.message_comm.get_point();
-        let D_EG = final_balance_ct.decrypt_handle.get_point();
+        let C_EG = final_balance_ct.commitment.get_point();
+        let D_EG = final_balance_ct.handle.get_point();
         let C_Ped = commitment.get_point();
 
         // append all current state to the transcript
@@ -201,7 +201,7 @@ mod test {
     #[test]
     fn test_withdraw_correctness() {
         // generate and verify proof for the proper setting
-        let elgamal_keypair = ElGamalKeypair::default();
+        let elgamal_keypair = ElGamalKeypair::random();
 
         let current_balance: u64 = 77;
         let current_balance_ct = elgamal_keypair.public.encrypt(current_balance);

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -201,7 +201,7 @@ mod test {
     #[test]
     fn test_withdraw_correctness() {
         // generate and verify proof for the proper setting
-        let elgamal_keypair = ElGamalKeypair::random();
+        let elgamal_keypair = ElGamalKeypair::new_rand();
 
         let current_balance: u64 = 77;
         let current_balance_ct = elgamal_keypair.public.encrypt(current_balance);

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,4 +1,21 @@
-#![allow(clippy::op_ref)]
+#![allow(clippy::integer_arithmetic, clippy::op_ref)]
+
+// The warning `clippy::op_ref` is disabled to allow efficient operator arithmetic of structs that
+// implement the `Copy` trait.
+//
+// ```
+// let opening_0: PedersenOpening = PedersenOpening::new_rand();
+// let opening_1: PedersenOpening = PedersenOpening::new_rand();
+//
+// // since PedersenOpening implement `Copy`, `opening_0` and `opening_1` will be copied as
+// // parameters before `opening_sum` is computed.
+// let opening_sum = opening_0 + opening_1;
+//
+// // if passed in as references, the extra copies will not occur
+// let opening_sum = &opening_0 + &opening_1;
+// ```
+//
+// `clippy::op_ref` is turned off to prevent clippy from warning that this is not idiomatic code.
 
 #[cfg(not(target_arch = "bpf"))]
 #[macro_use]

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -5,16 +5,16 @@
 pub(crate) mod macros;
 #[cfg(not(target_arch = "bpf"))]
 pub mod encryption;
-#[cfg(not(target_arch = "bpf"))]
-mod errors;
-#[cfg(not(target_arch = "bpf"))]
-mod range_proof;
-#[cfg(not(target_arch = "bpf"))]
-mod sigma_proofs;
-#[cfg(not(target_arch = "bpf"))]
-mod transcript;
+// #[cfg(not(target_arch = "bpf"))]
+// mod errors;
+// #[cfg(not(target_arch = "bpf"))]
+// mod range_proof;
+// #[cfg(not(target_arch = "bpf"))]
+// mod sigma_proofs;
+// #[cfg(not(target_arch = "bpf"))]
+// mod transcript;
 
-mod instruction;
-pub mod zk_token_elgamal;
-pub mod zk_token_proof_instruction;
-pub mod zk_token_proof_program;
+// mod instruction;
+// pub mod zk_token_elgamal;
+// pub mod zk_token_proof_instruction;
+// pub mod zk_token_proof_program;

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::op_ref)]
 
 #[cfg(not(target_arch = "bpf"))]
 #[macro_use]

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -5,16 +5,16 @@
 pub(crate) mod macros;
 #[cfg(not(target_arch = "bpf"))]
 pub mod encryption;
-// #[cfg(not(target_arch = "bpf"))]
-// mod errors;
-// #[cfg(not(target_arch = "bpf"))]
-// mod range_proof;
-// #[cfg(not(target_arch = "bpf"))]
-// mod sigma_proofs;
-// #[cfg(not(target_arch = "bpf"))]
-// mod transcript;
+#[cfg(not(target_arch = "bpf"))]
+mod errors;
+#[cfg(not(target_arch = "bpf"))]
+mod range_proof;
+#[cfg(not(target_arch = "bpf"))]
+mod sigma_proofs;
+#[cfg(not(target_arch = "bpf"))]
+mod transcript;
 
-// mod instruction;
-// pub mod zk_token_elgamal;
-// pub mod zk_token_proof_instruction;
-// pub mod zk_token_proof_program;
+mod instruction;
+pub mod zk_token_elgamal;
+pub mod zk_token_proof_instruction;
+pub mod zk_token_proof_program;

--- a/zk-token-sdk/src/macros.rs
+++ b/zk-token-sdk/src/macros.rs
@@ -74,4 +74,3 @@ macro_rules! define_mul_variants {
         }
     };
 }
-

--- a/zk-token-sdk/src/macros.rs
+++ b/zk-token-sdk/src/macros.rs
@@ -75,27 +75,3 @@ macro_rules! define_mul_variants {
     };
 }
 
-macro_rules! define_div_variants {
-    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
-        impl<'b> Div<&'b $rhs> for $lhs {
-            type Output = $out;
-            fn div(self, rhs: &'b $rhs) -> $out {
-                &self / rhs
-            }
-        }
-
-        impl<'a> Div<$rhs> for &'a $lhs {
-            type Output = $out;
-            fn div(self, rhs: $rhs) -> $out {
-                self / &rhs
-            }
-        }
-
-        impl Div<$rhs> for $lhs {
-            type Output = $out;
-            fn div(self, rhs: $rhs) -> $out {
-                &self / &rhs
-            }
-        }
-    };
-}

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -2,7 +2,7 @@
 use {
     crate::encryption::{
         elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-        pedersen::{G, H, PedersenCommitment, PedersenOpening},
+        pedersen::{PedersenCommitment, PedersenOpening, G, H},
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -121,7 +121,19 @@ impl EqualityProof {
                 -ww * c,
                 -ww,
             ],
-            vec![P_EG, &(*H), &Y_0, &(*G), D_EG, C_EG, &Y_1, &(*G), &(*H), C_Ped, &Y_2],
+            vec![
+                P_EG,
+                &(*H),
+                &Y_0,
+                &(*G),
+                D_EG,
+                C_EG,
+                &Y_1,
+                &(*G),
+                &(*H),
+                C_Ped,
+                &Y_2,
+            ],
         );
 
         if check.is_identity() {

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -185,7 +185,7 @@ mod test {
     #[test]
     fn test_equality_proof() {
         // success case
-        let elgamal_keypair = ElGamalKeypair::random();
+        let elgamal_keypair = ElGamalKeypair::new_rand();
         let message: u64 = 55;
 
         let ciphertext = elgamal_keypair.public.encrypt(message);
@@ -212,7 +212,7 @@ mod test {
             .is_ok());
 
         // fail case: encrypted and committed messages are different
-        let elgamal_keypair = ElGamalKeypair::random();
+        let elgamal_keypair = ElGamalKeypair::new_rand();
         let encrypted_message: u64 = 55;
         let committed_message: u64 = 77;
 

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -2,7 +2,7 @@
 use {
     crate::encryption::{
         elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-        pedersen::{PedersenBase, PedersenCommitment, PedersenOpening},
+        pedersen::{G, H, PedersenCommitment, PedersenOpening},
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -40,11 +40,8 @@ impl EqualityProof {
         transcript: &mut Transcript,
     ) -> Self {
         // extract the relevant scalar and Ristretto points from the inputs
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let P_EG = elgamal_keypair.public.get_point();
-        let D_EG = ciphertext.decrypt_handle.get_point();
+        let D_EG = ciphertext.handle.get_point();
 
         let s = elgamal_keypair.secret.get_scalar();
         let x = Scalar::from(message);
@@ -56,8 +53,8 @@ impl EqualityProof {
         let y_r = Scalar::random(&mut OsRng);
 
         let Y_0 = (y_s * P_EG).compress();
-        let Y_1 = RistrettoPoint::multiscalar_mul(vec![y_x, y_s], vec![G, D_EG]).compress();
-        let Y_2 = RistrettoPoint::multiscalar_mul(vec![y_x, y_r], vec![G, H]).compress();
+        let Y_1 = RistrettoPoint::multiscalar_mul(vec![y_x, y_s], vec![&(*G), D_EG]).compress();
+        let Y_2 = RistrettoPoint::multiscalar_mul(vec![y_x, y_r], vec![&(*G), &(*H)]).compress();
 
         // record masking factors in transcript
         transcript.append_point(b"Y_0", &Y_0);
@@ -90,12 +87,9 @@ impl EqualityProof {
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
         // extract the relevant scalar and Ristretto points from the inputs
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let P_EG = elgamal_pubkey.get_point();
-        let C_EG = ciphertext.message_comm.get_point();
-        let D_EG = ciphertext.decrypt_handle.get_point();
+        let C_EG = ciphertext.commitment.get_point();
+        let D_EG = ciphertext.handle.get_point();
 
         let C_Ped = commitment.get_point();
 
@@ -127,7 +121,7 @@ impl EqualityProof {
                 -ww * c,
                 -ww,
             ],
-            vec![P_EG, H, Y_0, G, D_EG, C_EG, Y_1, G, H, C_Ped, Y_2],
+            vec![P_EG, &(*H), &Y_0, &(*G), D_EG, C_EG, &Y_1, &(*G), &(*H), C_Ped, &Y_2],
         );
 
         if check.is_identity() {
@@ -179,7 +173,7 @@ mod test {
     #[test]
     fn test_equality_proof() {
         // success case
-        let elgamal_keypair = ElGamalKeypair::default();
+        let elgamal_keypair = ElGamalKeypair::random();
         let message: u64 = 55;
 
         let ciphertext = elgamal_keypair.public.encrypt(message);
@@ -206,7 +200,7 @@ mod test {
             .is_ok());
 
         // fail case: encrypted and committed messages are different
-        let elgamal_keypair = ElGamalKeypair::default();
+        let elgamal_keypair = ElGamalKeypair::random();
         let encrypted_message: u64 = 55;
         let committed_message: u64 = 77;
 

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_arch = "bpf"))]
 use {
-    crate::encryption::pedersen::{PedersenBase, PedersenCommitment, PedersenOpening},
+    crate::encryption::pedersen::{G, H, PedersenCommitment, PedersenOpening},
     rand::rngs::OsRng,
 };
 use {
@@ -36,9 +36,6 @@ impl FeeProof {
         transcript: &mut Transcript,
     ) -> Self {
         // extract the relevant scalar and Ristretto points from the input
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let x = Scalar::from(delta_fee);
         let m = Scalar::from(max_fee);
 
@@ -66,7 +63,7 @@ impl FeeProof {
             let z_max = Scalar::random(&mut OsRng);
             let c_max = Scalar::random(&mut OsRng);
             let Y_max =
-                RistrettoPoint::multiscalar_mul(vec![z_max, -c_max, c_max * m], vec![H, C_max, G])
+                RistrettoPoint::multiscalar_mul(vec![z_max, -c_max, c_max * m], vec![&(*H), C_max, &(*G)])
                     .compress();
 
             let fee_max_proof = FeeMaxProof {
@@ -81,9 +78,9 @@ impl FeeProof {
             let y_delta_claimed = Scalar::random(&mut OsRng);
 
             let Y_delta_real =
-                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_real], vec![G, H]).compress();
+                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_real], vec![&(*G), &(*H)]).compress();
             let Y_delta_claimed =
-                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_claimed], vec![G, H]).compress();
+                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_claimed], vec![&(*G), &(*H)]).compress();
 
             transcript.append_point(b"Y_max", &Y_max);
             transcript.append_point(b"Y_delta_real", &Y_delta_real);
@@ -119,13 +116,13 @@ impl FeeProof {
 
             let Y_delta_real = RistrettoPoint::multiscalar_mul(
                 vec![z_x, z_delta_real, -c_equality],
-                vec![G, H, C_delta_real],
+                vec![&(*G), &(*H), C_delta_real],
             )
             .compress();
 
             let Y_delta_claimed = RistrettoPoint::multiscalar_mul(
                 vec![z_x, z_delta_claimed, -c_equality],
-                vec![G, H, C_delta_claimed],
+                vec![&(*G), &(*H), C_delta_claimed],
             )
             .compress();
 
@@ -139,7 +136,7 @@ impl FeeProof {
 
             // generate max proof
             let y_max = Scalar::random(&mut OsRng);
-            let Y_max = (y_max * H).compress();
+            let Y_max = (y_max * &(*H)).compress();
 
             transcript.append_point(b"Y_max", &Y_max);
             transcript.append_point(b"Y_delta_real", &Y_delta_real);
@@ -174,9 +171,6 @@ impl FeeProof {
         transcript: &mut Transcript,
     ) -> Result<(), FeeProofError> {
         // extract the relevant scalar and Ristretto points from the input
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let m = Scalar::from(max_fee);
 
         let C_max = commitment_fee.get_point();
@@ -243,17 +237,17 @@ impl FeeProof {
             ],
             vec![
                 C_max,
-                G,
-                H,
-                Y_max,
-                G,
-                H,
+                &(*G),
+                &(*H),
+                &Y_max,
+                &(*G),
+                &(*H),
                 C_delta_real,
-                Y_delta_real,
-                G,
-                H,
+                &Y_delta_real,
+                &(*G),
+                &(*H),
                 C_delta_claimed,
-                Y_delta_claimed,
+                &Y_delta_claimed,
             ],
         );
 

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_arch = "bpf"))]
 use {
-    crate::encryption::pedersen::{G, H, PedersenCommitment, PedersenOpening},
+    crate::encryption::pedersen::{PedersenCommitment, PedersenOpening, G, H},
     rand::rngs::OsRng,
 };
 use {
@@ -62,9 +62,11 @@ impl FeeProof {
             // simulate max proof
             let z_max = Scalar::random(&mut OsRng);
             let c_max = Scalar::random(&mut OsRng);
-            let Y_max =
-                RistrettoPoint::multiscalar_mul(vec![z_max, -c_max, c_max * m], vec![&(*H), C_max, &(*G)])
-                    .compress();
+            let Y_max = RistrettoPoint::multiscalar_mul(
+                vec![z_max, -c_max, c_max * m],
+                vec![&(*H), C_max, &(*G)],
+            )
+            .compress();
 
             let fee_max_proof = FeeMaxProof {
                 Y_max,
@@ -78,9 +80,11 @@ impl FeeProof {
             let y_delta_claimed = Scalar::random(&mut OsRng);
 
             let Y_delta_real =
-                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_real], vec![&(*G), &(*H)]).compress();
+                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_real], vec![&(*G), &(*H)])
+                    .compress();
             let Y_delta_claimed =
-                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_claimed], vec![&(*G), &(*H)]).compress();
+                RistrettoPoint::multiscalar_mul(vec![y_x, y_delta_claimed], vec![&(*G), &(*H)])
+                    .compress();
 
             transcript.append_point(b"Y_max", &Y_max);
             transcript.append_point(b"Y_delta_real", &Y_delta_real);

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -2,7 +2,7 @@
 use {
     crate::encryption::{
         elgamal::{DecryptHandle, ElGamalPubkey},
-        pedersen::{G, H, PedersenCommitment, PedersenOpening},
+        pedersen::{PedersenCommitment, PedersenOpening, G, H},
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -120,7 +120,18 @@ impl ValidityProof {
                 -ww * c,
                 -ww,
             ],
-            vec![&(*H), &(*G), &C, &Y_0, P_dest, &D_dest, &Y_1, P_auditor, &D_auditor, &Y_2],
+            vec![
+                &(*H),
+                &(*G),
+                &C,
+                &Y_0,
+                P_dest,
+                &D_dest,
+                &Y_1,
+                P_auditor,
+                &D_auditor,
+                &Y_2,
+            ],
         );
 
         if check.is_identity() {

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -179,8 +179,8 @@ mod test {
 
     #[test]
     fn test_validity_proof() {
-        let elgamal_pubkey_dest = ElGamalKeypair::random().public;
-        let elgamal_pubkey_auditor = ElGamalKeypair::random().public;
+        let elgamal_pubkey_dest = ElGamalKeypair::new_rand().public;
+        let elgamal_pubkey_auditor = ElGamalKeypair::new_rand().public;
 
         let x_lo: u64 = 55;
         let x_hi: u64 = 77;

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -1,8 +1,8 @@
 #[cfg(not(target_arch = "bpf"))]
 use {
     crate::encryption::{
-        elgamal::ElGamalPubkey,
-        pedersen::{PedersenBase, PedersenCommitment, PedersenDecryptHandle, PedersenOpening},
+        elgamal::{DecryptHandle, ElGamalPubkey},
+        pedersen::{G, H, PedersenCommitment, PedersenOpening},
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -39,9 +39,6 @@ impl ValidityProof {
         transcript: &mut Transcript,
     ) -> Self {
         // extract the relevant scalar and Ristretto points from the inputs
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         let P_dest = elgamal_pubkey_dest.get_point();
         let P_auditor = elgamal_pubkey_auditor.get_point();
 
@@ -49,7 +46,7 @@ impl ValidityProof {
         let y_r = Scalar::random(&mut OsRng);
         let y_x = Scalar::random(&mut OsRng);
 
-        let Y_0 = RistrettoPoint::multiscalar_mul(vec![y_r, y_x], vec![H, G]).compress();
+        let Y_0 = RistrettoPoint::multiscalar_mul(vec![y_r, y_x], vec![&(*H), &(*G)]).compress();
         let Y_1 = (y_r * P_dest).compress();
         let Y_2 = (y_r * P_auditor).compress();
 
@@ -84,14 +81,10 @@ impl ValidityProof {
         elgamal_pubkey_dest: &ElGamalPubkey,
         elgamal_pubkey_auditor: &ElGamalPubkey,
         commitments: (&PedersenCommitment, &PedersenCommitment),
-        handle_dest: (&PedersenDecryptHandle, &PedersenDecryptHandle),
-        handle_auditor: (&PedersenDecryptHandle, &PedersenDecryptHandle),
+        handle_dest: (&DecryptHandle, &DecryptHandle),
+        handle_auditor: (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofError> {
-        // extract the relevant scalar and Ristretto points from the inputs
-        let G = PedersenBase::default().G;
-        let H = PedersenBase::default().H;
-
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
         transcript.validate_and_append_point(b"Y_1", &self.Y_1)?;
@@ -127,7 +120,7 @@ impl ValidityProof {
                 -ww * c,
                 -ww,
             ],
-            vec![H, G, C, Y_0, P_dest, D_dest, Y_1, P_auditor, D_auditor, Y_2],
+            vec![&(*H), &(*G), &C, &Y_0, P_dest, &D_dest, &Y_1, P_auditor, &D_auditor, &Y_2],
         );
 
         if check.is_identity() {
@@ -175,8 +168,8 @@ mod test {
 
     #[test]
     fn test_validity_proof() {
-        let elgamal_pubkey_dest = ElGamalKeypair::default().public;
-        let elgamal_pubkey_auditor = ElGamalKeypair::default().public;
+        let elgamal_pubkey_dest = ElGamalKeypair::random().public;
+        let elgamal_pubkey_auditor = ElGamalKeypair::random().public;
 
         let x_lo: u64 = 55;
         let x_hi: u64 = 77;

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -135,7 +135,7 @@ mod test {
 
     #[test]
     fn test_zero_balance_proof() {
-        let source_keypair = ElGamalKeypair::random();
+        let source_keypair = ElGamalKeypair::new_rand();
 
         let mut transcript_prover = Transcript::new(b"test");
         let mut transcript_verifier = Transcript::new(b"test");

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -2,7 +2,7 @@
 use {
     crate::encryption::{
         elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-        pedersen::PedersenBase,
+        pedersen::H,
     },
     curve25519_dalek::traits::MultiscalarMul,
     rand::rngs::OsRng,
@@ -38,8 +38,8 @@ impl ZeroBalanceProof {
         let P = elgamal_keypair.public.get_point();
         let s = elgamal_keypair.secret.get_scalar();
 
-        let C = elgamal_ciphertext.message_comm.get_point();
-        let D = elgamal_ciphertext.decrypt_handle.get_point();
+        let C = elgamal_ciphertext.commitment.get_point();
+        let D = elgamal_ciphertext.handle.get_point();
 
         // record ElGamal pubkey and ciphertext in the transcript
         transcript.append_point(b"P", &P.compress());
@@ -71,10 +71,8 @@ impl ZeroBalanceProof {
     ) -> Result<(), ZeroBalanceProofError> {
         // extract the relevant scalar and Ristretto points from the input
         let P = elgamal_pubkey.get_point();
-        let C = elgamal_ciphertext.message_comm.get_point();
-        let D = elgamal_ciphertext.decrypt_handle.get_point();
-
-        let H = PedersenBase::default().H;
+        let C = elgamal_ciphertext.commitment.get_point();
+        let D = elgamal_ciphertext.handle.get_point();
 
         // record ElGamal pubkey and ciphertext in the transcript
         transcript.validate_and_append_point(b"P", &P.compress())?;
@@ -96,7 +94,7 @@ impl ZeroBalanceProof {
         // check the required algebraic relation
         let check = RistrettoPoint::multiscalar_mul(
             vec![z, -c, -Scalar::one(), w * z, -w * c, -w],
-            vec![P, H, Y_P, D, C, Y_D],
+            vec![P, &(*H), &Y_P, D, C, &Y_D],
         );
 
         if check.is_identity() {
@@ -131,13 +129,13 @@ impl ZeroBalanceProof {
 mod test {
     use super::*;
     use crate::encryption::{
-        elgamal::ElGamalKeypair,
-        pedersen::{Pedersen, PedersenDecryptHandle, PedersenOpening},
+        elgamal::{DecryptHandle, ElGamalKeypair},
+        pedersen::{Pedersen, PedersenOpening},
     };
 
     #[test]
     fn test_zero_balance_proof() {
-        let source_keypair = ElGamalKeypair::default();
+        let source_keypair = ElGamalKeypair::random();
 
         let mut transcript_prover = Transcript::new(b"test");
         let mut transcript_verifier = Transcript::new(b"test");
@@ -175,11 +173,11 @@ mod test {
 
         // edge cases: only C or D is zero - such ciphertext is always invalid
         let zeroed_comm = Pedersen::with(0_u64, &PedersenOpening::default());
-        let handle = elgamal_ciphertext.decrypt_handle;
+        let handle = elgamal_ciphertext.handle;
 
         let zeroed_comm_ciphertext = ElGamalCiphertext {
-            message_comm: zeroed_comm,
-            decrypt_handle: handle,
+            commitment: zeroed_comm,
+            handle,
         };
 
         let proof = ZeroBalanceProof::new(
@@ -197,8 +195,8 @@ mod test {
 
         let (zero_comm, _) = Pedersen::new(0_u64);
         let zeroed_handle_ciphertext = ElGamalCiphertext {
-            message_comm: zero_comm,
-            decrypt_handle: PedersenDecryptHandle::default(),
+            commitment: zero_comm,
+            handle: DecryptHandle::default(),
         };
 
         let proof = ZeroBalanceProof::new(

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -1,8 +1,8 @@
 use super::pod;
 pub use target_arch::*;
 
-impl From<(pod::PedersenCommitment, pod::PedersenDecryptHandle)> for pod::ElGamalCiphertext {
-    fn from((comm, decrypt_handle): (pod::PedersenCommitment, pod::PedersenDecryptHandle)) -> Self {
+impl From<(pod::PedersenCommitment, pod::DecryptHandle)> for pod::ElGamalCiphertext {
+    fn from((comm, decrypt_handle): (pod::PedersenCommitment, pod::DecryptHandle)) -> Self {
         let mut buf = [0_u8; 64];
         buf[..32].copy_from_slice(&comm.0);
         buf[32..].copy_from_slice(&decrypt_handle.0);
@@ -17,8 +17,8 @@ mod target_arch {
         crate::{
             encryption::{
                 auth_encryption::AeCiphertext,
-                elgamal::{ElGamalCiphertext, ElGamalPubkey},
-                pedersen::{PedersenCommitment, PedersenDecryptHandle},
+                elgamal::{DecryptHandle, ElGamalCiphertext, ElGamalPubkey},
+                pedersen::PedersenCommitment,
             },
             errors::ProofError,
             range_proof::{errors::RangeProofError, RangeProof},
@@ -107,25 +107,25 @@ mod target_arch {
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    impl From<PedersenDecryptHandle> for pod::PedersenDecryptHandle {
-        fn from(handle: PedersenDecryptHandle) -> Self {
+    impl From<DecryptHandle> for pod::DecryptHandle {
+        fn from(handle: DecryptHandle) -> Self {
             Self(handle.to_bytes())
         }
     }
 
     // For proof verification, interpret pod::PedersenDecHandle as CompressedRistretto
     #[cfg(not(target_arch = "bpf"))]
-    impl From<pod::PedersenDecryptHandle> for CompressedRistretto {
-        fn from(pod: pod::PedersenDecryptHandle) -> Self {
+    impl From<pod::DecryptHandle> for CompressedRistretto {
+        fn from(pod: pod::DecryptHandle) -> Self {
             Self(pod.0)
         }
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    impl TryFrom<pod::PedersenDecryptHandle> for PedersenDecryptHandle {
+    impl TryFrom<pod::DecryptHandle> for DecryptHandle {
         type Error = ProofError;
 
-        fn try_from(pod: pod::PedersenDecryptHandle) -> Result<Self, Self::Error> {
+        fn try_from(pod: pod::DecryptHandle) -> Result<Self, Self::Error> {
             Self::from_bytes(&pod.0).ok_or(ProofError::InconsistentCTData)
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -324,17 +324,13 @@ mod tests {
         let comm_hi: pod::PedersenCommitment = comm_hi.into();
 
         // decryption handles associated with TransferValidityProof
-        let handle_source_lo: pod::DecryptHandle =
-            source_pk.decrypt_handle(&open_lo).into();
+        let handle_source_lo: pod::DecryptHandle = source_pk.decrypt_handle(&open_lo).into();
         let handle_dest_lo: pod::DecryptHandle = dest_pk.decrypt_handle(&open_lo).into();
-        let _handle_auditor_lo: pod::DecryptHandle =
-            auditor_pk.decrypt_handle(&open_lo).into();
+        let _handle_auditor_lo: pod::DecryptHandle = auditor_pk.decrypt_handle(&open_lo).into();
 
-        let handle_source_hi: pod::DecryptHandle =
-            source_pk.decrypt_handle(&open_hi).into();
+        let handle_source_hi: pod::DecryptHandle = source_pk.decrypt_handle(&open_hi).into();
         let handle_dest_hi: pod::DecryptHandle = dest_pk.decrypt_handle(&open_hi).into();
-        let _handle_auditor_hi: pod::DecryptHandle =
-            auditor_pk.decrypt_handle(&open_hi).into();
+        let _handle_auditor_hi: pod::DecryptHandle = auditor_pk.decrypt_handle(&open_hi).into();
 
         // source spendable and recipient pending
         let source_open = PedersenOpening::random();

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -251,7 +251,7 @@ mod tests {
 
         // spendable_ct should be an encryption of 0 for any public key when
         // `PedersenOpen::default()` is used
-        let public = ElGamalKeypair::random().public;
+        let public = ElGamalKeypair::new_rand().public;
         let balance: u64 = 0;
         assert_eq!(
             spendable_ct,
@@ -259,7 +259,7 @@ mod tests {
         );
 
         // homomorphism should work like any other ciphertext
-        let open = PedersenOpening::random();
+        let open = PedersenOpening::new_rand();
         let transfer_amount_ct = public.encrypt_with(55_u64, &open);
         let transfer_amount_pod: pod::ElGamalCiphertext = transfer_amount_ct.into();
 
@@ -275,7 +275,7 @@ mod tests {
 
         let added_ct = ops::add_to(&spendable_balance, 55).unwrap();
 
-        let public = ElGamalKeypair::random().public;
+        let public = ElGamalKeypair::new_rand().public;
         let expected: pod::ElGamalCiphertext = public
             .encrypt_with(55_u64, &PedersenOpening::default())
             .into();
@@ -286,8 +286,8 @@ mod tests {
     #[test]
     fn test_subtract_from() {
         let amount = 77_u64;
-        let public = ElGamalKeypair::random().public;
-        let open = PedersenOpening::random();
+        let public = ElGamalKeypair::new_rand().public;
+        let open = PedersenOpening::new_rand();
         let encrypted_amount: pod::ElGamalCiphertext = public.encrypt_with(amount, &open).into();
 
         let subtracted_ct = ops::subtract_from(&encrypted_amount, 55).unwrap();
@@ -312,9 +312,9 @@ mod tests {
         let (amount_lo, amount_hi) = split_u64_into_u32(transfer_amount);
 
         // generate public keys
-        let source_pk = ElGamalKeypair::random().public;
-        let dest_pk = ElGamalKeypair::random().public;
-        let auditor_pk = ElGamalKeypair::random().public;
+        let source_pk = ElGamalKeypair::new_rand().public;
+        let dest_pk = ElGamalKeypair::new_rand().public;
+        let auditor_pk = ElGamalKeypair::new_rand().public;
 
         // commitments associated with TransferRangeProof
         let (comm_lo, open_lo) = Pedersen::new(amount_lo);
@@ -333,8 +333,8 @@ mod tests {
         let _handle_auditor_hi: pod::DecryptHandle = auditor_pk.decrypt_handle(&open_hi).into();
 
         // source spendable and recipient pending
-        let source_open = PedersenOpening::random();
-        let dest_open = PedersenOpening::random();
+        let source_open = PedersenOpening::new_rand();
+        let dest_open = PedersenOpening::new_rand();
 
         let source_spendable_ct: pod::ElGamalCiphertext =
             source_pk.encrypt_with(77_u64, &source_open).into();

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -241,7 +241,6 @@ mod tests {
         },
         bytemuck::Zeroable,
         curve25519_dalek::scalar::Scalar,
-        rand::rngs::OsRng,
         std::convert::TryInto,
     };
 
@@ -252,7 +251,7 @@ mod tests {
 
         // spendable_ct should be an encryption of 0 for any public key when
         // `PedersenOpen::default()` is used
-        let public = ElGamalKeypair::default().public;
+        let public = ElGamalKeypair::random().public;
         let balance: u64 = 0;
         assert_eq!(
             spendable_ct,
@@ -260,7 +259,7 @@ mod tests {
         );
 
         // homomorphism should work like any other ciphertext
-        let open = PedersenOpening::random(&mut OsRng);
+        let open = PedersenOpening::random();
         let transfer_amount_ct = public.encrypt_with(55_u64, &open);
         let transfer_amount_pod: pod::ElGamalCiphertext = transfer_amount_ct.into();
 
@@ -276,7 +275,7 @@ mod tests {
 
         let added_ct = ops::add_to(&spendable_balance, 55).unwrap();
 
-        let public = ElGamalKeypair::default().public;
+        let public = ElGamalKeypair::random().public;
         let expected: pod::ElGamalCiphertext = public
             .encrypt_with(55_u64, &PedersenOpening::default())
             .into();
@@ -287,8 +286,8 @@ mod tests {
     #[test]
     fn test_subtract_from() {
         let amount = 77_u64;
-        let public = ElGamalKeypair::default().public;
-        let open = PedersenOpening::random(&mut OsRng);
+        let public = ElGamalKeypair::random().public;
+        let open = PedersenOpening::random();
         let encrypted_amount: pod::ElGamalCiphertext = public.encrypt_with(amount, &open).into();
 
         let subtracted_ct = ops::subtract_from(&encrypted_amount, 55).unwrap();
@@ -313,9 +312,9 @@ mod tests {
         let (amount_lo, amount_hi) = split_u64_into_u32(transfer_amount);
 
         // generate public keys
-        let source_pk = ElGamalKeypair::default().public;
-        let dest_pk = ElGamalKeypair::default().public;
-        let auditor_pk = ElGamalKeypair::default().public;
+        let source_pk = ElGamalKeypair::random().public;
+        let dest_pk = ElGamalKeypair::random().public;
+        let auditor_pk = ElGamalKeypair::random().public;
 
         // commitments associated with TransferRangeProof
         let (comm_lo, open_lo) = Pedersen::new(amount_lo);
@@ -325,21 +324,21 @@ mod tests {
         let comm_hi: pod::PedersenCommitment = comm_hi.into();
 
         // decryption handles associated with TransferValidityProof
-        let handle_source_lo: pod::PedersenDecryptHandle =
+        let handle_source_lo: pod::DecryptHandle =
             source_pk.decrypt_handle(&open_lo).into();
-        let handle_dest_lo: pod::PedersenDecryptHandle = dest_pk.decrypt_handle(&open_lo).into();
-        let _handle_auditor_lo: pod::PedersenDecryptHandle =
+        let handle_dest_lo: pod::DecryptHandle = dest_pk.decrypt_handle(&open_lo).into();
+        let _handle_auditor_lo: pod::DecryptHandle =
             auditor_pk.decrypt_handle(&open_lo).into();
 
-        let handle_source_hi: pod::PedersenDecryptHandle =
+        let handle_source_hi: pod::DecryptHandle =
             source_pk.decrypt_handle(&open_hi).into();
-        let handle_dest_hi: pod::PedersenDecryptHandle = dest_pk.decrypt_handle(&open_hi).into();
-        let _handle_auditor_hi: pod::PedersenDecryptHandle =
+        let handle_dest_hi: pod::DecryptHandle = dest_pk.decrypt_handle(&open_hi).into();
+        let _handle_auditor_hi: pod::DecryptHandle =
             auditor_pk.decrypt_handle(&open_hi).into();
 
         // source spendable and recipient pending
-        let source_open = PedersenOpening::random(&mut OsRng);
-        let dest_open = PedersenOpening::random(&mut OsRng);
+        let source_open = PedersenOpening::random();
+        let dest_open = PedersenOpening::random();
 
         let source_spendable_ct: pod::ElGamalCiphertext =
             source_pk.encrypt_with(77_u64, &source_open).into();

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -47,9 +47,9 @@ impl fmt::Debug for PedersenCommitment {
 
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq)]
 #[repr(transparent)]
-pub struct PedersenDecryptHandle(pub [u8; 32]);
+pub struct DecryptHandle(pub [u8; 32]);
 
-impl fmt::Debug for PedersenDecryptHandle {
+impl fmt::Debug for DecryptHandle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
     }


### PR DESCRIPTION
#### Summary of Changes

Did a pass over ElGamal and Pedersen to optimize the code and implement good cryptography hygiene. 

The main optimization changes are:
- Pedersen generators `G` and `H` are computed as `lazy_static` to prevent computing Sha3 every time `H` is derived.
- The arithmetic over Pedersen and ElGamal ciphertexts now use references on `RistrettoPoint` and `Scalar`. As `RistrettoPoint` and and `Scalar` implement copy, the rust operator functions make temporary copies of parameters. Working with references saves on copying 32 bytes.

The main security changes are:
- `PedersenOpening` generally contains sensitive information, so include `[zeroize(drop)]`
- All the temporary sampled `Scalar` elements are zeroized before the function returns.

Other main changes:
- `ElGamalKeypair::default()` is changed to `ElGamalKeypair::random()` (related to [PR](https://github.com/solana-labs/spl-zk-token/pull/93#issuecomment-1006917081))
- All the randomized functions derive `OsRng` internally to have a consistent interface
- `PedersenDecryptHandle` is renamed `DecryptHandle` and moved into the elgamal module where it fits in more logically