### PR TITLE
Optimize batching of transactions during replay for parallel processing

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -313,6 +313,9 @@ fn execute_batches(
     let cost_model = CostModel::new();
     let mut minimal_tx_cost = u64::MAX;
     let mut total_cost: u64 = 0;
+    // Allowing collect here, since it also computes the minimal tx cost, and aggregate cost.
+    // These two values are later used for checking if the tx_costs vector needs to be iterated over.
+    #[allow(clippy::needless_collect)]
     let tx_costs = sanitized_txs
         .iter()
         .map(|tx| {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -355,7 +355,7 @@ fn execute_batches(
     } else {
         execute_batches_internal(
             bank,
-            &batches,
+            batches,
             entry_callback,
             transaction_status_sender,
             replay_vote_sender,


### PR DESCRIPTION
#### Problem
The replay stage tries to parallelize execution of transaction batches. However, the batches could be uneven based on how long it takes to process each batch. This is not optimal use of parallel iterators, as it leads to work stealing and uneven distribution of work across threads.

#### Summary of Changes
This PR uses `CostModel` to compute total cost of executing the batches, and redistributes the transactions across batches that have similar execution cost. This improves the usage of parallel iterators by making each thread process similar amount of workload.

