### PR TITLE
removes adopt entrypoint's shred-version from gossip

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1633,23 +1633,9 @@ impl ClusterInfo {
                 }
             }
         }
-        // Adopt an entrypoint's `shred_version` if ours is unset
-        if self.my_shred_version() == 0 {
-            if let Some(entrypoint) = entrypoints
-                .iter()
-                .find(|entrypoint| entrypoint.shred_version != 0)
-            {
-                info!(
-                    "Setting shred version to {:?} from entrypoint {:?}",
-                    entrypoint.shred_version, entrypoint.id
-                );
-                self.my_contact_info.write().unwrap().shred_version = entrypoint.shred_version;
-            }
-        }
-        self.my_shred_version() != 0
-            && entrypoints
-                .iter()
-                .all(|entrypoint| entrypoint.id != Pubkey::default())
+        entrypoints
+            .iter()
+            .all(|entrypoint| entrypoint.id != Pubkey::default())
     }
 
     fn handle_purge(
@@ -4323,7 +4309,7 @@ mod tests {
             .any(|entrypoint| *entrypoint == gossiped_entrypoint2_info));
 
         assert!(entrypoints_processed);
-        assert_eq!(cluster_info.my_shred_version(), 1); // <-- shred version now adopted from entrypoint2
+        assert_eq!(cluster_info.my_shred_version(), 0);
     }
 
     #[test]

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -209,7 +209,7 @@ fn start_gossip_node(
     ledger_path: &Path,
     gossip_addr: &SocketAddr,
     gossip_socket: UdpSocket,
-    expected_shred_version: Option<u16>,
+    expected_shred_version: u16,
     gossip_validators: Option<HashSet<Pubkey>>,
     should_check_duplicate_instance: bool,
     socket_addr_space: SocketAddrSpace,
@@ -217,7 +217,7 @@ fn start_gossip_node(
     let contact_info = ClusterInfo::gossip_contact_info(
         identity_keypair.pubkey(),
         *gossip_addr,
-        expected_shred_version.unwrap_or(0),
+        expected_shred_version,
     );
     let mut cluster_info = ClusterInfo::new(contact_info, identity_keypair, socket_addr_space);
     cluster_info.set_entrypoints(cluster_entrypoints.to_vec());
@@ -245,9 +245,8 @@ fn get_rpc_peers(
     blacklist_timeout: &Instant,
     retry_reason: &mut Option<String>,
 ) -> Option<Vec<ContactInfo>> {
-    let shred_version = validator_config
-        .expected_shred_version
-        .unwrap_or_else(|| cluster_info.my_shred_version());
+    let shred_version = validator_config.expected_shred_version.unwrap();
+    assert_eq!(shred_version, cluster_info.my_shred_version());
     if shred_version == 0 {
         let all_zero_shred_versions = cluster_entrypoints.iter().all(|cluster_entrypoint| {
             cluster_info
@@ -436,7 +435,7 @@ mod without_incremental_snapshots {
                     ledger_path,
                     &node.info.gossip,
                     node.sockets.gossip.try_clone().unwrap(),
-                    validator_config.expected_shred_version,
+                    validator_config.expected_shred_version.unwrap(),
                     validator_config.gossip_validators.clone(),
                     should_check_duplicate_instance,
                     socket_addr_space,
@@ -851,7 +850,7 @@ mod with_incremental_snapshots {
                     ledger_path,
                     &node.info.gossip,
                     node.sockets.gossip.try_clone().unwrap(),
-                    validator_config.expected_shred_version,
+                    validator_config.expected_shred_version.unwrap(),
                     validator_config.gossip_validators.clone(),
                     should_check_duplicate_instance,
                     socket_addr_space,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2168,14 +2168,10 @@ pub fn main() {
             exit(1);
         }
     }
-    // TODO: Once entrypoints are updated to return shred-version, this should
-    // abort if it fails to obtain a shred-version, so that nodes always join
-    // gossip with a valid shred-version. The code to adopt entrypoint shred
-    // version can then be deleted from gossip and get_rpc_node above.
     let expected_shred_version = value_t!(matches, "expected_shred_version", u16)
         .ok()
-        .or_else(|| get_cluster_shred_version(&entrypoint_addrs));
-
+        .or_else(|| get_cluster_shred_version(&entrypoint_addrs))
+        .unwrap();
     let tower_storage: Arc<dyn solana_core::tower_storage::TowerStorage> =
         match value_t_or_exit!(matches, "tower_storage", String).as_str() {
             "file" => {
@@ -2341,7 +2337,7 @@ pub fn main() {
         expected_bank_hash: matches
             .value_of("expected_bank_hash")
             .map(|s| Hash::from_str(s).unwrap()),
-        expected_shred_version,
+        expected_shred_version: Some(expected_shred_version),
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),


### PR DESCRIPTION

#### Problem
Supporting different shred-versions or special casing `shred_version == 0`
in gossip has been hacky and problematic.
https://github.com/solana-labs/solana/pull/18066
added shred-version to ip-echo-server so that if a validator starts up
without `expected_shred_version` flag it can obtain the correct
shred-version from the entrypoint before joining gossip.
As such, the remaining code to adopt entrypoint's shred-version in
gossip is redundant and can be removed.

#### Summary of Changes
removes adopt entrypoint's shred-version from gossip