### PR TITLE
Return actual committed transactions from process_transactions()

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -623,7 +623,8 @@ impl BankingStage {
                         // duplicate signature, etc.)
                         //
                         // Note: This assumes that every packet deserializes into one transaction!
-                        consumed_buffered_packets_count += transactions_attempted_execution_count
+                        consumed_buffered_packets_count += original_unprocessed_indexes
+                            .len()
                             .saturating_sub(retryable_transaction_indexes.len());
 
                         // Out of the buffered packets just retried, collect any still unprocessed

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1036,7 +1036,9 @@ impl BankingStage {
                 sanitized_txs,
                 &mut loaded_transactions,
                 execution_results,
-                executed_with_successful_result_count as u64,
+                executed_transactions_count as u64,
+                executed_transactions_count.saturating_sub(executed_with_successful_result_count)
+                    as u64,
                 signature_count,
                 &mut execute_timings,
             );

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2718,10 +2718,10 @@ mod tests {
             } = process_transactions_summary;
             assert_eq!(chunk_start, 0);
             assert_eq!(transactions_attempted_execution_count, 1);
-            assert_eq!(committed_transactions_with_successful_result_count, 1);
             assert_eq!(failed_commit_count, 1);
             // MaxHeightReached error does not commit, should be zero here
             assert_eq!(committed_transactions_count, 0);
+            assert_eq!(committed_transactions_with_successful_result_count, 0);
 
             retryable_transaction_indexes.sort_unstable();
             let expected: Vec<usize> = (0..transactions.len()).collect();
@@ -2836,8 +2836,8 @@ mod tests {
         assert_eq!(committed_transactions_with_successful_result_count, 1);
         assert_eq!(failed_commit_count, 0);
         assert_eq!(
-            retryable_transaction_indexes.len(),
-            transactions_count - committed_transactions_count
+            retryable_transaction_indexes,
+            (1..transactions_count - 1).collect::<Vec<usize>>()
         );
     }
     #[test]
@@ -2887,10 +2887,11 @@ mod tests {
         assert_eq!(committed_transactions_count, 2);
         assert_eq!(committed_transactions_with_successful_result_count, 2);
         assert_eq!(failed_commit_count, 0,);
-        println!("retryable txs: {:?}", retryable_transaction_indexes);
+
+        // Everything except first and last index of the transactions failed and are last retryable
         assert_eq!(
-            retryable_transaction_indexes.len(),
-            transactions_count - committed_transactions_count
+            retryable_transaction_indexes,
+            (1..transactions_count - 1).collect::<Vec<usize>>()
         );
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1508,6 +1508,13 @@ impl BankingStage {
         );
         filter_pending_packets_time.stop();
 
+        inc_new_counter_info!(
+            "banking_stage-dropped_tx_before_forwarding",
+            retryable_transaction_indexes
+                .len()
+                .saturating_sub(filtered_retryable_tx_indexes.len())
+        );
+
         // Increment timing-based metrics
         banking_stage_stats
             .packet_conversion_elapsed
@@ -1551,8 +1558,6 @@ impl BankingStage {
         );
         unprocessed_packet_conversion_time.stop();
 
-        let tx_count = transaction_to_packet_indexes.len();
-
         let unprocessed_tx_indexes = (0..transactions.len()).collect_vec();
         let filtered_unprocessed_packet_indexes = Self::filter_pending_packets_from_pending_txs(
             bank,
@@ -1563,7 +1568,9 @@ impl BankingStage {
 
         inc_new_counter_info!(
             "banking_stage-dropped_tx_before_forwarding",
-            tx_count.saturating_sub(filtered_unprocessed_packet_indexes.len())
+            unprocessed_tx_indexes
+                .len()
+                .saturating_sub(filtered_unprocessed_packet_indexes.len())
         );
         banking_stage_stats
             .unprocessed_packet_conversion_elapsed

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -102,6 +102,7 @@ struct ProcessTransactionsSummary {
 
     // Total number of transactions that were passed as candidates for execution. See description
     // of struct above for possible outcomes for these transactions
+    #[allow(dead_code)]
     transactions_attempted_execution_count: usize,
 
     // Total number of transactions that made it into the block
@@ -598,7 +599,6 @@ impl BankingStage {
                         );
                         let ProcessTransactionsSummary {
                             reached_max_poh_height,
-                            transactions_attempted_execution_count,
                             retryable_transaction_indexes,
                             ..
                         } = process_transactions_summary;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -422,7 +422,7 @@ fn setup_fees(bank: Bank) -> Bank {
         &mut [], // loaded accounts
         vec![],  // transaction execution results
         0,       // executed tx count
-        0,       // executed with successful output tx count
+        0,       // executed with failure output tx count
         1,       // signature count
         &mut ExecuteTimings::default(),
     );

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -421,7 +421,8 @@ fn setup_fees(bank: Bank) -> Bank {
         &[],     // transactions
         &mut [], // loaded accounts
         vec![],  // transaction execution results
-        0,       // tx count
+        0,       // executed tx count
+        0,       // executed with successful output tx count
         1,       // signature count
         &mut ExecuteTimings::default(),
     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4272,9 +4272,9 @@ impl Bank {
         results
     }
 
-    /// `executed_transactions_count` is the number of transactions out of `sanitized_txs`
-    /// that was executed. Of those, `executed_transactions_count`,
-    /// `executed_with_failure_result_count` is the number of executed transactions that returned
+    /// `committed_transactions_count` is the number of transactions out of `sanitized_txs`
+    /// that was executed. Of those, `committed_transactions_count`,
+    /// `committed_with_failure_result_count` is the number of executed transactions that returned
     /// a failure result.
     pub fn commit_transactions(
         &self,
@@ -4311,7 +4311,7 @@ impl Bank {
                 .fetch_add(committed_with_failure_result_count, Relaxed);
         }
 
-        // Should be equivalent to checking `executed_transactions_count > 0`
+        // Should be equivalent to checking `committed_transactions_count > 0`
         if execution_results.iter().any(|result| result.was_executed()) {
             self.is_delta.store(true, Relaxed);
             self.transaction_entries_count.fetch_add(1, Relaxed);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4291,7 +4291,9 @@ impl Bank {
             "commit_transactions() working on a bank that is already frozen or is undergoing freezing!"
         );
 
-        self.increment_transaction_count(committed_transactions_count);
+        self.increment_transaction_count(
+            committed_transactions_count.saturating_sub(committed_with_failure_result_count),
+        );
         self.increment_signature_count(signature_count);
 
         inc_new_counter_info!(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -315,6 +315,10 @@ pub mod add_get_processed_sibling_instruction_syscall {
     solana_sdk::declare_id!("CFK1hRCNy8JJuAAY8Pb2GjLFNdCThS2qwZNe3izzBMgn");
 }
 
+pub mod bank_tranaction_count_fix {
+    solana_sdk::declare_id!("Vo5siZ442SaZBKPXNocthiXysNviW4UYPwRFggmbgAp");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -388,6 +392,7 @@ lazy_static! {
         (spl_associated_token_account_v1_0_4::id(), "SPL Associated Token Account Program release version 1.0.4, tied to token 3.3.0 #22648"),
         (reject_vote_account_close_unless_zero_credit_epoch::id(), "fail vote account withdraw to 0 unless account earned 0 credits in last completed epoch"),
         (add_get_processed_sibling_instruction_syscall::id(), "add add_get_processed_sibling_instruction_syscall"),
+        (bank_tranaction_count_fix::id(), "Fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
1) `process_transactions()`, `load_and_execute_transactions`, etc. returns values in large tuples which is hard to read
2) `process_transactions()` returns the chunk start of the last batch attempted processing, but doesn't actually return the number of transactions successfully committed, which means this stat: https://github.com/solana-labs/solana/blob/6d5bbca630bd59fb64f2bc446793c83482d8fba4/core/src/banking_stage.rs#L587-L589 doesn't accurately reflect the number of committed transactions
3) Return values from various banking stage processing functions are hard to read

#### Summary of Changes
1) Encapsulate processing results into structs for easier reading
 2) Report accurate number of attempted transactions, committed transactions, retryable transactions, etc. for consumption by metrics later
Fixes #
