### PR TITLE
Add error message for readlink -f failure

### DIFF
--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")" 
+cargo="$(readlink -f "${here}/../cargo")"
 
 if [[ -z $cargo ]]; then
-  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching 
-  to gnu readlink with 'brew install coreutils' and then symlink greadlink as 
+  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
+  to gnu readlink with 'brew install coreutils' and then symlink greadlink as
   /usr/local/bin/readlink."
   exit 1
 fi

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")"
+cargo="$(readlink -f "${here}/../cargo")" 
+
+if [[ -z $cargo ]]; then
+  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching 
+  to gnu readlink with 'brew install coreutils' and then symlink greadlink as 
+  /usr/local/bin/readlink."
+  exit 1
+fi
 
 set -e
 


### PR DESCRIPTION
#### Problem
scripts/cargo-for-all-lock-files.sh fails on Macs with default tools installed.

#### Summary of Changes
Add error message with suggested fix that works on Macs.