### PR TITLE
Precompiles owned by the native loader

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3219,7 +3219,7 @@ impl Bank {
         let (lamports, rent_epoch) = self.inherit_specially_retained_account_fields(&None);
         let account = AccountSharedData::from(Account {
             lamports,
-            owner: solana_sdk::system_program::id(),
+            owner: native_loader::id(),
             data: vec![],
             executable: true,
             rent_epoch,


### PR DESCRIPTION
#### Problem

Existing pre-compiles and builtins are owned by the native loader but new precompiles are added as system programs

#### Summary of Changes

For consistency, add all as owned by native loader

Fixes #
