### PR TITLE
Web3.js - enable maxRetries option to SendOptions

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -99,6 +99,8 @@ export type SendOptions = {
   skipPreflight?: boolean;
   /** preflight commitment level */
   preflightCommitment?: Commitment;
+  /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
+  maxRetries?: number;
 };
 
 /**
@@ -111,6 +113,8 @@ export type ConfirmOptions = {
   commitment?: Commitment;
   /** preflight commitment level */
   preflightCommitment?: Commitment;
+  /** Maximum number of times for the RPC node to retry sending the transaction to the leader. */
+  maxRetries?: number;
 };
 
 /**
@@ -3717,6 +3721,9 @@ export class Connection {
     const preflightCommitment =
       (options && options.preflightCommitment) || this.commitment;
 
+    if (options && options.maxRetries) {
+      config.maxRetries = options.maxRetries;
+    }
     if (skipPreflight) {
       config.skipPreflight = skipPreflight;
     }

--- a/web3.js/src/util/send-and-confirm-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-transaction.ts
@@ -24,7 +24,7 @@ export async function sendAndConfirmTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
-    maxRetries: options.maxRetries
+    maxRetries: options.maxRetries,
   };
 
   const signature = await connection.sendTransaction(

--- a/web3.js/src/util/send-and-confirm-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-transaction.ts
@@ -24,6 +24,7 @@ export async function sendAndConfirmTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
+    maxRetries: options.maxRetries
   };
 
   const signature = await connection.sendTransaction(


### PR DESCRIPTION
#### Problem

Detailed summary here - https://github.com/solana-labs/solana/pull/21181/files


#### Summary of Changes

Exposes the maxRetries option in solana/web3.js for developers to leverage the strategies specified here https://solanacookbook.com/guides/retrying-transactions.html#an-in-depth-look-at-sendtransaction

Fixes #
