### PR TITLE
Refactor and use MINIMUM_STAKE_DELEGATION constant

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -920,10 +920,8 @@ fn validate_split_amount(
     // account, the split amount must be at least the minimum stake delegation.  So if the minimum
     // stake delegation was 10 lamports, then a split amount of 1 lamport would not meet the
     // *delegation* requirements.
-    if source_stake.is_some() {
-        if lamports < MINIMUM_STAKE_DELEGATION {
-            return Err(InstructionError::InsufficientFunds);
-        }
+    if source_stake.is_some() && lamports < MINIMUM_STAKE_DELEGATION {
+        return Err(InstructionError::InsufficientFunds);
     }
 
     Ok(ValidatedSplitInfo {


### PR DESCRIPTION
#### Problem

The minimum stake delegation constant is not used outside of tests.

#### Summary of Changes

* Use the constant in `initialize()`, `delegate()`, `split()`, and `withdraw()`
* Refactor code to be safe and obvious

#### Notes

* No behavior is changed in this PR
* This PR builds on the tests added in #23259 and #23303 to ensure no behavior is changed
* Subsequent tasks for minimum stake delegation are being tracked in #22559
* I recommend _ignoring whitespace_ when looking at the diff here on github