### PR TITLE
Upgrade thread_local to 1.1.4 per RUSTSEC-2022-0006

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6599,7 +6599,7 @@ checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [


### PR DESCRIPTION
#### Problem
/solana/cargo stable audit found a security vulnerability:
https://rustsec.org/advisories/RUSTSEC-2022-0006

#### Summary of Changes
Upgrade thread_local to 1.1.4.
