### PR TITLE
fix: simulateTransaction accounts items can be null

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -469,7 +469,7 @@ export type SimulatedTransactionAccountInfo = {
 export type SimulatedTransactionResponse = {
   err: TransactionError | string | null;
   logs: Array<string> | null;
-  accounts?: SimulatedTransactionAccountInfo[] | null;
+  accounts?: (SimulatedTransactionAccountInfo | null)[] | null;
   unitsConsumed?: number;
 };
 
@@ -480,13 +480,15 @@ const SimulatedTransactionResponseStruct = jsonRpcResultAndContext(
     accounts: optional(
       nullable(
         array(
-          pick({
-            executable: boolean(),
-            owner: string(),
-            lamports: number(),
-            data: array(string()),
-            rentEpoch: optional(number()),
-          }),
+          nullable(
+            pick({
+              executable: boolean(),
+              owner: string(),
+              lamports: number(),
+              data: array(string()),
+              rentEpoch: optional(number()),
+            }),
+          ),
         ),
       ),
     ),

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3044,10 +3044,16 @@ describe('Connection', () => {
       const results2 = await connection.simulateTransaction(
         message,
         [account1],
-        [account1.publicKey],
+        [
+          account1.publicKey,
+          new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+        ],
       );
 
-      expect(results2.value.accounts).lengthOf(1);
+      expect(results2.value.accounts).lengthOf(2);
+      if (results2.value.accounts) {
+        expect(results2.value.accounts[1]).to.be.null;
+      }
     }).timeout(10000);
 
     it('transaction', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3046,7 +3046,7 @@ describe('Connection', () => {
         [account1],
         [
           account1.publicKey,
-          new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+          new PublicKey('Missing111111111111111111111111111111111111'),
         ],
       );
 


### PR DESCRIPTION
#### Problem
superstruct typing was not allowing an account to go null, resulting in the following exception in some circumstances

```
/lame-project/node_modules/superstruct/src/struct.ts:184
    const error = new StructError(tuple[0], function* () {
                  ^
StructError: At path: value.accounts.0 -- Expected an object, but received: null
    at validate (/lame-project//node_modules/superstruct/src/struct.ts:184:19)
    at Object.create (/lame-project/node_modules/superstruct/src/struct.ts:135:18)
    at coercer (/lame-project/node_modules/@solana/web3.js/src/connection.ts:194:17)
    at Struct.coercer (/lame-project/node_modules/superstruct/src/structs/coercions.ts:25:26)
    at next (/lame-project/node_modules/superstruct/src/utils.ts:132:20)
    at run.next (<anonymous>)
    at shiftIterator (/lame-project/node_modules/superstruct/src/utils.ts:47:33)
    at validate (/lame-project/node_modules/superstruct/src/struct.ts:181:17)
    at Object.create (/lame-project/node_modules/superstruct/src/struct.ts:135:18)
    at Connection.simulateTransaction (/lame-project/node_modules/@solana/web3.js/lib/index.cjs.js:6708:29) {
  value: null,
  type: 'type',
  refinement: undefined,
  key: 0,
  path: [ 'value', 'accounts', 0 ],
  branch: [
    { context: [Object], value: [Object] },
    { err: [Object], logs: [Array], accounts: [Array] },
    [ null ],
    null
  ],
  failures: [Function (anonymous)]
}
```

From the documentation
https://docs.solana.com/developing/clients/jsonrpc-api#simulatetransaction

`<null> - if the account doesn't exist or if err is not null`

#### Summary of Changes

Fixes #
