### PR TITLE
Allow cli users to authorize Staker signed by Withdrawer

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1384,7 +1384,13 @@ pub fn process_stake_authorize(
             if let Some(authorized) = authorized {
                 match authorization_type {
                     StakeAuthorize::Staker => {
-                        check_current_authority(&authorized.staker, &authority.pubkey())?;
+                        // first check authorized withdrawer
+                        check_current_authority(&authorized.withdrawer, &authority.pubkey())
+                            .or_else(|_| {
+                                // ...then check authorized staker. If neither matches, error will
+                                // print the stake key as `expected`
+                                check_current_authority(&authorized.staker, &authority.pubkey())
+                            })?;
                     }
                     StakeAuthorize::Withdrawer => {
                         check_current_authority(&authorized.withdrawer, &authority.pubkey())?;


### PR DESCRIPTION
#### Problem
The stake program allows either the current stake or withdraw authority to sign for a change to the stake authority, but solana-cli does not, because it does a strict staker-to-staker comparison in pre-tx checks: https://github.com/solana-labs/solana/blob/a43d04d2954cbead0c9ac98f3138f97b5c3c9590/cli/src/stake.rs#L1387

#### Summary of Changes
Check both withdraw and stake current authorities and ensure one of them matches. If neither does, the error message prints the Staker as the `expected` pubkey
