### PR TITLE
Introduce slot-specific packet metrics

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -10,6 +10,7 @@ use {
     rayon::prelude::*,
     solana_core::{
         banking_stage::{BankingStage, BankingStageStats},
+        leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
         qos_service::QosService,
     },
     solana_entry::entry::{next_hash, Entry},
@@ -98,6 +99,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &BankingStageStats::default(),
                 &recorder,
                 &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
+                &mut LeaderSlotMetricsTracker::new(0),
             );
         });
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1530,8 +1530,6 @@ impl BankingStage {
         );
         process_tx_time.stop();
 
-        // Indexes of transactions in the transactions slice that
-        // failed, but are retryable
         let ProcessTransactionsSummary {
             transactions_attempted_execution_count,
             committed_transactions_count,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -801,10 +801,6 @@ impl BankingStage {
             _ => (),
         }
 
-        // Check if we need to start new metrics for a new leader slot, or
-        // report metrics for a completed leader slot. Check after the `decision`
-        // above is executed to include forwarding in the metrics
-        slot_metrics_tracker.update_on_leader_slot_boundary(&bank_start);
         decision
     }
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -555,9 +555,6 @@ impl BankingStage {
                 if let Some((next_leader, bank)) = &reached_end_of_slot {
                     // We've hit the end of this slot, no need to perform more processing,
                     // just filter the remaining packets for the invalid (e.g. too old) ones
-
-                    // We've hit the end of the slot, no need to update the `slot_metrics_tracker`
-                    // since that only tracks intra-leader-slot metrics
                     let new_unprocessed_indexes = Self::filter_unprocessed_packets_at_end_of_slot(
                         bank,
                         packet_batch,
@@ -565,6 +562,12 @@ impl BankingStage {
                         my_pubkey,
                         *next_leader,
                         banking_stage_stats,
+                    );
+                    slot_metrics_tracker.increment_end_of_slot_filtered_invalid_count(
+                        original_unprocessed_indexes
+                            .len()
+                            .saturating_sub(new_unprocessed_indexes.len())
+                            as u64,
                     );
                     Self::update_buffered_packets_with_new_unprocessed(
                         original_unprocessed_indexes,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -592,6 +592,7 @@ impl BankingStage {
                             gossip_vote_sender,
                             banking_stage_stats,
                             qos_service,
+                            slot_metrics_tracker,
                         );
                         let ProcessTransactionsSummary {
                             reached_max_poh_height,
@@ -1531,7 +1532,6 @@ impl BankingStage {
             transaction_status_sender,
             gossip_vote_sender,
             qos_service,
-            slot_metrics_tracker,
         );
         process_tx_time.stop();
 
@@ -1542,7 +1542,7 @@ impl BankingStage {
             committed_transactions_count,
             failed_commit_count,
             ref retryable_transaction_indexes,
-            cost_model_limit_transactions_count,
+            cost_model_throttled_transactions_count,
             ..
         } = process_transactions_summary;
 
@@ -1565,8 +1565,8 @@ impl BankingStage {
                 .saturating_sub(retryable_transaction_indexes.len()) as u64,
         );
 
-        slot_metrics_tracker.increment_cost_model_limit_transactions_count(
-            cost_model_limit_transactions_count as u64,
+        slot_metrics_tracker.increment_cost_model_throttled_transactions_count(
+            cost_model_throttled_transactions_count as u64,
         );
 
         let retryable_tx_count = retryable_transaction_indexes.len();
@@ -2336,7 +2336,7 @@ mod tests {
 
             poh_recorder
                 .lock()
-                .unwrap()
+                .unwrap()   
                 .is_exited
                 .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -897,6 +897,12 @@ impl BankingStage {
                 }
             }
 
+            let current_poh_bank = {
+                let poh = poh_recorder.lock().unwrap();
+                poh.bank_start()
+            };
+            slot_metrics_tracker.update_on_leader_slot_boundary(&current_poh_bank);
+
             let recv_timeout = if !buffered_packet_batches.is_empty() {
                 // If packets are buffered, let's wait for less time on recv from the channel.
                 // This helps detect the next leader faster, and processing the buffered

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2,7 +2,10 @@
 //! to contruct a software pipeline. The stage uses all available CPU cores and
 //! can do its processing in parallel with signature verification on the GPU.
 use {
-    crate::{leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker, qos_service::QosService},
+    crate::{
+        leader_slot_banking_stage_metrics::{LeaderSlotMetricsTracker, ProcessTransactionsSummary},
+        qos_service::QosService,
+    },
     crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError},
     histogram::Histogram,
     itertools::Itertools,
@@ -84,42 +87,6 @@ const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 128;
 
 const NUM_VOTE_PROCESSING_THREADS: u32 = 2;
 const MIN_THREADS_BANKING: u32 = 1;
-
-/// A summary of what happened to transactions passed to the execution pipeline.
-/// Transactions can
-/// 1) Did not even make it to execution due to being filtered out by things like AccountInUse
-/// lock conflictss or CostModel compute limits. These types of errors are retryable and
-/// counted in `Self::retryable_transaction_indexes`.
-/// 2) Did not execute due to some fatal error like too old, or duplicate signature. These
-/// will be dropped from the transactions queue and not counted in `Self::retryable_transaction_indexes`
-/// 3) Were executed and committed, captured by `committed_transactions_count` below.
-/// 4) Were executed and failed commit, captured by `failed_commit_count` below.
-struct ProcessTransactionsSummary {
-    // Returns true if we hit the end of the block/max PoH height for the block before
-    // processing all the transactions in the batch.
-    reached_max_poh_height: bool,
-
-    // Total number of transactions that were passed as candidates for execution. See description
-    // of struct above for possible outcomes for these transactions
-    transactions_attempted_execution_count: usize,
-
-    // Total number of transactions that made it into the block
-    committed_transactions_count: usize,
-
-    // Total number of transactions that made it into the block where the transactions
-    // output from execution was success/no error.
-    committed_transactions_with_successful_result_count: usize,
-
-    // All transactions that were executed but then failed record because the
-    // slot ended
-    failed_commit_count: usize,
-
-    // Indexes of transactions in the transactions slice that were not committed but are retryable
-    retryable_transaction_indexes: Vec<usize>,
-
-    // The number of transactions filtered out by the cost model
-    cost_model_throttled_transactions_count: usize,
-}
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -1544,41 +1511,11 @@ impl BankingStage {
         process_tx_time.stop();
 
         let ProcessTransactionsSummary {
-            transactions_attempted_execution_count,
-            committed_transactions_count,
-            committed_transactions_with_successful_result_count,
-            failed_commit_count,
             ref retryable_transaction_indexes,
-            cost_model_throttled_transactions_count,
             ..
         } = process_transactions_summary;
 
-        slot_metrics_tracker.increment_transactions_attempted_execution_count(
-            transactions_attempted_execution_count as u64,
-        );
-
-        slot_metrics_tracker
-            .increment_committed_transactions_count(committed_transactions_count as u64);
-
-        slot_metrics_tracker.increment_committed_transactions_with_successful_result_count(
-            committed_transactions_with_successful_result_count as u64,
-        );
-
-        slot_metrics_tracker
-            .increment_executed_transactions_failed_commit_count(failed_commit_count as u64);
-
-        slot_metrics_tracker
-            .increment_retryable_transactions_count(retryable_transaction_indexes.len() as u64);
-
-        slot_metrics_tracker.increment_nonretryable_errored_transactions_count(
-            transactions_attempted_execution_count
-                .saturating_sub(committed_transactions_count)
-                .saturating_sub(retryable_transaction_indexes.len()) as u64,
-        );
-
-        slot_metrics_tracker.increment_cost_model_throttled_transactions_count(
-            cost_model_throttled_transactions_count as u64,
-        );
+        slot_metrics_tracker.accumulate_process_transactions_summary(&process_transactions_summary);
 
         let retryable_tx_count = retryable_transaction_indexes.len();
         inc_new_counter_info!("banking_stage-unprocessed_transactions", retryable_tx_count);

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -354,7 +354,7 @@ impl LeaderSlotMetricsTracker {
         &mut self,
         process_transactions_summary: &ProcessTransactionsSummary,
     ) {
-        if self.leader_slot_metrics.is_some() {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             let ProcessTransactionsSummary {
                 transactions_attempted_execution_count,
                 committed_transactions_count,
@@ -364,28 +364,56 @@ impl LeaderSlotMetricsTracker {
                 cost_model_throttled_transactions_count,
                 ..
             } = process_transactions_summary;
-            self.increment_transactions_attempted_execution_count(
-                *transactions_attempted_execution_count as u64,
+
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .transactions_attempted_execution_count,
+                *transactions_attempted_execution_count as u64
             );
 
-            self.increment_committed_transactions_count(*committed_transactions_count as u64);
-
-            self.increment_committed_transactions_with_successful_result_count(
-                *committed_transactions_with_successful_result_count as u64,
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .committed_transactions_count,
+                *committed_transactions_count as u64
             );
 
-            self.increment_executed_transactions_failed_commit_count(*failed_commit_count as u64);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .committed_transactions_with_successful_result_count,
+                *committed_transactions_with_successful_result_count as u64
+            );
 
-            self.increment_retryable_transactions_count(retryable_transaction_indexes.len() as u64);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .executed_transactions_failed_commit_count,
+                *failed_commit_count as u64
+            );
 
-            self.increment_nonretryable_errored_transactions_count(
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .retryable_errored_transaction_count,
+                retryable_transaction_indexes.len() as u64
+            );
+
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .nonretryable_errored_transactions_count,
                 transactions_attempted_execution_count
                     .saturating_sub(*committed_transactions_count)
-                    .saturating_sub(retryable_transaction_indexes.len()) as u64,
+                    .saturating_sub(retryable_transaction_indexes.len()) as u64
             );
 
-            self.increment_cost_model_throttled_transactions_count(
-                *cost_model_throttled_transactions_count as u64,
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .cost_model_throttled_transactions_count,
+                *cost_model_throttled_transactions_count as u64
             );
         }
     }
@@ -440,86 +468,6 @@ impl LeaderSlotMetricsTracker {
                 leader_slot_metrics
                     .packet_count_metrics
                     .retryable_packets_filtered_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_transactions_attempted_execution_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .transactions_attempted_execution_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_committed_transactions_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .committed_transactions_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_committed_transactions_with_successful_result_count(
-        &mut self,
-        count: u64,
-    ) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .committed_transactions_with_successful_result_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_retryable_transactions_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .retryable_errored_transaction_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_nonretryable_errored_transactions_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .nonretryable_errored_transactions_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_executed_transactions_failed_commit_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .executed_transactions_failed_commit_count,
-                count
-            );
-        }
-    }
-
-    pub(crate) fn increment_cost_model_throttled_transactions_count(&mut self, count: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .packet_count_metrics
-                    .cost_model_throttled_transactions_count,
                 count
             );
         }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -255,7 +255,7 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    // Returns true if metrics were reported
+    // Returns reported slot if metrics were reported
     pub(crate) fn update_on_leader_slot_boundary(
         &mut self,
         bank_start: &Option<BankStart>,

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -68,6 +68,9 @@ struct LeaderSlotPacketCountMetrics {
 
     // total number of valid unprocessed packets in the buffer that were removed after being forwarded
     cleared_from_buffer_after_forward_count: u64,
+
+    // total number of packets removed at the end of the slot due to being too old, duplicate, etc.
+    end_of_slot_filtered_invalid_count: u64,
 }
 
 impl LeaderSlotPacketCountMetrics {
@@ -216,6 +219,11 @@ impl LeaderSlotMetrics {
                 "cleared_from_buffer_after_forward_count",
                 self.packet_count_metrics
                     .cleared_from_buffer_after_forward_count as i64,
+                i64
+            ),
+            (
+                "end_of_slot_filtered_invalid_count",
+                self.packet_count_metrics.end_of_slot_filtered_invalid_count as i64,
                 i64
             ),
         );
@@ -406,6 +414,17 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
+    pub(crate) fn increment_executed_transactions_failed_commit_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .executed_transactions_failed_commit_count = leader_slot_metrics
+                .packet_count_metrics
+                .executed_transactions_failed_commit_count
+                .saturating_add(count);
+        }
+    }
+
     pub(crate) fn increment_cost_model_throttled_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             leader_slot_metrics
@@ -461,13 +480,13 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    pub(crate) fn increment_executed_transactions_failed_commit_count(&mut self, count: u64) {
+    pub(crate) fn increment_end_of_slot_filtered_invalid_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             leader_slot_metrics
                 .packet_count_metrics
-                .executed_transactions_failed_commit_count = leader_slot_metrics
+                .end_of_slot_filtered_invalid_count = leader_slot_metrics
                 .packet_count_metrics
-                .executed_transactions_failed_commit_count
+                .end_of_slot_filtered_invalid_count
                 .saturating_add(count);
         }
     }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -1,4 +1,8 @@
-use {solana_poh::poh_recorder::BankStart, solana_sdk::clock::Slot, std::time::Instant};
+use {
+    solana_poh::poh_recorder::BankStart,
+    solana_sdk::{clock::Slot, saturating_add_assign},
+    std::time::Instant,
+};
 
 /// A summary of what happened to transactions passed to the execution pipeline.
 /// Transactions can
@@ -379,78 +383,78 @@ impl LeaderSlotMetricsTracker {
 
     pub(crate) fn increment_total_new_valid_packets(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .total_new_valid_packets = leader_slot_metrics
-                .packet_count_metrics
-                .total_new_valid_packets
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .total_new_valid_packets,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_newly_failed_sigverify_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .newly_failed_sigverify_count = leader_slot_metrics
-                .packet_count_metrics
-                .newly_failed_sigverify_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .newly_failed_sigverify_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_exceeded_buffer_limit_dropped_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .exceeded_buffer_limit_dropped_packets_count = leader_slot_metrics
-                .packet_count_metrics
-                .exceeded_buffer_limit_dropped_packets_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .exceeded_buffer_limit_dropped_packets_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_newly_buffered_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .newly_buffered_packets_count = leader_slot_metrics
-                .packet_count_metrics
-                .newly_buffered_packets_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .newly_buffered_packets_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_retryable_packets_filtered_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .retryable_packets_filtered_count = leader_slot_metrics
-                .packet_count_metrics
-                .retryable_packets_filtered_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .retryable_packets_filtered_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_transactions_attempted_execution_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .transactions_attempted_execution_count = leader_slot_metrics
-                .packet_count_metrics
-                .transactions_attempted_execution_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .transactions_attempted_execution_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_committed_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .committed_transactions_count = leader_slot_metrics
-                .packet_count_metrics
-                .committed_transactions_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .committed_transactions_count,
+                count
+            );
         }
     }
 
@@ -459,111 +463,111 @@ impl LeaderSlotMetricsTracker {
         count: u64,
     ) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .committed_transactions_with_successful_result_count = leader_slot_metrics
-                .packet_count_metrics
-                .committed_transactions_with_successful_result_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .committed_transactions_with_successful_result_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_retryable_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .retryable_errored_transaction_count = leader_slot_metrics
-                .packet_count_metrics
-                .retryable_errored_transaction_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .retryable_errored_transaction_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_nonretryable_errored_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .nonretryable_errored_transactions_count = leader_slot_metrics
-                .packet_count_metrics
-                .nonretryable_errored_transactions_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .nonretryable_errored_transactions_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_executed_transactions_failed_commit_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .executed_transactions_failed_commit_count = leader_slot_metrics
-                .packet_count_metrics
-                .executed_transactions_failed_commit_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .executed_transactions_failed_commit_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_cost_model_throttled_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .cost_model_throttled_transactions_count = leader_slot_metrics
-                .packet_count_metrics
-                .cost_model_throttled_transactions_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .cost_model_throttled_transactions_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_failed_forwarded_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .failed_forwarded_packets_count = leader_slot_metrics
-                .packet_count_metrics
-                .failed_forwarded_packets_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .failed_forwarded_packets_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_successful_forwarded_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .successful_forwarded_packets_count = leader_slot_metrics
-                .packet_count_metrics
-                .successful_forwarded_packets_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .successful_forwarded_packets_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_packet_batch_forward_failure_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .packet_batch_forward_failure_count = leader_slot_metrics
-                .packet_count_metrics
-                .packet_batch_forward_failure_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .packet_batch_forward_failure_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_cleared_from_buffer_after_forward_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .cleared_from_buffer_after_forward_count = leader_slot_metrics
-                .packet_count_metrics
-                .cleared_from_buffer_after_forward_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .cleared_from_buffer_after_forward_count,
+                count
+            );
         }
     }
 
     pub(crate) fn increment_end_of_slot_filtered_invalid_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            leader_slot_metrics
-                .packet_count_metrics
-                .end_of_slot_filtered_invalid_count = leader_slot_metrics
-                .packet_count_metrics
-                .end_of_slot_filtered_invalid_count
-                .saturating_add(count);
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .packet_count_metrics
+                    .end_of_slot_filtered_invalid_count,
+                count
+            );
         }
     }
 }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -57,7 +57,7 @@ struct LeaderSlotPacketCountMetrics {
     // total number of transactions that were excluded from the block because they were too expensive
     // according to the cost model. These transactions are added back to the buffered queue and are
     // already counted in `self.retrayble_errored_transaction_count`.
-    cost_model_limit_transactions_count: u64,
+    cost_model_throttled_transactions_count: u64,
 
     // total number of unprocessed packets that were valid for forwarding
     forwardable_packet_candidates_count: u64,
@@ -436,11 +436,11 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    pub(crate) fn increment_cost_model_limit_transactions_count(&mut self, count: u64) {
+    pub(crate) fn increment_cost_model_throttled_transactions_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
             leader_slot_metrics
                 .packet_count_metrics
-                .cost_model_limit_transactions_count
+                .cost_model_throttled_transactions_count
                 .saturating_add(count);
         }
     }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -59,11 +59,10 @@ struct LeaderSlotPacketCountMetrics {
     // already counted in `self.retrayble_errored_transaction_count`.
     cost_model_throttled_transactions_count: u64,
 
-    // total number of unprocessed packets that were valid for forwarding
-    forwardable_packet_candidates_count: u64,
+    // total number of forwardsable packets that failed forwarding
+    failed_forwarded_packets_count: u64,
 
-    // total number of the `forwardable_packet_candidates_count` packets that were successfully
-    // forwarded
+    // total number of forwardsable packets that were successfully forwarded
     successful_forwarded_packets_count: u64,
 
     // total number of attempted forwards that failed. Note this is not a count of the number of packets
@@ -215,9 +214,8 @@ impl LeaderSlotMetrics {
                 i64
             ),
             (
-                "forwardable_packet_candidates_count",
-                self.packet_count_metrics
-                    .forwardable_packet_candidates_count as i64,
+                "failed_forwarded_packets_count",
+                self.packet_count_metrics.failed_forwarded_packets_count as i64,
                 i64
             ),
             (
@@ -439,13 +437,13 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    pub(crate) fn increment_forwardable_packet_candidates_count(&mut self, count: u64) {
+    pub(crate) fn increment_failed_forwarded_packets_count(&mut self, count: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             leader_slot_metrics
                 .packet_count_metrics
-                .forwardable_packet_candidates_count = leader_slot_metrics
+                .failed_forwarded_packets_count = leader_slot_metrics
                 .packet_count_metrics
-                .forwardable_packet_candidates_count
+                .failed_forwarded_packets_count
                 .saturating_add(count);
         }
     }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -1,0 +1,492 @@
+use {solana_poh::poh_recorder::BankStart, solana_sdk::clock::Slot, std::time::Instant};
+
+// Metrics surrounding wallclock time spent in various parts of BankingStage during this
+// validator's leader slot
+#[derive(Debug, Default)]
+struct LeaderSlotTimingMetrics {}
+
+// Metrics describing packets ingested/processed in various parts of BankingStage during this
+// validator's leader slot
+#[derive(Debug, Default)]
+struct LeaderSlotPacketCountMetrics {
+    // total number of packets in the buffer when the leader slot began
+    buffered_packets_starting_count: u64,
+
+    // total number of live packets TPU received from verified receiver for processing.
+    total_new_valid_packets: u64,
+
+    // total number of packets TPU received from sigverify that failed signature verification.
+    newly_failed_sigverify_count: u64,
+
+    // total number of dropped packet due to the thread's buffered packets capacity being reached.
+    exceeded_buffer_limit_dropped_packets_count: u64,
+
+    // total number of packets that got added to the pending buffer after arriving to BankingStage
+    newly_buffered_packets_count: u64,
+
+    // total number of transactions in the buffer that were filtered out due to things like age and
+    // duplicate signature checks
+    buffered_packets_filtered_count: u64,
+
+    // total number of transactions that attempted execution in this slot. Should equal the sum
+    // of `committed_transactions_count`, `retryable_errored_transaction_count`, and
+    // `nonretryable_errored_transaction_count`.
+    attempted_transactions_execution_count: u64,
+
+    // total number of transactions that were executed and committed into the block
+    // on this thread
+    committed_transactions_count: u64,
+
+    // total number of transactions that were executed, got a successful execution output/no error,
+    // and were then committed into the block
+    committed_transactions_with_successful_result_count: u64,
+
+    // total number of transactions that were not executed or failed commit, BUT were added back to the buffered
+    // queue becaus they were retryable errors
+    retryable_errored_transaction_count: u64,
+
+    // total number of transactions that attempted execution due to some fatal error (too old, duplicate signature, etc.)
+    // AND were dropped from the buffered queue
+    nonretryable_errored_transaction_count: u64,
+
+    // total number of transactions that were executed, but failed to be committed into the Poh stream because
+    // the block ended. Some of these may be already counted in `nonretryable_errored_transaction_count` if they
+    // then hit the age limit after failing to be comitted.
+    executed_transactions_failed_record_count: u64,
+
+    // total number of transactions that were excluded from the block because they were too expensive
+    // according to the cost model. These transactions are added back to the buffered queue and are
+    // already counted in `self.retrayble_errored_transaction_count`.
+    cost_model_limit_transactions_count: u64,
+
+    // total number of unprocessed packets that were valid for forwarding
+    forwardable_packet_candidates_count: u64,
+
+    // total number of the `forwardable_packet_candidates_count` packets that were successfully
+    // forwarded
+    successful_forwarded_packets_count: u64,
+
+    // total number of attempted forwards that failed. Note this is not a count of the number of packets
+    // that failed, just the total number of batches of packets that failed forwarding
+    packet_batch_forward_failure_count: u64,
+
+    // total number of valid unprocessed packets in the buffer that were removed after being forwarded
+    cleared_from_buffer_after_forward_count: u64,
+
+    // accumulated number of verified txs, which excludes unsanitized transactions and
+    // non-vote transactions when in vote-only mode from ingested packets
+    verified_txs_count: u64,
+
+    // accumulated number of transactions been processed, includes those landed and those to be
+    // returned (due to AccountInUse, and other QoS related reasons)
+    processed_txs_count: u64,
+
+    // accumulated number of transactions buffered for retry, often due to AccountInUse and QoS
+    // reasons, includes retried_txs_per_block_limit_count and retried_txs_per_account_limit_count
+    retryable_txs_count: u64,
+
+    // accumulated time in micro-sec spent in computing transaction cost. It is the main performance
+    // overhead introduced by cost_model
+    compute_cost_time: u64,
+
+    // total nummber of transactions in the reporting period to be computed for theit cost. It is
+    // usually the number of sanitized transactions leader receives.
+    compute_cost_count: u64,
+
+    // acumulated time in micro-sec spent in tracking each bank's cost. It is the second part of
+    // overhead introduced
+    cost_tracking_time: u64,
+
+    // number of transactions to be included in blocks
+    selected_txs_count: u64,
+
+    // number of transactions to be queued for retry due to its potential to breach block limit
+    retried_txs_per_block_limit_count: u64,
+
+    // number of transactions to be queued for retry due to its potential to breach vote limit
+    retried_txs_per_vote_limit_count: u64,
+
+    // number of transactions to be queued for retry due to its potential to breach writable
+    // account limit
+    retried_txs_per_account_limit_count: u64,
+
+    // number of transactions to be queued for retry due to its account data limits
+    retried_txs_per_account_data_limit_count: u64,
+
+    // accumulated estimated signature Compute Unites to be packed into block
+    estimated_signature_cu: u64,
+
+    // accumulated estimated write locks Compute Units to be packed into block
+    estimated_write_lock_cu: u64,
+
+    // accumulated estimated instructino data Compute Units to be packed into block
+    estimated_data_bytes_cu: u64,
+
+    // accumulated estimated program Compute Units to be packed into block
+    estimated_execute_cu: u64,
+
+    // accumulated actual program Compute Units that have been packed into block
+    actual_execute_cu: u64,
+
+    // accumulated actual program execute micro-sec that have been packed into block
+    actual_execute_time_us: u64,
+}
+
+impl LeaderSlotPacketCountMetrics {
+    fn new(buffered_packets_starting_count: u64) -> Self {
+        Self {
+            buffered_packets_starting_count,
+            ..Self::default()
+        }
+    }
+}
+
+impl LeaderSlotMetricsTracker {
+    pub(crate) fn new(id: u32) -> Self {
+        Self {
+            leader_slot_metrics: None,
+            id,
+        }
+    }
+
+    pub(crate) fn update_on_leader_slot_boundary(&mut self, bank_start: &Option<BankStart>) {
+        match (self.leader_slot_metrics.as_mut(), bank_start) {
+            (None, None) => {}
+
+            (Some(leader_slot_metrics), None) => {
+                // Slot has ended, time to report metrics
+                leader_slot_metrics.report();
+            }
+
+            (None, Some(bank_start)) => {
+                // Our leader slot has begain, time to create a new slot tracker
+                self.leader_slot_metrics = Some(LeaderSlotMetrics::new(
+                    self.id,
+                    bank_start.working_bank.slot(),
+                    &bank_start.bank_creation_time,
+                    // TODO: track the number of packets in buffered queue
+                    0,
+                ));
+            }
+
+            (Some(leader_slot_metrics), Some(bank_start)) => {
+                if leader_slot_metrics.slot != bank_start.working_bank.slot() {
+                    // Last slot has ended, new slot has began
+                    leader_slot_metrics.report();
+                    self.leader_slot_metrics = Some(LeaderSlotMetrics::new(
+                        self.id,
+                        bank_start.working_bank.slot(),
+                        &bank_start.bank_creation_time,
+                        // TODO: track the number of packets in buffered queue,
+                        0,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LeaderSlotMetrics {
+    // banking_stage creates one QosService instance per working threads, that is uniquely
+    // identified by id. This field allows to categorize metrics for gossip votes, TPU votes
+    // and other transactions.
+    id: u32,
+
+    // aggregate metrics per slot
+    slot: Slot,
+
+    // when the bank was detected
+    bank_detected_time: Instant,
+
+    // delay from when the bank was created to when this thread detected it
+    bank_detected_delay_us: u64,
+
+    packet_count_metrics: LeaderSlotPacketCountMetrics,
+
+    timing_metrics: LeaderSlotTimingMetrics,
+}
+
+impl LeaderSlotMetrics {
+    pub(crate) fn new(
+        id: u32,
+        slot: Slot,
+        bank_creation_time: &Instant,
+        buffered_packets_starting_count: u64,
+    ) -> Self {
+        Self {
+            id,
+            slot,
+            bank_detected_time: Instant::now(),
+            bank_detected_delay_us: bank_creation_time.elapsed().as_micros() as u64,
+            packet_count_metrics: LeaderSlotPacketCountMetrics::new(
+                buffered_packets_starting_count,
+            ),
+            timing_metrics: LeaderSlotTimingMetrics::default(),
+        }
+    }
+
+    pub(crate) fn report(&self) {
+        let bank_detected_to_now = self.bank_detected_time.elapsed().as_micros() as u64;
+        datapoint_info!(
+            "banking_stage-leader_slot_timing_metrics",
+            ("id", self.id as i64, i64),
+            ("slot", self.slot as i64, i64),
+            ("bank_detected_to_now_us", bank_detected_to_now, i64),
+            (
+                "bank_creation_to_now_us",
+                bank_detected_to_now + self.bank_detected_delay_us,
+                i64
+            ),
+            ("bank_detected_delay_us", self.bank_detected_delay_us, i64),
+        );
+
+        datapoint_info!(
+            "banking_stage-leader_slot_packet_count_metrics",
+            ("id", self.id as i64, i64),
+            ("slot", self.slot as i64, i64),
+            /*
+            (
+                "processed_txs_count",
+                self.processed_txs_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "retryable_txs_count",
+                self.retryable_txs_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "compute_cost_time",
+                self.compute_cost_time.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "compute_cost_count",
+                self.compute_cost_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "cost_tracking_time",
+                self.cost_tracking_time.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "selected_txs_count",
+                self.selected_txs_count.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "retried_txs_per_block_limit_count",
+                self.retried_txs_per_block_limit_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "retried_txs_per_vote_limit_count",
+                self.retried_txs_per_vote_limit_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "retried_txs_per_account_limit_count",
+                self.retried_txs_per_account_limit_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "retried_txs_per_account_data_limit_count",
+                self.retried_txs_per_account_data_limit_count
+                    .swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "estimated_signature_cu",
+                self.estimated_signature_cu.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "estimated_write_lock_cu",
+                self.estimated_write_lock_cu.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "estimated_data_bytes_cu",
+                self.estimated_data_bytes_cu.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "estimated_execute_cu",
+                self.estimated_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "actual_execute_cu",
+                self.actual_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "actual_execute_time_us",
+                self.actual_execute_time_us.swap(0, Ordering::Relaxed) as i64,
+                i64
+            ),*/
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct LeaderSlotMetricsTracker {
+    // Only `Some` if BankingStage detects it's time to construct our leader slot,
+    // otherwise `None`
+    leader_slot_metrics: Option<LeaderSlotMetrics>,
+    id: u32,
+}
+
+impl LeaderSlotMetricsTracker {
+    pub(crate) fn increment_total_new_valid_packets(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .total_new_valid_packets
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_newly_failed_sigverify_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .newly_failed_sigverify_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_exceeded_buffer_limit_dropped_packets_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .exceeded_buffer_limit_dropped_packets_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_newly_buffered_packets_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .newly_buffered_packets_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_buffered_packets_filtered_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .buffered_packets_filtered_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_attempted_transactions_execution_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .attempted_transactions_execution_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_committed_transactions_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .committed_transactions_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_committed_transactions_with_successful_result_count(
+        &mut self,
+        count: u64,
+    ) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .committed_transactions_with_successful_result_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_retryable_errored_transaction_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .retryable_errored_transaction_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_nonretryable_errored_transaction_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .nonretryable_errored_transaction_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_cost_model_limit_transactions_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .cost_model_limit_transactions_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_forwardable_packet_candidates_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .forwardable_packet_candidates_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_successful_forwarded_packets_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .successful_forwarded_packets_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_packet_batch_forward_failure_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .packet_batch_forward_failure_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_cleared_from_buffer_after_forward_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .cleared_from_buffer_after_forward_count
+                .saturating_add(count);
+        }
+    }
+
+    pub(crate) fn increment_executed_transactions_failed_record_count(&mut self, count: u64) {
+        if let Some(leader_slot_metrics) = &self.leader_slot_metrics {
+            leader_slot_metrics
+                .packet_count_metrics
+                .executed_transactions_failed_record_count
+                .saturating_add(count);
+        }
+    }
+}

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -187,91 +187,95 @@ impl LeaderSlotMetrics {
             "banking_stage-leader_slot_packet_count_metrics",
             ("id", self.id as i64, i64),
             ("slot", self.slot as i64, i64),
-            /*
             (
-                "processed_txs_count",
-                self.processed_txs_count.swap(0, Ordering::Relaxed) as i64,
+                "total_new_valid_packets",
+                self.packet_count_metrics.total_new_valid_packets as i64,
                 i64
             ),
             (
-                "retryable_txs_count",
-                self.retryable_txs_count.swap(0, Ordering::Relaxed) as i64,
+                "newly_failed_sigverify_count",
+                self.packet_count_metrics.newly_failed_sigverify_count as i64,
                 i64
             ),
             (
-                "compute_cost_time",
-                self.compute_cost_time.swap(0, Ordering::Relaxed) as i64,
+                "exceeded_buffer_limit_dropped_packets_count",
+                self.packet_count_metrics
+                    .exceeded_buffer_limit_dropped_packets_count as i64,
                 i64
             ),
             (
-                "compute_cost_count",
-                self.compute_cost_count.swap(0, Ordering::Relaxed) as i64,
+                "newly_buffered_packets_count",
+                self.packet_count_metrics.newly_buffered_packets_count as i64,
                 i64
             ),
             (
-                "cost_tracking_time",
-                self.cost_tracking_time.swap(0, Ordering::Relaxed) as i64,
+                "retryable_packets_filtered_count",
+                self.packet_count_metrics.retryable_packets_filtered_count as i64,
                 i64
             ),
             (
-                "selected_txs_count",
-                self.selected_txs_count.swap(0, Ordering::Relaxed) as i64,
+                "transactions_attempted_execution_count",
+                self.packet_count_metrics
+                    .transactions_attempted_execution_count as i64,
                 i64
             ),
             (
-                "retried_txs_per_block_limit_count",
-                self.retried_txs_per_block_limit_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                "committed_transactions_count",
+                self.packet_count_metrics.committed_transactions_count as i64,
                 i64
             ),
             (
-                "retried_txs_per_vote_limit_count",
-                self.retried_txs_per_vote_limit_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                "committed_transactions_with_successful_result_count",
+                self.packet_count_metrics
+                    .committed_transactions_with_successful_result_count as i64,
                 i64
             ),
             (
-                "retried_txs_per_account_limit_count",
-                self.retried_txs_per_account_limit_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                "retryable_errored_transaction_count",
+                self.packet_count_metrics
+                    .retryable_errored_transaction_count as i64,
                 i64
             ),
             (
-                "retried_txs_per_account_data_limit_count",
-                self.retried_txs_per_account_data_limit_count
-                    .swap(0, Ordering::Relaxed) as i64,
+                "nonretryable_errored_transactions_count",
+                self.packet_count_metrics
+                    .nonretryable_errored_transactions_count as i64,
                 i64
             ),
             (
-                "estimated_signature_cu",
-                self.estimated_signature_cu.swap(0, Ordering::Relaxed) as i64,
+                "executed_transactions_failed_commit_count",
+                self.packet_count_metrics
+                    .executed_transactions_failed_commit_count as i64,
                 i64
             ),
             (
-                "estimated_write_lock_cu",
-                self.estimated_write_lock_cu.swap(0, Ordering::Relaxed) as i64,
+                "cost_model_throttled_transactions_count",
+                self.packet_count_metrics
+                    .cost_model_throttled_transactions_count as i64,
                 i64
             ),
             (
-                "estimated_data_bytes_cu",
-                self.estimated_data_bytes_cu.swap(0, Ordering::Relaxed) as i64,
+                "forwardable_packet_candidates_count",
+                self.packet_count_metrics
+                    .forwardable_packet_candidates_count as i64,
                 i64
             ),
             (
-                "estimated_execute_cu",
-                self.estimated_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                "successful_forwarded_packets_count",
+                self.packet_count_metrics.successful_forwarded_packets_count as i64,
                 i64
             ),
             (
-                "actual_execute_cu",
-                self.actual_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                "packet_batch_forward_failure_count",
+                self.packet_count_metrics.packet_batch_forward_failure_count as i64,
                 i64
             ),
             (
-                "actual_execute_time_us",
-                self.actual_execute_time_us.swap(0, Ordering::Relaxed) as i64,
+                "cleared_from_buffer_after_forward_count",
+                self.packet_count_metrics
+                    .cleared_from_buffer_after_forward_count as i64,
                 i64
-            ),*/
+            ),
         );
     }
 }

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -240,7 +240,7 @@ pub struct LeaderSlotMetricsTracker {
 }
 
 impl LeaderSlotMetricsTracker {
-    pub(crate) fn new(id: u32) -> Self {
+    pub fn new(id: u32) -> Self {
         Self {
             leader_slot_metrics: None,
             id,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod fork_choice;
 pub mod gen_keys;
 pub mod heaviest_subtree_fork_choice;
 pub mod latest_validator_votes_for_frozen_banks;
+pub mod leader_slot_banking_stage_metrics;
 pub mod ledger_cleanup_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -60,6 +60,7 @@ type Result<T> = std::result::Result<T, PohRecorderError>;
 
 pub type WorkingBankEntry = (Arc<Bank>, (Entry, u64));
 
+#[derive(Clone)]
 pub struct BankStart {
     pub working_bank: Arc<Bank>,
     pub bank_creation_time: Arc<Instant>,


### PR DESCRIPTION
#### Problem
Hard to debug why there are drops in the number of transactions in specific slots

#### Summary of Changes
1) Introduce slot-specific leader slot banking stage metrics via tracking in `LeaderSlotMetricsTracker`
2) `LeaderSlotMetricsTracker` tracks when a slot begins and ends via `LeaderSlotMetricsTracker::update_on_leader_slot_boundary()`. 
3) Test 2) via a suite of `test_update_on_leader_slot_boundary_*()` tests
3) Increment various packet ingestion, processing, forwarding metrics in  `LeaderSlotMetricsTracker`

Follow-up PR:  Increment various timing metrics about where time is being spent

Fixes #
