### PR TITLE
fix a typo in fork stake subtract update

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -80,7 +80,7 @@ impl UpdateOperation {
             Self::Add(stake) => *stake += new_stake,
             Self::MarkValid(_slot) => panic!("Should not get here"),
             Self::MarkInvalid(_slot) => panic!("Should not get here"),
-            Self::Subtract(stake) => *stake += new_stake,
+            Self::Subtract(stake) => *stake -= new_stake,
         }
     }
 }
@@ -2028,7 +2028,7 @@ mod test {
                 ),
                 (
                     ((3, Hash::default()), UpdateLabel::Subtract),
-                    UpdateOperation::Subtract(2 * stake),
+                    UpdateOperation::Subtract(0),
                 ),
                 (
                     ((5, Hash::default()), UpdateLabel::Subtract),

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -768,7 +768,7 @@ mod test {
             if slot == 6 {
                 assert_eq!(stake_voted_at, 3 * stake);
             } else {
-                assert_eq!(stake_voted_at, 0);
+                assert_eq!(stake_voted_at, 400);
             }
         }
 


### PR DESCRIPTION
#### Problem
There is a typo in fork state subtract update function, which does an add instead of sub.

#### Summary of Changes

Fixes #
