### PR TITLE
Restore wait_for_nonzero_fees to TestValidatorGenesis::start_with_mint_address

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -380,7 +380,15 @@ impl TestValidatorGenesis {
         mint_address: Pubkey,
         socket_addr_space: SocketAddrSpace,
     ) -> Result<TestValidator, Box<dyn std::error::Error>> {
-        TestValidator::start(mint_address, self, socket_addr_space)
+        TestValidator::start(mint_address, self, socket_addr_space).map(|test_validator| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .unwrap();
+            runtime.block_on(test_validator.wait_for_nonzero_fees());
+            test_validator
+        })
     }
 
     /// Start a test validator
@@ -404,18 +412,9 @@ impl TestValidatorGenesis {
         socket_addr_space: SocketAddrSpace,
     ) -> (TestValidator, Keypair) {
         let mint_keypair = Keypair::new();
-        match TestValidator::start(mint_keypair.pubkey(), self, socket_addr_space) {
-            Ok(test_validator) => {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_io()
-                    .enable_time()
-                    .build()
-                    .unwrap();
-                runtime.block_on(test_validator.wait_for_nonzero_fees());
-                (test_validator, mint_keypair)
-            }
-            Err(err) => panic!("Test validator failed to start: {}", err),
-        }
+        self.start_with_mint_address(mint_keypair.pubkey(), socket_addr_space)
+            .map(|test_validator| (test_validator, mint_keypair))
+            .unwrap_or_else(|err| panic!("Test validator failed to start: {}", err))
     }
 
     pub async fn start_async(&self) -> (TestValidator, Keypair) {


### PR DESCRIPTION
#### Problem
solana-tokens tests are [flaky](https://buildkite.com/solana-labs/solana/builds/65812#bde3f7c2-b8f9-4b0a-a744-5949c5ec18fa). Errors look like this:
```
thread 'commands::tests::test_check_payer_balances_distribute_tokens_separate_payers' panicked at 'assertion failed: `(left == right)`
  left: `"0.0000025"`,
 right: `"0"`', tokens/src/commands.rs:1757:13
```
This is because the logic to wait for non-zero fees didn't make it into TestValidatorGenesis::start_with_mint_address here: https://github.com/solana-labs/solana/pull/22738

#### Summary of Changes
Some DRY to bring TestValidatorGenesis::start_with_mint_address back into the fold. solana-tokens tests now pass consistently
