### PR TITLE
Add safety check to ensure slot meta next_slots are unique

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3630,7 +3630,11 @@ fn handle_chaining_for_slot(
 
                 // This is a newly inserted slot/orphan so run the chaining logic to link it to a
                 // newly discovered parent
-                chain_new_slot_to_prev_slot(&mut prev_slot_meta.borrow_mut(), slot, &mut meta_mut);
+                chain_new_slot_to_parent_slot(
+                    &mut prev_slot_meta.borrow_mut(),
+                    slot,
+                    &mut meta_mut,
+                );
 
                 // If the parent of `slot` is a newly inserted orphan, insert it into the orphans
                 // column family
@@ -3730,18 +3734,28 @@ fn is_orphan(meta: &SlotMeta) -> bool {
     meta.parent_slot.is_none()
 }
 
-// 1) Chain current_slot to the previous slot defined by prev_slot_meta
+// 1) Chain current_slot to the parent slot defined by parent_slot_meta
 // 2) Determine whether to set the is_connected flag
-fn chain_new_slot_to_prev_slot(
-    prev_slot_meta: &mut SlotMeta,
+fn chain_new_slot_to_parent_slot(
+    parent_slot_meta: &mut SlotMeta,
     current_slot: Slot,
     current_slot_meta: &mut SlotMeta,
 ) {
+    let already_chained = parent_slot_meta.next_slots.contains(&current_slot);
+
     // Ensure that next_slots never has duplicated slots
-    if !prev_slot_meta.next_slots.contains(&current_slot) {
-        prev_slot_meta.next_slots.push(current_slot);
+    if already_chained {
+        debug_assert!(!already_chained, "slot was already chained to its parent");
+        datapoint_warn!(
+            "chained_duplicate_slot",
+            ("slot", current_slot, i64),
+            ("parent_slot", parent_slot_meta.slot, i64),
+        );
+    } else {
+        parent_slot_meta.next_slots.push(current_slot);
     }
-    current_slot_meta.is_connected = prev_slot_meta.is_connected && prev_slot_meta.is_full();
+
+    current_slot_meta.is_connected = parent_slot_meta.is_connected && parent_slot_meta.is_full();
 }
 
 fn is_newly_completed_slot(slot_meta: &SlotMeta, backup_slot_meta: &Option<SlotMeta>) -> bool {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3737,7 +3737,10 @@ fn chain_new_slot_to_prev_slot(
     current_slot: Slot,
     current_slot_meta: &mut SlotMeta,
 ) {
-    prev_slot_meta.next_slots.push(current_slot);
+    // Ensure that next_slots never has duplicated slots
+    if !prev_slot_meta.next_slots.contains(&current_slot) {
+        prev_slot_meta.next_slots.push(current_slot);
+    }
     current_slot_meta.is_connected = prev_slot_meta.is_connected && prev_slot_meta.is_full();
 }
 


### PR DESCRIPTION
#### Problem
It's possible but probably unlikely that a parent slot has already recorded the connection to a child slot but the same slot is processed again, leading to duplicate entries in `SlotMeta.next_slots`

#### Summary of Changes
Add a safety check to ensure that there is only one copy of a child slot in `SlotMeta.next_slots`

Fixes #
