### PR TITLE
chore: remove reference to nonexistent script

### DIFF
--- a/web3.js/.travis/script.sh
+++ b/web3.js/.travis/script.sh
@@ -13,4 +13,3 @@ npm run doc
 npm run lint
 npm run codecov
 npm run test:live-with-test-validator
-npm run test:browser-with-test-validator


### PR DESCRIPTION
web3.js release has been broken since November it seems...