### PR TITLE
make max_roots_inclusive clear

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2000,7 +2000,7 @@ impl AccountsDb {
         timings: &mut CleanKeyTimings,
     ) -> Vec<Pubkey> {
         let mut dirty_store_processing_time = Measure::start("dirty_store_processing");
-        let max_slot = max_clean_root.unwrap_or_else(|| self.accounts_index.max_root());
+        let max_slot = max_clean_root.unwrap_or_else(|| self.accounts_index.max_root_inclusive());
         let mut dirty_stores = Vec::with_capacity(self.dirty_stores.len());
         self.dirty_stores.retain(|(slot, _store_id), store| {
             if *slot > max_slot {


### PR DESCRIPTION
#### Problem
Sometimes we use a max that is inclusive, sometimes exclusive.
It is easy to have subtle bugs when either could be intended and sometimes we have to translate between inclusive and exclusive values.

#### Summary of Changes
Make it clear that max_roots is inclusive on this api.
Fixes #
