### PR TITLE
removes Rng field from WeightedShuffle struct

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -411,8 +411,9 @@ fn enable_turbine_peers_shuffle_patch(shred_slot: Slot, root_bank: &Bank) -> boo
 fn shuffle_nodes<'a, R: Rng>(rng: &mut R, nodes: &[&'a Node]) -> Vec<&'a Node> {
     // Nodes are sorted by (stake, pubkey) in descending order.
     let stakes: Vec<u64> = nodes.iter().map(|node| node.stake).collect();
-    WeightedShuffle::new(rng, &stakes)
+    WeightedShuffle::new(&stakes)
         .unwrap()
+        .shuffle(rng)
         .map(|i| nodes[i])
         .collect()
 }

--- a/gossip/benches/weighted_shuffle.rs
+++ b/gossip/benches/weighted_shuffle.rs
@@ -32,8 +32,9 @@ fn bench_weighted_shuffle_new(bencher: &mut Bencher) {
     let weights = make_weights(&mut rng);
     bencher.iter(|| {
         rng.fill(&mut seed[..]);
-        WeightedShuffle::new(&mut ChaChaRng::from_seed(seed), &weights)
-            .unwrap()
+        let shuffle = WeightedShuffle::new(&weights).unwrap();
+        shuffle
+            .shuffle(&mut ChaChaRng::from_seed(seed))
             .collect::<Vec<_>>()
     });
 }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2010,7 +2010,7 @@ impl ClusterInfo {
             return packet_batch;
         }
         let mut rng = rand::thread_rng();
-        let shuffle = WeightedShuffle::new(&mut rng, &scores).unwrap();
+        let shuffle = WeightedShuffle::new(&scores).unwrap().shuffle(&mut rng);
         let mut total_bytes = 0;
         let mut sent = 0;
         for (addr, response) in shuffle.map(|i| &responses[i]) {

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -246,8 +246,9 @@ impl CrdsGossipPull {
             return Err(CrdsGossipError::NoPeers);
         }
         let mut rng = rand::thread_rng();
-        let mut peers = WeightedShuffle::new(&mut rng, &weights)
+        let mut peers = WeightedShuffle::new(&weights)
             .unwrap()
+            .shuffle(&mut rng)
             .map(|i| peers[i]);
         let peer = {
             let mut rng = rand::thread_rng();

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -169,8 +169,9 @@ impl CrdsGossipPush {
                 .filter(|(_, stake)| *stake > 0)
                 .collect();
             let weights: Vec<_> = peers.iter().map(|(_, stake)| *stake).collect();
-            WeightedShuffle::new(&mut rng, &weights)
+            WeightedShuffle::new(&weights)
                 .unwrap()
+                .shuffle(&mut rng)
                 .map(move |i| peers[i])
         };
         let mut keep = HashSet::new();
@@ -369,7 +370,7 @@ impl CrdsGossipPush {
             return;
         }
         let num_bloom_items = MIN_NUM_BLOOM_ITEMS.max(network_size);
-        let shuffle = WeightedShuffle::new(&mut rng, &weights).unwrap();
+        let shuffle = WeightedShuffle::new(&weights).unwrap().shuffle(&mut rng);
         let mut active_set = self.active_set.write().unwrap();
         let need = Self::compute_need(self.num_active, active_set.len(), ratio);
         for peer in shuffle.map(|i| peers[i]) {


### PR DESCRIPTION
#### Problem
Follow up changes need to copy this struct which is currently not possible due to `rng: &'a mut R` field.

#### Summary of Changes
* removed the `Rng` field from the struct.
* `rng` argument is passed in the new `shuffle` method.
