### PR TITLE
Refactor: Use instruction_trace instead of instruction_context_stack

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -814,12 +814,10 @@ impl<'a> InvokeContext<'a> {
             })
             .unwrap_or_else(|| Ok(native_loader::id()))?;
 
-        let stack_height = self
+        let nesting_level = self
             .transaction_context
             .get_instruction_context_stack_height();
-
-        let is_top_level_instruction = stack_height == 0;
-
+        let is_top_level_instruction = nesting_level == 0;
         if !is_top_level_instruction {
             // Verify the calling program hasn't misbehaved
             let mut verify_caller_time = Measure::start("verify_caller_time");
@@ -836,7 +834,7 @@ impl<'a> InvokeContext<'a> {
 
             self.transaction_context
                 .record_instruction(InstructionContext::new(
-                    stack_height.saturating_add(1),
+                    nesting_level,
                     program_indices,
                     instruction_accounts,
                     instruction_data,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1344,6 +1344,16 @@ mod tests {
         // Check call depth increases and has a limit
         let mut depth_reached = 0;
         for _ in 0..invoke_stack.len() {
+            if depth_reached > 0 {
+                invoke_context
+                    .transaction_context
+                    .record_instruction(InstructionContext::new(
+                        depth_reached,
+                        &[MAX_DEPTH + depth_reached],
+                        &instruction_accounts,
+                        &[],
+                    ));
+            }
             if Err(InstructionError::CallDepth)
                 == invoke_context.push(&instruction_accounts, &[MAX_DEPTH + depth_reached], &[])
             {
@@ -1471,6 +1481,9 @@ mod tests {
 
         // External modification tests
         {
+            /*invoke_context
+            .transaction_context
+            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();
@@ -1537,6 +1550,9 @@ mod tests {
             ),
         ];
         for case in cases {
+            /*invoke_context
+            .transaction_context
+            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();
@@ -1550,6 +1566,9 @@ mod tests {
         let compute_units_to_consume = 10;
         let expected_results = vec![Ok(()), Err(InstructionError::GenericError)];
         for expected_result in expected_results {
+            /*invoke_context
+            .transaction_context
+            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1013,13 +1013,6 @@ impl<'a> InvokeContext<'a> {
         self.transaction_context
             .get_key_of_account_at_index(index_in_transaction)
     }
-
-    /// Get an instruction context
-    pub fn get_instruction_context_at(&self, level: usize) -> Option<&InstructionContext> {
-        self.transaction_context
-            .get_instruction_context_at(level)
-            .ok()
-    }
 }
 
 pub struct MockInvokeContextPreparation {
@@ -1481,9 +1474,6 @@ mod tests {
 
         // External modification tests
         {
-            /*invoke_context
-            .transaction_context
-            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();
@@ -1550,9 +1540,6 @@ mod tests {
             ),
         ];
         for case in cases {
-            /*invoke_context
-            .transaction_context
-            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();
@@ -1566,9 +1553,6 @@ mod tests {
         let compute_units_to_consume = 10;
         let expected_results = vec![Ok(()), Err(InstructionError::GenericError)];
         for expected_result in expected_results {
-            /*invoke_context
-            .transaction_context
-            .record_instruction(InstructionContext::new(0, &[4], &instruction_accounts, &[]));*/
             invoke_context
                 .push(&instruction_accounts, &[4], &[])
                 .unwrap();

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -834,10 +834,13 @@ impl<'a> InvokeContext<'a> {
             );
             verify_caller_result?;
 
-            self.transaction_context.record_instruction(
-                stack_height.saturating_add(1),
-                InstructionContext::new(program_indices, instruction_accounts, instruction_data),
-            );
+            self.transaction_context
+                .record_instruction(InstructionContext::new(
+                    stack_height.saturating_add(1),
+                    program_indices,
+                    instruction_accounts,
+                    instruction_data,
+                ));
         }
 
         let result = self
@@ -1002,11 +1005,6 @@ impl<'a> InvokeContext<'a> {
     /// Get cached sysvars
     pub fn get_sysvar_cache(&self) -> &SysvarCache {
         &self.sysvar_cache
-    }
-
-    /// Get instruction trace
-    pub fn get_instruction_trace(&self) -> &[Vec<(usize, InstructionContext)>] {
-        self.transaction_context.get_instruction_trace()
     }
 
     // Get pubkey of account at index

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -103,7 +103,7 @@ fn create_inputs() -> TransactionContext {
     let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
-        .push(&[0], &instruction_accounts, &instruction_data)
+        .push(&[0], &instruction_accounts, &instruction_data, true)
         .unwrap();
     transaction_context
 }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3037,7 +3037,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
         );
 
         let stack_height = invoke_context.get_stack_height();
-        let instruction_trace = invoke_context.get_instruction_trace();
+        let instruction_trace = invoke_context.transaction_context.get_instruction_trace();
         let instruction_context = if stack_height == TRANSACTION_LEVEL_STACK_HEIGHT {
             // pick one of the top-level instructions
             instruction_trace
@@ -3050,8 +3050,8 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
             // Walk the last list of inner instructions
             instruction_trace.last().and_then(|inners| {
                 let mut current_index = 0;
-                inners.iter().rev().skip(1).find(|(this_stack_height, _)| {
-                    if stack_height == *this_stack_height {
+                inners.iter().rev().skip(1).find(|instruction_context| {
+                    if stack_height == instruction_context.get_stack_height() {
                         if index == current_index {
                             return true;
                         } else {
@@ -3061,8 +3061,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
                     false
                 })
             })
-        }
-        .map(|(_, instruction_context)| instruction_context);
+        };
 
         if let Some(instruction_context) = instruction_context {
             let ProcessedSiblingInstruction {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -15876,15 +15876,15 @@ pub(crate) mod tests {
     fn test_inner_instructions_list_from_instruction_trace() {
         let instruction_trace = vec![
             vec![
-                InstructionContext::new(1, &[], &[], &[1]),
-                InstructionContext::new(2, &[], &[], &[2]),
+                InstructionContext::new(0, &[], &[], &[1]),
+                InstructionContext::new(1, &[], &[], &[2]),
             ],
             vec![],
             vec![
-                InstructionContext::new(1, &[], &[], &[3]),
-                InstructionContext::new(2, &[], &[], &[4]),
-                InstructionContext::new(3, &[], &[], &[5]),
-                InstructionContext::new(2, &[], &[], &[6]),
+                InstructionContext::new(0, &[], &[], &[3]),
+                InstructionContext::new(1, &[], &[], &[4]),
+                InstructionContext::new(2, &[], &[], &[5]),
+                InstructionContext::new(1, &[], &[], &[6]),
             ],
         ];
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -702,7 +702,7 @@ pub fn inner_instructions_list_from_instruction_trace(
             inner_instructions_trace
                 .iter()
                 .skip(1)
-                .map(|(_, instruction_context)| {
+                .map(|instruction_context| {
                     CompiledInstruction::new_from_raw_parts(
                         instruction_context.get_program_id_index() as u8,
                         instruction_context.get_instruction_data().to_vec(),
@@ -15876,15 +15876,15 @@ pub(crate) mod tests {
     fn test_inner_instructions_list_from_instruction_trace() {
         let instruction_trace = vec![
             vec![
-                (1, InstructionContext::new(&[], &[], &[1])),
-                (2, InstructionContext::new(&[], &[], &[2])),
+                InstructionContext::new(1, &[], &[], &[1]),
+                InstructionContext::new(2, &[], &[], &[2]),
             ],
             vec![],
             vec![
-                (1, InstructionContext::new(&[], &[], &[3])),
-                (2, InstructionContext::new(&[], &[], &[4])),
-                (3, InstructionContext::new(&[], &[], &[5])),
-                (2, InstructionContext::new(&[], &[], &[6])),
+                InstructionContext::new(1, &[], &[], &[3]),
+                InstructionContext::new(2, &[], &[], &[4]),
+                InstructionContext::new(3, &[], &[], &[5]),
+                InstructionContext::new(2, &[], &[], &[6]),
             ],
         ];
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -307,6 +307,10 @@ pub mod disable_bpf_unresolved_symbols_at_runtime {
     solana_sdk::declare_id!("4yuaYAj2jGMGTh1sSmi4G2eFscsDq8qjugJXZoBN6YEa");
 }
 
+pub mod record_instruction_in_transaction_context_push {
+    solana_sdk::declare_id!("3aJdcZqxoLpSBxgeYGjPwaYS1zzcByxUDqJkbzWAH1Zb");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -378,6 +382,7 @@ lazy_static! {
         (bank_tranaction_count_fix::id(), "Fixes Bank::transaction_count to include all committed transactions, not just successful ones"),
         (disable_bpf_deprecated_load_instructions::id(), "Disable ldabs* and ldind* BPF instructions"),
         (disable_bpf_unresolved_symbols_at_runtime::id(), "Disable reporting of unresolved BPF symbols at runtime"),
+        (record_instruction_in_transaction_context_push::id(), "Move the CPI stack overflow check to the end of push"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The `instruction_context_stack` and `instruction_trace` in `TransactionContext` are storing the same copies of `InstructionContext`, thus are redundant.

#### Summary of Changes
- Let the `instruction_context_stack` reference the `instruction_trace` by using indices.
This works as the `instruction_trace` is append only and indices are never shifted.
- Have `TransactionContext::push()` do the `TransactionContext::record_instruction()`.
This requires a feature gate (`record_instruction_in_transaction_context_push`) because the priority of the CPI stack overflow error changes.

Fixes #
