### PR TITLE
Sigma pass

### DIFF
--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -31,7 +31,7 @@ mod sigma_proofs;
 #[cfg(not(target_arch = "bpf"))]
 mod transcript;
 
-mod instruction;
+// mod instruction;
 pub mod zk_token_elgamal;
-pub mod zk_token_proof_instruction;
-pub mod zk_token_proof_program;
+// pub mod zk_token_proof_instruction;
+// pub mod zk_token_proof_program;

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -31,7 +31,7 @@ mod sigma_proofs;
 #[cfg(not(target_arch = "bpf"))]
 mod transcript;
 
-// mod instruction;
+mod instruction;
 pub mod zk_token_elgamal;
-// pub mod zk_token_proof_instruction;
-// pub mod zk_token_proof_program;
+pub mod zk_token_proof_instruction;
+pub mod zk_token_proof_program;

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -6,7 +6,7 @@
 //! the decryption key for the ciphertext and the Pedersen opening for the commitment.
 //!
 //! The protocol guarantees computationally soundness (by the hardness of discrete log) and perfect
-//! zero-knowledge.
+//! zero-knowledge in the random oracle model.
 
 #[cfg(not(target_arch = "bpf"))]
 use {

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -89,7 +89,6 @@ impl EqualityProof {
         }
     }
 
-    /// TODO:
     pub fn verify(
         self,
         elgamal_pubkey: &ElGamalPubkey,

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -289,10 +289,7 @@ mod test {
         let public = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
         let secret = ElGamalSecretKey::new_rand();
 
-        let elgamal_keypair = ElGamalKeypair {
-            public,
-            secret
-        };
+        let elgamal_keypair = ElGamalKeypair { public, secret };
 
         let message: u64 = 55;
         let ciphertext = elgamal_keypair.public.encrypt(message);

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -27,10 +27,10 @@ use {
 #[derive(Clone)]
 pub struct FeeSigmaProof {
     /// Proof that the committed fee amount equals the maximum fee bound
-    pub fee_max_proof: FeeMaxProof,
+    fee_max_proof: FeeMaxProof,
 
     /// Proof that the "real" delta value is equal to the "claimed" delta value
-    pub fee_equality_proof: FeeEqualityProof,
+    fee_equality_proof: FeeEqualityProof,
 }
 
 #[allow(non_snake_case, dead_code)]
@@ -216,8 +216,7 @@ impl FeeSigmaProof {
         let Y_delta =
             RistrettoPoint::multiscalar_mul(vec![y_x, y_delta], vec![&(*G), &(*H)]).compress();
         let Y_claimed =
-            RistrettoPoint::multiscalar_mul(vec![y_x, y_claimed], vec![&(*G), &(*H)])
-                .compress();
+            RistrettoPoint::multiscalar_mul(vec![y_x, y_claimed], vec![&(*G), &(*H)]).compress();
 
         transcript.append_point(b"Y_max_proof", &Y_max_proof);
         transcript.append_point(b"Y_delta", &Y_delta);
@@ -270,10 +269,7 @@ impl FeeSigmaProof {
 
         transcript.validate_and_append_point(b"Y_max_proof", &self.fee_max_proof.Y_max_proof)?;
         transcript.validate_and_append_point(b"Y_delta", &self.fee_equality_proof.Y_delta)?;
-        transcript.validate_and_append_point(
-            b"Y_claimed",
-            &self.fee_equality_proof.Y_claimed,
-        )?;
+        transcript.validate_and_append_point(b"Y_claimed", &self.fee_equality_proof.Y_claimed)?;
 
         let Y_max = self
             .fee_max_proof
@@ -348,9 +344,9 @@ impl FeeSigmaProof {
 #[allow(non_snake_case)]
 #[derive(Clone, Copy)]
 pub struct FeeMaxProof {
-    pub Y_max_proof: CompressedRistretto,
-    pub z_max_proof: Scalar,
-    pub c_max_proof: Scalar,
+    Y_max_proof: CompressedRistretto,
+    z_max_proof: Scalar,
+    c_max_proof: Scalar,
 }
 
 impl ConditionallySelectable for FeeMaxProof {
@@ -370,33 +366,26 @@ impl ConditionallySelectable for FeeMaxProof {
 #[allow(non_snake_case)]
 #[derive(Clone, Copy)]
 pub struct FeeEqualityProof {
-    pub Y_delta: CompressedRistretto,
-    pub Y_claimed: CompressedRistretto,
-    pub z_x: Scalar,
-    pub z_delta: Scalar,
-    pub z_claimed: Scalar,
+    Y_delta: CompressedRistretto,
+    Y_claimed: CompressedRistretto,
+    z_x: Scalar,
+    z_delta: Scalar,
+    z_claimed: Scalar,
 }
 
 impl ConditionallySelectable for FeeEqualityProof {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Self {
             Y_delta: conditional_select_ristretto(&a.Y_delta, &b.Y_delta, choice),
-            Y_claimed: conditional_select_ristretto(
-                &a.Y_claimed,
-                &b.Y_claimed,
-                choice,
-            ),
+            Y_claimed: conditional_select_ristretto(&a.Y_claimed, &b.Y_claimed, choice),
             z_x: Scalar::conditional_select(&a.z_x, &b.z_x, choice),
             z_delta: Scalar::conditional_select(&a.z_delta, &b.z_delta, choice),
-            z_claimed: Scalar::conditional_select(
-                &a.z_claimed,
-                &b.z_claimed,
-                choice,
-            ),
+            z_claimed: Scalar::conditional_select(&a.z_claimed, &b.z_claimed, choice),
         }
     }
 }
 
+#[allow(clippy::needless_range_loop)]
 fn conditional_select_ristretto(
     a: &CompressedRistretto,
     b: &CompressedRistretto,
@@ -447,10 +436,10 @@ mod test {
 
         assert!(proof
             .verify(
-                max_fee,
                 &commitment_fee,
                 &commitment_delta,
                 &commitment_claimed,
+                max_fee,
                 &mut transcript_verifier,
             )
             .is_ok());

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -295,7 +295,6 @@ impl FeeProof {
     }
 }
 
-/// TODO: mention copy
 #[allow(non_snake_case)]
 #[derive(Clone, Copy)]
 pub struct FeeMaxProof {
@@ -326,7 +325,6 @@ fn conditional_select_ristretto(
     CompressedRistretto(bytes)
 }
 
-/// TODO: mention copy
 #[allow(non_snake_case)]
 #[derive(Clone, Copy)]
 pub struct FeeEqualityProof {
@@ -439,14 +437,6 @@ mod test {
             max_fee,
             &mut transcript_prover,
         );
-
-        // let proof = FeeProof::create_proof_fee_below_max(
-        //     &commitment_fee,
-        //     (delta, &opening_delta),
-        //     &opening_delta_claimed,
-        //     max_fee,
-        //     &mut transcript_prover,
-        // );
 
         assert!(proof
             .verify(

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -1,3 +1,5 @@
+//! TODO
+
 pub mod equality_proof;
 pub mod errors;
 pub mod fee_proof;

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -1,4 +1,19 @@
-//! TODO
+//! Collection of sigma proofs (more precisely, "arguments") that are used in the Solana zk-token
+//! protocol.
+//!
+//! The module contains implementations of the following proof systems that work on Pedersen
+//! commitments and twisted ElGamal ciphertexts:
+//! - Equality proof: can be used to certify that a twisted ElGamal ciphertext and a Pedersen
+//! commitment encrypt/encode the same message.
+//! - Validity proof: can be used to certify that a twisted ElGamal ciphertext is a properly-formed
+//! ciphertext with respect to a pair of ElGamal public keys.
+//! - Zero-balance proof: can be used to certify that a twisted ElGamal ciphertext encrypts the
+//! message 0.
+//! - Fee proof: can be used to certify that an ElGamal ciphertext properly encrypts a transfer
+//! fee.
+//!
+//! We refer to the zk-token paper for the formal details and security proofs of these argument
+//! systems.
 
 pub mod equality_proof;
 pub mod errors;

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -6,7 +6,7 @@
 //! the proof, a prover must provide the Pedersen opening associated with the commitment.
 //!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
-//! zero-knowledge.
+//! zero-knowledge in the random oracle model.
 
 #[cfg(not(target_arch = "bpf"))]
 use {

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -158,16 +158,16 @@ impl ValidityProof {
                 &ww_negated,         // -ww
             ],
             vec![
-                &(*H),      // H
-                &(*G),      // G
-                &C,         // C
-                &Y_0,       // Y_0
-                P_dest,     // P_dest
-                &D_dest,    // D_dest
-                &Y_1,       // Y_1
-                P_auditor,  // P_auditor
-                &D_auditor, // D_auditor
-                &Y_2,       // Y_2
+                &(*H),     // H
+                &(*G),     // G
+                C,         // C
+                &Y_0,      // Y_0
+                P_dest,    // P_dest
+                D_dest,    // D_dest
+                &Y_1,      // Y_1
+                P_auditor, // P_auditor
+                D_auditor, // D_auditor
+                &Y_2,      // Y_2
             ],
         );
 
@@ -230,8 +230,8 @@ impl AggregatedValidityProof {
     /// The function simples aggregates the input openings and invokes the standard ciphertext
     /// validity proof constructor.
     pub fn new<T: Into<Scalar>>(
-        (amount_lo, amount_hi): (T, T),
         (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        (amount_lo, amount_hi): (T, T),
         (opening_lo, opening_hi): (&PedersenOpening, &PedersenOpening),
         transcript: &mut Transcript,
     ) -> Self {
@@ -257,8 +257,8 @@ impl AggregatedValidityProof {
     /// This function is randomized. It uses `OsRng` internally to generate random scalars.
     pub fn verify(
         self,
-        (commitment_lo, commitment_hi): (&PedersenCommitment, &PedersenCommitment),
         (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        (commitment_lo, commitment_hi): (&PedersenCommitment, &PedersenCommitment),
         (handle_lo_dest, handle_hi_dest): (&DecryptHandle, &DecryptHandle),
         (handle_lo_auditor, handle_hi_auditor): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
@@ -284,7 +284,7 @@ impl AggregatedValidityProof {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidityProofError> {
-        ValidityProof::from_bytes(bytes).map(|proof| Self(proof))
+        ValidityProof::from_bytes(bytes).map(Self)
     }
 }
 
@@ -465,16 +465,16 @@ mod test {
         let mut transcript_verifier = Transcript::new(b"Test");
 
         let proof = AggregatedValidityProof::new(
-            (amount_lo, amount_hi),
             (&elgamal_pubkey_dest, &elgamal_pubkey_auditor),
+            (amount_lo, amount_hi),
             (&open_lo, &open_hi),
             &mut transcript_prover,
         );
 
         assert!(proof
             .verify(
-                (&commitment_lo, &commitment_hi),
                 (&elgamal_pubkey_dest, &elgamal_pubkey_auditor),
+                (&commitment_lo, &commitment_hi),
                 (&handle_lo_dest, &handle_hi_dest),
                 (&handle_lo_auditor, &handle_hi_auditor),
                 &mut transcript_verifier,

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -5,7 +5,7 @@
 //! proof, a prover must provide the decryption key for the ciphertext.
 //!
 //! The protocol guarantees computationally soundness (by the hardness of discrete log) and perfect
-//! zero-knowledge.
+//! zero-knowledge in the random oracle model.
 
 #[cfg(not(target_arch = "bpf"))]
 use {

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -23,7 +23,9 @@ mod target_arch {
             errors::ProofError,
             range_proof::{errors::RangeProofError, RangeProof},
             sigma_proofs::{
-                equality_proof::EqualityProof, errors::*, validity_proof::ValidityProof,
+                equality_proof::EqualityProof,
+                errors::*,
+                validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
         },
@@ -168,6 +170,20 @@ mod target_arch {
         type Error = ValidityProofError;
 
         fn try_from(pod: pod::ValidityProof) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
+    impl From<AggregatedValidityProof> for pod::AggregatedValidityProof {
+        fn from(proof: AggregatedValidityProof) -> Self {
+            Self(proof.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::AggregatedValidityProof> for AggregatedValidityProof {
+        type Error = ValidityProofError;
+
+        fn try_from(pod: pod::AggregatedValidityProof) -> Result<Self, Self::Error> {
             Self::from_bytes(&pod.0)
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -75,6 +75,16 @@ pub struct ValidityProof(pub [u8; 160]);
 unsafe impl Zeroable for ValidityProof {}
 unsafe impl Pod for ValidityProof {}
 
+/// Serialization of aggregated validity proofs
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct AggregatedValidityProof(pub [u8; 160]);
+
+// `AggregatedValidityProof` is a Pod and Zeroable.
+// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
+unsafe impl Zeroable for AggregatedValidityProof {}
+unsafe impl Pod for AggregatedValidityProof {}
+
 /// Serialization of zero balance proofs
 #[derive(Clone, Copy)]
 #[repr(transparent)]


### PR DESCRIPTION
Doing a pass over the sigma proof code, finalizing parts of the code.

#### Summary of Changes

- Changed Ristretto arithmetic to use reference arithmetic to prevent copy
- Added zeroization to all sensitive scalar values
- Added aggregated validity proof
- Fixed fee prove to run in constant time
- Added edge case tests for each sigma proofs
- Cleaned up proof structs visibility
- Added docs to sigma proofs