### PR TITLE
Reject close of active vote accounts

### DIFF
--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -153,7 +153,10 @@ pub fn process_instruction(
             } else {
                 None
             };
-            vote_state::withdraw(me, lamports, to, &signers, rent_sysvar.as_deref())
+            let reject_vote_account_close_feature_active = 
+                invoke_context.feature_set.is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id());
+
+            vote_state::withdraw(me, lamports, to, &signers, rent_sysvar.as_deref(), reject_vote_account_close_feature_active)
         }
         VoteInstruction::AuthorizeChecked(vote_authorize) => {
             if invoke_context

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -153,10 +153,18 @@ pub fn process_instruction(
             } else {
                 None
             };
-            let reject_vote_account_close_feature_active =
-                invoke_context.feature_set.is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id());
+            let reject_vote_account_close_feature_active = invoke_context
+                .feature_set
+                .is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id());
 
-            vote_state::withdraw(me, lamports, to, &signers, rent_sysvar.as_deref(), reject_vote_account_close_feature_active)
+            vote_state::withdraw(
+                me,
+                lamports,
+                to,
+                &signers,
+                rent_sysvar.as_deref(),
+                reject_vote_account_close_feature_active,
+            )
         }
         VoteInstruction::AuthorizeChecked(vote_authorize) => {
             if invoke_context

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -27,6 +27,7 @@ use {
 mod get_sysvar_with_keyed_account_check {
     use super::*;
 
+    // This might work
     pub fn clock(
         keyed_account: &KeyedAccount,
         invoke_context: &InvokeContext,
@@ -157,6 +158,10 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id());
 
+            let clock = &from_keyed_account::<Clock>(keyed_account_at_index(
+                keyed_accounts,
+                first_instruction_account + 1,
+            )?)?;
             vote_state::withdraw(
                 me,
                 lamports,
@@ -164,6 +169,7 @@ pub fn process_instruction(
                 &signers,
                 rent_sysvar.as_deref(),
                 reject_vote_account_close_feature_active,
+                clock,
             )
         }
         VoteInstruction::AuthorizeChecked(vote_authorize) => {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -153,7 +153,7 @@ pub fn process_instruction(
             } else {
                 None
             };
-            let reject_vote_account_close_feature_active = 
+            let reject_vote_account_close_feature_active =
                 invoke_context.feature_set.is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id());
 
             vote_state::withdraw(me, lamports, to, &signers, rent_sysvar.as_deref(), reject_vote_account_close_feature_active)

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1462,15 +1462,15 @@ mod tests {
 
         vote_state.epoch_credits = Vec::new();
 
-        let mut epoch = 0;
+        // let mut epoch = 0;
         let mut current_epoch_credits = 0;
         let mut previous_epoch_credits = 0;
-        for credits in credits_to_append {
+        for (epoch, credits) in credits_to_append.into_iter().enumerate() {
             current_epoch_credits += credits;
             vote_state
                 .epoch_credits
-                .push((epoch, current_epoch_credits, previous_epoch_credits));
-            epoch += 1;
+                .push((u64::try_from(epoch).unwrap(), current_epoch_credits, previous_epoch_credits));
+            // epoch += 1;
             previous_epoch_credits = current_epoch_credits;
         }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1452,7 +1452,7 @@ mod tests {
     }
 
     fn create_test_account_with_epoch_credits(
-        credits_to_append: &Vec<u64>,
+        credits_to_append: &[u64],
     ) -> (Pubkey, RefCell<AccountSharedData>) {
         let (vote_pubkey, vote_account) = create_test_account();
         let vote_account_space = vote_account.borrow().data().len();
@@ -1466,11 +1466,11 @@ mod tests {
         let mut current_epoch_credits = 0;
         let mut previous_epoch_credits = 0;
         for credits in credits_to_append {
-            current_epoch_credits = current_epoch_credits + credits;
+            current_epoch_credits += credits;
             vote_state
                 .epoch_credits
                 .push((epoch, current_epoch_credits, previous_epoch_credits));
-            epoch = epoch + 1;
+            epoch += 1;
             previous_epoch_credits = current_epoch_credits;
         }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1168,7 +1168,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             let maybe_last_epoch_credits = vote_state.epoch_credits.last();
             match maybe_last_epoch_credits {
                 None => false,
-                Some(last_epoch_credits) => (last_epoch_credits.1 - last_epoch_credits.2) > 0,
+                Some((epoch_credits, previous_epoch_credits)) => epoch_credits.saturating_sub(previous_epoch_credits) > 0,
             }
         }
     };

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -2671,7 +2671,7 @@ mod tests {
                 assert_eq!(vote_account.borrow().lamports(), lamports);
                 assert_eq!(to_account.borrow().lamports(), 0);
                 let post_state: VoteStateVersions = vote_account.borrow().state().unwrap();
-                // State has been deinitialized since balance is zero
+                // State is still initialized
                 assert!(!post_state.is_uninitialized());
             }
         }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -2408,7 +2408,7 @@ mod tests {
         }
 
         // non rent exempt withdraw, after 7txXZZD6 feature activation
-        // with 0 credit epoch, before ALBk3EWd feature activation       
+        // with 0 credit epoch, before ALBk3EWd feature activation
         {
             let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
             let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
@@ -2435,7 +2435,7 @@ mod tests {
         }
 
         // non rent exempt withdraw, after 7txXZZD6 feature activation
-        // without 0 credit epoch, before ALBk3EWd feature activation       
+        // without 0 credit epoch, before ALBk3EWd feature activation
         {
             let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(false);
             let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
@@ -2462,7 +2462,7 @@ mod tests {
         }
 
         // non rent exempt withdraw, after 7txXZZD6 feature activation
-        // with 0 credit epoch, after ALBk3EWd feature activation       
+        // with 0 credit epoch, after ALBk3EWd feature activation
         {
             let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
             let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1168,7 +1168,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             let maybe_last_epoch_credits = vote_state.epoch_credits.last();
             match maybe_last_epoch_credits {
                 None => false,
-                Some(last_epoch_credits) => (last_epoch_credits.1 - last_epoch_credits.2) > 0
+                Some(last_epoch_credits) => (last_epoch_credits.1 - last_epoch_credits.2) > 0,
             }
         }
     };
@@ -1176,8 +1176,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
     if remaining_balance == 0 {
         if reject_vote_account_close_feature_active && received_credits_previous_epoch {
             return Err(InstructionError::ActiveVoteAccountClose);
-        }
-        else {
+        } else {
             // Deinitialize upon zero-balance
             vote_account.set_state(&VoteStateVersions::new_current(VoteState::default()))?;
         }
@@ -1454,7 +1453,9 @@ mod tests {
         )
     }
 
-    fn create_test_account_with_epoch_credits(last_epoch_zero_credit: bool) -> (Pubkey, RefCell<AccountSharedData>) {
+    fn create_test_account_with_epoch_credits(
+        last_epoch_zero_credit: bool,
+    ) -> (Pubkey, RefCell<AccountSharedData>) {
         let (vote_pubkey, vote_account) = create_test_account();
         let vote_account_space = vote_account.borrow().data().len();
 
@@ -1467,11 +1468,16 @@ mod tests {
 
         if last_epoch_zero_credit {
             let last_epoch_credits = vote_state.epoch_credits.last().unwrap();
-            let zero_credit_epoch = (last_epoch_credits.0+1, last_epoch_credits.1, last_epoch_credits.1);
+            let zero_credit_epoch = (
+                last_epoch_credits.0 + 1,
+                last_epoch_credits.1,
+                last_epoch_credits.1,
+            );
             vote_state.epoch_credits.push(zero_credit_epoch);
         }
         let lamports = vote_account.borrow().lamports();
-        let mut vote_account_with_epoch_credits = AccountSharedData::new(lamports, vote_account_space, &vote_pubkey);
+        let mut vote_account_with_epoch_credits =
+            AccountSharedData::new(lamports, vote_account_space, &vote_pubkey);
         let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account_with_epoch_credits);
         let ref_vote_account_with_epoch_credits = RefCell::new(vote_account_with_epoch_credits);
@@ -2302,8 +2308,13 @@ mod tests {
         // non rent exempt withdraw, before 7txXZZD6 feature activation
         // without 0 credit epoch, before ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(false);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(false);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2329,8 +2340,13 @@ mod tests {
         // non rent exempt withdraw, before 7txXZZD6 feature activation
         // with 0 credit epoch, before ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(true);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2356,8 +2372,13 @@ mod tests {
         // non rent exempt withdraw, before 7txXZZD6 feature activation
         // without 0 credit epoch, after ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(false);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(false);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2383,8 +2404,13 @@ mod tests {
         // non rent exempt withdraw, before 7txXZZD6 feature activation
         // with 0 credit epoch, after ALBk3EWd activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(true);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2410,8 +2436,13 @@ mod tests {
         // non rent exempt withdraw, after 7txXZZD6 feature activation
         // with 0 credit epoch, before ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(true);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2437,8 +2468,13 @@ mod tests {
         // non rent exempt withdraw, after 7txXZZD6 feature activation
         // without 0 credit epoch, before ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(false);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(false);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2464,8 +2500,13 @@ mod tests {
         // non rent exempt withdraw, after 7txXZZD6 feature activation
         // with 0 credit epoch, after ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(true);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(true);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2491,8 +2532,13 @@ mod tests {
         // non rent exempt withdraw, after 7txXZZD6 feature activation
         // without 0 credit epoch, after ALBk3EWd feature activation
         {
-            let (vote_pubkey, vote_account_with_epoch_credits) = create_test_account_with_epoch_credits(false);
-            let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account_with_epoch_credits)];
+            let (vote_pubkey, vote_account_with_epoch_credits) =
+                create_test_account_with_epoch_credits(false);
+            let keyed_accounts = &[KeyedAccount::new(
+                &vote_pubkey,
+                true,
+                &vote_account_with_epoch_credits,
+            )];
             let lamports = vote_account_with_epoch_credits.borrow().lamports();
             let rent_sysvar = Rent::default();
             let minimum_balance = rent_sysvar
@@ -2551,7 +2597,8 @@ mod tests {
             for rent_sysvar in [None, Some(&rent_sysvar)] {
                 for last_epoch_zero_credits in [false, true] {
                     let to_account = RefCell::new(AccountSharedData::default());
-                    let (vote_pubkey, vote_account) = create_test_account_with_epoch_credits(last_epoch_zero_credits);
+                    let (vote_pubkey, vote_account) =
+                        create_test_account_with_epoch_credits(last_epoch_zero_credits);
                     let lamports = vote_account.borrow().lamports();
                     let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account)];
                     let signers: HashSet<Pubkey> = get_signers(keyed_accounts);

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1465,7 +1465,7 @@ mod tests {
         // let mut epoch = 0;
         let mut current_epoch_credits = 0;
         let mut previous_epoch_credits = 0;
-        for (epoch, credits) in credits_to_append.into_iter().enumerate() {
+        for (epoch, credits) in credits_to_append.iter().enumerate() {
             current_epoch_credits += credits;
             vote_state
                 .epoch_credits

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1467,9 +1467,11 @@ mod tests {
         let mut previous_epoch_credits = 0;
         for (epoch, credits) in credits_to_append.iter().enumerate() {
             current_epoch_credits += credits;
-            vote_state
-                .epoch_credits
-                .push((u64::try_from(epoch).unwrap(), current_epoch_credits, previous_epoch_credits));
+            vote_state.epoch_credits.push((
+                u64::try_from(epoch).unwrap(),
+                current_epoch_credits,
+                previous_epoch_credits,
+            ));
             // epoch += 1;
             previous_epoch_credits = current_epoch_credits;
         }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1470,7 +1470,6 @@ mod tests {
 
         vote_state.epoch_credits = Vec::new();
 
-        // let mut epoch = 0;
         let mut current_epoch_credits = 0;
         let mut previous_epoch_credits = 0;
         for (epoch, credits) in credits_to_append.iter().enumerate() {
@@ -1480,7 +1479,6 @@ mod tests {
                 current_epoch_credits,
                 previous_epoch_credits,
             ));
-            // epoch += 1;
             previous_epoch_credits = current_epoch_credits;
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -214,7 +214,7 @@ impl RentDebits {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "FPLuTUU5MjwsijzDubxY6BvBEkWULhYNUyY6Puqejb4g")]
+#[frozen_abi(digest = "6XkxpmzmKZguLZMS1KmU7N2dAcv8MmNhyobJCwRLkTdi")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 
 // Eager rent collection repeats in cyclic manner.

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -254,7 +254,7 @@ pub enum InstructionError {
     AccountsDataBudgetExceeded,
 
     /// Active vote account close
-    #[error("Cannot close vote account unless it received 0 credits in the most recent epoch")]
+    #[error("Cannot close vote account unless it stopped voting at least one full epoch ago")]
     ActiveVoteAccountClose,
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -255,8 +255,7 @@ pub enum InstructionError {
 
     /// Active vote account close
     #[error("Cannot close vote account unless it received 0 credits in the most recent epoch")]
-    ActiveVoteAccountClose
-
+    ActiveVoteAccountClose,
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 }

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -252,6 +252,11 @@ pub enum InstructionError {
     /// Accounts data budget exceeded
     #[error("Requested account data allocation exceeded the accounts data budget")]
     AccountsDataBudgetExceeded,
+
+    /// Active vote account close
+    #[error("Cannot close vote account unless it received 0 credits in the most recent epoch")]
+    ActiveVoteAccountClose
+
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 }

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -51,7 +51,7 @@ pub enum ProgramError {
     IllegalOwner,
     #[error("Requested account data allocation exceeded the accounts data budget")]
     AccountsDataBudgetExceeded,
-    #[error("Cannot close vote account unless it received 0 credits in the most recent epoch")]
+    #[error("Cannot close vote account unless it stopped voting at least one full epoch ago")]
     ActiveVoteAccountClose,
 }
 

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -51,6 +51,8 @@ pub enum ProgramError {
     IllegalOwner,
     #[error("Requested account data allocation exceeded the accounts data budget")]
     AccountsDataBudgetExceeded,
+    #[error("Cannot close vote account unless it received 0 credits in the most recent epoch")]
+    ActiveVoteAccountClose,
 }
 
 pub trait PrintProgramError {
@@ -90,6 +92,7 @@ impl PrintProgramError for ProgramError {
             Self::UnsupportedSysvar => msg!("Error: UnsupportedSysvar"),
             Self::IllegalOwner => msg!("Error: IllegalOwner"),
             Self::AccountsDataBudgetExceeded => msg!("Error: AccountsDataBudgetExceeded"),
+            Self::ActiveVoteAccountClose => msg!("Error: ActiveVoteAccountClose"),
         }
     }
 }
@@ -121,6 +124,7 @@ pub const ACCOUNT_NOT_RENT_EXEMPT: u64 = to_builtin!(16);
 pub const UNSUPPORTED_SYSVAR: u64 = to_builtin!(17);
 pub const ILLEGAL_OWNER: u64 = to_builtin!(18);
 pub const ACCOUNTS_DATA_BUDGET_EXCEEDED: u64 = to_builtin!(19);
+pub const ACTIVE_VOTE_ACCOUNT_CLOSE: u64 = to_builtin!(20);
 // Warning: Any new program errors added here must also be:
 // - Added to the below conversions
 // - Added as an equivilent to InstructionError
@@ -148,6 +152,7 @@ impl From<ProgramError> for u64 {
             ProgramError::UnsupportedSysvar => UNSUPPORTED_SYSVAR,
             ProgramError::IllegalOwner => ILLEGAL_OWNER,
             ProgramError::AccountsDataBudgetExceeded => ACCOUNTS_DATA_BUDGET_EXCEEDED,
+            ProgramError::ActiveVoteAccountClose => ACTIVE_VOTE_ACCOUNT_CLOSE,
             ProgramError::Custom(error) => {
                 if error == 0 {
                     CUSTOM_ZERO
@@ -181,6 +186,7 @@ impl From<u64> for ProgramError {
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
             ILLEGAL_OWNER => Self::IllegalOwner,
             ACCOUNTS_DATA_BUDGET_EXCEEDED => Self::AccountsDataBudgetExceeded,
+            ACTIVE_VOTE_ACCOUNT_CLOSE => Self::ActiveVoteAccountClose,
             _ => Self::Custom(error as u32),
         }
     }
@@ -210,6 +216,7 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::UnsupportedSysvar => Ok(Self::UnsupportedSysvar),
             Self::Error::IllegalOwner => Ok(Self::IllegalOwner),
             Self::Error::AccountsDataBudgetExceeded => Ok(Self::AccountsDataBudgetExceeded),
+            Self::Error::ActiveVoteAccountClose => Ok(Self::ActiveVoteAccountClose),
             _ => Err(error),
         }
     }
@@ -241,6 +248,7 @@ where
             UNSUPPORTED_SYSVAR => Self::UnsupportedSysvar,
             ILLEGAL_OWNER => Self::IllegalOwner,
             ACCOUNTS_DATA_BUDGET_EXCEEDED => Self::AccountsDataBudgetExceeded,
+            ACTIVE_VOTE_ACCOUNT_CLOSE => Self::ActiveVoteAccountClose,
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -305,6 +305,9 @@ pub mod vote_withdraw_authority_may_change_authorized_voter {
 
 pub mod spl_associated_token_account_v1_0_4 {
     solana_sdk::declare_id!("FaTa4SpiaSNH44PGC4z8bnGVTkSRYaWvrBs3KTu8XQQq");
+
+pub mod reject_vote_account_close_unless_zero_credit_epoch {
+    solana_sdk::declare_id!("ALBk3EWdeAg2WAGf6GPDUf1nynyNqCdEVmgouG7rpuCj");
 }
 
 lazy_static! {
@@ -378,6 +381,7 @@ lazy_static! {
         (update_syscall_base_costs::id(), "Update syscall base costs"),
         (vote_withdraw_authority_may_change_authorized_voter::id(), "vote account withdraw authority may change the authorized voter #22521"),
         (spl_associated_token_account_v1_0_4::id(), "SPL Associated Token Account Program release version 1.0.4, tied to token 3.3.0 #22648"),
+        (reject_vote_account_close_unless_zero_credit_epoch::id(), "fail vote account withdraw to 0 unless account earned 0 credits in last completed epoch"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -305,6 +305,7 @@ pub mod vote_withdraw_authority_may_change_authorized_voter {
 
 pub mod spl_associated_token_account_v1_0_4 {
     solana_sdk::declare_id!("FaTa4SpiaSNH44PGC4z8bnGVTkSRYaWvrBs3KTu8XQQq");
+}
 
 pub mod reject_vote_account_close_unless_zero_credit_epoch {
     solana_sdk::declare_id!("ALBk3EWdeAg2WAGf6GPDUf1nynyNqCdEVmgouG7rpuCj");

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -113,6 +113,7 @@ enum InstructionErrorType {
     UNSUPPORTED_SYSVAR = 48;
     ILLEGAL_OWNER = 49;
     ACCOUNTS_DATA_BUDGET_EXCEEDED = 50;
+    ACTIVE_VOTE_ACCOUNT_CLOSE = 51;
 }
 
 message UnixTimestamp {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -689,6 +689,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
                     48 => InstructionError::UnsupportedSysvar,
                     49 => InstructionError::IllegalOwner,
                     50 => InstructionError::AccountsDataBudgetExceeded,
+                    51 => InstructionError::ActiveVoteAccountClose,
                     _ => return Err("Invalid InstructionError"),
                 };
 
@@ -978,6 +979,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             }
                             InstructionError::AccountsDataBudgetExceeded => {
                                 tx_by_addr::InstructionErrorType::AccountsDataBudgetExceeded
+                            }
+                            InstructionError::ActiveVoteAccountClose => {
+                                tx_by_addr::InstructionErrorType::ActiveVoteAccountClose
                             }
                         } as i32,
                         custom: match instruction_error {


### PR DESCRIPTION
[Issue 10461](https://github.com/solana-labs/solana/issues/10461)

#### Problem

Withdrawing the rent exempt reserve from a vote account will close the account. This shouldn't be allowed for active vote accounts.

#### Summary of Changes

Attempted withdraws of the rent exempt reserve check whether the vote account received any credits in the most recent completed epoch. If they did, the withdraw is rejected with an error.

Note: This change is feature gated, and [PR 21639](https://github.com/solana-labs/solana/pull/21639) also created a feature in the same function, so the unit test matrix has ballooned and includes a lot of duplicated code. The duplication could be factored out but I choose to leave most of it unrolled to simplify cleanup once both features are activated.