### PR TITLE
Small optimization

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -300,7 +300,7 @@ pub struct RetransmitInfo {
 impl RetransmitInfo {
     pub fn reached_retransmit_threshold(&self) -> bool {
         let backoff = std::cmp::min(self.retry_iteration, RETRANSMIT_BACKOFF_CAP);
-        let backoff_duration_ms = 2_u64.pow(backoff) * RETRANSMIT_BASE_DELAY_MS;
+        let backoff_duration_ms = (1_u64 << backoff) * RETRANSMIT_BASE_DELAY_MS;
         self.retry_time
             .map(|time| time.elapsed().as_millis() > backoff_duration_ms.into())
             .unwrap_or(true)


### PR DESCRIPTION
#### Problem
rust compiler didn't do a good job for computing 2.pow(n) optimization. 
[codegen example](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(j:1,lang:rust,source:'pub+fn+pow(num:+u32)+-%3E+u64+%7B%0A++++2u64.pow(num)%0A%7D%0A%0Apub+fn+shift(num:+u32)+-%3E+u64+%7B%0A++++1u64+%3C%3C+(num)%0A%7D'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1210,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',trim:'1'),lang:rust,libs:!(),options:'-O',source:1),l:'5',n:'0',o:'rustc+1.21.0+(Editor+%231,+Compiler+%231)+Rust',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

#### Summary of Changes
Replace *2.pow(n) with shift operator.

Fixes #
