### PR TITLE
Reduce flakiness in web3.js block tests

### DIFF
--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1978,9 +1978,13 @@ describe('Connection', () => {
     while (x < 10) {
       const block1 = await connection.getBlock(x);
       if (block1 && block1.transactions.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          expect(block1.parentSlot).to.be.above(0);
+          expect(block1.previousBlockhash).to.not.eq(blockhash0);
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.transactions[0].transaction).not.to.be.null;
         break;
       }
@@ -2087,9 +2091,13 @@ describe('Connection', () => {
     while (x < 10) {
       const block1 = await connection.getConfirmedBlock(x);
       if (block1.transactions.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          expect(block1.parentSlot).to.be.above(0);
+          expect(block1.previousBlockhash).to.not.eq(blockhash0);
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.transactions[0].transaction).not.to.be.null;
         break;
       }
@@ -2224,9 +2232,13 @@ describe('Connection', () => {
     while (x < 10) {
       const block1 = await connection.getBlockSignatures(x);
       if (block1.signatures.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          expect(block1.parentSlot).to.be.above(0);
+          expect(block1.previousBlockhash).to.not.eq(blockhash0);
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.signatures[0]).not.to.be.null;
         expect(block1).to.not.have.property('rewards');
         break;


### PR DESCRIPTION
#### Problem
It seems like there might be a race in getBlock-related web3.js tests where we advance the counter before the block is available, but then catch a later block. https://github.com/solana-labs/solana/runs/5115543902?check_suite_focus=true

#### Summary of Changes
Make test cases less brittle. I'm not yet sure if this is the best approach.
