### PR TITLE
 Add get_processed_sibling_instruction syscall

### DIFF
--- a/program-runtime/src/instruction_recorder.rs
+++ b/program-runtime/src/instruction_recorder.rs
@@ -7,9 +7,9 @@ use {
 };
 
 /// Records and compiles cross-program invoked instructions
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct InstructionRecorder {
-    inner: Rc<RefCell<Vec<Instruction>>>,
+    inner: Rc<RefCell<Vec<(usize, Instruction)>>>,
 }
 
 impl InstructionRecorder {
@@ -20,11 +20,39 @@ impl InstructionRecorder {
         self.inner
             .borrow()
             .iter()
-            .map(|ix| message.try_compile_instruction(ix))
+            .skip(1)
+            .map(|(_, ix)| message.try_compile_instruction(ix))
             .collect()
     }
 
-    pub fn record_instruction(&self, instruction: Instruction) {
-        self.inner.borrow_mut().push(instruction);
+    pub fn record_instruction(&self, stack_height: usize, instruction: Instruction) {
+        self.inner.borrow_mut().push((stack_height, instruction));
+    }
+
+    pub fn get(&self, index: usize) -> Option<Instruction> {
+        self.inner
+            .borrow()
+            .get(index)
+            .map(|(_, instruction)| instruction.clone())
+    }
+
+    pub fn find(&self, stack_height: usize, index: usize) -> Option<Instruction> {
+        let mut current_index = 0;
+        self.inner
+            .borrow()
+            .iter()
+            .rev()
+            .skip(1)
+            .find(|(this_stack_height, _)| {
+                if stack_height == *this_stack_height {
+                    if index == current_index {
+                        return true;
+                    } else {
+                        current_index = current_index.saturating_add(1);
+                    }
+                }
+                false
+            })
+            .map(|(_, instruction)| instruction.clone())
     }
 }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -98,7 +98,11 @@ pub fn builtin_process_instruction(
 
     let log_collector = invoke_context.get_log_collector();
     let program_id = invoke_context.get_caller()?;
-    stable_log::program_invoke(&log_collector, program_id, invoke_context.invoke_depth());
+    stable_log::program_invoke(
+        &log_collector,
+        program_id,
+        invoke_context.get_stack_height(),
+    );
 
     // Skip the processor account
     let keyed_accounts = &invoke_context.get_keyed_accounts()?[1..];
@@ -246,7 +250,11 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             .map(|(i, _)| message.is_writable(i))
             .collect::<Vec<bool>>();
 
-        stable_log::program_invoke(&log_collector, &program_id, invoke_context.invoke_depth());
+        stable_log::program_invoke(
+            &log_collector,
+            &program_id,
+            invoke_context.get_stack_height(),
+        );
 
         // Convert AccountInfos into Accounts
         let mut account_indices = Vec::with_capacity(message.account_keys.len());
@@ -305,9 +313,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             }
         }
 
-        if let Some(instruction_recorder) = &invoke_context.instruction_recorder {
-            instruction_recorder.record_instruction(instruction.clone());
-        }
+        invoke_context.record_instruction(invoke_context.get_stack_height(), instruction.clone());
 
         let message = SanitizedMessage::Legacy(message);
         invoke_context

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2773,6 +2773,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-sibling-instructions"
+version = "1.9.6"
+dependencies = [
+ "solana-program 1.9.6",
+]
+
+[[package]]
+name = "solana-bpf-rust-sibling_inner-instructions"
+version = "1.9.6"
+dependencies = [
+ "solana-program 1.9.6",
+]
+
+[[package]]
 name = "solana-bpf-rust-spoof1"
 version = "1.9.6"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -81,6 +81,8 @@ members = [
     "rust/sanity",
     "rust/secp256k1_recover",
     "rust/sha",
+    "rust/sibling_inner_instruction",
+    "rust/sibling_instruction",
     "rust/spoof1",
     "rust/spoof1_system",
     "rust/sysvar",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -91,6 +91,8 @@ fn main() {
             "sanity",
             "secp256k1_recover",
             "sha",
+            "sibling_inner_instruction",
+            "sibling_instruction",
             "spoof1",
             "spoof1_system",
             "upgradeable",

--- a/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_inner_instruction/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-bpf-rust-sibling_inner-instructions"
+version = "1.9.6"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-log-data"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.9.6" }
+
+[features]
+default = ["program"]
+program = []
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/sibling_inner_instruction/src/lib.rs
+++ b/programs/bpf/rust/sibling_inner_instruction/src/lib.rs
@@ -1,0 +1,69 @@
+//! Example Rust-based BPF program that queries sibling instructions
+
+#![cfg(feature = "program")]
+
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    instruction::{
+        get_processed_sibling_instruction, get_stack_height, AccountMeta, Instruction,
+        TRANSACTION_LEVEL_STACK_HEIGHT,
+    },
+    msg,
+    pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("sibling inner");
+
+    // account 0 is mint
+    // account 1 is noop
+    // account 2 is invoke_and_return
+
+    // Check sibling instructions
+
+    let sibling_instruction2 = Instruction::new_with_bytes(
+        *accounts[2].key,
+        &[3],
+        vec![AccountMeta::new_readonly(*accounts[1].key, false)],
+    );
+    let sibling_instruction1 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[2],
+        vec![
+            AccountMeta::new_readonly(*accounts[0].key, true),
+            AccountMeta::new_readonly(*accounts[1].key, false),
+        ],
+    );
+    let sibling_instruction0 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[1],
+        vec![
+            AccountMeta::new_readonly(*accounts[1].key, false),
+            AccountMeta::new_readonly(*accounts[0].key, true),
+        ],
+    );
+
+    assert_eq!(TRANSACTION_LEVEL_STACK_HEIGHT + 1, get_stack_height());
+    assert_eq!(
+        get_processed_sibling_instruction(0),
+        Some(sibling_instruction0)
+    );
+    assert_eq!(
+        get_processed_sibling_instruction(1),
+        Some(sibling_instruction1)
+    );
+    assert_eq!(
+        get_processed_sibling_instruction(2),
+        Some(sibling_instruction2)
+    );
+    assert_eq!(get_processed_sibling_instruction(3), None);
+
+    Ok(())
+}

--- a/programs/bpf/rust/sibling_instruction/Cargo.toml
+++ b/programs/bpf/rust/sibling_instruction/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-bpf-rust-sibling-instructions"
+version = "1.9.6"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-log-data"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.9.6" }
+
+[features]
+default = ["program"]
+program = []
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/sibling_instruction/src/lib.rs
+++ b/programs/bpf/rust/sibling_instruction/src/lib.rs
@@ -1,0 +1,100 @@
+//! Example Rust-based BPF program that queries sibling instructions
+
+#![cfg(feature = "program")]
+
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    instruction::{
+        get_processed_sibling_instruction, get_stack_height, AccountMeta, Instruction,
+        TRANSACTION_LEVEL_STACK_HEIGHT,
+    },
+    msg,
+    program::invoke,
+    pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("sibling");
+
+    // account 0 is mint
+    // account 1 is noop
+    // account 2 is invoke_and_return
+    // account 3 is sibling_inner
+
+    // Invoke child instructions
+
+    let instruction3 = Instruction::new_with_bytes(
+        *accounts[2].key,
+        &[3],
+        vec![AccountMeta::new_readonly(*accounts[1].key, false)],
+    );
+    let instruction2 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[2],
+        vec![
+            AccountMeta::new_readonly(*accounts[0].key, true),
+            AccountMeta::new_readonly(*accounts[1].key, false),
+        ],
+    );
+    let instruction1 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[1],
+        vec![
+            AccountMeta::new_readonly(*accounts[1].key, false),
+            AccountMeta::new_readonly(*accounts[0].key, true),
+        ],
+    );
+    let instruction0 = Instruction::new_with_bytes(
+        *accounts[3].key,
+        &[0],
+        vec![
+            AccountMeta::new_readonly(*accounts[0].key, false),
+            AccountMeta::new_readonly(*accounts[1].key, false),
+            AccountMeta::new_readonly(*accounts[2].key, false),
+            AccountMeta::new_readonly(*accounts[3].key, false),
+        ],
+    );
+    invoke(&instruction3, accounts)?;
+    invoke(&instruction2, accounts)?;
+    invoke(&instruction1, accounts)?;
+    invoke(&instruction0, accounts)?;
+
+    // Check sibling instructions
+
+    let sibling_instruction1 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[43],
+        vec![
+            AccountMeta::new_readonly(*accounts[1].key, false),
+            AccountMeta::new(*accounts[0].key, true),
+        ],
+    );
+    let sibling_instruction0 = Instruction::new_with_bytes(
+        *accounts[1].key,
+        &[42],
+        vec![
+            AccountMeta::new(*accounts[0].key, true),
+            AccountMeta::new_readonly(*accounts[1].key, false),
+        ],
+    );
+
+    assert_eq!(TRANSACTION_LEVEL_STACK_HEIGHT, get_stack_height());
+    assert_eq!(
+        get_processed_sibling_instruction(0),
+        Some(sibling_instruction0)
+    );
+    assert_eq!(
+        get_processed_sibling_instruction(1),
+        Some(sibling_instruction1)
+    );
+    assert_eq!(get_processed_sibling_instruction(2), None);
+
+    Ok(())
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3327,3 +3327,79 @@ fn test_program_bpf_realloc_invoke() {
         TransactionError::InstructionError(0, InstructionError::InvalidRealloc)
     );
 }
+
+#[test]
+#[cfg(any(feature = "bpf_rust"))]
+fn test_program_bpf_processed_inner_instruction() {
+    solana_logger::setup();
+
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(50);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    let (name, id, entrypoint) = solana_bpf_loader_program!();
+    bank.add_builtin(&name, &id, entrypoint);
+    let bank = Arc::new(bank);
+    let bank_client = BankClient::new_shared(&bank);
+
+    let sibling_program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_sibling_instructions",
+    );
+    let sibling_inner_program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_sibling_inner_instructions",
+    );
+    let noop_program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_noop",
+    );
+    let invoke_and_return_program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_invoke_and_return",
+    );
+
+    let instruction2 = Instruction::new_with_bytes(
+        noop_program_id,
+        &[43],
+        vec![
+            AccountMeta::new_readonly(noop_program_id, false),
+            AccountMeta::new(mint_keypair.pubkey(), true),
+        ],
+    );
+    let instruction1 = Instruction::new_with_bytes(
+        noop_program_id,
+        &[42],
+        vec![
+            AccountMeta::new(mint_keypair.pubkey(), true),
+            AccountMeta::new_readonly(noop_program_id, false),
+        ],
+    );
+    let instruction0 = Instruction::new_with_bytes(
+        sibling_program_id,
+        &[1, 2, 3, 0, 4, 5, 6],
+        vec![
+            AccountMeta::new(mint_keypair.pubkey(), true),
+            AccountMeta::new_readonly(noop_program_id, false),
+            AccountMeta::new_readonly(invoke_and_return_program_id, false),
+            AccountMeta::new_readonly(sibling_inner_program_id, false),
+        ],
+    );
+    let message = Message::new(
+        &[instruction2, instruction1, instruction0],
+        Some(&mint_keypair.pubkey()),
+    );
+    assert!(bank_client
+        .send_and_confirm_message(&[&mint_keypair], message)
+        .is_ok());
+}

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -298,7 +298,7 @@ fn process_instruction_common(
     if program.executable()? {
         debug_assert_eq!(
             first_instruction_account,
-            1 - (invoke_context.invoke_depth() > 1) as usize,
+            1 - (invoke_context.get_stack_height() > 1) as usize,
         );
 
         if !check_loader_id(&program.owner()?) {
@@ -1036,7 +1036,7 @@ impl Executor for BpfExecutor {
     ) -> Result<(), InstructionError> {
         let log_collector = invoke_context.get_log_collector();
         let compute_meter = invoke_context.get_compute_meter();
-        let invoke_depth = invoke_context.invoke_depth();
+        let stack_height = invoke_context.get_stack_height();
 
         let mut serialize_time = Measure::start("serialize");
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
@@ -1068,7 +1068,7 @@ impl Executor for BpfExecutor {
             create_vm_time.stop();
 
             execute_time = Measure::start("execute");
-            stable_log::program_invoke(&log_collector, &program_id, invoke_depth);
+            stable_log::program_invoke(&log_collector, &program_id, stack_height);
             let mut instruction_meter = ThisInstructionMeter::new(compute_meter.clone());
             let before = compute_meter.borrow().get_remaining();
             let result = if use_jit {

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -20,7 +20,7 @@ fn process_instruction_with_program_logging(
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
     let program_id = invoke_context.get_caller()?;
-    stable_log::program_invoke(&logger, program_id, invoke_context.invoke_depth());
+    stable_log::program_invoke(&logger, program_id, invoke_context.get_stack_height());
 
     let result = process_instruction(first_instruction_account, instruction_data, invoke_context);
 

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -528,7 +528,8 @@ pub fn checked_add(a: u64, b: u64) -> Result<u64, InstructionError> {
 /// default [`AccountMeta::new`] constructor creates writable accounts, this is
 /// a minor hazard: use [`AccountMeta::new_readonly`] to specify that an account
 /// is not writable.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[repr(C)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 pub struct AccountMeta {
     /// An account's public key.
     pub pubkey: Pubkey,
@@ -639,8 +640,16 @@ impl CompiledInstruction {
         let data = serialize(data).unwrap();
         Self {
             program_id_index: program_ids_index,
-            data,
             accounts,
+            data,
+        }
+    }
+
+    pub fn new_from_raw_parts(program_id_index: u8, data: Vec<u8>, accounts: Vec<u8>) -> Self {
+        Self {
+            program_id_index,
+            accounts,
+            data,
         }
     }
 
@@ -666,6 +675,32 @@ impl CompiledInstruction {
             unique_index += 1;
         }
         Ok(())
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    pub fn decompile(
+        &self,
+        message: &crate::message::SanitizedMessage,
+    ) -> Result<Instruction, InstructionError> {
+        Ok(Instruction::new_with_bytes(
+            *message
+                .get_account_key(self.program_id_index as usize)
+                .ok_or(InstructionError::MissingAccount)?,
+            &self.data,
+            self.accounts
+                .iter()
+                .map(|account_index| {
+                    let account_index = *account_index as usize;
+                    Ok(AccountMeta {
+                        is_signer: message.is_signer(account_index),
+                        is_writable: message.is_writable(account_index),
+                        pubkey: *message
+                            .get_account_key(account_index)
+                            .ok_or(InstructionError::MissingAccount)?,
+                    })
+                })
+                .collect::<Result<Vec<AccountMeta>, InstructionError>>()?,
+        ))
     }
 }
 
@@ -695,4 +730,138 @@ mod test {
         assert_eq!((6, 6), do_work(&[0, 0, 1, 1, 2, 2, 3, 3]));
         assert_eq!((0, 2), do_work(&[2, 2]));
     }
+}
+
+/// Use to query and convey information about the sibling instruction components
+/// when calling the `sol_get_processed_sibling_instruction` syscall.
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct ProcessedSiblingInstruction {
+    /// Length of the instruction data
+    pub data_len: usize,
+    /// Number of AccountMeta structures
+    pub accounts_len: usize,
+}
+
+/// Returns a sibling instruction from the processed sibling instruction list.
+///
+/// The processed sibling instruction list is a reverse-ordered list of
+/// successfully processed sibling instructions. For example, given the call flow:
+///
+/// A
+/// B -> C -> D
+/// B -> E
+/// B -> F
+///
+/// Then B's processed sibling instruction list is: `[A]`
+/// Then F's processed sibling instruction list is: `[E, C]`
+pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_get_processed_sibling_instruction(
+                index: u64,
+                meta: *mut ProcessedSiblingInstruction,
+                program_id: *mut Pubkey,
+                data: *mut u8,
+                accounts: *mut AccountMeta,
+            ) -> u64;
+        }
+
+        let mut meta = ProcessedSiblingInstruction::default();
+        let mut program_id = Pubkey::default();
+
+        if 1 == unsafe {
+            sol_get_processed_sibling_instruction(
+                index as u64,
+                &mut meta,
+                &mut program_id,
+                &mut u8::default(),
+                &mut AccountMeta::default(),
+            )
+        } {
+            let mut data = Vec::new();
+            let mut accounts = Vec::new();
+            data.resize_with(meta.data_len, u8::default);
+            accounts.resize_with(meta.accounts_len, AccountMeta::default);
+
+            let _ = unsafe {
+                sol_get_processed_sibling_instruction(
+                    index as u64,
+                    &mut meta,
+                    &mut program_id,
+                    data.as_mut_ptr(),
+                    accounts.as_mut_ptr(),
+                )
+            };
+
+            Some(Instruction::new_with_bytes(program_id, &data, accounts))
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    crate::program_stubs::sol_get_processed_sibling_instruction(index)
+}
+
+// Stack height when processing transaction-level instructions
+pub const TRANSACTION_LEVEL_STACK_HEIGHT: usize = 1;
+
+/// Get the current stack height, transaction-level instructions are height
+/// TRANSACTION_LEVEL_STACK_HEIGHT, fist invoked inner instruction is height
+/// TRANSACTION_LEVEL_STACK_HEIGHT + 1, etc...
+pub fn get_stack_height() -> usize {
+    #[cfg(target_arch = "bpf")]
+    {
+        extern "C" {
+            fn sol_get_stack_height() -> u64;
+        }
+
+        unsafe { sol_get_stack_height() as usize }
+    }
+
+    #[cfg(not(target_arch = "bpf"))]
+    {
+        crate::program_stubs::sol_get_stack_height() as usize
+    }
+}
+
+#[test]
+fn test_account_meta_layout() {
+    #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+    struct AccountMetaRust {
+        pub pubkey: Pubkey,
+        pub is_signer: bool,
+        pub is_writable: bool,
+    }
+
+    let account_meta_rust = AccountMetaRust::default();
+    let base_rust_addr = &account_meta_rust as *const _ as u64;
+    let pubkey_rust_addr = &account_meta_rust.pubkey as *const _ as u64;
+    let is_signer_rust_addr = &account_meta_rust.is_signer as *const _ as u64;
+    let is_writable_rust_addr = &account_meta_rust.is_writable as *const _ as u64;
+
+    let account_meta_c = AccountMeta::default();
+    let base_c_addr = &account_meta_c as *const _ as u64;
+    let pubkey_c_addr = &account_meta_c.pubkey as *const _ as u64;
+    let is_signer_c_addr = &account_meta_c.is_signer as *const _ as u64;
+    let is_writable_c_addr = &account_meta_c.is_writable as *const _ as u64;
+
+    assert_eq!(
+        std::mem::size_of::<AccountMetaRust>(),
+        std::mem::size_of::<AccountMeta>()
+    );
+    assert_eq!(
+        pubkey_rust_addr - base_rust_addr,
+        pubkey_c_addr - base_c_addr
+    );
+    assert_eq!(
+        is_signer_rust_addr - base_rust_addr,
+        is_signer_c_addr - base_c_addr
+    );
+    assert_eq!(
+        is_writable_rust_addr - base_rust_addr,
+        is_writable_c_addr - base_c_addr
+    );
 }

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -91,6 +91,12 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_log_data(&self, fields: &[&[u8]]) {
         println!("data: {}", fields.iter().map(base64::encode).join(" "));
     }
+    fn sol_get_processed_sibling_instruction(&self, _index: usize) -> Option<Instruction> {
+        None
+    }
+    fn sol_get_stack_height(&self) -> u64 {
+        0
+    }
 }
 
 struct DefaultSyscallStubs {}
@@ -175,4 +181,15 @@ pub(crate) fn sol_set_return_data(data: &[u8]) {
 
 pub(crate) fn sol_log_data(data: &[&[u8]]) {
     SYSCALL_STUBS.read().unwrap().sol_log_data(data)
+}
+
+pub(crate) fn sol_get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_processed_sibling_instruction(index)
+}
+
+pub(crate) fn sol_get_stack_height() -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_stack_height()
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -295,6 +295,10 @@ pub mod disable_bpf_unresolved_symbols_at_runtime {
     solana_sdk::declare_id!("4yuaYAj2jGMGTh1sSmi4G2eFscsDq8qjugJXZoBN6YEa");
 }
 
+pub mod add_get_processed_sibling_instruction_syscall {
+    solana_sdk::declare_id!("CFK1hRCNy8JJuAAY8Pb2GjLFNdCThS2qwZNe3izzBMgn");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -363,6 +367,7 @@ lazy_static! {
         (bank_tranaction_count_fix::id(), "Fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
         (disable_bpf_deprecated_load_instructions::id(), "Disable ldabs* and ldind* BPF instructions"),
         (disable_bpf_unresolved_symbols_at_runtime::id(), "Disable reporting of unresolved BPF symbols at runtime"),
+        (add_get_processed_sibling_instruction_syscall::id(), "add add_get_processed_sibling_instruction_syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

There are scenarios where instructions (top-level or via CPI) would like to know what the last instruction processed was. Some examples are verification of assert instructions or to check for memo instructions.  Programs can already check tx level instructions via the `Sysvar1nstructions1111111111111111111111111` but there is no way to get information about what inner instructions have been processed.

#### Summary of Changes

Add a syscall that allows a program to query what sibling instructions have been successfully processed.

```
/// Returns a sibling instruction from the processed sibling instruction list.
///
/// The processed sibling instruction list is a reverse-ordered list of
/// successfully processed sibling instructions. For example, given the call flow:
///
/// A
/// B -> C -> D
/// B -> E
/// B -> F
///
/// Then B's processed sibling instruction list is: [A]
/// Then F's processed sibling instruction list is: [E, C]
```

#### Summary of Changes

Backport of #22859

Fixes #
