### PR TITLE
v1.9: Fix stable-bpf job by referencing `Signature` directly

### DIFF
--- a/sdk/src/ed25519_instruction.rs
+++ b/sdk/src/ed25519_instruction.rs
@@ -116,8 +116,8 @@ pub fn verify(
             SIGNATURE_SERIALIZED_SIZE,
         )?;
 
-        let signature = ed25519_dalek::Signature::from_bytes(signature)
-            .map_err(|_| PrecompileError::InvalidSignature)?;
+        let signature =
+            Signature::from_bytes(signature).map_err(|_| PrecompileError::InvalidSignature)?;
 
         // Parse out pubkey
         let pubkey = get_data_slice(


### PR DESCRIPTION
#### Problem

v1.9 build isn't working because of a supposed "unused import" in the stable-bpf job, e.g. https://buildkite.com/solana-labs/solana/builds/64232#04be2dcc-38f7-46e1-b4dd-af9a89934462

#### Summary of Changes

Reference the imported `Signature` type directly instead of through `ed25519_dalek::Signature`.

I wasn't sure who to tag on this, but @mvines changed it last, and @CriesofCarrots made some changes to `Cargo.toml` recently, so tag!
