### PR TITLE
Safer invoke context

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -241,10 +241,15 @@ impl<'a> InvokeContext<'a> {
         let mut sysvar_cache = SysvarCache::default();
         sysvar_cache.fill_missing_entries(|pubkey| {
             (0..transaction_context.get_number_of_accounts()).find_map(|index| {
-                if transaction_context.get_key_of_account_at_index(index) == pubkey {
+                if transaction_context
+                    .get_key_of_account_at_index(index)
+                    .unwrap()
+                    == pubkey
+                {
                     Some(
                         transaction_context
                             .get_account_at_index(index)
+                            .unwrap()
                             .borrow()
                             .clone(),
                     )
@@ -283,10 +288,13 @@ impl<'a> InvokeContext<'a> {
             return Err(InstructionError::CallDepth);
         }
 
-        let program_id = program_indices.last().map(|account_index| {
-            self.transaction_context
-                .get_key_of_account_at_index(*account_index)
-        });
+        let program_id = program_indices
+            .last()
+            .map(|account_index| {
+                self.transaction_context
+                    .get_key_of_account_at_index(*account_index)
+            })
+            .transpose()?;
         if program_id.is_none()
             && self
                 .feature_set
@@ -328,12 +336,13 @@ impl<'a> InvokeContext<'a> {
                 {
                     let account = self
                         .transaction_context
-                        .get_account_at_index(instruction_account.index_in_transaction)
+                        .get_account_at_index(instruction_account.index_in_transaction)?
                         .borrow()
                         .clone();
                     self.pre_accounts.push(PreAccount::new(
-                        self.transaction_context
-                            .get_key_of_account_at_index(instruction_account.index_in_transaction),
+                        self.transaction_context.get_key_of_account_at_index(
+                            instruction_account.index_in_transaction,
+                        )?,
                         account,
                     ));
                     return Ok(());
@@ -372,26 +381,26 @@ impl<'a> InvokeContext<'a> {
         let keyed_accounts = program_indices
             .iter()
             .map(|account_index| {
-                (
+                Ok((
                     false,
                     false,
                     self.transaction_context
-                        .get_key_of_account_at_index(*account_index),
+                        .get_key_of_account_at_index(*account_index)?,
                     self.transaction_context
-                        .get_account_at_index(*account_index),
-                )
+                        .get_account_at_index(*account_index)?,
+                ))
             })
             .chain(instruction_accounts.iter().map(|instruction_account| {
-                (
+                Ok((
                     instruction_account.is_signer,
                     instruction_account.is_writable,
                     self.transaction_context
-                        .get_key_of_account_at_index(instruction_account.index_in_transaction),
+                        .get_key_of_account_at_index(instruction_account.index_in_transaction)?,
                     self.transaction_context
-                        .get_account_at_index(instruction_account.index_in_transaction),
-                )
+                        .get_account_at_index(instruction_account.index_in_transaction)?,
+                ))
             }))
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, InstructionError>>()?;
 
         // Unsafe will be removed together with the keyed_accounts
         self.invoke_stack.push(StackFrame::new(
@@ -433,7 +442,7 @@ impl<'a> InvokeContext<'a> {
         // Verify all executable accounts have zero outstanding refs
         for account_index in program_indices.iter() {
             self.transaction_context
-                .get_account_at_index(*account_index)
+                .get_account_at_index(*account_index)?
                 .try_borrow_mut()
                 .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
         }
@@ -446,7 +455,7 @@ impl<'a> InvokeContext<'a> {
                 // Verify account has no outstanding references
                 let _ = self
                     .transaction_context
-                    .get_account_at_index(instruction_account.index_in_transaction)
+                    .get_account_at_index(instruction_account.index_in_transaction)?
                     .try_borrow_mut()
                     .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
             }
@@ -454,7 +463,7 @@ impl<'a> InvokeContext<'a> {
             pre_account_index = pre_account_index.saturating_add(1);
             let account = self
                 .transaction_context
-                .get_account_at_index(instruction_account.index_in_transaction)
+                .get_account_at_index(instruction_account.index_in_transaction)?
                 .borrow();
             pre_account
                 .verify(
@@ -521,9 +530,9 @@ impl<'a> InvokeContext<'a> {
                 < transaction_context.get_number_of_accounts()
             {
                 let key = transaction_context
-                    .get_key_of_account_at_index(instruction_account.index_in_transaction);
+                    .get_key_of_account_at_index(instruction_account.index_in_transaction)?;
                 let account = transaction_context
-                    .get_account_at_index(instruction_account.index_in_transaction);
+                    .get_account_at_index(instruction_account.index_in_transaction)?;
                 let is_writable = if before_instruction_context_push {
                     instruction_context
                         .try_borrow_account(
@@ -607,7 +616,7 @@ impl<'a> InvokeContext<'a> {
         for instruction_account in instruction_accounts.iter() {
             let account_length = self
                 .transaction_context
-                .get_account_at_index(instruction_account.index_in_transaction)
+                .get_account_at_index(instruction_account.index_in_transaction)?
                 .borrow()
                 .data()
                 .len();
@@ -630,7 +639,7 @@ impl<'a> InvokeContext<'a> {
                 && prev_size
                     != self
                         .transaction_context
-                        .get_account_at_index(account_index)
+                        .get_account_at_index(account_index)?
                         .borrow()
                         .data()
                         .len()
@@ -798,8 +807,12 @@ impl<'a> InvokeContext<'a> {
         *compute_units_consumed = 0;
         let program_id = program_indices
             .last()
-            .map(|index| *self.transaction_context.get_key_of_account_at_index(*index))
-            .unwrap_or_else(native_loader::id);
+            .map(|index| {
+                self.transaction_context
+                    .get_key_of_account_at_index(*index)
+                    .map(|pubkey| *pubkey)
+            })
+            .unwrap_or_else(|| Ok(native_loader::id()))?;
 
         let stack_height = self
             .transaction_context
@@ -1364,6 +1377,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(owned_index)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = (MAX_DEPTH + owned_index) as u8;
             invoke_context
@@ -1378,11 +1392,13 @@ mod tests {
             let data = invoke_context
                 .transaction_context
                 .get_account_at_index(not_owned_index)
+                .unwrap()
                 .borrow_mut()
                 .data()[0];
             invoke_context
                 .transaction_context
                 .get_account_at_index(not_owned_index)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = (MAX_DEPTH + not_owned_index) as u8;
             assert_eq!(
@@ -1393,6 +1409,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(not_owned_index)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = data;
 
@@ -1468,6 +1485,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(1)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = 1;
             assert_eq!(
@@ -1477,6 +1495,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(1)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = 0;
 
@@ -1484,6 +1503,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(2)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = 1;
             assert_eq!(
@@ -1493,6 +1513,7 @@ mod tests {
             invoke_context
                 .transaction_context
                 .get_account_at_index(2)
+                .unwrap()
                 .borrow_mut()
                 .data_as_mut_slice()[0] = 0;
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1010,7 +1010,10 @@ impl<'a> InvokeContext<'a> {
     }
 
     // Get pubkey of account at index
-    pub fn get_key_of_account_at_index(&self, index_in_transaction: usize) -> &Pubkey {
+    pub fn get_key_of_account_at_index(
+        &self,
+        index_in_transaction: usize,
+    ) -> Result<&Pubkey, InstructionError> {
         self.transaction_context
             .get_key_of_account_at_index(index_in_transaction)
     }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -271,7 +271,8 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         for instruction_account in instruction_accounts.iter() {
             let account_key = invoke_context
                 .transaction_context
-                .get_key_of_account_at_index(instruction_account.index_in_transaction);
+                .get_key_of_account_at_index(instruction_account.index_in_transaction)
+                .unwrap();
             let account_info_index = account_infos
                 .iter()
                 .position(|account_info| account_info.unsigned_key() == account_key)
@@ -281,6 +282,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             let mut account = invoke_context
                 .transaction_context
                 .get_account_at_index(instruction_account.index_in_transaction)
+                .unwrap()
                 .borrow_mut();
             account.copy_into_owner_from_slice(account_info.owner.as_ref());
             account.set_data_from_slice(&account_info.try_borrow_data().unwrap());
@@ -309,6 +311,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             let account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow_mut();
             let account_info = &account_infos[account_info_index];
             **account_info.try_borrow_mut_lamports().unwrap() = account.lamports();

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -493,6 +493,7 @@ mod tests {
             let account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow();
             assert_eq!(account.lamports(), account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
@@ -518,6 +519,7 @@ mod tests {
             let mut account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow_mut();
             account.set_lamports(0);
             account.set_data(vec![0; 0]);
@@ -536,6 +538,7 @@ mod tests {
             let account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow();
             assert_eq!(&*account, original_account);
         }
@@ -567,6 +570,7 @@ mod tests {
             let account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow();
             assert_eq!(account.lamports(), account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
@@ -579,6 +583,7 @@ mod tests {
             let mut account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow_mut();
             account.set_lamports(0);
             account.set_data(vec![0; 0]);
@@ -596,6 +601,7 @@ mod tests {
             let account = invoke_context
                 .transaction_context
                 .get_account_at_index(index_in_transaction)
+                .unwrap()
                 .borrow();
             assert_eq!(&*account, original_account);
         }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2546,10 +2546,12 @@ where
     for instruction_account in instruction_accounts.iter() {
         let account = invoke_context
             .transaction_context
-            .get_account_at_index(instruction_account.index_in_transaction);
+            .get_account_at_index(instruction_account.index_in_transaction)
+            .map_err(SyscallError::InstructionError)?;
         let account_key = invoke_context
             .transaction_context
-            .get_key_of_account_at_index(instruction_account.index_in_transaction);
+            .get_key_of_account_at_index(instruction_account.index_in_transaction)
+            .map_err(SyscallError::InstructionError)?;
         if account.borrow().executable() {
             // Use the known account
             accounts.push((instruction_account.index_in_transaction, None));
@@ -2725,6 +2727,7 @@ fn call<'a, 'b: 'a>(
             let callee_account = invoke_context
                 .transaction_context
                 .get_account_at_index(*callee_account_index)
+                .map_err(SyscallError::InstructionError)?
                 .borrow();
             *caller_account.lamports = callee_account.lamports();
             *caller_account.owner = *callee_account.owner();

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3106,16 +3106,20 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
                 *program_id =
                     instruction_context.get_program_id(invoke_context.transaction_context);
                 data.clone_from_slice(instruction_context.get_instruction_data());
-                let account_metas = instruction_context
-                    .get_instruction_accounts_metas()
-                    .iter()
-                    .map(|meta| AccountMeta {
-                        pubkey: *invoke_context
-                            .get_key_of_account_at_index(meta.index_in_transaction),
-                        is_signer: meta.is_signer,
-                        is_writable: meta.is_writable,
-                    })
-                    .collect::<Vec<_>>();
+                let account_metas = question_mark!(
+                    instruction_context
+                        .get_instruction_accounts_metas()
+                        .iter()
+                        .map(|meta| Ok(AccountMeta {
+                            pubkey: *invoke_context
+                                .get_key_of_account_at_index(meta.index_in_transaction)
+                                .map_err(SyscallError::InstructionError)?,
+                            is_signer: meta.is_signer,
+                            is_writable: meta.is_writable,
+                        }))
+                        .collect::<Result<Vec<_>, EbpfError<BpfError>>>(),
+                    result
+                );
                 accounts.clone_from_slice(account_metas.as_slice());
             }
             *data_len = instruction_context.get_instruction_data().len();

--- a/runtime/src/account_rent_state.rs
+++ b/runtime/src/account_rent_state.rs
@@ -60,7 +60,9 @@ pub(crate) fn check_rent_state(
             debug!(
                 "Account {:?} not rent exempt, state {:?}",
                 transaction_context.get_key_of_account_at_index(index),
-                transaction_context.get_account_at_index(index).borrow(),
+                transaction_context
+                    .get_account_at_index(index)
+                    .map(|account| account.borrow()),
             );
             return Err(TransactionError::InvalidRentPayingAccount);
         }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -96,13 +96,27 @@ impl TransactionContext {
     }
 
     /// Searches for an account by its key
-    pub fn get_key_of_account_at_index(&self, index_in_transaction: usize) -> &Pubkey {
-        &self.account_keys[index_in_transaction]
+    pub fn get_key_of_account_at_index(
+        &self,
+        index_in_transaction: usize,
+    ) -> Result<&Pubkey, InstructionError> {
+        if index_in_transaction < self.account_keys.len() {
+            Ok(&self.account_keys[index_in_transaction])
+        } else {
+            Err(InstructionError::NotEnoughAccountKeys)
+        }
     }
 
     /// Searches for an account by its key
-    pub fn get_account_at_index(&self, index_in_transaction: usize) -> &RefCell<AccountSharedData> {
-        &self.accounts[index_in_transaction]
+    pub fn get_account_at_index(
+        &self,
+        index_in_transaction: usize,
+    ) -> Result<&RefCell<AccountSharedData>, InstructionError> {
+        if index_in_transaction < self.account_keys.len() {
+            Ok(&self.accounts[index_in_transaction])
+        } else {
+            Err(InstructionError::NotEnoughAccountKeys)
+        }
     }
 
     /// Searches for an account by its key

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -100,11 +100,9 @@ impl TransactionContext {
         &self,
         index_in_transaction: usize,
     ) -> Result<&Pubkey, InstructionError> {
-        if index_in_transaction < self.account_keys.len() {
-            Ok(&self.account_keys[index_in_transaction])
-        } else {
-            Err(InstructionError::NotEnoughAccountKeys)
-        }
+        self.account_keys
+            .get(index_in_transaction)
+            .ok_or(InstructionError::NotEnoughAccountKeys)
     }
 
     /// Searches for an account by its key
@@ -112,11 +110,9 @@ impl TransactionContext {
         &self,
         index_in_transaction: usize,
     ) -> Result<&RefCell<AccountSharedData>, InstructionError> {
-        if index_in_transaction < self.account_keys.len() {
-            Ok(&self.accounts[index_in_transaction])
-        } else {
-            Err(InstructionError::NotEnoughAccountKeys)
-        }
+        self.accounts
+            .get(index_in_transaction)
+            .ok_or(InstructionError::NotEnoughAccountKeys)
     }
 
     /// Searches for an account by its key


### PR DESCRIPTION
#### Problem

Some Invoke context APis take an index and access a vector unchecked, which could cause panics

#### Summary of Changes

Check the passed index and switch the function to return `Result`

Fixes #
