### PR TITLE
explorer: show only AccountHeader for tokens

### DIFF
--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -175,7 +175,7 @@ export function AccountHeader({
     );
   }
 
-  if (tokenDetails || isToken) {
+  if (tokenDetails && isToken) {
     return (
       <div className="row align-items-end">
         <div className="col-auto">


### PR DESCRIPTION
#### Problem
Is described here #22980 

#### Summary of Changes
Change "||" to "&&" this  makes the tokenDetails only visible for actual tokens
