### PR TITLE
Mention staking reward in getInflationReward doc

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1290,7 +1290,7 @@ Result:
 
 ### getInflationReward
 
-Returns the inflation reward for a list of addresses for an epoch
+Returns the inflation / staking reward for a list of addresses for an epoch
 
 #### Parameters:
 - `<array>` - An array of addresses to query, as base-58 encoded strings


### PR DESCRIPTION
#### Problem

Took me a while to figure out which RPC call is used to get staking rewards. Considering that I was unable to get much help in the discord server, I'm sure I was not the only one who got stuck here.

#### Summary of Changes

Mentions staking rewards in the RPC call description.

Fixes #22963
