### PR TITLE
Put accounts data len updates behind feature gate

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4576,7 +4576,11 @@ impl Bank {
             .write()
             .unwrap()
             .extend(rent_debits.into_unordered_rewards_iter());
-        if total_collected.account_data_len_reclaimed > 0 {
+        if self
+            .feature_set
+            .is_active(&feature_set::cap_accounts_data_len::id())
+            && total_collected.account_data_len_reclaimed > 0
+        {
             self.update_accounts_data_len(-(total_collected.account_data_len_reclaimed as i64));
         }
 
@@ -15414,7 +15418,7 @@ pub(crate) mod tests {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000_000);
         let mut bank = Bank::new_for_tests(&genesis_config);
-        bank.activate_feature(&solana_sdk::feature_set::cap_accounts_data_len::id());
+        bank.activate_feature(&feature_set::cap_accounts_data_len::id());
 
         let mut i = 0;
         let result = loop {


### PR DESCRIPTION
#### Problem

Updates to the Bank's `accounts_data_len` when collecting rent is not feature gated behind `cap_accounts_data_len`. This should've been feature-gated when it was first merged in #22412.

See [here](https://github.com/solana-labs/solana/blob/28442aa9226907ceb926287906cc14135aafd18e/program-runtime/src/invoke_context.rs#L436) and [here](https://github.com/solana-labs/solana/blob/28442aa9226907ceb926287906cc14135aafd18e/program-runtime/src/invoke_context.rs#L494) for existing usage of the feature.

#### Summary of Changes

Put the update behind the feature gate.

Related to #21604 