### PR TITLE
Rename struct to imported name

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -413,7 +413,7 @@ impl JsonRpcRequestProcessor {
                 })
                 .collect::<Result<Vec<_>>>()?
         };
-        Ok(result).map(|result| match with_context {
+        Ok(match with_context {
             true => OptionalContext::Context(new_response(&bank, result)),
             false => OptionalContext::NoContext(result),
         })

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -113,7 +113,7 @@ const MAX_RPC_EPOCH_CREDITS_HISTORY: usize = 5;
 
 fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
     let context = RpcResponseContext { slot: bank.slot() };
-    Response { context, value }
+    RpcResponse { context, value }
 }
 
 /// Wrapper for rpc return types of methods that provide responses both with and without context.
@@ -742,7 +742,7 @@ impl JsonRpcRequestProcessor {
         let bank = self.bank(config.commitment);
 
         if let Some((slot, accounts)) = self.get_cached_largest_accounts(&config.filter) {
-            Ok(Response {
+            Ok(RpcResponse {
                 context: RpcResponseContext { slot },
                 value: accounts,
             })

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -400,7 +400,8 @@ impl JsonRpcRequestProcessor {
                 self.get_filtered_program_accounts(&bank, program_id, filters)?
             }
         };
-        let accounts = if program_id == &spl_token_id() && encoding == UiAccountEncoding::JsonParsed {
+        let accounts = if program_id == &spl_token_id() && encoding == UiAccountEncoding::JsonParsed
+        {
             get_parsed_token_accounts(bank.clone(), keyed_accounts.into_iter()).collect()
         } else {
             keyed_accounts

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -400,7 +400,7 @@ impl JsonRpcRequestProcessor {
                 self.get_filtered_program_accounts(&bank, program_id, filters)?
             }
         };
-        let result = if program_id == &spl_token_id() && encoding == UiAccountEncoding::JsonParsed {
+        let accounts = if program_id == &spl_token_id() && encoding == UiAccountEncoding::JsonParsed {
             get_parsed_token_accounts(bank.clone(), keyed_accounts.into_iter()).collect()
         } else {
             keyed_accounts
@@ -414,8 +414,8 @@ impl JsonRpcRequestProcessor {
                 .collect::<Result<Vec<_>>>()?
         };
         Ok(match with_context {
-            true => OptionalContext::Context(new_response(&bank, result)),
-            false => OptionalContext::NoContext(result),
+            true => OptionalContext::Context(new_response(&bank, accounts)),
+            false => OptionalContext::NoContext(accounts),
         })
     }
 


### PR DESCRIPTION
Not required changes but makes code clear:
- `Response` imported as `RpcResponse` but still used in two places as `Response` (I thought that it's not possible!)
- `map` for `Result` not required