### PR TITLE
Modify link of the document targeting the GitHub URL listed wrong comments

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -336,7 +336,7 @@ less disk usage may be requested by adding an argument to `--limit-ledger-size`
 if desired. Check `solana-validator --help` for the default limit value used by
 `--limit-ledger-size`. More information about
 selecting a custom limit value is [available
-here](https://github.com/solana-labs/solana/blob/583cec922b6107e0f85c7e14cb5e642bc7dfb340/core/src/ledger_cleanup_service.rs#L15-L26).
+here](https://github.com/solana-labs/solana/blob/36167b032c03fc7d1d8c288bb621920aaf903311/core/src/ledger_cleanup_service.rs#L23-L34).
 
 ### Systemd Unit
 


### PR DESCRIPTION
#### Problem

The `available here` link of the document below
https://docs.solana.com/running-validator/validator-start#limiting-ledger-size-to-conserve-disk-space
is targeting the GitHub URL listed wrong comments.

#### Summary of Changes

I update the current link with https://github.com/solana-labs/solana/blob/36167b032c03fc7d1d8c288bb621920aaf903311/core/src/ledger_cleanup_service.rs#L23-L34

Fixes #23113
