### PR TITLE
chore: update Connection to non-deprecated endpoints

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1616,6 +1616,8 @@ const GetParsedTransactionRpcResult = jsonRpcResult(
 
 /**
  * Expected JSON RPC response for the "getRecentBlockhash" message
+ *
+ * @deprecated Deprecated since Solana v1.8.0. Please use {@link GetLatestBlockhashRpcResult} instead.
  */
 const GetRecentBlockhashAndContextRpcResult = jsonRpcResultAndContext(
   pick({
@@ -1623,6 +1625,16 @@ const GetRecentBlockhashAndContextRpcResult = jsonRpcResultAndContext(
     feeCalculator: pick({
       lamportsPerSignature: number(),
     }),
+  }),
+);
+
+/**
+ * Expected JSON RPC response for the "getLatestBlockhash" message
+ */
+const GetLatestBlockhashRpcResult = jsonRpcResultAndContext(
+  pick({
+    blockhash: string(),
+    lastValidBlockHeight: number(),
   }),
 );
 
@@ -3009,6 +3021,8 @@ export class Connection {
   /**
    * Fetch a recent blockhash from the cluster, return with context
    * @return {Promise<RpcResponseAndContext<{blockhash: Blockhash, feeCalculator: FeeCalculator}>>}
+   *
+   * @deprecated Deprecated since Solana v1.8.0. Please use {@link getLatestBlockhash} instead.
    */
   async getRecentBlockhashAndContext(
     commitment?: Commitment,
@@ -3048,6 +3062,8 @@ export class Connection {
 
   /**
    * Fetch the fee calculator for a recent blockhash from the cluster, return with context
+   *
+   * @deprecated Deprecated since Solana v1.8.0. Please use {@link getFeeForMessage} instead.
    */
   async getFeeCalculatorForBlockhash(
     blockhash: Blockhash,
@@ -3094,6 +3110,8 @@ export class Connection {
   /**
    * Fetch a recent blockhash from the cluster
    * @return {Promise<{blockhash: Blockhash, feeCalculator: FeeCalculator}>}
+   *
+   * @deprecated Deprecated since Solana v1.8.0. Please use {@link getLatestBlockhash} instead.
    */
   async getRecentBlockhash(
     commitment?: Commitment,
@@ -3104,6 +3122,39 @@ export class Connection {
     } catch (e) {
       throw new Error('failed to get recent blockhash: ' + e);
     }
+  }
+
+  /**
+   * Fetch the latest blockhash from the cluster
+   * @return {Promise<{blockhash: Blockhash, lastValidBlockHeight: number}>}
+   */
+  async getLatestBlockhash(
+    commitment?: Commitment,
+  ): Promise<{blockhash: Blockhash; lastValidBlockHeight: number}> {
+    try {
+      const res = await this.getLatestBlockhashAndContext(commitment);
+      return res.value;
+    } catch (e) {
+      throw new Error('failed to get recent blockhash: ' + e);
+    }
+  }
+
+  /**
+   * Fetch the latest blockhash from the cluster
+   * @return {Promise<{blockhash: Blockhash, lastValidBlockHeight: number}>}
+   */
+  async getLatestBlockhashAndContext(
+    commitment?: Commitment,
+  ): Promise<
+    RpcResponseAndContext<{blockhash: Blockhash; lastValidBlockHeight: number}>
+  > {
+    const args = this._buildArgs([], commitment);
+    const unsafeRes = await this._rpcRequest('getLatestBlockhash', args);
+    const res = create(unsafeRes, GetLatestBlockhashRpcResult);
+    if ('error' in res) {
+      throw new Error('failed to get latest blockhash: ' + res.error.message);
+    }
+    return res.result;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1552,18 +1552,18 @@ describe('Connection', () => {
 
     // Find a block that has a transaction, usually Block 1
     let slot = 0;
-    let confirmedTransaction: string | undefined;
-    while (!confirmedTransaction) {
+    let transaction: string | undefined;
+    while (!transaction) {
       slot++;
       const block = await connection.getBlock(slot);
       if (block && block.transactions.length > 0) {
-        confirmedTransaction = block.transactions[0].transaction.signatures[0];
+        transaction = block.transactions[0].transaction.signatures[0];
       }
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
-      params: [confirmedTransaction],
+      method: 'getTransaction',
+      params: [transaction],
       value: {
         slot,
         transaction: {
@@ -1604,7 +1604,7 @@ describe('Connection', () => {
       },
     });
 
-    const result = await connection.getTransaction(confirmedTransaction);
+    const result = await connection.getTransaction(transaction);
 
     if (!result) {
       expect(result).to.be.ok;
@@ -1612,7 +1612,7 @@ describe('Connection', () => {
     }
 
     const resultSignature = result.transaction.signatures[0];
-    expect(resultSignature).to.eq(confirmedTransaction);
+    expect(resultSignature).to.eq(transaction);
 
     const newAddress = Keypair.generate().publicKey;
     const recentSignature = await helpers.airdrop({
@@ -1622,7 +1622,7 @@ describe('Connection', () => {
     });
 
     await mockRpcResponse({
-      method: 'getConfirmedTransaction',
+      method: 'getTransaction',
       params: [recentSignature],
       value: null,
     });

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1501,9 +1501,10 @@ describe('Connection', () => {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
+        blockHeight: 0,
         blockTime: 1614281964,
         blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
         previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
@@ -1896,9 +1897,10 @@ describe('Connection', () => {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [0],
       value: {
+        blockHeight: 0,
         blockTime: 1614281964,
         blockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
         previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
@@ -1921,9 +1923,10 @@ describe('Connection', () => {
     expect(block0.parentSlot).to.eq(0);
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [1],
       value: {
+        blockHeight: 0,
         blockTime: 1614281964,
         blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
         previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
@@ -1985,7 +1988,7 @@ describe('Connection', () => {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [Number.MAX_SAFE_INTEGER],
       error: {
         message: `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
@@ -2109,7 +2112,7 @@ describe('Connection', () => {
 
   it('get blocks between two slots', async () => {
     await mockRpcResponse({
-      method: 'getConfirmedBlocks',
+      method: 'getBlocks',
       params: [0, 10],
       value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     });
@@ -2129,7 +2132,7 @@ describe('Connection', () => {
 
   it('get blocks from starting slot', async () => {
     await mockRpcResponse({
-      method: 'getConfirmedBlocks',
+      method: 'getBlocks',
       params: [0],
       value: [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
@@ -2155,7 +2158,7 @@ describe('Connection', () => {
     expect(blocks).to.contain(latestSlot);
   });
 
-  it('get confirmed block signatures', async () => {
+  it('get block signatures', async () => {
     await mockRpcResponse({
       method: 'getSlot',
       params: [],
@@ -2167,7 +2170,7 @@ describe('Connection', () => {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [
         0,
         {
@@ -2176,6 +2179,7 @@ describe('Connection', () => {
         },
       ],
       value: {
+        blockHeight: 0,
         blockTime: 1614281964,
         blockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
         previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
@@ -2185,7 +2189,7 @@ describe('Connection', () => {
     });
 
     // Block 0 never has any transactions in test validator
-    const block0 = await connection.getConfirmedBlockSignatures(0);
+    const block0 = await connection.getBlockSignatures(0);
     const blockhash0 = block0.blockhash;
     expect(block0.signatures).to.have.length(0);
     expect(blockhash0).not.to.be.null;
@@ -2194,7 +2198,7 @@ describe('Connection', () => {
     expect(block0).to.not.have.property('rewards');
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [
         1,
         {
@@ -2203,6 +2207,7 @@ describe('Connection', () => {
         },
       ],
       value: {
+        blockHeight: 1,
         blockTime: 1614281964,
         blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
         previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
@@ -2217,7 +2222,7 @@ describe('Connection', () => {
     // Find a block that has a transaction, usually Block 1
     let x = 1;
     while (x < 10) {
-      const block1 = await connection.getConfirmedBlockSignatures(x);
+      const block1 = await connection.getBlockSignatures(x);
       if (block1.signatures.length >= 1) {
         expect(block1.previousBlockhash).to.eq(blockhash0);
         expect(block1.blockhash).not.to.be.null;
@@ -2230,14 +2235,14 @@ describe('Connection', () => {
     }
 
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
+      method: 'getBlock',
       params: [Number.MAX_SAFE_INTEGER],
       error: {
         message: `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
       },
     });
     await expect(
-      connection.getConfirmedBlockSignatures(Number.MAX_SAFE_INTEGER),
+      connection.getBlockSignatures(Number.MAX_SAFE_INTEGER),
     ).to.be.rejectedWith(
       `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
     );

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -2260,6 +2260,18 @@ describe('Connection', () => {
     }
   });
 
+  it('get latest blockhash', async () => {
+    const commitments: Commitment[] = ['processed', 'confirmed', 'finalized'];
+    for (const commitment of commitments) {
+      const {blockhash, lastValidBlockHeight} = await helpers.latestBlockhash({
+        connection,
+        commitment,
+      });
+      expect(bs58.decode(blockhash)).to.have.length(32);
+      expect(lastValidBlockHeight).to.be.at.least(0);
+    }
+  });
+
   it('get fee calculator', async () => {
     const {blockhash} = await helpers.recentBlockhash({connection});
     await mockRpcResponse({
@@ -2287,7 +2299,7 @@ describe('Connection', () => {
     const accountFrom = Keypair.generate();
     const accountTo = Keypair.generate();
 
-    const {blockhash} = await helpers.recentBlockhash({connection});
+    const {blockhash} = await helpers.latestBlockhash({connection});
 
     const transaction = new Transaction({
       feePayer: accountFrom.publicKey,
@@ -2977,7 +2989,7 @@ describe('Connection', () => {
       });
 
       const recentBlockhash = await (
-        await helpers.recentBlockhash({connection})
+        await helpers.latestBlockhash({connection})
       ).blockhash;
       const message = new Message({
         accountKeys: [

--- a/web3.js/test/mocks/rpc-http.ts
+++ b/web3.js/test/mocks/rpc-http.ts
@@ -104,6 +104,32 @@ export const mockRpcResponse = async ({
     );
 };
 
+const latestBlockhash = async ({
+  connection,
+  commitment,
+}: {
+  connection: Connection;
+  commitment?: Commitment;
+}) => {
+  const blockhash = uniqueBlockhash();
+  const params = [];
+  if (commitment) {
+    params.push({commitment});
+  }
+
+  await mockRpcResponse({
+    method: 'getLatestBlockhash',
+    params,
+    value: {
+      blockhash,
+      lastValidBlockHeight: 3090,
+    },
+    withContext: true,
+  });
+
+  return await connection.getLatestBlockhash(commitment);
+};
+
 const recentBlockhash = async ({
   connection,
   commitment,
@@ -145,7 +171,7 @@ const processTransaction = async ({
   commitment: Commitment;
   err?: any;
 }) => {
-  const blockhash = (await recentBlockhash({connection})).blockhash;
+  const blockhash = (await latestBlockhash({connection})).blockhash;
   transaction.recentBlockhash = blockhash;
   transaction.sign(...signers);
 
@@ -211,4 +237,5 @@ export const helpers = {
   airdrop,
   processTransaction,
   recentBlockhash,
+  latestBlockhash,
 };


### PR DESCRIPTION
#### Problem

People were getting 429s for using deprecated endpoints, but it's not their fault -- web3 is currently using deprecated endpoints with no option to use something else!

#### Summary of Changes

A few calls were defaulting to their deprecated counterparts, so bring everything up to speed.  From what I'm seeing on the docs, the differences are:

* getConfirmedBlock -> getBlock: added `blockHeight` in return
* getConfirmedTransaction -> getTransaction: no change, although I think the docs are incorrect since they mention rewards, and no rewards are ever returned.  Could be some copy-paste from getBlock?
* getLatestBlockhash -> only returns the hash and last valid block height

Note that some of the implementations for the deprecated functions is repetitive, but this is to maintain the exact same behavior as before.

@CriesofCarrots just for some quick :eyes: that the differences between the deprecated and non-deprecated types are correct

Fixes #
