### PR TITLE
Fix panic in ProgramTestContext::warp_to_slot() when warping one slot

### DIFF
--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -132,7 +132,7 @@ async fn clock_sysvar_updated_from_warp() {
     );
 
     let mut context = program_test.start_with_context().await;
-    let expected_slot = 100_000;
+    let mut expected_slot = 100_000;
     let instruction = Instruction::new_with_bincode(
         program_id,
         &expected_slot,
@@ -175,14 +175,31 @@ async fn clock_sysvar_updated_from_warp() {
         .await
         .unwrap();
 
+    // Try warping ahead one slot (corner case in warp logic)
+    expected_slot += 1;
+    assert!(context.warp_to_slot(expected_slot).is_ok());
+    let instruction = Instruction::new_with_bincode(
+        program_id,
+        &expected_slot,
+        vec![AccountMeta::new_readonly(clock::id(), false)],
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
     // Try warping again to the same slot
     assert_eq!(
         context.warp_to_slot(expected_slot).unwrap_err(),
         ProgramTestError::InvalidWarpSlot,
     );
-
-    // Try warping ahead one slot
-    assert!(context.warp_to_slot(expected_slot + 1).is_ok());
 }
 
 #[tokio::test]

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -180,6 +180,9 @@ async fn clock_sysvar_updated_from_warp() {
         context.warp_to_slot(expected_slot).unwrap_err(),
         ProgramTestError::InvalidWarpSlot,
     );
+
+    // Try warping ahead one slot
+    assert!(context.warp_to_slot(expected_slot + 1).is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### Problem
warp_to_slot() first warps to one slot before desired slot in order to
freeze the bank at warp slot. This would cause issues when warping by
one slot as that would attempt to warp to the same slot and hit a sanity
check assertion.

Not really sure how common the use-case for warping one slot would be; but, I think we should handle it appropriately anyways.

#### Summary of Changes
Add an if statement to handle warp ahead one slot case.

Fixes #22948
