### PR TITLE
pubsub: Include vote account address in vote subscription 

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -290,6 +290,8 @@ pub struct RpcIdentity {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcVote {
+    /// Vote account address, as base-58 encoded string
+    pub vote_pubkey: String,
     pub slots: Vec<Slot>,
     pub hash: String,
     pub timestamp: Option<UnixTimestamp>,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -688,7 +688,7 @@ impl ClusterInfoVoteListener {
         }
 
         if is_new_vote {
-            subscriptions.notify_vote(vote);
+            subscriptions.notify_vote(*vote_pubkey, vote);
             let _ = verified_vote_sender.send((*vote_pubkey, vote_slots));
         }
     }

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -1316,12 +1316,12 @@ mod tests {
             hash: Hash::default(),
             timestamp: None,
         };
-        subscriptions.notify_vote(VoteTransaction::from(vote));
+        subscriptions.notify_vote(Pubkey::default(), VoteTransaction::from(vote));
 
         let response = receiver.recv();
         assert_eq!(
             response,
-            r#"{"jsonrpc":"2.0","method":"voteNotification","params":{"result":{"slots":[1,2],"hash":"11111111111111111111111111111111","timestamp":null},"subscription":0}}"#
+            r#"{"jsonrpc":"2.0","method":"voteNotification","params":{"result":{"votePubkey":"11111111111111111111111111111111","slots":[1,2],"hash":"11111111111111111111111111111111","timestamp":null},"subscription":0}}"#
         );
     }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_ledger::{blockstore::create_new_ledger, create_new_tmp_ledger},
     solana_net_utils::PortRange,
-    solana_rpc::rpc::JsonRpcConfig,
+    solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, snapshot_config::SnapshotConfig,
@@ -91,6 +91,7 @@ pub struct TestValidatorGenesis {
     tower_storage: Option<Arc<dyn TowerStorage>>,
     pub rent: Rent,
     rpc_config: JsonRpcConfig,
+    pubsub_config: PubSubConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
     warp_slot: Option<Slot>,
     no_bpf_jit: bool,
@@ -146,6 +147,11 @@ impl TestValidatorGenesis {
 
     pub fn rpc_config(&mut self, rpc_config: JsonRpcConfig) -> &mut Self {
         self.rpc_config = rpc_config;
+        self
+    }
+
+    pub fn pubsub_config(&mut self, pubsub_config: PubSubConfig) -> &mut Self {
+        self.pubsub_config = pubsub_config;
         self
     }
 
@@ -606,6 +612,7 @@ impl TestValidator {
                 ),
             )),
             rpc_config: config.rpc_config.clone(),
+            pubsub_config: config.pubsub_config.clone(),
             accounts_hash_interval_slots: 100,
             account_paths: vec![ledger_path.join("accounts")],
             poh_verify: false, // Skip PoH verification of ledger on startup for speed


### PR DESCRIPTION
The pubsub [vote subscription](https://docs.solana.com/developing/clients/jsonrpc-api#votesubscribe---unstable-disabled-by-default) is less useful than it could be due to the lack of the vote account address in its notifications.  Add it.

Additionally `solana-test-validator` now allows you to frob the vote subscription with a `--rpc-pubsub-enable-vote-subscription` flag just like its big brother, `solana-validator`