### PR TITLE
add 'ticks-per-slot' to 'solana-test-validator'

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -96,6 +96,7 @@ pub struct TestValidatorGenesis {
     no_bpf_jit: bool,
     accounts: HashMap<Pubkey, AccountSharedData>,
     programs: Vec<ProgramInfo>,
+    ticks_per_slot: Option<u64>,
     epoch_schedule: Option<EpochSchedule>,
     node_config: TestValidatorNodeConfig,
     pub validator_exit: Arc<RwLock<Exit>>,
@@ -125,6 +126,11 @@ impl TestValidatorGenesis {
 
     pub fn fee_rate_governor(&mut self, fee_rate_governor: FeeRateGovernor) -> &mut Self {
         self.fee_rate_governor = fee_rate_governor;
+        self
+    }
+
+    pub fn ticks_per_slot(&mut self, ticks_per_slot: u64) -> &mut Self {
+        self.ticks_per_slot = Some(ticks_per_slot);
         self
     }
 
@@ -464,6 +470,10 @@ impl TestValidator {
         genesis_config.epoch_schedule = config
             .epoch_schedule
             .unwrap_or_else(EpochSchedule::without_warmup);
+
+        if let Some(ticks_per_slot) = config.ticks_per_slot {
+            genesis_config.ticks_per_slot = ticks_per_slot;
+        }
 
         let ledger_path = match &config.ledger_path {
             None => create_new_tmp_ledger!(&genesis_config).0,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -5,8 +5,8 @@ use {
     solana_clap_utils::{
         input_parsers::{pubkey_of, pubkeys_of, value_of},
         input_validators::{
-            is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
-            normalize_to_url_if_moniker, is_parsable,
+            is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
+            normalize_to_url_if_moniker,
         },
     },
     solana_client::rpc_client::RpcClient,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -188,6 +188,13 @@ fn main() {
                 .help("Disable the just-in-time compiler and instead use the interpreter for BPF. Windows always disables JIT."),
         )
         .arg(
+            Arg::with_name("ticks_per_slot")
+                .long("ticks-per-slot")
+                .value_name("TICKS")
+                .takes_value(true)
+                .help("The number of ticks in a slot"),
+        )
+        .arg(
             Arg::with_name("slots_per_epoch")
                 .long("slots-per-epoch")
                 .value_name("SLOTS")
@@ -397,6 +404,7 @@ fn main() {
 
     let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
     let faucet_port = value_t_or_exit!(matches, "faucet_port", u16);
+    let ticks_per_slot = value_t!(matches, "ticks_per_slot", u64).ok();
     let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
     let gossip_host = matches.value_of("gossip_host").map(|gossip_host| {
         solana_net_utils::parse_host(gossip_host).unwrap_or_else(|err| {
@@ -539,6 +547,7 @@ fn main() {
             ("clone_account", "--clone"),
             ("account", "--account"),
             ("mint_address", "--mint"),
+            ("ticks_per_slot", "--ticks-per-slot"),
             ("slots_per_epoch", "--slots-per-epoch"),
             ("faucet_sol", "--faucet-sol"),
         ] {
@@ -618,6 +627,10 @@ fn main() {
 
     if let Some(warp_slot) = warp_slot {
         genesis.warp_slot(warp_slot);
+    }
+
+    if let Some(ticks_per_slot) = ticks_per_slot {
+        genesis.ticks_per_slot(ticks_per_slot);
     }
 
     if let Some(slots_per_epoch) = slots_per_epoch {

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -6,7 +6,7 @@ use {
         input_parsers::{pubkey_of, pubkeys_of, value_of},
         input_validators::{
             is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
-            normalize_to_url_if_moniker,
+            normalize_to_url_if_moniker, is_parsable,
         },
     },
     solana_client::rpc_client::RpcClient,
@@ -191,6 +191,7 @@ fn main() {
             Arg::with_name("ticks_per_slot")
                 .long("ticks-per-slot")
                 .value_name("TICKS")
+                .validator(is_parsable::<u64>)
                 .takes_value(true)
                 .help("The number of ticks in a slot"),
         )


### PR DESCRIPTION
#### Problem
It's not possible to set the tick rate for the `solana-test-validator`.

#### Summary of Changes
- Introduce `--ticks-per-slot` argument to `solana-test-validator`.
- Add `ticks-per-slot` to `TestValidatorGenesis` struct.

#### A new issue
- Setting the tick rate to a low value such as "256" does not run into any issues (on new ledger and from a restart)
- Large values such as "1280" have a problem with **restarting**. No transactions are processed with a large tick rate **after a restart**. Starting the test validator without an existing ledger works as expected.

Fixes #
https://github.com/solana-labs/solana/issues/22222 