### PR TITLE
Add moniker_override to solana CLI config

### DIFF
--- a/clap-utils/src/clusters.rs
+++ b/clap-utils/src/clusters.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+
+pub enum Clusters {
+    Testnet,
+    MainnetBeta,
+    Devnet,
+    Development,
+    Custom,
+}
+
+impl Clusters {
+    pub fn get_cluster(moniker: &str) -> Self {
+        match moniker {
+            "t" | "testnet" => Clusters::Testnet,
+            "m" | "mainnet-beta" => Clusters::MainnetBeta,
+            "d" | "devnet" => Clusters::Devnet,
+            "l" | "localhost" => Clusters::Development,
+            _ => Clusters::Custom,
+        }
+    }
+
+    fn as_str(&self) -> String {
+        match self {
+            Clusters::Testnet => "t",
+            Clusters::MainnetBeta => "m",
+            Clusters::Devnet => "d",
+            Clusters::Development => "l",
+            Clusters::Custom => "c",
+        }
+        .to_string()
+    }
+
+    fn get_public_url(&self) -> String {
+        match self {
+            Clusters::Testnet => "https://api.testnet.solana.com",
+            Clusters::MainnetBeta => "https://api.mainnet-beta.solana.com",
+            Clusters::Devnet => "https://api.devnet.solana.com",
+            Clusters::Development => "http://localhost:8899",
+            Clusters::Custom => "",
+        }
+        .to_string()
+    }
+
+    pub fn get_rpc_url(&self, custom: &HashMap<String, String>) -> String {
+        custom
+            .get(&self.as_str())
+            .unwrap_or(&self.get_public_url())
+            .to_string()
+    }
+}

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -195,6 +195,16 @@ where
     }
 }
 
+pub fn is_url_or_moniker_or_custom<T>(string: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    if string.to_string() == "c".to_string() {
+        return Ok(());
+    }
+    is_url_or_moniker(string)
+}
+
 pub fn is_url_or_moniker<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -199,7 +199,7 @@ pub fn is_url_or_moniker_or_custom<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    if string.to_string() == "c".to_string() {
+    if string.to_string() == *"c" {
         return Ok(());
     }
     is_url_or_moniker(string)

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -23,6 +23,7 @@ impl std::fmt::Debug for DisplayError {
     }
 }
 
+pub mod clusters;
 pub mod fee_payer;
 pub mod input_parsers;
 pub mod input_validators;

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -67,8 +67,8 @@ pub struct Config {
     /// A moniker override config
     ///
     /// Optional YAML map to override moniker settings to custom set ones
-    #[serde(default)]
-    pub moniker_override: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub moniker_override: HashMap<String, String>,
 }
 
 impl Default for Config {
@@ -92,7 +92,7 @@ impl Default for Config {
 
         let commitment = "confirmed".to_string();
 
-        let moniker_override = None;
+        let moniker_override = HashMap::<String, String>::new();
 
         Self {
             json_rpc_url,

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -100,7 +100,7 @@ impl Default for Config {
             keypair_path,
             address_labels,
             commitment,
-            moniker_override
+            moniker_override,
         }
     }
 }

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -64,6 +64,11 @@ pub struct Config {
     /// `solana_sdk::commitment_config::CommitmentLevel::Confirmed`.
     #[serde(default)]
     pub commitment: String,
+    /// A moniker override config
+    ///
+    /// Optional YAML map to override moniker settings to custom set ones
+    #[serde(default)]
+    pub moniker_override: Option<HashMap<String, String>>,
 }
 
 impl Default for Config {
@@ -87,12 +92,15 @@ impl Default for Config {
 
         let commitment = "confirmed".to_string();
 
+        let moniker_override = None;
+
         Self {
             json_rpc_url,
             websocket_url,
             keypair_path,
             address_labels,
             commitment,
+            moniker_override
         }
     }
 }

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -34,7 +34,7 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .value_name("URL_OR_MONIKER")
                 .takes_value(true)
                 .global(true)
-                .validator(is_url_or_moniker)
+                .validator(is_url_or_moniker_or_custom)
                 .help(
                     "URL for Solana's JSON RPC or moniker (or their first letter): \
                        [mainnet-beta, testnet, devnet, localhost]",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ use {
     clap::{crate_description, crate_name, value_t_or_exit, ArgMatches},
     console::style,
     solana_clap_utils::{
-        input_validators::normalize_to_url_if_moniker,
+        clusters::Clusters,
         keypair::{CliSigners, DefaultSigner},
         DisplayError,
     },
@@ -89,15 +89,9 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 }
                 ("set", Some(subcommand_matches)) => {
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
-                        let json_rpc_url = normalize_to_url_if_moniker(url);
-                        let empty = &HashMap::<String, String>::new();
-                        config.json_rpc_url = config
-                            .moniker_override
-                            .as_ref()
-                            .unwrap_or(empty)
-                            .get(url)
-                            .unwrap_or(&json_rpc_url)
-                            .to_string();
+                        let cluster = Clusters::get_cluster(url);
+                        config.json_rpc_url =
+                            Clusters::get_rpc_url(&cluster, &config.moniker_override);
                         // Revert to a computed `websocket_url` value when `json_rpc_url` is
                         // changed
                         config.websocket_url = "".to_string();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,11 +89,15 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 }
                 ("set", Some(subcommand_matches)) => {
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
-
                         let json_rpc_url = normalize_to_url_if_moniker(url);
                         let empty = &HashMap::<String, String>::new();
-                        config.json_rpc_url = config.moniker_override.as_ref()
-                                             .unwrap_or(empty).get(url).unwrap_or(&json_rpc_url).to_string();
+                        config.json_rpc_url = config
+                            .moniker_override
+                            .as_ref()
+                            .unwrap_or(empty)
+                            .get(url)
+                            .unwrap_or(&json_rpc_url)
+                            .to_string();
                         // Revert to a computed `websocket_url` value when `json_rpc_url` is
                         // changed
                         config.websocket_url = "".to_string();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -89,7 +89,11 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 }
                 ("set", Some(subcommand_matches)) => {
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
-                        config.json_rpc_url = normalize_to_url_if_moniker(url);
+
+                        let json_rpc_url = normalize_to_url_if_moniker(url);
+                        let empty = &HashMap::<String, String>::new();
+                        config.json_rpc_url = config.moniker_override.as_ref()
+                                             .unwrap_or(empty).get(url).unwrap_or(&json_rpc_url).to_string();
                         // Revert to a computed `websocket_url` value when `json_rpc_url` is
                         // changed
                         config.websocket_url = "".to_string();


### PR DESCRIPTION
#### Problem
`solana config set -u d` this always sets the RPC to `https://api.devnet.solana.com`.
Or `-m` always sets to `https://api.mainnet-beta.solana.com`.
This isn't ideal if you want to switch between custom RPCs with ease. This change lets users define a custom RPC for the shorthand monikers. I wanted to let users define custom monikers like `z`, but changing input-validators was giving me grief. maybe later.

```yaml
...
moniker_override:
  m: "https://my-mainnet-rpc.io"
  d: "https://fast-devnet-rpc.io"
```

#### Summary of Changes
Add moniker_override optional setting to config.yaml. 
