### PR TITLE
fix memory ordering in append_vec

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -286,11 +286,11 @@ impl AppendVec {
         // This mutex forces append to be single threaded, but concurrent with reads
         // See UNSAFE usage in `append_ptr`
         let _lock = self.append_lock.lock().unwrap();
-        self.current_len.store(0, Ordering::Relaxed);
+        self.current_len.store(0, Ordering::Release);
     }
 
     pub fn len(&self) -> usize {
-        self.current_len.load(Ordering::Relaxed)
+        self.current_len.load(Ordering::Acquire)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -360,7 +360,7 @@ impl AppendVec {
             offset = next_offset;
             num_accounts += 1;
         }
-        let aligned_current_len = u64_align!(self.current_len.load(Ordering::Relaxed));
+        let aligned_current_len = u64_align!(self.current_len.load(Ordering::Acquire));
 
         (offset == aligned_current_len, num_accounts)
     }
@@ -419,7 +419,7 @@ impl AppendVec {
         for val in vals {
             self.append_ptr(offset, val.0, val.1)
         }
-        self.current_len.store(*offset, Ordering::Relaxed);
+        self.current_len.store(*offset, Ordering::Release);
         Some(pos)
     }
 


### PR DESCRIPTION
#### Problem
The current memory ordering in AppendVec is not thread-safe. In Relaxed ordering, the compiler could reorder *current_len* write before *map* write in the writer thread.  In such case, when reader tries to access the last element in the map specified by *current_len*, the last element in the map may not have been updated.

#### Summary of Changes
Change all loads of *current_len* to *Acquire* and stores of *current_len* to *Release*. This will force all the write to *map* happens before write to *current_len*. Thus, eliminate the race condition.

Fixes #
