### PR TITLE
Cleanup serde snapshot common.rs

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -44,7 +44,6 @@ use {
     },
 };
 
-mod common;
 mod newer;
 mod storage;
 mod tests;

--- a/runtime/src/serde_snapshot/common.rs
+++ b/runtime/src/serde_snapshot/common.rs
@@ -1,8 +1,0 @@
-use {super::*, std::collections::HashSet};
-
-#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]
-pub(crate) struct UnusedAccounts {
-    unused1: HashSet<Pubkey>,
-    unused2: HashSet<Pubkey>,
-    unused3: HashMap<Pubkey, u64>,
-}

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -1,16 +1,22 @@
 use {
     super::{
-        common::UnusedAccounts,
         storage::SerializableAccountStorageEntry,
         utils::{serialize_iter_as_map, serialize_iter_as_seq},
         *,
     },
     crate::{ancestors::AncestorsForSerialization, stakes::StakesCache},
     solana_measure::measure::Measure,
-    std::{cell::RefCell, sync::RwLock},
+    std::{cell::RefCell, collections::HashSet, sync::RwLock},
 };
 
 type AccountsDbFields = super::AccountsDbFields<SerializableAccountStorageEntry>;
+
+#[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize, AbiExample)]
+struct UnusedAccounts {
+    unused1: HashSet<Pubkey>,
+    unused2: HashSet<Pubkey>,
+    unused3: HashMap<Pubkey, u64>,
+}
 
 // Deserializable version of Bank which need not be serializable,
 // because it's handled by SerializableVersionedBank.

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -305,7 +305,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "7PcarCw6gpw9Yw8xypdxQP24TFjLiaHyuDkq95cgwtte")]
+    #[frozen_abi(digest = "HVyzePMkma8T54PymRW32FAgDXpSdom59K6RnPsCNJjj")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
Some cleanup of serde snapshot to prep for subsequent PRs that move around/add more stuff. This one moves `UnusedAccounts` into `newer` and removes `common`.

Related to #21604 