### PR TITLE
(LedgerStore) Use `rocksdb_fifo` as the blockstore directory when FIFO is used

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -13,7 +13,10 @@ use {
     },
     solana_entry::poh::compute_hashes_per_tick,
     solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account},
-    solana_ledger::{blockstore::create_new_ledger, blockstore_db::AccessType},
+    solana_ledger::{
+        blockstore::create_new_ledger,
+        blockstore_db::{AccessType, ShredStorageType},
+    },
     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -630,6 +633,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &genesis_config,
         max_genesis_archive_unpacked_size,
         AccessType::PrimaryOnly,
+        ShredStorageType::default(),
     )?;
 
     println!("{}", genesis_config);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -23,7 +23,9 @@ use {
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
         blockstore::{create_new_ledger, Blockstore, PurgeType},
-        blockstore_db::{self, AccessType, BlockstoreOptions, BlockstoreRecoveryMode, Database},
+        blockstore_db::{
+            self, AccessType, BlockstoreOptions, BlockstoreRecoveryMode, Database, ShredStorageType,
+        },
         blockstore_processor::ProcessOptions,
         shred::Shred,
     },
@@ -1715,6 +1717,7 @@ fn main() {
                     &genesis_config,
                     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     AccessType::PrimaryOnly,
+                    ShredStorageType::default(),
                 )
                 .unwrap_or_else(|err| {
                     eprintln!("Failed to write genesis config: {:?}", err);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -971,6 +971,7 @@ pub struct WriteBatch<'a> {
     map: HashMap<&'static str, &'a ColumnFamily>,
 }
 
+#[derive(Clone)]
 pub enum ShredStorageType {
     // Stores shreds under RocksDB's default compaction (level).
     RocksLevel,
@@ -978,6 +979,12 @@ pub enum ShredStorageType {
     // allows ledger store to reclaim storage more efficiently with
     // lower I/O overhead.
     RocksFifo(BlockstoreRocksFifoOptions),
+}
+
+impl Default for ShredStorageType {
+    fn default() -> Self {
+        Self::RocksLevel
+    }
 }
 
 pub struct BlockstoreOptions {
@@ -1003,6 +1010,7 @@ impl Default for BlockstoreOptions {
     }
 }
 
+#[derive(Clone)]
 pub struct BlockstoreRocksFifoOptions {
     // The maximum storage size for storing data shreds in column family
     // [`cf::DataShred`].  Typically, data shreds contribute around 25% of the

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -467,6 +467,9 @@ fn is_valid_genesis_archive_entry(parts: &[&str], kind: tar::EntryType) -> bool 
         (["rocksdb"], Directory) => true,
         (["rocksdb", _], GNUSparse) => true,
         (["rocksdb", _], Regular) => true,
+        (["rocksdb_fifo"], Directory) => true,
+        (["rocksdb_fifo", _], GNUSparse) => true,
+        (["rocksdb_fifo", _], Regular) => true,
         _ => false,
     }
 }
@@ -600,6 +603,18 @@ mod tests {
             &["rocksdb", "foo"],
             tar::EntryType::GNUSparse,
         ));
+        assert!(is_valid_genesis_archive_entry(
+            &["rocksdb_fifo"],
+            tar::EntryType::Directory
+        ));
+        assert!(is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo"],
+            tar::EntryType::Regular
+        ));
+        assert!(is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo"],
+            tar::EntryType::GNUSparse,
+        ));
 
         assert!(!is_valid_genesis_archive_entry(
             &["aaaa"],
@@ -631,6 +646,30 @@ mod tests {
         ));
         assert!(!is_valid_genesis_archive_entry(
             &["rocksdb", "foo", "bar"],
+            tar::EntryType::GNUSparse
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo"],
+            tar::EntryType::Regular
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo"],
+            tar::EntryType::GNUSparse,
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo"],
+            tar::EntryType::Directory,
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo", "bar"],
+            tar::EntryType::Directory,
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo", "bar"],
+            tar::EntryType::Regular
+        ));
+        assert!(!is_valid_genesis_archive_entry(
+            &["rocksdb_fifo", "foo", "bar"],
             tar::EntryType::GNUSparse
         ));
     }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -12,7 +12,9 @@ use {
         gossip_service::discover_cluster,
         socketaddr,
     },
-    solana_ledger::{blockstore::create_new_ledger, create_new_tmp_ledger},
+    solana_ledger::{
+        blockstore::create_new_ledger, blockstore_db::ShredStorageType, create_new_tmp_ledger,
+    },
     solana_net_utils::PortRange,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
     solana_runtime::{
@@ -580,6 +582,7 @@ impl TestValidator {
                         .max_genesis_archive_unpacked_size
                         .unwrap_or(MAX_GENESIS_ARCHIVE_UNPACKED_SIZE),
                     solana_ledger::blockstore_db::AccessType::PrimaryOnly,
+                    ShredStorageType::default(),
                 )
                 .map_err(|err| {
                     format!(


### PR DESCRIPTION
#### Summary of Changes
To avoid mixing the use of different shred storage types, each shred storage type
will have its blockstore in a different directory.

This PR still keeps the RocksFifo setting hidden.  The default ShredStorageType and
blockstore directory are still RocksLevel and `rocksdb`.

Will follow-up with PRs on making FIFO option public in ledger-tool and validator.

#### Test Plan
* Added a new test to verify the existence of `rocksdb-fifo` directory when FIFO compaction is used.
* Updated existing test to verify the current setting still store ledger under `rocksdb` directory.
* Manually ran ledger_cleanup_test with both level and fifo compaction and verified the resulting ledger.
* Ran a validator with this PR. 