### PR TITLE
Cleanup use declaration

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -42,14 +42,13 @@ use {
         },
         thread::Builder,
     },
+    storage::{SerializableStorage, SerializedAppendVecId},
 };
 
 mod newer;
 mod storage;
 mod tests;
 mod utils;
-
-use storage::{SerializableStorage, SerializedAppendVecId};
 
 // a number of test cases in accounts_db use this
 #[cfg(test)]


### PR DESCRIPTION
Cleanup the `use` declaration in `serde_snapshot.rs`.