### PR TITLE
Return the accounts data len delta after processing messages

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -212,7 +212,7 @@ impl<'a> InvokeContext<'a> {
         feature_set: Arc<FeatureSet>,
         blockhash: Hash,
         lamports_per_signature: u64,
-        current_accounts_data_len: u64,
+        initial_accounts_data_len: u64,
     ) -> Self {
         Self {
             transaction_context,
@@ -225,7 +225,7 @@ impl<'a> InvokeContext<'a> {
             current_compute_budget: compute_budget,
             compute_budget,
             compute_meter: ComputeMeter::new_ref(compute_budget.max_units),
-            accounts_data_meter: AccountsDataMeter::new(current_accounts_data_len),
+            accounts_data_meter: AccountsDataMeter::new(initial_accounts_data_len),
             executors,
             feature_set,
             timings: ExecuteDetailsTimings::default(),
@@ -1657,7 +1657,7 @@ mod tests {
 
         invoke_context
             .accounts_data_meter
-            .set_current(user_account_data_len as u64);
+            .set_initial(user_account_data_len as u64);
         invoke_context
             .accounts_data_meter
             .set_maximum(user_account_data_len as u64 * 3);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3878,7 +3878,7 @@ impl Bank {
                 .map(|_| info)
             })
             .map(|info| {
-                self.store_accounts_data_len(info.accounts_data_len);
+                self.update_accounts_data_len(info.accounts_data_len_delta);
             })
             .map_err(|err| {
                 match err {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -38,8 +38,8 @@ impl ::solana_frozen_abi::abi_example::AbiExample for MessageProcessor {
 /// Resultant information gathered from calling process_message()
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ProcessedMessageInfo {
-    /// The new accounts data len
-    pub accounts_data_len: u64,
+    /// The change in accounts data len
+    pub accounts_data_len_delta: i64,
 }
 
 impl MessageProcessor {
@@ -149,7 +149,7 @@ impl MessageProcessor {
                 .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
         }
         Ok(ProcessedMessageInfo {
-            accounts_data_len: invoke_context.get_accounts_data_meter().current(),
+            accounts_data_len_delta: invoke_context.get_accounts_data_meter().delta(),
         })
     }
 }


### PR DESCRIPTION
#### Problem

Tracking and consuming from `Bank::accounts_data_len` could race if multiple threads call `Bank::process_message()`. The original behavior in #21807 was correct, and #21813 introduced the race.

#### Summary of Changes

* Change `AccountsDataMeter` to track the accounts data len _delta_
* MessageProcessor returns the delta (from above) instead of the final accounts data len
* Bank _updates_ its accounts data len from the delta instead of storing the final accounts data len

Related to #21604