### PR TITLE
web3.js Remove deprecated commitments

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2745,17 +2745,12 @@ export class Connection {
     let timeoutMs = this._confirmTransactionInitialTimeout || 60 * 1000;
     switch (subscriptionCommitment) {
       case 'processed':
-      case 'recent':
-      case 'single':
-      case 'confirmed':
-      case 'singleGossip': {
+      case 'confirmed': {
         timeoutMs = this._confirmTransactionInitialTimeout || 30 * 1000;
         break;
       }
       // exhaust enums to ensure full coverage
       case 'finalized':
-      case 'max':
-      case 'root':
     }
 
     try {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -224,24 +224,6 @@ function notificationResultAndContext<T, U>(value: Struct<T, U>) {
 }
 
 /**
- * The level of commitment desired when querying state
- * <pre>
- *   'processed': Query the most recent block which has reached 1 confirmation by the connected node
- *   'confirmed': Query the most recent block which has reached 1 confirmation by the cluster
- *   'finalized': Query the most recent block which has been finalized by the cluster
- * </pre>
- */
-export type Commitment =
-  | 'processed'
-  | 'confirmed'
-  | 'finalized'
-  | 'recent' // Deprecated as of v1.5.5
-  | 'single' // Deprecated as of v1.5.5
-  | 'singleGossip' // Deprecated as of v1.5.5
-  | 'root' // Deprecated as of v1.5.5
-  | 'max'; // Deprecated as of v1.5.5
-
-/**
  * A subset of Commitment levels, which are at least optimistically confirmed
  * <pre>
  *   'confirmed': Query the most recent block which has reached 1 confirmation by the cluster
@@ -249,6 +231,16 @@ export type Commitment =
  * </pre>
  */
 export type Finality = 'confirmed' | 'finalized';
+
+/**
+ * The level of commitment desired when querying state
+ * <pre>
+ *   'processed': Query the most recent block which has reached 1 confirmation by the connected node
+ *   'confirmed': Query the most recent block which has reached 1 confirmation by the cluster
+ *   'finalized': Query the most recent block which has been finalized by the cluster
+ * </pre>
+ */
+export type Commitment = 'processed' | Finality;
 
 /**
  * Filter for largest accounts query


### PR DESCRIPTION
#### Problem
Old snippets can be carried over with the deprecated commitment as default or on RPC methods.

This create this ambiguity where the deprecated commitment resolves to something but to what?!?

#### Summary of Changes
Remove deprecated commitments

This will force consumers to fix whatever deprecated commitment they might have but that should be a good thing.

Fixes #
