### PR TITLE
(LedgerStore/FIFO) Refactor FIFO options and sanity check

### DIFF
--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -9,7 +9,7 @@ mod tests {
         solana_core::ledger_cleanup_service::LedgerCleanupService,
         solana_ledger::{
             blockstore::{make_many_slot_shreds, Blockstore},
-            blockstore_db::{BlockstoreOptions, ShredStorageType},
+            blockstore_db::{BlockstoreOptions, BlockstoreRocksFifoOptions, ShredStorageType},
             get_tmp_ledger_path,
         },
         solana_measure::measure::Measure,
@@ -309,8 +309,10 @@ mod tests {
             &ledger_path,
             if config.fifo_compaction {
                 BlockstoreOptions {
-                    shred_storage_type: ShredStorageType::RocksFifo,
-                    shred_data_cf_size: config.shred_data_cf_size,
+                    shred_storage_type: ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
+                        shred_data_cf_size: config.shred_data_cf_size,
+                        ..BlockstoreRocksFifoOptions::default()
+                    }),
                     ..BlockstoreOptions::default()
                 }
             } else {


### PR DESCRIPTION
#### Summary of Changes
This PR introduces BlockstoreRocksFifoOptions and performs a sanity check on FIFO options.

When the sanity check fails, blockstore will panic instead of falling back to level compaction.
This will allow users to easily identify and fix any misconfiguration.

Dependency: #23103