### PR TITLE
Refactor: Add trait for loading addresses

### DIFF
--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -6,7 +6,7 @@ use {
     solana_sdk::{
         hash::Hash,
         transaction::{
-            Result, SanitizedTransaction, TransactionError, TransactionVerificationMode,
+            DisabledAddressLoader, Result, SanitizedTransaction, TransactionVerificationMode,
             VersionedTransaction,
         },
     },
@@ -35,9 +35,12 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                         versioned_tx.message.hash()
                     };
 
-                SanitizedTransaction::try_create(versioned_tx, message_hash, None, |_| {
-                    Err(TransactionError::UnsupportedVersion)
-                })
+                SanitizedTransaction::try_create(
+                    versioned_tx,
+                    message_hash,
+                    None,
+                    &DisabledAddressLoader,
+                )
             }?;
 
             Ok(sanitized_tx)
@@ -73,10 +76,12 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
         move |versioned_tx: VersionedTransaction| -> Result<SanitizedTransaction> {
             let sanitized_tx = {
                 let message_hash = versioned_tx.verify_and_hash_message()?;
-
-                SanitizedTransaction::try_create(versioned_tx, message_hash, None, |_| {
-                    Err(TransactionError::UnsupportedVersion)
-                })
+                SanitizedTransaction::try_create(
+                    versioned_tx,
+                    message_hash,
+                    None,
+                    &DisabledAddressLoader,
+                )
             }?;
 
             Ok(sanitized_tx)

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -932,7 +932,9 @@ mod tests {
             pubkey::Pubkey,
             signature::{Keypair, Signer},
             system_transaction,
-            transaction::{Result, SanitizedTransaction, TransactionError, VersionedTransaction},
+            transaction::{
+                DisabledAddressLoader, Result, SanitizedTransaction, VersionedTransaction,
+            },
         },
     };
 
@@ -1016,9 +1018,12 @@ mod tests {
                             versioned_tx.message.hash()
                         };
 
-                    SanitizedTransaction::try_create(versioned_tx, message_hash, None, |_| {
-                        Err(TransactionError::UnsupportedVersion)
-                    })
+                    SanitizedTransaction::try_create(
+                        versioned_tx,
+                        message_hash,
+                        None,
+                        &DisabledAddressLoader,
+                    )
                 }?;
 
                 Ok(sanitized_tx)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -68,7 +68,10 @@ use {
         stake_history::StakeHistory,
         system_instruction,
         sysvar::stake_history,
-        transaction::{self, SanitizedTransaction, TransactionError, VersionedTransaction},
+        transaction::{
+            self, DisabledAddressLoader, SanitizedTransaction, TransactionError,
+            VersionedTransaction,
+        },
     },
     solana_send_transaction_service::{
         send_transaction_service::{SendTransactionService, TransactionInfo},
@@ -4273,10 +4276,8 @@ where
 
 fn sanitize_transaction(transaction: VersionedTransaction) -> Result<SanitizedTransaction> {
     let message_hash = transaction.message.hash();
-    SanitizedTransaction::try_create(transaction, message_hash, None, |_| {
-        Err(TransactionError::UnsupportedVersion)
-    })
-    .map_err(|err| Error::invalid_params(format!("invalid transaction: {}", err)))
+    SanitizedTransaction::try_create(transaction, message_hash, None, &DisabledAddressLoader)
+        .map_err(|err| Error::invalid_params(format!("invalid transaction: {}", err)))
 }
 
 pub(crate) fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<Exit>> {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -216,7 +216,7 @@ pub(crate) mod tests {
             signature::{Keypair, Signature, Signer},
             system_transaction,
             transaction::{
-                SanitizedTransaction, Transaction, TransactionError, VersionedTransaction,
+                DisabledAddressLoader, SanitizedTransaction, Transaction, VersionedTransaction,
             },
         },
         solana_transaction_status::{
@@ -298,11 +298,13 @@ pub(crate) mod tests {
         let message_hash = Hash::new_unique();
         let transaction = build_test_transaction_legacy();
         let transaction = VersionedTransaction::from(transaction);
-        let transaction =
-            SanitizedTransaction::try_create(transaction, message_hash, Some(true), |_| {
-                Err(TransactionError::UnsupportedVersion)
-            })
-            .unwrap();
+        let transaction = SanitizedTransaction::try_create(
+            transaction,
+            message_hash,
+            Some(true),
+            &DisabledAddressLoader,
+        )
+        .unwrap();
 
         let expected_transaction = transaction.clone();
         let pubkey = Pubkey::new_unique();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -109,10 +109,7 @@ use {
         inflation::Inflation,
         instruction::CompiledInstruction,
         lamports::LamportsError,
-        message::{
-            v0::{LoadedAddresses, MessageAddressTableLookup},
-            SanitizedMessage,
-        },
+        message::SanitizedMessage,
         native_loader,
         native_token::sol_to_lamports,
         nonce, nonce_account,
@@ -127,7 +124,7 @@ use {
         sysvar::{self, Sysvar, SysvarId},
         timing::years_as_slots,
         transaction::{
-            AddressLookupError, Result, SanitizedTransaction, Transaction, TransactionError,
+            Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode, VersionedTransaction,
         },
         transaction_context::{TransactionAccount, TransactionContext},
@@ -157,6 +154,7 @@ use {
     },
 };
 
+mod address_lookup_table;
 mod sysvar_cache;
 mod transaction_account_state_info;
 
@@ -3182,9 +3180,7 @@ impl Bank {
             .into_iter()
             .map(|tx| {
                 let message_hash = tx.message.hash();
-                SanitizedTransaction::try_create(tx, message_hash, None, |_| {
-                    Err(TransactionError::UnsupportedVersion)
-                })
+                SanitizedTransaction::try_create(tx, message_hash, None, self)
             })
             .collect::<Result<Vec<_>>>()?;
         let lock_results = self
@@ -3585,33 +3581,6 @@ impl Bank {
     fn remove_executor(&self, pubkey: &Pubkey) {
         let mut cache = self.cached_executors.write().unwrap();
         Arc::make_mut(&mut cache).remove(pubkey);
-    }
-
-    pub fn load_lookup_table_addresses(
-        &self,
-        address_table_lookups: &[MessageAddressTableLookup],
-    ) -> Result<LoadedAddresses> {
-        if !self.versioned_tx_message_enabled() {
-            return Err(TransactionError::UnsupportedVersion);
-        }
-
-        let slot_hashes = self
-            .sysvar_cache
-            .read()
-            .unwrap()
-            .get_slot_hashes()
-            .map_err(|_| TransactionError::AccountNotFound)?;
-
-        Ok(address_table_lookups
-            .iter()
-            .map(|address_table_lookup| {
-                self.rc.accounts.load_lookup_table_addresses(
-                    &self.ancestors,
-                    address_table_lookup,
-                    &slot_hashes,
-                )
-            })
-            .collect::<std::result::Result<_, AddressLookupError>>()?)
     }
 
     /// Execute a transaction using the provided loaded accounts and update
@@ -5526,9 +5495,7 @@ impl Bank {
                 tx.message.hash()
             };
 
-            SanitizedTransaction::try_create(tx, message_hash, None, |lookups| {
-                self.load_lookup_table_addresses(lookups)
-            })
+            SanitizedTransaction::try_create(tx, message_hash, None, self)
         }?;
 
         if verification_mode == TransactionVerificationMode::HashAndVerifyPrecompiles

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -1,0 +1,38 @@
+use {
+    super::Bank,
+    solana_sdk::{
+        message::v0::{LoadedAddresses, MessageAddressTableLookup},
+        transaction::{
+            AddressLoader, AddressLookupError, Result as TransactionResult, TransactionError,
+        },
+    },
+};
+
+impl AddressLoader for Bank {
+    fn load_addresses(
+        &self,
+        address_table_lookups: &[MessageAddressTableLookup],
+    ) -> TransactionResult<LoadedAddresses> {
+        if !self.versioned_tx_message_enabled() {
+            return Err(TransactionError::UnsupportedVersion);
+        }
+
+        let slot_hashes = self
+            .sysvar_cache
+            .read()
+            .unwrap()
+            .get_slot_hashes()
+            .map_err(|_| TransactionError::AccountNotFound)?;
+
+        Ok(address_table_lookups
+            .iter()
+            .map(|address_table_lookup| {
+                self.rc.accounts.load_lookup_table_addresses(
+                    &self.ancestors,
+                    address_table_lookup,
+                    &slot_hashes,
+                )
+            })
+            .collect::<Result<_, AddressLookupError>>()?)
+    }
+}

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -236,7 +236,7 @@ mod tests {
             hash::Hash,
             signature::{Keypair, Signer},
             system_transaction,
-            transaction::{TransactionError, VersionedTransaction},
+            transaction::{DisabledAddressLoader, VersionedTransaction},
         },
         solana_vote_program::vote_transaction,
         std::{cmp, sync::Arc},
@@ -285,7 +285,7 @@ mod tests {
             VersionedTransaction::from(transaction),
             message_hash,
             Some(true),
-            |_| Err(TransactionError::UnsupportedVersion),
+            &DisabledAddressLoader,
         )
         .unwrap();
         (vote_transaction, vec![mint_keypair.pubkey()], 10)


### PR DESCRIPTION
#### Problem
Passing closures everywhere for dynamic address loading is annoying

#### Summary of Changes
- Add `AddressLoader` trait which is implemented by `Bank` and a new `DisabledAddressLoader` struct

Fixes #
