### PR TITLE
Use parallel iterator for executing transactions in an entry

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -62,6 +62,7 @@ use {
         genesis_config::{ClusterType, GenesisConfig},
         hash::Hash,
         pubkey::Pubkey,
+        saturating_add_assign,
         timing::AtomicInterval,
     },
     solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
@@ -215,6 +216,39 @@ pub struct ErrorCounters {
     pub not_allowed_during_cluster_maintenance: usize,
     pub invalid_writable_account: usize,
     pub invalid_rent_paying_account: usize,
+}
+
+impl ErrorCounters {
+    pub fn accumulate(&mut self, other: &ErrorCounters) {
+        saturating_add_assign!(self.total, other.total);
+        saturating_add_assign!(self.account_in_use, other.account_in_use);
+        saturating_add_assign!(self.account_loaded_twice, other.account_loaded_twice);
+        saturating_add_assign!(self.account_not_found, other.account_not_found);
+        saturating_add_assign!(self.blockhash_not_found, other.blockhash_not_found);
+        saturating_add_assign!(self.blockhash_too_old, other.blockhash_too_old);
+        saturating_add_assign!(self.call_chain_too_deep, other.call_chain_too_deep);
+        saturating_add_assign!(self.already_processed, other.already_processed);
+        saturating_add_assign!(self.instruction_error, other.instruction_error);
+        saturating_add_assign!(self.insufficient_funds, other.insufficient_funds);
+        saturating_add_assign!(self.invalid_account_for_fee, other.invalid_account_for_fee);
+        saturating_add_assign!(self.invalid_account_index, other.invalid_account_index);
+        saturating_add_assign!(
+            self.invalid_program_for_execution,
+            other.invalid_program_for_execution
+        );
+        saturating_add_assign!(
+            self.not_allowed_during_cluster_maintenance,
+            other.not_allowed_during_cluster_maintenance
+        );
+        saturating_add_assign!(
+            self.invalid_writable_account,
+            other.invalid_writable_account
+        );
+        saturating_add_assign!(
+            self.invalid_rent_paying_account,
+            other.invalid_rent_paying_account
+        );
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3804,7 +3804,7 @@ impl Bank {
             thread_pool.install(|| {
                 loaded_txs
                     .par_iter_mut()
-                    .zip(sanitized_txs.into_par_iter())
+                    .zip(sanitized_txs.par_iter())
                     .map(|(accs, tx)| match accs {
                         (Err(e), _nonce) => ExecutionResultWithTimingAndError {
                             result: TransactionExecutionResult::NotExecuted(e.clone()),


### PR DESCRIPTION
#### Problem
Replay stage is taking long to process transactions in a given entry. The transactions can be executed in parallel to take advantage of multiple CPU cores. Currently, all the transactions in a given entry are being processed on a single thread.

#### Summary of Changes
Use `par_iter` to parallelize execution of transactions in a given entry. Collect and return transaction results, timings and error counters. Timings and counters are coalesced to match the current design.

Fixes #
