### PR TITLE
web3.js: Improve PublicKeyData value detection

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -32,7 +32,7 @@ export type PublicKeyData = {
 };
 
 function isPublicKeyData(value: PublicKeyInitData): value is PublicKeyData {
-  return (value as PublicKeyData)._bn !== undefined;
+  return BN.isBN((value as PublicKeyData)._bn);
 }
 
 /**

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -4,7 +4,7 @@ import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import {Keypair} from '../src/keypair';
-import {PublicKey, MAX_SEED_LENGTH} from '../src/publickey';
+import {PublicKey, MAX_SEED_LENGTH, PublicKeyData} from '../src/publickey';
 
 use(chaiAsPromised);
 
@@ -37,6 +37,14 @@ describe('PublicKey', function () {
 
     expect(() => {
       new PublicKey('12345');
+    }).to.throw();
+
+    expect(() => {
+      const rawJSONPublicKeyData = {
+        _bn: '135693854574979916511997248057056142015550763280047535983739356259273198796800000',
+      };
+      // Type must be cast due to _bn being labeled internal
+      new PublicKey(rawJSONPublicKeyData as unknown as PublicKeyData);
     }).to.throw();
   });
 


### PR DESCRIPTION
#### Problem
A potential runtime error can occur in `PublicKey` due to the internal `_bn` check not enforcing a BN type to a client.

#### Summary of Changes
- Add regression test with legacy JSON-ified `PublicKey`
- Add more strict check for `isPublicKeyData` to actually error when type is wrong
