### PR TITLE
Use internal function for encoding accounts

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7430,7 +7430,7 @@ pub mod tests {
                 "jsonrpc":"2.0",
                 "id":1,
                 "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"programId": "{}"}}]
+                "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
             }}"#,
             owner,
             spl_token_id(),
@@ -7482,7 +7482,7 @@ pub mod tests {
             r#"{{
                 "jsonrpc":"2.0",
                 "id":1,"method":"getTokenAccountsByOwner",
-                "params":["{}", {{"mint": "{}"}}]
+                "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
             }}"#,
             owner, mint,
         );
@@ -7547,7 +7547,7 @@ pub mod tests {
                 "jsonrpc":"2.0",
                 "id":1,
                 "method":"getTokenAccountsByDelegate",
-                "params":["{}", {{"programId": "{}"}}]
+                "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
             }}"#,
             delegate,
             spl_token_id(),
@@ -7565,7 +7565,7 @@ pub mod tests {
                 "jsonrpc":"2.0",
                 "id":1,"method":
                 "getTokenAccountsByDelegate",
-                "params":["{}", {{"mint": "{}"}}]
+                "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
             }}"#,
             delegate, mint,
         );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1800,17 +1800,13 @@ impl JsonRpcRequestProcessor {
         } else {
             keyed_accounts
                 .into_iter()
-                .map(|(pubkey, account)| RpcKeyedAccount {
-                    pubkey: pubkey.to_string(),
-                    account: UiAccount::encode(
-                        &pubkey,
-                        &account,
-                        encoding,
-                        None,
-                        data_slice_config,
-                    ),
+                .map(|(pubkey, account)| {
+                    Ok(RpcKeyedAccount {
+                        pubkey: pubkey.to_string(),
+                        account: encode_account(&account, &pubkey, encoding, data_slice_config)?,
+                    })
                 })
-                .collect()
+                .collect::<Result<Vec<_>>>()?
         };
         Ok(new_response(&bank, accounts))
     }
@@ -1857,17 +1853,13 @@ impl JsonRpcRequestProcessor {
         } else {
             keyed_accounts
                 .into_iter()
-                .map(|(pubkey, account)| RpcKeyedAccount {
-                    pubkey: pubkey.to_string(),
-                    account: UiAccount::encode(
-                        &pubkey,
-                        &account,
-                        encoding,
-                        None,
-                        data_slice_config,
-                    ),
+                .map(|(pubkey, account)| {
+                    Ok(RpcKeyedAccount {
+                        pubkey: pubkey.to_string(),
+                        account: encode_account(&account, &pubkey, encoding, data_slice_config)?,
+                    })
                 })
-                .collect()
+                .collect::<Result<Vec<_>>>()?
         };
         Ok(new_response(&bank, accounts))
     }
@@ -3617,25 +3609,22 @@ pub mod rpc_full {
                 if result.is_err() {
                     Some(vec![None; config_accounts.addresses.len()])
                 } else {
-                    let mut accounts = vec![];
-                    for address_str in config_accounts.addresses {
-                        let address = verify_pubkey(&address_str)?;
-                        accounts.push(
-                            post_simulation_accounts
-                                .iter()
-                                .find(|(key, _account)| key == &address)
-                                .map(|(pubkey, account)| {
-                                    UiAccount::encode(
-                                        pubkey,
-                                        account,
-                                        accounts_encoding,
-                                        None,
-                                        None,
-                                    )
-                                }),
-                        );
-                    }
-                    Some(accounts)
+                    Some(
+                        config_accounts
+                            .addresses
+                            .iter()
+                            .map(|address_str| {
+                                let address = verify_pubkey(address_str)?;
+                                post_simulation_accounts
+                                    .iter()
+                                    .find(|(key, _account)| key == &address)
+                                    .map(|(pubkey, account)| {
+                                        encode_account(account, pubkey, accounts_encoding, None)
+                                    })
+                                    .transpose()
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                    )
                 }
             } else {
                 None


### PR DESCRIPTION
`rpc.rs` already has a function for encoding accounts that checks account data length with encoding but few methods still use `UiAccount::encode`, is this was done by occasion?

https://github.com/solana-labs/solana/blob/cc746931767b1e997844e2ea7e77596d16c82b4f/rpc/src/rpc.rs#L2228-L2248