### PR TITLE
Add solana_client::nonblocking::rpc_client::RpcClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4713,6 +4713,7 @@ name = "solana-client"
 version = "1.10.0"
 dependencies = [
  "assert_matches",
+ "async-trait",
  "base64 0.13.0",
  "bincode",
  "bs58 0.4.0",
@@ -5985,6 +5986,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-streamer",
+ "tokio",
 ]
 
 [[package]]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1706,7 +1706,7 @@ mod tests {
         serde_json::{json, Value},
         solana_client::{
             blockhash_query,
-            mock_sender::SIGNATURE,
+            mock_sender_for_cli::SIGNATURE,
             rpc_request::RpcRequest,
             rpc_response::{Response, RpcResponseContext},
         },

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1.52"
 base64 = "0.13.0"
 bincode = "1.3.3"
 bs58 = "0.4.0"

--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -1,4 +1,4 @@
-//! The standard [`RpcSender`] over HTTP.
+//! Nonblocking [`RpcSender`] over HTTP.
 
 use {
     crate::{
@@ -8,6 +8,7 @@ use {
         rpc_response::RpcSimulateTransactionResult,
         rpc_sender::*,
     },
+    async_trait::async_trait,
     log::*,
     reqwest::{
         self,
@@ -25,13 +26,13 @@ use {
 };
 
 pub struct HttpSender {
-    client: Arc<reqwest::blocking::Client>,
+    client: Arc<reqwest::Client>,
     url: String,
     request_id: AtomicU64,
     stats: RwLock<RpcTransportStats>,
 }
 
-/// The standard [`RpcSender`] over HTTP.
+/// Nonblocking [`RpcSender`] over HTTP.
 impl HttpSender {
     /// Create an HTTP RPC sender.
     ///
@@ -45,15 +46,11 @@ impl HttpSender {
     ///
     /// The URL is an HTTP URL, usually for port 8899.
     pub fn new_with_timeout(url: String, timeout: Duration) -> Self {
-        // `reqwest::blocking::Client` panics if run in a tokio async context.  Shuttle the
-        // request to a different tokio thread to avoid this
         let client = Arc::new(
-            tokio::task::block_in_place(move || {
-                reqwest::blocking::Client::builder()
-                    .timeout(timeout)
-                    .build()
-            })
-            .expect("build rpc client"),
+            reqwest::Client::builder()
+                .timeout(timeout)
+                .build()
+                .expect("build rpc client"),
         );
 
         Self {
@@ -100,12 +97,17 @@ impl<'a> Drop for StatsUpdater<'a> {
     }
 }
 
+#[async_trait]
 impl RpcSender for HttpSender {
     fn get_transport_stats(&self) -> RpcTransportStats {
         self.stats.read().unwrap().clone()
     }
 
-    fn send(&self, request: RpcRequest, params: serde_json::Value) -> Result<serde_json::Value> {
+    async fn send(
+        &self,
+        request: RpcRequest,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
         let mut stats_updater = StatsUpdater::new(&self.stats);
 
         let request_id = self.request_id.fetch_add(1, Ordering::Relaxed);
@@ -113,18 +115,15 @@ impl RpcSender for HttpSender {
 
         let mut too_many_requests_retries = 5;
         loop {
-            // `reqwest::blocking::Client` panics if run in a tokio async context.  Shuttle the
-            // request to a different tokio thread to avoid this
             let response = {
                 let client = self.client.clone();
                 let request_json = request_json.clone();
-                tokio::task::block_in_place(move || {
-                    client
-                        .post(&self.url)
-                        .header(CONTENT_TYPE, "application/json")
-                        .body(request_json)
-                        .send()
-                })
+                client
+                    .post(&self.url)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(request_json)
+                    .send()
+                    .await
             }?;
 
             if !response.status().is_success() {
@@ -155,8 +154,7 @@ impl RpcSender for HttpSender {
                 return Err(response.error_for_status().unwrap_err().into());
             }
 
-            let mut json =
-                tokio::task::block_in_place(move || response.json::<serde_json::Value>())?;
+            let mut json = response.json::<serde_json::Value>().await?;
             if json["error"].is_object() {
                 return match serde_json::from_value::<RpcErrorObject>(json["error"].clone()) {
                     Ok(rpc_error_object) => {
@@ -208,14 +206,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn http_sender_on_tokio_multi_thread() {
         let http_sender = HttpSender::new("http://localhost:1234".to_string());
-        let _ = http_sender.send(RpcRequest::GetVersion, serde_json::Value::Null);
+        let _ = http_sender
+            .send(RpcRequest::GetVersion, serde_json::Value::Null)
+            .await;
     }
 
     #[tokio::test(flavor = "current_thread")]
-    #[should_panic(expected = "can call blocking only when running on the multi-threaded runtime")]
-    async fn http_sender_ontokio_current_thread_should_panic() {
-        // RpcClient::new() will panic in the tokio current-thread runtime due to `tokio::task::block_in_place()` usage, and there
-        // doesn't seem to be a way to detect whether the tokio runtime is multi_thread or current_thread...
-        let _ = HttpSender::new("http://localhost:1234".to_string());
+    async fn http_sender_on_tokio_current_thread() {
+        let http_sender = HttpSender::new("http://localhost:1234".to_string());
+        let _ = http_sender
+            .send(RpcRequest::GetVersion, serde_json::Value::Null)
+            .await;
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -4,8 +4,9 @@ extern crate serde_derive;
 
 pub mod blockhash_query;
 pub mod client_error;
-pub mod http_sender;
-pub mod mock_sender;
+pub(crate) mod http_sender;
+pub(crate) mod mock_sender;
+pub mod nonblocking;
 pub mod nonce_utils;
 pub mod perf_utils;
 pub mod pubsub_client;
@@ -17,8 +18,15 @@ pub mod rpc_deprecated_config;
 pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;
-pub mod rpc_sender;
+pub(crate) mod rpc_sender;
 pub mod spinner;
 pub mod thin_client;
 pub mod tpu_client;
 pub mod transaction_executor;
+
+pub mod mock_sender_for_cli {
+    /// Magic `SIGNATURE` value used by `solana-cli` unit tests.
+    /// Please don't use this constant.
+    pub const SIGNATURE: &str =
+        "43yNSFC6fYTuPgTNFFhF4axw7AfWxB2BPdurme8yrsWEYwm8299xh8n6TAHjGymiSub1XtyxTNyd9GBfY2hxoBw8";
+}

--- a/client/src/nonblocking/mod.rs
+++ b/client/src/nonblocking/mod.rs
@@ -1,0 +1,1 @@
+pub mod rpc_client;

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -1,4 +1,4 @@
-//! Communication with a Solana node over RPC.
+//! Communication with a Solana node over RPC asynchronously .
 //!
 //! Software that interacts with the Solana blockchain, whether querying its
 //! state or submitting transactions, communicates with a Solana node over
@@ -7,27 +7,33 @@
 //! [JSON-RPC]: https://www.jsonrpc.org/specification
 
 #[allow(deprecated)]
-use crate::rpc_deprecated_config::{RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig};
+use crate::rpc_deprecated_config::{
+    RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
+    RpcGetConfirmedSignaturesForAddress2Config,
+};
 use {
     crate::{
-        client_error::Result as ClientResult,
+        client_error::{ClientError, ClientErrorKind, Result as ClientResult},
         http_sender::HttpSender,
         mock_sender::{MockSender, Mocks},
-        nonblocking::{self, rpc_client::get_rpc_request_str},
+        rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClientConfig},
         rpc_config::{RpcAccountInfoConfig, *},
-        rpc_request::{RpcRequest, TokenAccountsFilter},
+        rpc_request::{RpcError, RpcRequest, RpcResponseErrorData, TokenAccountsFilter},
         rpc_response::*,
         rpc_sender::*,
+        spinner,
     },
-    serde_json::Value,
+    bincode::serialize,
+    log::*,
+    serde_json::{json, Value},
     solana_account_decoder::{
-        parse_token::{UiTokenAccount, UiTokenAmount},
-        UiAccount, UiAccountEncoding,
+        parse_token::{TokenAccountType, UiTokenAccount, UiTokenAmount},
+        UiAccount, UiAccountData, UiAccountEncoding,
     },
     solana_sdk::{
         account::Account,
-        clock::{Epoch, Slot, UnixTimestamp},
-        commitment_config::CommitmentConfig,
+        clock::{Epoch, Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT, MAX_HASH_AGE_IN_SECONDS},
+        commitment_config::{CommitmentConfig, CommitmentLevel},
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -35,37 +41,22 @@ use {
         message::Message,
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, Transaction},
+        transaction::{self, uses_durable_nonce, Transaction},
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, TransactionStatus,
         UiConfirmedBlock, UiTransactionEncoding,
     },
-    std::{net::SocketAddr, str::FromStr, time::Duration},
+    solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY,
+    std::{
+        cmp::min,
+        net::SocketAddr,
+        str::FromStr,
+        sync::RwLock,
+        time::{Duration, Instant},
+    },
+    tokio::time::sleep,
 };
-
-#[derive(Default)]
-pub struct RpcClientConfig {
-    pub commitment_config: CommitmentConfig,
-    pub confirm_transaction_initial_timeout: Option<Duration>,
-}
-
-impl RpcClientConfig {
-    pub fn with_commitment(commitment_config: CommitmentConfig) -> Self {
-        RpcClientConfig {
-            commitment_config,
-            ..Self::default()
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct GetConfirmedSignaturesForAddress2Config {
-    pub before: Option<Signature>,
-    pub until: Option<Signature>,
-    pub limit: Option<usize>,
-    pub commitment: Option<CommitmentConfig>,
-}
 
 /// A client of a remote Solana node.
 ///
@@ -146,14 +137,9 @@ pub struct GetConfirmedSignaturesForAddress2Config {
 /// returns `true`. The default timeout is 30 seconds, and may be changed by
 /// calling an appropriate constructor with a `timeout` parameter.
 pub struct RpcClient {
-    rpc_client: nonblocking::rpc_client::RpcClient,
-    runtime: Option<tokio::runtime::Runtime>,
-}
-
-impl Drop for RpcClient {
-    fn drop(&mut self) {
-        self.runtime.take().expect("runtime").shutdown_background();
-    }
+    sender: Box<dyn RpcSender + Send + Sync + 'static>,
+    config: RpcClientConfig,
+    node_version: RwLock<Option<semver::Version>>,
 }
 
 impl RpcClient {
@@ -163,20 +149,14 @@ impl RpcClient {
     /// `RpcSender`. Most applications should use one of the other constructors,
     /// such as [`new`] and [`new_mock`], which create an `RpcClient`
     /// encapsulating an [`HttpSender`] and [`MockSender`] respectively.
-    fn new_sender<T: RpcSender + Send + Sync + 'static>(
+    pub(crate) fn new_sender<T: RpcSender + Send + Sync + 'static>(
         sender: T,
         config: RpcClientConfig,
     ) -> Self {
         Self {
-            rpc_client: nonblocking::rpc_client::RpcClient::new_sender(sender, config),
-            runtime: Some(
-                tokio::runtime::Builder::new_current_thread()
-                    .thread_name("rpc-client")
-                    .enable_io()
-                    .enable_time()
-                    .build()
-                    .unwrap(),
-            ),
+            sender: Box::new(sender),
+            node_version: RwLock::new(None),
+            config,
         }
     }
 
@@ -461,6 +441,24 @@ impl RpcClient {
         Self::new_with_timeout(url, timeout)
     }
 
+    async fn get_node_version(&self) -> Result<semver::Version, RpcError> {
+        let r_node_version = self.node_version.read().unwrap();
+        if let Some(version) = &*r_node_version {
+            Ok(version.clone())
+        } else {
+            drop(r_node_version);
+            let mut w_node_version = self.node_version.write().unwrap();
+            let node_version = self.get_version().await.map_err(|e| {
+                RpcError::RpcRequestError(format!("cluster version query failed: {}", e))
+            })?;
+            let node_version = semver::Version::parse(&node_version.solana_core).map_err(|e| {
+                RpcError::RpcRequestError(format!("failed to parse cluster version: {}", e))
+            })?;
+            *w_node_version = Some(node_version.clone());
+            Ok(node_version)
+        }
+    }
+
     /// Get the configured default [commitment level][cl].
     ///
     /// [cl]: https://docs.solana.com/developing/clients/jsonrpc-api#configuring-state-commitment
@@ -475,7 +473,44 @@ impl RpcClient {
     /// explicitly provide a [`CommitmentConfig`], like
     /// [`RpcClient::confirm_transaction_with_commitment`].
     pub fn commitment(&self) -> CommitmentConfig {
-        self.rpc_client.commitment()
+        self.config.commitment_config
+    }
+
+    async fn use_deprecated_commitment(&self) -> Result<bool, RpcError> {
+        Ok(self.get_node_version().await? < semver::Version::new(1, 5, 5))
+    }
+
+    async fn maybe_map_commitment(
+        &self,
+        requested_commitment: CommitmentConfig,
+    ) -> Result<CommitmentConfig, RpcError> {
+        if matches!(
+            requested_commitment.commitment,
+            CommitmentLevel::Finalized | CommitmentLevel::Confirmed | CommitmentLevel::Processed
+        ) && self.use_deprecated_commitment().await?
+        {
+            return Ok(CommitmentConfig::use_deprecated_commitment(
+                requested_commitment,
+            ));
+        }
+        Ok(requested_commitment)
+    }
+
+    #[allow(deprecated)]
+    async fn maybe_map_request(&self, mut request: RpcRequest) -> Result<RpcRequest, RpcError> {
+        if self.get_node_version().await? < semver::Version::new(1, 7, 0) {
+            request = match request {
+                RpcRequest::GetBlock => RpcRequest::GetConfirmedBlock,
+                RpcRequest::GetBlocks => RpcRequest::GetConfirmedBlocks,
+                RpcRequest::GetBlocksWithLimit => RpcRequest::GetConfirmedBlocksWithLimit,
+                RpcRequest::GetSignaturesForAddress => {
+                    RpcRequest::GetConfirmedSignaturesForAddress2
+                }
+                RpcRequest::GetTransaction => RpcRequest::GetConfirmedTransaction,
+                _ => request,
+            };
+        }
+        Ok(request)
     }
 
     /// Submit a transaction and wait for confirmation.
@@ -538,48 +573,104 @@ impl RpcClient {
     /// let signature = rpc_client.send_and_confirm_transaction(&tx)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn send_and_confirm_transaction(
+    pub async fn send_and_confirm_transaction(
         &self,
         transaction: &Transaction,
     ) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.send_and_confirm_transaction(transaction))
-    }
+        const SEND_RETRIES: usize = 1;
+        const GET_STATUS_RETRIES: usize = usize::MAX;
 
-    pub fn send_and_confirm_transaction_with_spinner(
-        &self,
-        transaction: &Transaction,
-    ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .send_and_confirm_transaction_with_spinner(transaction),
+        'sending: for _ in 0..SEND_RETRIES {
+            let signature = self.send_transaction(transaction).await?;
+
+            let recent_blockhash = if uses_durable_nonce(transaction).is_some() {
+                let (recent_blockhash, ..) = self
+                    .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
+                    .await?;
+                recent_blockhash
+            } else {
+                transaction.message.recent_blockhash
+            };
+
+            for status_retry in 0..GET_STATUS_RETRIES {
+                match self.get_signature_status(&signature).await? {
+                    Some(Ok(_)) => return Ok(signature),
+                    Some(Err(e)) => return Err(e.into()),
+                    None => {
+                        if !self
+                            .is_blockhash_valid(&recent_blockhash, CommitmentConfig::processed())
+                            .await?
+                        {
+                            // Block hash is not found by some reason
+                            break 'sending;
+                        } else if cfg!(not(test))
+                            // Ignore sleep at last step.
+                            && status_retry < GET_STATUS_RETRIES
+                        {
+                            // Retry twice a second
+                            sleep(Duration::from_millis(500)).await;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        Err(RpcError::ForUser(
+            "unable to confirm transaction. \
+             This can happen in situations such as transaction expiration \
+             and insufficient fee-payer funds"
+                .to_string(),
         )
+        .into())
     }
 
-    pub fn send_and_confirm_transaction_with_spinner_and_commitment(
+    pub async fn send_and_confirm_transaction_with_spinner(
+        &self,
+        transaction: &Transaction,
+    ) -> ClientResult<Signature> {
+        self.send_and_confirm_transaction_with_spinner_and_commitment(
+            transaction,
+            self.commitment(),
+        )
+        .await
+    }
+
+    pub async fn send_and_confirm_transaction_with_spinner_and_commitment(
         &self,
         transaction: &Transaction,
         commitment: CommitmentConfig,
     ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .send_and_confirm_transaction_with_spinner_and_commitment(transaction, commitment),
+        self.send_and_confirm_transaction_with_spinner_and_config(
+            transaction,
+            commitment,
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(commitment.commitment),
+                ..RpcSendTransactionConfig::default()
+            },
         )
+        .await
     }
 
-    pub fn send_and_confirm_transaction_with_spinner_and_config(
+    pub async fn send_and_confirm_transaction_with_spinner_and_config(
         &self,
         transaction: &Transaction,
         commitment: CommitmentConfig,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .send_and_confirm_transaction_with_spinner_and_config(
-                    transaction,
-                    commitment,
-                    config,
-                ),
-        )
+        let recent_blockhash = if uses_durable_nonce(transaction).is_some() {
+            self.get_latest_blockhash_with_commitment(CommitmentConfig::processed())
+                .await?
+                .0
+        } else {
+            transaction.message.recent_blockhash
+        };
+        let signature = self
+            .send_transaction_with_config(transaction, config)
+            .await?;
+        self.confirm_transaction_with_spinner(&signature, &recent_blockhash, commitment)
+            .await?;
+        Ok(signature)
     }
 
     /// Submits a signed transaction to the network.
@@ -651,8 +742,19 @@ impl RpcClient {
     /// let signature = rpc_client.send_transaction(&tx)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.send_transaction(transaction))
+    pub async fn send_transaction(&self, transaction: &Transaction) -> ClientResult<Signature> {
+        self.send_transaction_with_config(
+            transaction,
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(
+                    self.maybe_map_commitment(self.commitment())
+                        .await?
+                        .commitment,
+                ),
+                ..RpcSendTransactionConfig::default()
+            },
+        )
+        .await
     }
 
     /// Submits a signed transaction to the network.
@@ -733,22 +835,74 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn send_transaction_with_config(
+    pub async fn send_transaction_with_config(
         &self,
         transaction: &Transaction,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .send_transaction_with_config(transaction, config),
-        )
-    }
+        let encoding = if let Some(encoding) = config.encoding {
+            encoding
+        } else {
+            self.default_cluster_transaction_encoding().await?
+        };
+        let preflight_commitment = CommitmentConfig {
+            commitment: config.preflight_commitment.unwrap_or_default(),
+        };
+        let preflight_commitment = self.maybe_map_commitment(preflight_commitment).await?;
+        let config = RpcSendTransactionConfig {
+            encoding: Some(encoding),
+            preflight_commitment: Some(preflight_commitment.commitment),
+            ..config
+        };
+        let serialized_encoded = serialize_and_encode::<Transaction>(transaction, encoding)?;
+        let signature_base58_str: String = match self
+            .send(
+                RpcRequest::SendTransaction,
+                json!([serialized_encoded, config]),
+            )
+            .await
+        {
+            Ok(signature_base58_str) => signature_base58_str,
+            Err(err) => {
+                if let ClientErrorKind::RpcError(RpcError::RpcResponseError {
+                    code,
+                    message,
+                    data,
+                }) = &err.kind
+                {
+                    debug!("{} {}", code, message);
+                    if let RpcResponseErrorData::SendTransactionPreflightFailure(
+                        RpcSimulateTransactionResult {
+                            logs: Some(logs), ..
+                        },
+                    ) = data
+                    {
+                        for (i, log) in logs.iter().enumerate() {
+                            debug!("{:>3}: {}", i + 1, log);
+                        }
+                        debug!("");
+                    }
+                }
+                return Err(err);
+            }
+        };
 
-    pub fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        self.invoke(self.rpc_client.send(request, params))
+        let signature = signature_base58_str
+            .parse::<Signature>()
+            .map_err(|err| Into::<ClientError>::into(RpcError::ParseError(err.to_string())))?;
+        // A mismatching RPC response signature indicates an issue with the RPC node, and
+        // should not be passed along to confirmation methods. The transaction may or may
+        // not have been submitted to the cluster, so callers should verify the success of
+        // the correct transaction signature independently.
+        if signature != transaction.signatures[0] {
+            Err(RpcError::RpcRequestError(format!(
+                "RPC node returned mismatched signature {:?}, expected {:?}",
+                signature, transaction.signatures[0]
+            ))
+            .into())
+        } else {
+            Ok(transaction.signatures[0])
+        }
     }
 
     /// Check the confirmation status of a transaction.
@@ -803,8 +957,11 @@ impl RpcClient {
     /// }
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn confirm_transaction(&self, signature: &Signature) -> ClientResult<bool> {
-        self.invoke(self.rpc_client.confirm_transaction(signature))
+    pub async fn confirm_transaction(&self, signature: &Signature) -> ClientResult<bool> {
+        Ok(self
+            .confirm_transaction_with_commitment(signature, self.commitment())
+            .await?
+            .value)
     }
 
     /// Check the confirmation status of a transaction.
@@ -861,28 +1018,124 @@ impl RpcClient {
     /// }
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn confirm_transaction_with_commitment(
+    pub async fn confirm_transaction_with_commitment(
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<bool> {
-        self.invoke(
-            self.rpc_client
-                .confirm_transaction_with_commitment(signature, commitment_config),
-        )
+        let Response { context, value } = self.get_signature_statuses(&[*signature]).await?;
+
+        Ok(Response {
+            context,
+            value: value[0]
+                .as_ref()
+                .filter(|result| result.satisfies_commitment(commitment_config))
+                .map(|result| result.status.is_ok())
+                .unwrap_or_default(),
+        })
     }
 
-    pub fn confirm_transaction_with_spinner(
+    pub async fn confirm_transaction_with_spinner(
         &self,
         signature: &Signature,
         recent_blockhash: &Hash,
-        commitment_config: CommitmentConfig,
+        commitment: CommitmentConfig,
     ) -> ClientResult<()> {
-        self.invoke(self.rpc_client.confirm_transaction_with_spinner(
-            signature,
-            recent_blockhash,
-            commitment_config,
-        ))
+        let desired_confirmations = if commitment.is_finalized() {
+            MAX_LOCKOUT_HISTORY + 1
+        } else {
+            1
+        };
+        let mut confirmations = 0;
+
+        let progress_bar = spinner::new_progress_bar();
+
+        progress_bar.set_message(format!(
+            "[{}/{}] Finalizing transaction {}",
+            confirmations, desired_confirmations, signature,
+        ));
+
+        let now = Instant::now();
+        let confirm_transaction_initial_timeout = self
+            .config
+            .confirm_transaction_initial_timeout
+            .unwrap_or_default();
+        let (signature, status) = loop {
+            // Get recent commitment in order to count confirmations for successful transactions
+            let status = self
+                .get_signature_status_with_commitment(signature, CommitmentConfig::processed())
+                .await?;
+            if status.is_none() {
+                let blockhash_not_found = !self
+                    .is_blockhash_valid(recent_blockhash, CommitmentConfig::processed())
+                    .await?;
+                if blockhash_not_found && now.elapsed() >= confirm_transaction_initial_timeout {
+                    break (signature, status);
+                }
+            } else {
+                break (signature, status);
+            }
+
+            if cfg!(not(test)) {
+                sleep(Duration::from_millis(500)).await;
+            }
+        };
+        if let Some(result) = status {
+            if let Err(err) = result {
+                return Err(err.into());
+            }
+        } else {
+            return Err(RpcError::ForUser(
+                "unable to confirm transaction. \
+                                      This can happen in situations such as transaction expiration \
+                                      and insufficient fee-payer funds"
+                    .to_string(),
+            )
+            .into());
+        }
+        let now = Instant::now();
+        loop {
+            // Return when specified commitment is reached
+            // Failed transactions have already been eliminated, `is_some` check is sufficient
+            if self
+                .get_signature_status_with_commitment(signature, commitment)
+                .await?
+                .is_some()
+            {
+                progress_bar.set_message("Transaction confirmed");
+                progress_bar.finish_and_clear();
+                return Ok(());
+            }
+
+            progress_bar.set_message(format!(
+                "[{}/{}] Finalizing transaction {}",
+                min(confirmations + 1, desired_confirmations),
+                desired_confirmations,
+                signature,
+            ));
+            sleep(Duration::from_millis(500)).await;
+            confirmations = self
+                .get_num_blocks_since_signature_confirmation(signature)
+                .await
+                .unwrap_or(confirmations);
+            if now.elapsed().as_secs() >= MAX_HASH_AGE_IN_SECONDS as u64 {
+                return Err(
+                    RpcError::ForUser("transaction not finalized. \
+                                      This can happen when a transaction lands in an abandoned fork. \
+                                      Please retry.".to_string()).into(),
+                );
+            }
+        }
+    }
+
+    async fn default_cluster_transaction_encoding(
+        &self,
+    ) -> Result<UiTransactionEncoding, RpcError> {
+        if self.get_node_version().await? < semver::Version::new(1, 3, 16) {
+            Ok(UiTransactionEncoding::Base58)
+        } else {
+            Ok(UiTransactionEncoding::Base64)
+        }
     }
 
     /// Simulates sending a transaction.
@@ -939,11 +1192,18 @@ impl RpcClient {
     /// assert!(result.value.err.is_none());
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn simulate_transaction(
+    pub async fn simulate_transaction(
         &self,
         transaction: &Transaction,
     ) -> RpcResult<RpcSimulateTransactionResult> {
-        self.invoke(self.rpc_client.simulate_transaction(transaction))
+        self.simulate_transaction_with_config(
+            transaction,
+            RpcSimulateTransactionConfig {
+                commitment: Some(self.commitment()),
+                ..RpcSimulateTransactionConfig::default()
+            },
+        )
+        .await
     }
 
     /// Simulates sending a transaction.
@@ -1016,15 +1276,29 @@ impl RpcClient {
     /// assert!(result.value.err.is_none());
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn simulate_transaction_with_config(
+    pub async fn simulate_transaction_with_config(
         &self,
         transaction: &Transaction,
         config: RpcSimulateTransactionConfig,
     ) -> RpcResult<RpcSimulateTransactionResult> {
-        self.invoke(
-            self.rpc_client
-                .simulate_transaction_with_config(transaction, config),
+        let encoding = if let Some(encoding) = config.encoding {
+            encoding
+        } else {
+            self.default_cluster_transaction_encoding().await?
+        };
+        let commitment = config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment).await?;
+        let config = RpcSimulateTransactionConfig {
+            encoding: Some(encoding),
+            commitment: Some(commitment),
+            ..config
+        };
+        let serialized_encoded = serialize_and_encode::<Transaction>(transaction, encoding)?;
+        self.send(
+            RpcRequest::SimulateTransaction,
+            json!([serialized_encoded, config]),
         )
+        .await
     }
 
     /// Returns the highest slot information that the node has snapshots for.
@@ -1049,8 +1323,19 @@ impl RpcClient {
     /// let snapshot_slot_info = rpc_client.get_highest_snapshot_slot()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
-        self.invoke(self.rpc_client.get_highest_snapshot_slot())
+    pub async fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
+        if self.get_node_version().await? < semver::Version::new(1, 9, 0) {
+            #[allow(deprecated)]
+            self.get_snapshot_slot()
+                .await
+                .map(|full| RpcSnapshotSlotInfo {
+                    full,
+                    incremental: None,
+                })
+        } else {
+            self.send(RpcRequest::GetHighestSnapshotSlot, Value::Null)
+                .await
+        }
     }
 
     #[deprecated(
@@ -1058,8 +1343,8 @@ impl RpcClient {
         note = "Please use RpcClient::get_highest_snapshot_slot() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_snapshot_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_snapshot_slot())
+    pub async fn get_snapshot_slot(&self) -> ClientResult<Slot> {
+        self.send(RpcRequest::GetSnapshotSlot, Value::Null).await
     }
 
     /// Check if a transaction has been processed with the default [commitment level][cl].
@@ -1116,11 +1401,12 @@ impl RpcClient {
     /// let status = rpc_client.get_signature_status(&signature)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signature_status(
+    pub async fn get_signature_status(
         &self,
         signature: &Signature,
     ) -> ClientResult<Option<transaction::Result<()>>> {
-        self.invoke(self.rpc_client.get_signature_status(signature))
+        self.get_signature_status_with_commitment(signature, self.commitment())
+            .await
     }
 
     /// Gets the statuses of a list of transaction signatures.
@@ -1194,11 +1480,13 @@ impl RpcClient {
     /// assert!(status.err.is_none());
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signature_statuses(
+    pub async fn get_signature_statuses(
         &self,
         signatures: &[Signature],
     ) -> RpcResult<Vec<Option<TransactionStatus>>> {
-        self.invoke(self.rpc_client.get_signature_statuses(signatures))
+        let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
+        self.send(RpcRequest::GetSignatureStatuses, json!([signatures]))
+            .await
     }
 
     /// Gets the statuses of a list of transaction signatures.
@@ -1262,14 +1550,18 @@ impl RpcClient {
     /// }
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signature_statuses_with_history(
+    pub async fn get_signature_statuses_with_history(
         &self,
         signatures: &[Signature],
     ) -> RpcResult<Vec<Option<TransactionStatus>>> {
-        self.invoke(
-            self.rpc_client
-                .get_signature_statuses_with_history(signatures),
+        let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
+        self.send(
+            RpcRequest::GetSignatureStatuses,
+            json!([signatures, {
+                "searchTransactionHistory": true
+            }]),
         )
+        .await
     }
 
     /// Check if a transaction has been processed with the given [commitment level][cl].
@@ -1330,15 +1622,21 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signature_status_with_commitment(
+    pub async fn get_signature_status_with_commitment(
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Option<transaction::Result<()>>> {
-        self.invoke(
-            self.rpc_client
-                .get_signature_status_with_commitment(signature, commitment_config),
-        )
+        let result: Response<Vec<Option<TransactionStatus>>> = self
+            .send(
+                RpcRequest::GetSignatureStatuses,
+                json!([[signature.to_string()]]),
+            )
+            .await?;
+        Ok(result.value[0]
+            .clone()
+            .filter(|result| result.satisfies_commitment(commitment_config))
+            .map(|status_meta| status_meta.status))
     }
 
     /// Check if a transaction has been processed with the given [commitment level][cl].
@@ -1397,20 +1695,24 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signature_status_with_commitment_and_history(
+    pub async fn get_signature_status_with_commitment_and_history(
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
         search_transaction_history: bool,
     ) -> ClientResult<Option<transaction::Result<()>>> {
-        self.invoke(
-            self.rpc_client
-                .get_signature_status_with_commitment_and_history(
-                    signature,
-                    commitment_config,
-                    search_transaction_history,
-                ),
-        )
+        let result: Response<Vec<Option<TransactionStatus>>> = self
+            .send(
+                RpcRequest::GetSignatureStatuses,
+                json!([[signature.to_string()], {
+                    "searchTransactionHistory": search_transaction_history
+                }]),
+            )
+            .await?;
+        Ok(result.value[0]
+            .clone()
+            .filter(|result| result.satisfies_commitment(commitment_config))
+            .map(|status_meta| status_meta.status))
     }
 
     /// Returns the slot that has reached the configured [commitment level][cl].
@@ -1434,8 +1736,8 @@ impl RpcClient {
     /// let slot = rpc_client.get_slot()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_slot())
+    pub async fn get_slot(&self) -> ClientResult<Slot> {
+        self.get_slot_with_commitment(self.commitment()).await
     }
 
     /// Returns the slot that has reached the given [commitment level][cl].
@@ -1461,11 +1763,15 @@ impl RpcClient {
     /// let slot = rpc_client.get_slot_with_commitment(commitment_config)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_slot_with_commitment(
+    pub async fn get_slot_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_slot_with_commitment(commitment_config))
+        self.send(
+            RpcRequest::GetSlot,
+            json!([self.maybe_map_commitment(commitment_config).await?]),
+        )
+        .await
     }
 
     /// Returns the block height that has reached the configured [commitment level][cl].
@@ -1489,8 +1795,9 @@ impl RpcClient {
     /// let block_height = rpc_client.get_block_height()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_height(&self) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_block_height())
+    pub async fn get_block_height(&self) -> ClientResult<u64> {
+        self.get_block_height_with_commitment(self.commitment())
+            .await
     }
 
     /// Returns the block height that has reached the given [commitment level][cl].
@@ -1518,14 +1825,15 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_height_with_commitment(
+    pub async fn get_block_height_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_block_height_with_commitment(commitment_config),
+        self.send(
+            RpcRequest::GetBlockHeight,
+            json!([self.maybe_map_commitment(commitment_config).await?]),
         )
+        .await
     }
 
     /// Returns the slot leaders for a given slot range.
@@ -1550,8 +1858,27 @@ impl RpcClient {
     /// let leaders = rpc_client.get_slot_leaders(start_slot, limit)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_slot_leaders(&self, start_slot: Slot, limit: u64) -> ClientResult<Vec<Pubkey>> {
-        self.invoke(self.rpc_client.get_slot_leaders(start_slot, limit))
+    pub async fn get_slot_leaders(
+        &self,
+        start_slot: Slot,
+        limit: u64,
+    ) -> ClientResult<Vec<Pubkey>> {
+        self.send(RpcRequest::GetSlotLeaders, json!([start_slot, limit]))
+            .await
+            .and_then(|slot_leaders: Vec<String>| {
+                slot_leaders
+                    .iter()
+                    .map(|slot_leader| {
+                        Pubkey::from_str(slot_leader).map_err(|err| {
+                            ClientErrorKind::Custom(format!(
+                                "pubkey deserialization failed: {}",
+                                err
+                            ))
+                            .into()
+                        })
+                    })
+                    .collect()
+            })
     }
 
     /// Get block production for the current epoch.
@@ -1573,8 +1900,8 @@ impl RpcClient {
     /// let production = rpc_client.get_block_production()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_production(&self) -> RpcResult<RpcBlockProduction> {
-        self.invoke(self.rpc_client.get_block_production())
+    pub async fn get_block_production(&self) -> RpcResult<RpcBlockProduction> {
+        self.send(RpcRequest::GetBlockProduction, Value::Null).await
     }
 
     /// Get block production for the current or previous epoch.
@@ -1618,11 +1945,12 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_production_with_config(
+    pub async fn get_block_production_with_config(
         &self,
         config: RpcBlockProductionConfig,
     ) -> RpcResult<RpcBlockProduction> {
-        self.invoke(self.rpc_client.get_block_production_with_config(config))
+        self.send(RpcRequest::GetBlockProduction, json!([config]))
+            .await
     }
 
     /// Returns epoch activation information for a stake account.
@@ -1696,12 +2024,22 @@ impl RpcClient {
     /// assert_eq!(activation.state, StakeActivationState::Activating);
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_stake_activation(
+    pub async fn get_stake_activation(
         &self,
         stake_account: Pubkey,
         epoch: Option<Epoch>,
     ) -> ClientResult<RpcStakeActivation> {
-        self.invoke(self.rpc_client.get_stake_activation(stake_account, epoch))
+        self.send(
+            RpcRequest::GetStakeActivation,
+            json!([
+                stake_account.to_string(),
+                RpcEpochConfig {
+                    epoch,
+                    commitment: Some(self.commitment()),
+                }
+            ]),
+        )
+        .await
     }
 
     /// Returns information about the current supply.
@@ -1727,8 +2065,8 @@ impl RpcClient {
     /// let supply = rpc_client.supply()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn supply(&self) -> RpcResult<RpcSupply> {
-        self.invoke(self.rpc_client.supply())
+    pub async fn supply(&self) -> RpcResult<RpcSupply> {
+        self.supply_with_commitment(self.commitment()).await
     }
 
     /// Returns information about the current supply.
@@ -1754,11 +2092,15 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn supply_with_commitment(
+    pub async fn supply_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<RpcSupply> {
-        self.invoke(self.rpc_client.supply_with_commitment(commitment_config))
+        self.send(
+            RpcRequest::GetSupply,
+            json!([self.maybe_map_commitment(commitment_config).await?]),
+        )
+        .await
     }
 
     /// Returns the 20 largest accounts, by lamport balance.
@@ -1791,11 +2133,18 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_largest_accounts_with_config(
+    pub async fn get_largest_accounts_with_config(
         &self,
         config: RpcLargestAccountsConfig,
     ) -> RpcResult<Vec<RpcAccountBalance>> {
-        self.invoke(self.rpc_client.get_largest_accounts_with_config(config))
+        let commitment = config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment).await?;
+        let config = RpcLargestAccountsConfig {
+            commitment: Some(commitment),
+            ..config
+        };
+        self.send(RpcRequest::GetLargestAccounts, json!([config]))
+            .await
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1821,8 +2170,9 @@ impl RpcClient {
     /// let accounts = rpc_client.get_vote_accounts()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(self.rpc_client.get_vote_accounts())
+    pub async fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
+        self.get_vote_accounts_with_commitment(self.commitment())
+            .await
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1851,14 +2201,15 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_vote_accounts_with_commitment(
+    pub async fn get_vote_accounts_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(
-            self.rpc_client
-                .get_vote_accounts_with_commitment(commitment_config),
-        )
+        self.get_vote_accounts_with_config(RpcGetVoteAccountsConfig {
+            commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+            ..RpcGetVoteAccountsConfig::default()
+        })
+        .await
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1900,22 +2251,44 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_vote_accounts_with_config(
+    pub async fn get_vote_accounts_with_config(
         &self,
         config: RpcGetVoteAccountsConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(self.rpc_client.get_vote_accounts_with_config(config))
+        self.send(RpcRequest::GetVoteAccounts, json!([config]))
+            .await
     }
 
-    pub fn wait_for_max_stake(
+    pub async fn wait_for_max_stake(
         &self,
         commitment: CommitmentConfig,
         max_stake_percent: f32,
     ) -> ClientResult<()> {
-        self.invoke(
-            self.rpc_client
-                .wait_for_max_stake(commitment, max_stake_percent),
-        )
+        let mut current_percent;
+        loop {
+            let vote_accounts = self.get_vote_accounts_with_commitment(commitment).await?;
+
+            let mut max = 0;
+            let total_active_stake = vote_accounts
+                .current
+                .iter()
+                .chain(vote_accounts.delinquent.iter())
+                .map(|vote_account| {
+                    max = std::cmp::max(max, vote_account.activated_stake);
+                    vote_account.activated_stake
+                })
+                .sum::<u64>();
+            current_percent = 100f32 * max as f32 / total_active_stake as f32;
+            if current_percent < max_stake_percent {
+                break;
+            }
+            info!(
+                "Waiting for stake to drop below {} current: {:.1}",
+                max_stake_percent, current_percent
+            );
+            sleep(Duration::from_secs(10)).await;
+        }
+        Ok(())
     }
 
     /// Returns information about all the nodes participating in the cluster.
@@ -1938,8 +2311,8 @@ impl RpcClient {
     /// let cluster_nodes = rpc_client.get_cluster_nodes()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_cluster_nodes(&self) -> ClientResult<Vec<RpcContactInfo>> {
-        self.invoke(self.rpc_client.get_cluster_nodes())
+    pub async fn get_cluster_nodes(&self) -> ClientResult<Vec<RpcContactInfo>> {
+        self.send(RpcRequest::GetClusterNodes, Value::Null).await
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -1970,8 +2343,9 @@ impl RpcClient {
     /// let block = rpc_client.get_block(slot)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block(slot))
+    pub async fn get_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
+        self.get_block_with_encoding(slot, UiTransactionEncoding::Json)
+            .await
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -1999,12 +2373,16 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_with_encoding(
+    pub async fn get_block_with_encoding(
         &self,
         slot: Slot,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block_with_encoding(slot, encoding))
+        self.send(
+            self.maybe_map_request(RpcRequest::GetBlock).await?,
+            json!([slot, encoding]),
+        )
+        .await
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -2041,18 +2419,23 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_with_config(
+    pub async fn get_block_with_config(
         &self,
         slot: Slot,
         config: RpcBlockConfig,
     ) -> ClientResult<UiConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block_with_config(slot, config))
+        self.send(
+            self.maybe_map_request(RpcRequest::GetBlock).await?,
+            json!([slot, config]),
+        )
+        .await
     }
 
     #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_block() instead")]
     #[allow(deprecated)]
-    pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_confirmed_block(slot))
+    pub async fn get_confirmed_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
+        self.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Json)
+            .await
     }
 
     #[deprecated(
@@ -2060,15 +2443,13 @@ impl RpcClient {
         note = "Please use RpcClient::get_block_with_encoding() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_block_with_encoding(
+    pub async fn get_confirmed_block_with_encoding(
         &self,
         slot: Slot,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_block_with_encoding(slot, encoding),
-        )
+        self.send(RpcRequest::GetConfirmedBlock, json!([slot, encoding]))
+            .await
     }
 
     #[deprecated(
@@ -2076,15 +2457,13 @@ impl RpcClient {
         note = "Please use RpcClient::get_block_with_config() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_block_with_config(
+    pub async fn get_confirmed_block_with_config(
         &self,
         slot: Slot,
         config: RpcConfirmedBlockConfig,
     ) -> ClientResult<UiConfirmedBlock> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_block_with_config(slot, config),
-        )
+        self.send(RpcRequest::GetConfirmedBlock, json!([slot, config]))
+            .await
     }
 
     /// Returns a list of finalized blocks between two slots.
@@ -2132,8 +2511,16 @@ impl RpcClient {
     /// let blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks(start_slot, end_slot))
+    pub async fn get_blocks(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+    ) -> ClientResult<Vec<Slot>> {
+        self.send(
+            self.maybe_map_request(RpcRequest::GetBlocks).await?,
+            json!([start_slot, end_slot]),
+        )
+        .await
     }
 
     /// Returns a list of confirmed blocks between two slots.
@@ -2192,17 +2579,26 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_blocks_with_commitment(
+    pub async fn get_blocks_with_commitment(
         &self,
         start_slot: Slot,
         end_slot: Option<Slot>,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_commitment(
-            start_slot,
-            end_slot,
-            commitment_config,
-        ))
+        let json = if end_slot.is_some() {
+            json!([
+                start_slot,
+                end_slot,
+                self.maybe_map_commitment(commitment_config).await?
+            ])
+        } else {
+            json!([
+                start_slot,
+                self.maybe_map_commitment(commitment_config).await?
+            ])
+        };
+        self.send(self.maybe_map_request(RpcRequest::GetBlocks).await?, json)
+            .await
     }
 
     /// Returns a list of finalized blocks starting at the given slot.
@@ -2239,8 +2635,17 @@ impl RpcClient {
     /// let blocks = rpc_client.get_blocks_with_limit(start_slot, limit)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_blocks_with_limit(&self, start_slot: Slot, limit: usize) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_limit(start_slot, limit))
+    pub async fn get_blocks_with_limit(
+        &self,
+        start_slot: Slot,
+        limit: usize,
+    ) -> ClientResult<Vec<Slot>> {
+        self.send(
+            self.maybe_map_request(RpcRequest::GetBlocksWithLimit)
+                .await?,
+            json!([start_slot, limit]),
+        )
+        .await
     }
 
     /// Returns a list of confirmed blocks starting at the given slot.
@@ -2284,27 +2689,36 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_blocks_with_limit_and_commitment(
+    pub async fn get_blocks_with_limit_and_commitment(
         &self,
         start_slot: Slot,
         limit: usize,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_limit_and_commitment(
-            start_slot,
-            limit,
-            commitment_config,
-        ))
+        self.send(
+            self.maybe_map_request(RpcRequest::GetBlocksWithLimit)
+                .await?,
+            json!([
+                start_slot,
+                limit,
+                self.maybe_map_commitment(commitment_config).await?
+            ]),
+        )
+        .await
     }
 
     #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_blocks() instead")]
     #[allow(deprecated)]
-    pub fn get_confirmed_blocks(
+    pub async fn get_confirmed_blocks(
         &self,
         start_slot: Slot,
         end_slot: Option<Slot>,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_confirmed_blocks(start_slot, end_slot))
+        self.send(
+            RpcRequest::GetConfirmedBlocks,
+            json!([start_slot, end_slot]),
+        )
+        .await
     }
 
     #[deprecated(
@@ -2312,17 +2726,25 @@ impl RpcClient {
         note = "Please use RpcClient::get_blocks_with_commitment() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_commitment(
+    pub async fn get_confirmed_blocks_with_commitment(
         &self,
         start_slot: Slot,
         end_slot: Option<Slot>,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_confirmed_blocks_with_commitment(
-            start_slot,
-            end_slot,
-            commitment_config,
-        ))
+        let json = if end_slot.is_some() {
+            json!([
+                start_slot,
+                end_slot,
+                self.maybe_map_commitment(commitment_config).await?
+            ])
+        } else {
+            json!([
+                start_slot,
+                self.maybe_map_commitment(commitment_config).await?
+            ])
+        };
+        self.send(RpcRequest::GetConfirmedBlocks, json).await
     }
 
     #[deprecated(
@@ -2330,15 +2752,16 @@ impl RpcClient {
         note = "Please use RpcClient::get_blocks_with_limit() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_limit(
+    pub async fn get_confirmed_blocks_with_limit(
         &self,
         start_slot: Slot,
         limit: usize,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_blocks_with_limit(start_slot, limit),
+        self.send(
+            RpcRequest::GetConfirmedBlocksWithLimit,
+            json!([start_slot, limit]),
         )
+        .await
     }
 
     #[deprecated(
@@ -2346,20 +2769,21 @@ impl RpcClient {
         note = "Please use RpcClient::get_blocks_with_limit_and_commitment() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_blocks_with_limit_and_commitment(
+    pub async fn get_confirmed_blocks_with_limit_and_commitment(
         &self,
         start_slot: Slot,
         limit: usize,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_blocks_with_limit_and_commitment(
-                    start_slot,
-                    limit,
-                    commitment_config,
-                ),
+        self.send(
+            RpcRequest::GetConfirmedBlocksWithLimit,
+            json!([
+                start_slot,
+                limit,
+                self.maybe_map_commitment(commitment_config).await?
+            ]),
         )
+        .await
     }
 
     /// Get confirmed signatures for transactions involving an address.
@@ -2399,11 +2823,15 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signatures_for_address(
+    pub async fn get_signatures_for_address(
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(self.rpc_client.get_signatures_for_address(address))
+        self.get_signatures_for_address_with_config(
+            address,
+            GetConfirmedSignaturesForAddress2Config::default(),
+        )
+        .await
     }
 
     /// Get confirmed signatures for transactions involving an address.
@@ -2458,15 +2886,27 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_signatures_for_address_with_config(
+    pub async fn get_signatures_for_address_with_config(
         &self,
         address: &Pubkey,
         config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(
-            self.rpc_client
-                .get_signatures_for_address_with_config(address, config),
-        )
+        let config = RpcSignaturesForAddressConfig {
+            before: config.before.map(|signature| signature.to_string()),
+            until: config.until.map(|signature| signature.to_string()),
+            limit: config.limit,
+            commitment: config.commitment,
+        };
+
+        let result: Vec<RpcConfirmedTransactionStatusWithSignature> = self
+            .send(
+                self.maybe_map_request(RpcRequest::GetSignaturesForAddress)
+                    .await?,
+                json!([address.to_string(), config]),
+            )
+            .await?;
+
+        Ok(result)
     }
 
     #[deprecated(
@@ -2474,14 +2914,15 @@ impl RpcClient {
         note = "Please use RpcClient::get_signatures_for_address() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_signatures_for_address2(
+    pub async fn get_confirmed_signatures_for_address2(
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_signatures_for_address2(address),
+        self.get_confirmed_signatures_for_address2_with_config(
+            address,
+            GetConfirmedSignaturesForAddress2Config::default(),
         )
+        .await
     }
 
     #[deprecated(
@@ -2489,15 +2930,26 @@ impl RpcClient {
         note = "Please use RpcClient::get_signatures_for_address_with_config() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_signatures_for_address2_with_config(
+    pub async fn get_confirmed_signatures_for_address2_with_config(
         &self,
         address: &Pubkey,
         config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_signatures_for_address2_with_config(address, config),
-        )
+        let config = RpcGetConfirmedSignaturesForAddress2Config {
+            before: config.before.map(|signature| signature.to_string()),
+            until: config.until.map(|signature| signature.to_string()),
+            limit: config.limit,
+            commitment: config.commitment,
+        };
+
+        let result: Vec<RpcConfirmedTransactionStatusWithSignature> = self
+            .send(
+                RpcRequest::GetConfirmedSignaturesForAddress2,
+                json!([address.to_string(), config]),
+            )
+            .await?;
+
+        Ok(result)
     }
 
     /// Returns transaction details for a confirmed transaction.
@@ -2543,12 +2995,16 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_transaction(
+    pub async fn get_transaction(
         &self,
         signature: &Signature,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(self.rpc_client.get_transaction(signature, encoding))
+        self.send(
+            self.maybe_map_request(RpcRequest::GetTransaction).await?,
+            json!([signature.to_string(), encoding]),
+        )
+        .await
     }
 
     /// Returns transaction details for a confirmed transaction.
@@ -2603,15 +3059,16 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_transaction_with_config(
+    pub async fn get_transaction_with_config(
         &self,
         signature: &Signature,
         config: RpcTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            self.rpc_client
-                .get_transaction_with_config(signature, config),
+        self.send(
+            self.maybe_map_request(RpcRequest::GetTransaction).await?,
+            json!([signature.to_string(), config]),
         )
+        .await
     }
 
     #[deprecated(
@@ -2619,15 +3076,16 @@ impl RpcClient {
         note = "Please use RpcClient::get_transaction() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_transaction(
+    pub async fn get_confirmed_transaction(
         &self,
         signature: &Signature,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_transaction(signature, encoding),
+        self.send(
+            RpcRequest::GetConfirmedTransaction,
+            json!([signature.to_string(), encoding]),
         )
+        .await
     }
 
     #[deprecated(
@@ -2635,15 +3093,16 @@ impl RpcClient {
         note = "Please use RpcClient::get_transaction_with_config() instead"
     )]
     #[allow(deprecated)]
-    pub fn get_confirmed_transaction_with_config(
+    pub async fn get_confirmed_transaction_with_config(
         &self,
         signature: &Signature,
         config: RpcConfirmedTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_transaction_with_config(signature, config),
+        self.send(
+            RpcRequest::GetConfirmedTransaction,
+            json!([signature.to_string(), config]),
         )
+        .await
     }
 
     /// Returns the estimated production time of a block.
@@ -2667,8 +3126,21 @@ impl RpcClient {
     /// let block_time = rpc_client.get_block_time(slot)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
-        self.invoke(self.rpc_client.get_block_time(slot))
+    pub async fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
+        let request = RpcRequest::GetBlockTime;
+        let response = self.send(request, json!([slot])).await;
+
+        response
+            .map(|result_json: Value| {
+                if result_json.is_null() {
+                    return Err(RpcError::ForUser(format!("Block Not Found: slot={}", slot)).into());
+                }
+                let result = serde_json::from_value(result_json)
+                    .map_err(|err| ClientError::new_with_request(err.into(), request))?;
+                trace!("Response block timestamp {:?} {:?}", slot, result);
+                Ok(result)
+            })
+            .map_err(|err| err.into_with_request(request))?
     }
 
     /// Returns information about the current epoch.
@@ -2694,8 +3166,8 @@ impl RpcClient {
     /// let epoch_info = rpc_client.get_epoch_info()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_epoch_info(&self) -> ClientResult<EpochInfo> {
-        self.invoke(self.rpc_client.get_epoch_info())
+    pub async fn get_epoch_info(&self) -> ClientResult<EpochInfo> {
+        self.get_epoch_info_with_commitment(self.commitment()).await
     }
 
     /// Returns information about the current epoch.
@@ -2721,14 +3193,15 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_epoch_info_with_commitment(
+    pub async fn get_epoch_info_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<EpochInfo> {
-        self.invoke(
-            self.rpc_client
-                .get_epoch_info_with_commitment(commitment_config),
+        self.send(
+            RpcRequest::GetEpochInfo,
+            json!([self.maybe_map_commitment(commitment_config).await?]),
         )
+        .await
     }
 
     /// Returns the leader schedule for an epoch.
@@ -2758,11 +3231,12 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_leader_schedule(
+    pub async fn get_leader_schedule(
         &self,
         slot: Option<Slot>,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.invoke(self.rpc_client.get_leader_schedule(slot))
+        self.get_leader_schedule_with_commitment(slot, self.commitment())
+            .await
     }
 
     /// Returns the leader schedule for an epoch.
@@ -2790,15 +3264,19 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_leader_schedule_with_commitment(
+    pub async fn get_leader_schedule_with_commitment(
         &self,
         slot: Option<Slot>,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.invoke(
-            self.rpc_client
-                .get_leader_schedule_with_commitment(slot, commitment_config),
+        self.get_leader_schedule_with_config(
+            slot,
+            RpcLeaderScheduleConfig {
+                commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+                ..RpcLeaderScheduleConfig::default()
+            },
         )
+        .await
     }
 
     /// Returns the leader schedule for an epoch.
@@ -2831,15 +3309,13 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_leader_schedule_with_config(
+    pub async fn get_leader_schedule_with_config(
         &self,
         slot: Option<Slot>,
         config: RpcLeaderScheduleConfig,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.invoke(
-            self.rpc_client
-                .get_leader_schedule_with_config(slot, config),
-        )
+        self.send(RpcRequest::GetLeaderSchedule, json!([slot, config]))
+            .await
     }
 
     /// Returns epoch schedule information from this cluster's genesis config.
@@ -2861,8 +3337,8 @@ impl RpcClient {
     /// let epoch_schedule = rpc_client.get_epoch_schedule()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_epoch_schedule(&self) -> ClientResult<EpochSchedule> {
-        self.invoke(self.rpc_client.get_epoch_schedule())
+    pub async fn get_epoch_schedule(&self) -> ClientResult<EpochSchedule> {
+        self.send(RpcRequest::GetEpochSchedule, Value::Null).await
     }
 
     /// Returns a list of recent performance samples, in reverse slot order.
@@ -2890,11 +3366,12 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_recent_performance_samples(
+    pub async fn get_recent_performance_samples(
         &self,
         limit: Option<usize>,
     ) -> ClientResult<Vec<RpcPerfSample>> {
-        self.invoke(self.rpc_client.get_recent_performance_samples(limit))
+        self.send(RpcRequest::GetRecentPerformanceSamples, json!([limit]))
+            .await
     }
 
     /// Returns the identity pubkey for the current node.
@@ -2916,8 +3393,15 @@ impl RpcClient {
     /// let identity = rpc_client.get_identity()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_identity(&self) -> ClientResult<Pubkey> {
-        self.invoke(self.rpc_client.get_identity())
+    pub async fn get_identity(&self) -> ClientResult<Pubkey> {
+        let rpc_identity: RpcIdentity = self.send(RpcRequest::GetIdentity, Value::Null).await?;
+
+        rpc_identity.identity.parse::<Pubkey>().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Pubkey".to_string()).into(),
+                RpcRequest::GetIdentity,
+            )
+        })
     }
 
     /// Returns the current inflation governor.
@@ -2945,8 +3429,9 @@ impl RpcClient {
     /// let inflation_governor = rpc_client.get_inflation_governor()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_inflation_governor(&self) -> ClientResult<RpcInflationGovernor> {
-        self.invoke(self.rpc_client.get_inflation_governor())
+    pub async fn get_inflation_governor(&self) -> ClientResult<RpcInflationGovernor> {
+        self.send(RpcRequest::GetInflationGovernor, Value::Null)
+            .await
     }
 
     /// Returns the specific inflation values for the current epoch.
@@ -2968,8 +3453,8 @@ impl RpcClient {
     /// let inflation_rate = rpc_client.get_inflation_rate()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_inflation_rate(&self) -> ClientResult<RpcInflationRate> {
-        self.invoke(self.rpc_client.get_inflation_rate())
+    pub async fn get_inflation_rate(&self) -> ClientResult<RpcInflationRate> {
+        self.send(RpcRequest::GetInflationRate, Value::Null).await
     }
 
     /// Returns the inflation reward for a list of addresses for an epoch.
@@ -3004,12 +3489,26 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_inflation_reward(
+    pub async fn get_inflation_reward(
         &self,
         addresses: &[Pubkey],
         epoch: Option<Epoch>,
     ) -> ClientResult<Vec<Option<RpcInflationReward>>> {
-        self.invoke(self.rpc_client.get_inflation_reward(addresses, epoch))
+        let addresses: Vec<_> = addresses
+            .iter()
+            .map(|address| address.to_string())
+            .collect();
+        self.send(
+            RpcRequest::GetInflationReward,
+            json!([
+                addresses,
+                RpcEpochConfig {
+                    epoch,
+                    commitment: Some(self.commitment()),
+                }
+            ]),
+        )
+        .await
     }
 
     /// Returns the current solana version running on the node.
@@ -3035,8 +3534,8 @@ impl RpcClient {
     /// assert!(version >= expected_version);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn get_version(&self) -> ClientResult<RpcVersionInfo> {
-        self.invoke(self.rpc_client.get_version())
+    pub async fn get_version(&self) -> ClientResult<RpcVersionInfo> {
+        self.send(RpcRequest::GetVersion, Value::Null).await
     }
 
     /// Returns the lowest slot that the node has information about in its ledger.
@@ -3062,8 +3561,8 @@ impl RpcClient {
     /// let slot = rpc_client.minimum_ledger_slot()?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn minimum_ledger_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.minimum_ledger_slot())
+    pub async fn minimum_ledger_slot(&self) -> ClientResult<Slot> {
+        self.send(RpcRequest::MinimumLedgerSlot, Value::Null).await
     }
 
     /// Returns all information associated with the account of the provided pubkey.
@@ -3109,8 +3608,11 @@ impl RpcClient {
     /// let account = rpc_client.get_account(&alice_pubkey)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
-        self.invoke(self.rpc_client.get_account(pubkey))
+    pub async fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
+        self.get_account_with_commitment(pubkey, self.commitment())
+            .await?
+            .value
+            .ok_or_else(|| RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into())
     }
 
     /// Returns all information associated with the account of the provided pubkey.
@@ -3152,15 +3654,48 @@ impl RpcClient {
     /// assert!(account.value.is_some());
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_account_with_commitment(
+    pub async fn get_account_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<Account>> {
-        self.invoke(
-            self.rpc_client
-                .get_account_with_commitment(pubkey, commitment_config),
-        )
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64Zstd),
+            commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+            data_slice: None,
+        };
+        let response = self
+            .send(
+                RpcRequest::GetAccountInfo,
+                json!([pubkey.to_string(), config]),
+            )
+            .await;
+
+        response
+            .map(|result_json: Value| {
+                if result_json.is_null() {
+                    return Err(
+                        RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into(),
+                    );
+                }
+                let Response {
+                    context,
+                    value: rpc_account,
+                } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
+                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
+
+                Ok(Response {
+                    context,
+                    value: account,
+                })
+            })
+            .map_err(|err| {
+                Into::<ClientError>::into(RpcError::ForUser(format!(
+                    "AccountNotFound: pubkey={}: {}",
+                    pubkey, err
+                )))
+            })?
     }
 
     /// Get the max slot seen from retransmit stage.
@@ -3182,8 +3717,9 @@ impl RpcClient {
     /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// let slot = rpc_client.get_max_retransmit_slot()?;
     /// # Ok::<(), ClientError>(())
-    pub fn get_max_retransmit_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_max_retransmit_slot())
+    pub async fn get_max_retransmit_slot(&self) -> ClientResult<Slot> {
+        self.send(RpcRequest::GetMaxRetransmitSlot, Value::Null)
+            .await
     }
 
     /// Get the max slot seen from after [shred](https://docs.solana.com/terminology#shred) insert.
@@ -3205,8 +3741,9 @@ impl RpcClient {
     /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
     /// let slot = rpc_client.get_max_shred_insert_slot()?;
     /// # Ok::<(), ClientError>(())
-    pub fn get_max_shred_insert_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_max_shred_insert_slot())
+    pub async fn get_max_shred_insert_slot(&self) -> ClientResult<Slot> {
+        self.send(RpcRequest::GetMaxShredInsertSlot, Value::Null)
+            .await
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3239,8 +3776,14 @@ impl RpcClient {
     /// let accounts = rpc_client.get_multiple_accounts(&pubkeys)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> ClientResult<Vec<Option<Account>>> {
-        self.invoke(self.rpc_client.get_multiple_accounts(pubkeys))
+    pub async fn get_multiple_accounts(
+        &self,
+        pubkeys: &[Pubkey],
+    ) -> ClientResult<Vec<Option<Account>>> {
+        Ok(self
+            .get_multiple_accounts_with_commitment(pubkeys, self.commitment())
+            .await?
+            .value)
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3274,15 +3817,20 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_multiple_accounts_with_commitment(
+    pub async fn get_multiple_accounts_with_commitment(
         &self,
         pubkeys: &[Pubkey],
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
-        self.invoke(
-            self.rpc_client
-                .get_multiple_accounts_with_commitment(pubkeys, commitment_config),
+        self.get_multiple_accounts_with_config(
+            pubkeys,
+            RpcAccountInfoConfig {
+                encoding: Some(UiAccountEncoding::Base64Zstd),
+                commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+                data_slice: None,
+            },
         )
+        .await
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3323,15 +3871,31 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_multiple_accounts_with_config(
+    pub async fn get_multiple_accounts_with_config(
         &self,
         pubkeys: &[Pubkey],
         config: RpcAccountInfoConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
-        self.invoke(
-            self.rpc_client
-                .get_multiple_accounts_with_config(pubkeys, config),
-        )
+        let config = RpcAccountInfoConfig {
+            commitment: config.commitment.or_else(|| Some(self.commitment())),
+            ..config
+        };
+        let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
+        let response = self
+            .send(RpcRequest::GetMultipleAccounts, json!([pubkeys, config]))
+            .await?;
+        let Response {
+            context,
+            value: accounts,
+        } = serde_json::from_value::<Response<Vec<Option<UiAccount>>>>(response)?;
+        let accounts: Vec<Option<Account>> = accounts
+            .into_iter()
+            .map(|rpc_account| rpc_account.and_then(|a| a.decode()))
+            .collect();
+        Ok(Response {
+            context,
+            value: accounts,
+        })
     }
 
     /// Gets the raw data associated with an account.
@@ -3367,8 +3931,8 @@ impl RpcClient {
     /// let account_data = rpc_client.get_account_data(&alice_pubkey)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_account_data(&self, pubkey: &Pubkey) -> ClientResult<Vec<u8>> {
-        self.invoke(self.rpc_client.get_account_data(pubkey))
+    pub async fn get_account_data(&self, pubkey: &Pubkey) -> ClientResult<Vec<u8>> {
+        Ok(self.get_account(pubkey).await?.data)
     }
 
     /// Returns minimum balance required to make an account with specified data length rent exempt.
@@ -3392,11 +3956,24 @@ impl RpcClient {
     /// let balance = rpc_client.get_minimum_balance_for_rent_exemption(data_len)?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_minimum_balance_for_rent_exemption(data_len),
-        )
+    pub async fn get_minimum_balance_for_rent_exemption(
+        &self,
+        data_len: usize,
+    ) -> ClientResult<u64> {
+        let request = RpcRequest::GetMinimumBalanceForRentExemption;
+        let minimum_balance_json: Value = self
+            .send(request, json!([data_len]))
+            .await
+            .map_err(|err| err.into_with_request(request))?;
+
+        let minimum_balance: u64 = serde_json::from_value(minimum_balance_json)
+            .map_err(|err| ClientError::new_with_request(err.into(), request))?;
+        trace!(
+            "Response minimum balance {:?} {:?}",
+            data_len,
+            minimum_balance
+        );
+        Ok(minimum_balance)
     }
 
     /// Request the balance of the provided account pubkey.
@@ -3427,8 +4004,11 @@ impl RpcClient {
     /// let balance = rpc_client.get_balance(&alice.pubkey())?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_balance(pubkey))
+    pub async fn get_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
+        Ok(self
+            .get_balance_with_commitment(pubkey, self.commitment())
+            .await?
+            .value)
     }
 
     /// Request the balance of the provided account pubkey.
@@ -3460,15 +4040,19 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_balance_with_commitment(
+    pub async fn get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_balance_with_commitment(pubkey, commitment_config),
+        self.send(
+            RpcRequest::GetBalance,
+            json!([
+                pubkey.to_string(),
+                self.maybe_map_commitment(commitment_config).await?
+            ]),
         )
+        .await
     }
 
     /// Returns all accounts owned by the provided program pubkey.
@@ -3500,8 +4084,21 @@ impl RpcClient {
     /// let accounts = rpc_client.get_program_accounts(&alice.pubkey())?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.invoke(self.rpc_client.get_program_accounts(pubkey))
+    pub async fn get_program_accounts(
+        &self,
+        pubkey: &Pubkey,
+    ) -> ClientResult<Vec<(Pubkey, Account)>> {
+        self.get_program_accounts_with_config(
+            pubkey,
+            RpcProgramAccountsConfig {
+                account_config: RpcAccountInfoConfig {
+                    encoding: Some(UiAccountEncoding::Base64Zstd),
+                    ..RpcAccountInfoConfig::default()
+                },
+                ..RpcProgramAccountsConfig::default()
+            },
+        )
+        .await
     }
 
     /// Returns all accounts owned by the provided program pubkey.
@@ -3559,30 +4156,48 @@ impl RpcClient {
     /// )?;
     /// # Ok::<(), ClientError>(())
     /// ```
-    pub fn get_program_accounts_with_config(
+    pub async fn get_program_accounts_with_config(
         &self,
         pubkey: &Pubkey,
         config: RpcProgramAccountsConfig,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.invoke(
-            self.rpc_client
-                .get_program_accounts_with_config(pubkey, config),
-        )
+        let commitment = config
+            .account_config
+            .commitment
+            .unwrap_or_else(|| self.commitment());
+        let commitment = self.maybe_map_commitment(commitment).await?;
+        let account_config = RpcAccountInfoConfig {
+            commitment: Some(commitment),
+            ..config.account_config
+        };
+        let config = RpcProgramAccountsConfig {
+            account_config,
+            ..config
+        };
+        let accounts: Vec<RpcKeyedAccount> = self
+            .send(
+                RpcRequest::GetProgramAccounts,
+                json!([pubkey.to_string(), config]),
+            )
+            .await?;
+        parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
     }
 
     /// Request the transaction count.
-    pub fn get_transaction_count(&self) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_transaction_count())
+    pub async fn get_transaction_count(&self) -> ClientResult<u64> {
+        self.get_transaction_count_with_commitment(self.commitment())
+            .await
     }
 
-    pub fn get_transaction_count_with_commitment(
+    pub async fn get_transaction_count_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_transaction_count_with_commitment(commitment_config),
+        self.send(
+            RpcRequest::GetTransactionCount,
+            json!([self.maybe_map_commitment(commitment_config).await?]),
         )
+        .await
     }
 
     #[deprecated(
@@ -3590,8 +4205,12 @@ impl RpcClient {
         note = "Please use `get_latest_blockhash` and `get_fee_for_message` instead"
     )]
     #[allow(deprecated)]
-    pub fn get_fees(&self) -> ClientResult<Fees> {
-        self.invoke(self.rpc_client.get_fees())
+    pub async fn get_fees(&self) -> ClientResult<Fees> {
+        #[allow(deprecated)]
+        Ok(self
+            .get_fees_with_commitment(self.commitment())
+            .await?
+            .value)
     }
 
     #[deprecated(
@@ -3599,14 +4218,44 @@ impl RpcClient {
         note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
     )]
     #[allow(deprecated)]
-    pub fn get_fees_with_commitment(&self, commitment_config: CommitmentConfig) -> RpcResult<Fees> {
-        self.invoke(self.rpc_client.get_fees_with_commitment(commitment_config))
+    pub async fn get_fees_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> RpcResult<Fees> {
+        let Response {
+            context,
+            value: fees,
+        } = self
+            .send::<Response<RpcFees>>(
+                RpcRequest::GetFees,
+                json!([self.maybe_map_commitment(commitment_config).await?]),
+            )
+            .await?;
+        let blockhash = fees.blockhash.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Hash".to_string()).into(),
+                RpcRequest::GetFees,
+            )
+        })?;
+        Ok(Response {
+            context,
+            value: Fees {
+                blockhash,
+                fee_calculator: fees.fee_calculator,
+                last_valid_block_height: fees.last_valid_block_height,
+            },
+        })
     }
 
     #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
     #[allow(deprecated)]
-    pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke(self.rpc_client.get_recent_blockhash())
+    pub async fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
+        #[allow(deprecated)]
+        let (blockhash, fee_calculator, _last_valid_slot) = self
+            .get_recent_blockhash_with_commitment(self.commitment())
+            .await?
+            .value;
+        Ok((blockhash, fee_calculator))
     }
 
     #[deprecated(
@@ -3614,23 +4263,88 @@ impl RpcClient {
         note = "Please use `get_latest_blockhash_with_commitment` instead"
     )]
     #[allow(deprecated)]
-    pub fn get_recent_blockhash_with_commitment(
+    pub async fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<(Hash, FeeCalculator, Slot)> {
-        self.invoke(
-            self.rpc_client
-                .get_recent_blockhash_with_commitment(commitment_config),
-        )
+        let (context, blockhash, fee_calculator, last_valid_slot) = if let Ok(Response {
+            context,
+            value:
+                RpcFees {
+                    blockhash,
+                    fee_calculator,
+                    last_valid_slot,
+                    ..
+                },
+        }) = self
+            .send::<Response<RpcFees>>(
+                RpcRequest::GetFees,
+                json!([self.maybe_map_commitment(commitment_config).await?]),
+            )
+            .await
+        {
+            (context, blockhash, fee_calculator, last_valid_slot)
+        } else if let Ok(Response {
+            context,
+            value:
+                DeprecatedRpcFees {
+                    blockhash,
+                    fee_calculator,
+                    last_valid_slot,
+                },
+        }) = self
+            .send::<Response<DeprecatedRpcFees>>(
+                RpcRequest::GetFees,
+                json!([self.maybe_map_commitment(commitment_config).await?]),
+            )
+            .await
+        {
+            (context, blockhash, fee_calculator, last_valid_slot)
+        } else if let Ok(Response {
+            context,
+            value:
+                RpcBlockhashFeeCalculator {
+                    blockhash,
+                    fee_calculator,
+                },
+        }) = self
+            .send::<Response<RpcBlockhashFeeCalculator>>(
+                RpcRequest::GetRecentBlockhash,
+                json!([self.maybe_map_commitment(commitment_config).await?]),
+            )
+            .await
+        {
+            (context, blockhash, fee_calculator, 0)
+        } else {
+            return Err(ClientError::new_with_request(
+                RpcError::ParseError("RpcBlockhashFeeCalculator or RpcFees".to_string()).into(),
+                RpcRequest::GetRecentBlockhash,
+            ));
+        };
+
+        let blockhash = blockhash.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Hash".to_string()).into(),
+                RpcRequest::GetRecentBlockhash,
+            )
+        })?;
+        Ok(Response {
+            context,
+            value: (blockhash, fee_calculator, last_valid_slot),
+        })
     }
 
     #[deprecated(since = "1.9.0", note = "Please `get_fee_for_message` instead")]
     #[allow(deprecated)]
-    pub fn get_fee_calculator_for_blockhash(
+    pub async fn get_fee_calculator_for_blockhash(
         &self,
         blockhash: &Hash,
     ) -> ClientResult<Option<FeeCalculator>> {
-        self.invoke(self.rpc_client.get_fee_calculator_for_blockhash(blockhash))
+        #[allow(deprecated)]
+        Ok(self
+            .get_fee_calculator_for_blockhash_with_commitment(blockhash, self.commitment())
+            .await?
+            .value)
     }
 
     #[deprecated(
@@ -3638,15 +4352,25 @@ impl RpcClient {
         note = "Please `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
     )]
     #[allow(deprecated)]
-    pub fn get_fee_calculator_for_blockhash_with_commitment(
+    pub async fn get_fee_calculator_for_blockhash_with_commitment(
         &self,
         blockhash: &Hash,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<FeeCalculator>> {
-        self.invoke(
-            self.rpc_client
-                .get_fee_calculator_for_blockhash_with_commitment(blockhash, commitment_config),
-        )
+        let Response { context, value } = self
+            .send::<Response<Option<RpcFeeCalculator>>>(
+                RpcRequest::GetFeeCalculatorForBlockhash,
+                json!([
+                    blockhash.to_string(),
+                    self.maybe_map_commitment(commitment_config).await?
+                ]),
+            )
+            .await?;
+
+        Ok(Response {
+            context,
+            value: value.map(|rf| rf.fee_calculator),
+        })
     }
 
     #[deprecated(
@@ -3654,8 +4378,18 @@ impl RpcClient {
         note = "Please do not use, will no longer be available in the future"
     )]
     #[allow(deprecated)]
-    pub fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {
-        self.invoke(self.rpc_client.get_fee_rate_governor())
+    pub async fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {
+        let Response {
+            context,
+            value: RpcFeeRateGovernor { fee_rate_governor },
+        } = self
+            .send::<Response<RpcFeeRateGovernor>>(RpcRequest::GetFeeRateGovernor, Value::Null)
+            .await?;
+
+        Ok(Response {
+            context,
+            value: fee_rate_governor,
+        })
     }
 
     #[deprecated(
@@ -3663,513 +4397,669 @@ impl RpcClient {
         note = "Please do not use, will no longer be available in the future"
     )]
     #[allow(deprecated)]
-    pub fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke(self.rpc_client.get_new_blockhash(blockhash))
+    pub async fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {
+        let mut num_retries = 0;
+        let start = Instant::now();
+        while start.elapsed().as_secs() < 5 {
+            #[allow(deprecated)]
+            if let Ok((new_blockhash, fee_calculator)) = self.get_recent_blockhash().await {
+                if new_blockhash != *blockhash {
+                    return Ok((new_blockhash, fee_calculator));
+                }
+            }
+            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+
+            // Retry ~twice during a slot
+            sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2)).await;
+            num_retries += 1;
+        }
+        Err(RpcError::ForUser(format!(
+            "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
+            start.elapsed().as_millis(),
+            num_retries,
+            blockhash
+        ))
+        .into())
     }
 
-    pub fn get_first_available_block(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_first_available_block())
+    pub async fn get_first_available_block(&self) -> ClientResult<Slot> {
+        self.send(RpcRequest::GetFirstAvailableBlock, Value::Null)
+            .await
     }
 
-    pub fn get_genesis_hash(&self) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_genesis_hash())
+    pub async fn get_genesis_hash(&self) -> ClientResult<Hash> {
+        let hash_str: String = self.send(RpcRequest::GetGenesisHash, Value::Null).await?;
+        let hash = hash_str.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Hash".to_string()).into(),
+                RpcRequest::GetGenesisHash,
+            )
+        })?;
+        Ok(hash)
     }
 
-    pub fn get_health(&self) -> ClientResult<()> {
-        self.invoke(self.rpc_client.get_health())
+    pub async fn get_health(&self) -> ClientResult<()> {
+        self.send::<String>(RpcRequest::GetHealth, Value::Null)
+            .await
+            .map(|_| ())
     }
 
-    pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
-        self.invoke(self.rpc_client.get_token_account(pubkey))
+    pub async fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
+        Ok(self
+            .get_token_account_with_commitment(pubkey, self.commitment())
+            .await?
+            .value)
     }
 
-    pub fn get_token_account_with_commitment(
+    pub async fn get_token_account_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<UiTokenAccount>> {
-        self.invoke(
-            self.rpc_client
-                .get_token_account_with_commitment(pubkey, commitment_config),
-        )
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::JsonParsed),
+            commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+            data_slice: None,
+        };
+        let response = self
+            .send(
+                RpcRequest::GetAccountInfo,
+                json!([pubkey.to_string(), config]),
+            )
+            .await;
+
+        response
+            .map(|result_json: Value| {
+                if result_json.is_null() {
+                    return Err(
+                        RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into(),
+                    );
+                }
+                let Response {
+                    context,
+                    value: rpc_account,
+                } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
+                trace!("Response account {:?} {:?}", pubkey, rpc_account);
+                let response = {
+                    if let Some(rpc_account) = rpc_account {
+                        if let UiAccountData::Json(account_data) = rpc_account.data {
+                            let token_account_type: TokenAccountType =
+                                serde_json::from_value(account_data.parsed)?;
+                            if let TokenAccountType::Account(token_account) = token_account_type {
+                                return Ok(Response {
+                                    context,
+                                    value: Some(token_account),
+                                });
+                            }
+                        }
+                    }
+                    Err(Into::<ClientError>::into(RpcError::ForUser(format!(
+                        "Account could not be parsed as token account: pubkey={}",
+                        pubkey
+                    ))))
+                };
+                response?
+            })
+            .map_err(|err| {
+                Into::<ClientError>::into(RpcError::ForUser(format!(
+                    "AccountNotFound: pubkey={}: {}",
+                    pubkey, err
+                )))
+            })?
     }
 
-    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
-        self.invoke(self.rpc_client.get_token_account_balance(pubkey))
+    pub async fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
+        Ok(self
+            .get_token_account_balance_with_commitment(pubkey, self.commitment())
+            .await?
+            .value)
     }
 
-    pub fn get_token_account_balance_with_commitment(
+    pub async fn get_token_account_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<UiTokenAmount> {
-        self.invoke(
-            self.rpc_client
-                .get_token_account_balance_with_commitment(pubkey, commitment_config),
+        self.send(
+            RpcRequest::GetTokenAccountBalance,
+            json!([
+                pubkey.to_string(),
+                self.maybe_map_commitment(commitment_config).await?
+            ]),
         )
+        .await
     }
 
-    pub fn get_token_accounts_by_delegate(
+    pub async fn get_token_accounts_by_delegate(
         &self,
         delegate: &Pubkey,
         token_account_filter: TokenAccountsFilter,
     ) -> ClientResult<Vec<RpcKeyedAccount>> {
-        self.invoke(
-            self.rpc_client
-                .get_token_accounts_by_delegate(delegate, token_account_filter),
-        )
+        Ok(self
+            .get_token_accounts_by_delegate_with_commitment(
+                delegate,
+                token_account_filter,
+                self.commitment(),
+            )
+            .await?
+            .value)
     }
 
-    pub fn get_token_accounts_by_delegate_with_commitment(
+    pub async fn get_token_accounts_by_delegate_with_commitment(
         &self,
         delegate: &Pubkey,
         token_account_filter: TokenAccountsFilter,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<RpcKeyedAccount>> {
-        self.invoke(
-            self.rpc_client
-                .get_token_accounts_by_delegate_with_commitment(
-                    delegate,
-                    token_account_filter,
-                    commitment_config,
-                ),
+        let token_account_filter = match token_account_filter {
+            TokenAccountsFilter::Mint(mint) => RpcTokenAccountsFilter::Mint(mint.to_string()),
+            TokenAccountsFilter::ProgramId(program_id) => {
+                RpcTokenAccountsFilter::ProgramId(program_id.to_string())
+            }
+        };
+
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::JsonParsed),
+            commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+            data_slice: None,
+        };
+
+        self.send(
+            RpcRequest::GetTokenAccountsByOwner,
+            json!([delegate.to_string(), token_account_filter, config]),
         )
+        .await
     }
 
-    pub fn get_token_accounts_by_owner(
+    pub async fn get_token_accounts_by_owner(
         &self,
         owner: &Pubkey,
         token_account_filter: TokenAccountsFilter,
     ) -> ClientResult<Vec<RpcKeyedAccount>> {
-        self.invoke(
-            self.rpc_client
-                .get_token_accounts_by_owner(owner, token_account_filter),
-        )
+        Ok(self
+            .get_token_accounts_by_owner_with_commitment(
+                owner,
+                token_account_filter,
+                self.commitment(),
+            )
+            .await?
+            .value)
     }
 
-    pub fn get_token_accounts_by_owner_with_commitment(
+    pub async fn get_token_accounts_by_owner_with_commitment(
         &self,
         owner: &Pubkey,
         token_account_filter: TokenAccountsFilter,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<RpcKeyedAccount>> {
-        self.invoke(self.rpc_client.get_token_accounts_by_owner_with_commitment(
-            owner,
-            token_account_filter,
-            commitment_config,
-        ))
+        let token_account_filter = match token_account_filter {
+            TokenAccountsFilter::Mint(mint) => RpcTokenAccountsFilter::Mint(mint.to_string()),
+            TokenAccountsFilter::ProgramId(program_id) => {
+                RpcTokenAccountsFilter::ProgramId(program_id.to_string())
+            }
+        };
+
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::JsonParsed),
+            commitment: Some(self.maybe_map_commitment(commitment_config).await?),
+            data_slice: None,
+        };
+
+        self.send(
+            RpcRequest::GetTokenAccountsByOwner,
+            json!([owner.to_string(), token_account_filter, config]),
+        )
+        .await
     }
 
-    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
-        self.invoke(self.rpc_client.get_token_supply(mint))
+    pub async fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
+        Ok(self
+            .get_token_supply_with_commitment(mint, self.commitment())
+            .await?
+            .value)
     }
 
-    pub fn get_token_supply_with_commitment(
+    pub async fn get_token_supply_with_commitment(
         &self,
         mint: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<UiTokenAmount> {
-        self.invoke(
-            self.rpc_client
-                .get_token_supply_with_commitment(mint, commitment_config),
+        self.send(
+            RpcRequest::GetTokenSupply,
+            json!([
+                mint.to_string(),
+                self.maybe_map_commitment(commitment_config).await?
+            ]),
         )
+        .await
     }
 
-    pub fn request_airdrop(&self, pubkey: &Pubkey, lamports: u64) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.request_airdrop(pubkey, lamports))
+    pub async fn request_airdrop(&self, pubkey: &Pubkey, lamports: u64) -> ClientResult<Signature> {
+        self.request_airdrop_with_config(
+            pubkey,
+            lamports,
+            RpcRequestAirdropConfig {
+                commitment: Some(self.commitment()),
+                ..RpcRequestAirdropConfig::default()
+            },
+        )
+        .await
     }
 
-    pub fn request_airdrop_with_blockhash(
+    pub async fn request_airdrop_with_blockhash(
         &self,
         pubkey: &Pubkey,
         lamports: u64,
         recent_blockhash: &Hash,
     ) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.request_airdrop_with_blockhash(
+        self.request_airdrop_with_config(
             pubkey,
             lamports,
-            recent_blockhash,
-        ))
+            RpcRequestAirdropConfig {
+                commitment: Some(self.commitment()),
+                recent_blockhash: Some(recent_blockhash.to_string()),
+            },
+        )
+        .await
     }
 
-    pub fn request_airdrop_with_config(
+    pub async fn request_airdrop_with_config(
         &self,
         pubkey: &Pubkey,
         lamports: u64,
         config: RpcRequestAirdropConfig,
     ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .request_airdrop_with_config(pubkey, lamports, config),
+        let commitment = config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment).await?;
+        let config = RpcRequestAirdropConfig {
+            commitment: Some(commitment),
+            ..config
+        };
+        self.send(
+            RpcRequest::RequestAirdrop,
+            json!([pubkey.to_string(), lamports, config]),
         )
+        .await
+        .and_then(|signature: String| {
+            Signature::from_str(&signature).map_err(|err| {
+                ClientErrorKind::Custom(format!("signature deserialization failed: {}", err)).into()
+            })
+        })
+        .map_err(|_| {
+            RpcError::ForUser(
+                "airdrop request failed. \
+                    This can happen when the rate limit is reached."
+                    .to_string(),
+            )
+            .into()
+        })
     }
 
-    pub fn poll_get_balance_with_commitment(
+    pub(crate) async fn poll_balance_with_timeout_and_commitment(
+        &self,
+        pubkey: &Pubkey,
+        polling_frequency: &Duration,
+        timeout: &Duration,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<u64> {
+        let now = Instant::now();
+        loop {
+            match self
+                .get_balance_with_commitment(pubkey, commitment_config)
+                .await
+            {
+                Ok(bal) => {
+                    return Ok(bal.value);
+                }
+                Err(e) => {
+                    sleep(*polling_frequency).await;
+                    if now.elapsed() > *timeout {
+                        return Err(e);
+                    }
+                }
+            };
+        }
+    }
+
+    pub async fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .poll_get_balance_with_commitment(pubkey, commitment_config),
+        self.poll_balance_with_timeout_and_commitment(
+            pubkey,
+            &Duration::from_millis(100),
+            &Duration::from_secs(1),
+            commitment_config,
         )
+        .await
     }
 
-    pub fn wait_for_balance_with_commitment(
+    pub async fn wait_for_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         expected_balance: Option<u64>,
         commitment_config: CommitmentConfig,
-    ) -> Option<u64> {
-        self.invoke(self.rpc_client.wait_for_balance_with_commitment(
-            pubkey,
-            expected_balance,
-            commitment_config,
-        ))
-        .ok()
+    ) -> ClientResult<u64> {
+        const LAST: usize = 30;
+        let mut run = 0;
+        loop {
+            let balance_result = self
+                .poll_get_balance_with_commitment(pubkey, commitment_config)
+                .await;
+            if expected_balance.is_none() || (balance_result.is_err() && run == LAST) {
+                return balance_result;
+            }
+            trace!(
+                "wait_for_balance_with_commitment [{}] {:?} {:?}",
+                run,
+                balance_result,
+                expected_balance
+            );
+            if let (Some(expected_balance), Ok(balance_result)) = (expected_balance, balance_result)
+            {
+                if expected_balance == balance_result {
+                    return Ok(balance_result);
+                }
+            }
+            run += 1;
+        }
     }
 
     /// Poll the server to confirm a transaction.
-    pub fn poll_for_signature(&self, signature: &Signature) -> ClientResult<()> {
-        self.invoke(self.rpc_client.poll_for_signature(signature))
+    pub async fn poll_for_signature(&self, signature: &Signature) -> ClientResult<()> {
+        self.poll_for_signature_with_commitment(signature, self.commitment())
+            .await
     }
 
     /// Poll the server to confirm a transaction.
-    pub fn poll_for_signature_with_commitment(
+    pub async fn poll_for_signature_with_commitment(
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<()> {
-        self.invoke(
-            self.rpc_client
-                .poll_for_signature_with_commitment(signature, commitment_config),
-        )
+        let now = Instant::now();
+        loop {
+            if let Ok(Some(_)) = self
+                .get_signature_status_with_commitment(signature, commitment_config)
+                .await
+            {
+                break;
+            }
+            if now.elapsed().as_secs() > 15 {
+                return Err(RpcError::ForUser(format!(
+                    "signature not found after {} seconds",
+                    now.elapsed().as_secs()
+                ))
+                .into());
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+        Ok(())
     }
 
     /// Poll the server to confirm a transaction.
-    pub fn poll_for_signature_confirmation(
+    pub async fn poll_for_signature_confirmation(
         &self,
         signature: &Signature,
         min_confirmed_blocks: usize,
     ) -> ClientResult<usize> {
-        self.invoke(
-            self.rpc_client
-                .poll_for_signature_confirmation(signature, min_confirmed_blocks),
-        )
+        let mut now = Instant::now();
+        let mut confirmed_blocks = 0;
+        loop {
+            let response = self
+                .get_num_blocks_since_signature_confirmation(signature)
+                .await;
+            match response {
+                Ok(count) => {
+                    if confirmed_blocks != count {
+                        info!(
+                            "signature {} confirmed {} out of {} after {} ms",
+                            signature,
+                            count,
+                            min_confirmed_blocks,
+                            now.elapsed().as_millis()
+                        );
+                        now = Instant::now();
+                        confirmed_blocks = count;
+                    }
+                    if count >= min_confirmed_blocks {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    debug!("check_confirmations request failed: {:?}", err);
+                }
+            };
+            if now.elapsed().as_secs() > 20 {
+                info!(
+                    "signature {} confirmed {} out of {} failed after {} ms",
+                    signature,
+                    confirmed_blocks,
+                    min_confirmed_blocks,
+                    now.elapsed().as_millis()
+                );
+                if confirmed_blocks > 0 {
+                    return Ok(confirmed_blocks);
+                } else {
+                    return Err(RpcError::ForUser(format!(
+                        "signature not found after {} seconds",
+                        now.elapsed().as_secs()
+                    ))
+                    .into());
+                }
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+        Ok(confirmed_blocks)
     }
 
-    pub fn get_num_blocks_since_signature_confirmation(
+    pub async fn get_num_blocks_since_signature_confirmation(
         &self,
         signature: &Signature,
     ) -> ClientResult<usize> {
-        self.invoke(
-            self.rpc_client
-                .get_num_blocks_since_signature_confirmation(signature),
-        )
+        let result: Response<Vec<Option<TransactionStatus>>> = self
+            .send(
+                RpcRequest::GetSignatureStatuses,
+                json!([[signature.to_string()]]),
+            )
+            .await?;
+
+        let confirmations = result.value[0]
+            .clone()
+            .ok_or_else(|| {
+                ClientError::new_with_request(
+                    ClientErrorKind::Custom("signature not found".to_string()),
+                    RpcRequest::GetSignatureStatuses,
+                )
+            })?
+            .confirmations
+            .unwrap_or(MAX_LOCKOUT_HISTORY + 1);
+        Ok(confirmations)
     }
 
-    pub fn get_latest_blockhash(&self) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_latest_blockhash())
+    pub async fn get_latest_blockhash(&self) -> ClientResult<Hash> {
+        let (blockhash, _) = self
+            .get_latest_blockhash_with_commitment(self.commitment())
+            .await?;
+        Ok(blockhash)
     }
 
     #[allow(deprecated)]
-    pub fn get_latest_blockhash_with_commitment(
+    pub async fn get_latest_blockhash_with_commitment(
         &self,
         commitment: CommitmentConfig,
     ) -> ClientResult<(Hash, u64)> {
-        self.invoke(
-            self.rpc_client
-                .get_latest_blockhash_with_commitment(commitment),
-        )
+        let (blockhash, last_valid_block_height) =
+            if self.get_node_version().await? < semver::Version::new(1, 9, 0) {
+                let Fees {
+                    blockhash,
+                    last_valid_block_height,
+                    ..
+                } = self.get_fees_with_commitment(commitment).await?.value;
+                (blockhash, last_valid_block_height)
+            } else {
+                let RpcBlockhash {
+                    blockhash,
+                    last_valid_block_height,
+                } = self
+                    .send::<Response<RpcBlockhash>>(
+                        RpcRequest::GetLatestBlockhash,
+                        json!([self.maybe_map_commitment(commitment).await?]),
+                    )
+                    .await?
+                    .value;
+                let blockhash = blockhash.parse().map_err(|_| {
+                    ClientError::new_with_request(
+                        RpcError::ParseError("Hash".to_string()).into(),
+                        RpcRequest::GetLatestBlockhash,
+                    )
+                })?;
+                (blockhash, last_valid_block_height)
+            };
+        Ok((blockhash, last_valid_block_height))
     }
 
     #[allow(deprecated)]
-    pub fn is_blockhash_valid(
+    pub async fn is_blockhash_valid(
         &self,
         blockhash: &Hash,
         commitment: CommitmentConfig,
     ) -> ClientResult<bool> {
-        self.invoke(self.rpc_client.is_blockhash_valid(blockhash, commitment))
+        let result = if self.get_node_version().await? < semver::Version::new(1, 9, 0) {
+            self.get_fee_calculator_for_blockhash_with_commitment(blockhash, commitment)
+                .await?
+                .value
+                .is_some()
+        } else {
+            self.send::<Response<bool>>(
+                RpcRequest::IsBlockhashValid,
+                json!([blockhash.to_string(), commitment,]),
+            )
+            .await?
+            .value
+        };
+        Ok(result)
     }
 
     #[allow(deprecated)]
-    pub fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_fee_for_message(message))
-    }
-
-    pub fn get_new_latest_blockhash(&self, blockhash: &Hash) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_new_latest_blockhash(blockhash))
-    }
-
-    pub fn get_transport_stats(&self) -> RpcTransportStats {
-        self.rpc_client.get_transport_stats()
-    }
-
-    fn invoke<T, F: std::future::Future<Output = ClientResult<T>>>(&self, f: F) -> ClientResult<T> {
-        // `block_on()` panics if called within an asynchronous execution context. Whereas
-        // `block_in_place()` only panics if called from a current_thread runtime, which is the
-        // lesser evil.
-        tokio::task::block_in_place(move || self.runtime.as_ref().expect("runtime").block_on(f))
-    }
-}
-
-/// Mocks for documentation examples
-#[doc(hidden)]
-pub fn create_rpc_client_mocks() -> crate::mock_sender::Mocks {
-    let mut mocks = std::collections::HashMap::new();
-
-    let get_account_request = RpcRequest::GetAccountInfo;
-    let get_account_response = serde_json::to_value(Response {
-        context: RpcResponseContext { slot: 1 },
-        value: {
-            let pubkey = Pubkey::from_str("BgvYtJEfmZYdVKiptmMjxGzv8iQoo4MWjsP3QsTkhhxa").unwrap();
-            let account = Account {
-                lamports: 1_000_000,
-                data: vec![],
-                owner: pubkey,
-                executable: false,
-                rent_epoch: 0,
-            };
-            UiAccount::encode(&pubkey, &account, UiAccountEncoding::Base64, None, None)
-        },
-    })
-    .unwrap();
-
-    mocks.insert(get_account_request, get_account_response);
-
-    mocks
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        crate::{client_error::ClientErrorKind, mock_sender::PUBKEY},
-        assert_matches::assert_matches,
-        crossbeam_channel::unbounded,
-        jsonrpc_core::{futures::prelude::*, Error, IoHandler, Params},
-        jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder},
-        serde_json::{json, Number},
-        solana_sdk::{
-            instruction::InstructionError,
-            signature::{Keypair, Signer},
-            system_transaction,
-            transaction::TransactionError,
-        },
-        std::{io, thread},
-    };
-
-    #[test]
-    fn test_send() {
-        _test_send();
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    #[should_panic(expected = "can call blocking only when running on the multi-threaded runtime")]
-    async fn test_send_async_current_thread() {
-        _test_send();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_send_async_multi_thread() {
-        _test_send();
-    }
-
-    fn _test_send() {
-        let (sender, receiver) = unbounded();
-        thread::spawn(move || {
-            let rpc_addr = "0.0.0.0:0".parse().unwrap();
-            let mut io = IoHandler::default();
-            // Successful request
-            io.add_method("getBalance", |_params: Params| {
-                future::ok(Value::Number(Number::from(50)))
-            });
-            // Failed request
-            io.add_method("getRecentBlockhash", |params: Params| {
-                if params != Params::None {
-                    future::err(Error::invalid_request())
-                } else {
-                    future::ok(Value::String(
-                        "deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx".to_string(),
-                    ))
-                }
-            });
-
-            let server = ServerBuilder::new(io)
-                .threads(1)
-                .cors(DomainsValidation::AllowOnly(vec![
-                    AccessControlAllowOrigin::Any,
-                ]))
-                .start_http(&rpc_addr)
-                .expect("Unable to start RPC server");
-            sender.send(*server.address()).unwrap();
-            server.wait();
-        });
-
-        let rpc_addr = receiver.recv().unwrap();
-        let rpc_client = RpcClient::new_socket(rpc_addr);
-
-        let balance: u64 = rpc_client
-            .send(
-                RpcRequest::GetBalance,
-                json!(["deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx"]),
-            )
-            .unwrap();
-        assert_eq!(balance, 50);
-
-        #[allow(deprecated)]
-        let blockhash: String = rpc_client
-            .send(RpcRequest::GetRecentBlockhash, Value::Null)
-            .unwrap();
-        assert_eq!(blockhash, "deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
-
-        // Send erroneous parameter
-        #[allow(deprecated)]
-        let blockhash: ClientResult<String> =
-            rpc_client.send(RpcRequest::GetRecentBlockhash, json!(["parameter"]));
-        assert!(blockhash.is_err());
-    }
-
-    #[test]
-    fn test_send_transaction() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let key = Keypair::new();
-        let to = solana_sdk::pubkey::new_rand();
-        let blockhash = Hash::default();
-        let tx = system_transaction::transfer(&key, &to, 50, blockhash);
-
-        let signature = rpc_client.send_transaction(&tx);
-        assert_eq!(signature.unwrap(), tx.signatures[0]);
-
-        let rpc_client = RpcClient::new_mock("fails".to_string());
-
-        let signature = rpc_client.send_transaction(&tx);
-        assert!(signature.is_err());
-
-        // Test bad signature returned from rpc node
-        let rpc_client = RpcClient::new_mock("malicious".to_string());
-        let signature = rpc_client.send_transaction(&tx);
-        assert!(signature.is_err());
-    }
-
-    #[test]
-    fn test_get_recent_blockhash() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let expected_blockhash: Hash = PUBKEY.parse().unwrap();
-
-        let blockhash = rpc_client.get_latest_blockhash().expect("blockhash ok");
-        assert_eq!(blockhash, expected_blockhash);
-
-        let rpc_client = RpcClient::new_mock("fails".to_string());
-
-        #[allow(deprecated)]
-        let result = rpc_client.get_recent_blockhash();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_custom_request() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let slot = rpc_client.get_slot().unwrap();
-        assert_eq!(slot, 0);
-
-        let custom_slot = rpc_client
-            .send::<Slot>(RpcRequest::Custom { method: "getSlot" }, Value::Null)
-            .unwrap();
-
-        assert_eq!(slot, custom_slot);
-    }
-
-    #[test]
-    fn test_get_signature_status() {
-        let signature = Signature::default();
-
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-        let status = rpc_client.get_signature_status(&signature).unwrap();
-        assert_eq!(status, Some(Ok(())));
-
-        let rpc_client = RpcClient::new_mock("sig_not_found".to_string());
-        let status = rpc_client.get_signature_status(&signature).unwrap();
-        assert_eq!(status, None);
-
-        let rpc_client = RpcClient::new_mock("account_in_use".to_string());
-        let status = rpc_client.get_signature_status(&signature).unwrap();
-        assert_eq!(status, Some(Err(TransactionError::AccountInUse)));
-    }
-
-    #[test]
-    fn test_send_and_confirm_transaction() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let key = Keypair::new();
-        let to = solana_sdk::pubkey::new_rand();
-        let blockhash = Hash::default();
-        let tx = system_transaction::transfer(&key, &to, 50, blockhash);
-        let result = rpc_client.send_and_confirm_transaction(&tx);
-        result.unwrap();
-
-        let rpc_client = RpcClient::new_mock("account_in_use".to_string());
-        let result = rpc_client.send_and_confirm_transaction(&tx);
-        assert!(result.is_err());
-
-        let rpc_client = RpcClient::new_mock("instruction_error".to_string());
-        let result = rpc_client.send_and_confirm_transaction(&tx);
-        assert_matches!(
-            result.unwrap_err().kind(),
-            ClientErrorKind::TransactionError(TransactionError::InstructionError(
-                0,
-                InstructionError::UninitializedAccount
-            ))
-        );
-
-        let rpc_client = RpcClient::new_mock("sig_not_found".to_string());
-        let result = rpc_client.send_and_confirm_transaction(&tx);
-        if let ClientErrorKind::Io(err) = result.unwrap_err().kind() {
-            assert_eq!(err.kind(), io::ErrorKind::Other);
+    pub async fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
+        if self.get_node_version().await? < semver::Version::new(1, 9, 0) {
+            let fee_calculator = self
+                .get_fee_calculator_for_blockhash(&message.recent_blockhash)
+                .await?
+                .ok_or_else(|| ClientErrorKind::Custom("Invalid blockhash".to_string()))?;
+            Ok(fee_calculator
+                .lamports_per_signature
+                .saturating_mul(message.header.num_required_signatures as u64))
+        } else {
+            let serialized_encoded =
+                serialize_and_encode::<Message>(message, UiTransactionEncoding::Base64)?;
+            let result = self
+                .send::<Response<Option<u64>>>(
+                    RpcRequest::GetFeeForMessage,
+                    json!([serialized_encoded, self.commitment()]),
+                )
+                .await?;
+            result
+                .value
+                .ok_or_else(|| ClientErrorKind::Custom("Invalid blockhash".to_string()).into())
         }
     }
 
-    #[test]
-    fn test_rpc_client_thread() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-        thread::spawn(move || rpc_client);
+    pub async fn get_new_latest_blockhash(&self, blockhash: &Hash) -> ClientResult<Hash> {
+        let mut num_retries = 0;
+        let start = Instant::now();
+        while start.elapsed().as_secs() < 5 {
+            if let Ok(new_blockhash) = self.get_latest_blockhash().await {
+                if new_blockhash != *blockhash {
+                    return Ok(new_blockhash);
+                }
+            }
+            debug!("Got same blockhash ({:?}), will retry...", blockhash);
+
+            // Retry ~twice during a slot
+            sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2)).await;
+            num_retries += 1;
+        }
+        Err(RpcError::ForUser(format!(
+            "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
+            start.elapsed().as_millis(),
+            num_retries,
+            blockhash
+        ))
+        .into())
     }
 
-    // Regression test that the get_block_production_with_config
-    // method internally creates the json params array correctly.
-    #[test]
-    fn get_block_production_with_config_no_error() -> ClientResult<()> {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    pub async fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        assert!(params.is_array() || params.is_null());
 
-        let config = RpcBlockProductionConfig {
-            identity: Some(Keypair::new().pubkey().to_string()),
-            range: None,
-            commitment: None,
-        };
-
-        let prod = rpc_client.get_block_production_with_config(config)?.value;
-
-        assert!(!prod.by_identity.is_empty());
-
-        Ok(())
+        let response = self
+            .sender
+            .send(request, params)
+            .await
+            .map_err(|err| err.into_with_request(request))?;
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_request(err.into(), request))
     }
 
-    #[test]
-    fn test_get_latest_blockhash() {
-        let rpc_client = RpcClient::new_mock("succeeds".to_string());
-
-        let expected_blockhash: Hash = PUBKEY.parse().unwrap();
-
-        let blockhash = rpc_client.get_latest_blockhash().expect("blockhash ok");
-        assert_eq!(blockhash, expected_blockhash);
-
-        let rpc_client = RpcClient::new_mock("fails".to_string());
-
-        #[allow(deprecated)]
-        let is_err = rpc_client.get_latest_blockhash().is_err();
-        assert!(is_err);
+    pub fn get_transport_stats(&self) -> RpcTransportStats {
+        self.sender.get_transport_stats()
     }
+}
+
+fn serialize_and_encode<T>(input: &T, encoding: UiTransactionEncoding) -> ClientResult<String>
+where
+    T: serde::ser::Serialize,
+{
+    let serialized = serialize(input)
+        .map_err(|e| ClientErrorKind::Custom(format!("Serialization failed: {}", e)))?;
+    let encoded = match encoding {
+        UiTransactionEncoding::Base58 => bs58::encode(serialized).into_string(),
+        UiTransactionEncoding::Base64 => base64::encode(serialized),
+        _ => {
+            return Err(ClientErrorKind::Custom(format!(
+                "unsupported encoding: {}. Supported encodings: base58, base64",
+                encoding
+            ))
+            .into())
+        }
+    };
+    Ok(encoded)
+}
+
+pub(crate) fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
+    if tls {
+        format!("https://{}", rpc_addr)
+    } else {
+        format!("http://{}", rpc_addr)
+    }
+}
+
+pub(crate) fn parse_keyed_accounts(
+    accounts: Vec<RpcKeyedAccount>,
+    request: RpcRequest,
+) -> ClientResult<Vec<(Pubkey, Account)>> {
+    let mut pubkey_accounts: Vec<(Pubkey, Account)> = Vec::with_capacity(accounts.len());
+    for RpcKeyedAccount { pubkey, account } in accounts.into_iter() {
+        let pubkey = pubkey.parse().map_err(|_| {
+            ClientError::new_with_request(
+                RpcError::ParseError("Pubkey".to_string()).into(),
+                request,
+            )
+        })?;
+        pubkey_accounts.push((
+            pubkey,
+            account.decode().ok_or_else(|| {
+                ClientError::new_with_request(
+                    RpcError::ParseError("Account from rpc".to_string()).into(),
+                    request,
+                )
+            })?,
+        ));
+    }
+    Ok(pubkey_accounts)
 }

--- a/client/src/rpc_sender.rs
+++ b/client/src/rpc_sender.rs
@@ -1,7 +1,7 @@
 //! A transport for RPC calls.
-
 use {
     crate::{client_error::Result, rpc_request::RpcRequest},
+    async_trait::async_trait,
     std::time::Duration,
 };
 
@@ -26,10 +26,14 @@ pub struct RpcTransportStats {
 /// It is typically implemented by [`HttpSender`] in production, and
 /// [`MockSender`] in unit tests.
 ///
-/// [`RpcClient`]: crate::rpc_client::RpcClient
 /// [`HttpSender`]: crate::http_sender::HttpSender
 /// [`MockSender`]: crate::mock_sender::MockSender
-pub trait RpcSender {
-    fn send(&self, request: RpcRequest, params: serde_json::Value) -> Result<serde_json::Value>;
+#[async_trait]
+pub(crate) trait RpcSender {
+    async fn send(
+        &self,
+        request: RpcRequest,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value>;
     fn get_transport_stats(&self) -> RpcTransportStats;
 }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
 name = "solana-client"
 version = "1.10.0"
 dependencies = [
+ "async-trait",
  "base64 0.13.0",
  "bincode",
  "bs58 0.4.0",

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -27,6 +27,7 @@ solana-rpc = { path = "../rpc", version = "=1.10.0" }
 solana-runtime = { path = "../runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 solana-streamer = { path = "../streamer", version = "=1.10.0" }
+tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem
No async RpcClient

#### Summary of Changes
Add one.  Also add `[tokio::test]` support to `TestValidator`. The work that @BroderickCarlin did in https://github.com/solana-labs/solana/pull/20683 provided a very helpful base for this PR.

Here's an example of what porting client code to the nonblocking RpcClient looks like (spoiler: it's quite simple): https://github.com/mvines/solana-cli-template/pull/4/files

Fixes https://github.com/solana-labs/solana/issues/19716