### PR TITLE
Fix snap server

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -38,14 +38,14 @@ impl HttpSender {
     ///
     /// The URL is an HTTP URL, usually for port 8899, as in
     /// "http://localhost:8899". The sender has a default timeout of 30 seconds.
-    pub fn new(url: String) -> Self {
+    pub fn new<U: ToString>(url: U) -> Self {
         Self::new_with_timeout(url, Duration::from_secs(30))
     }
 
     /// Create an HTTP RPC sender.
     ///
     /// The URL is an HTTP URL, usually for port 8899.
-    pub fn new_with_timeout(url: String, timeout: Duration) -> Self {
+    pub fn new_with_timeout<U: ToString>(url: U, timeout: Duration) -> Self {
         let client = Arc::new(
             reqwest::Client::builder()
                 .timeout(timeout)
@@ -55,7 +55,7 @@ impl HttpSender {
 
         Self {
             client,
-            url,
+            url: url.to_string(),
             request_id: AtomicU64::new(0),
             stats: RwLock::new(RpcTransportStats::default()),
         }

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -74,13 +74,13 @@ pub struct MockSender {
 ///    from [`RpcRequest`] to a JSON [`Value`] response, Any entries in this map
 ///    override the default behavior for the given request.
 impl MockSender {
-    pub fn new(url: String) -> Self {
+    pub fn new<U: ToString>(url: U) -> Self {
         Self::new_with_mocks(url, Mocks::default())
     }
 
-    pub fn new_with_mocks(url: String, mocks: Mocks) -> Self {
+    pub fn new_with_mocks<U: ToString>(url: U, mocks: Mocks) -> Self {
         Self {
-            url,
+            url: url.to_string(),
             mocks: RwLock::new(mocks),
         }
     }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -197,7 +197,7 @@ impl RpcClient {
     /// let url = "http://localhost:8899".to_string();
     /// let client = RpcClient::new(url);
     /// ```
-    pub fn new(url: String) -> Self {
+    pub fn new<U: ToString>(url: U) -> Self {
         Self::new_with_commitment(url, CommitmentConfig::default())
     }
 
@@ -220,7 +220,7 @@ impl RpcClient {
     /// let commitment_config = CommitmentConfig::processed();
     /// let client = RpcClient::new_with_commitment(url, commitment_config);
     /// ```
-    pub fn new_with_commitment(url: String, commitment_config: CommitmentConfig) -> Self {
+    pub fn new_with_commitment<U: ToString>(url: U, commitment_config: CommitmentConfig) -> Self {
         Self::new_sender(
             HttpSender::new(url),
             RpcClientConfig::with_commitment(commitment_config),
@@ -246,7 +246,7 @@ impl RpcClient {
     /// let timeout = Duration::from_secs(1);
     /// let client = RpcClient::new_with_timeout(url, timeout);
     /// ```
-    pub fn new_with_timeout(url: String, timeout: Duration) -> Self {
+    pub fn new_with_timeout<U: ToString>(url: U, timeout: Duration) -> Self {
         Self::new_sender(
             HttpSender::new_with_timeout(url, timeout),
             RpcClientConfig::with_commitment(CommitmentConfig::default()),
@@ -275,8 +275,8 @@ impl RpcClient {
     ///     commitment_config,
     /// );
     /// ```
-    pub fn new_with_timeout_and_commitment(
-        url: String,
+    pub fn new_with_timeout_and_commitment<U: ToString>(
+        url: U,
         timeout: Duration,
         commitment_config: CommitmentConfig,
     ) -> Self {
@@ -318,8 +318,8 @@ impl RpcClient {
     ///     confirm_transaction_initial_timeout,
     /// );
     /// ```
-    pub fn new_with_timeouts_and_commitment(
-        url: String,
+    pub fn new_with_timeouts_and_commitment<U: ToString>(
+        url: U,
         timeout: Duration,
         commitment_config: CommitmentConfig,
         confirm_transaction_initial_timeout: Duration,
@@ -353,7 +353,7 @@ impl RpcClient {
     /// let url = "fails".to_string();
     /// let successful_client = RpcClient::new_mock(url);
     /// ```
-    pub fn new_mock(url: String) -> Self {
+    pub fn new_mock<U: ToString>(url: U) -> Self {
         Self::new_sender(
             MockSender::new(url),
             RpcClientConfig::with_commitment(CommitmentConfig::default()),
@@ -387,7 +387,7 @@ impl RpcClient {
     /// let url = "succeeds".to_string();
     /// let client = RpcClient::new_mock_with_mocks(url, mocks);
     /// ```
-    pub fn new_mock_with_mocks(url: String, mocks: Mocks) -> Self {
+    pub fn new_mock_with_mocks<U: ToString>(url: U, mocks: Mocks) -> Self {
         Self::new_sender(
             MockSender::new_with_mocks(url, mocks),
             RpcClientConfig::with_commitment(CommitmentConfig::default()),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2403,6 +2403,9 @@ pub mod rpc_minimal {
             commitment: Option<CommitmentConfig>,
         ) -> Result<EpochInfo>;
 
+        #[rpc(meta, name = "getGenesisHash")]
+        fn get_genesis_hash(&self, meta: Self::Metadata) -> Result<String>;
+
         #[rpc(meta, name = "getHealth")]
         fn get_health(&self, meta: Self::Metadata) -> Result<String>;
 
@@ -2479,6 +2482,11 @@ pub mod rpc_minimal {
             debug!("get_epoch_info rpc request received");
             let bank = meta.bank(commitment);
             Ok(bank.get_epoch_info())
+        }
+
+        fn get_genesis_hash(&self, meta: Self::Metadata) -> Result<String> {
+            debug!("get_genesis_hash rpc request received");
+            Ok(meta.genesis_hash.to_string())
         }
 
         fn get_health(&self, meta: Self::Metadata) -> Result<String> {
@@ -3155,9 +3163,6 @@ pub mod rpc_full {
             limit: Option<usize>,
         ) -> Result<Vec<RpcPerfSample>>;
 
-        #[rpc(meta, name = "getGenesisHash")]
-        fn get_genesis_hash(&self, meta: Self::Metadata) -> Result<String>;
-
         #[rpc(meta, name = "getSignatureStatuses")]
         fn get_signature_statuses(
             &self,
@@ -3353,11 +3358,6 @@ pub mod rpc_full {
                     }
                 })
                 .collect())
-        }
-
-        fn get_genesis_hash(&self, meta: Self::Metadata) -> Result<String> {
-            debug!("get_genesis_hash rpc request received");
-            Ok(meta.genesis_hash.to_string())
         }
 
         fn get_signature_statuses(

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -117,10 +117,7 @@ impl Default for TestValidatorGenesis {
             ledger_path: Option::<PathBuf>::default(),
             tower_storage: Option::<Arc<dyn TowerStorage>>::default(),
             rent: Rent::default(),
-            rpc_config: JsonRpcConfig {
-                full_api: true,
-                ..JsonRpcConfig::default()
-            },
+            rpc_config: JsonRpcConfig::default_for_test(),
             pubsub_config: PubSubConfig::default(),
             rpc_ports: Option::<(u16, u16)>::default(),
             warp_slot: Option::<Slot>::default(),

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -47,7 +47,7 @@ pub struct RpcBootstrapConfig {
     pub no_snapshot_fetch: bool,
     pub only_known_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
-    pub no_check_vote_account: bool,
+    pub check_vote_account: Option<String>,
     pub incremental_snapshot_fetch: bool,
 }
 
@@ -603,7 +603,8 @@ mod without_incremental_snapshots {
             }
         })
         .map(|_| {
-            if !validator_config.voting_disabled && !bootstrap_config.no_check_vote_account {
+            if let Some(url) = bootstrap_config.check_vote_account.as_ref() {
+                let rpc_client = RpcClient::new(url);
                 check_vote_account(
                     &rpc_client,
                     &identity_keypair.pubkey(),
@@ -943,7 +944,8 @@ mod with_incremental_snapshots {
                 )
             })
             .map(|_| {
-                if !validator_config.voting_disabled && !bootstrap_config.no_check_vote_account {
+                if let Some(url) = bootstrap_config.check_vote_account.as_ref() {
+                    let rpc_client = RpcClient::new(url);
                     check_vote_account(
                         &rpc_client,
                         &identity_keypair.pubkey(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -547,7 +547,17 @@ pub fn main() {
                 .takes_value(false)
                 .conflicts_with("no_voting")
                 .requires("entrypoint")
+                .hidden(true)
                 .help("Skip the RPC vote account sanity check")
+        )
+        .arg(
+            Arg::with_name("check_vote_account")
+                .long("check-vote-account")
+                .takes_value(true)
+                .value_name("RPC_URL")
+                .requires("entrypoint")
+                .conflicts_with_all(&["no_check_vote_account", "no_voting"])
+                .help("Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL must expose `--full-rpc-api`")
         )
         .arg(
             Arg::with_name("restricted_repair_only_mode")
@@ -1948,10 +1958,15 @@ pub fn main() {
 
     let init_complete_file = matches.value_of("init_complete_file");
 
+    if matches.is_present("no_check_vote_account") {
+        info!("vote account sanity checks are no longer performed by default. --no-check-vote-account is deprecated and can be removed from the command line");
+    }
     let rpc_bootstrap_config = bootstrap::RpcBootstrapConfig {
         no_genesis_fetch: matches.is_present("no_genesis_fetch"),
         no_snapshot_fetch: matches.is_present("no_snapshot_fetch"),
-        no_check_vote_account: matches.is_present("no_check_vote_account"),
+        check_vote_account: matches
+            .value_of("check_vote_account")
+            .map(|url| url.to_string()),
         only_known_rpc: matches.is_present("only_known_rpc"),
         max_genesis_archive_unpacked_size: value_t_or_exit!(
             matches,


### PR DESCRIPTION
#### Problem

Switching RPC to the minimal API by default broke snapshot fetch and vote account sanity checks

#### Summary of Changes

* restore snapshot fetch by moving `getGenesisHash` to the minimal API
* switch vote account sanity checks to opt-in
