### PR TITLE
Cleanup: TransactionContext

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1283,13 +1283,13 @@ mod tests {
                 MockInstruction::NoopFail => return Err(InstructionError::GenericError),
                 MockInstruction::ModifyOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&[1])?,
+                    .set_data(&[1]),
                 MockInstruction::ModifyNotOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 1)?
-                    .set_data(&[1])?,
+                    .set_data(&[1]),
                 MockInstruction::ModifyReadonly => instruction_context
                     .try_borrow_instruction_account(transaction_context, 2)?
-                    .set_data(&[1])?,
+                    .set_data(&[1]),
                 MockInstruction::ConsumeComputeUnits {
                     compute_units_to_consume,
                     desired_result,
@@ -1303,7 +1303,7 @@ mod tests {
                 }
                 MockInstruction::Resize { new_len } => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&vec![0; new_len])?,
+                    .set_data(&vec![0; new_len]),
             }
         } else {
             return Err(InstructionError::InvalidInstructionData);

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -178,8 +178,8 @@ pub fn builtin_process_instruction(
         let mut borrowed_account =
             instruction_context.try_borrow_account(transaction_context, index_in_instruction)?;
         if borrowed_account.is_writable() {
-            borrowed_account.set_lamports(lamports)?;
-            borrowed_account.set_data(&data)?;
+            borrowed_account.set_lamports(lamports);
+            borrowed_account.set_data(&data);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -706,10 +706,13 @@ pub fn inner_instructions_list_from_instruction_trace(
                     CompiledInstruction::new_from_raw_parts(
                         instruction_context.get_program_id_index() as u8,
                         instruction_context.get_instruction_data().to_vec(),
-                        instruction_context
-                            .get_instruction_accounts_metas()
-                            .iter()
-                            .map(|meta| meta.index_in_transaction as u8)
+                        (instruction_context.get_number_of_program_accounts()
+                            ..instruction_context.get_number_of_accounts())
+                            .map(|index_in_instruction| {
+                                instruction_context
+                                    .get_index_in_transaction(index_in_instruction)
+                                    .unwrap_or_default() as u8
+                            })
                             .collect(),
                     )
                 })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -14921,7 +14921,8 @@ pub(crate) mod tests {
             let instruction_context = transaction_context.get_current_instruction_context()?;
             instruction_context
                 .try_borrow_instruction_account(transaction_context, 1)?
-                .set_data(&[0; 40])
+                .set_data(&[0; 40]);
+            Ok(())
         }
 
         let program_id = solana_sdk::pubkey::new_rand();

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -210,7 +210,7 @@ mod tests {
                     MockSystemInstruction::ChangeData { data } => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 1)?
-                            .set_data(&[data])?;
+                            .set_data(&[data]);
                         Ok(())
                     }
                 }
@@ -409,7 +409,7 @@ mod tests {
                             .try_borrow_instruction_account(transaction_context, 2)?;
                         dup_account.checked_sub_lamports(lamports)?;
                         to_account.checked_add_lamports(lamports)?;
-                        dup_account.set_data(&[data])?;
+                        dup_account.set_data(&[data]);
                         drop(dup_account);
                         let mut from_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?;

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -565,10 +565,15 @@ impl<'a> BorrowedAccount<'a> {
         self.verify_writability()
     }
 
-    /*pub fn realloc(&self, new_len: usize, zero_init: bool) {
+    /// Resizes the account data (transaction wide)
+    ///
+    /// Fills it with zeros at the end if is extended or truncates at the end otherwise.
+    pub fn set_data_length(&mut self, new_len: usize) -> Result<(), InstructionError> {
+        self.account.data_mut().resize(new_len, 0);
         // TODO: return Err(InstructionError::InvalidRealloc);
         // TODO: return Err(InstructionError::AccountDataSizeChanged);
-    }*/
+        self.verify_writability()
+    }
 
     /// Deserializes the account data into a state
     pub fn get_state<T: serde::de::DeserializeOwned>(&self) -> Result<T, InstructionError> {

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -253,13 +253,6 @@ impl TransactionContext {
 /// List of (stack height, instruction) for each top-level instruction
 pub type InstructionTrace = Vec<Vec<(usize, InstructionContext)>>;
 
-#[derive(Clone, Debug)]
-pub struct AccountMeta {
-    pub index_in_transaction: usize,
-    pub is_signer: bool,
-    pub is_writable: bool,
-}
-
 /// Loaded instruction shared between runtime and programs.
 ///
 /// This context is valid for the entire duration of a (possibly cross program) instruction being processed.
@@ -302,17 +295,6 @@ impl InstructionContext {
     /// Number of accounts in this Instruction (without program accounts)
     pub fn get_number_of_instruction_accounts(&self) -> usize {
         self.instruction_accounts.len()
-    }
-
-    pub fn get_instruction_accounts_metas(&self) -> Vec<AccountMeta> {
-        self.instruction_accounts
-            .iter()
-            .map(|instruction_account| AccountMeta {
-                index_in_transaction: instruction_account.index_in_transaction,
-                is_signer: instruction_account.is_signer,
-                is_writable: instruction_account.is_writable,
-            })
-            .collect()
     }
 
     /// Number of accounts in this Instruction

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -5,6 +5,7 @@ use crate::{
     instruction::{InstructionError, TRANSACTION_LEVEL_STACK_HEIGHT},
     lamports::LamportsError,
     pubkey::Pubkey,
+    sysvar::Sysvar,
 };
 use std::{
     cell::{RefCell, RefMut},
@@ -113,6 +114,17 @@ impl TransactionContext {
         self.accounts
             .get(index_in_transaction)
             .ok_or(InstructionError::NotEnoughAccountKeys)
+    }
+
+    /// Checks if the account key at the given index is the belongs to the given sysvar
+    pub fn check_sysvar<S: Sysvar>(
+        &self,
+        index_in_transaction: usize,
+    ) -> Result<(), InstructionError> {
+        if !S::check_id(&self.account_keys[index_in_transaction]) {
+            return Err(InstructionError::InvalidArgument);
+        }
+        Ok(())
     }
 
     /// Searches for an account by its key

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -545,6 +545,15 @@ impl<'a> BorrowedAccount<'a> {
         self.account.data()
     }
 
+    /// Returns a writable slice of the account data (transaction wide)
+    pub fn get_data_mut(&mut self) -> Result<&mut [u8], InstructionError> {
+        if self.is_writable() {
+            Ok(self.account.data_as_mut_slice())
+        } else {
+            Err(InstructionError::Immutable)
+        }
+    }
+
     /// Overwrites the account data and size (transaction wide)
     pub fn set_data(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         if data.len() == self.account.data().len() {


### PR DESCRIPTION
#### Problem
There are many `TODO`s left in transaction_context.rs
Also, the goal of ABIv2 to check incorrect accesses in-program was dropped and we are back to verifying the metadata at the end (similar to `PreAccount`s).

#### Summary of Changes
- Adds `BorrowedAccount::check_sysvar()`
- Adds `BorrowedAccount::get_data_mut()`
- Implements account resizing in `BorrowedAccount`
- Exposes `is_signer()` and `is_writable()` in `InstructionContext`
- Removes `AccountMeta` and `get_instruction_accounts_metas()`
- Removes result return values from `BorrowedAccount`

Fixes #
