### PR TITLE
Retaining transaction logs when transaction plugin is loaded.

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3040,6 +3040,7 @@ mod tests {
                 true,
                 None,
                 blockstore.clone(),
+                false,
                 &Arc::new(AtomicBool::new(false)),
             );
 
@@ -3052,7 +3053,6 @@ mod tests {
                 0,
                 Some(TransactionStatusSender {
                     sender: transaction_status_sender,
-                    enable_cpi_and_log_storage: false,
                 }),
                 &gossip_vote_sender,
                 &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
@@ -3199,6 +3199,7 @@ mod tests {
                 true,
                 None,
                 blockstore.clone(),
+                false,
                 &Arc::new(AtomicBool::new(false)),
             );
 
@@ -3211,7 +3212,6 @@ mod tests {
                 0,
                 Some(TransactionStatusSender {
                     sender: transaction_status_sender,
-                    enable_cpi_and_log_storage: false,
                 }),
                 &gossip_vote_sender,
                 &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1505,7 +1505,6 @@ fn initialize_rpc_transaction_history_services(
     let (transaction_status_sender, transaction_status_receiver) = unbounded();
     let transaction_status_sender = Some(TransactionStatusSender {
         sender: transaction_status_sender,
-        enable_cpi_and_log_storage,
     });
     let transaction_status_service = Some(TransactionStatusService::new(
         transaction_status_receiver,
@@ -1513,6 +1512,7 @@ fn initialize_rpc_transaction_history_services(
         enable_rpc_transaction_history,
         transaction_notifier.clone(),
         blockstore.clone(),
+        enable_cpi_and_log_storage,
         exit,
     ));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1305,7 +1305,7 @@ fn new_banks_from_ledger(
                 blockstore.clone(),
                 exit,
                 enable_rpc_transaction_history,
-                config.rpc_config.enable_cpi_and_log_storage || transaction_notifier.is_some(),
+                config.rpc_config.enable_cpi_and_log_storage,
                 transaction_notifier,
             )
         } else {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1305,7 +1305,7 @@ fn new_banks_from_ledger(
                 blockstore.clone(),
                 exit,
                 enable_rpc_transaction_history,
-                config.rpc_config.enable_cpi_and_log_storage,
+                config.rpc_config.enable_cpi_and_log_storage || transaction_notifier.is_some(),
                 transaction_notifier,
             )
         } else {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1488,7 +1488,6 @@ pub struct TransactionStatusBatch {
 #[derive(Clone)]
 pub struct TransactionStatusSender {
     pub sender: Sender<TransactionStatusMessage>,
-    pub enable_cpi_and_log_storage: bool,
 }
 
 impl TransactionStatusSender {
@@ -1496,20 +1495,13 @@ impl TransactionStatusSender {
         &self,
         bank: Arc<Bank>,
         transactions: Vec<SanitizedTransaction>,
-        mut execution_results: Vec<TransactionExecutionResult>,
+        execution_results: Vec<TransactionExecutionResult>,
         balances: TransactionBalancesSet,
         token_balances: TransactionTokenBalancesSet,
         rent_debits: Vec<RentDebits>,
     ) {
         let slot = bank.slot();
-        if !self.enable_cpi_and_log_storage {
-            execution_results.iter_mut().for_each(|execution_result| {
-                if let TransactionExecutionResult::Executed(details) = execution_result {
-                    details.log_messages.take();
-                    details.inner_instructions.take();
-                }
-            });
-        }
+
         if let Err(e) = self
             .sender
             .send(TransactionStatusMessage::Batch(TransactionStatusBatch {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4330,6 +4330,7 @@ pub fn create_test_transactions_and_populate_blockstore(
             true,
             None,
             blockstore,
+            false,
             &Arc::new(AtomicBool::new(false)),
         );
 
@@ -4343,7 +4344,6 @@ pub fn create_test_transactions_and_populate_blockstore(
             Some(
                 &solana_ledger::blockstore_processor::TransactionStatusSender {
                     sender: transaction_status_sender,
-                    enable_cpi_and_log_storage: false,
                 },
             ),
             Some(&replay_vote_sender),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -34,6 +34,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: Arc<Blockstore>,
+        enable_cpi_and_log_storage: bool,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let exit = exit.clone();
@@ -50,6 +51,7 @@ impl TransactionStatusService {
                     enable_rpc_transaction_history,
                     transaction_notifier.clone(),
                     &blockstore,
+                    enable_cpi_and_log_storage,
                 ) {
                     break;
                 }
@@ -64,6 +66,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: &Arc<Blockstore>,
+        enable_cpi_and_log_storage: bool,
     ) -> Result<(), RecvTimeoutError> {
         match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))? {
             TransactionStatusMessage::Batch(TransactionStatusBatch {
@@ -142,7 +145,7 @@ impl TransactionStatusService {
                                 .collect(),
                         );
                         let loaded_addresses = transaction.get_loaded_addresses();
-                        let transaction_status_meta = TransactionStatusMeta {
+                        let mut transaction_status_meta = TransactionStatusMeta {
                             status,
                             fee,
                             pre_balances,
@@ -163,6 +166,12 @@ impl TransactionStatusService {
                                 &transaction,
                             );
                         }
+
+                        if !enable_cpi_and_log_storage {
+                            transaction_status_meta.log_messages.take();
+                            transaction_status_meta.inner_instructions.take();
+                        }
+
                         if enable_rpc_transaction_history {
                             if let Some(memos) = extract_and_fmt_memos(transaction.message()) {
                                 blockstore
@@ -385,6 +394,7 @@ pub(crate) mod tests {
             false,
             Some(test_notifier.clone()),
             blockstore,
+            false,
             &exit,
         );
 

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -167,7 +167,7 @@ impl TransactionStatusService {
                             );
                         }
 
-                        if !enable_cpi_and_log_storage {
+                        if !(enable_cpi_and_log_storage || transaction_notifier.is_some()) {
                             transaction_status_meta.log_messages.take();
                             transaction_status_meta.inner_instructions.take();
                         }


### PR DESCRIPTION
#### Problem
Transaction logs are not being saved to the database through the plugin interface.

#### Summary of Changes
Retain the transaction logs when transaction notification plugin is loaded.

Fixes #
https://github.com/lijunwangs/solana-accountsdb-plugin-postgres/issues/6