### PR TITLE
Refactor: Unify `SysvarCache`

### DIFF
--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use {
-    solana_program_runtime::{invoke_context::InvokeContext, sysvar_cache::SysvarCache},
+    solana_program_runtime::invoke_context::InvokeContext,
     solana_sdk::{
         account::{create_account_for_test, Account, AccountSharedData},
         clock::{Clock, Slot},
@@ -148,10 +148,6 @@ fn do_bench_process_vote_instruction(bencher: &mut Bencher, feature: Option<Pubk
         })
         .collect::<Vec<_>>();
 
-    let mut sysvar_cache = SysvarCache::default();
-    sysvar_cache.set_clock(clock);
-    sysvar_cache.set_slot_hashes(slot_hashes);
-
     bencher.iter(|| {
         let mut transaction_context = TransactionContext::new(
             vec![
@@ -174,12 +170,8 @@ fn do_bench_process_vote_instruction(bencher: &mut Bencher, feature: Option<Pubk
             1,
         );
 
-        let mut invoke_context = InvokeContext::new_mock_with_sysvars_and_features(
-            &mut transaction_context,
-            &sysvar_cache,
-            feature_set.clone(),
-        );
-
+        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+        invoke_context.feature_set = feature_set.clone();
         invoke_context
             .push(&instruction_accounts, &program_indices, &[])
             .unwrap();

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -1,51 +1,14 @@
-use {
-    super::Bank,
-    solana_program_runtime::sysvar_cache::SysvarCache,
-    solana_sdk::{account::ReadableAccount, sysvar::Sysvar},
-};
+use super::Bank;
 
 impl Bank {
     pub(crate) fn fill_missing_sysvar_cache_entries(&self) {
         let mut sysvar_cache = self.sysvar_cache.write().unwrap();
-        if sysvar_cache.get_clock().is_err() {
-            if let Some(clock) = self.load_sysvar_account() {
-                sysvar_cache.set_clock(clock);
-            }
-        }
-        if sysvar_cache.get_epoch_schedule().is_err() {
-            if let Some(epoch_schedule) = self.load_sysvar_account() {
-                sysvar_cache.set_epoch_schedule(epoch_schedule);
-            }
-        }
-        #[allow(deprecated)]
-        if sysvar_cache.get_fees().is_err() {
-            if let Some(fees) = self.load_sysvar_account() {
-                sysvar_cache.set_fees(fees);
-            }
-        }
-        if sysvar_cache.get_rent().is_err() {
-            if let Some(rent) = self.load_sysvar_account() {
-                sysvar_cache.set_rent(rent);
-            }
-        }
-        if sysvar_cache.get_slot_hashes().is_err() {
-            if let Some(slot_hashes) = self.load_sysvar_account() {
-                sysvar_cache.set_slot_hashes(slot_hashes);
-            }
-        }
+        sysvar_cache.fill_missing_entries(|pubkey| self.get_account_with_fixed_root(pubkey));
     }
 
     pub(crate) fn reset_sysvar_cache(&self) {
         let mut sysvar_cache = self.sysvar_cache.write().unwrap();
-        *sysvar_cache = SysvarCache::default();
-    }
-
-    fn load_sysvar_account<T: Sysvar>(&self) -> Option<T> {
-        if let Some(account) = self.get_account_with_fixed_root(&T::id()) {
-            bincode::deserialize(account.data()).ok()
-        } else {
-            None
-        }
+        sysvar_cache.reset();
     }
 }
 


### PR DESCRIPTION
#### Problem
Runtime and tests use different code paths to fill the `SysvarCache`.

#### Summary of Changes
- Unifies `SysvarCache` filling in the runtime and tests.
- Removes `new_mock_with_sysvars_and_features()`.
- Removes `mock_process_instruction_with_sysvars()`.
- Replaces `from_keyed_account()` by `SysvarCache` in vote processor and BPF loader.

Fixes #
