### PR TITLE
removes VoteTracker::new in favor of VoteTracker::default

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4478,7 +4478,7 @@ pub mod tests {
         // runs in `update_propagation_status`
         assert!(!progress_map.get_leader_propagation_slot_must_exist(10).0);
 
-        let vote_tracker = VoteTracker::new(&bank_forks.root_bank());
+        let vote_tracker = VoteTracker::default();
         vote_tracker.insert_vote(10, vote_pubkey);
         ReplayStage::update_propagation_status(
             &mut progress_map,
@@ -4563,7 +4563,7 @@ pub mod tests {
             );
         }
 
-        let vote_tracker = VoteTracker::new(&bank_forks.root_bank());
+        let vote_tracker = VoteTracker::default();
         for vote_pubkey in &vote_pubkeys {
             // Insert a vote for the last bank for each voter
             vote_tracker.insert_vote(10, *vote_pubkey);
@@ -4650,7 +4650,7 @@ pub mod tests {
             progress_map.insert(i, fork_progress);
         }
 
-        let vote_tracker = VoteTracker::new(&bank_forks.root_bank());
+        let vote_tracker = VoteTracker::default();
         // Insert a new vote
         vote_tracker.insert_vote(10, vote_pubkeys[2]);
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -504,7 +504,7 @@ pub mod tests {
             None,
             None,
             None,
-            Arc::new(VoteTracker::new(&bank)),
+            Arc::<VoteTracker>::default(),
             retransmit_slots_sender,
             gossip_verified_vote_hash_receiver,
             verified_vote_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -96,7 +96,6 @@ use {
     std::{
         collections::{HashMap, HashSet},
         net::SocketAddr,
-        ops::Deref,
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
@@ -805,10 +804,7 @@ impl Validator {
             "New shred signal for the TVU should be the same as the clear bank signal."
         );
 
-        let vote_tracker = Arc::new(VoteTracker::new(
-            bank_forks.read().unwrap().root_bank().deref(),
-        ));
-
+        let vote_tracker = Arc::<VoteTracker>::default();
         let mut cost_model = CostModel::default();
         cost_model.initialize_cost_table(&blockstore.read_program_costs().unwrap());
         let cost_model = Arc::new(RwLock::new(cost_model));


### PR DESCRIPTION
#### Problem
`VoteTracker::new` does not need a bank.

#### Summary of Changes
removed `VoteTracker::new` in favor of `VoteTracker::default`