### PR TITLE
Add verified/unverified badge to Program Account view

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -15,6 +15,8 @@ import { useCluster } from "providers/cluster";
 import { ErrorCard } from "components/common/ErrorCard";
 import { UnknownAccountCard } from "components/account/UnknownAccountCard";
 import { Downloadable } from "components/common/Downloadable";
+import { VerifiedBadge } from "components/common/VerifiedBadge";
+import { InfoTooltip } from "components/common/InfoTooltip";
 
 export function UpgradeableLoaderAccountSection({
   account,
@@ -123,6 +125,17 @@ export function UpgradeableProgramSection({
           </td>
         </tr>
         <tr>
+          <td>
+            <LastVerifiedBuildLabel />
+          </td>
+          <td className="text-lg-end">
+            <VerifiedBadge
+              programAddress={account.pubkey}
+              programDeploySlot={programData.slot}
+            />
+          </td>
+        </tr>
+        <tr>
           <td>Last Deployed Slot</td>
           <td className="text-lg-end">
             <Slot slot={programData.slot} link />
@@ -138,6 +151,22 @@ export function UpgradeableProgramSection({
         )}
       </TableCardBody>
     </div>
+  );
+}
+
+function LastVerifiedBuildLabel() {
+  return (
+    <InfoTooltip text="Anchor service verifying programs deployed on-chain against published source code. Click to learn more.">
+      <a
+        href={
+          "https://project-serum.github.io/anchor/getting-started/verification.html#building"
+        }
+        target="_blank"
+        rel="noreferrer"
+      >
+        Verifiable Build Status
+      </a>
+    </InfoTooltip>
   );
 }
 

--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -15,8 +15,9 @@ import { useCluster } from "providers/cluster";
 import { ErrorCard } from "components/common/ErrorCard";
 import { UnknownAccountCard } from "components/account/UnknownAccountCard";
 import { Downloadable } from "components/common/Downloadable";
-import { VerifiedBadge } from "components/common/VerifiedBadge";
+import { CheckingBadge, VerifiedBadge } from "components/common/VerifiedBadge";
 import { InfoTooltip } from "components/common/InfoTooltip";
+import { useVerifiableBuilds } from "utils/program-verification";
 
 export function UpgradeableLoaderAccountSection({
   account,
@@ -74,6 +75,7 @@ export function UpgradeableProgramSection({
   const refresh = useFetchAccountInfo();
   const { cluster } = useCluster();
   const label = addressLabel(account.pubkey.toBase58(), cluster);
+  const { loading, verifiableBuilds } = useVerifiableBuilds(account.pubkey);
   return (
     <div className="card">
       <div className="card-header">
@@ -129,10 +131,15 @@ export function UpgradeableProgramSection({
             <LastVerifiedBuildLabel />
           </td>
           <td className="text-lg-end">
-            <VerifiedBadge
-              programAddress={account.pubkey}
-              programDeploySlot={programData.slot}
-            />
+            {loading ? (
+              <CheckingBadge />
+            ) : (
+              <>
+                {verifiableBuilds.map((b) => (
+                  <VerifiedBadge verifiableBuild={b} />
+                ))}
+              </>
+            )}
           </td>
         </tr>
         <tr>
@@ -156,16 +163,8 @@ export function UpgradeableProgramSection({
 
 function LastVerifiedBuildLabel() {
   return (
-    <InfoTooltip text="Anchor service verifying programs deployed on-chain against published source code. Click to learn more.">
-      <a
-        href={
-          "https://project-serum.github.io/anchor/getting-started/verification.html#building"
-        }
-        target="_blank"
-        rel="noreferrer"
-      >
-        Verifiable Build Status
-      </a>
+    <InfoTooltip text="Indicates whether the program currently deployed on-chain is verified to match the associated published source code, when it is available.">
+      Verifiable Build Status
     </InfoTooltip>
   );
 }

--- a/explorer/src/components/common/VerifiedBadge.tsx
+++ b/explorer/src/components/common/VerifiedBadge.tsx
@@ -1,39 +1,38 @@
-import { PublicKey } from "@solana/web3.js";
-import { buildLinkPath, useVerifiedBuild } from "utils/program-verification";
+import { VerifiableBuild } from "utils/program-verification";
 
 export function VerifiedBadge({
-  programAddress,
-  programDeploySlot,
+  verifiableBuild,
 }: {
-  programAddress: PublicKey;
-  programDeploySlot: number;
+  verifiableBuild: VerifiableBuild;
 }) {
-  const { loading, verifiedBuild } = useVerifiedBuild(programAddress);
-  if (loading)
-    return (
-      <h3 className="mb-0">
-        <span className="badge bg-dark rank">Checking</span>
-      </h3>
-    );
-
-  if (verifiedBuild && verifiedBuild.verified_slot === programDeploySlot) {
+  if (verifiableBuild && verifiableBuild.verified_slot) {
     return (
       <h3 className="mb-0">
         <a
           className="c-pointer badge bg-success-soft rank"
-          href={buildLinkPath(verifiedBuild)}
+          href={verifiableBuild.url}
           target="_blank"
           rel="noreferrer"
         >
-          Verified
+          {verifiableBuild.label}: Verified
         </a>
       </h3>
     );
   } else {
     return (
       <h3 className="mb-0">
-        <span className="badge bg-warning-soft rank">Unverified</span>
+        <span className="badge bg-warning-soft rank">
+          {verifiableBuild.label}: Unverified
+        </span>
       </h3>
     );
   }
+}
+
+export function CheckingBadge() {
+  return (
+    <h3 className="mb-0">
+      <span className="badge bg-dark rank">Checking</span>
+    </h3>
+  );
 }

--- a/explorer/src/components/common/VerifiedBadge.tsx
+++ b/explorer/src/components/common/VerifiedBadge.tsx
@@ -1,0 +1,39 @@
+import { PublicKey } from "@solana/web3.js";
+import { buildLinkPath, useVerifiedBuild } from "utils/program-verification";
+
+export function VerifiedBadge({
+  programAddress,
+  programDeploySlot,
+}: {
+  programAddress: PublicKey;
+  programDeploySlot: number;
+}) {
+  const { loading, verifiedBuild } = useVerifiedBuild(programAddress);
+  if (loading)
+    return (
+      <h3 className="mb-0">
+        <span className="badge bg-dark rank">Checking</span>
+      </h3>
+    );
+
+  if (verifiedBuild && verifiedBuild.verified_slot === programDeploySlot) {
+    return (
+      <h3 className="mb-0">
+        <a
+          className="c-pointer badge bg-success-soft rank"
+          href={buildLinkPath(verifiedBuild)}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Verified
+        </a>
+      </h3>
+    );
+  } else {
+    return (
+      <h3 className="mb-0">
+        <span className="badge bg-warning-soft rank">Unverified</span>
+      </h3>
+    );
+  }
+}

--- a/explorer/src/utils/program-verification.tsx
+++ b/explorer/src/utils/program-verification.tsx
@@ -1,0 +1,69 @@
+import { PublicKey } from "@solana/web3.js";
+import { useEffect, useState } from "react";
+
+export interface AnchorBuild {
+  aborted: boolean;
+  address: string;
+  created_at: string;
+  updated_at: string;
+  descriptor: string[];
+  docker: string;
+  id: number;
+  name: string;
+  sha256: string;
+  upgrade_authority: string;
+  verified: string;
+  verified_slot: number;
+  state: string;
+}
+
+export function buildLinkPath(verifiedBuild: AnchorBuild) {
+  return `https://anchor.projectserum.com/build/${verifiedBuild.id}`;
+}
+
+/**
+ * Returns a verified build from the anchor registry. null if no such
+ * verified build exists, e.g., if the program has been upgraded since the
+ * last verified build.
+ */
+export async function getVerifiedBuild(
+  programId: PublicKey,
+  limit: number = 5
+): Promise<AnchorBuild | null> {
+  const url = `https://anchor.projectserum.com/api/v0/program/${programId.toString()}/latest?limit=${limit}`;
+  const latestBuildsResp = await fetch(url);
+
+  // Filter out all non successful builds.
+  const latestBuilds = (await latestBuildsResp.json()).filter(
+    (b: AnchorBuild) =>
+      !b.aborted && b.state === "Built" && b.verified === "Verified"
+  ) as AnchorBuild[];
+
+  if (latestBuilds.length === 0) {
+    return null;
+  }
+
+  // Get the latest build.
+  return latestBuilds[0];
+}
+
+export function useVerifiedBuild(programAddress: PublicKey) {
+  const [loading, setLoading] = useState(true);
+  const [verifiedBuild, setVerifiedBuild] = useState<AnchorBuild | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    getVerifiedBuild(programAddress)
+      .then(setVerifiedBuild)
+      .catch((error) => {
+        console.log(error);
+        setVerifiedBuild(null);
+      })
+      .finally(() => setLoading(false));
+  }, [programAddress, setVerifiedBuild, setLoading]);
+
+  return {
+    loading,
+    verifiedBuild,
+  };
+}


### PR DESCRIPTION
#### Problem
Anchor verified builds hosts a catalog of verified programs, including in particular the slot said program was deployed. This allows for instance:
* projects to audit a specific version of their program, and prove that said version is the one currently on-chain
* users to browse the source code of the program currently deployed

However there is currently no direct link between the program account details in the explorer and this resource.

#### Summary of Changes
Add verified/unverified badge to the `Program Account` view, to make apparent which programs published the source for the currently deployed program.

Fixes #
