### PR TITLE
Enable incremental snapshots by default

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -7,7 +7,7 @@ source multinode-demo/common.sh
 
 rm -rf config/run/init-completed config/ledger config/snapshot-ledger
 
-SOLANA_RUN_SH_VALIDATOR_ARGS="--snapshot-interval-slots 200" timeout 120 ./scripts/run.sh &
+SOLANA_RUN_SH_VALIDATOR_ARGS="--full-snapshot-interval-slots 200" timeout 120 ./scripts/run.sh &
 pid=$!
 
 attempts=20

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -123,6 +123,7 @@ args+=(
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 200
+  --no-incremental-snapshots
   --identity "$identity"
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -249,6 +249,7 @@ default_arg --vote-account "$vote_account"
 default_arg --ledger "$ledger_dir"
 default_arg --log -
 default_arg --full-rpc-api
+default_arg --no-incremental-snapshots
 
 if [[ $maybeRequireTower = true ]]; then
   default_arg --require-tower

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2434,7 +2434,7 @@ pub fn main() {
         exit(1);
     }
     if matches.is_present("incremental_snapshots") {
-        warn!("--incremental_snapshots is now the default behavior. This flag is deprecated and can be removed from the launch args")
+        warn!("--incremental-snapshots is now the default behavior. This flag is deprecated and can be removed from the launch args")
     }
 
     if matches.is_present("limit_ledger_size") {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -792,10 +792,11 @@ pub fn main() {
                        download from other validators"),
         )
         .arg(
-            Arg::with_name("incremental_snapshots")
-                .long("incremental-snapshots")
+            Arg::with_name("no_incremental_snapshots")
+                .long("no-incremental-snapshots")
                 .takes_value(false)
-                .long_help("Enable incremental snapshots by setting this flag. \
+                .help("Disable incremental snapshots")
+                .long_help("Disable incremental snapshots by setting this flag. \
                    When enabled, --snapshot-interval-slots will set the \
                    incremental snapshot interval. To set the full snapshot \
                    interval, use --full-snapshot-interval-slots.")
@@ -1910,7 +1911,7 @@ pub fn main() {
             "max_genesis_archive_unpacked_size",
             u64
         ),
-        incremental_snapshot_fetch: matches.is_present("incremental_snapshots"),
+        incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
     };
 
     let private_rpc = matches.is_present("private_rpc");
@@ -2373,7 +2374,7 @@ pub fn main() {
         value_t_or_exit!(matches, "incremental_snapshot_interval_slots", u64);
     let (full_snapshot_archive_interval_slots, incremental_snapshot_archive_interval_slots) =
         if incremental_snapshot_interval_slots > 0 {
-            if matches.is_present("incremental_snapshots") {
+            if !matches.is_present("no_incremental_snapshots") {
                 (
                     value_t_or_exit!(matches, "full_snapshot_interval_slots", u64),
                     incremental_snapshot_interval_slots,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -792,6 +792,18 @@ pub fn main() {
                        download from other validators"),
         )
         .arg(
+            Arg::with_name("incremental_snapshots")
+                .long("incremental-snapshots")
+                .takes_value(false)
+                .hidden(true)
+                .conflicts_with("no_incremental_snapshots")
+                .help("Enable incremental snapshots")
+                .long_help("Enable incremental snapshots by setting this flag. \
+                   When enabled, --snapshot-interval-slots will set the \
+                   incremental snapshot interval. To set the full snapshot \
+                   interval, use --full-snapshot-interval-slots.")
+         )
+        .arg(
             Arg::with_name("no_incremental_snapshots")
                 .long("no-incremental-snapshots")
                 .takes_value(false)
@@ -2420,6 +2432,9 @@ pub fn main() {
             validator_config.accounts_hash_interval_slots);
 
         exit(1);
+    }
+    if matches.is_present("incremental_snapshots") {
+        warn!("--incremental_snapshots is now the default behavior. This flag is deprecated and can be removed from the launch args")
     }
 
     if matches.is_present("limit_ledger_size") {


### PR DESCRIPTION
#### Problem

Incremental snapshots were disabled by default.

#### Summary of Changes

Enable incremental snapshots by default. This hides the `--incremental-snapshots` validator CLI flag, and adds the `--no-incremental-snapshots` flag.

- [x] Should I also backport this to v1.9?
  - A: No (see [here](https://github.com/solana-labs/solana/pull/22938#pullrequestreview-876896887))
