### PR TITLE
Fix typo in components/instruction/wormhole

### DIFF
--- a/explorer/src/components/instruction/WormholeDetailsCard.tsx
+++ b/explorer/src/components/instruction/WormholeDetailsCard.tsx
@@ -3,7 +3,7 @@ import { TransactionInstruction, SignatureResult } from "@solana/web3.js";
 import { InstructionCard } from "./InstructionCard";
 import { useCluster } from "providers/cluster";
 import { reportError } from "utils/sentry";
-import { parsWormholeInstructionTitle } from "./wormhole/types";
+import { parseWormholeInstructionTitle } from "./wormhole/types";
 
 export function WormholeDetailsCard({
   ix,
@@ -24,7 +24,7 @@ export function WormholeDetailsCard({
 
   let title;
   try {
-    title = parsWormholeInstructionTitle(ix);
+    title = parseWormholeInstructionTitle(ix);
   } catch (error) {
     reportError(error, {
       url: url,

--- a/explorer/src/components/instruction/wormhole/types.ts
+++ b/explorer/src/components/instruction/wormhole/types.ts
@@ -21,7 +21,7 @@ export function isWormholeInstruction(
   return PROGRAM_IDS.includes(instruction.programId.toBase58());
 }
 
-export function parsWormholeInstructionTitle(
+export function parseWormholeInstructionTitle(
   instruction: TransactionInstruction
 ): string {
   const code = instruction.data[0];


### PR DESCRIPTION
#### Problem
Fix typo in components/instruction/wormhole, The e is missing in the function `parsWormholeInstructionTitle`

#### Summary of Changes

Rename:
`parsWormholeInstructionTitle` => `parseWormholeInstructionTitle`
