### PR TITLE
shrink batches when over 80% of the space is wasted

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -136,7 +136,7 @@ fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch> {
 #[bench]
 fn bench_sigverify_stage(bencher: &mut Bencher) {
     solana_logger::setup();
-    println!("start");
+    trace!("start");
     let (packet_s, packet_r) = unbounded();
     let (verified_s, verified_r) = unbounded();
     let verifier = TransactionSigVerifier::default();
@@ -146,7 +146,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
     bencher.iter(move || {
         let now = Instant::now();
         let mut batches = gen_batches(use_same_tx);
-        println!(
+        trace!(
             "starting... generation took: {} ms batches: {}",
             duration_as_ms(&now.elapsed()),
             batches.len()
@@ -160,19 +160,19 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
             }
         }
         let mut received = 0;
-        println!("sent: {}", sent_len);
+        trace!("sent: {}", sent_len);
         loop {
             if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 while let Some(v) = verifieds.pop() {
                     received += v.packets.len();
                     batches.push(v);
                 }
-                if received >= sent_len {
+                if use_same_tx || received >= sent_len {
                     break;
                 }
             }
         }
-        println!("received: {}", received);
+        trace!("received: {}", received);
     });
     stage.join().unwrap();
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -455,12 +455,13 @@ mod tests {
                     received += v.packets.len();
                     batches.push(v);
                 }
-                if received >= sent_len {
+                if use_same_tx || received >= sent_len {
                     break;
                 }
             }
         }
         println!("received: {}", received);
+        drop(packet_s);
         stage.join().unwrap();
     }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -413,11 +413,7 @@ mod tests {
             let tx = test_tx();
             to_packet_batches(&vec![tx; len], chunk_size)
         } else {
-            let txs: Vec<_> = (0..len)
-                .map(|_| {
-                    test_tx()
-                })
-                .collect();
+            let txs: Vec<_> = (0..len).map(|_| test_tx()).collect();
             to_packet_batches(&txs, chunk_size)
         }
     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -421,7 +421,7 @@ mod tests {
     #[test]
     fn test_sigverify_stage() {
         solana_logger::setup();
-        println!("start");
+        trace!("start");
         let (packet_s, packet_r) = unbounded();
         let (verified_s, verified_r) = unbounded();
         let verifier = TransactionSigVerifier::default();
@@ -430,7 +430,7 @@ mod tests {
         let use_same_tx = true;
         let now = Instant::now();
         let mut batches = gen_batches(use_same_tx);
-        println!(
+        trace!(
             "starting... generation took: {} ms batches: {}",
             duration_as_ms(&now.elapsed()),
             batches.len()
@@ -444,7 +444,7 @@ mod tests {
             }
         }
         let mut received = 0;
-        println!("sent: {}", sent_len);
+        trace!("sent: {}", sent_len);
         loop {
             if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 while let Some(v) = verifieds.pop() {
@@ -456,7 +456,7 @@ mod tests {
                 }
             }
         }
-        println!("received: {}", received);
+        trace!("received: {}", received);
         drop(packet_s);
         stage.join().unwrap();
     }

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -1,0 +1,86 @@
+#![allow(clippy::integer_arithmetic)]
+#![feature(test)]
+
+extern crate test;
+
+use {
+    rand::prelude::*,
+    solana_perf::{
+        packet::{to_packet_batches, PacketBatch, PACKETS_PER_BATCH},
+        sigverify,
+    },
+    test::Bencher,
+};
+
+const NUM_PACKETS: usize = 1024 * 4;
+
+fn test_packet_with_size(size: usize, rng: &mut ThreadRng) -> Vec<u8> {
+    // subtract 8 bytes because the length will get serialized as well
+    (0..size.checked_sub(8).unwrap())
+        .map(|_| rng.gen())
+        .collect()
+}
+
+fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) {
+    // verify packets
+    bencher.iter(|| {
+        let _ans = sigverify::shrink_batches(&mut batches);
+        batches.iter_mut().for_each(|b| {
+            b.packets
+                .iter_mut()
+                .for_each(|p| p.meta.set_discard(thread_rng().gen()))
+        });
+    });
+}
+
+#[bench]
+#[ignore]
+fn bench_shrink_diff_small_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+
+    let batches = to_packet_batches(
+        &(0..NUM_PACKETS)
+            .map(|_| test_packet_with_size(128, &mut rng))
+            .collect::<Vec<_>>(),
+        PACKETS_PER_BATCH,
+    );
+
+    do_bench_shrink_packets(bencher, batches);
+}
+
+#[bench]
+#[ignore]
+fn bench_shrink_diff_big_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+
+    let batches = to_packet_batches(
+        &(0..NUM_PACKETS)
+            .map(|_| test_packet_with_size(1024, &mut rng))
+            .collect::<Vec<_>>(),
+        PACKETS_PER_BATCH,
+    );
+
+    do_bench_shrink_packets(bencher, batches);
+}
+
+#[bench]
+#[ignore]
+fn bench_shrink_count_packets(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+
+    let mut batches = to_packet_batches(
+        &(0..NUM_PACKETS)
+            .map(|_| test_packet_with_size(128, &mut rng))
+            .collect::<Vec<_>>(),
+        PACKETS_PER_BATCH,
+    );
+    batches.iter_mut().for_each(|b| {
+        b.packets
+            .iter_mut()
+            .for_each(|p| p.meta.set_discard(thread_rng().gen()))
+    });
+
+    bencher.iter(|| {
+        let _ = sigverify::count_valid_packets(&batches);
+    });
+}

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -508,22 +508,22 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) -> usize {
     let mut valid_batch_ix = 0;
     let mut valid_packet_ix = 0;
     let mut last_valid_batch = 0;
-    for j in 0..batches.len() {
-        for jj in 0..batches[j].packets.len() {
-            if batches[j].packets[jj].meta.discard() {
+    for batch_ix in 0..batches.len() {
+        for packet_ix in 0..batches[batch_ix].packets.len() {
+            if batches[batch_ix].packets[packet_ix].meta.discard() {
                 continue;
             }
-            last_valid_batch = j.saturating_add(1);
+            last_valid_batch = batch_ix.saturating_add(1);
             let mut found_spot = false;
-            while valid_batch_ix < j && !found_spot {
+            while valid_batch_ix < batch_ix && !found_spot {
                 while valid_packet_ix < batches[valid_batch_ix].packets.len() {
                     if batches[valid_batch_ix].packets[valid_packet_ix]
                         .meta
                         .discard()
                     {
                         batches[valid_batch_ix].packets[valid_packet_ix] =
-                            batches[j].packets[jj].clone();
-                        batches[j].packets[jj].meta.set_discard(true);
+                            batches[batch_ix].packets[packet_ix].clone();
+                        batches[batch_ix].packets[packet_ix].meta.set_discard(true);
                         last_valid_batch = valid_batch_ix.saturating_add(1);
                         found_spot = true;
                         break;

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -508,12 +508,12 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) -> usize {
     let mut valid_batch_ix = 0;
     let mut valid_packet_ix = 0;
     let mut last_valid_batch = 0;
-    for j in 1..batches.len() {
+    for j in 0..batches.len() {
         for jj in 0..batches[j].packets.len() {
             if batches[j].packets[jj].meta.discard() {
                 continue;
             }
-            last_valid_batch = j;
+            last_valid_batch = j.saturating_add(1);
             let mut found_spot = false;
             while valid_batch_ix < j && !found_spot {
                 while valid_packet_ix < batches[valid_batch_ix].packets.len() {
@@ -524,7 +524,7 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) -> usize {
                         batches[valid_batch_ix].packets[valid_packet_ix] =
                             batches[j].packets[jj].clone();
                         batches[j].packets[jj].meta.set_discard(true);
-                        last_valid_batch = valid_batch_ix;
+                        last_valid_batch = valid_batch_ix.saturating_add(1);
                         found_spot = true;
                         break;
                     }
@@ -537,7 +537,7 @@ pub fn shrink_batches(batches: &mut Vec<PacketBatch>) -> usize {
             }
         }
     }
-    last_valid_batch.saturating_add(1)
+    last_valid_batch
 }
 
 pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {
@@ -1479,7 +1479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_shrink() {
+    fn test_shrink_fuzz() {
         for _ in 0..5 {
             let mut batches = to_packet_batches(
                 &(0..PACKETS_PER_BATCH * 3)
@@ -1518,6 +1518,182 @@ mod tests {
             let packet_count2 = count_valid_packets(&batches);
             assert_eq!(packet_count, packet_count2);
             assert_eq!(start, end);
+        }
+    }
+
+    #[test]
+    fn test_shrink_empty() {
+        const PACKET_COUNT: usize = 1024;
+        const BATCH_COUNT: usize = PACKET_COUNT / PACKETS_PER_BATCH;
+
+        // No batches
+        // truncate of 1 on len 0 is a noop
+        assert_eq!(shrink_batches(&mut vec![]), 0);
+        // One empty batch
+        assert_eq!(shrink_batches(&mut vec![PacketBatch::with_capacity(0)]), 0);
+        // Many empty batches
+        let mut batches = (0..BATCH_COUNT)
+            .map(|_| PacketBatch::with_capacity(0))
+            .collect::<Vec<_>>();
+        assert_eq!(shrink_batches(&mut batches), 0);
+    }
+
+    #[test]
+    fn test_shrink_vectors() {
+        const PACKET_COUNT: usize = 1024;
+        const BATCH_COUNT: usize = PACKET_COUNT / PACKETS_PER_BATCH;
+
+        let set_discards = [
+            // contiguous
+            // 0
+            // No discards
+            |_, _| false,
+            // All discards
+            |_, _| true,
+            // single partitions
+            // discard last half of packets
+            |b, p| ((b * PACKETS_PER_BATCH) + p) >= (PACKET_COUNT / 2),
+            // discard first half of packets
+            |b, p| ((b * PACKETS_PER_BATCH) + p) < (PACKET_COUNT / 2),
+            // discard last half of each batch
+            |_, p| p >= (PACKETS_PER_BATCH / 2),
+            // 5
+            // discard first half of each batch
+            |_, p| p < (PACKETS_PER_BATCH / 2),
+            // uniform sparse
+            // discard even packets
+            |b, p| ((b * PACKETS_PER_BATCH) + p) % 2 == 0,
+            // discard odd packets
+            |b, p| ((b * PACKETS_PER_BATCH) + p) % 2 == 1,
+            // discard even batches
+            |b, _| b % 2 == 0,
+            // discard odd batches
+            |b, _| b % 2 == 1,
+            // edges
+            // 10
+            // discard first batch
+            |b, _| b == 0,
+            // discard last batch
+            |b, _| b == BATCH_COUNT - 1,
+            // discard first and last batches
+            |b, _| b == 0 || b == BATCH_COUNT - 1,
+            // discard all but first and last batches
+            |b, _| b != 0 && b != BATCH_COUNT - 1,
+            // discard first packet
+            |b, p| ((b * PACKETS_PER_BATCH) + p) == 0,
+            // 15
+            // discard all but first packet
+            |b, p| ((b * PACKETS_PER_BATCH) + p) != 0,
+            // discard last packet
+            |b, p| ((b * PACKETS_PER_BATCH) + p) == PACKET_COUNT - 1,
+            // discard all but last packet
+            |b, p| ((b * PACKETS_PER_BATCH) + p) != PACKET_COUNT - 1,
+            // discard first packet of each batch
+            |_, p| p == 0,
+            // discard all but first packet of each batch
+            |_, p| p != 0,
+            // 20
+            // discard last packet of each batch
+            |_, p| p == PACKETS_PER_BATCH - 1,
+            // discard all but last packet of each batch
+            |_, p| p != PACKETS_PER_BATCH - 1,
+            // discard first and last packet of each batch
+            |_, p| p == 0 || p == PACKETS_PER_BATCH - 1,
+            // discard all but first and last packet of each batch
+            |_, p| p != 0 && p != PACKETS_PER_BATCH - 1,
+            // discard all after first packet in second to last batch
+            |b, p| (b == BATCH_COUNT - 2 && p > 0) || b == BATCH_COUNT - 1,
+            // 25
+        ];
+
+        let expect_valids = [
+            // (expected_batches, expected_valid_packets)
+            //
+            // contiguous
+            // 0
+            (BATCH_COUNT, PACKET_COUNT),
+            (0, 0),
+            // single partitions
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            // 5
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            // uniform sparse
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            (BATCH_COUNT / 2, PACKET_COUNT / 2),
+            // edges
+            // 10
+            (BATCH_COUNT - 1, PACKET_COUNT - PACKETS_PER_BATCH),
+            (BATCH_COUNT - 1, PACKET_COUNT - PACKETS_PER_BATCH),
+            (BATCH_COUNT - 2, PACKET_COUNT - 2 * PACKETS_PER_BATCH),
+            (2, 2 * PACKETS_PER_BATCH),
+            (BATCH_COUNT, PACKET_COUNT - 1),
+            // 15
+            (1, 1),
+            (BATCH_COUNT, PACKET_COUNT - 1),
+            (1, 1),
+            (
+                (BATCH_COUNT * (PACKETS_PER_BATCH - 1) + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                (PACKETS_PER_BATCH - 1) * BATCH_COUNT,
+            ),
+            (
+                (BATCH_COUNT + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                BATCH_COUNT,
+            ),
+            // 20
+            (
+                (BATCH_COUNT * (PACKETS_PER_BATCH - 1) + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                (PACKETS_PER_BATCH - 1) * BATCH_COUNT,
+            ),
+            (
+                (BATCH_COUNT + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                BATCH_COUNT,
+            ),
+            (
+                (BATCH_COUNT * (PACKETS_PER_BATCH - 2) + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                (PACKETS_PER_BATCH - 2) * BATCH_COUNT,
+            ),
+            (
+                (2 * BATCH_COUNT + PACKETS_PER_BATCH) / PACKETS_PER_BATCH,
+                PACKET_COUNT - (PACKETS_PER_BATCH - 2) * BATCH_COUNT,
+            ),
+            (BATCH_COUNT - 1, PACKET_COUNT - 2 * PACKETS_PER_BATCH + 1),
+            // 25
+        ];
+
+        let test_cases = set_discards.iter().zip(&expect_valids).enumerate();
+        for (i, (set_discard, (expect_batch_count, expect_valid_packets))) in test_cases {
+            println!("test_shrink case: {}", i);
+            let mut batches = to_packet_batches(
+                &(0..PACKET_COUNT).map(|_| test_tx()).collect::<Vec<_>>(),
+                PACKETS_PER_BATCH,
+            );
+            assert_eq!(batches.len(), BATCH_COUNT);
+            assert_eq!(count_valid_packets(&batches), PACKET_COUNT);
+            batches.iter_mut().enumerate().for_each(|(i, b)| {
+                b.packets
+                    .iter_mut()
+                    .enumerate()
+                    .for_each(|(j, p)| p.meta.set_discard(set_discard(i, j)))
+            });
+            assert_eq!(count_valid_packets(&batches), *expect_valid_packets);
+            println!("show valid packets for case {}", i);
+            batches.iter_mut().enumerate().for_each(|(i, b)| {
+                b.packets.iter_mut().enumerate().for_each(|(j, p)| {
+                    if !p.meta.discard() {
+                        println!("{} {}", i, j)
+                    }
+                })
+            });
+            println!("done show valid packets for case {}", i);
+            let shrunken_batch_count = shrink_batches(&mut batches);
+            println!("shrunk batch test {} count: {}", i, shrunken_batch_count);
+            assert_eq!(shrunken_batch_count, *expect_batch_count);
+            batches.truncate(shrunken_batch_count);
+            assert_eq!(count_valid_packets(&batches), *expect_valid_packets);
         }
     }
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -1492,11 +1492,32 @@ mod tests {
                     .iter_mut()
                     .for_each(|p| p.meta.set_discard(thread_rng().gen()))
             });
+            //find all the non discarded packets
+            let mut start = vec![];
+            batches.iter_mut().for_each(|b| {
+                b.packets
+                    .iter_mut()
+                    .filter(|p| !p.meta.discard())
+                    .for_each(|p| start.push(p.clone()))
+            });
+            start.sort_by_key(|p| p.data);
+
             let packet_count = count_valid_packets(&batches);
             let res = shrink_batches(&mut batches);
             batches.truncate(res);
+
+            //make sure all the non discarded packets are the same
+            let mut end = vec![];
+            batches.iter_mut().for_each(|b| {
+                b.packets
+                    .iter_mut()
+                    .filter(|p| !p.meta.discard())
+                    .for_each(|p| end.push(p.clone()))
+            });
+            end.sort_by_key(|p| p.data);
             let packet_count2 = count_valid_packets(&batches);
             assert_eq!(packet_count, packet_count2);
+            assert_eq!(start, end);
         }
     }
 }


### PR DESCRIPTION
#### Problem

Additional empty batches in the pipeline may starve the banking stage

#### Summary of Changes

shrink the batches if more then 80% of the space is wasted

4096

test bench_shrink_count_packets      ... bench:       2,372 ns/iter (+/- 787)
test bench_shrink_diff_big_packets   ... bench:     109,311 ns/iter (+/- 613)
test bench_shrink_diff_small_packets ... bench:     109,724 ns/iter (+/- 784)

roughly 22ns per packet.

Fixes #

tag @buffalu