### PR TITLE
fix recycler free stat report

### DIFF
--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -153,9 +153,10 @@ impl<T: Default + Reset> RecyclerX<T> {
             if gc.len() > RECYCLER_SHRINK_SIZE
                 && self.size_factor.load(Ordering::Acquire) >= SIZE_FACTOR_AFTER_SHRINK
             {
-                self.stats
-                    .freed
-                    .fetch_add(gc.len() - RECYCLER_SHRINK_SIZE, Ordering::Relaxed);
+                self.stats.freed.fetch_add(
+                    gc.len().saturating_sub(RECYCLER_SHRINK_SIZE),
+                    Ordering::Relaxed,
+                );
                 for mut x in gc.drain(RECYCLER_SHRINK_SIZE..) {
                     x.set_recycler(Weak::default());
                 }

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -14,8 +14,12 @@ use {
 // cushion against *normal* variations in the workload while bounding the
 // number of redundant garbage collected objects after temporary bursts.
 const RECYCLER_SHRINK_SIZE: usize = 1024;
-// Lookback window for averaging number of garbage collected objects in terms
-// of number of allocations.
+
+// Lookback window for exponential moving averaging number of garbage collected
+// objects in terms of number of allocations. The half-life of the decaying
+// factor based on the window size defined below is 11356. This means a sample
+// of gc.size() that is 11356 allocations ago has half of the weight as the most
+// recent sample of gc.size() at current allocation.
 const RECYCLER_SHRINK_WINDOW: usize = 16384;
 
 #[derive(Debug, Default)]

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -153,10 +153,10 @@ impl<T: Default + Reset> RecyclerX<T> {
             if gc.len() > RECYCLER_SHRINK_SIZE
                 && self.size_factor.load(Ordering::Acquire) >= SIZE_FACTOR_AFTER_SHRINK
             {
-                let mut num_recycled = 0;
+                let mut num_recycled: usize = 0;
                 for mut x in gc.drain(RECYCLER_SHRINK_SIZE..) {
                     x.set_recycler(Weak::default());
-                    num_recycled += 1;
+                    num_recycled = num_recycled.saturating_add(1);
                 }
                 self.stats.freed.fetch_add(num_recycled, Ordering::Relaxed);
                 self.size_factor

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -153,12 +153,12 @@ impl<T: Default + Reset> RecyclerX<T> {
             if gc.len() > RECYCLER_SHRINK_SIZE
                 && self.size_factor.load(Ordering::Acquire) >= SIZE_FACTOR_AFTER_SHRINK
             {
-                let mut num_recycled: usize = 0;
+                self.stats
+                    .freed
+                    .fetch_add(gc.len() - RECYCLER_SHRINK_SIZE, Ordering::Relaxed);
                 for mut x in gc.drain(RECYCLER_SHRINK_SIZE..) {
                     x.set_recycler(Weak::default());
-                    num_recycled = num_recycled.saturating_add(1);
                 }
-                self.stats.freed.fetch_add(num_recycled, Ordering::Relaxed);
                 self.size_factor
                     .store(SIZE_FACTOR_AFTER_SHRINK, Ordering::Release);
             }

--- a/perf/src/recycler.rs
+++ b/perf/src/recycler.rs
@@ -153,10 +153,12 @@ impl<T: Default + Reset> RecyclerX<T> {
             if gc.len() > RECYCLER_SHRINK_SIZE
                 && self.size_factor.load(Ordering::Acquire) >= SIZE_FACTOR_AFTER_SHRINK
             {
+                let mut num_recycled = 0;
                 for mut x in gc.drain(RECYCLER_SHRINK_SIZE..) {
                     x.set_recycler(Weak::default());
-                    self.stats.freed.fetch_add(1, Ordering::Relaxed);
+                    num_recycled += 1;
                 }
+                self.stats.freed.fetch_add(num_recycled, Ordering::Relaxed);
                 self.size_factor
                     .store(SIZE_FACTOR_AFTER_SHRINK, Ordering::Release);
             }


### PR DESCRIPTION
#### Problem
When reporting recycler performance stat, the *free* counter is reporting total number of allocations + 1.

#### Summary of Changes
Add separate counter to track freed packets.

Fixes #
