### PR TITLE
Export BanksClientError

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -5,9 +5,9 @@
 //! but they are undocumented, may change over time, and are generally more
 //! cumbersome to use.
 
+pub use crate::error::BanksClientError;
 pub use solana_banks_interface::{BanksClient as TarpcClient, TransactionStatus};
 use {
-    crate::error::BanksClientError,
     borsh::BorshDeserialize,
     futures::{future::join_all, Future, FutureExt, TryFutureExt},
     solana_banks_interface::{BanksRequest, BanksResponse, BanksTransactionResultWithSimulation},


### PR DESCRIPTION
#### Problem
BanksClientError which is returned from many banks client method calls is not exported, which makes it difficult to handle the errors.

#### Summary of Changes
Export it

Fixes #22697
