### PR TITLE
Update Metaplex/js package to use new Token Standard Metadata

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -8,7 +8,7 @@
     "@bonfida/spl-name-service": "^0.1.22",
     "@cloudflare/stream-react": "^1.2.0",
     "@metamask/jazzicon": "^2.0.0",
-    "@metaplex/js": "4.11.3",
+    "@metaplex/js": "4.12.0",
     "@project-serum/serum": "^0.13.61",
     "@react-hook/debounce": "^4.0.0",
     "@sentry/react": "^6.16.1",


### PR DESCRIPTION
#### Problem
Explorer don't show collection and uses, because metaplex/js is using an older version

#### Summary of Changes
Update metaplex/js version

![Screen Shot 2022-01-27 at 3 37 05 PM](https://user-images.githubusercontent.com/14321810/151439645-80af523c-e9e1-4825-8828-3f7d00419a98.png)
