### PR TITLE
v1.9: Enforce tx metadata upload to bigtable

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -34,7 +34,9 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
-    solana_transaction_status::{ConfirmedBlock, TransactionDetails, UiTransactionEncoding},
+    solana_transaction_status::{
+        ConfirmedBlockWithOptionalMetadata, TransactionDetails, UiTransactionEncoding,
+    },
     std::{
         collections::HashSet,
         net::{IpAddr, SocketAddr},
@@ -278,26 +280,8 @@ fn test_block_subscription() {
     let maybe_actual = receiver.recv_timeout(Duration::from_millis(400));
     match maybe_actual {
         Ok(actual) => {
-<<<<<<< HEAD
             let complete_block = blockstore.get_complete_block(slot, false).unwrap();
-            let block = complete_block.clone().configure(
-                UiTransactionEncoding::Json,
-                TransactionDetails::Signatures,
-                false,
-            );
-            let expected = RpcBlockUpdate {
-                slot,
-                block: Some(block),
-                err: None,
-            };
-            let block = complete_block.configure(
-=======
-            let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
-            let legacy_block = ConfirmedBlock::from(versioned_block)
-                .into_legacy_block()
-                .unwrap();
-            let block = legacy_block.configure(
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+            let block = ConfirmedBlockWithOptionalMetadata::from(complete_block).configure(
                 UiTransactionEncoding::Json,
                 TransactionDetails::Signatures,
                 false,

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -8,7 +8,7 @@ use {
             RpcAccountInfoConfig, RpcBlockSubscribeConfig, RpcBlockSubscribeFilter,
             RpcProgramAccountsConfig,
         },
-        rpc_response::{RpcBlockUpdate, SlotInfo},
+        rpc_response::SlotInfo,
     },
     solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path},
     solana_rpc::{
@@ -34,7 +34,7 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
-    solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
+    solana_transaction_status::{ConfirmedBlock, TransactionDetails, UiTransactionEncoding},
     std::{
         collections::HashSet,
         net::{IpAddr, SocketAddr},
@@ -212,6 +212,7 @@ fn test_block_subscription() {
         ..
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
+    let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
     // setup Blockstore
@@ -225,6 +226,8 @@ fn test_block_subscription() {
     let keypair2 = Keypair::new();
     let keypair3 = Keypair::new();
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+    bank.transfer(rent_exempt_amount, &alice, &keypair2.pubkey())
+        .unwrap();
     let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
         vec![&alice, &keypair1, &keypair2, &keypair3],
         0,
@@ -275,6 +278,7 @@ fn test_block_subscription() {
     let maybe_actual = receiver.recv_timeout(Duration::from_millis(400));
     match maybe_actual {
         Ok(actual) => {
+<<<<<<< HEAD
             let complete_block = blockstore.get_complete_block(slot, false).unwrap();
             let block = complete_block.clone().configure(
                 UiTransactionEncoding::Json,
@@ -287,11 +291,18 @@ fn test_block_subscription() {
                 err: None,
             };
             let block = complete_block.configure(
+=======
+            let versioned_block = blockstore.get_complete_block(slot, false).unwrap();
+            let legacy_block = ConfirmedBlock::from(versioned_block)
+                .into_legacy_block()
+                .unwrap();
+            let block = legacy_block.configure(
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 UiTransactionEncoding::Json,
                 TransactionDetails::Signatures,
                 false,
             );
-            assert_eq!(actual.value.slot, expected.slot);
+            assert_eq!(actual.value.slot, slot);
             assert!(block.eq(&actual.value.block.unwrap()));
         }
         Err(e) => {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3245,16 +3245,9 @@ mod tests {
         );
         let ix_error_signature = ix_error_tx.signatures[0];
         let entry_2 = next_entry(&entry_1.hash, 1, vec![ix_error_tx.clone()]);
-        let fail_tx = system_transaction::transfer(
-            &mint_keypair,
-            &pubkey1,
-            rent_exempt_amount,
-            genesis_config.hash(),
-        );
-        let entry_3 = next_entry(&entry_2.hash, 1, vec![fail_tx.clone()]);
-        let entries = vec![entry_1, entry_2, entry_3];
+        let entries = vec![entry_1, entry_2];
 
-        let transactions = sanitize_transactions(vec![success_tx, ix_error_tx, fail_tx]);
+        let transactions = sanitize_transactions(vec![success_tx, ix_error_tx]);
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair1.pubkey())
             .unwrap();
 
@@ -3314,6 +3307,7 @@ mod tests {
             transaction_status_service.join().unwrap();
 
             let confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
+<<<<<<< HEAD
             assert_eq!(confirmed_block.transactions.len(), 3);
 
             for TransactionWithStatusMeta { transaction, meta } in
@@ -3335,6 +3329,26 @@ mod tests {
                     assert_eq!(meta, None);
                 }
             }
+=======
+            let actual_tx_results: Vec<_> = confirmed_block
+                .transactions
+                .into_iter()
+                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                    (transaction.signatures[0], meta.status)
+                })
+                .collect();
+            let expected_tx_results = vec![
+                (success_signature, Ok(())),
+                (
+                    ix_error_signature,
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::Custom(1),
+                    )),
+                ),
+            ];
+            assert_eq!(actual_tx_results, expected_tx_results);
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 
             poh_recorder
                 .lock()
@@ -3346,6 +3360,165 @@ mod tests {
         Blockstore::destroy(ledger_path.path()).unwrap();
     }
 
+<<<<<<< HEAD
+=======
+    fn generate_new_address_lookup_table(
+        authority: Option<Pubkey>,
+        num_addresses: usize,
+    ) -> AddressLookupTable<'static> {
+        let mut addresses = Vec::with_capacity(num_addresses);
+        addresses.resize_with(num_addresses, Pubkey::new_unique);
+        AddressLookupTable {
+            meta: LookupTableMeta {
+                authority,
+                ..LookupTableMeta::default()
+            },
+            addresses: Cow::Owned(addresses),
+        }
+    }
+
+    fn store_address_lookup_table(
+        bank: &Bank,
+        account_address: Pubkey,
+        address_lookup_table: AddressLookupTable<'static>,
+    ) -> AccountSharedData {
+        let mut data = Vec::new();
+        address_lookup_table.serialize_for_tests(&mut data).unwrap();
+
+        let mut account =
+            AccountSharedData::new(1, data.len(), &solana_address_lookup_table_program::id());
+        account.set_data(data);
+        bank.store_account(&account_address, &account);
+
+        account
+    }
+
+    #[test]
+    fn test_write_persist_loaded_addresses() {
+        solana_logger::setup();
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_slow_genesis_config(10_000);
+        let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        let keypair = Keypair::new();
+
+        let address_table_key = Pubkey::new_unique();
+        let address_table_state = generate_new_address_lookup_table(None, 2);
+        store_address_lookup_table(&bank, address_table_key, address_table_state);
+
+        let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::new_unique(), 1));
+        let message = VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            recent_blockhash: genesis_config.hash(),
+            account_keys: vec![keypair.pubkey()],
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: address_table_key,
+                writable_indexes: vec![0],
+                readonly_indexes: vec![1],
+            }],
+            instructions: vec![],
+        });
+
+        let tx = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
+        let message_hash = tx.message.hash();
+        let sanitized_tx =
+            SanitizedTransaction::try_create(tx.clone(), message_hash, Some(false), bank.as_ref())
+                .unwrap();
+
+        let entry = next_versioned_entry(&genesis_config.hash(), 1, vec![tx]);
+        let entries = vec![entry];
+
+        bank.transfer(1, &mint_keypair, &keypair.pubkey()).unwrap();
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        {
+            let blockstore = Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger");
+            let blockstore = Arc::new(blockstore);
+            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
+                bank.tick_height(),
+                bank.last_blockhash(),
+                bank.clone(),
+                Some((4, 4)),
+                bank.ticks_per_slot(),
+                &Pubkey::new_unique(),
+                &blockstore,
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
+            );
+            let recorder = poh_recorder.recorder();
+            let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+
+            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
+
+            poh_recorder.lock().unwrap().set_bank(&bank);
+
+            let shreds = entries_to_test_shreds(&entries, bank.slot(), 0, true, 0);
+            blockstore.insert_shreds(shreds, None, false).unwrap();
+            blockstore.set_roots(std::iter::once(&bank.slot())).unwrap();
+
+            let (transaction_status_sender, transaction_status_receiver) = unbounded();
+            let transaction_status_service = TransactionStatusService::new(
+                transaction_status_receiver,
+                Arc::new(AtomicU64::default()),
+                true,
+                None,
+                blockstore.clone(),
+                &Arc::new(AtomicBool::new(false)),
+            );
+
+            let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
+
+            let _ = BankingStage::process_and_record_transactions(
+                &bank,
+                &[sanitized_tx.clone()],
+                &recorder,
+                0,
+                Some(TransactionStatusSender {
+                    sender: transaction_status_sender,
+                    enable_cpi_and_log_storage: false,
+                }),
+                &gossip_vote_sender,
+                &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
+            );
+
+            transaction_status_service.join().unwrap();
+
+            let mut confirmed_block = blockstore.get_rooted_block(bank.slot(), false).unwrap();
+            assert_eq!(confirmed_block.transactions.len(), 1);
+
+            let recorded_meta = confirmed_block.transactions.pop().unwrap().meta;
+            assert_eq!(
+                recorded_meta,
+                TransactionStatusMeta {
+                    status: Ok(()),
+                    pre_balances: vec![1, 0, 0],
+                    post_balances: vec![1, 0, 0],
+                    pre_token_balances: Some(vec![]),
+                    post_token_balances: Some(vec![]),
+                    rewards: Some(vec![]),
+                    loaded_addresses: sanitized_tx.get_loaded_addresses(),
+                    ..TransactionStatusMeta::default()
+                }
+            );
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
+        }
+        Blockstore::destroy(ledger_path.path()).unwrap();
+    }
+
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     #[allow(clippy::type_complexity)]
     fn setup_conflicting_transactions(
         ledger_path: &Path,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3223,6 +3223,7 @@ mod tests {
         genesis_config.rent.lamports_per_byte_year = 50;
         genesis_config.rent.exemption_threshold = 2.0;
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        let rent_exempt_minimum = bank.get_minimum_balance_for_rent_exemption(0);
         let pubkey = solana_sdk::pubkey::new_rand();
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let keypair1 = Keypair::new();
@@ -3238,7 +3239,8 @@ mod tests {
         let entries = vec![entry_1, entry_2];
 
         let transactions = sanitize_transactions(vec![success_tx, ix_error_tx]);
-        bank.transfer(1, &mint_keypair, &keypair1.pubkey()).unwrap();
+        bank.transfer(rent_exempt_minimum, &mint_keypair, &keypair1.pubkey())
+            .unwrap();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3024,7 +3024,7 @@ pub mod tests {
             transaction::TransactionError,
         },
         solana_streamer::socket::SocketAddrSpace,
-        solana_transaction_status::TransactionWithStatusMeta,
+        solana_transaction_status::TransactionWithMetadata,
         solana_vote_program::{
             vote_state::{VoteState, VoteStateVersions},
             vote_transaction,
@@ -3884,33 +3884,10 @@ pub mod tests {
             .into_iter();
 
             let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
-<<<<<<< HEAD
-            assert_eq!(confirmed_block.transactions.len(), 3);
-
-            for TransactionWithStatusMeta { transaction, meta } in
-                confirmed_block.transactions.into_iter()
-            {
-                if transaction.signatures[0] == signatures[0] {
-                    let meta = meta.unwrap();
-                    assert_eq!(meta.status, Ok(()));
-                } else if transaction.signatures[0] == signatures[1] {
-                    let meta = meta.unwrap();
-                    assert_eq!(
-                        meta.status,
-                        Err(TransactionError::InstructionError(
-                            0,
-                            InstructionError::Custom(1)
-                        ))
-                    );
-                } else {
-                    assert_eq!(meta, None);
-                }
-            }
-=======
             let actual_tx_results: Vec<_> = confirmed_block
                 .transactions
                 .into_iter()
-                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                .map(|TransactionWithMetadata { transaction, meta }| {
                     (transaction.signatures[0], meta.status)
                 })
                 .collect();
@@ -3926,7 +3903,6 @@ pub mod tests {
             ];
             assert_eq!(actual_tx_results, expected_tx_results);
             assert!(test_signatures_iter.next().is_none());
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
         Blockstore::destroy(&ledger_path).unwrap();
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3874,15 +3874,17 @@ pub mod tests {
             let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
             let slot = bank1.slot();
 
-            let signatures = create_test_transactions_and_populate_blockstore(
+            let mut test_signatures_iter = create_test_transactions_and_populate_blockstore(
                 vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
                 bank0.slot(),
                 bank1,
                 blockstore.clone(),
                 Arc::new(AtomicU64::default()),
-            );
+            )
+            .into_iter();
 
             let confirmed_block = blockstore.get_rooted_block(slot, false).unwrap();
+<<<<<<< HEAD
             assert_eq!(confirmed_block.transactions.len(), 3);
 
             for TransactionWithStatusMeta { transaction, meta } in
@@ -3904,6 +3906,27 @@ pub mod tests {
                     assert_eq!(meta, None);
                 }
             }
+=======
+            let actual_tx_results: Vec<_> = confirmed_block
+                .transactions
+                .into_iter()
+                .map(|VersionedTransactionWithStatusMeta { transaction, meta }| {
+                    (transaction.signatures[0], meta.status)
+                })
+                .collect();
+            let expected_tx_results = vec![
+                (test_signatures_iter.next().unwrap(), Ok(())),
+                (
+                    test_signatures_iter.next().unwrap(),
+                    Err(TransactionError::InstructionError(
+                        0,
+                        InstructionError::Custom(1),
+                    )),
+                ),
+            ];
+            assert_eq!(actual_tx_results, expected_tx_results);
+            assert!(test_signatures_iter.next().is_none());
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
         Blockstore::destroy(&ledger_path).unwrap();
     }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -16,7 +16,11 @@ use {
     },
     solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType},
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
+<<<<<<< HEAD
     solana_transaction_status::{ConfirmedBlock, EncodedTransaction, UiTransactionEncoding},
+=======
+    solana_transaction_status::{Encodable, LegacyConfirmedBlock, UiTransactionEncoding},
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     std::{
         collections::HashSet,
         path::Path,
@@ -30,7 +34,6 @@ async fn upload(
     blockstore: Blockstore,
     starting_slot: Slot,
     ending_slot: Option<Slot>,
-    allow_missing_metadata: bool,
     force_reupload: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None, None)
@@ -42,7 +45,6 @@ async fn upload(
         bigtable,
         starting_slot,
         ending_slot,
-        allow_missing_metadata,
         force_reupload,
         Arc::new(AtomicBool::new(false)),
     )
@@ -73,10 +75,17 @@ async fn block(slot: Slot, output_format: OutputFormat) -> Result<(), Box<dyn st
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
+<<<<<<< HEAD
     let block = bigtable.get_confirmed_block(slot).await?;
+=======
+    let confirmed_block = bigtable.get_confirmed_block(slot).await?;
+    let legacy_block = confirmed_block
+        .into_legacy_block()
+        .ok_or_else(|| "Failed to read versioned transaction in block".to_string())?;
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 
     let cli_block = CliBlock {
-        encoded_confirmed_block: block.encode(UiTransactionEncoding::Base64),
+        encoded_confirmed_block: legacy_block.encode(UiTransactionEncoding::Base64),
         slot,
     };
     println!("{}", output_format.formatted_string(&cli_block));
@@ -153,6 +162,7 @@ async fn confirm(
     let mut get_transaction_error = None;
     if verbose {
         match bigtable.get_confirmed_transaction(signature).await {
+<<<<<<< HEAD
             Ok(Some(confirmed_transaction)) => {
                 transaction = Some(CliTransaction {
                     transaction: EncodedTransaction::encode(
@@ -163,6 +173,22 @@ async fn confirm(
                     block_time: confirmed_transaction.block_time,
                     slot: Some(confirmed_transaction.slot),
                     decoded_transaction: confirmed_transaction.transaction.transaction,
+=======
+            Ok(Some(confirmed_tx)) => {
+                let legacy_confirmed_tx = confirmed_tx
+                    .into_legacy_confirmed_transaction()
+                    .ok_or_else(|| "Failed to read versioned transaction in block".to_string())?;
+
+                transaction = Some(CliTransaction {
+                    transaction: legacy_confirmed_tx
+                        .tx_with_meta
+                        .transaction
+                        .encode(UiTransactionEncoding::Json),
+                    meta: legacy_confirmed_tx.tx_with_meta.meta.map(|m| m.into()),
+                    block_time: legacy_confirmed_tx.block_time,
+                    slot: Some(legacy_confirmed_tx.slot),
+                    decoded_transaction: legacy_confirmed_tx.tx_with_meta.transaction,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     prefix: "  ".to_string(),
                     sigverify_status: vec![],
                 });
@@ -194,7 +220,7 @@ pub async fn transaction_history(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new(true, None, None).await?;
 
-    let mut loaded_block: Option<(Slot, ConfirmedBlock)> = None;
+    let mut loaded_block: Option<(Slot, LegacyConfirmedBlock)> = None;
     while limit > 0 {
         let results = bigtable
             .get_confirmed_signatures_for_address(
@@ -260,7 +286,14 @@ pub async fn transaction_history(
                             println!("  Unable to get confirmed transaction details: {}", err);
                             break;
                         }
+<<<<<<< HEAD
                         Ok(block) => {
+=======
+                        Ok(confirmed_block) => {
+                            let block = confirmed_block.into_legacy_block().ok_or_else(|| {
+                                "Failed to read versioned transaction in block".to_string()
+                            })?;
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                             loaded_block = Some((result.slot, block));
                         }
                     }
@@ -305,12 +338,6 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .index(2)
                                 .help("Stop uploading at this slot [default: last available slot]"),
-                        )
-                        .arg(
-                            Arg::with_name("allow_missing_metadata")
-                                .long("allow-missing-metadata")
-                                .takes_value(false)
-                                .help("Don't panic if transaction metadata is missing"),
                         )
                         .arg(
                             Arg::with_name("force_reupload")
@@ -506,7 +533,6 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
         ("upload", Some(arg_matches)) => {
             let starting_slot = value_t!(arg_matches, "starting_slot", Slot).unwrap_or(0);
             let ending_slot = value_t!(arg_matches, "ending_slot", Slot).ok();
-            let allow_missing_metadata = arg_matches.is_present("allow_missing_metadata");
             let force_reupload = arg_matches.is_present("force_reupload");
             let blockstore = crate::open_blockstore(
                 &canonicalize_ledger_path(ledger_path),
@@ -518,7 +544,6 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 blockstore,
                 starting_slot,
                 ending_slot,
-                allow_missing_metadata,
                 force_reupload,
             ))
         }

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -25,7 +25,6 @@ pub async fn upload_confirmed_blocks(
     bigtable: solana_storage_bigtable::LedgerStorage,
     starting_slot: Slot,
     ending_slot: Option<Slot>,
-    allow_missing_metadata: bool,
     force_reupload: bool,
     exit: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -186,20 +185,7 @@ pub async fn upload_confirmed_blocks(
                 num_blocks -= 1;
                 None
             }
-            Some(confirmed_block) => {
-                if confirmed_block
-                    .transactions
-                    .iter()
-                    .any(|transaction| transaction.meta.is_none())
-                {
-                    if allow_missing_metadata {
-                        info!("Transaction metadata missing from slot {}", slot);
-                    } else {
-                        panic!("Transaction metadata missing from slot {}", slot);
-                    }
-                }
-                Some(bigtable.upload_confirmed_block(slot, confirmed_block))
-            }
+            Some(confirmed_block) => Some(bigtable.upload_confirmed_block(slot, confirmed_block)),
         });
 
         for result in futures::future::join_all(uploads).await {

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -72,7 +72,6 @@ impl BigTableUploadService {
                 bigtable_ledger_storage.clone(),
                 start_slot,
                 Some(end_slot),
-                true,
                 false,
                 exit.clone(),
             ));

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -41,8 +41,14 @@ use {
     },
     solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
     solana_transaction_status::{
+<<<<<<< HEAD
         ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Rewards,
         TransactionStatusMeta, TransactionWithStatusMeta,
+=======
+        ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta, Rewards,
+        TransactionStatusMeta, TransactionWithStatusMeta, VersionedConfirmedBlock,
+        VersionedTransactionWithStatusMeta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     },
     std::{
         borrow::Cow,
@@ -1947,6 +1953,7 @@ impl Blockstore {
         iterator: impl Iterator<Item = VersionedTransaction>,
     ) -> Result<Vec<TransactionWithStatusMeta>> {
         iterator
+<<<<<<< HEAD
             .map(|versioned_tx| {
                 // TODO: add support for versioned transactions
                 if let Some(transaction) = versioned_tx.into_legacy_transaction() {
@@ -1961,6 +1968,16 @@ impl Blockstore {
                 } else {
                     Err(BlockstoreError::UnsupportedTransactionVersion)
                 }
+=======
+            .map(|transaction| {
+                let signature = transaction.signatures[0];
+                Ok(VersionedTransactionWithStatusMeta {
+                    transaction,
+                    meta: self
+                        .read_transaction_status((signature, slot))?
+                        .ok_or(BlockstoreError::MissingTransactionMetadata)?,
+                })
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             })
             .collect()
     }
@@ -2212,7 +2229,11 @@ impl Blockstore {
     pub fn get_rooted_transaction(
         &self,
         signature: Signature,
+<<<<<<< HEAD
     ) -> Result<Option<ConfirmedTransaction>> {
+=======
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_rooted_transaction".to_string(), String)
@@ -2225,7 +2246,11 @@ impl Blockstore {
         &self,
         signature: Signature,
         highest_confirmed_slot: Slot,
+<<<<<<< HEAD
     ) -> Result<Option<ConfirmedTransaction>> {
+=======
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_complete_transaction".to_string(), String)
@@ -2242,8 +2267,13 @@ impl Blockstore {
         &self,
         signature: Signature,
         confirmed_unrooted_slots: &[Slot],
+<<<<<<< HEAD
     ) -> Result<Option<ConfirmedTransaction>> {
         if let Some((slot, status)) =
+=======
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+        if let Some((slot, meta)) =
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             self.get_transaction_status(signature, confirmed_unrooted_slots)?
         {
             let transaction = self
@@ -2256,12 +2286,20 @@ impl Blockstore {
                 .ok_or(BlockstoreError::UnsupportedTransactionVersion)?;
 
             let block_time = self.get_block_time(slot)?;
+<<<<<<< HEAD
             Ok(Some(ConfirmedTransaction {
                 slot,
                 transaction: TransactionWithStatusMeta {
                     transaction,
                     meta: Some(status),
                 },
+=======
+            Ok(Some(ConfirmedTransactionWithStatusMeta {
+                slot,
+                tx_with_meta: TransactionWithStatusMeta::Complete(
+                    VersionedTransactionWithStatusMeta { transaction, meta },
+                ),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 block_time,
             }))
         } else {
@@ -6120,7 +6158,7 @@ pub mod tests {
                     .unwrap();
                 TransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -6130,21 +6168,27 @@ pub mod tests {
                         pre_token_balances: Some(vec![]),
                         post_token_balances: Some(vec![]),
                         rewards: Some(vec![]),
+<<<<<<< HEAD
                     }),
+=======
+                        loaded_addresses: LoadedAddresses::default(),
+                    },
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 }
             })
             .collect();
 
         // Even if marked as root, a slot that is empty of entries should return an error
-        let confirmed_block_err = blockstore.get_rooted_block(slot - 1, true).unwrap_err();
-        assert_matches!(confirmed_block_err, BlockstoreError::SlotUnavailable);
+        assert_matches!(
+            blockstore.get_rooted_block(slot - 1, true),
+            Err(BlockstoreError::SlotUnavailable)
+        );
 
         // The previous_blockhash of `expected_block` is default because its parent slot is a root,
         // but empty of entries (eg. snapshot root slots). This now returns an error.
-        let confirmed_block_err = blockstore.get_rooted_block(slot, true).unwrap_err();
         assert_matches!(
-            confirmed_block_err,
-            BlockstoreError::ParentEntriesUnavailable
+            blockstore.get_rooted_block(slot, true),
+            Err(BlockstoreError::ParentEntriesUnavailable)
         );
 
         // Test if require_previous_blockhash is false
@@ -6951,7 +6995,7 @@ pub mod tests {
                     .unwrap();
                 TransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -6961,7 +7005,12 @@ pub mod tests {
                         pre_token_balances,
                         post_token_balances,
                         rewards,
+<<<<<<< HEAD
                     }),
+=======
+                        loaded_addresses: LoadedAddresses::default(),
+                    },
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 }
             })
             .collect();
@@ -6970,9 +7019,15 @@ pub mod tests {
             let signature = transaction.transaction.signatures[0];
             assert_eq!(
                 blockstore.get_rooted_transaction(signature).unwrap(),
+<<<<<<< HEAD
                 Some(ConfirmedTransaction {
                     slot,
                     transaction: transaction.clone(),
+=======
+                Some(ConfirmedTransactionWithStatusMeta {
+                    slot,
+                    tx_with_meta: TransactionWithStatusMeta::Complete(tx_with_meta.clone()),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     block_time: None
                 })
             );
@@ -6980,9 +7035,15 @@ pub mod tests {
                 blockstore
                     .get_complete_transaction(signature, slot + 1)
                     .unwrap(),
+<<<<<<< HEAD
                 Some(ConfirmedTransaction {
                     slot,
                     transaction,
+=======
+                Some(ConfirmedTransactionWithStatusMeta {
+                    slot,
+                    tx_with_meta: TransactionWithStatusMeta::Complete(tx_with_meta),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     block_time: None
                 })
             );
@@ -7055,7 +7116,7 @@ pub mod tests {
                     .unwrap();
                 TransactionWithStatusMeta {
                     transaction,
-                    meta: Some(TransactionStatusMeta {
+                    meta: TransactionStatusMeta {
                         status: Ok(()),
                         fee: 42,
                         pre_balances,
@@ -7065,7 +7126,12 @@ pub mod tests {
                         pre_token_balances,
                         post_token_balances,
                         rewards,
+<<<<<<< HEAD
                     }),
+=======
+                        loaded_addresses: LoadedAddresses::default(),
+                    },
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 }
             })
             .collect();
@@ -7076,9 +7142,15 @@ pub mod tests {
                 blockstore
                     .get_complete_transaction(signature, slot)
                     .unwrap(),
+<<<<<<< HEAD
                 Some(ConfirmedTransaction {
                     slot,
                     transaction,
+=======
+                Some(ConfirmedTransactionWithStatusMeta {
+                    slot,
+                    tx_with_meta: TransactionWithStatusMeta::Complete(tx_with_meta),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     block_time: None
                 })
             );
@@ -7841,6 +7913,16 @@ pub mod tests {
                 .unwrap();
             transactions.push(transaction.into());
         }
+
+        let map_result =
+            blockstore.map_transactions_to_statuses(slot, transactions.clone().into_iter());
+        assert!(map_result.is_ok());
+        let map = map_result.unwrap();
+        assert_eq!(map.len(), 4);
+        for (x, m) in map.iter().enumerate() {
+            assert_eq!(m.meta.fee, x as u64);
+        }
+
         // Push transaction that will not have matching status, as a test case
         transactions.push(
             Transaction::new_with_compiled_instructions(
@@ -7853,14 +7935,9 @@ pub mod tests {
             .into(),
         );
 
-        let map_result = blockstore.map_transactions_to_statuses(slot, transactions.into_iter());
-        assert!(map_result.is_ok());
-        let map = map_result.unwrap();
-        assert_eq!(map.len(), 5);
-        for (x, m) in map.iter().take(4).enumerate() {
-            assert_eq!(m.meta.as_ref().unwrap().fee, x as u64);
-        }
-        assert_eq!(map[4].meta, None);
+        let map_result =
+            blockstore.map_transactions_to_statuses(slot, transactions.clone().into_iter());
+        assert_matches!(map_result, Err(BlockstoreError::MissingTransactionMetadata));
     }
 
     #[test]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -102,6 +102,7 @@ pub enum BlockstoreError {
     ParentEntriesUnavailable,
     SlotUnavailable,
     UnsupportedTransactionVersion,
+    MissingTransactionMetadata,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/local-cluster/tests/local_cluster_slow.rs
+++ b/local-cluster/tests/local_cluster_slow.rs
@@ -877,46 +877,27 @@ fn find_latest_replayed_slot_from_ledger(
             latest_slot = new_latest_slot;
             info!("Checking latest_slot {}", latest_slot);
             // Wait for the slot to be fully received by the validator
-            let entries;
             loop {
                 info!("Waiting for slot {} to be full", latest_slot);
                 if blockstore.is_full(latest_slot) {
-                    entries = blockstore.get_slot_entries(latest_slot, 0).unwrap();
-                    assert!(!entries.is_empty());
                     break;
                 } else {
                     sleep(Duration::from_millis(50));
                     blockstore = open_blockstore(ledger_path);
                 }
             }
-            // Check the slot has been replayed
-            let non_tick_entry = entries.into_iter().find(|e| !e.transactions.is_empty());
-            if let Some(non_tick_entry) = non_tick_entry {
-                // Wait for the slot to be replayed
-                loop {
-                    info!("Waiting for slot {} to be replayed", latest_slot);
-                    if !blockstore
-                        .map_transactions_to_statuses(
-                            latest_slot,
-                            non_tick_entry.transactions.clone().into_iter(),
-                        )
-                        .unwrap()
-                        .is_empty()
-                    {
-                        return (
-                            latest_slot,
-                            AncestorIterator::new(latest_slot, &blockstore).collect(),
-                        );
-                    } else {
-                        sleep(Duration::from_millis(50));
-                        blockstore = open_blockstore(ledger_path);
-                    }
+            // Wait for the slot to be replayed
+            loop {
+                info!("Waiting for slot {} to be replayed", latest_slot);
+                if blockstore.get_bank_hash(latest_slot).is_some() {
+                    return (
+                        latest_slot,
+                        AncestorIterator::new(latest_slot, &blockstore).collect(),
+                    );
+                } else {
+                    sleep(Duration::from_millis(50));
+                    blockstore = open_blockstore(ledger_path);
                 }
-            } else {
-                info!(
-                    "No transactions in slot {}, can't tell if it was replayed",
-                    latest_slot
-                );
             }
         }
         sleep(Duration::from_millis(50));

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -57,16 +57,12 @@ use solana_sdk::{
     system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
     system_program, sysvar,
     sysvar::{clock, rent},
-    transaction::{SanitizedTransaction, Transaction, TransactionError, VersionedTransaction},
+    transaction::{SanitizedTransaction, Transaction, TransactionError},
 };
 use solana_transaction_status::{
-<<<<<<< HEAD
     token_balances::collect_token_balances, ConfirmedTransaction, InnerInstructions,
-    TransactionStatusMeta, TransactionWithStatusMeta,
-=======
-    token_balances::collect_token_balances, ConfirmedTransactionWithStatusMeta, InnerInstructions,
-    TransactionStatusMeta, TransactionWithStatusMeta, VersionedTransactionWithStatusMeta,
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+    TransactionStatusMeta,
+    TransactionWithMetadata,
 };
 use std::{collections::HashMap, env, fs::File, io::Read, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -425,12 +421,10 @@ fn execute_transactions(
 
                     Ok(ConfirmedTransaction {
                         slot: bank.slot(),
-                        tx_with_meta: TransactionWithStatusMeta::Complete(
-                            VersionedTransactionWithStatusMeta {
-                                transaction: VersionedTransaction::from(tx.clone()),
-                                meta: tx_status_meta,
-                            },
-                        ),
+                        transaction: TransactionWithMetadata {
+                            transaction: tx.clone(),
+                            meta: tx_status_meta,
+                        },
                         block_time: None,
                     })
                 }
@@ -2472,17 +2466,11 @@ fn test_program_upgradeable_locks() {
 
     assert!(matches!(
         results1[0],
-<<<<<<< HEAD
         Ok(ConfirmedTransaction {
-            transaction: TransactionWithStatusMeta {
-                meta: Some(TransactionStatusMeta { status: Ok(()), .. }),
-=======
-        Ok(ConfirmedTransactionWithStatusMeta {
-            tx_with_meta: TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+            transaction: TransactionWithMetadata {
                 meta: TransactionStatusMeta { status: Ok(()), .. },
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 ..
-            }),
+            },
             ..
         })
     ));
@@ -2490,15 +2478,9 @@ fn test_program_upgradeable_locks() {
 
     assert!(matches!(
         results2[0],
-<<<<<<< HEAD
         Ok(ConfirmedTransaction {
-            transaction: TransactionWithStatusMeta {
-                meta: Some(TransactionStatusMeta {
-=======
-        Ok(ConfirmedTransactionWithStatusMeta {
-            tx_with_meta: TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+            transaction: TransactionWithMetadata {
                 meta: TransactionStatusMeta {
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     status: Err(TransactionError::InstructionError(
                         0,
                         InstructionError::ProgramFailedToComplete
@@ -2506,7 +2488,7 @@ fn test_program_upgradeable_locks() {
                     ..
                 },
                 ..
-            }),
+            },
             ..
         })
     ));

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -57,11 +57,16 @@ use solana_sdk::{
     system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
     system_program, sysvar,
     sysvar::{clock, rent},
-    transaction::{SanitizedTransaction, Transaction, TransactionError},
+    transaction::{SanitizedTransaction, Transaction, TransactionError, VersionedTransaction},
 };
 use solana_transaction_status::{
+<<<<<<< HEAD
     token_balances::collect_token_balances, ConfirmedTransaction, InnerInstructions,
     TransactionStatusMeta, TransactionWithStatusMeta,
+=======
+    token_balances::collect_token_balances, ConfirmedTransactionWithStatusMeta, InnerInstructions,
+    TransactionStatusMeta, TransactionWithStatusMeta, VersionedTransactionWithStatusMeta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 };
 use std::{collections::HashMap, env, fs::File, io::Read, path::PathBuf, str::FromStr, sync::Arc};
 
@@ -420,10 +425,12 @@ fn execute_transactions(
 
                     Ok(ConfirmedTransaction {
                         slot: bank.slot(),
-                        transaction: TransactionWithStatusMeta {
-                            transaction: tx.clone(),
-                            meta: Some(tx_status_meta),
-                        },
+                        tx_with_meta: TransactionWithStatusMeta::Complete(
+                            VersionedTransactionWithStatusMeta {
+                                transaction: VersionedTransaction::from(tx.clone()),
+                                meta: tx_status_meta,
+                            },
+                        ),
                         block_time: None,
                     })
                 }
@@ -2465,11 +2472,17 @@ fn test_program_upgradeable_locks() {
 
     assert!(matches!(
         results1[0],
+<<<<<<< HEAD
         Ok(ConfirmedTransaction {
             transaction: TransactionWithStatusMeta {
                 meta: Some(TransactionStatusMeta { status: Ok(()), .. }),
+=======
+        Ok(ConfirmedTransactionWithStatusMeta {
+            tx_with_meta: TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+                meta: TransactionStatusMeta { status: Ok(()), .. },
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 ..
-            },
+            }),
             ..
         })
     ));
@@ -2477,17 +2490,23 @@ fn test_program_upgradeable_locks() {
 
     assert!(matches!(
         results2[0],
+<<<<<<< HEAD
         Ok(ConfirmedTransaction {
             transaction: TransactionWithStatusMeta {
                 meta: Some(TransactionStatusMeta {
+=======
+        Ok(ConfirmedTransactionWithStatusMeta {
+            tx_with_meta: TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+                meta: TransactionStatusMeta {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     status: Err(TransactionError::InstructionError(
                         0,
                         InstructionError::ProgramFailedToComplete
                     )),
                     ..
-                }),
+                },
                 ..
-            },
+            }),
             ..
         })
     ));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -76,7 +76,12 @@ use {
     solana_storage_bigtable::Error as StorageError,
     solana_streamer::socket::SocketAddrSpace,
     solana_transaction_status::{
+<<<<<<< HEAD
         ConfirmedBlock, ConfirmedTransactionStatusWithSignature, EncodedConfirmedTransaction,
+=======
+        ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
+        ConfirmedTransactionWithStatusMeta, Encodable, EncodedConfirmedTransactionWithStatusMeta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         Reward, RewardType, TransactionConfirmationStatus, TransactionStatus, UiConfirmedBlock,
         UiTransactionEncoding,
     },
@@ -914,12 +919,8 @@ impl JsonRpcRequestProcessor {
         &self,
         result: &std::result::Result<T, BlockstoreError>,
         slot: Slot,
-    ) -> Result<()>
-    where
-        T: std::fmt::Debug,
-    {
-        if result.is_err() {
-            let err = result.as_ref().unwrap_err();
+    ) -> Result<()> {
+        if let Err(err) = result {
             debug!(
                 "check_blockstore_root, slot: {:?}, max root: {:?}, err: {:?}",
                 slot,
@@ -940,21 +941,16 @@ impl JsonRpcRequestProcessor {
         &self,
         result: &std::result::Result<T, BlockstoreError>,
         slot: Slot,
-    ) -> Result<()>
-    where
-        T: std::fmt::Debug,
-    {
-        if result.is_err() {
-            if let BlockstoreError::SlotCleanedUp = result.as_ref().unwrap_err() {
-                return Err(RpcCustomError::BlockCleanedUp {
-                    slot,
-                    first_available_block: self
-                        .blockstore
-                        .get_first_available_block()
-                        .unwrap_or_default(),
-                }
-                .into());
+    ) -> Result<()> {
+        if let Err(BlockstoreError::SlotCleanedUp) = result {
+            return Err(RpcCustomError::BlockCleanedUp {
+                slot,
+                first_available_block: self
+                    .blockstore
+                    .get_first_available_block()
+                    .unwrap_or_default(),
             }
+            .into());
         }
         Ok(())
     }
@@ -962,15 +958,9 @@ impl JsonRpcRequestProcessor {
     fn check_bigtable_result<T>(
         &self,
         result: &std::result::Result<T, solana_storage_bigtable::Error>,
-    ) -> Result<()>
-    where
-        T: std::fmt::Debug,
-    {
-        if result.is_err() {
-            let err = result.as_ref().unwrap_err();
-            if let solana_storage_bigtable::Error::BlockNotFound(slot) = err {
-                return Err(RpcCustomError::LongTermStorageSlotSkipped { slot: *slot }.into());
-            }
+    ) -> Result<()> {
+        if let Err(solana_storage_bigtable::Error::BlockNotFound(slot)) = result {
+            return Err(RpcCustomError::LongTermStorageSlotSkipped { slot: *slot }.into());
         }
         Ok(())
     }
@@ -1014,8 +1004,14 @@ impl JsonRpcRequestProcessor {
                 let result = self.blockstore.get_rooted_block(slot, true);
                 self.check_blockstore_root(&result, slot)?;
                 let configure_block = |confirmed_block: ConfirmedBlock| {
+<<<<<<< HEAD
+=======
+                    let legacy_block = confirmed_block
+                        .into_legacy_block()
+                        .ok_or(RpcCustomError::UnsupportedTransactionVersion)?;
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     let mut confirmed_block =
-                        confirmed_block.configure(encoding, transaction_details, show_rewards);
+                        legacy_block.configure(encoding, transaction_details, show_rewards);
                     if slot == 0 {
                         confirmed_block.block_time = Some(self.genesis_creation_time());
                         confirmed_block.block_height = Some(0);
@@ -1031,13 +1027,22 @@ impl JsonRpcRequestProcessor {
                     }
                 }
                 self.check_slot_cleaned_up(&result, slot)?;
+<<<<<<< HEAD
                 return Ok(result.ok().map(configure_block));
+=======
+                return result
+                    .ok()
+                    .map(ConfirmedBlock::from)
+                    .map(configure_block)
+                    .transpose();
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             } else if commitment.is_confirmed() {
                 // Check if block is confirmed
                 let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
                 if confirmed_bank.status_cache_ancestors().contains(&slot) {
                     self.check_status_is_complete(slot)?;
                     let result = self.blockstore.get_complete_block(slot, true);
+<<<<<<< HEAD
                     return Ok(result.ok().map(|mut confirmed_block| {
                         if confirmed_block.block_time.is_none()
                             || confirmed_block.block_height.is_none()
@@ -1055,6 +1060,34 @@ impl JsonRpcRequestProcessor {
                         }
                         confirmed_block.configure(encoding, transaction_details, show_rewards)
                     }));
+=======
+                    return result
+                        .ok()
+                        .map(ConfirmedBlock::from)
+                        .map(|confirmed_block| -> Result<UiConfirmedBlock> {
+                            let mut legacy_block = confirmed_block
+                                .into_legacy_block()
+                                .ok_or(RpcCustomError::UnsupportedTransactionVersion)?;
+
+                            if legacy_block.block_time.is_none()
+                                || legacy_block.block_height.is_none()
+                            {
+                                let r_bank_forks = self.bank_forks.read().unwrap();
+                                let bank = r_bank_forks.get(slot).cloned();
+                                if let Some(bank) = bank {
+                                    if legacy_block.block_time.is_none() {
+                                        legacy_block.block_time = Some(bank.clock().unix_timestamp);
+                                    }
+                                    if legacy_block.block_height.is_none() {
+                                        legacy_block.block_height = Some(bank.block_height());
+                                    }
+                                }
+                            }
+
+                            Ok(legacy_block.configure(encoding, transaction_details, show_rewards))
+                        })
+                        .transpose();
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 }
             }
         } else {
@@ -1379,14 +1412,31 @@ impl JsonRpcRequestProcessor {
 
         if self.config.enable_rpc_transaction_history {
             let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
+<<<<<<< HEAD
             let transaction = if commitment.is_confirmed() {
+=======
+            let confirmed_transaction = if commitment.is_confirmed() {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 let highest_confirmed_slot = confirmed_bank.slot();
                 self.blockstore
                     .get_complete_transaction(signature, highest_confirmed_slot)
             } else {
                 self.blockstore.get_rooted_transaction(signature)
             };
+<<<<<<< HEAD
             match transaction.unwrap_or(None) {
+=======
+
+            let encode_transaction =
+                |confirmed_tx_with_meta: ConfirmedTransactionWithStatusMeta| -> Result<EncodedConfirmedTransactionWithStatusMeta> {
+                    let legacy_tx_with_meta = confirmed_tx_with_meta.into_legacy_confirmed_transaction()
+                        .ok_or(RpcCustomError::UnsupportedTransactionVersion)?;
+
+                    Ok(legacy_tx_with_meta.encode(encoding))
+                };
+
+            match confirmed_transaction.unwrap_or(None) {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 Some(mut confirmed_transaction) => {
                     if commitment.is_confirmed()
                         && confirmed_bank // should be redundant
@@ -1399,8 +1449,9 @@ impl JsonRpcRequestProcessor {
                                 .get(confirmed_transaction.slot)
                                 .map(|bank| bank.clock().unix_timestamp);
                         }
-                        return Ok(Some(confirmed_transaction.encode(encoding)));
+                        return Ok(Some(encode_transaction(confirmed_transaction)?));
                     }
+
                     if confirmed_transaction.slot
                         <= self
                             .block_commitment_cache
@@ -1408,7 +1459,7 @@ impl JsonRpcRequestProcessor {
                             .unwrap()
                             .highest_confirmed_root()
                     {
-                        return Ok(Some(confirmed_transaction.encode(encoding)));
+                        return Ok(Some(encode_transaction(confirmed_transaction)?));
                     }
                 }
                 None => {
@@ -1417,7 +1468,12 @@ impl JsonRpcRequestProcessor {
                             .get_confirmed_transaction(&signature)
                             .await
                             .unwrap_or(None)
+<<<<<<< HEAD
                             .map(|confirmed| confirmed.encode(encoding)));
+=======
+                            .map(encode_transaction)
+                            .transpose();
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                     }
                 }
             }
@@ -4315,15 +4371,7 @@ pub fn create_test_transactions_and_populate_blockstore(
     );
     let ix_error_signature = ix_error_tx.signatures[0];
     let entry_2 = solana_entry::entry::next_entry(&entry_1.hash, 1, vec![ix_error_tx]);
-    // Failed transaction
-    let fail_tx = solana_sdk::system_transaction::transfer(
-        mint_keypair,
-        &keypair2.pubkey(),
-        rent_exempt_amount,
-        Hash::default(),
-    );
-    let entry_3 = solana_entry::entry::next_entry(&entry_2.hash, 1, vec![fail_tx]);
-    let entries = vec![entry_1, entry_2, entry_3];
+    let entries = vec![entry_1, entry_2];
 
     let shreds = solana_ledger::blockstore::entries_to_test_shreds(
         entries.clone(),
@@ -4349,17 +4397,20 @@ pub fn create_test_transactions_and_populate_blockstore(
 
     // Check that process_entries successfully writes can_commit transactions statuses, and
     // that they are matched properly by get_rooted_block
-    let _result = solana_ledger::blockstore_processor::process_entries_for_tests(
-        &bank,
-        entries,
-        true,
-        Some(
-            &solana_ledger::blockstore_processor::TransactionStatusSender {
-                sender: transaction_status_sender,
-                enable_cpi_and_log_storage: false,
-            },
+    assert_eq!(
+        solana_ledger::blockstore_processor::process_entries_for_tests(
+            &bank,
+            entries,
+            true,
+            Some(
+                &solana_ledger::blockstore_processor::TransactionStatusSender {
+                    sender: transaction_status_sender,
+                    enable_cpi_and_log_storage: false,
+                },
+            ),
+            Some(&replay_vote_sender),
         ),
-        Some(&replay_vote_sender),
+        Ok(())
     );
 
     transaction_status_service.join().unwrap();
@@ -6605,7 +6656,7 @@ pub mod tests {
         let confirmed_block: Option<EncodedConfirmedBlock> =
             serde_json::from_value(result["result"].clone()).unwrap();
         let confirmed_block = confirmed_block.unwrap();
-        assert_eq!(confirmed_block.transactions.len(), 3);
+        assert_eq!(confirmed_block.transactions.len(), 2);
         assert_eq!(confirmed_block.rewards, vec![]);
 
         for EncodedTransactionWithStatusMeta { transaction, meta } in
@@ -6650,7 +6701,7 @@ pub mod tests {
         let confirmed_block: Option<EncodedConfirmedBlock> =
             serde_json::from_value(result["result"].clone()).unwrap();
         let confirmed_block = confirmed_block.unwrap();
-        assert_eq!(confirmed_block.transactions.len(), 3);
+        assert_eq!(confirmed_block.transactions.len(), 2);
         assert_eq!(confirmed_block.rewards, vec![]);
 
         for EncodedTransactionWithStatusMeta { transaction, meta } in

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -39,12 +39,8 @@ use {
         timing::timestamp,
         transaction,
     },
-<<<<<<< HEAD
-    solana_transaction_status::ConfirmedBlock,
+    solana_transaction_status::{ConfirmedBlock, ConfirmedBlockWithOptionalMetadata},
     solana_vote_program::vote_state::Vote,
-=======
-    solana_transaction_status::{ConfirmedBlock, LegacyConfirmedBlock},
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     std::{
         cell::RefCell,
         collections::{HashMap, VecDeque},
@@ -282,7 +278,7 @@ impl RpcNotifier {
 }
 
 fn filter_block_result_txs(
-    mut block: LegacyConfirmedBlock,
+    mut block: ConfirmedBlock,
     last_modified_slot: Slot,
     params: &BlockSubscriptionParams,
 ) -> Option<RpcBlockUpdate> {
@@ -301,7 +297,7 @@ fn filter_block_result_txs(
         }
     }
 
-    let block = block.configure(
+    let block = ConfirmedBlockWithOptionalMetadata::from(block).configure(
         params.encoding,
         params.transaction_details,
         params.show_rewards,
@@ -962,31 +958,10 @@ impl RpcSubscriptions {
                                 if s > max_complete_transaction_status_slot.load(Ordering::SeqCst) {
                                     break;
                                 }
-<<<<<<< HEAD
                                 match blockstore.get_complete_block(s, false) {
                                     Ok(block) => {
-                                        if let Some(res) = filter_block_result_txs(block, s, params)
-=======
-
-                                let block_update_result = blockstore
-                                    .get_complete_block(s, false)
-                                    .map_err(|e| {
-                                        error!("get_complete_block error: {}", e);
-                                        RpcBlockUpdateError::BlockStoreError
-                                    })
-                                    .and_then(|versioned_block| {
-                                        ConfirmedBlock::from(versioned_block)
-                                            .into_legacy_block()
-                                            .ok_or(
-                                                RpcBlockUpdateError::UnsupportedTransactionVersion,
-                                            )
-                                    });
-
-                                match block_update_result {
-                                    Ok(block_update) => {
                                         if let Some(block_update) =
-                                            filter_block_result_txs(block_update, s, params)
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+                                            filter_block_result_txs(block, s, params)
                                         {
                                             notifier.notify(
                                                 Response {
@@ -1431,15 +1406,12 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
-<<<<<<< HEAD
         let block = blockstore.get_complete_block(slot, false).unwrap();
-        let block = block.configure(params.encoding, params.transaction_details, false);
-=======
-        let confirmed_block =
-            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let legacy_block = confirmed_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+        let block = ConfirmedBlockWithOptionalMetadata::from(block).configure(
+            params.encoding,
+            params.transaction_details,
+            false,
+        );
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1543,23 +1515,18 @@ pub(crate) mod tests {
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
         // make sure it filtered out the other keypairs
-<<<<<<< HEAD
         let mut block = blockstore.get_complete_block(slot, false).unwrap();
         block.transactions.retain(|tx| {
             tx.transaction
-=======
-        let confirmed_block =
-            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let mut legacy_block = confirmed_block.into_legacy_block().unwrap();
-        legacy_block.transactions.retain(|tx_with_meta| {
-            tx_with_meta
-                .transaction
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 .message
                 .account_keys
                 .contains(&keypair1.pubkey())
         });
-        let block = block.configure(params.encoding, params.transaction_details, false);
+        let block = ConfirmedBlockWithOptionalMetadata::from(block).configure(
+            params.encoding,
+            params.transaction_details,
+            false,
+        );
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1655,15 +1622,12 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
-<<<<<<< HEAD
         let block = blockstore.get_complete_block(slot, false).unwrap();
-        let block = block.configure(params.encoding, params.transaction_details, false);
-=======
-        let confirmed_block =
-            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
-        let legacy_block = confirmed_block.into_legacy_block().unwrap();
-        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+        let block = ConfirmedBlockWithOptionalMetadata::from(block).configure(
+            params.encoding,
+            params.transaction_details,
+            false,
+        );
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -39,8 +39,12 @@ use {
         timing::timestamp,
         transaction,
     },
+<<<<<<< HEAD
     solana_transaction_status::ConfirmedBlock,
     solana_vote_program::vote_state::Vote,
+=======
+    solana_transaction_status::{ConfirmedBlock, LegacyConfirmedBlock},
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     std::{
         cell::RefCell,
         collections::{HashMap, VecDeque},
@@ -278,30 +282,26 @@ impl RpcNotifier {
 }
 
 fn filter_block_result_txs(
-    block: ConfirmedBlock,
+    mut block: LegacyConfirmedBlock,
     last_modified_slot: Slot,
     params: &BlockSubscriptionParams,
 ) -> Option<RpcBlockUpdate> {
-    let transactions = match params.kind {
+    block.transactions = match params.kind {
         BlockSubscriptionKind::All => block.transactions,
         BlockSubscriptionKind::MentionsAccountOrProgram(pk) => block
             .transactions
             .into_iter()
-            .filter(|tx| tx.transaction.message.account_keys.contains(&pk))
+            .filter(|tx_with_meta| tx_with_meta.transaction.message.account_keys.contains(&pk))
             .collect(),
     };
 
-    if transactions.is_empty() {
+    if block.transactions.is_empty() {
         if let BlockSubscriptionKind::MentionsAccountOrProgram(_) = params.kind {
             return None;
         }
     }
 
-    let block = ConfirmedBlock {
-        transactions,
-        ..block
-    }
-    .configure(
+    let block = block.configure(
         params.encoding,
         params.transaction_details,
         params.show_rewards,
@@ -962,14 +962,36 @@ impl RpcSubscriptions {
                                 if s > max_complete_transaction_status_slot.load(Ordering::SeqCst) {
                                     break;
                                 }
+<<<<<<< HEAD
                                 match blockstore.get_complete_block(s, false) {
                                     Ok(block) => {
                                         if let Some(res) = filter_block_result_txs(block, s, params)
+=======
+
+                                let block_update_result = blockstore
+                                    .get_complete_block(s, false)
+                                    .map_err(|e| {
+                                        error!("get_complete_block error: {}", e);
+                                        RpcBlockUpdateError::BlockStoreError
+                                    })
+                                    .and_then(|versioned_block| {
+                                        ConfirmedBlock::from(versioned_block)
+                                            .into_legacy_block()
+                                            .ok_or(
+                                                RpcBlockUpdateError::UnsupportedTransactionVersion,
+                                            )
+                                    });
+
+                                match block_update_result {
+                                    Ok(block_update) => {
+                                        if let Some(block_update) =
+                                            filter_block_result_txs(block_update, s, params)
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                                         {
                                             notifier.notify(
                                                 Response {
                                                     context: RpcResponseContext { slot: s },
-                                                    value: res,
+                                                    value: block_update,
                                                 },
                                                 subscription,
                                                 false,
@@ -1346,8 +1368,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_confirmed_block_subscribe() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1388,10 +1415,11 @@ pub(crate) mod tests {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1403,8 +1431,15 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
+<<<<<<< HEAD
         let block = blockstore.get_complete_block(slot, false).unwrap();
         let block = block.configure(params.encoding, params.transaction_details, false);
+=======
+        let confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        let legacy_block = confirmed_block.into_legacy_block().unwrap();
+        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),
@@ -1443,8 +1478,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_confirmed_block_subscribe_with_mentions() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1486,10 +1526,11 @@ pub(crate) mod tests {
         let bank = bank_forks.read().unwrap().working_bank();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1502,9 +1543,18 @@ pub(crate) mod tests {
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
         // make sure it filtered out the other keypairs
+<<<<<<< HEAD
         let mut block = blockstore.get_complete_block(slot, false).unwrap();
         block.transactions.retain(|tx| {
             tx.transaction
+=======
+        let confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        let mut legacy_block = confirmed_block.into_legacy_block().unwrap();
+        legacy_block.transactions.retain(|tx_with_meta| {
+            tx_with_meta
+                .transaction
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 .message
                 .account_keys
                 .contains(&keypair1.pubkey())
@@ -1538,8 +1588,13 @@ pub(crate) mod tests {
     #[serial]
     fn test_check_finalized_block_subscribe() {
         let exit = Arc::new(AtomicBool::new(false));
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
+        let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1579,10 +1634,11 @@ pub(crate) mod tests {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
-        let keypair4 = Keypair::new();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
+        bank.transfer(rent_exempt_amount, &mint_keypair, &keypair2.pubkey())
+            .unwrap();
         let _confirmed_block_signatures = create_test_transactions_and_populate_blockstore(
-            vec![&keypair1, &keypair2, &keypair3, &keypair4],
+            vec![&mint_keypair, &keypair1, &keypair2, &keypair3],
             0,
             bank,
             blockstore.clone(),
@@ -1599,8 +1655,15 @@ pub(crate) mod tests {
         let actual_resp = receiver.recv();
         let actual_resp = serde_json::from_str::<serde_json::Value>(&actual_resp).unwrap();
 
+<<<<<<< HEAD
         let block = blockstore.get_complete_block(slot, false).unwrap();
         let block = block.configure(params.encoding, params.transaction_details, false);
+=======
+        let confirmed_block =
+            ConfirmedBlock::from(blockstore.get_complete_block(slot, false).unwrap());
+        let legacy_block = confirmed_block.into_legacy_block().unwrap();
+        let block = legacy_block.configure(params.encoding, params.transaction_details, false);
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         let expected_resp = RpcBlockUpdate {
             slot,
             block: Some(block),

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -790,22 +790,55 @@ mod tests {
         super::*,
         crate::StoredConfirmedBlock,
         prost::Message,
+<<<<<<< HEAD
         solana_sdk::{hash::Hash, signature::Keypair, system_transaction},
         solana_storage_proto::convert::generated,
         solana_transaction_status::{
             ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
+=======
+        solana_sdk::{
+            hash::Hash, message::v0::LoadedAddresses, signature::Keypair, system_transaction,
+            transaction::VersionedTransaction,
+        },
+        solana_storage_proto::convert::generated,
+        solana_transaction_status::{
+            ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
+            VersionedTransactionWithStatusMeta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         },
         std::convert::TryInto,
     };
+
+    fn confirmed_block_into_protobuf(confirmed_block: ConfirmedBlock) -> generated::ConfirmedBlock {
+        let ConfirmedBlock {
+            previous_blockhash,
+            blockhash,
+            parent_slot,
+            transactions,
+            rewards,
+            block_time,
+            block_height,
+        } = confirmed_block;
+
+        generated::ConfirmedBlock {
+            previous_blockhash,
+            blockhash,
+            parent_slot,
+            transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
+            rewards: rewards.into_iter().map(|r| r.into()).collect(),
+            block_time: block_time.map(|timestamp| generated::UnixTimestamp { timestamp }),
+            block_height: block_height.map(|block_height| generated::BlockHeight { block_height }),
+        }
+    }
 
     #[test]
     fn test_deserialize_protobuf_or_bincode_cell_data() {
         let from = Keypair::new();
         let recipient = solana_sdk::pubkey::new_rand();
         let transaction = system_transaction::transfer(&from, &recipient, 42, Hash::default());
-        let with_meta = TransactionWithStatusMeta {
-            transaction,
-            meta: Some(TransactionStatusMeta {
+        let with_meta = TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+            transaction: VersionedTransaction::from(transaction),
+            meta: TransactionStatusMeta {
                 status: Ok(()),
                 fee: 1,
                 pre_balances: vec![43, 0, 1],
@@ -815,9 +848,16 @@ mod tests {
                 pre_token_balances: Some(vec![]),
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
+<<<<<<< HEAD
             }),
         };
         let block = ConfirmedBlock {
+=======
+                loaded_addresses: LoadedAddresses::default(),
+            },
+        });
+        let expected_block = ConfirmedBlock {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             transactions: vec![with_meta],
             parent_slot: 1,
             blockhash: Hash::default().to_string(),
@@ -827,11 +867,11 @@ mod tests {
             block_height: Some(1),
         };
         let bincode_block = compress_best(
-            &bincode::serialize::<StoredConfirmedBlock>(&block.clone().into()).unwrap(),
+            &bincode::serialize::<StoredConfirmedBlock>(&expected_block.clone().into()).unwrap(),
         )
         .unwrap();
 
-        let protobuf_block = generated::ConfirmedBlock::from(block.clone());
+        let protobuf_block = confirmed_block_into_protobuf(expected_block.clone());
         let mut buf = Vec::with_capacity(protobuf_block.encoded_len());
         protobuf_block.encode(&mut buf).unwrap();
         let protobuf_block = compress_best(&buf).unwrap();
@@ -861,8 +901,17 @@ mod tests {
         )
         .unwrap();
         if let CellData::Bincode(bincode_block) = deserialized {
+<<<<<<< HEAD
             let mut block = block;
             if let Some(meta) = &mut block.transactions[0].meta {
+=======
+            let mut block = expected_block;
+            if let TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+                meta,
+                ..
+            }) = &mut block.transactions[0]
+            {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 meta.inner_instructions = None; // Legacy bincode implementation does not support inner_instructions
                 meta.log_messages = None; // Legacy bincode implementation does not support log_messages
                 meta.pre_token_balances = None; // Legacy bincode implementation does not support token balances

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -790,21 +790,11 @@ mod tests {
         super::*,
         crate::StoredConfirmedBlock,
         prost::Message,
-<<<<<<< HEAD
         solana_sdk::{hash::Hash, signature::Keypair, system_transaction},
         solana_storage_proto::convert::generated,
         solana_transaction_status::{
-            ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
-=======
-        solana_sdk::{
-            hash::Hash, message::v0::LoadedAddresses, signature::Keypair, system_transaction,
-            transaction::VersionedTransaction,
-        },
-        solana_storage_proto::convert::generated,
-        solana_transaction_status::{
-            ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,
-            VersionedTransactionWithStatusMeta,
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+            ConfirmedBlock, ConfirmedBlockWithOptionalMetadata, TransactionStatusMeta,
+            TransactionWithMetadata,
         },
         std::convert::TryInto,
     };
@@ -824,7 +814,7 @@ mod tests {
             previous_blockhash,
             blockhash,
             parent_slot,
-            transactions: transactions.into_iter().map(|tx| tx.into()).collect(),
+            transactions: transactions.into_iter().map(Into::into).collect(),
             rewards: rewards.into_iter().map(|r| r.into()).collect(),
             block_time: block_time.map(|timestamp| generated::UnixTimestamp { timestamp }),
             block_height: block_height.map(|block_height| generated::BlockHeight { block_height }),
@@ -836,8 +826,8 @@ mod tests {
         let from = Keypair::new();
         let recipient = solana_sdk::pubkey::new_rand();
         let transaction = system_transaction::transfer(&from, &recipient, 42, Hash::default());
-        let with_meta = TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
-            transaction: VersionedTransaction::from(transaction),
+        let with_meta = TransactionWithMetadata {
+            transaction,
             meta: TransactionStatusMeta {
                 status: Ok(()),
                 fee: 1,
@@ -848,16 +838,9 @@ mod tests {
                 pre_token_balances: Some(vec![]),
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
-<<<<<<< HEAD
-            }),
-        };
-        let block = ConfirmedBlock {
-=======
-                loaded_addresses: LoadedAddresses::default(),
             },
-        });
+        };
         let expected_block = ConfirmedBlock {
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             transactions: vec![with_meta],
             parent_slot: 1,
             blockhash: Hash::default().to_string(),
@@ -867,7 +850,10 @@ mod tests {
             block_height: Some(1),
         };
         let bincode_block = compress_best(
-            &bincode::serialize::<StoredConfirmedBlock>(&expected_block.clone().into()).unwrap(),
+            &bincode::serialize::<StoredConfirmedBlock>(
+                &ConfirmedBlockWithOptionalMetadata::from(expected_block.clone()).into(),
+            )
+            .unwrap(),
         )
         .unwrap();
 
@@ -886,7 +872,10 @@ mod tests {
         )
         .unwrap();
         if let CellData::Protobuf(protobuf_block) = deserialized {
-            assert_eq!(block, protobuf_block.try_into().unwrap());
+            assert_eq!(
+                ConfirmedBlockWithOptionalMetadata::from(expected_block.clone()),
+                protobuf_block.try_into().unwrap(),
+            );
         } else {
             panic!("deserialization should produce CellData::Protobuf");
         }
@@ -901,24 +890,19 @@ mod tests {
         )
         .unwrap();
         if let CellData::Bincode(bincode_block) = deserialized {
-<<<<<<< HEAD
-            let mut block = block;
-            if let Some(meta) = &mut block.transactions[0].meta {
-=======
             let mut block = expected_block;
-            if let TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
-                meta,
-                ..
-            }) = &mut block.transactions[0]
             {
->>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
+                let mut meta = &mut block.transactions[0].meta;
                 meta.inner_instructions = None; // Legacy bincode implementation does not support inner_instructions
                 meta.log_messages = None; // Legacy bincode implementation does not support log_messages
                 meta.pre_token_balances = None; // Legacy bincode implementation does not support token balances
                 meta.post_token_balances = None; // Legacy bincode implementation does not support token balances
                 meta.rewards = None; // Legacy bincode implementation does not support rewards
             }
-            assert_eq!(block, bincode_block.into());
+            assert_eq!(
+                ConfirmedBlockWithOptionalMetadata::from(block),
+                ConfirmedBlockWithOptionalMetadata::from(bincode_block)
+            );
         } else {
             panic!("deserialization should produce CellData::Bincode");
         }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -13,10 +13,17 @@ use {
     },
     solana_storage_proto::convert::{generated, tx_by_addr},
     solana_transaction_status::{
+<<<<<<< HEAD
         extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransaction,
         ConfirmedTransactionStatusWithSignature, Reward, TransactionByAddrInfo,
         TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
         TransactionWithStatusMeta,
+=======
+        extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
+        ConfirmedTransactionWithStatusMeta, Reward, TransactionByAddrInfo,
+        TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
+        TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedTransactionWithStatusMeta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     },
     std::{
         collections::{HashMap, HashSet},
@@ -114,6 +121,7 @@ struct StoredConfirmedBlock {
     block_height: Option<u64>,
 }
 
+#[cfg(test)]
 impl From<ConfirmedBlock> for StoredConfirmedBlock {
     fn from(confirmed_block: ConfirmedBlock) -> Self {
         let ConfirmedBlock {
@@ -168,20 +176,51 @@ struct StoredConfirmedBlockTransaction {
     meta: Option<StoredConfirmedBlockTransactionStatusMeta>,
 }
 
+#[cfg(test)]
 impl From<TransactionWithStatusMeta> for StoredConfirmedBlockTransaction {
     fn from(value: TransactionWithStatusMeta) -> Self {
+<<<<<<< HEAD
         Self {
             transaction: value.transaction,
             meta: value.meta.map(|meta| meta.into()),
+=======
+        match value {
+            TransactionWithStatusMeta::MissingMetadata(transaction) => Self {
+                transaction: VersionedTransaction::from(transaction),
+                meta: None,
+            },
+            TransactionWithStatusMeta::Complete(VersionedTransactionWithStatusMeta {
+                transaction,
+                meta,
+            }) => Self {
+                transaction,
+                meta: Some(meta.into()),
+            },
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
     }
 }
 
 impl From<StoredConfirmedBlockTransaction> for TransactionWithStatusMeta {
+<<<<<<< HEAD
     fn from(value: StoredConfirmedBlockTransaction) -> Self {
         Self {
             transaction: value.transaction,
             meta: value.meta.map(|meta| meta.into()),
+=======
+    fn from(tx_with_meta: StoredConfirmedBlockTransaction) -> Self {
+        let StoredConfirmedBlockTransaction { transaction, meta } = tx_with_meta;
+        match meta {
+            None => Self::MissingMetadata(
+                transaction
+                    .into_legacy_transaction()
+                    .expect("versioned transactions always have meta"),
+            ),
+            Some(meta) => Self::Complete(VersionedTransactionWithStatusMeta {
+                transaction,
+                meta: meta.into(),
+            }),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
     }
 }
@@ -438,7 +477,11 @@ impl LedgerStorage {
     pub async fn get_confirmed_transaction(
         &self,
         signature: &Signature,
+<<<<<<< HEAD
     ) -> Result<Option<ConfirmedTransaction>> {
+=======
+    ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         debug!(
             "LedgerStorage::get_confirmed_transaction request received: {:?}",
             signature
@@ -463,17 +506,23 @@ impl LedgerStorage {
                 warn!("Transaction info for {} is corrupt", signature);
                 Ok(None)
             }
-            Some(bucket_block_transaction) => {
-                if bucket_block_transaction.transaction.signatures[0] != *signature {
+            Some(tx_with_meta) => {
+                if tx_with_meta.transaction_signature() != signature {
                     warn!(
                         "Transaction info or confirmed block for {} is corrupt",
                         signature
                     );
                     Ok(None)
                 } else {
+<<<<<<< HEAD
                     Ok(Some(ConfirmedTransaction {
                         slot,
                         transaction: bucket_block_transaction,
+=======
+                    Ok(Some(ConfirmedTransactionWithStatusMeta {
+                        slot,
+                        tx_with_meta,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                         block_time: block.block_time,
                     }))
                 }
@@ -635,8 +684,13 @@ impl LedgerStorage {
 
         let mut tx_cells = vec![];
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
+<<<<<<< HEAD
             let TransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
             let err = meta.as_ref().and_then(|meta| meta.status.clone().err());
+=======
+            let VersionedTransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
+            let err = meta.status.clone().err();
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             let index = index as u32;
             let signature = transaction.signatures[0];
             let memo = extract_and_fmt_memos(&transaction.message);
@@ -723,6 +777,7 @@ impl LedgerStorage {
         let mut expected_tx_infos: HashMap<String, UploadedTransaction> = HashMap::new();
         let confirmed_block = self.get_confirmed_block(slot).await?;
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
+<<<<<<< HEAD
             let TransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
             let signature = transaction.signatures[0];
             let index = index as u32;
@@ -731,13 +786,43 @@ impl LedgerStorage {
             for address in &transaction.message.account_keys {
                 if !is_sysvar_id(address) {
                     addresses.insert(address);
+=======
+            match transaction_with_meta {
+                TransactionWithStatusMeta::MissingMetadata(transaction) => {
+                    let signature = transaction.signatures[0];
+                    let index = index as u32;
+                    let err = None;
+
+                    for address in transaction.message.account_keys.iter() {
+                        if !is_sysvar_id(address) {
+                            addresses.insert(address);
+                        }
+                    }
+
+                    expected_tx_infos.insert(
+                        signature.to_string(),
+                        UploadedTransaction { slot, index, err },
+                    );
+                }
+                TransactionWithStatusMeta::Complete(tx_with_meta) => {
+                    let VersionedTransactionWithStatusMeta { transaction, meta } = tx_with_meta;
+                    let signature = transaction.signatures[0];
+                    let index = index as u32;
+                    let err = meta.status.clone().err();
+
+                    for address in tx_with_meta.account_keys().iter() {
+                        if !is_sysvar_id(address) {
+                            addresses.insert(address);
+                        }
+                    }
+
+                    expected_tx_infos.insert(
+                        signature.to_string(),
+                        UploadedTransaction { slot, index, err },
+                    );
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
                 }
             }
-
-            expected_tx_infos.insert(
-                signature.to_string(),
-                UploadedTransaction { slot, index, err },
-            );
         }
 
         let address_slot_rows: Vec<_> = addresses

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -111,9 +111,15 @@ impl From<generated::Reward> for Reward {
     }
 }
 
+<<<<<<< HEAD
 impl From<ConfirmedBlock> for generated::ConfirmedBlock {
     fn from(confirmed_block: ConfirmedBlock) -> Self {
         let ConfirmedBlock {
+=======
+impl From<VersionedConfirmedBlock> for generated::ConfirmedBlock {
+    fn from(confirmed_block: VersionedConfirmedBlock) -> Self {
+        let VersionedConfirmedBlock {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             previous_blockhash,
             blockhash,
             parent_slot,
@@ -166,22 +172,41 @@ impl TryFrom<generated::ConfirmedBlock> for ConfirmedBlock {
 }
 
 impl From<TransactionWithStatusMeta> for generated::ConfirmedTransaction {
-    fn from(value: TransactionWithStatusMeta) -> Self {
-        let meta = value.meta.map(|meta| meta.into());
-        Self {
-            transaction: Some(value.transaction.into()),
-            meta,
+    fn from(tx_with_meta: TransactionWithStatusMeta) -> Self {
+        match tx_with_meta {
+            TransactionWithStatusMeta::MissingMetadata(transaction) => Self {
+                transaction: Some(generated::Transaction::from(transaction)),
+                meta: None,
+            },
+            TransactionWithStatusMeta::Complete(tx_with_meta) => Self::from(tx_with_meta),
         }
     }
 }
 
+<<<<<<< HEAD
+=======
+impl From<VersionedTransactionWithStatusMeta> for generated::ConfirmedTransaction {
+    fn from(value: VersionedTransactionWithStatusMeta) -> Self {
+        Self {
+            transaction: Some(value.transaction.into()),
+            meta: Some(value.meta.into()),
+        }
+    }
+}
+
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 impl TryFrom<generated::ConfirmedTransaction> for TransactionWithStatusMeta {
     type Error = bincode::Error;
     fn try_from(value: generated::ConfirmedTransaction) -> std::result::Result<Self, Self::Error> {
         let meta = value.meta.map(|meta| meta.try_into()).transpose()?;
-        Ok(Self {
-            transaction: value.transaction.expect("transaction is required").into(),
-            meta,
+        let transaction = value.transaction.expect("transaction is required").into();
+        Ok(match meta {
+            Some(meta) => Self::Complete(VersionedTransactionWithStatusMeta { transaction, meta }),
+            None => Self::MissingMetadata(
+                transaction
+                    .into_legacy_transaction()
+                    .expect("meta is required for versioned transactions"),
+            ),
         })
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -355,8 +355,12 @@ pub struct Reward {
 
 pub type Rewards = Vec<Reward>;
 
+<<<<<<< HEAD
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+=======
+#[derive(Clone, Debug, PartialEq)]
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 pub struct ConfirmedBlock {
     pub previous_blockhash: String,
     pub blockhash: String,
@@ -367,9 +371,79 @@ pub struct ConfirmedBlock {
     pub block_height: Option<u64>,
 }
 
+<<<<<<< HEAD
 impl ConfirmedBlock {
     pub fn encode(self, encoding: UiTransactionEncoding) -> EncodedConfirmedBlock {
         EncodedConfirmedBlock {
+=======
+// Confirmed block with type guarantees that transaction metadata
+// is always present. Used for uploading to BigTable.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VersionedConfirmedBlock {
+    pub previous_blockhash: String,
+    pub blockhash: String,
+    pub parent_slot: Slot,
+    pub transactions: Vec<VersionedTransactionWithStatusMeta>,
+    pub rewards: Rewards,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+}
+
+// Confirmed block which only supports legacy transactions. Used
+// until migration to versioned transactions is completed.
+pub struct LegacyConfirmedBlock {
+    pub previous_blockhash: String,
+    pub blockhash: String,
+    pub parent_slot: Slot,
+    pub transactions: Vec<LegacyTransactionWithStatusMeta>,
+    pub rewards: Rewards,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+}
+
+impl ConfirmedBlock {
+    /// Downgrades a versioned block into a legacy block type
+    /// if it only contains legacy transactions
+    pub fn into_legacy_block(self) -> Option<LegacyConfirmedBlock> {
+        Some(LegacyConfirmedBlock {
+            previous_blockhash: self.previous_blockhash,
+            blockhash: self.blockhash,
+            parent_slot: self.parent_slot,
+            transactions: self
+                .transactions
+                .into_iter()
+                .map(|tx_with_meta| tx_with_meta.into_legacy_transaction_with_meta())
+                .collect::<Option<Vec<_>>>()?,
+            rewards: self.rewards,
+            block_time: self.block_time,
+            block_height: self.block_height,
+        })
+    }
+}
+
+impl From<VersionedConfirmedBlock> for ConfirmedBlock {
+    fn from(block: VersionedConfirmedBlock) -> Self {
+        Self {
+            previous_blockhash: block.previous_blockhash,
+            blockhash: block.blockhash,
+            parent_slot: block.parent_slot,
+            transactions: block
+                .transactions
+                .into_iter()
+                .map(TransactionWithStatusMeta::Complete)
+                .collect(),
+            rewards: block.rewards,
+            block_time: block.block_time,
+            block_height: block.block_height,
+        }
+    }
+}
+
+impl Encodable for LegacyConfirmedBlock {
+    type Encoded = EncodedConfirmedBlock;
+    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
+        Self::Encoded {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
             previous_blockhash: self.previous_blockhash,
             blockhash: self.blockhash,
             parent_slot: self.parent_slot,
@@ -384,6 +458,10 @@ impl ConfirmedBlock {
         }
     }
 
+<<<<<<< HEAD
+=======
+impl LegacyConfirmedBlock {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     pub fn configure(
         self,
         encoding: UiTransactionEncoding,
@@ -471,6 +549,7 @@ impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
     }
 }
 
+<<<<<<< HEAD
 impl From<UiConfirmedBlock> for EncodedConfirmedBlock {
     fn from(block: UiConfirmedBlock) -> Self {
         Self {
@@ -564,17 +643,89 @@ pub struct UiParsedMessage {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionWithStatusMeta {
+=======
+#[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
+pub enum TransactionWithStatusMeta {
+    // Very old transactions may be missing metadata
+    MissingMetadata(Transaction),
+    // Versioned stored transaction always have metadata
+    Complete(VersionedTransactionWithStatusMeta),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VersionedTransactionWithStatusMeta {
+    pub transaction: VersionedTransaction,
+    pub meta: TransactionStatusMeta,
+}
+
+pub struct LegacyTransactionWithStatusMeta {
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
     pub transaction: Transaction,
     pub meta: Option<TransactionStatusMeta>,
 }
 
 impl TransactionWithStatusMeta {
+<<<<<<< HEAD
     fn encode(self, encoding: UiTransactionEncoding) -> EncodedTransactionWithStatusMeta {
         let message = self.transaction.message();
         let meta = self.meta.map(|meta| meta.encode(encoding, message));
         EncodedTransactionWithStatusMeta {
             transaction: EncodedTransaction::encode(self.transaction, encoding),
             meta,
+=======
+    pub fn transaction_signature(&self) -> &Signature {
+        match self {
+            Self::MissingMetadata(transaction) => &transaction.signatures[0],
+            Self::Complete(VersionedTransactionWithStatusMeta { transaction, .. }) => {
+                &transaction.signatures[0]
+            }
+        }
+    }
+
+    pub fn into_legacy_transaction_with_meta(self) -> Option<LegacyTransactionWithStatusMeta> {
+        match self {
+            TransactionWithStatusMeta::MissingMetadata(transaction) => {
+                Some(LegacyTransactionWithStatusMeta {
+                    transaction,
+                    meta: None,
+                })
+            }
+            TransactionWithStatusMeta::Complete(tx_with_meta) => {
+                tx_with_meta.into_legacy_transaction_with_meta()
+            }
+        }
+    }
+}
+
+impl VersionedTransactionWithStatusMeta {
+    pub fn account_keys(&self) -> AccountKeys {
+        AccountKeys::new(
+            self.transaction.message.static_account_keys(),
+            Some(&self.meta.loaded_addresses),
+        )
+    }
+
+    pub fn into_legacy_transaction_with_meta(self) -> Option<LegacyTransactionWithStatusMeta> {
+        Some(LegacyTransactionWithStatusMeta {
+            transaction: self.transaction.into_legacy_transaction()?,
+            meta: Some(self.meta),
+        })
+    }
+}
+
+impl Encodable for LegacyTransactionWithStatusMeta {
+    type Encoded = EncodedTransactionWithStatusMeta;
+    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
+        Self::Encoded {
+            transaction: self.transaction.encode(encoding),
+            meta: self.meta.map(|meta| match encoding {
+                UiTransactionEncoding::JsonParsed => {
+                    UiTransactionStatusMeta::parse(meta, &self.transaction.message)
+                }
+                _ => UiTransactionStatusMeta::from(meta),
+            }),
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
     }
 }
@@ -586,16 +737,64 @@ pub struct EncodedTransactionWithStatusMeta {
     pub meta: Option<UiTransactionStatusMeta>,
 }
 
+<<<<<<< HEAD
 impl TransactionStatusMeta {
     fn encode(self, encoding: UiTransactionEncoding, message: &Message) -> UiTransactionStatusMeta {
         match encoding {
             UiTransactionEncoding::JsonParsed => UiTransactionStatusMeta::parse(self, message),
             _ => self.into(),
+=======
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfirmedTransactionWithStatusMeta {
+    pub slot: Slot,
+    pub tx_with_meta: TransactionWithStatusMeta,
+    pub block_time: Option<UnixTimestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VersionedConfirmedTransactionWithStatusMeta {
+    pub slot: Slot,
+    pub tx_with_meta: VersionedTransactionWithStatusMeta,
+    pub block_time: Option<UnixTimestamp>,
+}
+
+pub struct LegacyConfirmedTransactionWithStatusMeta {
+    pub slot: Slot,
+    pub tx_with_meta: LegacyTransactionWithStatusMeta,
+    pub block_time: Option<UnixTimestamp>,
+}
+
+impl Encodable for LegacyConfirmedTransactionWithStatusMeta {
+    type Encoded = EncodedConfirmedTransactionWithStatusMeta;
+    fn encode(self, encoding: UiTransactionEncoding) -> Self::Encoded {
+        Self::Encoded {
+            slot: self.slot,
+            transaction: self.tx_with_meta.encode(encoding),
+            block_time: self.block_time,
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
         }
     }
 }
 
+<<<<<<< HEAD
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, Hash, PartialEq)]
+=======
+impl ConfirmedTransactionWithStatusMeta {
+    /// Downgrades a versioned confirmed transaction into a legacy
+    /// confirmed transaction if it contains a legacy transaction.
+    pub fn into_legacy_confirmed_transaction(
+        self,
+    ) -> Option<LegacyConfirmedTransactionWithStatusMeta> {
+        Some(LegacyConfirmedTransactionWithStatusMeta {
+            tx_with_meta: self.tx_with_meta.into_legacy_transaction_with_meta()?,
+            block_time: self.block_time,
+            slot: self.slot,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+>>>>>>> d5dec989b9 (Enforce tx metadata upload with static types (#23028))
 #[serde(rename_all = "camelCase")]
 pub enum UiTransactionEncoding {
     Binary, // Legacy. Retained for RPC backwards compatibility


### PR DESCRIPTION
#### Problem
Transaction status metadata types allow metadata to be None which can cause problems when that metadata is required for RPC requests.

#### Summary of Changes
Very similar to https://github.com/solana-labs/solana/pull/23028
- Fetching a block from the blockstore which doesn't have all tx metas, will now return an error.
- Removed `allow_missing_metadata` cli option from ledger tool uploader because it's impossible for that to happen
- Introduced new types for representing whether metadata is complete or not.

Fixes #
