### PR TITLE
Add --rpc option and deprecate other rpc options

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -50,7 +50,6 @@ $ solana-validator \
     --known-validator dv3qDFk1DTF36Z62bNvrCXe9sKATA6xvVy6A798xxAS \
     --only-known-rpc \
     --ledger ledger \
-    --rpc-port 8899 \
     --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.devnet.solana.com:8001 \
     --entrypoint entrypoint2.devnet.solana.com:8001 \
@@ -102,7 +101,6 @@ $ solana-validator \
     --known-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
     --only-known-rpc \
     --ledger ledger \
-    --rpc-port 8899 \
     --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.testnet.solana.com:8001 \
     --entrypoint entrypoint2.testnet.solana.com:8001 \
@@ -156,8 +154,6 @@ $ solana-validator \
     --known-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
     --only-known-rpc \
     --ledger ledger \
-    --rpc-port 8899 \
-    --private-rpc \
     --dynamic-port-range 8000-8020 \
     --entrypoint entrypoint.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint2.mainnet-beta.solana.com:8001 \

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -33,7 +33,6 @@ solana-validator \
   --identity <VALIDATOR_IDENTITY_KEYPAIR> \
   --entrypoint <CLUSTER_ENTRYPOINT> \
   --expected-genesis-hash <EXPECTED_GENESIS_HASH> \
-  --rpc-port 8899 \
   --no-voting \
   --enable-rpc-transaction-history \
   --limit-ledger-size \
@@ -60,8 +59,7 @@ Specifying one or more `--known-validator` parameters can protect you from booti
 
 Optional parameters to consider:
 
-- `--private-rpc` prevents your RPC port from being published for use by other nodes
-- `--rpc-bind-address` allows you to specify a different IP address to bind the RPC port
+- `--rpc=public:<BIND_ADDRESS>` allows you to specify a different IP address to bind the RPC port
 
 ### Automatic Restarts and Monitoring
 

--- a/docs/src/running-validator/validator-reqs.md
+++ b/docs/src/running-validator/validator-reqs.md
@@ -105,7 +105,7 @@ be limited to any free 12 port range with `--dynamic-port-range`
 #### Optional
 For security purposes, it is not suggested that the following ports be open to
 the internet on staked, mainnet-beta validators.
-- 8899 TCP - JSONRPC over HTTP. Change with `--rpc-port RPC_PORT``
+- 8899 TCP - JSONRPC over HTTP. Change with `--rpc=public:<RPC_PORT>``
 - 8900 TCP - JSONRPC over Websockets. Derived. Uses `RPC_PORT + 1`
 
 ## GPU Requirements

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -289,7 +289,6 @@ Connect to the cluster by running:
 solana-validator \
   --identity ~/validator-keypair.json \
   --vote-account ~/vote-account-keypair.json \
-  --rpc-port 8899 \
   --entrypoint entrypoint.devnet.solana.com:8001 \
   --limit-ledger-size \
   --log ~/solana-validator.log


### PR DESCRIPTION
#### Problem

RPC command line options are numerous and unnecessarily onerous to use for common node configurations.  This led to numerous mainnet-beta validator nodes that have unsafe RPC configurations.

#### Summary of Changes

Added --rpc command line option to the solana-validator command and deprecated (by hiding) the existing options.  The single --rpc command line option more easily, readily, and explainably covers the vastly most common validator use cases, including:

- No RPC supported at all
- Private RPC only visible to the validator itself
- Public RPC that serves only snapshots
- Full public RPC

In addition, sensible defaults based on the common configuration parameters that distinguish validators from RPC nodes are supplied.

Fixes #
