### PR TITLE
fix: flag was incorrect in doc

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -272,7 +272,7 @@ Read more about [creating and managing a vote account](vote-accounts.md).
 If you know and respect other validator operators, you can specify this on the command line with the `--known-validator <PUBKEY>`
 argument to `solana-validator`. You can specify multiple ones by repeating the argument `--known-validator <PUBKEY1> --known-validator <PUBKEY2>`.
 This has two effects, one is when the validator is booting with `--only-known-rpc`, it will only ask that set of
-known nodes for downloading genesis and snapshot data. Another is that in combination with the `--halt-on-known-validator-hash-mismatch` option,
+known nodes for downloading genesis and snapshot data. Another is that in combination with the `--halt-on-known-validators-accounts-hash-mismatch` option,
 it will monitor the merkle root hash of the entire accounts state of other known nodes on gossip and if the hashes produce any mismatch,
 the validator will halt the node to prevent the validator from voting or processing potentially incorrect state values. At the moment, the slot that
 the validator publishes the hash on is tied to the snapshot interval. For the feature to be effective, all validators in the known


### PR DESCRIPTION
#### Problem
documentation for solana-validator is incorrect.
#### Summary of Changes
fixed the flag "--halt-on-known-validators-accounts-hash-mismatch"
