### PR TITLE
feat: add inspectTransaction and automatic logging on error

### DIFF
--- a/web3.js/src/index.ts
+++ b/web3.js/src/index.ts
@@ -24,6 +24,8 @@ export * from './util/borsh-schema';
 export * from './util/send-and-confirm-transaction';
 export * from './util/send-and-confirm-raw-transaction';
 export * from './util/cluster';
+export * as inspect from './util/inspect-transaction';
+export {inspectTransaction} from './util/inspect-transaction';
 
 /**
  * There are 1-billion lamports in one SOL

--- a/web3.js/src/util/cluster.ts
+++ b/web3.js/src/util/cluster.ts
@@ -11,7 +11,8 @@ const endpoint = {
   },
 };
 
-export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
+export const CLUSTER_NAMES = ['devnet', 'testnet', 'mainnet-beta'] as const;
+export type Cluster = typeof CLUSTER_NAMES[number];
 
 /**
  * Retrieves the RPC API URL for the specified cluster

--- a/web3.js/src/util/inspect-transaction.ts
+++ b/web3.js/src/util/inspect-transaction.ts
@@ -1,0 +1,186 @@
+import type {Buffer} from 'buffer';
+
+import {CLUSTER_NAMES, Cluster, clusterApiUrl} from './cluster';
+import {Message} from '../message';
+import {Transaction} from '../transaction';
+
+/**
+ * Checks if all transactions should be logged
+ * Returns true if one of the following is set
+ *   env variable `SOLANA_TRANSACTION_LOG_LEVEL`
+ *   `process.env.SOLANA_TRANSACTION_LOG_LEVEL`
+ *   `window.SOLANA_TRANSACTION_LOG_LEVEL`
+ */
+export function checkLogAllTransactions(): boolean {
+  return (
+    (typeof window != 'undefined' && 'SOLANA_LOG_ALL_TRANSACTIONS' in window) ||
+    process.env['SOLANA_LOG_ALL_TRANSACTIONS'] !== undefined
+  );
+}
+
+export const DEFAULT_EXPLORER_BASE_URL = 'https://explorer.solana.com';
+export let EXPLORER_BASE_URL = DEFAULT_EXPLORER_BASE_URL;
+
+/**
+ * Sets the base url for all inspect functions
+ *
+ * Defaults to `DEFAULT_EXPLORER_BASE_URL`
+ *
+ * @param {string} url
+ */
+export function setExplorerBaseUrl(url: string): void {
+  EXPLORER_BASE_URL = url;
+}
+
+/**
+ * Log a link to inspect message, defaults to console.log
+ *
+ * Link is of the form
+ *   `https://explorer.solana.com/tx/inspector?message=<base64 encoded message>` for transaction messages
+ *   `https://explorer.solana.com/tx/<signature>/inspect` for signatures
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {Buffer | Message | Transaction | string} inspectData
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @param {(...any) => void} log? = console.log
+ */
+export function inspectTransaction(
+  inspectData: Buffer | Message | Transaction | string,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+  log: (...args: any[]) => void = console.log,
+): void {
+  log(getInspectTransactionUrl(inspectData, clusterOrUrl));
+}
+
+/**
+ * Get a link to inspect the transaction message or signature
+ *
+ * Link is of the form
+ *   `https://explorer.solana.com/tx/inspector?message=<base64 encoded message>` for transaction messages
+ *   `https://explorer.solana.com/tx/<signature>/inspect` for signatures
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {Buffer | Message | Transaction | string} inspectData
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @returns {string}
+ */
+export function getInspectTransactionUrl(
+  inspectData: Buffer | Message | Transaction | string,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+): string {
+  if (typeof inspectData === 'string') {
+    return getInspectSignatureUrl(inspectData, clusterOrUrl);
+  } else {
+    return getInspectMessageUrl(inspectData, clusterOrUrl);
+  }
+}
+
+/**
+ * Log a link to inspect the transaction message, defaults to console.log
+ *
+ * Link is of the form `https://explorer.solana.com/tx/inspector?message=<base64 encoded message>`
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {Buffer | Message | Transaction} inspectData
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @param {(...any) => void} log? = console.log
+ */
+export function inspectMessage(
+  inspectData: Buffer | Message | Transaction,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+  log: (...args: any[]) => void = console.log,
+): void {
+  log(getInspectMessageUrl(inspectData, clusterOrUrl));
+}
+
+/**
+ * Get a link to inspect the transaction message
+ *
+ * Link is of the form `https://explorer.solana.com/tx/inspector?message=<base64 encoded message>`
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {Buffer | Message | Transaction} inspectData
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @returns {string}
+ */
+export function getInspectMessageUrl(
+  inspectData: Buffer | Message | Transaction,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+): string {
+  const url = getExplorerUrlWithCluster('tx/inspector', clusterOrUrl);
+
+  let message = inspectData;
+  if (inspectData instanceof Message || inspectData instanceof Transaction) {
+    message = inspectData.serialize();
+  }
+
+  url.searchParams.append('message', message.toString('base64'));
+
+  return url.href;
+}
+
+/**
+ * Log a link to inspect the transaction signature, defaults to console.log
+ *
+ * Link is of the form `https://explorer.solana.com/tx/<signature>/inspect`
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {string} signature
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @param {(...any) => void} log? = console.log
+ */
+export function inspectSignature(
+  signature: string,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+  log: (...args: any[]) => void = console.log,
+): void {
+  log(getInspectSignatureUrl(signature, clusterOrUrl));
+}
+
+/**
+ * Get a link to inspect the transaction signature
+ *
+ * Link is of the form `https://explorer.solana.com/tx/<signature>/inspect`
+ * Respects `EXPLORER_BASE_URL`
+ *
+ * @param {string} signature
+ * @param {Cluster | string} cluster? = "mainnet-beta"
+ * @returns {string}
+ */
+export function getInspectSignatureUrl(
+  signature: string,
+  clusterOrUrl: Cluster | string = 'mainnet-beta',
+): string {
+  const url = getExplorerUrlWithCluster(
+    `tx/${signature}/inspect`,
+    clusterOrUrl,
+  );
+  return url.href;
+}
+
+/**
+ * @internal
+ */
+export function getExplorerUrlWithCluster(
+  path: string,
+  clusterOrUrl: Cluster | string,
+): URL {
+  const url = new URL(path, EXPLORER_BASE_URL);
+
+  for (let cluster of CLUSTER_NAMES)
+    if (clusterApiUrl(cluster, true) == clusterOrUrl) {
+      clusterOrUrl = cluster;
+      break;
+    }
+
+  if (CLUSTER_NAMES.includes(clusterOrUrl as Cluster)) {
+    if (clusterOrUrl !== 'mainnet-beta') {
+      url.searchParams.append('cluster', clusterOrUrl);
+    }
+  } else {
+    url.searchParams.append('cluster', 'custom');
+    url.searchParams.append('customUrl', clusterOrUrl);
+  }
+
+  return url;
+}

--- a/web3.js/test/inspect-transaction.test.ts
+++ b/web3.js/test/inspect-transaction.test.ts
@@ -1,0 +1,73 @@
+import {expect} from 'chai';
+import * as bs58 from 'bs58';
+
+import {Transaction} from '../src/transaction';
+import {clusterApiUrl} from '../src/util/cluster';
+import {
+  getInspectTransactionUrl,
+  getExplorerUrlWithCluster,
+} from '../src/util/inspect-transaction';
+
+describe('Inspect Transaction', () => {
+  const transaction = Transaction.from(
+    Buffer.from(
+      'AVuErQHaXv0SG0/PchunfxHKt8wMRfMZzqV0tkC5qO6owYxWU2v871AoWywGoFQr4z+q/7mE8lIufNl/kxj+nQ0BAAEDE5j2LG0aRXxRumpLXz29L2n8qTIWIY3ImX5Ba9F9k8r9Q5/Mtmcn8onFxt47xKj+XdXXd3C8j/FcPu7csUrz/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAgIAAQwCAAAAMQAAAAAAAAA=',
+      'base64',
+    ),
+  );
+
+  describe('resolves explorer url', () => {
+    describe('resolves named clusters', () => {
+      it('does not specify cluster for mainnet-beta', () => {
+        expect(getExplorerUrlWithCluster('/', 'mainnet-beta').href).to.eq(
+          'https://explorer.solana.com/',
+        );
+      });
+      it('devnet and testnet adds query parameter', () => {
+        expect(getExplorerUrlWithCluster('/', 'devnet').href).to.eq(
+          'https://explorer.solana.com/?cluster=devnet',
+        );
+        expect(getExplorerUrlWithCluster('/', 'testnet').href).to.eq(
+          'https://explorer.solana.com/?cluster=testnet',
+        );
+      });
+    });
+
+    describe('resolves default cluster urls', () => {
+      it('mainnet-beta', () => {
+        expect(
+          getExplorerUrlWithCluster('/', clusterApiUrl('mainnet-beta', true))
+            .href,
+        ).to.eq('https://explorer.solana.com/');
+      });
+      it('devnet and testnet', () => {
+        expect(
+          getExplorerUrlWithCluster('/', clusterApiUrl('devnet', true)).href,
+        ).to.eq('https://explorer.solana.com/?cluster=devnet');
+        expect(
+          getExplorerUrlWithCluster('/', clusterApiUrl('testnet', true)).href,
+        ).to.eq('https://explorer.solana.com/?cluster=testnet');
+      });
+    });
+
+    it('resolves custom rpc urls', () => {
+      expect(
+        getExplorerUrlWithCluster('/', 'https://solana-rpc.example.com').href,
+      ).to.eq(
+        'https://explorer.solana.com/?cluster=custom&customUrl=https%3A%2F%2Fsolana-rpc.example.com',
+      );
+    });
+  });
+
+  it('inspects transaction signatures', () => {
+    expect(getInspectTransactionUrl(bs58.encode(transaction.signature!))).to.eq(
+      'https://explorer.solana.com/tx/2q8Fs6wmDHcdNKJnVJoXYnDVqrWm8GYsxYt2QwUPvadkEQXinWJRwWVzxdUmJY9YH8iZETcXjk3ZdBcDUkuUtfKz/inspect',
+    );
+  });
+
+  it('inspects encoded transactions', () => {
+    expect(getInspectTransactionUrl(transaction)).to.eq(
+      'https://explorer.solana.com/tx/inspector?message=AVuErQHaXv0SG0%2FPchunfxHKt8wMRfMZzqV0tkC5qO6owYxWU2v871AoWywGoFQr4z%2Bq%2F7mE8lIufNl%2Fkxj%2BnQ0BAAEDE5j2LG0aRXxRumpLXz29L2n8qTIWIY3ImX5Ba9F9k8r9Q5%2FMtmcn8onFxt47xKj%2BXdXXd3C8j%2FFcPu7csUrz%2FAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAgIAAQwCAAAAMQAAAAAAAAA%3D',
+    );
+  });
+});


### PR DESCRIPTION
#### Problem
It is difficult to inspect failed transactions.

#### Summary of Changes
Add an easy way to generate links to the explorer transaction inspector,
for transactions, messages and signatures

Links are automatically logged to `console.error` on transaction failure,
or all transactions are logged if `SOLANA_INSPECT_TRANSACTIONS` is set

Move transaction failure logs to a console group
