### PR TITLE
Explorer: Add missing deployment slot check for verifiable build badge

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -135,8 +135,12 @@ export function UpgradeableProgramSection({
               <CheckingBadge />
             ) : (
               <>
-                {verifiableBuilds.map((b) => (
-                  <VerifiedBadge verifiableBuild={b} />
+                {verifiableBuilds.map((b, i) => (
+                  <VerifiedBadge
+                    key={i}
+                    verifiableBuild={b}
+                    deploySlot={programData.slot}
+                  />
                 ))}
               </>
             )}

--- a/explorer/src/components/common/VerifiedBadge.tsx
+++ b/explorer/src/components/common/VerifiedBadge.tsx
@@ -2,10 +2,12 @@ import { VerifiableBuild } from "utils/program-verification";
 
 export function VerifiedBadge({
   verifiableBuild,
+  deploySlot,
 }: {
   verifiableBuild: VerifiableBuild;
+  deploySlot: number;
 }) {
-  if (verifiableBuild && verifiableBuild.verified_slot) {
+  if (verifiableBuild && verifiableBuild.verified_slot === deploySlot) {
     return (
       <h3 className="mb-0">
         <a


### PR DESCRIPTION
#### Problem
During the iterations on the previous PR the deploy slot check required to display the verified/unverified badge was forgotten.

#### Summary of Changes
* Add check that the current program was deployed at the same slot as the last build was verified, when available.

Fixes #23025