### PR TITLE
program-test: Derive `Debug` on more types to use `unwrap_err`

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -37,7 +37,7 @@ mod error;
 // This exists only for backward compatibility
 pub trait BanksClientExt {}
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct BanksClient {
     inner: TarpcClient,
 }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -442,6 +442,7 @@ fn setup_fees(bank: Bank) -> Bank {
     bank
 }
 
+#[derive(Debug)]
 pub struct ProgramTest {
     accounts: Vec<(Pubkey, AccountSharedData)>,
     builtins: Vec<Builtin>,
@@ -942,6 +943,7 @@ impl ProgramTestBanksClientExt for BanksClient {
     }
 }
 
+#[derive(Debug)]
 struct DroppableTask<T>(Arc<AtomicBool>, JoinHandle<T>);
 
 impl<T> Drop for DroppableTask<T> {
@@ -950,6 +952,7 @@ impl<T> Drop for DroppableTask<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct ProgramTestContext {
     pub banks_client: BanksClient,
     pub last_blockhash: Hash,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -40,6 +40,7 @@ struct SetRootTimings {
     prune_remove_ms: i64,
 }
 
+#[derive(Debug)]
 pub struct BankForks {
     banks: HashMap<Slot, Arc<Bank>>,
     descendants: HashMap<Slot, HashSet<Slot>>,


### PR DESCRIPTION
#### Problem

It's useful to `unwrap_err` in types using `ProgramTest` and friends, but they require `Debug` to be implemented.

#### Summary of Changes

Do the easy thing, and just derive Debug on all dependent types.

Fixes #
