### PR TITLE
rpc: use minimal mode by default

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -673,7 +673,7 @@ pub mod test {
     #[test]
     fn test_accounts_cluster_bench() {
         solana_logger::setup();
-        let validator_config = ValidatorConfig::default();
+        let validator_config = ValidatorConfig::default_for_test();
         let num_nodes = 1;
         let mut config = ClusterConfig {
             cluster_lamports: 10_000_000,

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -29,7 +29,7 @@ fn test_bench_tps_local_cluster(config: Config) {
             node_stakes: vec![999_990; NUM_NODES],
             cluster_lamports: 200_000_000,
             validator_configs: make_identical_validator_configs(
-                &ValidatorConfig::default(),
+                &ValidatorConfig::default_for_test(),
                 NUM_NODES,
             ),
             native_instruction_processors,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -228,6 +228,14 @@ impl Default for ValidatorConfig {
     }
 }
 
+impl ValidatorConfig {
+    pub fn default_for_test() -> Self {
+        let mut config = Self::default();
+        config.rpc_config.full_api = true;
+        config
+    }
+}
+
 // `ValidatorStartProgress` contains status information that is surfaced to the node operator over
 // the admin RPC channel to help them to follow the general progress of node startup without
 // having to watch log messages.
@@ -650,7 +658,7 @@ impl Validator {
                     leader_schedule_cache.clone(),
                     max_complete_transaction_status_slot,
                 )),
-                if config.rpc_config.minimal_api {
+                if !config.rpc_config.full_api {
                     None
                 } else {
                     let (trigger, pubsub_service) = PubSubService::new(
@@ -1765,7 +1773,7 @@ mod tests {
         let voting_keypair = Arc::new(Keypair::new());
         let config = ValidatorConfig {
             rpc_addrs: Some((validator_node.info.rpc, validator_node.info.rpc_pubsub)),
-            ..ValidatorConfig::default()
+            ..ValidatorConfig::default_for_test()
         };
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
         let validator = Validator::new(
@@ -1847,7 +1855,7 @@ mod tests {
                 let vote_account_keypair = Keypair::new();
                 let config = ValidatorConfig {
                     rpc_addrs: Some((validator_node.info.rpc, validator_node.info.rpc_pubsub)),
-                    ..ValidatorConfig::default()
+                    ..ValidatorConfig::default_for_test()
                 };
                 Validator::new(
                     validator_node,
@@ -1890,7 +1898,7 @@ mod tests {
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let mut config = ValidatorConfig::default();
+        let mut config = ValidatorConfig::default_for_test();
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
 

--- a/docs/src/proposals/cluster-test-framework.md
+++ b/docs/src/proposals/cluster-test-framework.md
@@ -50,7 +50,7 @@ To enable specific scenarios, the cluster needs to be booted with special config
 For example:
 
 ```text
-let mut validator_config = ValidatorConfig::default();
+let mut validator_config = ValidatorConfig::default_for_test();
 let local = LocalCluster::new_with_config(
                 num_nodes,
                 10_000,
@@ -66,7 +66,7 @@ For example, there is a bug that shows that the cluster fails when it is flooded
 Configure the RPC service:
 
 ```text
-let mut validator_config = ValidatorConfig::default();
+let mut validator_config = ValidatorConfig::default_for_test();
 validator_config.rpc_config.enable_rpc_gossip_push = true;
 validator_config.rpc_config.enable_rpc_gossip_refresh_active_set = true;
 ```

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -122,7 +122,7 @@ impl LocalCluster {
             node_stakes: stakes,
             cluster_lamports,
             validator_configs: make_identical_validator_configs(
-                &ValidatorConfig::default(),
+                &ValidatorConfig::default_for_test(),
                 num_nodes,
             ),
             ..ClusterConfig::default()

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -257,7 +257,7 @@ pub fn run_cluster_partition<C>(
     let enable_partition = Arc::new(AtomicBool::new(true));
     let mut validator_config = ValidatorConfig {
         enable_partition: Some(enable_partition.clone()),
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
 
     // Returns:
@@ -375,13 +375,13 @@ pub fn test_faulty_node(
 
     let error_validator_config = ValidatorConfig {
         broadcast_stage_type: faulty_node_type,
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
     let mut validator_configs = Vec::with_capacity(num_nodes);
 
     // First validator is the bootstrap leader with the malicious broadcast logic.
     validator_configs.push(error_validator_config);
-    validator_configs.resize_with(num_nodes, ValidatorConfig::default);
+    validator_configs.resize_with(num_nodes, ValidatorConfig::default_for_test);
 
     let mut validator_keys = Vec::with_capacity(num_nodes);
     validator_keys.resize_with(num_nodes, || (Arc::new(Keypair::new()), true));

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -87,7 +87,10 @@ fn test_local_cluster_start_and_exit_with_config() {
     solana_logger::setup();
     const NUM_NODES: usize = 1;
     let mut config = ClusterConfig {
-        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), NUM_NODES),
+        validator_configs: make_identical_validator_configs(
+            &ValidatorConfig::default_for_test(),
+            NUM_NODES,
+        ),
         node_stakes: vec![3; NUM_NODES],
         cluster_lamports: 100,
         ticks_per_slot: 8,
@@ -107,7 +110,7 @@ fn test_ledger_cleanup_service() {
     let num_nodes = 3;
     let validator_config = ValidatorConfig {
         max_ledger_shreds: Some(100),
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
         cluster_lamports: 10_000,
@@ -293,7 +296,7 @@ fn test_leader_failure_4() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_leader_failure_4");
     let num_nodes = 4;
-    let validator_config = ValidatorConfig::default();
+    let validator_config = ValidatorConfig::default_for_test();
     let mut config = ClusterConfig {
         cluster_lamports: 10_000,
         node_stakes: vec![100; 4],
@@ -384,7 +387,7 @@ fn test_cluster_partition_1_1_1() {
 fn test_two_unbalanced_stakes() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     error!("test_two_unbalanced_stakes");
-    let validator_config = ValidatorConfig::default();
+    let validator_config = ValidatorConfig::default_for_test();
     let num_ticks_per_second = 100;
     let num_ticks_per_slot = 10;
     let num_slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH as u64;
@@ -423,7 +426,10 @@ fn test_forwarding() {
     let mut config = ClusterConfig {
         node_stakes: vec![999_990, 3],
         cluster_lamports: 2_000_000,
-        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), 2),
+        validator_configs: make_identical_validator_configs(
+            &ValidatorConfig::default_for_test(),
+            2,
+        ),
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
@@ -454,7 +460,7 @@ fn test_restart_node() {
     error!("test_restart_node");
     let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH * 2;
     let ticks_per_slot = 16;
-    let validator_config = ValidatorConfig::default();
+    let validator_config = ValidatorConfig::default_for_test();
     let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![100; 1],
@@ -498,7 +504,10 @@ fn test_mainnet_beta_cluster_type() {
         cluster_type: ClusterType::MainnetBeta,
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
-        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), 1),
+        validator_configs: make_identical_validator_configs(
+            &ValidatorConfig::default_for_test(),
+            1,
+        ),
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
@@ -1577,7 +1586,7 @@ fn test_fake_shreds_broadcast_leader() {
 #[test]
 fn test_wait_for_max_stake() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
-    let validator_config = ValidatorConfig::default();
+    let validator_config = ValidatorConfig::default_for_test();
     let mut config = ClusterConfig {
         cluster_lamports: 10_000,
         node_stakes: vec![100; 4],
@@ -1600,7 +1609,7 @@ fn test_no_voting() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let validator_config = ValidatorConfig {
         voting_disabled: true,
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
         cluster_lamports: 10_000,
@@ -1653,7 +1662,7 @@ fn test_optimistic_confirmation_violation_detection() {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default(),
+            &ValidatorConfig::default_for_test(),
             node_stakes.len(),
         ),
         validator_keys: Some(validator_keys),
@@ -1774,7 +1783,7 @@ fn test_validator_saves_tower() {
 
     let validator_config = ValidatorConfig {
         require_tower: true,
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
     let validator_identity_keypair = Arc::new(Keypair::new());
     let validator_id = validator_identity_keypair.pubkey();
@@ -1968,7 +1977,7 @@ fn test_slot_hash_expiry() {
     // We want B to not vote (we are trying to simulate its votes not landing until it gets to the
     // minority fork)
     let mut validator_configs =
-        make_identical_validator_configs(&ValidatorConfig::default(), node_stakes.len());
+        make_identical_validator_configs(&ValidatorConfig::default_for_test(), node_stakes.len());
     validator_configs[1].voting_disabled = true;
 
     let mut config = ClusterConfig {
@@ -2149,7 +2158,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default(),
+            &ValidatorConfig::default_for_test(),
             node_stakes.len(),
         ),
         validator_keys: Some(validator_keys),
@@ -2260,7 +2269,7 @@ fn test_hard_fork_invalidates_tower() {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default(),
+            &ValidatorConfig::default_for_test(),
             node_stakes.len(),
         ),
         validator_keys: Some(validator_keys),
@@ -2392,7 +2401,7 @@ fn test_restart_tower_rollback() {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default(),
+            &ValidatorConfig::default_for_test(),
             node_stakes.len(),
         ),
         validator_keys: Some(validator_keys),
@@ -2758,7 +2767,7 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
         validator_configs: make_identical_validator_configs(
-            &ValidatorConfig::default(),
+            &ValidatorConfig::default_for_test(),
             node_stakes.len(),
         ),
         validator_keys: Some(validator_keys),
@@ -2861,7 +2870,7 @@ impl SnapshotValidatorConfig {
             snapshot_config: Some(snapshot_config),
             account_paths: account_storage_paths,
             accounts_hash_interval_slots,
-            ..ValidatorConfig::default()
+            ..ValidatorConfig::default_for_test()
         };
 
         SnapshotValidatorConfig {

--- a/local-cluster/tests/local_cluster_flakey.rs
+++ b/local-cluster/tests/local_cluster_flakey.rs
@@ -129,7 +129,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     // below only for slots <= `next_slot_on_a`, validator A will not know how it's last vote chains
     // to the otehr forks, and may violate switching proofs on restart.
     let mut validator_configs =
-        make_identical_validator_configs(&ValidatorConfig::default(), node_stakes.len());
+        make_identical_validator_configs(&ValidatorConfig::default_for_test(), node_stakes.len());
 
     validator_configs[0].voting_disabled = true;
     validator_configs[2].voting_disabled = true;

--- a/local-cluster/tests/local_cluster_slow.rs
+++ b/local-cluster/tests/local_cluster_slow.rs
@@ -844,7 +844,10 @@ fn test_listener_startup() {
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         num_listeners: 3,
-        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), 1),
+        validator_configs: make_identical_validator_configs(
+            &ValidatorConfig::default_for_test(),
+            1,
+        ),
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -129,6 +129,7 @@ args+=(
   --no-poh-speed-test
   --no-os-network-limits-test
   --no-wait-for-vote-to-start-leader
+  --full-rpc-api
 )
 default_arg --gossip-port 8001
 default_arg --log -

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -248,6 +248,7 @@ default_arg --identity "$identity"
 default_arg --vote-account "$vote_account"
 default_arg --ledger "$ledger_dir"
 default_arg --log -
+default_arg --full-rpc-api
 
 if [[ $maybeRequireTower = true ]]; then
   default_arg --require-tower

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -145,7 +145,7 @@ fn setup_snapshot_validator_config(
         account_paths: account_storage_paths,
         accounts_hash_interval_slots: snapshot_interval_slots,
         accountsdb_repl_service_config,
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
 
     SnapshotValidatorConfig {
@@ -160,7 +160,10 @@ fn test_local_cluster_start_and_exit_with_config(socket_addr_space: SocketAddrSp
     solana_logger::setup();
     const NUM_NODES: usize = 1;
     let mut config = ClusterConfig {
-        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), NUM_NODES),
+        validator_configs: make_identical_validator_configs(
+            &ValidatorConfig::default_for_test(),
+            NUM_NODES,
+        ),
         node_stakes: vec![3; NUM_NODES],
         cluster_lamports: 100,
         ticks_per_slot: 8,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -149,7 +149,7 @@ pub struct JsonRpcConfig {
     pub rpc_threads: usize,
     pub rpc_niceness_adj: i8,
     pub rpc_bigtable_timeout: Option<Duration>,
-    pub minimal_api: bool,
+    pub full_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
 }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -380,7 +380,7 @@ impl JsonRpcService {
                 (None, None)
             };
 
-        let minimal_api = config.minimal_api;
+        let full_api = config.full_api;
         let obsolete_v1_7_api = config.obsolete_v1_7_api;
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
@@ -424,7 +424,7 @@ impl JsonRpcService {
                 let mut io = MetaIoHandler::default();
 
                 io.extend_with(rpc_minimal::MinimalImpl.to_delegate());
-                if !minimal_api {
+                if full_api {
                     io.extend_with(rpc_bank::BankDataImpl.to_delegate());
                     io.extend_with(rpc_accounts::AccountsDataImpl.to_delegate());
                     io.extend_with(rpc_full::FullImpl.to_delegate());

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -84,7 +84,6 @@ impl Default for TestValidatorNodeConfig {
     }
 }
 
-#[derive(Default)]
 pub struct TestValidatorGenesis {
     fee_rate_governor: FeeRateGovernor,
     ledger_path: Option<PathBuf>,
@@ -107,6 +106,37 @@ pub struct TestValidatorGenesis {
     pub max_genesis_archive_unpacked_size: Option<u64>,
     pub accountsdb_plugin_config_files: Option<Vec<PathBuf>>,
     pub accounts_db_caching_enabled: bool,
+}
+
+impl Default for TestValidatorGenesis {
+    fn default() -> Self {
+        Self {
+            fee_rate_governor: FeeRateGovernor::default(),
+            ledger_path: Option::<PathBuf>::default(),
+            tower_storage: Option::<Arc<dyn TowerStorage>>::default(),
+            rent: Rent::default(),
+            rpc_config: JsonRpcConfig {
+                full_api: true,
+                ..JsonRpcConfig::default()
+            },
+            pubsub_config: PubSubConfig::default(),
+            rpc_ports: Option::<(u16, u16)>::default(),
+            warp_slot: Option::<Slot>::default(),
+            no_bpf_jit: bool::default(),
+            accounts: HashMap::<Pubkey, AccountSharedData>::default(),
+            programs: Vec::<ProgramInfo>::default(),
+            ticks_per_slot: Option::<u64>::default(),
+            epoch_schedule: Option::<EpochSchedule>::default(),
+            node_config: TestValidatorNodeConfig::default(),
+            validator_exit: Arc::<RwLock<Exit>>::default(),
+            start_progress: Arc::<RwLock<ValidatorStartProgress>>::default(),
+            authorized_voter_keypairs: Arc::<RwLock<Vec<Arc<Keypair>>>>::default(),
+            max_ledger_shreds: Option::<u64>::default(),
+            max_genesis_archive_unpacked_size: Option::<u64>::default(),
+            accountsdb_plugin_config_files: Option::<Vec<PathBuf>>::default(),
+            accounts_db_caching_enabled: bool::default(),
+        }
+    }
 }
 
 impl TestValidatorGenesis {
@@ -630,7 +660,7 @@ impl TestValidator {
             rocksdb_compaction_interval: Some(100), // Compact every 100 slots
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
-            ..ValidatorConfig::default()
+            ..ValidatorConfig::default_for_test()
         };
         if let Some(ref tower_storage) = config.tower_storage {
             validator_config.tower_storage = tower_storage.clone();

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -665,7 +665,7 @@ pub mod test {
     fn test_transaction_dos() {
         solana_logger::setup();
 
-        let validator_config = ValidatorConfig::default();
+        let validator_config = ValidatorConfig::default_for_test();
         let num_nodes = 1;
         let mut config = ClusterConfig {
             cluster_lamports: 10_000_000,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -576,7 +576,15 @@ pub fn main() {
             Arg::with_name("minimal_rpc_api")
                 .long("--minimal-rpc-api")
                 .takes_value(false)
+                .hidden(true)
                 .help("Only expose the RPC methods required to serve snapshots to other nodes"),
+        )
+        .arg(
+            Arg::with_name("full_rpc_api")
+                .long("--full-rpc-api")
+                .conflicts_with("minimal_rpc_api")
+                .takes_value(false)
+                .help("Expose RPC methods for querying chain state and transaction history"),
         )
         .arg(
             Arg::with_name("obsolete_v1_7_rpc_api")
@@ -2123,6 +2131,10 @@ pub fn main() {
         None
     };
 
+    if matches.is_present("minimal_rpc_api") {
+        warn!("--minimal-rpc-api is now the default behavior. This flag is deprecated and can be removed from the launch args")
+    }
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,
@@ -2144,7 +2156,7 @@ pub fn main() {
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
             }),
-            minimal_api: matches.is_present("minimal_rpc_api"),
+            full_api: matches.is_present("full_rpc_api"),
             obsolete_v1_7_api: matches.is_present("obsolete_v1_7_rpc_api"),
             max_multiple_accounts: Some(value_t_or_exit!(
                 matches,


### PR DESCRIPTION
#### Problem

Validators need to explicitly reduce their RPC exposure rather than deliberately increase it.  Which is a dumb default.

#### Summary of Changes

`--minimal-rpc-api` by default. (now deprecated, use ~`--extended-rpc-api`~ `--full-rpc-api` to enable the full method set)