### PR TITLE
Fix poh recorder initialization on startup

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -575,29 +575,25 @@ impl Validator {
         );
 
         let poh_config = Arc::new(genesis_config.poh_config.clone());
-        let (mut poh_recorder, entry_receiver, record_receiver) =
-            PohRecorder::new_with_clear_signal(
-                bank.tick_height(),
-                bank.last_blockhash(),
-                bank.clone(),
-                leader_schedule_cache.next_leader_slot(
-                    &id,
-                    bank.slot(),
-                    &bank,
-                    Some(&blockstore),
-                    GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
-                ),
-                bank.ticks_per_slot(),
+        let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new_with_clear_signal(
+            bank.tick_height(),
+            bank.last_blockhash(),
+            bank.clone(),
+            leader_schedule_cache.next_leader_slot(
                 &id,
-                &blockstore,
-                blockstore.new_shreds_signals.first().cloned(),
-                &leader_schedule_cache,
-                &poh_config,
-                exit.clone(),
-            );
-        if config.snapshot_config.is_some() {
-            poh_recorder.set_bank(&bank);
-        }
+                bank.slot(),
+                &bank,
+                Some(&blockstore),
+                GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
+            ),
+            bank.ticks_per_slot(),
+            &id,
+            &blockstore,
+            blockstore.new_shreds_signals.first().cloned(),
+            &leader_schedule_cache,
+            &poh_config,
+            exit.clone(),
+        );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
#### Problem
The poh recorder working bank is set on validator startup for no good reason that I can tell. It should be set during replay stage if the validator is the next leader, no need to set it here.
