### PR TITLE
Adds custom inspect function to PublicKey

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -3,6 +3,7 @@ import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 import nacl from 'tweetnacl';
 import {sha256} from '@ethersproject/sha2';
+import util from 'util';
 
 import {Struct, SOLANA_SCHEMA} from './util/borsh-schema';
 import {toBuffer} from './util/to-buffer';
@@ -117,6 +118,13 @@ export class PublicKey extends Struct {
    */
   toString(): string {
     return this.toBase58();
+  }
+
+  /**
+   * Returns public key in string format when console.log is called
+   */
+  [util.inspect.custom]() {
+    return this.toString();
   }
 
   /**

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import {Buffer} from 'buffer';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import util from 'util';
 
 import {Keypair} from '../src/keypair';
 import {PublicKey, MAX_SEED_LENGTH} from '../src/publickey';
@@ -56,19 +57,25 @@ describe('PublicKey', function () {
     const key = new PublicKey('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
     expect(key.toBase58()).to.eq('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
     expect(key.toString()).to.eq('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
+    expect(util.inspect(key)).to.eq(
+      'CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3',
+    );
 
     const key2 = new PublicKey('1111111111111111111111111111BukQL');
     expect(key2.toBase58()).to.eq('1111111111111111111111111111BukQL');
     expect(key2.toString()).to.eq('1111111111111111111111111111BukQL');
+    expect(util.inspect(key2)).to.eq('1111111111111111111111111111BukQL');
 
     const key3 = new PublicKey('11111111111111111111111111111111');
     expect(key3.toBase58()).to.eq('11111111111111111111111111111111');
+    expect(util.inspect(key3)).to.eq('11111111111111111111111111111111');
 
     const key4 = new PublicKey([
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0,
     ]);
     expect(key4.toBase58()).to.eq('11111111111111111111111111111111');
+    expect(util.inspect(key4)).to.eq('11111111111111111111111111111111');
   });
 
   it('toJSON', () => {


### PR DESCRIPTION
#### Problem
Public Keys are logged in a not-so-great format when console logged in Node.Js.

Example:
```
//   authorizedPubkey: PublicKey {
//     _bn: <BN: 919981a5497e8f85c805547439ae59f607ea625b86b1138ea6e41a68ab8ee038>
//   },
```

#### Summary of Changes
- Added a custom inspect function to PublicKey that returns its string format
- Added tests for the custom inspect function

Fixes #20022