### PR TITLE
Prepare RPC subsystem for multiple SPL Token program ids

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -5,7 +5,7 @@ use {
         parse_nonce::parse_nonce,
         parse_stake::parse_stake,
         parse_sysvar::parse_sysvar,
-        parse_token::{parse_token, spl_token_id},
+        parse_token::{parse_token, spl_token_ids},
         parse_vote::parse_vote,
     },
     inflector::Inflector,
@@ -21,7 +21,6 @@ lazy_static! {
     static ref STAKE_PROGRAM_ID: Pubkey = stake::program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref SYSVAR_PROGRAM_ID: Pubkey = sysvar::id();
-    static ref TOKEN_PROGRAM_ID: Pubkey = spl_token_id();
     static ref VOTE_PROGRAM_ID: Pubkey = solana_vote_program::id();
     pub static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableAccount> = {
         let mut m = HashMap::new();
@@ -31,7 +30,9 @@ lazy_static! {
         );
         m.insert(*CONFIG_PROGRAM_ID, ParsableAccount::Config);
         m.insert(*SYSTEM_PROGRAM_ID, ParsableAccount::Nonce);
-        m.insert(*TOKEN_PROGRAM_ID, ParsableAccount::SplToken);
+        for spl_token_id in spl_token_ids() {
+            m.insert(spl_token_id, ParsableAccount::SplToken);
+        }
         m.insert(*STAKE_PROGRAM_ID, ParsableAccount::Stake);
         m.insert(*SYSVAR_PROGRAM_ID, ParsableAccount::Sysvar);
         m.insert(*VOTE_PROGRAM_ID, ParsableAccount::Vote);

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -15,14 +15,29 @@ use {
 
 // A helper function to convert spl_token::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
-pub fn spl_token_id() -> Pubkey {
+fn spl_token_id() -> Pubkey {
     Pubkey::new_from_array(spl_token::id().to_bytes())
+}
+
+// Returns all known SPL Token program ids
+pub fn spl_token_ids() -> Vec<Pubkey> {
+    vec![spl_token_id()]
+}
+
+// Check if the provided program id as a known SPL Token program id
+pub fn is_known_spl_token_id(program_id: &Pubkey) -> bool {
+    *program_id == spl_token_id()
 }
 
 // A helper function to convert spl_token::native_mint::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
 pub fn spl_token_native_mint() -> Pubkey {
     Pubkey::new_from_array(spl_token::native_mint::id().to_bytes())
+}
+
+// The program id of the `spl_token_native_mint` account
+pub fn spl_token_native_mint_program_id() -> Pubkey {
+    spl_token_id()
 }
 
 // A helper function to convert a solana_sdk::pubkey::Pubkey to spl_sdk::pubkey::Pubkey

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -2,7 +2,9 @@ use {
     jsonrpc_core::{Error, Result},
     solana_account_decoder::{
         parse_account_data::AccountAdditionalData,
-        parse_token::{get_token_account_mint, spl_token_id, spl_token_native_mint},
+        parse_token::{
+            get_token_account_mint, spl_token_native_mint, spl_token_native_mint_program_id,
+        },
         UiAccount, UiAccountData, UiAccountEncoding,
     },
     solana_client::rpc_response::RpcKeyedAccount,
@@ -75,7 +77,10 @@ where
 /// program_id) and decimals
 pub fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(Pubkey, u8)> {
     if mint == &spl_token_native_mint() {
-        Ok((spl_token_id(), spl_token::native_mint::DECIMALS))
+        Ok((
+            spl_token_native_mint_program_id(),
+            spl_token::native_mint::DECIMALS,
+        ))
     } else {
         let mint_account = bank.get_account(mint).ok_or_else(|| {
             Error::invalid_params("Invalid param: could not find mint".to_string())

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -10,7 +10,7 @@ use {
     },
     inflector::Inflector,
     serde_json::Value,
-    solana_account_decoder::parse_token::spl_token_id,
+    solana_account_decoder::parse_token::spl_token_ids,
     solana_sdk::{
         instruction::CompiledInstruction, message::AccountKeys, pubkey::Pubkey, stake,
         system_program,
@@ -30,7 +30,6 @@ lazy_static! {
     static ref MEMO_V3_PROGRAM_ID: Pubkey = spl_memo_id_v3();
     static ref STAKE_PROGRAM_ID: Pubkey = stake::program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
-    static ref TOKEN_PROGRAM_ID: Pubkey = spl_token_id();
     static ref VOTE_PROGRAM_ID: Pubkey = solana_vote_program::id();
     static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableProgram> = {
         let mut m = HashMap::new();
@@ -40,7 +39,9 @@ lazy_static! {
         );
         m.insert(*MEMO_V1_PROGRAM_ID, ParsableProgram::SplMemo);
         m.insert(*MEMO_V3_PROGRAM_ID, ParsableProgram::SplMemo);
-        m.insert(*TOKEN_PROGRAM_ID, ParsableProgram::SplToken);
+        for spl_token_id in spl_token_ids() {
+            m.insert(spl_token_id, ParsableProgram::SplToken);
+        }
         m.insert(*BPF_LOADER_PROGRAM_ID, ParsableProgram::BpfLoader);
         m.insert(
             *BPF_UPGRADEABLE_LOADER_PROGRAM_ID,

--- a/transaction-status/src/token_balances.rs
+++ b/transaction-status/src/token_balances.rs
@@ -1,8 +1,8 @@
 use {
     crate::TransactionTokenBalance,
     solana_account_decoder::parse_token::{
-        pubkey_from_spl_token, spl_token_id, spl_token_native_mint, token_amount_to_ui_amount,
-        UiTokenAmount,
+        is_known_spl_token_id, pubkey_from_spl_token, spl_token_native_mint,
+        token_amount_to_ui_amount, UiTokenAmount,
     },
     solana_measure::measure::Measure,
     solana_metrics::datapoint_debug,
@@ -35,10 +35,6 @@ impl TransactionTokenBalancesSet {
     }
 }
 
-fn is_token_program(program_id: &Pubkey) -> bool {
-    program_id == &spl_token_id()
-}
-
 fn get_mint_decimals(bank: &Bank, mint: &Pubkey) -> Option<u8> {
     if mint == &spl_token_native_mint() {
         Some(spl_token::native_mint::DECIMALS)
@@ -63,12 +59,12 @@ pub fn collect_token_balances(
 
     for transaction in batch.sanitized_transactions() {
         let account_keys = transaction.message().account_keys();
-        let has_token_program = account_keys.iter().any(is_token_program);
+        let has_token_program = account_keys.iter().any(is_known_spl_token_id);
 
         let mut transaction_balances: Vec<TransactionTokenBalance> = vec![];
         if has_token_program {
             for (index, account_id) in account_keys.iter().enumerate() {
-                if transaction.message().is_invoked(index) || is_token_program(account_id) {
+                if transaction.message().is_invoked(index) || is_known_spl_token_id(account_id) {
                     continue;
                 }
 


### PR DESCRIPTION
All the tree beyond `runtime/` should now be willing to accept multiple SPL Token program IDs

For account indexing, that is: https://github.com/solana-labs/solana/blob/b2e475b5c4250f1bd57d176282abcdb1e017d9e5/runtime/src/accounts_index.rs#L1574
I'm thinking `update_secondary_indexes()` can just be enhanced to be aware of the token-2022 program id as well, and the two token indexes support both old and new programs