### PR TITLE
docs-ci: prebuild cli bin with output to appease TravisCI hang check

### DIFF
--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -9,6 +9,9 @@ source ../ci/rust-version.sh stable
 
 : "${rust_stable:=}" # Pacify shellcheck
 
+# pre-build with output enabled to appease Travis CI's hang check
+"$cargo" build -p solana-cli
+
 usage=$("$cargo" stable -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
 
 out=${1:-src/cli/usage.md}


### PR DESCRIPTION
#### Problem

Docs CI `solana` bin is run in `--quiet` mode and frequently take longer than 10min to build, frequently exceeding Travis CI's no-output hang check

#### Summary of Changes

Pre-build bin w/o `--quiet`