### PR TITLE
Add --locked to spl-token-cli install

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -133,7 +133,7 @@ mkdir -p "$installDir/bin"
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
+    "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir"
   fi
 )
 


### PR DESCRIPTION
#### Problem
CI build failing with:


Some errors have detailed explanations: E0277, E0599.
--
  | For more information about an error, try `rustc --explain E0277`.
  | error: could not compile `proc-macro-crate`
  |  
  | To learn more, run the command again with --verbose.
  | warning: build failed, waiting for other jobs to finish...
  | error: failed to compile `spl-token-cli v2.0.15`, intermediate artifacts can be found at `/tmp/cargo-installrI2IxU`
  |  


#### Summary of Changes
Add --locked flag 
