### PR TITLE
fix: swallow error if socket has already been closed

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4110,7 +4110,11 @@ export class Connection {
         this._rpcWebSocketConnected = false;
         this._rpcWebSocketIdleTimeout = setTimeout(() => {
           this._rpcWebSocketIdleTimeout = null;
-          this._rpcWebSocket.close();
+          try {
+            this._rpcWebSocket.close();
+          } catch {
+            // swallow error if socket has already been closed.
+          }
         }, 500);
       }
       return;

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4112,8 +4112,13 @@ export class Connection {
           this._rpcWebSocketIdleTimeout = null;
           try {
             this._rpcWebSocket.close();
-          } catch {
+          } catch (err) {
             // swallow error if socket has already been closed.
+            if (err instanceof Error) {
+              console.log(
+                `Error when closing socket connection: ${err.message}`,
+              );
+            }
           }
         }, 500);
       }


### PR DESCRIPTION
#### Problem
We are seeing a high level of crashes in mobile Phantom related to this error. The socket connection can end up in a state where the socket has already been closed by `rpc-websockets` when this gets triggered. Potentially the socket receives a close-event without having any subscriptions (although it shouldn't happen) and then proceeds to attempt closing. I've discussed different options with @jstarry and opted for swallowing the error since it's very painful to debug and we are not 100% how the problem occurs.

#### Summary of Changes
Wraps closing in a try/catch, effectively swallowing any errors we might get.

Fixes [#21446](https://github.com/solana-labs/solana/issues/21446)
