### PR TITLE
DiskIdx: new items are not dirty by default

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -202,6 +202,12 @@ impl AccountMapEntryMeta {
             age: AtomicU8::new(storage.future_age_to_flush()),
         }
     }
+    pub fn new_clean<T: IndexValue>(storage: &Arc<BucketMapHolder<T>>) -> Self {
+        AccountMapEntryMeta {
+            dirty: AtomicBool::new(false),
+            age: AtomicU8::new(storage.future_age_to_flush()),
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -504,7 +504,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         Arc::new(AccountMapEntryInner::new(
             slot_list,
             ref_count,
-            AccountMapEntryMeta::new_dirty(&self.storage),
+            AccountMapEntryMeta::new_clean(&self.storage),
         ))
     }
 


### PR DESCRIPTION
#### Problem
When items are loaded into the in-mem acct idx, the previous code was erroneously marking them as dirty. This causes the bg flushing to always write them back to disk, even if they have not changed. This results in unnecessary writes.
#### Summary of Changes
disk entries loaded into memory are marked as clean (not dirty).
Fixes #
