### PR TITLE
Update expected instruction count in `programs` test

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1422,7 +1422,7 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_noop", 481),
             ("solana_bpf_rust_param_passing", 146),
             ("solana_bpf_rust_rand", 488),
-            ("solana_bpf_rust_sanity", 9126),
+            ("solana_bpf_rust_sanity", 9128),
             ("solana_bpf_rust_secp256k1_recover", 25889),
             ("solana_bpf_rust_sha", 30692),
         ]);


### PR DESCRIPTION
#### Problem

The test [`assert_instruction_count`](https://github.com/solana-labs/solana/blob/fd0f5e4d1291dc36c349165a586e64188e794b6c/programs/bpf/tests/programs.rs#L1388) fails:

```
cargo +1.58.1 test --manifest-path programs/bpf/Cargo.toml --no-default-features --features=bpf_rust --test programs -- --nocapture
```

The reason is:

```
BPF program                          expected actual  diff
solana_bpf_rust_sanity                   9126   9128    +2 ( +0%)
```

The same happens in CI, so I assume it's not due to my setup.

#### Summary of Changes

Increase the expected instruction count from 9126 to 9128.

Fixes #
