### PR TITLE
validator: cleanup accounts path before bootstrap #22835

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -386,20 +386,6 @@ impl Validator {
             }
         }
 
-        info!("Cleaning accounts paths..");
-        *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
-        let mut start = Measure::start("clean_accounts_paths");
-        for accounts_path in &config.account_paths {
-            cleanup_accounts_path(accounts_path);
-        }
-        if let Some(ref shrink_paths) = config.account_shrink_paths {
-            for accounts_path in shrink_paths {
-                cleanup_accounts_path(accounts_path);
-            }
-        }
-        start.stop();
-        info!("done. {}", start);
-
         let exit = Arc::new(AtomicBool::new(false));
         {
             let exit = exit.clone();
@@ -1715,6 +1701,25 @@ fn cleanup_accounts_path(account_path: &std::path::Path) {
             account_path, e
         );
     }
+}
+
+pub fn cleanup_accounts_paths(
+    config: &ValidatorConfig,
+    start_progress: &Arc<RwLock<ValidatorStartProgress>>,
+) {
+    info!("Cleaning accounts paths..");
+    *start_progress.write().unwrap() = ValidatorStartProgress::CleaningAccounts;
+    let mut start = Measure::start("clean_accounts_paths");
+    for accounts_path in &config.account_paths {
+        cleanup_accounts_path(accounts_path);
+    }
+    if let Some(ref shrink_paths) = config.account_shrink_paths {
+        for accounts_path in shrink_paths {
+            cleanup_accounts_path(accounts_path);
+        }
+    }
+    start.stop();
+    info!("done. {}", start);
 }
 
 pub fn is_snapshot_config_valid(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -26,7 +26,10 @@ use {
         system_monitor_service::SystemMonitorService,
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
-        validator::{is_snapshot_config_valid, Validator, ValidatorConfig, ValidatorStartProgress},
+        validator::{
+            cleanup_accounts_paths, is_snapshot_config_valid, Validator, ValidatorConfig,
+            ValidatorStartProgress,
+        },
     },
     solana_gossip::{
         cluster_info::{Node, VALIDATOR_PORT_RANGE},
@@ -2309,6 +2312,7 @@ pub fn main() {
             })
             .collect()
     });
+    cleanup_accounts_paths(&validator_config, &start_progress);
 
     let maximum_local_snapshot_age = value_t_or_exit!(matches, "maximum_local_snapshot_age", u64);
     let maximum_full_snapshot_archives_to_retain =


### PR DESCRIPTION
#### Problem

Growed accounts do not allow to download new snapshot and run a validator  #22835

#### Summary of Changes

This looks like a crutch. I just would like to show the idea of fixing #22835
