### PR TITLE
Bumps solana_rbpf to version v0.2.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6389,9 +6389,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425e41726409233aa2b4e5063a94a8bc5861e6d59cf700cfd9dd142084437c6f"
+checksum = "537ce4f3a7501f4714aad0d24e2404098f6ba93b078165c766ba6e5712f54ed1"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ solana-config-program = { path = "../programs/config", version = "=1.10.0" }
 solana-faucet = { path = "../faucet", version = "=1.10.0" }
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
-solana_rbpf = "=0.2.22"
+solana_rbpf = "=0.2.23"
 solana-remote-wallet = { path = "../remote-wallet", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.10.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3766,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425e41726409233aa2b4e5063a94a8bc5861e6d59cf700cfd9dd142084437c6f"
+checksum = "537ce4f3a7501f4714aad0d24e2404098f6ba93b078165c766ba6e5712f54ed1"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.10.0" }
 solana-logger = { path = "../../logger", version = "=1.10.0" }
 solana-measure = { path = "../../measure", version = "=1.10.0" }
-solana_rbpf = "=0.2.22"
+solana_rbpf = "=0.2.23"
 solana-runtime = { path = "../../runtime", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.10.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../../sdk", version = "=1.10.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.22"
+solana_rbpf = "=0.2.23"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.10.
 solana-logger = { path = "../logger", version = "=1.10.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.10.0" }
 solana-sdk = { path = "../sdk", version = "=1.10.0" }
-solana_rbpf = "=0.2.22"
+solana_rbpf = "=0.2.23"


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.23](https://github.com/solana-labs/rbpf/releases/tag/v0.2.23) was released.

#### Summary of Changes

Fixes #
