### PR TITLE
Add deactivate-feature feature to test validator cli

### DIFF
--- a/docs/src/developing/test-validator.md
+++ b/docs/src/developing/test-validator.md
@@ -151,3 +151,19 @@ JSON RPC URL: http://127.0.0.1:8899
   [commitment levels](clients/jsonrpc-api#configuring-state-commitment),
   slot height of the last snapshot, transaction count,
   [voting authority](/running-validator/vote-accounts#vote-authority) balance
+
+## Appendix II: Runtime Features
+
+By default, the test validator runs with all [runtime features](programming-model/runtime#features) activated. 
+
+You can verify this using the [Solana command-line tools](cli/install-solana-cli-tools.md):
+
+```bash
+solana feature status -ul
+```
+
+Since this may not always be desired, especially when testing programs meant for deployment to mainnet, the CLI provides an option to deactivate specific features:
+
+```bash
+solana-test-validator --deactivate-feature <FEATURE_PUBKEY_1> --deactivate-feature <FEATURE_PUBKEY_2>
+```

--- a/docs/src/developing/test-validator.md
+++ b/docs/src/developing/test-validator.md
@@ -154,7 +154,7 @@ JSON RPC URL: http://127.0.0.1:8899
 
 ## Appendix II: Runtime Features
 
-By default, the test validator runs with all [runtime features](programming-model/runtime#features) activated. 
+By default, the test validator runs with all [runtime features](programming-model/runtime#features) activated.
 
 You can verify this using the [Solana command-line tools](cli/install-solana-cli-tools.md):
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -326,14 +326,14 @@ fn main() {
                 .help("Disables accounts caching"),
         )
         .arg(
-            Arg::with_name("disable_feature")
-                .long("disable-feature")
+            Arg::with_name("deactivate_feature")
+                .long("deactivate-feature")
                 .short("d")
                 .takes_value(true)
                 .value_name("FEATURE_PUBKEY")
                 .validator(is_pubkey)
                 .multiple(true)
-                .help("Disable this feature in genesis.")
+                .help("deactivate this feature in genesis.")
         )
         .get_matches();
 
@@ -559,7 +559,7 @@ fn main() {
         });
     }
 
-    let features_to_disable = pubkeys_of(&matches, "disable_feature").unwrap_or_default();
+    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[
@@ -639,7 +639,7 @@ fn main() {
         .rpc_port(rpc_port)
         .add_programs_with_path(&programs_to_load)
         .add_accounts_from_json_files(&accounts_to_load)
-        .deactivate_features(&features_to_disable);
+        .deactivate_features(&features_to_deactivate);
 
     if !accounts_to_clone.is_empty() {
         genesis.clone_accounts(

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -328,7 +328,6 @@ fn main() {
         .arg(
             Arg::with_name("deactivate_feature")
                 .long("deactivate-feature")
-                .short("d")
                 .takes_value(true)
                 .value_name("FEATURE_PUBKEY")
                 .validator(is_pubkey)

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -570,6 +570,7 @@ fn main() {
             ("ticks_per_slot", "--ticks-per-slot"),
             ("slots_per_epoch", "--slots-per-epoch"),
             ("faucet_sol", "--faucet-sol"),
+            ("deactivate_feature", "--deactivate-feature"),
         ] {
             if matches.is_present(name) {
                 println!("{} argument ignored, ledger already exists", long);


### PR DESCRIPTION
#### Problem
Copied from #23005:

Currently the solana-test-validator indiscriminately enables all features, vis-a-vis TestValidatorGenesis genesis_config creation which results in different behavior then devnet, testnet or mainnet-beta. Transaction wide budget being a great example of confusion to program developers.

TestValidatorGenesis has been updated to allow deactivation of features: https://github.com/solana-labs/solana/pull/22860 but currently only available programmatically within user testing that use it to get the local validator running.

solana-test-validator should expose CLI options to leverage this capability to provide developer with predictable state when deploying/running programs on other clusters.

#### Summary of Changes
Adds a `-d, --deactivate-feature` CLI flag to `solana-test-validator` which passes its pubkey arguments to the `TestValidatorGenesis::deactivate_features`

Fixes (part of) #23005

#### Proof of work
`./test-install/bin/solana-test-validator -d 21AWDosvp3pBamFW91KB35pNoaoZVTM7ess8nr2nt53B`
```
solana feature status -ul
...
21AWDosvp3pBamFW91KB35pNoaoZVTM7ess8nr2nt53B | inactive                    | merge NonceError into SystemError
```