### PR TITLE
Fix small problems in transaction-dos tool

### DIFF
--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -132,9 +132,9 @@ fn make_dos_message(
     Message::new(&instructions, Some(&keypair.pubkey()))
 }
 
-/// creates large transactions that all touch the same set of accounts, 
+/// creates large transactions that all touch the same set of accounts,
 /// so they can't be parallelized
-/// 
+///
 #[allow(clippy::too_many_arguments)]
 fn run_transactions_dos(
     entrypoint_addr: SocketAddr,


### PR DESCRIPTION
#### Problem
Test (`ignored`) for transaction-dos tool didn't work.

#### Summary of Changes
1. specify path to the program with `CARGO_MANIFEST_BUILD` to prevent problems when running from different directories
2. replaced transaction size upper bound with `PACKET_DATA_SIZE` constant
3. use correct blockhash not only for transaction but also for message to get fee value