### PR TITLE
Rpc dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5860,6 +5860,7 @@ dependencies = [
  "log 0.4.14",
  "solana-logger 1.10.0",
  "solana-metrics",
+ "solana-perf",
  "solana-runtime",
  "solana-sdk",
 ]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "solana-metrics",
+ "solana-perf",
  "solana-runtime",
  "solana-sdk",
 ]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.14"
 solana-metrics = { path = "../metrics", version = "=1.10.0" }
 solana-runtime = { path = "../runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
+solana-perf = { path = "../perf", version = "=1.10.0" }
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.10.0" }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -438,6 +438,7 @@ mod test {
                 None,
             ),
         );
+        let deduper = Deduper::new(1_000_000, Duration::from_millis(0));
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
@@ -446,6 +447,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -475,6 +477,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -504,6 +507,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -533,6 +537,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 1);
         assert_eq!(
@@ -563,6 +568,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 1);
         assert_eq!(
@@ -603,6 +609,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 1);
         assert_eq!(
@@ -621,6 +628,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -693,6 +701,7 @@ mod test {
                 None,
             ),
         );
+        let deduper = Deduper::new(1_000_000, Duration::from_millis(0));
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
@@ -701,6 +710,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -729,6 +739,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -759,6 +770,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -787,6 +799,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -816,6 +829,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert!(transactions.is_empty());
         assert_eq!(
@@ -845,6 +859,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 1);
         assert_eq!(
@@ -875,6 +890,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 1);
         assert_eq!(
@@ -900,6 +916,7 @@ mod test {
             &mut transactions,
             &None,
             &config,
+            &deduper,
         );
         assert_eq!(transactions.len(), 0);
         assert_eq!(


### PR DESCRIPTION
#### Problem

Public rpc servers seem to generate a ton of duplicate traffic, confirmed by @leoluk.  This is probably due to misconfigured clients.

#### Summary of Changes

Add the deduper logic such that send-transaction-service does not send a duplicate message more than once per slot.

Fixes #
