### PR TITLE
fix: getMultipleAccountInfos typings based on encoding

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2489,10 +2489,12 @@ export class Connection {
   /**
    * Fetch all the account info for multiple accounts specified by an array of public keys
    */
-  async getMultipleAccountsInfo(
+  async getMultipleAccountsInfo<
+    T extends Required<GetMultipleAccountsConfig>['encoding'] = 'base64',
+  >(
     publicKeys: PublicKey[],
     configOrCommitment?: GetMultipleAccountsConfig | Commitment,
-  ): Promise<(AccountInfo<Buffer | ParsedAccountData> | null)[]> {
+  ) {
     const keys = publicKeys.map(key => key.toBase58());
 
     let commitment;
@@ -2513,12 +2515,18 @@ export class Connection {
       unsafeRes,
       jsonRpcResultAndContext(array(nullable(ParsedAccountInfoResult))),
     );
+
     if ('error' in res) {
       throw new Error(
         'failed to get info for accounts ' + keys + ': ' + res.error.message,
       );
     }
-    return res.result.value;
+
+    return res.result.value as Array<
+      'jsonParsed' extends T
+        ? AccountInfo<Buffer | ParsedAccountData> | null
+        : AccountInfo<Buffer> | null
+    >;
   }
 
   /**


### PR DESCRIPTION
#### Problem
Typings with getMultipleAccountInfos was breaking build because of typing errors, which was returning ParsedAccountData even when encoding was base64

#### Summary of Changes

- return Buffer as default because encoding is base64 by edfault
- return ParsedAccountData if jsonParsed is specified

Fixes #

