### PR TITLE
fix typo in docs

### DIFF
--- a/docs/src/developing/programming-model/transactions.md
+++ b/docs/src/developing/programming-model/transactions.md
@@ -150,7 +150,7 @@ found in the [Accounts](accounts.md) section.
 
 ### Instruction data
 
-Each instruction caries a general purpose byte array that is passed to the
+Each instruction carries a general purpose byte array that is passed to the
 program along with the accounts. The contents of the instruction data is program
 specific and typically used to convey what operations the program should
 perform, and any additional information those operations may need above and


### PR DESCRIPTION
#### Problem
`carries` was spelled `caries`.
#### Summary of Changes
Add the missing `r`
Fixes #
