### PR TITLE
Add zeroed default for ElGamalCiphertext

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -19,6 +19,12 @@ impl fmt::Debug for ElGamalCiphertext {
     }
 }
 
+impl Default for ElGamalCiphertext {
+    fn default() -> Self {
+        Self::zeroed()
+    }
+}
+
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq)]
 #[repr(transparent)]
 pub struct ElGamalPubkey(pub [u8; 32]);


### PR DESCRIPTION
#### Problem
The Default impl for ElGamalCiphertext pod type was missed in #22532

#### Summary of Changes
Implement it
