### PR TITLE
Add sbf-tools version to cargo target cache name on CI agents

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -12,7 +12,8 @@ export PS4="++"
 # Restore target/ from the previous CI build on this machine
 #
 eval "$(ci/channel-info.sh)"
-export CARGO_TARGET_CACHE=$HOME/cargo-target-cache/"$CHANNEL"-"$BUILDKITE_LABEL"
+eval "$(ci/sbf-tools-info.sh)"
+export CARGO_TARGET_CACHE=$HOME/cargo-target-cache/"$CHANNEL"-"$BUILDKITE_LABEL"-"$SBF_TOOLS_VERSION"
 (
   set -x
   MAX_CACHE_SIZE=18 # gigabytes

--- a/ci/sbf-tools-info.sh
+++ b/ci/sbf-tools-info.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Finds the version of sbf-tools used by this source tree.
+#
+# stdout of this script may be eval-ed.
+#
+
+here="$(dirname "$0")"
+
+SBF_TOOLS_VERSION=unknown
+
+cargo_build_bpf_main="${here}/../sdk/cargo-build-bpf/src/main.rs"
+if [[ -f "${cargo_build_bpf_main}" ]]; then
+    version=$(sed -e 's/^.*bpf_tools_version\s*=\s*"\(v[0-9.]\+\)".*/\1/;t;d' "${cargo_build_bpf_main}")
+    if [[ ${version} != '' ]]; then
+        SBF_TOOLS_VERSION="${version}"
+    else
+        echo '--- unable to parse SBF_TOOLS_VERSION'
+    fi
+else
+    echo "--- '${cargo_build_bpf_main}' not present"
+fi
+
+echo SBF_TOOLS_VERSION="${SBF_TOOLS_VERSION}"

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -710,6 +710,8 @@ fn main() {
         }
     }
 
+    // The following line is scanned by CI configuration script to
+    // separate cargo caches according to the version of sbf-tools.
     let bpf_tools_version = "v1.23";
     let version = format!("{}\nbpf-tools {}", crate_version!(), bpf_tools_version);
     let matches = App::new(crate_name!())


### PR DESCRIPTION
#### Problem

SBF tools version updates busts the existing cargo target caches on buildkite agents.

#### Summary of Changes

Refine the naming of cache target subdirs to include the unique SBF tools version string
