### PR TITLE
Rename `AccountsDataMeter::consume`

### DIFF
--- a/program-runtime/src/accounts_data_meter.rs
+++ b/program-runtime/src/accounts_data_meter.rs
@@ -82,12 +82,13 @@ impl AccountsDataMeter {
         if amount > self.remaining() as i64 {
             return Err(InstructionError::AccountsDataBudgetExceeded);
         }
-        self.consume_unchecked(amount);
+        self.adjust_delta_unchecked(amount);
         Ok(())
     }
 
-    /// Unconditionally consume accounts data space.  Refer to `consume()` for more documentation.
-    pub fn consume_unchecked(&mut self, amount: i64) {
+    /// Unconditionally adjust accounts data space.  Refer to `adjust_delta()` for more
+    /// documentation.
+    pub fn adjust_delta_unchecked(&mut self, amount: i64) {
         self.delta = self.delta.saturating_add(amount);
     }
 }

--- a/program-runtime/src/accounts_data_meter.rs
+++ b/program-runtime/src/accounts_data_meter.rs
@@ -77,7 +77,7 @@ impl AccountsDataMeter {
     ///
     /// If `amount` is *positive*, we *increase* the space used by accounts data.  If `amount` is
     /// *negative*, we *decrease* the space used by accounts data.  If `amount` is greater than
-    /// the remaining space, return an error and *do not* consume more accounts data space.
+    /// the remaining space, return an error and *do not* adjust accounts data space.
     pub fn adjust_delta(&mut self, amount: i64) -> Result<(), InstructionError> {
         if amount > self.remaining() as i64 {
             return Err(InstructionError::AccountsDataBudgetExceeded);

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -507,7 +507,7 @@ impl<'a> InvokeContext<'a> {
             let post_data_len = account.data().len() as i64;
             let data_len_delta = post_data_len.saturating_sub(pre_data_len);
             if cap_accounts_data_len {
-                self.accounts_data_meter.consume(data_len_delta)?;
+                self.accounts_data_meter.adjust_delta(data_len_delta)?;
             } else {
                 self.accounts_data_meter.consume_unchecked(data_len_delta);
             }
@@ -600,7 +600,7 @@ impl<'a> InvokeContext<'a> {
                         let post_data_len = account.data().len() as i64;
                         let data_len_delta = post_data_len.saturating_sub(pre_data_len);
                         if cap_accounts_data_len {
-                            self.accounts_data_meter.consume(data_len_delta)?;
+                            self.accounts_data_meter.adjust_delta(data_len_delta)?;
                         } else {
                             self.accounts_data_meter.consume_unchecked(data_len_delta);
                         }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -509,7 +509,8 @@ impl<'a> InvokeContext<'a> {
             if cap_accounts_data_len {
                 self.accounts_data_meter.adjust_delta(data_len_delta)?;
             } else {
-                self.accounts_data_meter.consume_unchecked(data_len_delta);
+                self.accounts_data_meter
+                    .adjust_delta_unchecked(data_len_delta);
             }
 
             Ok(())
@@ -602,7 +603,8 @@ impl<'a> InvokeContext<'a> {
                         if cap_accounts_data_len {
                             self.accounts_data_meter.adjust_delta(data_len_delta)?;
                         } else {
-                            self.accounts_data_meter.consume_unchecked(data_len_delta);
+                            self.accounts_data_meter
+                                .adjust_delta_unchecked(data_len_delta);
                         }
 
                         return Ok(());


### PR DESCRIPTION
#### Problem

The name of `AccountsDataMeter::consume()` might be misleading.

#### Summary of Changes

- Rename it `AccountsDataMeter::adjust_delta`
- Update doc-comment
- Update names of test functions and comments inside tests

Fixes #23022 
