### PR TITLE
Support sending VersionedTransaction in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,6 +4503,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures 0.3.19",
+ "log 0.4.14",
  "solana-banks-interface",
  "solana-runtime",
  "solana-sdk",

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -11,7 +11,7 @@ use {
         message::Message,
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, Transaction, TransactionError},
+        transaction::{self, Transaction, TransactionError, VersionedTransaction},
     },
 };
 
@@ -63,6 +63,10 @@ pub trait Banks {
     ) -> BanksTransactionResultWithSimulation;
     async fn process_transaction_with_commitment_and_context(
         transaction: Transaction,
+        commitment: CommitmentLevel,
+    ) -> Option<transaction::Result<()>>;
+    async fn process_versioned_transaction_with_commitment_and_context(
+        transaction: VersionedTransaction,
         commitment: CommitmentLevel,
     ) -> Option<transaction::Result<()>>;
     async fn get_account_with_commitment_and_context(

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 bincode = "1.3.3"
 crossbeam-channel = "0.5"
 futures = "0.3"
+log = "0.4.11"
 solana-banks-interface = { path = "../banks-interface", version = "=1.10.0" }
 solana-runtime = { path = "../runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -2,6 +2,7 @@ use {
     bincode::{deserialize, serialize},
     crossbeam_channel::{unbounded, Receiver, Sender},
     futures::{future, prelude::stream::StreamExt},
+    log::warn,
     solana_banks_interface::{
         Banks, BanksRequest, BanksResponse, BanksTransactionResultWithSimulation,
         TransactionConfirmationStatus, TransactionSimulationDetails, TransactionStatus,
@@ -21,7 +22,7 @@ use {
         message::{Message, SanitizedMessage},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, SanitizedTransaction, Transaction},
+        transaction::{self, SanitizedTransaction, Transaction, VersionedTransaction},
     },
     solana_send_transaction_service::{
         send_transaction_service::{SendTransactionService, TransactionInfo},
@@ -79,12 +80,15 @@ impl BanksServer {
             while let Ok(info) = transaction_receiver.try_recv() {
                 transaction_infos.push(info);
             }
-            let transactions: Vec<_> = transaction_infos
+            let transactions: Vec<VersionedTransaction> = transaction_infos
                 .into_iter()
                 .map(|info| deserialize(&info.wire_transaction).unwrap())
                 .collect();
             let bank = bank_forks.read().unwrap().working_bank();
-            let _ = bank.try_process_transactions(transactions.iter());
+            let res = bank.try_process_entry_transactions(transactions);
+            if let Err(err) = res {
+                warn!("failed to process transactions: {:?}", err);
+            }
         }
     }
 
@@ -156,6 +160,20 @@ fn verify_transaction(
         Err(err)
     } else if let Err(err) = transaction.verify_precompiles(feature_set) {
         Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_versioned_transaction(
+    transaction: &VersionedTransaction,
+    _feature_set: &Arc<FeatureSet>,
+) -> transaction::Result<()> {
+    if let Err(err) = transaction.verify_and_hash_message() {
+        Err(err)
+    // TODO: Can't verify precompiles without looking up address map accounts...
+    //} else if let Err(err) = transaction.verify_precompiles(feature_set) {
+    //    Err(err)
     } else {
         Ok(())
     }
@@ -297,6 +315,36 @@ impl Banks for BanksServer {
         }
 
         let blockhash = &transaction.message.recent_blockhash;
+        let last_valid_block_height = self
+            .bank(commitment)
+            .get_blockhash_last_valid_block_height(blockhash)
+            .unwrap();
+        let signature = transaction.signatures.get(0).cloned().unwrap_or_default();
+        let info = TransactionInfo::new(
+            signature,
+            serialize(&transaction).unwrap(),
+            last_valid_block_height,
+            None,
+            None,
+        );
+        self.transaction_sender.send(info).unwrap();
+        self.poll_signature_status(&signature, blockhash, last_valid_block_height, commitment)
+            .await
+    }
+
+    async fn process_versioned_transaction_with_commitment_and_context(
+        self,
+        _: Context,
+        transaction: VersionedTransaction,
+        commitment: CommitmentLevel,
+    ) -> Option<transaction::Result<()>> {
+        if let Err(err) =
+            verify_versioned_transaction(&transaction, &self.bank(commitment).feature_set)
+        {
+            return Some(Err(err));
+        }
+
+        let blockhash = &transaction.message.recent_blockhash();
         let last_valid_block_height = self
             .bank(commitment)
             .get_blockhash_last_valid_block_height(blockhash)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3351,8 +3351,8 @@ impl Bank {
             .into_iter()
             .map(|tx| {
                 let message_hash = tx.message.hash();
-                SanitizedTransaction::try_create(tx, message_hash, None, |_| {
-                    Err(TransactionError::UnsupportedVersion)
+                SanitizedTransaction::try_create(tx, message_hash, None, |lookups| {
+                    self.load_lookup_table_addresses(lookups)
                 })
             })
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
#### Problem
- There was no way to create a `VersionedTransaction` from instructions and address lookup tables.
- There was no way to send these transactions in a test through `banks-client`
- The `Bank` rejected them because it didn't support receiving transactions with address maps from `banks-server`

#### Summary of Changes
- Fix `prepare_entry_batch()` in `Bank` to lookup table addresses.
- Add `process_versioned_transaction_with_commitment_and_context()` etc to `banks-{interface,client,server}` for use in tests.
- Add `v0::Message::new_*` functions to conveniently make instances.

#### Open questions
- Check `verify_versioned_transaction()` in banks_server: 
  For non-versioned transactions there's a `transaction.verify_precompiles()` that I haven't transfered over yet. Are program addresses guaranteed to be in the static address list, and not come from address lookup tables?
- Check the api and names of the `v0::Message::new_*()` functions.
  I copied liberally from the legacy message but think naming could be better.
- Also look at `pub struct AddressLookupTable` in versions/v0/mod.rs.
  I need information about the contents of the lookup tables to be able to compile instructions. Is there an existing data structure I should use instead?

@jstarry 
