### PR TITLE
Cleanup: get_program_key() and get_loader_key() in TransactionContext

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -445,7 +445,7 @@ impl<'a> InvokeContext<'a> {
         let cap_accounts_data_len = self.feature_set.is_active(&cap_accounts_data_len::id());
         let program_id = self
             .transaction_context
-            .get_program_key()
+            .get_current_program_key()
             .map_err(|_| InstructionError::CallDepth)?;
 
         // Verify all executable accounts have zero outstanding refs
@@ -531,7 +531,7 @@ impl<'a> InvokeContext<'a> {
         let transaction_context = &self.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let program_id = transaction_context
-            .get_program_key()
+            .get_current_program_key()
             .map_err(|_| InstructionError::CallDepth)?;
 
         // Verify the per-account instruction results
@@ -1268,7 +1268,7 @@ mod tests {
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        let program_id = transaction_context.get_program_key()?;
+        let program_id = transaction_context.get_current_program_key()?;
         assert_eq!(
             program_id,
             instruction_context

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -443,9 +443,12 @@ impl<'a> InvokeContext<'a> {
     ) -> Result<(), InstructionError> {
         let do_support_realloc = self.feature_set.is_active(&do_support_realloc::id());
         let cap_accounts_data_len = self.feature_set.is_active(&cap_accounts_data_len::id());
-        let program_id = self
+        let instruction_context = self
             .transaction_context
-            .get_current_program_key()
+            .get_current_instruction_context()
+            .map_err(|_| InstructionError::CallDepth)?;
+        let program_id = instruction_context
+            .get_program_key(self.transaction_context)
             .map_err(|_| InstructionError::CallDepth)?;
 
         // Verify all executable accounts have zero outstanding refs
@@ -530,8 +533,8 @@ impl<'a> InvokeContext<'a> {
         let cap_accounts_data_len = self.feature_set.is_active(&cap_accounts_data_len::id());
         let transaction_context = &self.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        let program_id = transaction_context
-            .get_current_program_key()
+        let program_id = instruction_context
+            .get_program_key(transaction_context)
             .map_err(|_| InstructionError::CallDepth)?;
 
         // Verify the per-account instruction results
@@ -1268,7 +1271,7 @@ mod tests {
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        let program_id = transaction_context.get_current_program_key()?;
+        let program_id = instruction_context.get_program_key(transaction_context)?;
         assert_eq!(
             program_id,
             instruction_context

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -170,9 +170,9 @@ impl NativeLoader {
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
-            let program_id = invoke_context
-                .transaction_context
-                .get_current_program_key()?;
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let program_id = instruction_context.get_program_key(transaction_context)?;
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             if native_loader::id() != *program_id {

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -170,7 +170,9 @@ impl NativeLoader {
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
-            let program_id = invoke_context.transaction_context.get_program_key()?;
+            let program_id = invoke_context
+                .transaction_context
+                .get_current_program_key()?;
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             if native_loader::id() != *program_id {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -101,7 +101,7 @@ pub fn builtin_process_instruction(
         ..instruction_context.get_number_of_accounts();
 
     let log_collector = invoke_context.get_log_collector();
-    let program_id = transaction_context.get_program_key()?;
+    let program_id = transaction_context.get_current_program_key()?;
     stable_log::program_invoke(
         &log_collector,
         program_id,
@@ -249,7 +249,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
         let caller = *invoke_context
             .transaction_context
-            .get_program_key()
+            .get_current_program_key()
             .unwrap();
 
         stable_log::program_invoke(
@@ -372,7 +372,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         let invoke_context = get_invoke_context();
         let caller = *invoke_context
             .transaction_context
-            .get_program_key()
+            .get_current_program_key()
             .unwrap();
         invoke_context
             .transaction_context

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -101,7 +101,7 @@ pub fn builtin_process_instruction(
         ..instruction_context.get_number_of_accounts();
 
     let log_collector = invoke_context.get_log_collector();
-    let program_id = transaction_context.get_current_program_key()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     stable_log::program_invoke(
         &log_collector,
         program_id,
@@ -246,10 +246,12 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
     ) -> ProgramResult {
         let invoke_context = get_invoke_context();
         let log_collector = invoke_context.get_log_collector();
-
-        let caller = *invoke_context
-            .transaction_context
-            .get_current_program_key()
+        let transaction_context = &invoke_context.transaction_context;
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
+            .unwrap();
+        let caller = instruction_context
+            .get_program_key(transaction_context)
             .unwrap();
 
         stable_log::program_invoke(
@@ -260,7 +262,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
         let signers = signers_seeds
             .iter()
-            .map(|seeds| Pubkey::create_program_address(seeds, &caller).unwrap())
+            .map(|seeds| Pubkey::create_program_address(seeds, caller).unwrap())
             .collect::<Vec<_>>();
         let (instruction_accounts, program_indices) = invoke_context
             .prepare_instruction(instruction, &signers)
@@ -370,12 +372,14 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
 
     fn sol_set_return_data(&self, data: &[u8]) {
         let invoke_context = get_invoke_context();
-        let caller = *invoke_context
-            .transaction_context
-            .get_current_program_key()
+        let transaction_context = &mut invoke_context.transaction_context;
+        let instruction_context = transaction_context
+            .get_current_instruction_context()
             .unwrap();
-        invoke_context
-            .transaction_context
+        let caller = *instruction_context
+            .get_program_key(transaction_context)
+            .unwrap();
+        transaction_context
             .set_return_data(caller, data.to_vec())
             .unwrap();
     }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -229,13 +229,12 @@ fn run_program(name: &str) -> u64 {
         let mut instruction_count = 0;
         let mut tracer = None;
         for i in 0..2 {
-            invoke_context
-                .transaction_context
+            let transaction_context = &mut invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context().unwrap();
+            let caller = *instruction_context.get_program_key(transaction_context).unwrap();
+            transaction_context
                 .set_return_data(
-                    *invoke_context
-                        .transaction_context
-                        .get_current_program_key()
-                        .unwrap(),
+                    caller,
                     Vec::new(),
                 )
                 .unwrap();

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -234,7 +234,7 @@ fn run_program(name: &str) -> u64 {
                 .set_return_data(
                     *invoke_context
                         .transaction_context
-                        .get_program_key()
+                        .get_current_program_key()
                         .unwrap(),
                     Vec::new(),
                 )

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -273,9 +273,9 @@ fn process_instruction_common(
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
-    let program_id = invoke_context
-        .transaction_context
-        .get_current_program_key()?;
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
 
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let first_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
@@ -352,9 +352,9 @@ fn process_instruction_common(
                     use_jit,
                     false,
                 )?;
-                let program_id = invoke_context
-                    .transaction_context
-                    .get_current_program_key()?;
+                let transaction_context = &invoke_context.transaction_context;
+                let instruction_context = transaction_context.get_current_instruction_context()?;
+                let program_id = instruction_context.get_program_key(transaction_context)?;
                 invoke_context.add_executor(program_id, executor.clone());
                 executor
             }
@@ -401,9 +401,9 @@ fn process_loader_upgradeable_instruction(
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
-    let program_id = invoke_context
-        .transaction_context
-        .get_current_program_key()?;
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     match limited_deserialize(instruction_data)? {
@@ -556,9 +556,9 @@ fn process_loader_upgradeable_instruction(
                 .accounts
                 .push(AccountMeta::new(*buffer.unsigned_key(), false));
 
-            let caller_program_id = invoke_context
-                .transaction_context
-                .get_current_program_key()?;
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let caller_program_id = instruction_context.get_program_key(transaction_context)?;
             let signers = [&[new_program_id.as_ref(), &[bump_seed]]]
                 .iter()
                 .map(|seeds| Pubkey::create_program_address(*seeds, caller_program_id))
@@ -955,9 +955,9 @@ fn process_loader_instruction(
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
-    let program_id = invoke_context
-        .transaction_context
-        .get_current_program_key()?;
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
     if program.owner()? != *program_id {
@@ -1046,17 +1046,13 @@ impl Executor for BpfExecutor {
         let log_collector = invoke_context.get_log_collector();
         let compute_meter = invoke_context.get_compute_meter();
         let stack_height = invoke_context.get_stack_height();
+        let transaction_context = &invoke_context.transaction_context;
+        let instruction_context = transaction_context.get_current_instruction_context()?;
+        let program_id = *instruction_context.get_program_key(transaction_context)?;
 
         let mut serialize_time = Measure::start("serialize");
-        let program_id = *invoke_context
-            .transaction_context
-            .get_current_program_key()?;
-        let (mut parameter_bytes, account_lengths) = serialize_parameters(
-            invoke_context.transaction_context,
-            invoke_context
-                .transaction_context
-                .get_current_instruction_context()?,
-        )?;
+        let (mut parameter_bytes, account_lengths) =
+            serialize_parameters(invoke_context.transaction_context, instruction_context)?;
         serialize_time.stop();
         let mut create_vm_time = Measure::start("create_vm");
         let mut execute_time;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -273,7 +273,9 @@ fn process_instruction_common(
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
-    let program_id = invoke_context.transaction_context.get_program_key()?;
+    let program_id = invoke_context
+        .transaction_context
+        .get_current_program_key()?;
 
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let first_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
@@ -350,7 +352,9 @@ fn process_instruction_common(
                     use_jit,
                     false,
                 )?;
-                let program_id = invoke_context.transaction_context.get_program_key()?;
+                let program_id = invoke_context
+                    .transaction_context
+                    .get_current_program_key()?;
                 invoke_context.add_executor(program_id, executor.clone());
                 executor
             }
@@ -397,7 +401,9 @@ fn process_loader_upgradeable_instruction(
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
-    let program_id = invoke_context.transaction_context.get_program_key()?;
+    let program_id = invoke_context
+        .transaction_context
+        .get_current_program_key()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     match limited_deserialize(instruction_data)? {
@@ -550,7 +556,9 @@ fn process_loader_upgradeable_instruction(
                 .accounts
                 .push(AccountMeta::new(*buffer.unsigned_key(), false));
 
-            let caller_program_id = invoke_context.transaction_context.get_program_key()?;
+            let caller_program_id = invoke_context
+                .transaction_context
+                .get_current_program_key()?;
             let signers = [&[new_program_id.as_ref(), &[bump_seed]]]
                 .iter()
                 .map(|seeds| Pubkey::create_program_address(*seeds, caller_program_id))
@@ -947,7 +955,9 @@ fn process_loader_instruction(
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
-    let program_id = invoke_context.transaction_context.get_program_key()?;
+    let program_id = invoke_context
+        .transaction_context
+        .get_current_program_key()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
     if program.owner()? != *program_id {
@@ -1038,7 +1048,9 @@ impl Executor for BpfExecutor {
         let stack_height = invoke_context.get_stack_height();
 
         let mut serialize_time = Measure::start("serialize");
-        let program_id = *invoke_context.transaction_context.get_program_key()?;
+        let program_id = *invoke_context
+            .transaction_context
+            .get_current_program_key()?;
         let (mut parameter_bytes, account_lengths) = serialize_parameters(
             invoke_context.transaction_context,
             invoke_context

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -289,7 +289,7 @@ pub fn bind_syscall_context_objects<'a, 'b>(
 
     let loader_id = invoke_context
         .transaction_context
-        .get_loader_key()
+        .get_current_loader_key()
         .map_err(SyscallError::InstructionError)?;
     let invoke_context = Rc::new(RefCell::new(invoke_context));
 
@@ -669,7 +669,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallPanic<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -720,7 +720,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLog<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -843,7 +843,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogPubkey<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -960,7 +960,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1020,7 +1020,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1097,7 +1097,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSha256<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1173,7 +1173,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetClockSysvar<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1210,7 +1210,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1248,7 +1248,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1285,7 +1285,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetRentSysvar<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1331,7 +1331,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallKeccak256<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1454,7 +1454,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1498,7 +1498,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemmove<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1542,7 +1542,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcmp<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1599,7 +1599,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemset<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1642,7 +1642,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1747,7 +1747,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOp<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1810,7 +1810,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithLoHi<'a, 'b>
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1877,7 +1877,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithScalar<'a, '
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -1939,7 +1939,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallBlake3<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -2676,7 +2676,7 @@ fn call<'a, 'b: 'a>(
     // Translate and verify caller's data
     let loader_id = invoke_context
         .transaction_context
-        .get_loader_key()
+        .get_current_loader_key()
         .map_err(SyscallError::InstructionError)?;
     let instruction = syscall.translate_instruction(
         &loader_id,
@@ -2686,7 +2686,7 @@ fn call<'a, 'b: 'a>(
     )?;
     let caller_program_id = invoke_context
         .transaction_context
-        .get_program_key()
+        .get_current_program_key()
         .map_err(SyscallError::InstructionError)?;
     let signers = syscall.translate_signers(
         &loader_id,
@@ -2804,7 +2804,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -2835,7 +2835,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
         let program_id = *question_mark!(
             invoke_context
                 .transaction_context
-                .get_program_key()
+                .get_current_program_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -2874,7 +2874,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetReturnData<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -2942,7 +2942,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogData<'a, 'b> {
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );
@@ -3023,7 +3023,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
         let loader_id = question_mark!(
             invoke_context
                 .transaction_context
-                .get_loader_key()
+                .get_current_loader_key()
                 .map_err(SyscallError::InstructionError),
             result
         );

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3061,6 +3061,28 @@ mod tests {
         };
     }
 
+    macro_rules! prepare_mockup {
+        ($invoke_context:ident,
+         $transaction_context:ident,
+         $program_key:ident,
+         $loader_key:expr $(,)?) => {
+            let $program_key = Pubkey::new_unique();
+            let mut $transaction_context = TransactionContext::new(
+                vec![
+                    (
+                        $loader_key,
+                        AccountSharedData::new(0, 0, &native_loader::id()),
+                    ),
+                    ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
+                ],
+                1,
+                1,
+            );
+            let mut $invoke_context = InvokeContext::new_mock(&mut $transaction_context, &[]);
+            $invoke_context.push(&[], &[0, 1], &[]).unwrap();
+        };
+    }
+
     #[allow(dead_code)]
     struct MockSlice {
         pub vm_addr: u64,
@@ -3355,14 +3377,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "UserError(SyscallError(Panic(\"Gaggablaghblagh!\", 42, 84)))")]
     fn test_syscall_sol_panic() {
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let mut syscall_panic = SyscallPanic {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
         };
@@ -3429,14 +3449,12 @@ mod tests {
 
     #[test]
     fn test_syscall_sol_log() {
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let mut syscall_sol_log = SyscallLog {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
         };
@@ -3530,14 +3548,12 @@ mod tests {
 
     #[test]
     fn test_syscall_sol_log_u64() {
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let cost = invoke_context.get_compute_budget().log_64_units;
         let mut syscall_sol_log_u64 = SyscallLogU64 {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3569,14 +3585,12 @@ mod tests {
 
     #[test]
     fn test_syscall_sol_pubkey() {
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let cost = invoke_context.get_compute_budget().log_pubkey_units;
         let mut syscall_sol_pubkey = SyscallLogPubkey {
             invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -3778,17 +3792,12 @@ mod tests {
     #[test]
     fn test_syscall_sha256() {
         let config = Config::default();
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(
-                program_id,
-                AccountSharedData::new(0, 0, &bpf_loader_deprecated::id()),
-            )],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader_deprecated::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
 
         let bytes1 = "Gaggablaghblagh!";
         let bytes2 = "flurbos";
@@ -3939,15 +3948,13 @@ mod tests {
         sysvar_cache.set_fees(src_fees.clone());
         sysvar_cache.set_rent(src_rent);
 
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.sysvar_cache = Cow::Owned(sysvar_cache);
-        invoke_context.push(&[], &[0], &[]).unwrap();
 
         // Test clock sysvar
         {
@@ -4190,14 +4197,12 @@ mod tests {
     fn test_create_program_address() {
         // These tests duplicate the direct tests in solana_program::pubkey
 
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let address = bpf_loader_upgradeable::id();
 
         let exceeded_seed = &[127; MAX_SEED_LEN + 1];
@@ -4303,14 +4308,12 @@ mod tests {
 
     #[test]
     fn test_find_program_address() {
-        let program_id = Pubkey::new_unique();
-        let mut transaction_context = TransactionContext::new(
-            vec![(program_id, AccountSharedData::new(0, 0, &bpf_loader::id()))],
-            1,
-            1,
+        prepare_mockup!(
+            invoke_context,
+            transaction_context,
+            program_id,
+            bpf_loader::id(),
         );
-        let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
-        invoke_context.push(&[], &[0], &[]).unwrap();
         let cost = invoke_context
             .get_compute_budget()
             .create_program_address_units;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -11212,9 +11212,9 @@ pub(crate) mod tests {
             _instruction_data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
-            let program_id = invoke_context
-                .transaction_context
-                .get_current_program_key()?;
+            let transaction_context = &invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let program_id = instruction_context.get_program_key(transaction_context)?;
             if mock_vote_program_id() != *program_id {
                 return Err(InstructionError::IncorrectProgramId);
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -11212,7 +11212,9 @@ pub(crate) mod tests {
             _instruction_data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
-            let program_id = invoke_context.transaction_context.get_program_key()?;
+            let program_id = invoke_context
+                .transaction_context
+                .get_current_program_key()?;
             if mock_vote_program_id() != *program_id {
                 return Err(InstructionError::IncorrectProgramId);
             }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -19,12 +19,16 @@ fn process_instruction_with_program_logging(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
-    let program_id = invoke_context.transaction_context.get_program_key()?;
+    let program_id = invoke_context
+        .transaction_context
+        .get_current_program_key()?;
     stable_log::program_invoke(&logger, program_id, invoke_context.get_stack_height());
 
     let result = process_instruction(first_instruction_account, instruction_data, invoke_context);
 
-    let program_id = invoke_context.transaction_context.get_program_key()?;
+    let program_id = invoke_context
+        .transaction_context
+        .get_current_program_key()?;
     match &result {
         Ok(()) => stable_log::program_success(&logger, program_id),
         Err(err) => stable_log::program_failure(&logger, program_id, err),

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -19,16 +19,16 @@ fn process_instruction_with_program_logging(
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
-    let program_id = invoke_context
-        .transaction_context
-        .get_current_program_key()?;
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     stable_log::program_invoke(&logger, program_id, invoke_context.get_stack_height());
 
     let result = process_instruction(first_instruction_account, instruction_data, invoke_context);
 
-    let program_id = invoke_context
-        .transaction_context
-        .get_current_program_key()?;
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let program_id = instruction_context.get_program_key(transaction_context)?;
     match &result {
         Ok(()) => stable_log::program_success(&logger, program_id),
         Err(err) => stable_log::program_failure(&logger, program_id, err),

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -229,14 +229,14 @@ impl TransactionContext {
     }
 
     /// Returns the key of the current InstructionContexts program account
-    pub fn get_program_key(&self) -> Result<&Pubkey, InstructionError> {
+    pub fn get_current_program_key(&self) -> Result<&Pubkey, InstructionError> {
         let instruction_context = self.get_current_instruction_context()?;
         let program_account = instruction_context.try_borrow_program_account(self)?;
         Ok(&self.account_keys[program_account.index_in_transaction])
     }
 
     /// Returns the owner of the current InstructionContexts program account
-    pub fn get_loader_key(&self) -> Result<Pubkey, InstructionError> {
+    pub fn get_current_loader_key(&self) -> Result<Pubkey, InstructionError> {
         let instruction_context = self.get_current_instruction_context()?;
         let program_account = instruction_context.try_borrow_program_account(self)?;
         Ok(*program_account.get_owner())

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -228,13 +228,6 @@ impl TransactionContext {
         Ok(())
     }
 
-    /// Returns the key of the current InstructionContexts program account
-    pub fn get_current_program_key(&self) -> Result<&Pubkey, InstructionError> {
-        let instruction_context = self.get_current_instruction_context()?;
-        let program_account = instruction_context.try_borrow_program_account(self)?;
-        Ok(&self.account_keys[program_account.index_in_transaction])
-    }
-
     /// Returns the owner of the current InstructionContexts program account
     pub fn get_current_loader_key(&self) -> Result<Pubkey, InstructionError> {
         let instruction_context = self.get_current_instruction_context()?;
@@ -406,6 +399,16 @@ impl InstructionContext {
             index_in_instruction,
             account,
         })
+    }
+
+    /// Gets the key of the last program account of this Instruction
+    pub fn get_program_key<'a, 'b: 'a>(
+        &'a self,
+        transaction_context: &'b TransactionContext,
+    ) -> Result<&'b Pubkey, InstructionError> {
+        let index_in_transaction =
+            self.get_index_in_transaction(self.program_accounts.len().saturating_sub(1))?;
+        transaction_context.get_key_of_account_at_index(index_in_transaction)
     }
 
     /// Gets the last program account of this Instruction

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -228,12 +228,6 @@ impl TransactionContext {
         Ok(())
     }
 
-    /// Returns the owner of the current InstructionContexts program account
-    pub fn get_current_loader_key(&self) -> Result<&Pubkey, InstructionError> {
-        let instruction_context = self.get_current_instruction_context()?;
-        instruction_context.get_loader_key(self)
-    }
-
     /// Gets the return data of the current InstructionContext or any above
     pub fn get_return_data(&self) -> (&Pubkey, &[u8]) {
         (&self.return_data.0, &self.return_data.1)
@@ -398,18 +392,6 @@ impl InstructionContext {
             index_in_instruction,
             account,
         })
-    }
-
-    /// Gets the key of the second last program account of this Instruction
-    ///
-    /// This is the owner of the last program account.
-    pub fn get_loader_key<'a, 'b: 'a>(
-        &'a self,
-        transaction_context: &'b TransactionContext,
-    ) -> Result<&'b Pubkey, InstructionError> {
-        let index_in_transaction =
-            self.get_index_in_transaction(self.program_accounts.len().saturating_sub(2))?;
-        transaction_context.get_key_of_account_at_index(index_in_transaction)
     }
 
     /// Gets the key of the last program account of this Instruction

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -229,10 +229,9 @@ impl TransactionContext {
     }
 
     /// Returns the owner of the current InstructionContexts program account
-    pub fn get_current_loader_key(&self) -> Result<Pubkey, InstructionError> {
+    pub fn get_current_loader_key(&self) -> Result<&Pubkey, InstructionError> {
         let instruction_context = self.get_current_instruction_context()?;
-        let program_account = instruction_context.try_borrow_program_account(self)?;
-        Ok(*program_account.get_owner())
+        instruction_context.get_loader_key(self)
     }
 
     /// Gets the return data of the current InstructionContext or any above
@@ -399,6 +398,18 @@ impl InstructionContext {
             index_in_instruction,
             account,
         })
+    }
+
+    /// Gets the key of the second last program account of this Instruction
+    ///
+    /// This is the owner of the last program account.
+    pub fn get_loader_key<'a, 'b: 'a>(
+        &'a self,
+        transaction_context: &'b TransactionContext,
+    ) -> Result<&'b Pubkey, InstructionError> {
+        let index_in_transaction =
+            self.get_index_in_transaction(self.program_accounts.len().saturating_sub(2))?;
+        transaction_context.get_key_of_account_at_index(index_in_transaction)
     }
 
     /// Gets the key of the last program account of this Instruction


### PR DESCRIPTION
#### Problem
`get_program_key()` on `TransactionContext` does not tell the user which program accounts key is taken and also prevents the optimization of sharing the current `InstructionContext` handle with other methods.
See: https://github.com/solana-labs/solana/pull/23056#discussion_r807598926

#### Summary of Changes
- Moves `get_program_key()` from `TransactionContext` to `InstructionContext`.
- Removes `get_loader_key()`.

Fixes #
