### PR TITLE
Fix ed25519 program owner on testnet

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7138,7 +7138,7 @@ pub(crate) mod tests {
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         }));
-        let sysvar_and_builtin_program_delta0 = 12;
+        let sysvar_and_builtin_program_delta0 = 11;
         assert_eq!(
             bank0.capitalization(),
             42 * 42 + sysvar_and_builtin_program_delta0
@@ -8893,7 +8893,7 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank0.restore_old_behavior_for_fragile_tests();
 
-        let sysvar_and_builtin_program_delta0 = 12;
+        let sysvar_and_builtin_program_delta0 = 11;
         assert_eq!(
             bank0.capitalization(),
             42 * 1_000_000_000 + sysvar_and_builtin_program_delta0
@@ -9028,7 +9028,7 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank.restore_old_behavior_for_fragile_tests();
 
-        let sysvar_and_builtin_program_delta = 12;
+        let sysvar_and_builtin_program_delta = 11;
         assert_eq!(
             bank.capitalization(),
             42 * 1_000_000_000 + sysvar_and_builtin_program_delta
@@ -13078,25 +13078,25 @@ pub(crate) mod tests {
             if bank.slot == 0 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "CMCWTWsU67zjmayMhSMGBTzHbW1WMCtkM5m7xk9qSnY5"
+                    "DqaWg7EVKzb5Fpe92zNBtXAWqLwcedgHDicYrCBnf3QK"
                 );
             }
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "4kbXeShX8vMnRuuADCkxSEir1oc2PrBNbx6vPkWcDtJU"
+                    "AYdhzhKrM74r9XuZBDGcHeFzg2DEtp1boggnEnzDjZSq"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "CSZ8QCDF8qhqKDxafPzjNJpHcRAXmQzAb8eUi1Emt35E"
+                    "EsbPVYzo1qz5reEUH5okKW4ExB6WbcidkVdW5mzpFn7C"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "Ewh1SYKy8eiSE77sEvjav33SznfWYSwa5TwqbiYWseG2"
+                    "H3DWrQ6FqbLkFNDxbWQ62UKRbw2dbuxf3oVF2VpBk6Ga"
                 );
                 break;
             }
@@ -13324,7 +13324,7 @@ pub(crate) mod tests {
         // No more slots should be shrunk
         assert_eq!(bank2.shrink_candidate_slots(), 0);
         // alive_counts represents the count of alive accounts in the three slots 0,1,2
-        assert_eq!(alive_counts, vec![11, 1, 7]);
+        assert_eq!(alive_counts, vec![10, 1, 7]);
     }
 
     #[test]
@@ -13372,7 +13372,7 @@ pub(crate) mod tests {
             .map(|_| bank.process_stale_slot_with_budget(0, force_to_return_alive_account))
             .sum();
         // consumed_budgets represents the count of alive accounts in the three slots 0,1,2
-        assert_eq!(consumed_budgets, 12);
+        assert_eq!(consumed_budgets, 11);
     }
 
     #[test]

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -129,11 +129,6 @@ fn genesis_builtins() -> Vec<Builtin> {
             solana_sdk::secp256k1_program::id(),
             dummy_process_instruction,
         ),
-        Builtin::new(
-            "ed25519_program",
-            solana_sdk::ed25519_program::id(),
-            dummy_process_instruction,
-        ),
     ]
 }
 
@@ -177,9 +172,15 @@ fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
             feature_set::prevent_calling_precompiles_as_programs::id(),
             ActivationType::RemoveProgram,
         ),
-        // TODO when feature `prevent_calling_precompiles_as_programs` is
-        // cleaned up also remove "ed25519_program" from the main builtins
-        // list
+        (
+            Builtin::new(
+                "ed25519_program",
+                solana_sdk::ed25519_program::id(),
+                dummy_process_instruction,
+            ),
+            feature_set::fix_ed25519_program_owner::id(),
+            ActivationType::NewProgram,
+        ),
         (
             Builtin::new(
                 "ed25519_program",

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -278,7 +278,7 @@ mod tests {
             ..GenesisConfig::default()
         };
         let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
-        let sysvar_and_native_program_delta = 12;
+        let sysvar_and_native_program_delta = 11;
         assert_eq!(
             bank.capitalization(),
             (num_genesis_accounts + num_non_circulating_accounts + num_stake_accounts) * balance

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -299,6 +299,10 @@ pub mod add_get_processed_sibling_instruction_syscall {
     solana_sdk::declare_id!("CFK1hRCNy8JJuAAY8Pb2GjLFNdCThS2qwZNe3izzBMgn");
 }
 
+pub mod fix_ed25519_program_owner {
+    solana_sdk::declare_id!("J2bcyU6gyhVBASNT3ZwaMkd5dPFyi83vrT42JhLjJfm7");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -368,6 +372,7 @@ lazy_static! {
         (disable_bpf_deprecated_load_instructions::id(), "Disable ldabs* and ldind* BPF instructions"),
         (disable_bpf_unresolved_symbols_at_runtime::id(), "Disable reporting of unresolved BPF symbols at runtime"),
         (add_get_processed_sibling_instruction_syscall::id(), "add add_get_processed_sibling_instruction_syscall"),
+        (fix_ed25519_program_owner::id(), "fix ed25519 program owner"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
Problem
Testnet's ed25519 program account is owned by the system program and not the native loader. This causes an assertion during snapshot load because the program is expected to exist and be owned by the native loader, if this is not the case then the program is re-added but during snapshot load the bank is frozen and thus panics.

Summary of Changes
Re-add the ed25519 program via a feature, this will reset the account's owner to the native loader.

Fixes #