### PR TITLE
solana-validator monitor: Remove getMaxRetransmitSlot RPC method usage

### DIFF
--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -124,7 +124,6 @@ impl Dashboard {
 
                 match get_validator_stats(&rpc_client, &identity) {
                     Ok((
-                        max_retransmit_slot,
                         processed_slot,
                         confirmed_slot,
                         finalized_slot,
@@ -145,7 +144,7 @@ impl Dashboard {
                         };
 
                         progress_bar.set_message(format!(
-                            "{}{}{}| \
+                            "{}{}| \
                                     Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: {} | \
                                     Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
                                     Transactions: {} | {}",
@@ -154,11 +153,6 @@ impl Dashboard {
                                 "".to_string()
                             } else {
                                 format!("| {} ", style(health).bold().red())
-                            },
-                            if max_retransmit_slot == 0 {
-                                "".to_string()
-                            } else {
-                                format!("| Max Slot: {} ", max_retransmit_slot)
                             },
                             processed_slot,
                             confirmed_slot,
@@ -257,11 +251,10 @@ fn get_contact_info(rpc_client: &RpcClient, identity: &Pubkey) -> Option<RpcCont
 fn get_validator_stats(
     rpc_client: &RpcClient,
     identity: &Pubkey,
-) -> client_error::Result<(Slot, Slot, Slot, Slot, u64, Sol, String)> {
+) -> client_error::Result<(Slot, Slot, Slot, u64, Sol, String)> {
     let finalized_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::finalized())?;
     let confirmed_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::confirmed())?;
     let processed_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::processed())?;
-    let max_retransmit_slot = rpc_client.get_max_retransmit_slot()?;
     let transaction_count =
         rpc_client.get_transaction_count_with_commitment(CommitmentConfig::processed())?;
     let identity_balance = rpc_client
@@ -290,7 +283,6 @@ fn get_validator_stats(
     };
 
     Ok((
-        max_retransmit_slot,
         processed_slot,
         confirmed_slot,
         finalized_slot,


### PR DESCRIPTION
`solana-validator monitor` no longer uses getMaxRetransmitSlot, which is not in the `--minimal-rpc-api` set.
