### PR TITLE
Enforce tx metadata upload with static types

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -10,7 +10,7 @@ use {
             RpcAccountInfoConfig, RpcBlockSubscribeConfig, RpcBlockSubscribeFilter,
             RpcProgramAccountsConfig,
         },
-        rpc_response::{RpcBlockUpdate, SlotInfo},
+        rpc_response::SlotInfo,
     },
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
     solana_rpc::{
@@ -36,7 +36,7 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
-    solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
+    solana_transaction_status::{ConfirmedBlock, TransactionDetails, UiTransactionEncoding},
     std::{
         collections::HashSet,
         net::{IpAddr, SocketAddr},
@@ -214,6 +214,7 @@ fn test_block_subscription() {
         ..
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
+    let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
     // setup Blockstore
@@ -227,6 +228,8 @@ fn test_block_subscription() {
     let keypair2 = Keypair::new();
     let keypair3 = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+    bank.transfer(rent_exempt_amount, &alice, &keypair2.pubkey())
+        .unwrap();
     let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
         vec![&alice, &keypair1, &keypair2, &keypair3],
         0,
@@ -277,24 +280,16 @@ fn test_block_subscription() {
     let maybe_actual = receiver.recv_timeout(Duration::from_millis(400));
     match maybe_actual {
         Ok(actual) => {
-            let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-            let legacy_block = versioned_block.into_legacy_block().unwrap();
-            let block = legacy_block.clone().configure(
-                UiTransactionEncoding::Json,
-                TransactionDetails::Signatures,
-                false,
-            );
-            let expected = RpcBlockUpdate {
-                slot,
-                block: Some(block),
-                err: None,
-            };
-            let block = legacy_block.configure(
-                UiTransactionEncoding::Json,
-                TransactionDetails::Signatures,
-                false,
-            );
-            assert_eq!(actual.value.slot, expected.slot);
+            let confirmed_block =
+                ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+            let block = confirmed_block
+                .encode_with_options(
+                    UiTransactionEncoding::Json,
+                    TransactionDetails::Signatures,
+                    false,
+                )
+                .unwrap();
+            assert_eq!(actual.value.slot, slot);
             assert!(block.eq(&actual.value.block.unwrap()));
         }
         Err(e) => {

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -3,6 +3,7 @@ use {
     crate::rpc_response::RpcSimulateTransactionResult,
     jsonrpc_core::{Error, ErrorCode},
     solana_sdk::clock::Slot,
+    solana_transaction_status::EncodeError,
     thiserror::Error,
 };
 
@@ -66,6 +67,14 @@ pub enum RpcCustomError {
 #[serde(rename_all = "camelCase")]
 pub struct NodeUnhealthyErrorData {
     pub num_slots_behind: Option<Slot>,
+}
+
+impl From<EncodeError> for RpcCustomError {
+    fn from(err: EncodeError) -> Self {
+        match err {
+            EncodeError::UnsupportedTransactionVersion => Self::UnsupportedTransactionVersion,
+        }
+    }
 }
 
 impl From<RpcCustomError> for Error {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2947,16 +2947,9 @@ mod tests {
         );
         let ix_error_signature = ix_error_tx.signatures[0];
         let entry_2 = next_entry(&entry_1.hash, 1, vec![ix_error_tx.clone()]);
-        let fail_tx = system_transaction::transfer(
-            &mint_keypair,
-            &pubkey1,
-            rent_exempt_amount,
-            genesis_config.hash(),
-        );
-        let entry_3 = next_entry(&entry_2.hash, 1, vec![fail_tx.clone()]);
-        let entries = vec![entry_1, entry_2, entry_3];
+        let entries = vec![entry_1, entry_2];
 
-        let transactions = sanitize_transactions(vec![success_tx, ix_error_tx, fail_tx]);
+        let transactions = sanitize_transactions(vec![success_tx, ix_error_tx]);
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair1.pubkey())
             .unwrap();
 
@@ -3016,27 +3009,24 @@ mod tests {
             transaction_status_service.join().unwrap();
 
             let confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
-            assert_eq!(confirmed_block.transactions.len(), 3);
-
-            for VersionedTransactionWithStatusMeta { transaction, meta } in
-                confirmed_block.transactions.into_iter()
-            {
-                if transaction.signatures[0] == success_signature {
-                    let meta = meta.unwrap();
-                    assert_eq!(meta.status, Ok(()));
-                } else if transaction.signatures[0] == ix_error_signature {
-                    let meta = meta.unwrap();
-                    assert_eq!(
-                        meta.status,
-                        Err(TransactionError::InstructionError(
-                            0,
-                            InstructionError::Custom(1)
-                        ))
-                    );
-                } else {
-                    assert_eq!(meta, None);
-                }
-            }
+            let actual_tx_results: Vec<_> = confirmed_block
+                .transactions
+                .into_iter()
+                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                    (transaction.signatures[0], meta.status)
+                })
+                .collect();
+            let expected_tx_results = vec![
+                (success_signature, Ok(())),
+                (
+                    ix_error_signature,
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::Custom(1),
+                    )),
+                ),
+            ];
+            assert_eq!(actual_tx_results, expected_tx_results);
 
             poh_recorder
                 .lock()
@@ -3183,7 +3173,7 @@ mod tests {
             let recorded_meta = confirmed_block.transactions.pop().unwrap().meta;
             assert_eq!(
                 recorded_meta,
-                Some(TransactionStatusMeta {
+                TransactionStatusMeta {
                     status: Ok(()),
                     pre_balances: vec![1, 0, 0],
                     post_balances: vec![1, 0, 0],
@@ -3192,7 +3182,7 @@ mod tests {
                     rewards: Some(vec![]),
                     loaded_addresses: sanitized_tx.get_loaded_addresses(),
                     ..TransactionStatusMeta::default()
-                })
+                }
             );
             poh_recorder
                 .lock()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3919,36 +3919,35 @@ pub mod tests {
             let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
             let slot = bank1.slot();
 
-            let signatures = create_test_transactions_and_populate_blockstore(
+            let mut test_signatures_iter = create_test_transactions_and_populate_blockstore(
                 vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
                 bank0.slot(),
                 bank1,
                 blockstore.clone(),
                 Arc::new(AtomicU64::default()),
-            );
+            )
+            .into_iter();
 
             let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
-            assert_eq!(confirmed_block.transactions.len(), 3);
-
-            for VersionedTransactionWithStatusMeta { transaction, meta } in
-                confirmed_block.transactions.into_iter()
-            {
-                if transaction.signatures[0] == signatures[0] {
-                    let meta = meta.unwrap();
-                    assert_eq!(meta.status, Ok(()));
-                } else if transaction.signatures[0] == signatures[1] {
-                    let meta = meta.unwrap();
-                    assert_eq!(
-                        meta.status,
-                        Err(TransactionError::InstructionError(
-                            0,
-                            InstructionError::Custom(1)
-                        ))
-                    );
-                } else {
-                    assert_eq!(meta, None);
-                }
-            }
+            let actual_tx_results: Vec<_> = confirmed_block
+                .transactions
+                .into_iter()
+                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                    (transaction.signatures[0], meta.status)
+                })
+                .collect();
+            let expected_tx_results = vec![
+                (test_signatures_iter.next().unwrap(), Ok(())),
+                (
+                    test_signatures_iter.next().unwrap(),
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::Custom(1),
+                    )),
+                ),
+            ];
+            assert!(test_signatures_iter.next().is_none());
+            assert_eq!(actual_tx_results, expected_tx_results);
         }
         Blockstore::destroy(&ledger_path).unwrap();
     }

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -26,7 +26,6 @@ pub async fn upload_confirmed_blocks(
     bigtable: solana_storage_bigtable::LedgerStorage,
     starting_slot: Slot,
     ending_slot: Option<Slot>,
-    allow_missing_metadata: bool,
     force_reupload: bool,
     exit: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -187,20 +186,7 @@ pub async fn upload_confirmed_blocks(
                 num_blocks -= 1;
                 None
             }
-            Some(confirmed_block) => {
-                if confirmed_block
-                    .transactions
-                    .iter()
-                    .any(|transaction| transaction.meta.is_none())
-                {
-                    if allow_missing_metadata {
-                        info!("Transaction metadata missing from slot {}", slot);
-                    } else {
-                        panic!("Transaction metadata missing from slot {}", slot);
-                    }
-                }
-                Some(bigtable.upload_confirmed_block(slot, confirmed_block))
-            }
+            Some(confirmed_block) => Some(bigtable.upload_confirmed_block(slot, confirmed_block)),
         });
 
         for result in futures::future::join_all(uploads).await {

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -72,7 +72,6 @@ impl BigTableUploadService {
                 bigtable_ledger_storage.clone(),
                 start_slot,
                 Some(end_slot),
-                true,
                 false,
                 exit.clone(),
             ));

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -42,8 +42,8 @@ use {
     },
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
     solana_transaction_status::{
-        ConfirmedTransactionStatusWithSignature, Rewards, TransactionStatusMeta,
-        VersionedConfirmedBlock, VersionedConfirmedTransactionWithStatusMeta,
+        ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta, Rewards,
+        TransactionStatusMeta, TransactionWithStatusMeta, VersionedConfirmedBlock,
         VersionedTransactionWithStatusMeta,
     },
     std::{
@@ -2036,9 +2036,8 @@ impl Blockstore {
                 Ok(VersionedTransactionWithStatusMeta {
                     transaction,
                     meta: self
-                        .read_transaction_status((signature, slot))
-                        .ok()
-                        .flatten(),
+                        .read_transaction_status((signature, slot))?
+                        .ok_or(BlockstoreError::MissingTransactionMetadata)?,
                 })
             })
             .collect()
@@ -2287,7 +2286,7 @@ impl Blockstore {
     pub fn get_rooted_transaction(
         &self,
         signature: Signature,
-    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_rooted_transaction", String)
@@ -2300,7 +2299,7 @@ impl Blockstore {
         &self,
         signature: Signature,
         highest_confirmed_slot: Slot,
-    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_complete_transaction", String)
@@ -2317,8 +2316,8 @@ impl Blockstore {
         &self,
         signature: Signature,
         confirmed_unrooted_slots: &[Slot],
-    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
-        if let Some((slot, status)) =
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+        if let Some((slot, meta)) =
             self.get_transaction_status(signature, confirmed_unrooted_slots)?
         {
             let transaction = self
@@ -2326,12 +2325,12 @@ impl Blockstore {
                 .ok_or(BlockstoreError::TransactionStatusSlotMismatch)?; // Should not happen
 
             let block_time = self.get_block_time(slot)?;
-            Ok(Some(VersionedConfirmedTransactionWithStatusMeta {
+            Ok(Some(ConfirmedTransactionWithStatusMeta {
                 slot,
-                tx_with_meta: VersionedTransactionWithStatusMeta {
+                tx_with_meta: TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
                     transaction,
-                    meta: Some(status),
-                },
+                    meta,
+                }),
                 block_time,
             }))
         } else {
@@ -6320,7 +6319,7 @@ pub mod tests {
                     .unwrap();
                 VersionedTransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -6331,21 +6330,22 @@ pub mod tests {
                         post_token_balances: Some(vec![]),
                         rewards: Some(vec![]),
                         loaded_addresses: LoadedAddresses::default(),
-                    }),
+                    },
                 }
             })
             .collect();
 
         // Even if marked as root, a slot that is empty of entries should return an error
-        let confirmed_block_err = blockstore.get_rooted_block(slot - 1, true).unwrap_err();
-        assert_matches!(confirmed_block_err, BlockstoreError::SlotUnavailable);
+        assert_matches!(
+            blockstore.get_rooted_block(slot - 1, true),
+            Err(BlockstoreError::SlotUnavailable)
+        );
 
         // The previous_blockhash of `expected_block` is default because its parent slot is a root,
         // but empty of entries (eg. snapshot root slots). This now returns an error.
-        let confirmed_block_err = blockstore.get_rooted_block(slot, true).unwrap_err();
         assert_matches!(
-            confirmed_block_err,
-            BlockstoreError::ParentEntriesUnavailable
+            blockstore.get_rooted_block(slot, true),
+            Err(BlockstoreError::ParentEntriesUnavailable)
         );
 
         // Test if require_previous_blockhash is false
@@ -7161,7 +7161,7 @@ pub mod tests {
                     .unwrap();
                 VersionedTransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -7172,7 +7172,7 @@ pub mod tests {
                         post_token_balances,
                         rewards,
                         loaded_addresses: LoadedAddresses::default(),
-                    }),
+                    },
                 }
             })
             .collect();
@@ -7181,9 +7181,9 @@ pub mod tests {
             let signature = tx_with_meta.transaction.signatures[0];
             assert_eq!(
                 blockstore.get_rooted_transaction(signature).unwrap(),
-                Some(VersionedConfirmedTransactionWithStatusMeta {
+                Some(ConfirmedTransactionWithStatusMeta {
                     slot,
-                    tx_with_meta: tx_with_meta.clone(),
+                    tx_with_meta: TransactionWithStatusMeta::Ok(tx_with_meta.clone()),
                     block_time: None
                 })
             );
@@ -7191,9 +7191,9 @@ pub mod tests {
                 blockstore
                     .get_complete_transaction(signature, slot + 1)
                     .unwrap(),
-                Some(VersionedConfirmedTransactionWithStatusMeta {
+                Some(ConfirmedTransactionWithStatusMeta {
                     slot,
-                    tx_with_meta,
+                    tx_with_meta: TransactionWithStatusMeta::Ok(tx_with_meta),
                     block_time: None
                 })
             );
@@ -7263,7 +7263,7 @@ pub mod tests {
                     .unwrap();
                 VersionedTransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -7274,7 +7274,7 @@ pub mod tests {
                         post_token_balances,
                         rewards,
                         loaded_addresses: LoadedAddresses::default(),
-                    }),
+                    },
                 }
             })
             .collect();
@@ -7285,9 +7285,9 @@ pub mod tests {
                 blockstore
                     .get_complete_transaction(signature, slot)
                     .unwrap(),
-                Some(VersionedConfirmedTransactionWithStatusMeta {
+                Some(ConfirmedTransactionWithStatusMeta {
                     slot,
-                    tx_with_meta,
+                    tx_with_meta: TransactionWithStatusMeta::Ok(tx_with_meta),
                     block_time: None
                 })
             );
@@ -8045,6 +8045,16 @@ pub mod tests {
                 .unwrap();
             transactions.push(transaction.into());
         }
+
+        let map_result =
+            blockstore.map_transactions_to_statuses(slot, transactions.clone().into_iter());
+        assert!(map_result.is_ok());
+        let map = map_result.unwrap();
+        assert_eq!(map.len(), 4);
+        for (x, m) in map.iter().enumerate() {
+            assert_eq!(m.meta.fee, x as u64);
+        }
+
         // Push transaction that will not have matching status, as a test case
         transactions.push(
             Transaction::new_with_compiled_instructions(
@@ -8057,14 +8067,9 @@ pub mod tests {
             .into(),
         );
 
-        let map_result = blockstore.map_transactions_to_statuses(slot, transactions.into_iter());
-        assert!(map_result.is_ok());
-        let map = map_result.unwrap();
-        assert_eq!(map.len(), 5);
-        for (x, m) in map.iter().take(4).enumerate() {
-            assert_eq!(m.meta.as_ref().unwrap().fee, x as u64);
-        }
-        assert_eq!(map[4].meta, None);
+        let map_result =
+            blockstore.map_transactions_to_statuses(slot, transactions.clone().into_iter());
+        assert_matches!(map_result, Err(BlockstoreError::MissingTransactionMetadata));
     }
 
     #[test]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -102,6 +102,7 @@ pub enum BlockstoreError {
     ParentEntriesUnavailable,
     SlotUnavailable,
     UnsupportedTransactionVersion,
+    MissingTransactionMetadata,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -54,11 +54,11 @@ use solana_sdk::{
     system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
     system_program, sysvar,
     sysvar::{clock, rent},
-    transaction::{SanitizedTransaction, Transaction, TransactionError},
+    transaction::{SanitizedTransaction, Transaction, TransactionError, VersionedTransaction},
 };
 use solana_transaction_status::{
     token_balances::collect_token_balances, ConfirmedTransactionWithStatusMeta, InnerInstructions,
-    TransactionStatusMeta, TransactionWithStatusMeta,
+    TransactionStatusMeta, TransactionWithStatusMeta, VersionedTransactionWithStatusMeta,
 };
 use std::{collections::HashMap, env, fs::File, io::Read, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -429,10 +429,12 @@ fn execute_transactions(
 
                     Ok(ConfirmedTransactionWithStatusMeta {
                         slot: bank.slot(),
-                        transaction: TransactionWithStatusMeta {
-                            transaction: tx.clone(),
-                            meta: Some(tx_status_meta),
-                        },
+                        tx_with_meta: TransactionWithStatusMeta::Ok(
+                            VersionedTransactionWithStatusMeta {
+                                transaction: VersionedTransaction::from(tx.clone()),
+                                meta: tx_status_meta,
+                            },
+                        ),
                         block_time: None,
                     })
                 }
@@ -2476,10 +2478,10 @@ fn test_program_upgradeable_locks() {
     assert!(matches!(
         results1[0],
         Ok(ConfirmedTransactionWithStatusMeta {
-            transaction: TransactionWithStatusMeta {
-                meta: Some(TransactionStatusMeta { status: Ok(()), .. }),
+            tx_with_meta: TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
+                meta: TransactionStatusMeta { status: Ok(()), .. },
                 ..
-            },
+            }),
             ..
         })
     ));
@@ -2488,16 +2490,16 @@ fn test_program_upgradeable_locks() {
     assert!(matches!(
         results2[0],
         Ok(ConfirmedTransactionWithStatusMeta {
-            transaction: TransactionWithStatusMeta {
-                meta: Some(TransactionStatusMeta {
+            tx_with_meta: TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
+                meta: TransactionStatusMeta {
                     status: Err(TransactionError::InstructionError(
                         0,
                         InstructionError::ProgramFailedToComplete
                     )),
                     ..
-                }),
+                },
                 ..
-            },
+            }),
             ..
         })
     ));

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -40,7 +40,7 @@ use {
         timing::timestamp,
         transaction,
     },
-    solana_transaction_status::ConfirmedBlock,
+    solana_transaction_status::{ConfirmedBlock, EncodeError, VersionedConfirmedBlock},
     std::{
         cell::RefCell,
         collections::{HashMap, VecDeque},
@@ -278,43 +278,45 @@ impl RpcNotifier {
 }
 
 fn filter_block_result_txs(
-    block: ConfirmedBlock,
+    mut block: VersionedConfirmedBlock,
     last_modified_slot: Slot,
     params: &BlockSubscriptionParams,
-) -> Option<RpcBlockUpdate> {
-    let transactions = match params.kind {
+) -> Result<Option<RpcBlockUpdate>, RpcBlockUpdateError> {
+    block.transactions = match params.kind {
         BlockSubscriptionKind::All => block.transactions,
         BlockSubscriptionKind::MentionsAccountOrProgram(pk) => block
             .transactions
             .into_iter()
-            .filter(|tx| tx.transaction.message.account_keys.contains(&pk))
+            .filter(|tx| tx.account_keys().iter().any(|key| key == &pk))
             .collect(),
     };
 
-    if transactions.is_empty() {
+    if block.transactions.is_empty() {
         if let BlockSubscriptionKind::MentionsAccountOrProgram(_) = params.kind {
-            return None;
+            return Ok(None);
         }
     }
 
-    let block = ConfirmedBlock {
-        transactions,
-        ..block
-    }
-    .configure(
-        params.encoding,
-        params.transaction_details,
-        params.show_rewards,
-    );
+    let block = ConfirmedBlock::from(block)
+        .encode_with_options(
+            params.encoding,
+            params.transaction_details,
+            params.show_rewards,
+        )
+        .map_err(|err| match err {
+            EncodeError::UnsupportedTransactionVersion => {
+                RpcBlockUpdateError::UnsupportedTransactionVersion
+            }
+        })?;
 
     // If last_modified_slot < last_notified_slot, then the last notif was for a fork.
     // That's the risk clients take when subscribing to non-finalized commitments.
     // This code lets the logic for dealing with forks live on the client side.
-    Some(RpcBlockUpdate {
+    Ok(Some(RpcBlockUpdate {
         slot: last_modified_slot,
         block: Some(block),
         err: None,
-    })
+    }))
 }
 
 fn filter_account_result(
@@ -959,26 +961,21 @@ impl RpcSubscriptions {
                                     break;
                                 }
 
-                                let block_result = blockstore
+                                let block_update_result = blockstore
                                     .get_complete_block(s, false)
                                     .map_err(|e| {
                                         error!("get_complete_block error: {}", e);
                                         RpcBlockUpdateError::BlockStoreError
                                     })
-                                    .and_then(|versioned_block| {
-                                        versioned_block.into_legacy_block().ok_or(
-                                            RpcBlockUpdateError::UnsupportedTransactionVersion,
-                                        )
-                                    });
+                                    .and_then(|block| filter_block_result_txs(block, s, params));
 
-                                match block_result {
-                                    Ok(block) => {
-                                        if let Some(res) = filter_block_result_txs(block, s, params)
-                                        {
+                                match block_update_result {
+                                    Ok(block_update) => {
+                                        if let Some(block_update) = block_update {
                                             notifier.notify(
                                                 Response {
                                                     context: RpcResponseContext { slot: s },
-                                                    value: res,
+                                                    value: block_update,
                                                 },
                                                 subscription,
                                                 false,
@@ -1354,8 +1351,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_confirmed_block_subscribe() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1396,10 +1398,11 @@ pub(crate) mod tests {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1411,9 +1414,11 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
-        let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-        let legacy_block = versioned_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        let block = confirmed_block
+            .encode_with_options(params.encoding, params.transaction_details, false)
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1452,8 +1457,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_confirmed_block_subscribe_with_mentions() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1495,10 +1505,11 @@ pub(crate) mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1511,16 +1522,17 @@ pub(crate) mod tests {
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
         // make sure it filtered out the other keypairs
-        let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-        let mut legacy_block = versioned_block.into_legacy_block().unwrap();
-        legacy_block.transactions.retain(|tx_with_meta| {
+        let mut confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        confirmed_block.transactions.retain(|tx_with_meta| {
             tx_with_meta
-                .transaction
-                .message
-                .account_keys
-                .contains(&keypair1.pubkey())
+                .transaction_account_keys()
+                .iter()
+                .any(|key| key == &keypair1.pubkey())
         });
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let block = confirmed_block
+            .encode_with_options(params.encoding, params.transaction_details, false)
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1549,8 +1561,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_finalized_block_subscribe() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1590,10 +1607,11 @@ pub(crate) mod tests {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1610,9 +1628,11 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
-        let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-        let legacy_block = versioned_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+        let confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        let block = confirmed_block
+            .encode_with_options(params.encoding, params.transaction_details, false)
+            .unwrap();
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -792,23 +792,46 @@ mod tests {
         prost::Message,
         solana_sdk::{
             hash::Hash, message::v0::LoadedAddresses, signature::Keypair, system_transaction,
+            transaction::VersionedTransaction,
         },
         solana_storage_proto::convert::generated,
         solana_transaction_status::{
             ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
-            VersionedConfirmedBlock,
+            VersionedTransactionWithStatusMeta,
         },
         std::convert::TryInto,
     };
+
+    fn confirmed_block_into_protobuf(confirmed_block: ConfirmedBlock) -> generated::ConfirmedBlock {
+        let ConfirmedBlock {
+            previous_blockhash,
+            blockhash,
+            parent_slot,
+            transactions,
+            rewards,
+            block_time,
+            block_height,
+        } = confirmed_block;
+
+        generated::ConfirmedBlock {
+            previous_blockhash,
+            blockhash,
+            parent_slot,
+            transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
+            rewards: rewards.into_iter().map(|r| r.into()).collect(),
+            block_time: block_time.map(|timestamp| generated::UnixTimestamp { timestamp }),
+            block_height: block_height.map(|block_height| generated::BlockHeight { block_height }),
+        }
+    }
 
     #[test]
     fn test_deserialize_protobuf_or_bincode_cell_data() {
         let from = Keypair::new();
         let recipient = solana_sdk::pubkey::new_rand();
         let transaction = system_transaction::transfer(&from, &recipient, 42, Hash::default());
-        let with_meta = TransactionWithStatusMeta {
-            transaction,
-            meta: Some(TransactionStatusMeta {
+        let with_meta = TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
+            transaction: VersionedTransaction::from(transaction),
+            meta: TransactionStatusMeta {
                 status: Ok(()),
                 fee: 1,
                 pre_balances: vec![43, 0, 1],
@@ -819,9 +842,9 @@ mod tests {
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
                 loaded_addresses: LoadedAddresses::default(),
-            }),
-        };
-        let block = ConfirmedBlock {
+            },
+        });
+        let expected_block = ConfirmedBlock {
             transactions: vec![with_meta],
             parent_slot: 1,
             blockhash: Hash::default().to_string(),
@@ -831,11 +854,11 @@ mod tests {
             block_height: Some(1),
         };
         let bincode_block = compress_best(
-            &bincode::serialize::<StoredConfirmedBlock>(&block.clone().into()).unwrap(),
+            &bincode::serialize::<StoredConfirmedBlock>(&expected_block.clone().into()).unwrap(),
         )
         .unwrap();
 
-        let protobuf_block = generated::ConfirmedBlock::from(block.clone());
+        let protobuf_block = confirmed_block_into_protobuf(expected_block.clone());
         let mut buf = Vec::with_capacity(protobuf_block.encoded_len());
         protobuf_block.encode(&mut buf).unwrap();
         let protobuf_block = compress_best(&buf).unwrap();
@@ -849,7 +872,6 @@ mod tests {
             "".to_string(),
         )
         .unwrap();
-        let expected_block: VersionedConfirmedBlock = block.into();
         if let CellData::Protobuf(protobuf_block) = deserialized {
             assert_eq!(expected_block, protobuf_block.try_into().unwrap());
         } else {
@@ -867,7 +889,10 @@ mod tests {
         .unwrap();
         if let CellData::Bincode(bincode_block) = deserialized {
             let mut block = expected_block;
-            if let Some(meta) = &mut block.transactions[0].meta {
+            if let TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
+                meta, ..
+            }) = &mut block.transactions[0]
+            {
                 meta.inner_instructions = None; // Legacy bincode implementation does not support inner_instructions
                 meta.log_messages = None; // Legacy bincode implementation does not support log_messages
                 meta.pre_token_balances = None; // Legacy bincode implementation does not support token balances

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -14,10 +14,10 @@ use {
     },
     solana_storage_proto::convert::{generated, tx_by_addr},
     solana_transaction_status::{
-        extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransactionStatusWithSignature, Reward,
-        TransactionByAddrInfo, TransactionConfirmationStatus, TransactionStatus,
-        TransactionStatusMeta, TransactionWithStatusMeta, VersionedConfirmedBlock,
-        VersionedConfirmedTransactionWithStatusMeta, VersionedTransactionWithStatusMeta,
+        extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
+        ConfirmedTransactionWithStatusMeta, Reward, TransactionByAddrInfo,
+        TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
+        TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedTransactionWithStatusMeta,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -115,6 +115,7 @@ struct StoredConfirmedBlock {
     block_height: Option<u64>,
 }
 
+#[cfg(test)]
 impl From<ConfirmedBlock> for StoredConfirmedBlock {
     fn from(confirmed_block: ConfirmedBlock) -> Self {
         let ConfirmedBlock {
@@ -139,7 +140,7 @@ impl From<ConfirmedBlock> for StoredConfirmedBlock {
     }
 }
 
-impl From<StoredConfirmedBlock> for VersionedConfirmedBlock {
+impl From<StoredConfirmedBlock> for ConfirmedBlock {
     fn from(confirmed_block: StoredConfirmedBlock) -> Self {
         let StoredConfirmedBlock {
             previous_blockhash,
@@ -169,20 +170,38 @@ struct StoredConfirmedBlockTransaction {
     meta: Option<StoredConfirmedBlockTransactionStatusMeta>,
 }
 
+#[cfg(test)]
 impl From<TransactionWithStatusMeta> for StoredConfirmedBlockTransaction {
     fn from(value: TransactionWithStatusMeta) -> Self {
-        Self {
-            transaction: value.transaction.into(),
-            meta: value.meta.map(|meta| meta.into()),
+        match value {
+            TransactionWithStatusMeta::MissingMetadata(transaction) => Self {
+                transaction: VersionedTransaction::from(transaction),
+                meta: None,
+            },
+            TransactionWithStatusMeta::Ok(VersionedTransactionWithStatusMeta {
+                transaction,
+                meta,
+            }) => Self {
+                transaction,
+                meta: Some(meta.into()),
+            },
         }
     }
 }
 
-impl From<StoredConfirmedBlockTransaction> for VersionedTransactionWithStatusMeta {
-    fn from(value: StoredConfirmedBlockTransaction) -> Self {
-        Self {
-            transaction: value.transaction,
-            meta: value.meta.map(|meta| meta.into()),
+impl From<StoredConfirmedBlockTransaction> for TransactionWithStatusMeta {
+    fn from(tx_with_meta: StoredConfirmedBlockTransaction) -> Self {
+        let StoredConfirmedBlockTransaction { transaction, meta } = tx_with_meta;
+        match meta {
+            None => Self::MissingMetadata(
+                transaction
+                    .into_legacy_transaction()
+                    .expect("versioned transactions always have meta"),
+            ),
+            Some(meta) => Self::Ok(VersionedTransactionWithStatusMeta {
+                transaction,
+                meta: meta.into(),
+            }),
         }
     }
 }
@@ -394,7 +413,7 @@ impl LedgerStorage {
     }
 
     /// Fetch the confirmed block from the desired slot
-    pub async fn get_confirmed_block(&self, slot: Slot) -> Result<VersionedConfirmedBlock> {
+    pub async fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
         debug!(
             "LedgerStorage::get_confirmed_block request received: {:?}",
             slot
@@ -440,7 +459,7 @@ impl LedgerStorage {
     pub async fn get_confirmed_transaction(
         &self,
         signature: &Signature,
-    ) -> Result<Option<VersionedConfirmedTransactionWithStatusMeta>> {
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
         debug!(
             "LedgerStorage::get_confirmed_transaction request received: {:?}",
             signature
@@ -465,17 +484,17 @@ impl LedgerStorage {
                 warn!("Transaction info for {} is corrupt", signature);
                 Ok(None)
             }
-            Some(bucket_block_transaction) => {
-                if bucket_block_transaction.transaction.signatures[0] != *signature {
+            Some(tx_with_meta) => {
+                if tx_with_meta.transaction_signature() != signature {
                     warn!(
                         "Transaction info or confirmed block for {} is corrupt",
                         signature
                     );
                     Ok(None)
                 } else {
-                    Ok(Some(VersionedConfirmedTransactionWithStatusMeta {
+                    Ok(Some(ConfirmedTransactionWithStatusMeta {
                         slot,
-                        tx_with_meta: bucket_block_transaction,
+                        tx_with_meta,
                         block_time: block.block_time,
                     }))
                 }
@@ -638,7 +657,7 @@ impl LedgerStorage {
         let mut tx_cells = vec![];
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
             let VersionedTransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
-            let err = meta.as_ref().and_then(|meta| meta.status.clone().err());
+            let err = meta.status.clone().err();
             let index = index as u32;
             let signature = transaction.signatures[0];
             let memo = extract_and_fmt_memos(transaction_with_meta);
@@ -725,21 +744,41 @@ impl LedgerStorage {
         let mut expected_tx_infos: HashMap<String, UploadedTransaction> = HashMap::new();
         let confirmed_block = self.get_confirmed_block(slot).await?;
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
-            let VersionedTransactionWithStatusMeta { transaction, meta } = transaction_with_meta;
-            let signature = transaction.signatures[0];
-            let index = index as u32;
-            let err = meta.as_ref().and_then(|meta| meta.status.clone().err());
+            match transaction_with_meta {
+                TransactionWithStatusMeta::MissingMetadata(transaction) => {
+                    let signature = transaction.signatures[0];
+                    let index = index as u32;
+                    let err = None;
 
-            for address in transaction_with_meta.account_keys().iter() {
-                if !is_sysvar_id(address) {
-                    addresses.insert(address);
+                    for address in transaction.message.account_keys.iter() {
+                        if !is_sysvar_id(address) {
+                            addresses.insert(address);
+                        }
+                    }
+
+                    expected_tx_infos.insert(
+                        signature.to_string(),
+                        UploadedTransaction { slot, index, err },
+                    );
+                }
+                TransactionWithStatusMeta::Ok(tx_with_meta) => {
+                    let VersionedTransactionWithStatusMeta { transaction, meta } = tx_with_meta;
+                    let signature = transaction.signatures[0];
+                    let index = index as u32;
+                    let err = meta.status.clone().err();
+
+                    for address in tx_with_meta.account_keys().iter() {
+                        if !is_sysvar_id(address) {
+                            addresses.insert(address);
+                        }
+                    }
+
+                    expected_tx_infos.insert(
+                        signature.to_string(),
+                        UploadedTransaction { slot, index, err },
+                    );
                 }
             }
-
-            expected_tx_infos.insert(
-                signature.to_string(),
-                UploadedTransaction { slot, index, err },
-            );
         }
 
         let address_slot_rows: Vec<_> = addresses

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -140,31 +140,7 @@ impl From<VersionedConfirmedBlock> for generated::ConfirmedBlock {
     }
 }
 
-impl From<ConfirmedBlock> for generated::ConfirmedBlock {
-    fn from(confirmed_block: ConfirmedBlock) -> Self {
-        let ConfirmedBlock {
-            previous_blockhash,
-            blockhash,
-            parent_slot,
-            transactions,
-            rewards,
-            block_time,
-            block_height,
-        } = confirmed_block;
-
-        Self {
-            previous_blockhash,
-            blockhash,
-            parent_slot,
-            transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
-            rewards: rewards.into_iter().map(|r| r.into()).collect(),
-            block_time: block_time.map(|timestamp| generated::UnixTimestamp { timestamp }),
-            block_height: block_height.map(|block_height| generated::BlockHeight { block_height }),
-        }
-    }
-}
-
-impl TryFrom<generated::ConfirmedBlock> for VersionedConfirmedBlock {
+impl TryFrom<generated::ConfirmedBlock> for ConfirmedBlock {
     type Error = bincode::Error;
     fn try_from(
         confirmed_block: generated::ConfirmedBlock,
@@ -195,32 +171,38 @@ impl TryFrom<generated::ConfirmedBlock> for VersionedConfirmedBlock {
 }
 
 impl From<TransactionWithStatusMeta> for generated::ConfirmedTransaction {
-    fn from(value: TransactionWithStatusMeta) -> Self {
-        let meta = value.meta.map(|meta| meta.into());
-        Self {
-            transaction: Some(value.transaction.into()),
-            meta,
+    fn from(tx_with_meta: TransactionWithStatusMeta) -> Self {
+        match tx_with_meta {
+            TransactionWithStatusMeta::MissingMetadata(transaction) => Self {
+                transaction: Some(generated::Transaction::from(transaction)),
+                meta: None,
+            },
+            TransactionWithStatusMeta::Ok(tx_with_meta) => Self::from(tx_with_meta),
         }
     }
 }
 
 impl From<VersionedTransactionWithStatusMeta> for generated::ConfirmedTransaction {
     fn from(value: VersionedTransactionWithStatusMeta) -> Self {
-        let meta = value.meta.map(|meta| meta.into());
         Self {
             transaction: Some(value.transaction.into()),
-            meta,
+            meta: Some(value.meta.into()),
         }
     }
 }
 
-impl TryFrom<generated::ConfirmedTransaction> for VersionedTransactionWithStatusMeta {
+impl TryFrom<generated::ConfirmedTransaction> for TransactionWithStatusMeta {
     type Error = bincode::Error;
     fn try_from(value: generated::ConfirmedTransaction) -> std::result::Result<Self, Self::Error> {
         let meta = value.meta.map(|meta| meta.try_into()).transpose()?;
-        Ok(Self {
-            transaction: value.transaction.expect("transaction is required").into(),
-            meta,
+        let transaction = value.transaction.expect("transaction is required").into();
+        Ok(match meta {
+            Some(meta) => Self::Ok(VersionedTransactionWithStatusMeta { transaction, meta }),
+            None => Self::MissingMetadata(
+                transaction
+                    .into_legacy_transaction()
+                    .expect("meta is required for versioned transactions"),
+            ),
         })
     }
 }


### PR DESCRIPTION
#### Problem
Transaction status metadata types allow metadata to be `None` which can cause problems when that metadata is required for RPC requests.

#### Summary of Changes
- Fetching a block from the blockstore which doesn't have all tx metas, will now return an error.
- Removed `allow_missing_metadata` cli option from ledger tool uploader because it's impossible for that to happen
- Introduced new `TransactionWithStatusMeta` enum which has variants for txs with and without metadata.
- It's now impossible for non-legacy transactions to be uploaded with missing metadata
- Various other refactorings to prepare for updating metadata and encoded RPC API types for versioned transactions

Fixes #
