### PR TITLE
Remove rewrite_rent_exempt_reserve()

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -5677,41 +5677,6 @@ mod tests {
     }
 
     #[test]
-    fn test_meta_rewrite_rent_exempt_reserve() {
-        let right_data_len = std::mem::size_of::<StakeState>() as u64;
-        let rent = Rent::default();
-        let expected_rent_exempt_reserve = rent.minimum_balance(right_data_len as usize);
-
-        let test_cases = [
-            (
-                right_data_len + 100,
-                Some((
-                    rent.minimum_balance(right_data_len as usize + 100),
-                    expected_rent_exempt_reserve,
-                )),
-            ), // large data_len, too small rent exempt
-            (right_data_len, None), // correct
-            (
-                right_data_len - 100,
-                Some((
-                    rent.minimum_balance(right_data_len as usize - 100),
-                    expected_rent_exempt_reserve,
-                )),
-            ), // small data_len, too large rent exempt
-        ];
-        for (data_len, expected_rewrite) in &test_cases {
-            let rent_exempt_reserve = rent.minimum_balance(*data_len as usize);
-            let mut meta = Meta {
-                rent_exempt_reserve,
-                ..Meta::default()
-            };
-            let actual_rewrite = meta.rewrite_rent_exempt_reserve(&rent, right_data_len as usize);
-            assert_eq!(actual_rewrite, *expected_rewrite);
-            assert_eq!(meta.rent_exempt_reserve, expected_rent_exempt_reserve);
-        }
-    }
-
-    #[test]
     fn test_calculate_lamports_per_byte_year() {
         let rent = Rent::default();
         let data_len = 200u64;

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -280,24 +280,6 @@ impl Meta {
         Ok(())
     }
 
-    pub fn rewrite_rent_exempt_reserve(
-        &mut self,
-        rent: &Rent,
-        data_len: usize,
-    ) -> Option<(u64, u64)> {
-        let corrected_rent_exempt_reserve = rent.minimum_balance(data_len);
-        if corrected_rent_exempt_reserve != self.rent_exempt_reserve {
-            // We forcibly update rent_excempt_reserve even
-            // if rent_exempt_reserve > account_balance, hoping user might restore
-            // rent_exempt status by depositing.
-            let (old, new) = (self.rent_exempt_reserve, corrected_rent_exempt_reserve);
-            self.rent_exempt_reserve = corrected_rent_exempt_reserve;
-            Some((old, new))
-        } else {
-            None
-        }
-    }
-
     pub fn auto(authorized: &Pubkey) -> Self {
         Self {
             authorized: Authorized::auto(authorized),


### PR DESCRIPTION
#### Problem

`rewrite_rent_exempt_reserve()` is only called in one test, to test its correctness. This fn seems unnecessary, given that it's not called, and that it could change rent, which likely isn't intended...

#### Summary of Changes

Remove `rewrite_rent_exempt_reserve()` and its test.

Is this OK to remove?