### PR TITLE
Zk instructions pass

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -23,6 +23,7 @@ use {
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
+        traits::Identity,
     },
     serde::{Deserialize, Serialize},
     solana_sdk::{
@@ -49,7 +50,7 @@ use {
 };
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
-struct ElGamal;
+pub struct ElGamal;
 impl ElGamal {
     /// Generates an ElGamal keypair.
     ///
@@ -103,6 +104,19 @@ impl ElGamal {
 
         ElGamalCiphertext { commitment, handle }
     }
+
+    /// On input a message, the function returns a twisted ElGamal ciphertext where the associated
+    /// Pedersen opening is always zero. Since the opening is zero, any twisted ElGamal ciphertext
+    /// of this form is a valid ciphertext under any ElGamal public key.
+    pub fn encode<T: Into<Scalar>>(
+        amount: T,
+    ) -> ElGamalCiphertext {
+        let commitment = PedersenCommitment(&amount.into() * &(*G));
+        let handle = DecryptHandle(RistrettoPoint::identity());
+
+        ElGamalCiphertext { commitment, handle }
+    }
+
 
     /// On input a secret key and a ciphertext, the function returns the decrypted message.
     ///

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -111,7 +111,7 @@ impl ElGamal {
     pub fn encode<T: Into<Scalar>>(
         amount: T,
     ) -> ElGamalCiphertext {
-        let commitment = PedersenCommitment(&amount.into() * &(*G));
+        let commitment = Pedersen::encode(amount);
         let handle = DecryptHandle(RistrettoPoint::identity());
 
         ElGamalCiphertext { commitment, handle }

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -94,6 +94,7 @@ impl ElGamal {
 
     /// On input a public key, message, and Pedersen opening, the function
     /// returns the corresponding ElGamal ciphertext.
+    #[cfg(not(target_arch = "bpf"))]
     fn encrypt_with<T: Into<Scalar>>(
         amount: T,
         public: &ElGamalPubkey,
@@ -108,6 +109,7 @@ impl ElGamal {
     /// On input a message, the function returns a twisted ElGamal ciphertext where the associated
     /// Pedersen opening is always zero. Since the opening is zero, any twisted ElGamal ciphertext
     /// of this form is a valid ciphertext under any ElGamal public key.
+    #[cfg(not(target_arch = "bpf"))]
     pub fn encode<T: Into<Scalar>>(amount: T) -> ElGamalCiphertext {
         let commitment = Pedersen::encode(amount);
         let handle = DecryptHandle(RistrettoPoint::identity());
@@ -119,6 +121,7 @@ impl ElGamal {
     ///
     /// The output of this function is of type `DiscreteLog`. To recover, the originally encrypted
     /// message, use `DiscreteLog::decode`.
+    #[cfg(not(target_arch = "bpf"))]
     fn decrypt(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> DiscreteLog {
         DiscreteLog {
             generator: *G,
@@ -128,6 +131,7 @@ impl ElGamal {
 
     /// On input a secret key and a ciphertext, the function returns the decrypted message
     /// interpretted as type `u32`.
+    #[cfg(not(target_arch = "bpf"))]
     fn decrypt_u32(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> Option<u32> {
         let discrete_log_instance = Self::decrypt(secret, ciphertext);
         discrete_log_instance.decode_u32()
@@ -135,6 +139,7 @@ impl ElGamal {
 
     /// On input a secret key, a ciphertext, and a pre-computed hashmap, the function returns the
     /// decrypted message interpretted as type `u32`.
+    #[cfg(not(target_arch = "bpf"))]
     fn decrypt_u32_online(
         secret: &ElGamalSecretKey,
         ciphertext: &ElGamalCiphertext,

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -108,15 +108,12 @@ impl ElGamal {
     /// On input a message, the function returns a twisted ElGamal ciphertext where the associated
     /// Pedersen opening is always zero. Since the opening is zero, any twisted ElGamal ciphertext
     /// of this form is a valid ciphertext under any ElGamal public key.
-    pub fn encode<T: Into<Scalar>>(
-        amount: T,
-    ) -> ElGamalCiphertext {
+    pub fn encode<T: Into<Scalar>>(amount: T) -> ElGamalCiphertext {
         let commitment = Pedersen::encode(amount);
         let handle = DecryptHandle(RistrettoPoint::identity());
 
         ElGamalCiphertext { commitment, handle }
     }
-
 
     /// On input a secret key and a ciphertext, the function returns the decrypted message.
     ///

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -52,6 +52,13 @@ impl Pedersen {
 
         PedersenCommitment(RistrettoPoint::multiscalar_mul(&[x, *r], &[*G, *H]))
     }
+
+    /// On input a message, the function returns a Pedersen commitment with zero as the opening.
+    ///
+    /// This function is deterministic.
+    pub fn encode<T: Into<Scalar>>(amount: T) -> PedersenCommitment {
+        PedersenCommitment(amount.into() * &(*G))
+    }
 }
 
 /// Pedersen opening type.

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 // TODO: clean up errors for encryption
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofError {
+    #[error("proof generation failed")]
+    Generation,
     #[error("proof failed to verify")]
     Verification,
     #[error("range proof failed to verify")]

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -41,8 +41,8 @@ impl From<EqualityProofError> for ProofError {
     }
 }
 
-impl From<FeeProofError> for ProofError {
-    fn from(_err: FeeProofError) -> Self {
+impl From<FeeSigmaProofError> for ProofError {
+    fn from(_err: FeeSigmaProofError) -> Self {
         Self::FeeProof
     }
 }

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -26,10 +26,10 @@ use {
 #[repr(C)]
 pub struct CloseAccountData {
     /// The source account ElGamal pubkey
-    pub elgamal_pubkey: pod::ElGamalPubkey, // 32 bytes
+    pub pubkey: pod::ElGamalPubkey, // 32 bytes
 
     /// The source account available balance in encrypted form
-    pub balance: pod::ElGamalCiphertext, // 64 bytes
+    pub ciphertext: pod::ElGamalCiphertext, // 64 bytes
 
     /// Proof that the source account available balance is zero
     pub proof: CloseAccountProof, // 64 bytes
@@ -37,12 +37,20 @@ pub struct CloseAccountData {
 
 #[cfg(not(target_arch = "bpf"))]
 impl CloseAccountData {
-    pub fn new(source_keypair: &ElGamalKeypair, balance: ElGamalCiphertext) -> Self {
-        let proof = CloseAccountProof::new(source_keypair, &balance);
+    pub fn new(keypair: &ElGamalKeypair, ciphertext: &ElGamalCiphertext) -> Self {
+        let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
+        let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
+
+        let mut transcript = CloseAccountProof::transcript_new(
+            &pod_pubkey,
+            &pod_ciphertext,
+        );
+
+        let proof = CloseAccountProof::new(keypair, ciphertext, &mut transcript);
 
         CloseAccountData {
-            elgamal_pubkey: source_keypair.public.into(),
-            balance: balance.into(),
+            pubkey: pod_pubkey,
+            ciphertext: pod_ciphertext,
             proof,
         }
     }
@@ -51,9 +59,14 @@ impl CloseAccountData {
 #[cfg(not(target_arch = "bpf"))]
 impl Verifiable for CloseAccountData {
     fn verify(&self) -> Result<(), ProofError> {
-        let elgamal_pubkey = self.elgamal_pubkey.try_into()?;
-        let balance = self.balance.try_into()?;
-        self.proof.verify(&elgamal_pubkey, &balance)
+        let mut transcript = CloseAccountProof::transcript_new(
+            &self.pubkey,
+            &self.ciphertext,
+        );
+
+        let pubkey = self.pubkey.try_into()?;
+        let ciphertext = self.ciphertext.try_into()?;
+        self.proof.verify(&pubkey, &ciphertext, &mut transcript)
     }
 }
 
@@ -69,18 +82,24 @@ pub struct CloseAccountProof {
 #[allow(non_snake_case)]
 #[cfg(not(target_arch = "bpf"))]
 impl CloseAccountProof {
-    fn transcript_new() -> Transcript {
-        Transcript::new(b"CloseAccountProof")
+    fn transcript_new(
+        pubkey: &pod::ElGamalPubkey,
+        ciphertext: &pod::ElGamalCiphertext,
+    ) -> Transcript {
+        let mut transcript = Transcript::new(b"CloseAccountProof");
+
+        transcript.append_pubkey(b"pubkey", &pubkey);
+        transcript.append_ciphertext(b"ciphertext", &ciphertext);
+
+        transcript
     }
 
-    pub fn new(source_keypair: &ElGamalKeypair, balance: &ElGamalCiphertext) -> Self {
-        let mut transcript = Self::transcript_new();
-        // TODO: Add ciphertext to transcript
-
-        // add a domain separator to record the start of the protocol
-        transcript.close_account_proof_domain_sep();
-
-        let proof = ZeroBalanceProof::new(source_keypair, balance, &mut transcript);
+    pub fn new(
+        keypair: &ElGamalKeypair,
+        ciphertext: &ElGamalCiphertext,
+        transcript: &mut Transcript,
+    ) -> Self {
+        let proof = ZeroBalanceProof::new(keypair, ciphertext, transcript);
 
         CloseAccountProof {
             proof: proof.into(),
@@ -89,72 +108,33 @@ impl CloseAccountProof {
 
     pub fn verify(
         &self,
-        elgamal_pubkey: &ElGamalPubkey,
-        balance: &ElGamalCiphertext,
+        pubkey: &ElGamalPubkey,
+        ciphertext: &ElGamalCiphertext,
+        transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
-        let mut transcript = Self::transcript_new();
-
-        // add a domain separator to record the start of the protocol
-        transcript.close_account_proof_domain_sep();
-
-        // verify zero balance proof
         let proof: ZeroBalanceProof = self.proof.try_into()?;
-        proof.verify(elgamal_pubkey, balance, &mut transcript)?;
+        proof.verify(pubkey, ciphertext, transcript)?;
+
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use {
-        super::*,
-        crate::encryption::{
-            elgamal::{DecryptHandle, ElGamalKeypair},
-            pedersen::{Pedersen, PedersenOpening},
-        },
-    };
+    use super::*;
 
     #[test]
     fn test_close_account_correctness() {
-        let source_keypair = ElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
 
         // general case: encryption of 0
-        let balance = source_keypair.public.encrypt(0_u64);
-        let proof = CloseAccountProof::new(&source_keypair, &balance);
-        assert!(proof.verify(&source_keypair.public, &balance).is_ok());
+        let ciphertext = keypair.public.encrypt(0_u64);
+        let close_account_data = CloseAccountData::new(&keypair, &ciphertext);
+        assert!(close_account_data.verify().is_ok());
 
         // general case: encryption of > 0
-        let balance = source_keypair.public.encrypt(1_u64);
-        let proof = CloseAccountProof::new(&source_keypair, &balance);
-        assert!(proof.verify(&source_keypair.public, &balance).is_err());
-
-        // // edge case: all zero ciphertext - such ciphertext should always be a valid encryption of 0
-        let zeroed_ct: ElGamalCiphertext = pod::ElGamalCiphertext::zeroed().try_into().unwrap();
-        let proof = CloseAccountProof::new(&source_keypair, &zeroed_ct);
-        assert!(proof.verify(&source_keypair.public, &zeroed_ct).is_ok());
-
-        // edge cases: only C or D is zero - such ciphertext is always invalid
-        let zeroed_comm = Pedersen::with(0_u64, &PedersenOpening::default());
-        let handle = balance.handle;
-
-        let zeroed_comm_ciphertext = ElGamalCiphertext {
-            commitment: zeroed_comm,
-            handle,
-        };
-
-        let proof = CloseAccountProof::new(&source_keypair, &zeroed_comm_ciphertext);
-        assert!(proof
-            .verify(&source_keypair.public, &zeroed_comm_ciphertext)
-            .is_err());
-
-        let zeroed_handle_ciphertext = ElGamalCiphertext {
-            commitment: balance.commitment,
-            handle: DecryptHandle::default(),
-        };
-
-        let proof = CloseAccountProof::new(&source_keypair, &zeroed_handle_ciphertext);
-        assert!(proof
-            .verify(&source_keypair.public, &zeroed_handle_ciphertext)
-            .is_err());
+        let ciphertext = keypair.public.encrypt(1_u64);
+        let close_account_data = CloseAccountData::new(&keypair, &ciphertext);
+        assert!(close_account_data.verify().is_err());
     }
 }

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -37,7 +37,7 @@ pub struct CloseAccountData {
 
 #[cfg(not(target_arch = "bpf"))]
 impl CloseAccountData {
-    pub fn new(keypair: &ElGamalKeypair, ciphertext: &ElGamalCiphertext) -> Self {
+    pub fn new(keypair: &ElGamalKeypair, ciphertext: &ElGamalCiphertext) -> Result<Self, ProofError> {
         let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
         let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
 
@@ -45,11 +45,11 @@ impl CloseAccountData {
 
         let proof = CloseAccountProof::new(keypair, ciphertext, &mut transcript);
 
-        CloseAccountData {
+        Ok(CloseAccountData {
             pubkey: pod_pubkey,
             ciphertext: pod_ciphertext,
             proof,
-        }
+        })
     }
 }
 
@@ -123,12 +123,12 @@ mod test {
 
         // general case: encryption of 0
         let ciphertext = keypair.public.encrypt(0_u64);
-        let close_account_data = CloseAccountData::new(&keypair, &ciphertext);
+        let close_account_data = CloseAccountData::new(&keypair, &ciphertext).unwrap();
         assert!(close_account_data.verify().is_ok());
 
         // general case: encryption of > 0
         let ciphertext = keypair.public.encrypt(1_u64);
-        let close_account_data = CloseAccountData::new(&keypair, &ciphertext);
+        let close_account_data = CloseAccountData::new(&keypair, &ciphertext).unwrap();
         assert!(close_account_data.verify().is_err());
     }
 }

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -37,7 +37,10 @@ pub struct CloseAccountData {
 
 #[cfg(not(target_arch = "bpf"))]
 impl CloseAccountData {
-    pub fn new(keypair: &ElGamalKeypair, ciphertext: &ElGamalCiphertext) -> Result<Self, ProofError> {
+    pub fn new(
+        keypair: &ElGamalKeypair,
+        ciphertext: &ElGamalCiphertext,
+    ) -> Result<Self, ProofError> {
         let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
         let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
 
@@ -82,8 +85,8 @@ impl CloseAccountProof {
     ) -> Transcript {
         let mut transcript = Transcript::new(b"CloseAccountProof");
 
-        transcript.append_pubkey(b"pubkey", &pubkey);
-        transcript.append_ciphertext(b"ciphertext", &ciphertext);
+        transcript.append_pubkey(b"pubkey", pubkey);
+        transcript.append_ciphertext(b"ciphertext", ciphertext);
 
         transcript
     }

--- a/zk-token-sdk/src/instruction/close_account.rs
+++ b/zk-token-sdk/src/instruction/close_account.rs
@@ -41,10 +41,7 @@ impl CloseAccountData {
         let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
         let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
 
-        let mut transcript = CloseAccountProof::transcript_new(
-            &pod_pubkey,
-            &pod_ciphertext,
-        );
+        let mut transcript = CloseAccountProof::transcript_new(&pod_pubkey, &pod_ciphertext);
 
         let proof = CloseAccountProof::new(keypair, ciphertext, &mut transcript);
 
@@ -59,10 +56,7 @@ impl CloseAccountData {
 #[cfg(not(target_arch = "bpf"))]
 impl Verifiable for CloseAccountData {
     fn verify(&self) -> Result<(), ProofError> {
-        let mut transcript = CloseAccountProof::transcript_new(
-            &self.pubkey,
-            &self.ciphertext,
-        );
+        let mut transcript = CloseAccountProof::transcript_new(&self.pubkey, &self.ciphertext);
 
         let pubkey = self.pubkey.try_into()?;
         let ciphertext = self.ciphertext.try_into()?;

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -1,12 +1,12 @@
-mod close_account;
-mod transfer;
-mod withdraw;
+pub mod close_account;
+pub mod transfer;
+pub mod withdraw;
 
 #[cfg(not(target_arch = "bpf"))]
 use crate::errors::ProofError;
 pub use {
     close_account::CloseAccountData,
-    transfer::{TransferCommitments, TransferData, TransferPubkeys},
+    transfer::{TransferCommitments, TransferData},
     withdraw::WithdrawData,
 };
 

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -1,14 +1,17 @@
 pub mod close_account;
 pub mod transfer;
+pub mod transfer_with_fee;
 pub mod withdraw;
 
 #[cfg(not(target_arch = "bpf"))]
-use crate::errors::ProofError;
-pub use {
-    close_account::CloseAccountData,
-    transfer::TransferData,
-    withdraw::WithdrawData,
+use {
+    crate::{encryption::{elgamal::ElGamalCiphertext, pedersen::PedersenCommitment}, errors::ProofError},
+    curve25519_dalek::scalar::Scalar,
 };
+pub use {close_account::CloseAccountData, transfer::TransferData, withdraw::WithdrawData};
+
+/// Constant for 2^32
+const TWO_32: u64 = 4294967296;
 
 #[cfg(not(target_arch = "bpf"))]
 pub trait Verifiable {
@@ -22,3 +25,32 @@ pub enum Role {
     Dest,
     Auditor,
 }
+
+/// Split u64 number into two u32 numbers
+#[cfg(not(target_arch = "bpf"))]
+pub fn split_u64_into_u32(amount: u64) -> (u32, u32) {
+    let lo = amount as u32;
+    let hi = (amount >> 32) as u32;
+
+    (lo, hi)
+}
+
+fn combine_u32_ciphertexts(
+    ciphertext_lo: &ElGamalCiphertext,
+    ciphertext_hi: &ElGamalCiphertext,
+) -> ElGamalCiphertext {
+    ciphertext_lo + &(ciphertext_hi * &Scalar::from(TWO_32))
+}
+
+#[cfg(not(target_arch = "bpf"))]
+pub fn combine_u32_commitments(
+    comm_lo: &PedersenCommitment,
+    comm_hi: &PedersenCommitment,
+) -> PedersenCommitment {
+    comm_lo + comm_hi * &Scalar::from(TWO_32)
+}
+
+// #[cfg(not(target_arch = "bpf"))]
+// pub fn combine_u32_handles(handle_lo: DecryptHandle, handle_hi: DecryptHandle) -> DecryptHandle {
+//     handle_lo + handle_hi * Scalar::from(TWO_32)
+// }

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -17,6 +17,7 @@ use {
 pub use {close_account::CloseAccountData, transfer::TransferData, withdraw::WithdrawData};
 
 /// Constant for 2^32
+#[cfg(not(target_arch = "bpf"))]
 const TWO_32: u64 = 4294967296;
 
 #[cfg(not(target_arch = "bpf"))]
@@ -41,6 +42,7 @@ pub fn split_u64_into_u32(amount: u64) -> (u32, u32) {
     (lo, hi)
 }
 
+#[cfg(not(target_arch = "bpf"))]
 fn combine_u32_ciphertexts(
     ciphertext_lo: &ElGamalCiphertext,
     ciphertext_hi: &ElGamalCiphertext,

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -6,7 +6,7 @@ pub mod withdraw;
 use crate::errors::ProofError;
 pub use {
     close_account::CloseAccountData,
-    transfer::{TransferCommitments, TransferData},
+    transfer::TransferData,
     withdraw::WithdrawData,
 };
 

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -5,7 +5,13 @@ pub mod withdraw;
 
 #[cfg(not(target_arch = "bpf"))]
 use {
-    crate::{encryption::{elgamal::ElGamalCiphertext, pedersen::PedersenCommitment}, errors::ProofError},
+    crate::{
+        encryption::{
+            elgamal::ElGamalCiphertext,
+            pedersen::{PedersenCommitment, PedersenOpening},
+        },
+        errors::ProofError,
+    },
     curve25519_dalek::scalar::Scalar,
 };
 pub use {close_account::CloseAccountData, transfer::TransferData, withdraw::WithdrawData};
@@ -50,7 +56,10 @@ pub fn combine_u32_commitments(
     comm_lo + comm_hi * &Scalar::from(TWO_32)
 }
 
-// #[cfg(not(target_arch = "bpf"))]
-// pub fn combine_u32_handles(handle_lo: DecryptHandle, handle_hi: DecryptHandle) -> DecryptHandle {
-//     handle_lo + handle_hi * Scalar::from(TWO_32)
-// }
+#[cfg(not(target_arch = "bpf"))]
+pub fn combine_u32_openings(
+    opening_lo: &PedersenOpening,
+    opening_hi: &PedersenOpening,
+) -> PedersenOpening {
+    opening_lo + opening_hi * &Scalar::from(TWO_32)
+}

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -123,7 +123,9 @@ impl TransferData {
         );
 
         // subtract transfer amount from the spendable ciphertext
-        let new_spendable_balance = spendable_balance.checked_sub(transfer_amount).ok_or(ProofError::Generation)?;
+        let new_spendable_balance = spendable_balance
+            .checked_sub(transfer_amount)
+            .ok_or(ProofError::Generation)?;
 
         let transfer_amount_lo_source = ElGamalCiphertext {
             commitment: ciphertext_lo.commitment,
@@ -155,7 +157,7 @@ impl TransferData {
         let proof = TransferProof::new(
             (amount_lo, amount_hi),
             keypair_source,
-            (&pubkey_dest, &pubkey_auditor),
+            (pubkey_dest, pubkey_auditor),
             &opening_lo,
             &opening_hi,
             (new_spendable_balance, &ciphertext_new_source),
@@ -358,7 +360,7 @@ impl TransferProof {
         // TODO: we can also consider verifying equality and range proof in a batch
         equality_proof.verify(
             &transfer_pubkeys.source,
-            &new_spendable_ciphertext,
+            new_spendable_ciphertext,
             &commitment,
             transcript,
         )?;
@@ -457,7 +459,8 @@ mod test {
             (spendable_balance, &spendable_ciphertext),
             &source_keypair,
             (&dest_pk, &auditor_pk),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(transfer_data.verify().is_ok());
     }
@@ -490,7 +493,8 @@ mod test {
             (spendable_balance, &spendable_ciphertext),
             &source_keypair,
             (&dest_pk, &auditor_pk),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             transfer_data

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -25,6 +25,7 @@ use {
 
 #[derive(Clone)]
 #[repr(C)]
+#[cfg(not(target_arch = "bpf"))]
 pub struct TransferAmountEncryption {
     pub commitment: PedersenCommitment,
     pub source: DecryptHandle,
@@ -32,6 +33,7 @@ pub struct TransferAmountEncryption {
     pub auditor: DecryptHandle,
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl TransferAmountEncryption {
     pub fn new(
         amount: u32,
@@ -393,12 +395,14 @@ impl TransferProof {
 /// The ElGamal public keys needed for a transfer
 #[derive(Clone)]
 #[repr(C)]
+#[cfg(not(target_arch = "bpf"))]
 pub struct TransferPubkeys {
     pub source: ElGamalPubkey,
     pub dest: ElGamalPubkey,
     pub auditor: ElGamalPubkey,
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl TransferPubkeys {
     // TODO: use constructor instead
     pub fn to_bytes(&self) -> [u8; 96] {
@@ -425,6 +429,7 @@ impl TransferPubkeys {
     }
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl pod::TransferPubkeys {
     pub fn new(source: &ElGamalPubkey, dest: &ElGamalPubkey, auditor: &ElGamalPubkey) -> Self {
         let mut bytes = [0u8; 96];

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -237,7 +237,7 @@ impl Verifiable for TransferData {
         let ciphertext_lo = self.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.ciphertext_hi.try_into()?;
         let transfer_pubkeys = self.transfer_pubkeys.try_into()?;
-        let new_spendable_ciphertext = self.new_spendable_ciphertext.try_into()?;
+        let new_spendable_ciphertext = self.ciphertext_new_source.try_into()?;
 
         self.proof.verify(
             &ciphertext_lo,
@@ -328,9 +328,9 @@ impl TransferProof {
 
         Self {
             commitment_new_source: commitment_new_source.into(),
-            equality_proof: equality_proof.try_into().expect("equality proof"),
-            validity_proof: validity_proof.try_into().expect("validity proof"),
-            range_proof: range_proof.try_into().expect("range proof"),
+            equality_proof: equality_proof.into(),
+            validity_proof: validity_proof.into(),
+            range_proof: range_proof.try_into().expect("range proof: length error"),
         }
     }
 

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -122,7 +122,7 @@ impl TransferData {
         );
 
         // subtract transfer amount from the spendable ciphertext
-        let new_spendable_balance = spendable_balance - transfer_amount;
+        let new_spendable_balance = spendable_balance - transfer_amount; // TODO: account for underflow
 
         let transfer_amount_lo_source = ElGamalCiphertext {
             commitment: ciphertext_lo.commitment,
@@ -335,7 +335,7 @@ impl TransferProof {
     }
 
     pub fn verify(
-        self,
+        &self,
         ciphertext_lo: &TransferAmountEncryption,
         ciphertext_hi: &TransferAmountEncryption,
         transfer_pubkeys: &TransferPubkeys,

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -1,0 +1,479 @@
+use {
+    crate::zk_token_elgamal::pod,
+    bytemuck::{Pod, Zeroable},
+};
+#[cfg(not(target_arch = "bpf"))]
+use {
+    crate::{
+        encryption::{
+            discrete_log::*,
+            elgamal::{
+                DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey,
+            },
+            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
+        },
+        errors::ProofError,
+        instruction::{
+            combine_u32_ciphertexts, combine_u32_commitments, split_u64_into_u32,
+            transfer::{TransferAmountEncryption, TransferPubkeys},
+            Role, Verifiable,
+        },
+        range_proof::RangeProof,
+        sigma_proofs::{fee_proof::FeeSigmaProof, validity_proof::ValidityProof},
+        transcript::TranscriptProtocol,
+    },
+    arrayref::{array_ref, array_refs},
+    curve25519_dalek::scalar::Scalar,
+    merlin::Transcript,
+    std::convert::TryInto,
+    subtle::{Choice, ConditionallySelectable, ConstantTimeGreater},
+};
+
+// #[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone)]
+#[repr(C)]
+pub struct TransferWithFeeData {
+    /// Group encryption of the low 32 bites of the transfer amount
+    pub ciphertext_lo: pod::TransferAmountEncryption,
+
+    /// Group encryption of the high 32 bits of the transfer amount
+    pub ciphertext_hi: pod::TransferAmountEncryption,
+
+    /// The public encryption keys associated with the transfer: source, dest, and auditor
+    pub transfer_pubkeys: pod::TransferWithFeePubkeys,
+
+    /// The final spendable ciphertext after the transfer,
+    pub new_spendable_ciphertext: pod::ElGamalCiphertext,
+
+    // transfer fee encryption
+    pub fee_ciphertext: pod::FeeEncryption,
+
+    // fee parameters
+    pub fee_parameters: pod::FeeParameters,
+
+    // transfer fee proof
+    pub transfer_fee_proof: TransferWithFeeProof,
+}
+
+#[cfg(not(target_arch = "bpf"))]
+impl TransferWithFeeData {
+    pub fn new(
+        transfer_amount: u64,
+        (spendable_balance, spendable_balance_ciphertext): (u64, &ElGamalCiphertext),
+        keypair_source: &ElGamalKeypair,
+        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        fee_parameters: FeeParameters,
+        pubkey_fee_collector: &ElGamalPubkey,
+    ) -> Self {
+        // split and encrypt transfer amount
+        let (amount_lo, amount_hi) = split_u64_into_u32(transfer_amount);
+
+        let (ciphertext_lo, opening_lo) = TransferAmountEncryption::new(
+            amount_lo,
+            &keypair_source.public,
+            pubkey_dest,
+            pubkey_auditor,
+        );
+        let (ciphertext_hi, opening_hi) = TransferAmountEncryption::new(
+            amount_hi,
+            &keypair_source.public,
+            pubkey_dest,
+            pubkey_auditor,
+        );
+
+        // subtract transfer amount from the spendable ciphertext
+        let new_spendable_balance = spendable_balance - transfer_amount;
+
+        let transfer_amount_lo_source = ElGamalCiphertext {
+            commitment: ciphertext_lo.commitment,
+            handle: ciphertext_lo.source,
+        };
+
+        let transfer_amount_hi_source = ElGamalCiphertext {
+            commitment: ciphertext_hi.commitment,
+            handle: ciphertext_hi.source,
+        };
+
+        let new_spendable_ciphertext = spendable_balance_ciphertext
+            - combine_u32_ciphertexts(&transfer_amount_lo_source, &transfer_amount_hi_source);
+
+        // calculate and encrypt fee
+        let (fee_amount, delta_fee) =
+            calculate_fee(transfer_amount, fee_parameters.fee_rate_basis_points);
+
+        let above_max = u64::ct_gt(&fee_parameters.maximum_fee, &fee_amount);
+        let fee_to_encrypt =
+            u64::conditional_select(&fee_amount, &fee_parameters.maximum_fee, above_max);
+
+        let (ciphertext_fee, opening_fee) =
+            FeeEncryption::new(fee_to_encrypt, pubkey_dest, pubkey_fee_collector);
+
+        let proof = TransferWithFeeProof::new(
+            (
+                transfer_amount,
+                &transfer_amount_commitment,
+                &transfer_amount_opening,
+            ),
+            (
+                fee_to_commit,
+                &transfer_fee_commitment,
+                &transfer_fee_opening,
+            ),
+            delta_fee,
+            (&pubkey_dest, &pubkey_fee_collector),
+            fee_parameters,
+        );
+
+        // TODO: pod for fee parameters
+        Self {
+            transfer_amount_commitment: transfer_amount_commitment.into(),
+            transfer_fee_commitment: transfer_fee_commitment.into(),
+            decrypt_handle_dest: decrypt_handle_dest.into(),
+            decrypt_handle_fee_collector: decrypt_handle_fee_collector.into(),
+            pubkey_dest: pubkey_dest.into(),
+            pubkey_fee_collector: pubkey_fee_collector.into(),
+            fee_parameters,
+            transfer_fee_proof,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "bpf"))]
+impl Verifiable for FeeData {
+    fn verify(&self) -> Result<(), ProofError> {
+        let transfer_amount_commitment: PedersenCommitment =
+            self.transfer_amount_commitment.try_into()?;
+        let transfer_fee_commitment: PedersenCommitment =
+            self.transfer_fee_commitment.try_into()?;
+        let decrypt_handle_dest: PedersenDecryptHandle = self.decrypt_handle_dest.try_into()?;
+        let decrypt_handle_fee_collector: PedersenDecryptHandle =
+            self.decrypt_handle_fee_collector.try_into()?;
+        let pubkey_dest = self.pubkey_dest.try_into()?;
+        let pubkey_fee_collector = self.pubkey_fee_collector.try_into()?;
+        let proof = self.transfer_fee_proof.clone();
+
+        proof.verify(
+            &transfer_amount_commitment,
+            &transfer_fee_commitment,
+            &decrypt_handle_dest,
+            &decrypt_handle_fee_collector,
+            &pubkey_dest,
+            &pubkey_fee_collector,
+            self.fee_parameters,
+        )
+    }
+}
+
+// #[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+#[derive(Clone)]
+pub struct FeeProof {
+    pub delta_claimed_commitment: pod::PedersenCommitment,
+    pub fee_sigma_proof: pod::FeeSigmaProof,
+    pub fee_validity_proof: pod::ValidityProof,
+    pub fee_range_proof: RangeProof, // will ultimately be aggregated, so use non-pod for now
+}
+
+#[allow(non_snake_case)]
+#[cfg(not(target_arch = "bpf"))]
+impl FeeProof {
+    fn transcript_new(
+        transfer_with_fee_pubkeys: &pod::TransferWithFeePubkeys,
+        ciphertext_lo: &pod::TransferAmountEncryption,
+        ciphertext_hi: &pod::TransferAmountEncryption,
+        ciphertext_fee: &pod::FeeEncryption,
+    ) -> Transcript {
+        let mut transcript = Transcript::new(b"FeeProof");
+
+        transcript.append_message(b"transfer-with-fee-pubkeys", &transfer_with_fee_pubkeys.0);
+        transcript.append_message(b"ciphertext-lo", &ciphertext_lo.0);
+        transcript.append_message(b"ciphertext-hi", &ciphertext_hi.0);
+        transcript.append_message(b"ciphertext-fee", ciphertext_fee.0);
+
+        transcript
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::many_single_char_names)]
+    pub fn new(
+        transfer_amount_lo_data: (u32, &TransferAmountEncryption, &PedersenOpening),
+        transfer_amount_hi_data: (u32, &TransferAmountEncryption, &PedersenOpening),
+        keypair_source: &ElGamalKeypair,
+        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        (source_new_balance, source_new_balance_ciphertext): (u64, &ElGamalCiphertext),
+
+        (fee_amount, ciphertext_fee, opening_fee): (u64, &FeeEncryption, &PedersenOpening),
+        delta_fee: u64,
+        pubkey_fee_collector: &ElGamalPubkey,
+
+        // transfer_amount_data: (u64, &PedersenCommitment, &PedersenOpening),
+        // fee_data: (u64, &PedersenCommitment, &PedersenOpening),
+        // delta_fee: u64,
+        fee_parameters: FeeParameters,
+        transcript: &mut Transcript,
+    ) -> Self {
+        let (transfer_amount_lo, ciphertext_lo, opening_lo) = transfer_amount_lo_data;
+        let (transfer_amount_hi, ciphertext_hi, opening_hi) = transfer_amount_hi_data;
+
+        // generate a Pedersen commitment for the remaining balance in source
+        let (source_commitment, source_opening) = Pedersen::new(source_new_balance);
+
+        //------------------------------------------
+        let fee_rate_scalar = Scalar::from(fee_parameters.fee_rate_basis_points);
+        let commitment_delta = ciphertext_fee.commitment * Scalar::from(10000_u64)
+            - &combine_u32_commitments(&ciphertext_lo.commitment, &ciphertext_hi.commitment);
+
+        let opening_delta = opening_fee * Scalar::from(10000_u64)
+            - &combine_u32_openings(&opening_lo, &opening_hi);
+
+        // TODO: use a utility function
+        // -------------------------------------------
+
+        let (commitment_claimed, opening_claimed) = Pedersen::new(delta_fee);
+
+        // TODO: sigma proofs for regular transfer
+
+        // TODO: fee sigma proof
+
+        // TODO: validity proof
+        // TODO: range proof for both transfer and fee
+
+
+        // 2. generate sigma proof
+        //
+        // TODO: consider grouping (commitment, value, opening) as a struct
+        let fee_sigma_proof = FeeSigmaProof::new(
+            fee_data,
+            (delta_fee, &delta_fee_comm, &delta_fee_opening),
+            (&delta_claimed_comm, &delta_claimed_opening),
+            fee_parameters.maximum_fee,
+            &mut transcript,
+        );
+
+        // 3. validity proof
+        let validity_proof = ValidityProof::new(
+            fee_data.0,
+            (pubkey_dest, pubkey_fee_collector),
+            fee_data.2,
+            &mut transcript,
+        );
+
+        // 4. generate range proof
+        //
+        // TODO: double check copy
+        // TODO: should ultimately be aggregated into other rangeproofs
+        // TODO: validity proof
+        let zero_opening = PedersenOpening::default();
+        let delta_claimed_opening_range_proof = delta_claimed_opening.clone();
+        let delta_claimed_negated_opening_range_proof =
+            zero_opening - delta_claimed_opening.clone();
+        let range_proof = RangeProof::new(
+            vec![delta_fee, 10000_u64 - delta_fee],
+            vec![16_usize, 16_usize],
+            vec![
+                &delta_claimed_opening_range_proof,
+                &delta_claimed_negated_opening_range_proof,
+            ],
+            &mut transcript,
+        );
+
+        Self {
+            delta_claimed_commitment: delta_claimed_comm.into(),
+            fee_sigma_proof: fee_sigma_proof.into(),
+            fee_validity_proof: validity_proof.into(),
+            fee_range_proof: range_proof,
+        }
+    }
+
+    pub fn verify(
+        self,
+        transfer_amount_commitment: &PedersenCommitment,
+        fee_commitment: &PedersenCommitment,
+        decrypt_handle_dest: &PedersenDecryptHandle,
+        decrypt_handle_fee_collector: &PedersenDecryptHandle,
+        pubkey_dest: &ElGamalPubkey,
+        pubkey_fee_collector: &ElGamalPubkey,
+        fee_parameters: FeeParameters,
+    ) -> Result<(), ProofError> {
+        let mut transcript = FeeProof::transcript_new();
+
+        // compute delta commitments
+        let fee_rate_scalar = Scalar::from(fee_parameters.fee_rate_basis_points);
+        let delta_commitment =
+            transfer_amount_commitment * fee_rate_scalar - fee_commitment * Scalar::from(10000_u64);
+        let delta_claimed_commitment = self.delta_claimed_commitment.try_into()?;
+
+        let fee_sigma_proof: FeeSigmaProof = self.fee_sigma_proof.try_into()?;
+        fee_sigma_proof.verify(
+            fee_parameters.maximum_fee,
+            &fee_commitment,
+            &delta_commitment,
+            &delta_claimed_commitment,
+            &mut transcript,
+        )?;
+
+        let validity_proof: ValidityProof = self.fee_validity_proof.try_into()?;
+        validity_proof.verify(
+            fee_commitment,
+            (pubkey_dest, pubkey_fee_collector),
+            (decrypt_handle_dest, decrypt_handle_fee_collector),
+            &mut transcript,
+        )?;
+
+        let comm_10000 = Pedersen::with(10000_u64, &PedersenOpening::default());
+        let delta_claimed_negated_opening_range_proof = comm_10000 - delta_claimed_commitment;
+
+        let range_proof: RangeProof = self.fee_range_proof.clone();
+        range_proof.verify(
+            vec![
+                &delta_claimed_commitment,
+                &delta_claimed_negated_opening_range_proof,
+            ],
+            vec![16, 16],
+            &mut transcript,
+        )?;
+
+        Ok(())
+    }
+}
+
+/// The ElGamal public keys needed for a transfer with fee
+#[derive(Clone)]
+#[repr(C)]
+pub struct TransferWithFeePubkeys {
+    pub source: ElGamalPubkey,
+    pub dest: ElGamalPubkey,
+    pub auditor: ElGamalPubkey,
+    pub fee_collector: ElGamalPubkey,
+}
+
+impl TransferWithFeePubkeys {
+    pub fn to_bytes(&self) -> [u8; 128] {
+        let mut bytes = [0u8; 128];
+        bytes[..32].copy_from_slice(&self.source.to_bytes());
+        bytes[32..64].copy_from_slice(&self.dest.to_bytes());
+        bytes[64..96].copy_from_slice(&self.auditor.to_bytes());
+        bytes[96..128].copy_from_slice(&self.fee_collector.to_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
+        let bytes = array_ref![bytes, 0, 128];
+        let (source, dest, auditor, fee_collector) = array_refs![bytes, 32, 32, 32, 32];
+
+        let source = ElGamalPubkey::from_bytes(source).ok_or(ProofError::Verification)?;
+        let dest = ElGamalPubkey::from_bytes(dest).ok_or(ProofError::Verification)?;
+        let auditor = ElGamalPubkey::from_bytes(auditor).ok_or(ProofError::Verification)?;
+        let fee_collector =
+            ElGamalPubkey::from_bytes(fee_collector).ok_or(ProofError::Verification)?;
+
+        Ok(Self {
+            source,
+            dest,
+            auditor,
+            fee_collector,
+        })
+    }
+}
+
+#[derive(Clone)]
+#[repr(C)]
+pub struct FeeEncryption {
+    pub commitment: PedersenCommitment,
+    pub dest: DecryptHandle,
+    pub fee_collector: DecryptHandle,
+}
+
+impl FeeEncryption {
+    pub fn new(
+        amount: u64,
+        pubkey_dest: &ElGamalPubkey,
+        pubkey_fee_collector: &ElGamalPubkey,
+    ) -> (Self, PedersenOpening) {
+        let (commitment, opening) = Pedersen::new(amount);
+        let fee_encryption = Self {
+            commitment,
+            dest: pubkey_dest.decrypt_handle(&opening),
+            fee_collector: pubkey_fee_collector.decrypt_handle(&opening),
+        };
+
+        (fee_encryption, opening)
+    }
+
+    pub fn to_bytes(&self) -> [u8; 96] {
+        let mut bytes = [0u8; 96];
+        bytes[..32].copy_from_slice(&self.commitment.to_bytes());
+        bytes[32..64].copy_from_slice(&self.dest.to_bytes());
+        bytes[64..96].copy_from_slice(&self.fee_collector.to_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
+        let bytes = array_ref![bytes, 0, 96];
+        let (commitment, dest, fee_collector) = array_refs![bytes, 32, 32, 32];
+
+        let commitment =
+            PedersenCommitment::from_bytes(commitment).ok_or(ProofError::Verification)?;
+        let dest = DecryptHandle::from_bytes(dest).ok_or(ProofError::Verification)?;
+        let fee_collector =
+            DecryptHandle::from_bytes(fee_collector).ok_or(ProofError::Verification)?;
+
+        Ok(Self {
+            commitment,
+            dest,
+            fee_collector,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FeeParameters {
+    /// Fee rate expressed as basis points of the transfer amount, i.e. increments of 0.01%
+    pub fee_rate_basis_points: u16,
+    /// Maximum fee assessed on transfers, expressed as an amount of tokens
+    pub maximum_fee: u64,
+}
+
+fn calculate_fee(transfer_amount: u64, fee_rate_basis_points: u16) -> (u64, u64) {
+    let fee_scaled = (transfer_amount as u128) * (fee_rate_basis_points as u128);
+
+    let fee = (fee_scaled / 10000) as u64;
+    let rem = (fee_scaled % 10000) as u64;
+
+    if rem == 0 {
+        (fee, rem)
+    } else {
+        (fee + 1, rem)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_fee_correctness() {
+        let transfer_amount: u64 = 100;
+        let (transfer_amount_comm, transfer_amount_opening) = Pedersen::new(transfer_amount);
+
+        let fee_parameters = FeeParameters {
+            fee_rate_basis_points: 100,
+            maximum_fee: 3,
+        };
+
+        let dest_pubkey = ElGamalKeypair::default().public;
+        let fee_collector_pubkey = ElGamalKeypair::default().public;
+
+        let fee_data = FeeData::new(
+            transfer_amount,
+            transfer_amount_comm,
+            transfer_amount_opening,
+            fee_parameters,
+            dest_pubkey,
+            fee_collector_pubkey,
+        );
+
+        assert!(fee_data.verify().is_ok());
+    }
+}

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -32,8 +32,10 @@ use {
     subtle::{ConditionallySelectable, ConstantTimeGreater},
 };
 
+#[cfg(not(target_arch = "bpf"))]
 const FEE_DENOMINATOR: u64 = 10000;
 
+#[cfg(not(target_arch = "bpf"))]
 lazy_static::lazy_static! {
     pub static ref COMMITMENT_FEE_DENOMINATOR: PedersenCommitment = Pedersen::encode(FEE_DENOMINATOR);
 }
@@ -470,6 +472,7 @@ impl TransferWithFeeProof {
 /// The ElGamal public keys needed for a transfer with fee
 #[derive(Clone)]
 #[repr(C)]
+#[cfg(not(target_arch = "bpf"))]
 pub struct TransferWithFeePubkeys {
     pub source: ElGamalPubkey,
     pub dest: ElGamalPubkey,
@@ -477,6 +480,7 @@ pub struct TransferWithFeePubkeys {
     pub fee_collector: ElGamalPubkey,
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl TransferWithFeePubkeys {
     pub fn to_bytes(&self) -> [u8; 128] {
         let mut bytes = [0u8; 128];
@@ -506,6 +510,7 @@ impl TransferWithFeePubkeys {
     }
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl pod::TransferWithFeePubkeys {
     pub fn new(
         source: &ElGamalPubkey,
@@ -524,12 +529,14 @@ impl pod::TransferWithFeePubkeys {
 
 #[derive(Clone)]
 #[repr(C)]
+#[cfg(not(target_arch = "bpf"))]
 pub struct FeeEncryption {
     pub commitment: PedersenCommitment,
     pub dest: DecryptHandle,
     pub fee_collector: DecryptHandle,
 }
 
+#[cfg(not(target_arch = "bpf"))]
 impl FeeEncryption {
     pub fn new(
         amount: u64,
@@ -580,6 +587,8 @@ pub struct FeeParameters {
     /// Maximum fee assessed on transfers, expressed as an amount of tokens
     pub maximum_fee: u64,
 }
+
+#[cfg(not(target_arch = "bpf"))]
 impl FeeParameters {
     pub fn to_bytes(&self) -> [u8; 10] {
         let mut bytes = [0u8; 10];
@@ -600,6 +609,7 @@ impl FeeParameters {
     }
 }
 
+#[cfg(not(target_arch = "bpf"))]
 fn calculate_fee(transfer_amount: u64, fee_rate_basis_points: u16) -> (u64, u64) {
     let fee_scaled = (transfer_amount as u128) * (fee_rate_basis_points as u128);
 
@@ -613,6 +623,7 @@ fn calculate_fee(transfer_amount: u64, fee_rate_basis_points: u16) -> (u64, u64)
     }
 }
 
+#[cfg(not(target_arch = "bpf"))]
 fn compute_delta_commitment_and_opening(
     (commitment_lo, opening_lo): (&PedersenCommitment, &PedersenOpening),
     (commitment_hi, opening_hi): (&PedersenCommitment, &PedersenOpening),
@@ -630,6 +641,7 @@ fn compute_delta_commitment_and_opening(
     (commitment_delta, opening_delta)
 }
 
+#[cfg(not(target_arch = "bpf"))]
 fn compute_delta_commitment(
     commitment_lo: &PedersenCommitment,
     commitment_hi: &PedersenCommitment,

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -59,10 +59,7 @@ impl WithdrawData {
 
         let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
         let pod_final_ciphertext: pod::ElGamalCiphertext = final_ciphertext.into();
-        let mut transcript = WithdrawProof::transcript_new(
-            &pod_pubkey,
-            &pod_final_ciphertext,
-        );
+        let mut transcript = WithdrawProof::transcript_new(&pod_pubkey, &pod_final_ciphertext);
         let proof = WithdrawProof::new(keypair, final_balance, &final_ciphertext, &mut transcript);
 
         Self {
@@ -76,14 +73,12 @@ impl WithdrawData {
 #[cfg(not(target_arch = "bpf"))]
 impl Verifiable for WithdrawData {
     fn verify(&self) -> Result<(), ProofError> {
-        let mut transcript = WithdrawProof::transcript_new(
-            &self.pubkey,
-            &self.final_ciphertext,
-        );
+        let mut transcript = WithdrawProof::transcript_new(&self.pubkey, &self.final_ciphertext);
 
         let elgamal_pubkey = self.pubkey.try_into()?;
         let final_balance_ciphertext = self.final_ciphertext.try_into()?;
-        self.proof.verify(&elgamal_pubkey, &final_balance_ciphertext, &mut transcript)
+        self.proof
+            .verify(&elgamal_pubkey, &final_balance_ciphertext, &mut transcript)
     }
 }
 
@@ -136,12 +131,8 @@ impl WithdrawProof {
             transcript,
         );
 
-        let range_proof = RangeProof::new(
-            vec![final_balance],
-            vec![64],
-            vec![&opening],
-            transcript,
-        );
+        let range_proof =
+            RangeProof::new(vec![final_balance], vec![64], vec![&opening], transcript);
 
         WithdrawProof {
             commitment: commitment.into(),
@@ -168,11 +159,7 @@ impl WithdrawProof {
         // verify range proof
         //
         // TODO: double compressing here - consider modifying range proof input type to `PedersenCommitment`
-        range_proof.verify(
-            vec![&commitment],
-            vec![64_usize],
-            transcript,
-        )?;
+        range_proof.verify(vec![&commitment], vec![64_usize], transcript)?;
 
         Ok(())
     }

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -185,7 +185,7 @@ impl WithdrawProof {
         //
         // TODO: double compressing here - consider modifying range proof input type to `PedersenCommitment`
         range_proof.verify(
-            vec![&commitment.get_point().compress()],
+            vec![&commitment],
             vec![64_usize],
             &mut transcript,
         )?;

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -121,6 +121,9 @@ impl WithdrawProof {
     ) -> Self {
         // generate a Pedersen commitment for `final_balance`
         let (commitment, opening) = Pedersen::new(final_balance);
+        let pod_commitment: pod::PedersenCommitment = commitment.into();
+
+        transcript.append_commitment(b"commitment", &pod_commitment);
 
         // generate equality_proof
         let equality_proof = EqualityProof::new(
@@ -135,7 +138,7 @@ impl WithdrawProof {
             RangeProof::new(vec![final_balance], vec![64], vec![&opening], transcript);
 
         WithdrawProof {
-            commitment: commitment.into(),
+            commitment: pod_commitment,
             equality_proof: equality_proof.try_into().expect("equality proof"),
             range_proof: range_proof.try_into().expect("range proof"),
         }
@@ -147,6 +150,8 @@ impl WithdrawProof {
         final_ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
+        transcript.append_commitment(b"commitmetn", &self.commitment);
+
         let commitment: PedersenCommitment = self.commitment.try_into()?;
         let equality_proof: EqualityProof = self.equality_proof.try_into()?;
         let range_proof: RangeProof = self.range_proof.try_into()?;

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -150,7 +150,7 @@ impl WithdrawProof {
         final_ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
-        transcript.append_commitment(b"commitmetn", &self.commitment);
+        transcript.append_commitment(b"commitment", &self.commitment);
 
         let commitment: PedersenCommitment = self.commitment.try_into()?;
         let equality_proof: EqualityProof = self.equality_proof.try_into()?;

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -6,8 +6,8 @@ use {
 use {
     crate::{
         encryption::{
-            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
+            elgamal::{ElGamal, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            pedersen::{Pedersen, PedersenCommitment},
         },
         errors::ProofError,
         instruction::Verifiable,
@@ -30,11 +30,11 @@ use {
 #[repr(C)]
 pub struct WithdrawData {
     /// The source account ElGamal pubkey
-    pub elgamal_pubkey: pod::ElGamalPubkey, // 32 bytes
+    pub pubkey: pod::ElGamalPubkey, // 32 bytes
 
     /// The source account available balance *after* the withdraw (encrypted by
     /// `source_pk`
-    pub final_balance_ct: pod::ElGamalCiphertext, // 64 bytes
+    pub final_ciphertext: pod::ElGamalCiphertext, // 64 bytes
 
     /// Range proof
     pub proof: WithdrawProof, // 736 bytes
@@ -44,9 +44,9 @@ impl WithdrawData {
     #[cfg(not(target_arch = "bpf"))]
     pub fn new(
         amount: u64,
-        source_keypair: &ElGamalKeypair,
+        keypair: &ElGamalKeypair,
         current_balance: u64,
-        current_balance_ct: ElGamalCiphertext,
+        current_ciphertext: &ElGamalCiphertext,
     ) -> Self {
         // subtract withdraw amount from current balance
         //
@@ -55,16 +55,19 @@ impl WithdrawData {
 
         // encode withdraw amount as an ElGamal ciphertext and subtract it from
         // current source balance
-        let amount_encoded = source_keypair
-            .public
-            .encrypt_with(amount, &PedersenOpening::default());
-        let final_balance_ct = current_balance_ct - amount_encoded;
+        let final_ciphertext = current_ciphertext - &ElGamal::encode(amount);
 
-        let proof = WithdrawProof::new(source_keypair, final_balance, &final_balance_ct);
+        let pod_pubkey = pod::ElGamalPubkey((&keypair.public).to_bytes());
+        let pod_final_ciphertext: pod::ElGamalCiphertext = final_ciphertext.into();
+        let mut transcript = WithdrawProof::transcript_new(
+            &pod_pubkey,
+            &pod_final_ciphertext,
+        );
+        let proof = WithdrawProof::new(keypair, final_balance, &final_ciphertext, &mut transcript);
 
         Self {
-            elgamal_pubkey: source_keypair.public.into(),
-            final_balance_ct: final_balance_ct.into(),
+            pubkey: pod_pubkey,
+            final_ciphertext: pod_final_ciphertext,
             proof,
         }
     }
@@ -73,9 +76,14 @@ impl WithdrawData {
 #[cfg(not(target_arch = "bpf"))]
 impl Verifiable for WithdrawData {
     fn verify(&self) -> Result<(), ProofError> {
-        let elgamal_pubkey = self.elgamal_pubkey.try_into()?;
-        let final_balance_ct = self.final_balance_ct.try_into()?;
-        self.proof.verify(&elgamal_pubkey, &final_balance_ct)
+        let mut transcript = WithdrawProof::transcript_new(
+            &self.pubkey,
+            &self.final_ciphertext,
+        );
+
+        let elgamal_pubkey = self.pubkey.try_into()?;
+        let final_balance_ciphertext = self.final_ciphertext.try_into()?;
+        self.proof.verify(&elgamal_pubkey, &final_balance_ciphertext, &mut transcript)
     }
 }
 
@@ -98,49 +106,41 @@ pub struct WithdrawProof {
 #[allow(non_snake_case)]
 #[cfg(not(target_arch = "bpf"))]
 impl WithdrawProof {
-    fn transcript_new() -> Transcript {
-        Transcript::new(b"WithdrawProof")
+    fn transcript_new(
+        pubkey: &pod::ElGamalPubkey,
+        ciphertext: &pod::ElGamalCiphertext,
+    ) -> Transcript {
+        let mut transcript = Transcript::new(b"WithdrawProof");
+
+        transcript.append_pubkey(b"pubkey", pubkey);
+        transcript.append_ciphertext(b"ciphertext", ciphertext);
+
+        transcript
     }
 
     pub fn new(
-        source_keypair: &ElGamalKeypair,
+        keypair: &ElGamalKeypair,
         final_balance: u64,
-        final_balance_ct: &ElGamalCiphertext,
+        final_ciphertext: &ElGamalCiphertext,
+        transcript: &mut Transcript,
     ) -> Self {
-        let mut transcript = Self::transcript_new();
-
-        // add a domain separator to record the start of the protocol
-        transcript.withdraw_proof_domain_sep();
-
         // generate a Pedersen commitment for `final_balance`
         let (commitment, opening) = Pedersen::new(final_balance);
 
-        // extract the relevant scalar and Ristretto points from the inputs
-        let P_EG = source_keypair.public.get_point();
-        let C_EG = final_balance_ct.commitment.get_point();
-        let D_EG = final_balance_ct.handle.get_point();
-        let C_Ped = commitment.get_point();
-
-        // append all current state to the transcript
-        transcript.append_point(b"P_EG", &P_EG.compress());
-        transcript.append_point(b"C_EG", &C_EG.compress());
-        transcript.append_point(b"D_EG", &D_EG.compress());
-        transcript.append_point(b"C_Ped", &C_Ped.compress());
-
         // generate equality_proof
         let equality_proof = EqualityProof::new(
-            source_keypair,
-            final_balance_ct,
+            keypair,
+            final_ciphertext,
             final_balance,
             &opening,
-            &mut transcript,
+            transcript,
         );
 
         let range_proof = RangeProof::new(
             vec![final_balance],
             vec![64],
             vec![&opening],
-            &mut transcript,
+            transcript,
         );
 
         WithdrawProof {
@@ -152,34 +152,18 @@ impl WithdrawProof {
 
     pub fn verify(
         &self,
-        source_pk: &ElGamalPubkey,
-        final_balance_ct: &ElGamalCiphertext,
+        pubkey: &ElGamalPubkey,
+        final_ciphertext: &ElGamalCiphertext,
+        transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
-        let mut transcript = Self::transcript_new();
-
         let commitment: PedersenCommitment = self.commitment.try_into()?;
         let equality_proof: EqualityProof = self.equality_proof.try_into()?;
         let range_proof: RangeProof = self.range_proof.try_into()?;
 
-        // add a domain separator to record the start of the protocol
-        transcript.withdraw_proof_domain_sep();
-
-        // extract the relevant scalar and Ristretto points from the inputs
-        let P_EG = source_pk.get_point();
-        let C_EG = final_balance_ct.commitment.get_point();
-        let D_EG = final_balance_ct.handle.get_point();
-        let C_Ped = commitment.get_point();
-
-        // append all current state to the transcript
-        transcript.append_point(b"P_EG", &P_EG.compress());
-        transcript.append_point(b"C_EG", &C_EG.compress());
-        transcript.append_point(b"D_EG", &D_EG.compress());
-        transcript.append_point(b"C_Ped", &C_Ped.compress());
-
         // verify equality proof
         //
         // TODO: we can also consider verifying equality and range proof in a batch
-        equality_proof.verify(source_pk, final_balance_ct, &commitment, &mut transcript)?;
+        equality_proof.verify(pubkey, final_ciphertext, &commitment, transcript)?;
 
         // verify range proof
         //
@@ -187,7 +171,7 @@ impl WithdrawProof {
         range_proof.verify(
             vec![&commitment],
             vec![64_usize],
-            &mut transcript,
+            transcript,
         )?;
 
         Ok(())
@@ -201,18 +185,18 @@ mod test {
     #[test]
     fn test_withdraw_correctness() {
         // generate and verify proof for the proper setting
-        let elgamal_keypair = ElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
 
         let current_balance: u64 = 77;
-        let current_balance_ct = elgamal_keypair.public.encrypt(current_balance);
+        let current_ciphertext = keypair.public.encrypt(current_balance);
 
         let withdraw_amount: u64 = 55;
 
         let data = WithdrawData::new(
             withdraw_amount,
-            &elgamal_keypair,
+            &keypair,
             current_balance,
-            current_balance_ct,
+            &current_ciphertext,
         );
         assert!(data.verify().is_ok());
 
@@ -220,9 +204,9 @@ mod test {
         let wrong_balance: u64 = 99;
         let data = WithdrawData::new(
             withdraw_amount,
-            &elgamal_keypair,
+            &keypair,
             wrong_balance,
-            current_balance_ct,
+            &current_ciphertext,
         );
         assert!(data.verify().is_err());
     }

--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -51,7 +51,9 @@ impl WithdrawData {
         // subtract withdraw amount from current balance
         //
         // errors if current_balance < amount
-        let final_balance = current_balance.checked_sub(amount).ok_or(ProofError::Generation)?;
+        let final_balance = current_balance
+            .checked_sub(amount)
+            .ok_or(ProofError::Generation)?;
 
         // encode withdraw amount as an ElGamal ciphertext and subtract it from
         // current source balance
@@ -189,7 +191,8 @@ mod test {
             &keypair,
             current_balance,
             &current_ciphertext,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(data.verify().is_ok());
 
         // generate and verify proof with wrong balance
@@ -199,7 +202,8 @@ mod test {
             &keypair,
             wrong_balance,
             &current_ciphertext,
-        ).unwrap();
+        )
+        .unwrap();
         assert!(data.verify().is_err());
     }
 }

--- a/zk-token-sdk/src/lib.rs
+++ b/zk-token-sdk/src/lib.rs
@@ -31,7 +31,8 @@ mod sigma_proofs;
 #[cfg(not(target_arch = "bpf"))]
 mod transcript;
 
-mod instruction;
+// TODO: re-organize visibility
+pub mod instruction;
 pub mod zk_token_elgamal;
 pub mod zk_token_proof_instruction;
 pub mod zk_token_proof_program;

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -403,11 +403,7 @@ mod tests {
         let proof = RangeProof::new(vec![55], vec![32], vec![&open], &mut transcript_create);
 
         assert!(proof
-            .verify(
-                vec![&comm],
-                vec![32],
-                &mut transcript_verify
-            )
+            .verify(vec![&comm], vec![32], &mut transcript_verify)
             .is_ok());
     }
 

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -427,10 +427,6 @@ mod tests {
             &mut transcript_create,
         );
 
-        let comm_1_point = comm_1.get_point().compress();
-        let comm_2_point = comm_2.get_point().compress();
-        let comm_3_point = comm_3.get_point().compress();
-
         assert!(proof
             .verify(
                 vec![&comm_1, &comm_2, &comm_3],

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -69,6 +69,8 @@ impl EqualityProof {
         opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
+        transcript.equality_proof_domain_sep();
+
         // extract the relevant scalar and Ristretto points from the inputs
         let P_EG = elgamal_keypair.public.get_point();
         let D_EG = ciphertext.handle.get_point();
@@ -127,6 +129,8 @@ impl EqualityProof {
         commitment: &PedersenCommitment,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
+        transcript.equality_proof_domain_sep();
+
         // extract the relevant scalar and Ristretto points from the inputs
         let P_EG = elgamal_pubkey.get_point();
         let C_EG = ciphertext.commitment.get_point();

--- a/zk-token-sdk/src/sigma_proofs/errors.rs
+++ b/zk-token-sdk/src/sigma_proofs/errors.rs
@@ -57,7 +57,7 @@ impl From<TranscriptError> for ZeroBalanceProofError {
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum FeeProofError {
+pub enum FeeSigmaProofError {
     #[error("the required algebraic relation does not hold")]
     AlgebraicRelation,
     #[error("malformed proof")]
@@ -68,7 +68,7 @@ pub enum FeeProofError {
     Transcript,
 }
 
-impl From<TranscriptError> for FeeProofError {
+impl From<TranscriptError> for FeeSigmaProofError {
     fn from(_err: TranscriptError) -> Self {
         Self::Transcript
     }

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -74,10 +74,14 @@ impl FeeSigmaProof {
             &mut transcript_fee_below_max,
         );
 
-        let above_max = u64::ct_gt(&max_fee, &fee_amount);
+        let below_max = u64::ct_gt(&max_fee, &fee_amount);
+
+        println!("fee amount: {}", fee_amount);
+        println!("max fee: {}", max_fee);
+        println!("below max: {:?}", below_max);
 
         // conditionally assign transcript; transcript is not conditionally selectable
-        if bool::from(above_max) {
+        if bool::from(below_max) {
             *transcript = transcript_fee_above_max;
         } else {
             *transcript = transcript_fee_below_max;
@@ -87,12 +91,12 @@ impl FeeSigmaProof {
             fee_max_proof: FeeMaxProof::conditional_select(
                 &proof_fee_above_max.fee_max_proof,
                 &proof_fee_below_max.fee_max_proof,
-                above_max,
+                below_max,
             ),
             fee_equality_proof: FeeEqualityProof::conditional_select(
                 &proof_fee_above_max.fee_equality_proof,
                 &proof_fee_below_max.fee_equality_proof,
-                above_max,
+                below_max,
             ),
         }
     }
@@ -228,6 +232,8 @@ impl FeeSigmaProof {
 
         transcript.challenge_scalar(b"w");
 
+        println!("{:?}", c);
+
         let z_x = c_equality * x + y_x;
         let z_delta = c_equality * r_delta + y_delta;
         let z_claimed = c_equality * r_claimed + y_claimed;
@@ -296,6 +302,8 @@ impl FeeSigmaProof {
         let c = transcript.challenge_scalar(b"c");
         let c_max_proof = self.fee_max_proof.c_max_proof;
         let c_equality = c - c_max_proof;
+
+        println!("{:?}", c);
 
         let w = transcript.challenge_scalar(b"w");
         let ww = w * w;

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -353,22 +353,35 @@ impl FeeSigmaProof {
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, FeeSigmaProofError> {
         let bytes = array_ref![bytes, 0, 256];
-        let (Y_max_proof, z_max_proof, c_max_proof, Y_delta, Y_claimed, z_x, z_delta, z_claimed) = 
+        let (Y_max_proof, z_max_proof, c_max_proof, Y_delta, Y_claimed, z_x, z_delta, z_claimed) =
             array_refs![bytes, 32, 32, 32, 32, 32, 32, 32, 32];
 
         let Y_max_proof = CompressedRistretto::from_slice(Y_max_proof);
-        let z_max_proof = Scalar::from_canonical_bytes(*z_max_proof).ok_or(FeeSigmaProofError::Format)?;
-        let c_max_proof = Scalar::from_canonical_bytes(*c_max_proof).ok_or(FeeSigmaProofError::Format)?;
+        let z_max_proof =
+            Scalar::from_canonical_bytes(*z_max_proof).ok_or(FeeSigmaProofError::Format)?;
+        let c_max_proof =
+            Scalar::from_canonical_bytes(*c_max_proof).ok_or(FeeSigmaProofError::Format)?;
 
         let Y_delta = CompressedRistretto::from_slice(Y_delta);
         let Y_claimed = CompressedRistretto::from_slice(Y_claimed);
         let z_x = Scalar::from_canonical_bytes(*z_x).ok_or(FeeSigmaProofError::Format)?;
         let z_delta = Scalar::from_canonical_bytes(*z_delta).ok_or(FeeSigmaProofError::Format)?;
-        let z_claimed = Scalar::from_canonical_bytes(*z_claimed).ok_or(FeeSigmaProofError::Format)?;
+        let z_claimed =
+            Scalar::from_canonical_bytes(*z_claimed).ok_or(FeeSigmaProofError::Format)?;
 
         Ok(Self {
-            fee_max_proof: FeeMaxProof { Y_max_proof, z_max_proof, c_max_proof },
-            fee_equality_proof: FeeEqualityProof { Y_delta, Y_claimed, z_x, z_delta, z_claimed },
+            fee_max_proof: FeeMaxProof {
+                Y_max_proof,
+                z_max_proof,
+                c_max_proof,
+            },
+            fee_equality_proof: FeeEqualityProof {
+                Y_delta,
+                Y_claimed,
+                z_x,
+                z_delta,
+                z_claimed,
+            },
         })
     }
 }

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -67,6 +67,8 @@ impl ValidityProof {
         opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
+        transcript.validity_proof_domain_sep();
+
         // extract the relevant scalar and Ristretto points from the inputs
         let P_dest = pubkey_dest.get_point();
         let P_auditor = pubkey_auditor.get_point();
@@ -120,6 +122,8 @@ impl ValidityProof {
         (handle_dest, handle_auditor): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofError> {
+        transcript.validity_proof_domain_sep();
+
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
         transcript.validate_and_append_point(b"Y_1", &self.Y_1)?;
@@ -235,6 +239,8 @@ impl AggregatedValidityProof {
         (opening_lo, opening_hi): (&PedersenOpening, &PedersenOpening),
         transcript: &mut Transcript,
     ) -> Self {
+        transcript.aggregated_validity_proof_domain_sep();
+
         let t = transcript.challenge_scalar(b"t");
 
         let aggregated_message = amount_lo.into() + amount_hi.into() * t;
@@ -263,6 +269,8 @@ impl AggregatedValidityProof {
         (handle_lo_auditor, handle_hi_auditor): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
     ) -> Result<(), ValidityProofError> {
+        transcript.aggregated_validity_proof_domain_sep();
+
         let t = transcript.challenge_scalar(b"t");
 
         let aggregated_commitment = commitment_lo + commitment_hi * t;

--- a/zk-token-sdk/src/sigma_proofs/validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/validity_proof.rs
@@ -62,7 +62,7 @@ impl ValidityProof {
     /// * `opening` - The opening associated with the Pedersen commitment
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn new<T: Into<Scalar>>(
-        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey), // TODO: rename pubkey_auditor
         amount: T,
         opening: &PedersenOpening,
         transcript: &mut Transcript,

--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -1,5 +1,8 @@
 use {
-    crate::errors::TranscriptError,
+    crate::{
+        zk_token_elgamal::pod,
+        errors::TranscriptError,
+    },
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar, traits::IsIdentity},
     merlin::Transcript,
 };
@@ -33,6 +36,18 @@ pub trait TranscriptProtocol {
 
     /// Append a `point` with the given `label`.
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto);
+
+    /// Append an ElGamal pubkey with the given `label`.
+    fn append_pubkey(&mut self, label: &'static [u8], point: &pod::ElGamalPubkey);
+
+    /// Append an ElGamal ciphertext with the given `label`.
+    fn append_ciphertext(&mut self, label: &'static [u8], point: &pod::ElGamalCiphertext);
+
+    /// Append a Pedersen commitment with the given `label`.
+    fn append_commitment(&mut self, label: &'static [u8], point: &pod::PedersenCommitment);
+
+    /// Append an ElGamal decryption handle with the given `label`.
+    fn append_handle(&mut self, label: &'static [u8], point: &pod::DecryptHandle);
 
     /// Check that a point is not the identity, then append it to the
     /// transcript.  Otherwise, return an error.
@@ -104,5 +119,21 @@ impl TranscriptProtocol for Transcript {
         self.challenge_bytes(label, &mut buf);
 
         Scalar::from_bytes_mod_order_wide(&buf)
+    }
+
+    fn append_pubkey(&mut self, label: &'static [u8], pubkey: &pod::ElGamalPubkey) {
+        self.append_message(label, &pubkey.0);
+    }
+
+    fn append_ciphertext(&mut self, label: &'static [u8], ciphertext: &pod::ElGamalCiphertext) {
+        self.append_message(label, &ciphertext.0);
+    }
+
+    fn append_commitment(&mut self, label: &'static [u8], commitment: &pod::PedersenCommitment) {
+        self.append_message(label, &commitment.0);
+    }
+
+    fn append_handle(&mut self, label: &'static [u8], handle: &pod::DecryptHandle) {
+        self.append_message(label, &handle.0);
     }
 }

--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        zk_token_elgamal::pod,
-        errors::TranscriptError,
-    },
+    crate::{errors::TranscriptError, zk_token_elgamal::pod},
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar, traits::IsIdentity},
     merlin::Transcript,
 };
@@ -151,21 +148,17 @@ impl TranscriptProtocol for Transcript {
 
     fn zero_balance_proof_domain_sep(&mut self) {
         self.append_message(b"dom-sep", b"zero-balance-proof")
-
     }
 
     fn validity_proof_domain_sep(&mut self) {
         self.append_message(b"dom-sep", b"validity-proof")
-
     }
 
     fn aggregated_validity_proof_domain_sep(&mut self) {
         self.append_message(b"dom-sep", b"aggregated-validity-proof")
-
     }
 
     fn fee_sigma_proof_domain_sep(&mut self) {
         self.append_message(b"dom-sep", b"fee-sigma-proof")
-
     }
 }

--- a/zk-token-sdk/src/transcript.rs
+++ b/zk-token-sdk/src/transcript.rs
@@ -22,9 +22,6 @@ pub trait TranscriptProtocol {
     /// Append a domain separator for close account proof.
     fn close_account_proof_domain_sep(&mut self);
 
-    /// Append a domain separator for update account public key proof.
-    fn update_account_public_key_proof_domain_sep(&mut self);
-
     /// Append a domain separator for withdraw proof.
     fn withdraw_proof_domain_sep(&mut self);
 
@@ -48,6 +45,21 @@ pub trait TranscriptProtocol {
 
     /// Append an ElGamal decryption handle with the given `label`.
     fn append_handle(&mut self, label: &'static [u8], point: &pod::DecryptHandle);
+
+    /// Append a domain separator for equality proof.
+    fn equality_proof_domain_sep(&mut self);
+
+    /// Append a domain separator for zero-balance proof.
+    fn zero_balance_proof_domain_sep(&mut self);
+
+    /// Append a domain separator for validity proof.
+    fn validity_proof_domain_sep(&mut self);
+
+    /// Append a domain separator for aggregated validity proof.
+    fn aggregated_validity_proof_domain_sep(&mut self);
+
+    /// Append a domain separator for fee sigma proof.
+    fn fee_sigma_proof_domain_sep(&mut self);
 
     /// Check that a point is not the identity, then append it to the
     /// transcript.  Otherwise, return an error.
@@ -79,10 +91,6 @@ impl TranscriptProtocol for Transcript {
 
     fn close_account_proof_domain_sep(&mut self) {
         self.append_message(b"dom-sep", b"CloseAccountProof");
-    }
-
-    fn update_account_public_key_proof_domain_sep(&mut self) {
-        self.append_message(b"dom-sep", b"UpdateAccountPublicKeyProof");
     }
 
     fn withdraw_proof_domain_sep(&mut self) {
@@ -135,5 +143,29 @@ impl TranscriptProtocol for Transcript {
 
     fn append_handle(&mut self, label: &'static [u8], handle: &pod::DecryptHandle) {
         self.append_message(label, &handle.0);
+    }
+
+    fn equality_proof_domain_sep(&mut self) {
+        self.append_message(b"dom-sep", b"equality-proof")
+    }
+
+    fn zero_balance_proof_domain_sep(&mut self) {
+        self.append_message(b"dom-sep", b"zero-balance-proof")
+
+    }
+
+    fn validity_proof_domain_sep(&mut self) {
+        self.append_message(b"dom-sep", b"validity-proof")
+
+    }
+
+    fn aggregated_validity_proof_domain_sep(&mut self) {
+        self.append_message(b"dom-sep", b"aggregated-validity-proof")
+
+    }
+
+    fn fee_sigma_proof_domain_sep(&mut self) {
+        self.append_message(b"dom-sep", b"fee-sigma-proof")
+
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -25,12 +25,13 @@ mod target_arch {
             sigma_proofs::{
                 equality_proof::EqualityProof,
                 errors::*,
+                fee_proof::FeeSigmaProof,
                 validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
             instruction::{
                 transfer::{TransferAmountEncryption, TransferPubkeys},
-                transfer_with_fee::{TransferWithFeePubkeys, FeeEncryption},
+                transfer_with_fee::{TransferWithFeePubkeys, FeeEncryption, FeeParameters},
             }
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
@@ -206,6 +207,21 @@ mod target_arch {
         }
     }
 
+    impl From<FeeSigmaProof> for pod::FeeSigmaProof {
+        fn from(proof: FeeSigmaProof) -> Self {
+            Self(proof.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::FeeSigmaProof> for FeeSigmaProof {
+        type Error = FeeSigmaProofError;
+
+        fn try_from(pod: pod::FeeSigmaProof) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
+
     impl TryFrom<RangeProof> for pod::RangeProof64 {
         type Error = RangeProofError;
 
@@ -325,8 +341,8 @@ mod target_arch {
     }
 
     impl From<TransferAmountEncryption> for pod::TransferAmountEncryption {
-        fn from(proof: TransferAmountEncryption) -> Self {
-            Self(proof.to_bytes())
+        fn from(ciphertext: TransferAmountEncryption) -> Self {
+            Self(ciphertext.to_bytes())
         }
     }
 
@@ -339,8 +355,8 @@ mod target_arch {
     }
 
     impl From<FeeEncryption> for pod::FeeEncryption {
-        fn from(proof: FeeEncryption) -> Self {
-            Self(proof.to_bytes())
+        fn from(ciphertext: FeeEncryption) -> Self {
+            Self(ciphertext.to_bytes())
         }
     }
 
@@ -352,6 +368,17 @@ mod target_arch {
         }
     }
 
+    impl From<FeeParameters> for pod::FeeParameters {
+        fn from(parameters: FeeParameters) -> Self {
+            Self(parameters.to_bytes())
+        }
+    }
+
+    impl From<pod::FeeParameters> for FeeParameters {
+        fn from(pod: pod::FeeParameters) -> Self {
+            Self::from_bytes(&pod.0)
+        }
+    }
 }
 
 #[cfg(target_arch = "bpf")]

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -262,6 +262,20 @@ mod target_arch {
         }
     }
 
+    impl From<TransferPubkeys> for pod::TransferPubkeys {
+        fn from(keys: TransferPubkeys) -> Self {
+            Self(keys.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::TransferPubkeys> for TransferPubkeys {
+        type Error = ProofError;
+
+        fn try_from(pod: pod::TransferPubkeys) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
     impl From<ElGamalGroupEncryption> for pod::ElGamalGroupEncryption {
         fn from(proof: ElGamalGroupEncryption) -> Self {
             Self(proof.to_bytes())

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -261,6 +261,20 @@ mod target_arch {
             Self::from_bytes(&pod.0)
         }
     }
+
+    impl From<ElGamalGroupEncryption> for pod::ElGamalGroupEncryption {
+        fn from(proof: ElGamalGroupEncryption) -> Self {
+            Self(proof.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::ElGamalGroupEncryption> for ElGamalGroupEncryption {
+        type Error = ProofError;
+
+        fn try_from(pod: pod::ElGamalGroupEncryption) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
 }
 
 #[cfg(target_arch = "bpf")]

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -28,7 +28,7 @@ mod target_arch {
                 validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
-            instruction::transfer::{ElGamalGroupEncryption, TransferPubkeys},
+            instruction::transfer::{TransferAmountEncryption, TransferPubkeys},
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -276,16 +276,16 @@ mod target_arch {
         }
     }
 
-    impl From<ElGamalGroupEncryption> for pod::ElGamalGroupEncryption {
-        fn from(proof: ElGamalGroupEncryption) -> Self {
+    impl From<TransferAmountEncryption> for pod::TransferAmountEncryption {
+        fn from(proof: TransferAmountEncryption) -> Self {
             Self(proof.to_bytes())
         }
     }
 
-    impl TryFrom<pod::ElGamalGroupEncryption> for ElGamalGroupEncryption {
+    impl TryFrom<pod::TransferAmountEncryption> for TransferAmountEncryption {
         type Error = ProofError;
 
-        fn try_from(pod: pod::ElGamalGroupEncryption) -> Result<Self, Self::Error> {
+        fn try_from(pod: pod::TransferAmountEncryption) -> Result<Self, Self::Error> {
             Self::from_bytes(&pod.0)
         }
     }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -28,7 +28,10 @@ mod target_arch {
                 validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
-            instruction::transfer::{TransferAmountEncryption, TransferPubkeys},
+            instruction::{
+                transfer::{TransferAmountEncryption, TransferPubkeys},
+                transfer_with_fee::{TransferWithFeePubkeys, FeeEncryption},
+            }
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -262,6 +265,37 @@ mod target_arch {
         }
     }
 
+    #[cfg(not(target_arch = "bpf"))]
+    impl TryFrom<RangeProof> for pod::RangeProof256 {
+        type Error = RangeProofError;
+
+        fn try_from(proof: RangeProof) -> Result<Self, Self::Error> {
+            if proof.ipp_proof.serialized_size() != 576 {
+                return Err(RangeProofError::Format);
+            }
+
+            let mut buf = [0_u8; 800];
+            buf[..32].copy_from_slice(proof.A.as_bytes());
+            buf[32..64].copy_from_slice(proof.S.as_bytes());
+            buf[64..96].copy_from_slice(proof.T_1.as_bytes());
+            buf[96..128].copy_from_slice(proof.T_2.as_bytes());
+            buf[128..160].copy_from_slice(proof.t_x.as_bytes());
+            buf[160..192].copy_from_slice(proof.t_x_blinding.as_bytes());
+            buf[192..224].copy_from_slice(proof.e_blinding.as_bytes());
+            buf[224..800].copy_from_slice(&proof.ipp_proof.to_bytes());
+            Ok(pod::RangeProof256(buf))
+        }
+    }
+
+    impl TryFrom<pod::RangeProof256> for RangeProof {
+        type Error = RangeProofError;
+
+        fn try_from(pod: pod::RangeProof256) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
+
     impl From<TransferPubkeys> for pod::TransferPubkeys {
         fn from(keys: TransferPubkeys) -> Self {
             Self(keys.to_bytes())
@@ -272,6 +306,20 @@ mod target_arch {
         type Error = ProofError;
 
         fn try_from(pod: pod::TransferPubkeys) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
+    impl From<TransferWithFeePubkeys> for pod::TransferWithFeePubkeys {
+        fn from(keys: TransferWithFeePubkeys) -> Self {
+            Self(keys.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::TransferWithFeePubkeys> for TransferWithFeePubkeys {
+        type Error = ProofError;
+
+        fn try_from(pod: pod::TransferWithFeePubkeys) -> Result<Self, Self::Error> {
             Self::from_bytes(&pod.0)
         }
     }
@@ -289,6 +337,21 @@ mod target_arch {
             Self::from_bytes(&pod.0)
         }
     }
+
+    impl From<FeeEncryption> for pod::FeeEncryption {
+        fn from(proof: FeeEncryption) -> Self {
+            Self(proof.to_bytes())
+        }
+    }
+
+    impl TryFrom<pod::FeeEncryption> for FeeEncryption {
+        type Error = ProofError;
+
+        fn try_from(pod: pod::FeeEncryption) -> Result<Self, Self::Error> {
+            Self::from_bytes(&pod.0)
+        }
+    }
+
 }
 
 #[cfg(target_arch = "bpf")]

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -318,7 +318,7 @@ mod tests {
 
         assert!(proof_deserialized
             .verify(
-                vec![&comm.get_point().compress()],
+                vec![&comm],
                 vec![64],
                 &mut transcript_verify
             )
@@ -346,16 +346,12 @@ mod tests {
             &mut transcript_create,
         );
 
-        let comm_1_point = comm_1.get_point().compress();
-        let comm_2_point = comm_2.get_point().compress();
-        let comm_3_point = comm_3.get_point().compress();
-
         let proof_serialized: pod::RangeProof128 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
 
         assert!(proof_deserialized
             .verify(
-                vec![&comm_1_point, &comm_2_point, &comm_3_point],
+                vec![&comm_1, &comm_2, &comm_3],
                 vec![64, 32, 32],
                 &mut transcript_verify,
             )

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -21,6 +21,10 @@ mod target_arch {
                 pedersen::PedersenCommitment,
             },
             errors::ProofError,
+            instruction::{
+                transfer::{TransferAmountEncryption, TransferPubkeys},
+                transfer_with_fee::{FeeEncryption, FeeParameters, TransferWithFeePubkeys},
+            },
             range_proof::{errors::RangeProofError, RangeProof},
             sigma_proofs::{
                 equality_proof::EqualityProof,
@@ -29,10 +33,6 @@ mod target_arch {
                 validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
-            instruction::{
-                transfer::{TransferAmountEncryption, TransferPubkeys},
-                transfer_with_fee::{TransferWithFeePubkeys, FeeEncryption, FeeParameters},
-            }
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
@@ -221,7 +221,6 @@ mod target_arch {
         }
     }
 
-
     impl TryFrom<RangeProof> for pod::RangeProof64 {
         type Error = RangeProofError;
 
@@ -310,7 +309,6 @@ mod target_arch {
             Self::from_bytes(&pod.0)
         }
     }
-
 
     impl From<TransferPubkeys> for pod::TransferPubkeys {
         fn from(keys: TransferPubkeys) -> Self {
@@ -407,11 +405,7 @@ mod tests {
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
 
         assert!(proof_deserialized
-            .verify(
-                vec![&comm],
-                vec![64],
-                &mut transcript_verify
-            )
+            .verify(vec![&comm], vec![64], &mut transcript_verify)
             .is_ok());
 
         // should fail to serialize to pod::RangeProof128

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -28,6 +28,7 @@ mod target_arch {
                 validity_proof::{AggregatedValidityProof, ValidityProof},
                 zero_balance_proof::ZeroBalanceProof,
             },
+            instruction::transfer::{ElGamalGroupEncryption, TransferPubkeys},
         },
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -136,3 +136,24 @@ impl Default for AeCiphertext {
         Self::zeroed()
     }
 }
+
+/// Serialization of group encryption used in the transfer instruction
+//  TODO: refactor this code into the instruction mod
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct TransferPubkeys(pub [u8; 96]);
+
+// `ElGamalGroupEncryption` is a Pod and Zeroable.
+// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
+unsafe impl Zeroable for TransferPubkeys {}
+unsafe impl Pod for TransferPubkeys {}
+
+/// Serialization of group encryption used in the transfer instruction
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct ElGamalGroupEncryption(pub [u8; 128]);
+
+// `ElGamalGroupEncryption` is a Pod and Zeroable.
+// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
+unsafe impl Zeroable for ElGamalGroupEncryption {}
+unsafe impl Pod for ElGamalGroupEncryption {}

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -115,6 +115,17 @@ pub struct RangeProof128(pub [u8; 736]);
 unsafe impl Zeroable for RangeProof128 {}
 unsafe impl Pod for RangeProof128 {}
 
+/// Serialization of range proofs for 128-bit numbers (for `TransferRangeProof` instruction)
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct RangeProof256(pub [u8; 800]);
+
+// `PodRangeProof256` is a Pod and Zeroable.
+// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
+unsafe impl Zeroable for RangeProof256 {}
+unsafe impl Pod for RangeProof256 {}
+
+
 /// Serialization for AeCiphertext
 #[derive(Clone, Copy, PartialEq)]
 #[repr(transparent)]
@@ -137,19 +148,25 @@ impl Default for AeCiphertext {
     }
 }
 
-/// Serialization of group encryption used in the transfer instruction
-//  TODO: refactor this code into the instruction mod
+// TODO: refactor this code into the instruction module
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct TransferPubkeys(pub [u8; 96]);
 
-// `TransferPubkeys` is a Pod and Zeroable.
-// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
 unsafe impl Zeroable for TransferPubkeys {}
 unsafe impl Pod for TransferPubkeys {}
 
-/// Serialization of group encryption used in the transfer instruction
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct TransferWithFeePubkeys(pub [u8; 128]);
+
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
 pub struct TransferAmountEncryption(pub [u8; 128]);
 
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct FeeEncryption(pub [u8; 96]);
+
+unsafe impl Zeroable for FeeEncryption {}
+unsafe impl Pod for FeeEncryption {}

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -143,17 +143,13 @@ impl Default for AeCiphertext {
 #[repr(transparent)]
 pub struct TransferPubkeys(pub [u8; 96]);
 
-// `ElGamalGroupEncryption` is a Pod and Zeroable.
+// `TransferPubkeys` is a Pod and Zeroable.
 // Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
 unsafe impl Zeroable for TransferPubkeys {}
 unsafe impl Pod for TransferPubkeys {}
 
 /// Serialization of group encryption used in the transfer instruction
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
-pub struct ElGamalGroupEncryption(pub [u8; 128]);
+pub struct TransferAmountEncryption(pub [u8; 128]);
 
-// `ElGamalGroupEncryption` is a Pod and Zeroable.
-// Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
-unsafe impl Zeroable for ElGamalGroupEncryption {}
-unsafe impl Pod for ElGamalGroupEncryption {}

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -95,6 +95,11 @@ pub struct ZeroBalanceProof(pub [u8; 96]);
 unsafe impl Zeroable for ZeroBalanceProof {}
 unsafe impl Pod for ZeroBalanceProof {}
 
+/// Serialization of fee sigma proof
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct FeeSigmaProof(pub [u8; 256]);
+
 /// Serialization of range proofs for 64-bit numbers (for `Withdraw` instruction)
 #[derive(Clone, Copy)]
 #[repr(transparent)]
@@ -170,3 +175,10 @@ pub struct FeeEncryption(pub [u8; 96]);
 
 unsafe impl Zeroable for FeeEncryption {}
 unsafe impl Pod for FeeEncryption {}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct FeeParameters(pub [u8; 10]);
+
+unsafe impl Zeroable for FeeParameters {}
+unsafe impl Pod for FeeParameters {}

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -130,7 +130,6 @@ pub struct RangeProof256(pub [u8; 800]);
 unsafe impl Zeroable for RangeProof256 {}
 unsafe impl Pod for RangeProof256 {}
 
-
 /// Serialization for AeCiphertext
 #[derive(Clone, Copy, PartialEq)]
 #[repr(transparent)]


### PR DESCRIPTION
#### Summary of Changes

Doing a pass over the zk instructions:
- Cleaned up transcript generation for each instructions. The transcript now includes all public input to the sigma proofs, which is important for security.
- Added transfer-with-fee instruction algorithms.
- Added pod structs for data that are used in transfer and transfer-with-fee instructions.

I still has to add some docs for the code. I will think about the best way to do that and add it in a separate PR.