### PR TITLE
chore: make block tests less brittle

### DIFF
--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1973,14 +1973,21 @@ describe('Connection', () => {
       },
     });
 
-    // Find a block that has a transaction, usually Block 1
+    // Find a block that has a transaction
+    // Compare data with parent
     let x = 1;
     while (x < 10) {
       const block1 = await connection.getBlock(x);
       if (block1 && block1.transactions.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          const parentBlock = await connection.getBlock(block1.parentSlot);
+          if (parentBlock) {
+            expect(block1.previousBlockhash).to.eq(parentBlock.blockhash);
+          }
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.transactions[0].transaction).not.to.be.null;
         break;
       }
@@ -2082,14 +2089,21 @@ describe('Connection', () => {
       },
     });
 
-    // Find a block that has a transaction, usually Block 1
+    // Find a block that has a transaction
+    // Compare data with parent
     let x = 1;
     while (x < 10) {
       const block1 = await connection.getConfirmedBlock(x);
       if (block1.transactions.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          const parentBlock = await connection.getBlock(block1.parentSlot);
+          if (parentBlock) {
+            expect(block1.previousBlockhash).to.eq(parentBlock.blockhash);
+          }
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.transactions[0].transaction).not.to.be.null;
         break;
       }
@@ -2219,14 +2233,21 @@ describe('Connection', () => {
       },
     });
 
-    // Find a block that has a transaction, usually Block 1
+    // Find a block that has a transaction
+    // Compare data with parent
     let x = 1;
     while (x < 10) {
       const block1 = await connection.getBlockSignatures(x);
       if (block1.signatures.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
+        if (block1.parentSlot == 0) {
+          expect(block1.previousBlockhash).to.eq(blockhash0);
+        } else {
+          const parentBlock = await connection.getBlock(block1.parentSlot);
+          if (parentBlock) {
+            expect(block1.previousBlockhash).to.eq(parentBlock.blockhash);
+          }
+        }
         expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
         expect(block1.signatures[0]).not.to.be.null;
         expect(block1).to.not.have.property('rewards');
         break;


### PR DESCRIPTION
#### Problem

Web3.js tests involving getting blocks assume that the first block found with a transaction in it will be block 1. That assumption held up for quite a while, and still seems to hold up locally. However, lately CI test validators have not been landing a vote in block 1.


#### Solution

Make tests less brittle by comparing against parent block, whatever that may be


