### PR TITLE
Restrict the Mergify copy command to core contributors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -113,3 +113,10 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v1.9
+
+commands_restrictions:
+  # The author of copied PRs is the Mergify user.
+  # Restrict `copy` access to Core Contributors
+  copy:
+    conditions:
+    - author=@core-contributors


### PR DESCRIPTION
Anybody can open a PR then use the Mergify copy command to duplicate it.  Prevent this.

ref: https://github.com/solana-labs/solana/pull/22758