### PR TITLE
fix serialize/deserialize in transaction.ts with stable sort

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -258,15 +258,17 @@ export class Transaction {
     });
 
     // Sort. Prioritizing first by signer, then by writable
-    accountMetas.sort(function (x, y) {
-      const pubkeySorting = x.pubkey
-        .toBase58()
-        .localeCompare(y.pubkey.toBase58());
-      const checkSigner = x.isSigner === y.isSigner ? 0 : x.isSigner ? -1 : 1;
-      const checkWritable =
-        x.isWritable === y.isWritable ? pubkeySorting : x.isWritable ? -1 : 1;
-      return checkSigner || checkWritable;
-    });
+    accountMetas
+      .map((item, index) => ({ item, index }))
+      .sort(function (xt, yt) {
+        const x = xt.item;
+        const y = yt.item;
+        const checkSigner = x.isSigner === y.isSigner ? 0 : x.isSigner ? -1 : 1;
+        const checkWritable =
+          x.isWritable === y.isWritable ? pubkeySorting : x.isWritable ? -1 : 1;
+        return checkSigner || checkWritable || xt.index - yt.index;
+      })
+     .map(({ item }) => item);
 
     // Cull duplicate account metas
     const uniqueMetas: AccountMeta[] = [];

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -257,8 +257,8 @@ export class Transaction {
       });
     });
 
-    // Sort. Prioritizing first by signer, then by writable
-    accountMetas
+    // Stable Sort. Prioritizing first by signer, then by writable
+    const sortedAccountMetas = accountMetas
       .map((item, index) => ({ item, index }))
       .sort(function (xt, yt) {
         const x = xt.item;
@@ -272,7 +272,7 @@ export class Transaction {
 
     // Cull duplicate account metas
     const uniqueMetas: AccountMeta[] = [];
-    accountMetas.forEach(accountMeta => {
+    sortedAccountMetas.forEach(accountMeta => {
       const pubkeyString = accountMeta.pubkey.toString();
       const uniqueIndex = uniqueMetas.findIndex(x => {
         return x.pubkey.toString() === pubkeyString;

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -265,7 +265,7 @@ export class Transaction {
         const y = yt.item;
         const checkSigner = x.isSigner === y.isSigner ? 0 : x.isSigner ? -1 : 1;
         const checkWritable =
-          x.isWritable === y.isWritable ? pubkeySorting : x.isWritable ? -1 : 1;
+          x.isWritable === y.isWritable ? 0 : x.isWritable ? -1 : 1;
         return checkSigner || checkWritable || xt.index - yt.index;
       })
      .map(({ item }) => item);

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -260,7 +260,7 @@ export class Transaction {
     // Stable Sort. Prioritizing first by signer, then by writable
     const sortedAccountMetas = accountMetas
       .map((item, index) => ({ item, index }))
-      .sort(function (xt, yt) {
+      .sort((xt, yt) => {
         const x = xt.item;
         const y = yt.item;
         const checkSigner = x.isSigner === y.isSigner ? 0 : x.isSigner ? -1 : 1;


### PR DESCRIPTION
#### Problem
see https://github.com/solana-labs/solana/issues/21722

Sorting pubkey alphabetically could lead to mismatch with offline sign process.
 When one signer sign transaction with rust (e.g. with solana cli tool) and another with web3. So, need to make order the same in both case.

#### Summary of Changes
make sort stable to determine result. JS have unstable sort.
Target behaviour is here: https://github.com/solana-labs/solana/blob/7ba57e7a7c87fca96917a773ed944270178368c9/sdk/program/src/message/legacy.rs#L87  
Rust have stable sort by default.

Fixes #
https://github.com/solana-labs/solana/issues/21722