### PR TITLE
Add git sha to binaries that are built outside of CI

### DIFF
--- a/cargo
+++ b/cargo
@@ -3,6 +3,11 @@
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 
+export CI_COMMIT=$(git rev-parse --short HEAD)
+# TODO does the CI use this file?
+export SOLANA_DEVBUILD=1
+git diff --quiet || export SOLANA_WORKING_TREE_DIRTY=1
+
 toolchain=
 case "$1" in
   stable)

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -403,6 +403,8 @@ impl Version {
                 minor: rng.gen(),
                 patch: rng.gen(),
                 commit: Some(rng.gen()),
+                devbuild: false,
+                working_tree_dirty: false,
                 feature_set: rng.gen(),
             },
         }

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -53,11 +53,12 @@ else
       (
         set -x
         # shellcheck disable=SC2086 # Don't want to double quote
-        cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
+        here=$(dirname "$0")
+        "$here"/../cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
       )
     fi
 
-    printf "cargo $CARGO_TOOLCHAIN run $maybe_release  --bin %s %s -- " "$program"
+    printf "$here/../cargo $CARGO_TOOLCHAIN run $maybe_release  --bin %s %s -- " "$program"
   }
 fi
 


### PR DESCRIPTION
#### Problem
local builds show a commit of "devbuild" in logs or when run with --version. This is problematic when non-CI builds are left running on validator hosts and makes debugging tricky.

#### Solution
* Update build scripts to populate the CI_COMMIT env var (which gets stored in the binaries)
* Add devbuild bool which is set based on the presence of the SOLANA_DEVBUILD env var. The env var is set by ./cargo and is intended to denote a non-CI build.
* Add a dirty bool which is set based on the presence of the SOLANA_WORKING_TREE_DIRTY env var. This recognizes that code can be built without being committed and will hopefully avoid confusion in cases where the debug information clearly doesn't match the code in the commit version.
* Incorporate the new bools (devbuild and dirty) into the version format.