### PR TITLE
Add script for running nightly rustfmt on all workspaces

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -19,7 +19,8 @@ pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
 if [[ ${HOST_RUST_VERSION} =~ ${pattern} ]]; then
     HOST_RUST_VERSION="${rust_stable%.*}"
 fi
-export CARGO_TARGET_CACHE=$HOME/cargo-target-cache/"$CHANNEL"-"$BUILDKITE_LABEL"-"$SBF_TOOLS_VERSION"-"$HOST_RUST_VERSION"
+CACHE_VERSION=1 # bump version to invalidate caches
+export CARGO_TARGET_CACHE=$HOME/cargo-target-cache/"$CHANNEL"-"$BUILDKITE_LABEL"-"$SBF_TOOLS_VERSION"-"$HOST_RUST_VERSION"-"$CACHE_VERSION"
 (
   set -x
   MAX_CACHE_SIZE=18 # gigabytes

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -69,20 +69,14 @@ _ ci/order-crates-for-publishing.py
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there
 _ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=warnings --deny=clippy::integer_arithmetic
 
-_ "$cargo" stable fmt --all -- --check
+_ "$cargo" nightly fmt --all -- --check
 
 _ ci/do-audit.sh
 
 {
   cd programs/bpf
-  for project in rust/*/ ; do
-    echo "+++ do_bpf_checks $project"
-    (
-      cd "$project"
-      _ "$cargo" nightly clippy -- --deny=warnings --allow=clippy::missing_safety_doc
-      _ "$cargo" stable fmt -- --check
-    )
-  done
+  _ "$cargo" nightly clippy --all -- --deny=warnings --allow=clippy::missing_safety_doc
+  _ "$cargo" nightly fmt --all -- --check
 }
 
 echo --- ok

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -5,34 +5,36 @@ extern crate test;
 #[macro_use]
 extern crate solana_bpf_loader_program;
 
-use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use solana_bpf_loader_program::{
-    create_vm, serialization::serialize_parameters, syscalls::register_syscalls, BpfError,
-    ThisInstructionMeter,
+use {
+    byteorder::{ByteOrder, LittleEndian, WriteBytesExt},
+    solana_bpf_loader_program::{
+        create_vm, serialization::serialize_parameters, syscalls::register_syscalls, BpfError,
+        ThisInstructionMeter,
+    },
+    solana_measure::measure::Measure,
+    solana_program_runtime::invoke_context::with_mock_invoke_context,
+    solana_rbpf::{
+        elf::Executable,
+        vm::{Config, InstructionMeter, SyscallRegistry},
+    },
+    solana_runtime::{
+        bank::Bank,
+        bank_client::BankClient,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        loader_utils::load_program,
+    },
+    solana_sdk::{
+        bpf_loader,
+        client::SyncClient,
+        entrypoint::SUCCESS,
+        instruction::{AccountMeta, Instruction},
+        message::Message,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+    },
+    std::{env, fs::File, io::Read, mem, path::PathBuf, sync::Arc},
+    test::Bencher,
 };
-use solana_measure::measure::Measure;
-use solana_program_runtime::invoke_context::with_mock_invoke_context;
-use solana_rbpf::{
-    elf::Executable,
-    vm::{Config, InstructionMeter, SyscallRegistry},
-};
-use solana_runtime::{
-    bank::Bank,
-    bank_client::BankClient,
-    genesis_utils::{create_genesis_config, GenesisConfigInfo},
-    loader_utils::load_program,
-};
-use solana_sdk::{
-    bpf_loader,
-    client::SyncClient,
-    entrypoint::SUCCESS,
-    instruction::{AccountMeta, Instruction},
-    message::Message,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-};
-use std::{env, fs::File, io::Read, mem, path::PathBuf, sync::Arc};
-use test::Bencher;
 
 /// BPF program file extension
 const PLATFORM_FILE_EXTENSION_BPF: &str = "so";

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -1,7 +1,9 @@
 extern crate walkdir;
 
-use std::{env, path::Path, process::Command};
-use walkdir::WalkDir;
+use {
+    std::{env, path::Path, process::Command},
+    walkdir::WalkDir,
+};
 
 fn rerun_if_changed(files: &[&str], directories: &[&str], excludes: &[&str]) {
     let mut all_files: Vec<_> = files.iter().map(|f| f.to_string()).collect();

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -2,8 +2,10 @@
 
 #[macro_use]
 extern crate alloc;
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64, msg};
-use std::{alloc::Layout, mem};
+use {
+    solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64, msg},
+    std::{alloc::Layout, mem},
+};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {

--- a/programs/bpf/rust/caller_access/src/lib.rs
+++ b/programs/bpf/rust/caller_access/src/lib.rs
@@ -1,15 +1,16 @@
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    instruction::{AccountMeta, Instruction},
-    msg,
-    program::invoke,
-    pubkey::Pubkey,
+use {
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program::invoke,
+        pubkey::Pubkey,
+    },
+    std::convert::TryInto,
 };
-use std::convert::TryInto;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/custom_heap/src/lib.rs
+++ b/programs/bpf/rust/custom_heap/src/lib.rs
@@ -1,17 +1,18 @@
 //! Example Rust-based BPF that tests out using a custom heap
 
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
-    msg,
-    pubkey::Pubkey,
-};
-use std::{
-    alloc::{alloc, Layout},
-    mem::{align_of, size_of},
-    ptr::null_mut,
-    usize,
+use {
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::{ProgramResult, HEAP_LENGTH, HEAP_START_ADDRESS},
+        msg,
+        pubkey::Pubkey,
+    },
+    std::{
+        alloc::{alloc, Layout},
+        mem::{align_of, size_of},
+        ptr::null_mut,
+        usize,
+    },
 };
 
 /// Developers can implement their own heap by defining their own
@@ -52,7 +53,7 @@ unsafe impl std::alloc::GlobalAlloc for BumpAllocator {
 #[global_allocator]
 static A: BumpAllocator = BumpAllocator;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -1,8 +1,10 @@
 //! Example Rust-based BPF program tests dependent crates
 
 extern crate solana_program;
-use byteorder::{ByteOrder, LittleEndian};
-use solana_program::entrypoint::SUCCESS;
+use {
+    byteorder::{ByteOrder, LittleEndian},
+    solana_program::entrypoint::SUCCESS,
+};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {

--- a/programs/bpf/rust/deprecated_loader/src/lib.rs
+++ b/programs/bpf/rust/deprecated_loader/src/lib.rs
@@ -4,8 +4,8 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, bpf_loader, entrypoint_deprecated,
-    entrypoint_deprecated::ProgramResult, log::*, msg, pubkey::Pubkey,
+    account_info::AccountInfo, bpf_loader, entrypoint_deprecated::ProgramResult, log::*, msg,
+    pubkey::Pubkey,
 };
 
 #[derive(Debug, PartialEq)]
@@ -26,7 +26,7 @@ fn custom_panic(info: &core::panic::PanicInfo<'_>) {
     msg!(&format!("{}", info));
 }
 
-entrypoint_deprecated!(process_instruction);
+solana_program::entrypoint_deprecated!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/dup_accounts/src/lib.rs
+++ b/programs/bpf/rust/dup_accounts/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
@@ -12,7 +11,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/error_handling/src/lib.rs
+++ b/programs/bpf/rust/error_handling/src/lib.rs
@@ -1,18 +1,19 @@
 //! Example Rust-based BPF program that exercises error handling
 
 extern crate solana_program;
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
-use solana_program::{
-    account_info::AccountInfo,
-    decode_error::DecodeError,
-    entrypoint,
-    entrypoint::ProgramResult,
-    msg,
-    program_error::{PrintProgramError, ProgramError},
-    pubkey::{Pubkey, PubkeyError},
+use {
+    num_derive::FromPrimitive,
+    num_traits::FromPrimitive,
+    solana_program::{
+        account_info::AccountInfo,
+        decode_error::DecodeError,
+        entrypoint::ProgramResult,
+        msg,
+        program_error::{PrintProgramError, ProgramError},
+        pubkey::{Pubkey, PubkeyError},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Custom program errors
 #[derive(Error, Debug, Clone, PartialEq, FromPrimitive)]
@@ -44,7 +45,7 @@ impl PrintProgramError for MyError {
     }
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/external_spend/src/lib.rs
+++ b/programs/bpf/rust/external_spend/src/lib.rs
@@ -1,11 +1,9 @@
 //! Example Rust-based BPF program that moves a lamport from one account to another
 
 extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/finalize/src/lib.rs
+++ b/programs/bpf/rust/finalize/src/lib.rs
@@ -4,11 +4,11 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult,
-    loader_instruction, msg, program::invoke, pubkey::Pubkey,
+    account_info::AccountInfo, bpf_loader, entrypoint::ProgramResult, loader_instruction, msg,
+    program::invoke, pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate solana_program;
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
@@ -13,7 +12,7 @@ use solana_program::{
     sysvar::instructions,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/invoke/src/processor.rs
+++ b/programs/bpf/rust/invoke/src/processor.rs
@@ -3,18 +3,19 @@
 #![cfg(feature = "program")]
 #![allow(unreachable_code)]
 
-use crate::instructions::*;
-use solana_bpf_rust_invoked::instructions::*;
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
-    instruction::Instruction,
-    msg,
-    program::{get_return_data, invoke, invoke_signed, set_return_data},
-    program_error::ProgramError,
-    pubkey::{Pubkey, PubkeyError},
-    system_instruction,
+use {
+    crate::instructions::*,
+    solana_bpf_rust_invoked::instructions::*,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
+        instruction::Instruction,
+        msg,
+        program::{get_return_data, invoke, invoke_signed, set_return_data},
+        program_error::ProgramError,
+        pubkey::{Pubkey, PubkeyError},
+        system_instruction,
+    },
 };
 
 fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo]) -> ProgramResult {
@@ -50,7 +51,7 @@ fn do_nested_invokes(num_nested_invokes: u64, accounts: &[AccountInfo]) -> Progr
     Ok(())
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/invoke_and_error/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_error/src/lib.rs
@@ -2,11 +2,14 @@
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
-    instruction::Instruction, program::invoke, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/invoke_and_ok/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_ok/src/lib.rs
@@ -2,11 +2,14 @@
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
-    instruction::Instruction, program::invoke, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -2,11 +2,14 @@
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
-    instruction::Instruction, program::invoke, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke,
+    pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -2,20 +2,22 @@
 
 #![cfg(feature = "program")]
 
-use crate::instructions::*;
-use solana_program::{
-    account_info::AccountInfo,
-    bpf_loader, entrypoint,
-    entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
-    log::sol_log_64,
-    msg,
-    program::{get_return_data, invoke, invoke_signed, set_return_data},
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    system_instruction,
+use {
+    crate::instructions::*,
+    solana_program::{
+        account_info::AccountInfo,
+        bpf_loader,
+        entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
+        log::sol_log_64,
+        msg,
+        program::{get_return_data, invoke, invoke_signed, set_return_data},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        system_instruction,
+    },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::cognitive_complexity)]
 fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/log_data/src/lib.rs
+++ b/programs/bpf/rust/log_data/src/lib.rs
@@ -3,11 +3,11 @@
 #![cfg(feature = "program")]
 
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, log::sol_log_data,
+    account_info::AccountInfo, entrypoint::ProgramResult, log::sol_log_data,
     program::set_return_data, pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::cognitive_complexity)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/mem/src/entrypoint.rs
+++ b/programs/bpf/rust/mem/src/entrypoint.rs
@@ -1,15 +1,16 @@
 //! Test mem functions
 
-use crate::{run_mem_tests, MemOps};
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    program_memory::{sol_memcmp, sol_memcpy, sol_memmove, sol_memset},
-    pubkey::Pubkey,
+use {
+    crate::{run_mem_tests, MemOps},
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        program_memory::{sol_memcmp, sol_memcpy, sol_memmove, sol_memset},
+        pubkey::Pubkey,
+    },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/mem/tests/lib.rs
+++ b/programs/bpf/rust/mem/tests/lib.rs
@@ -1,7 +1,9 @@
-use solana_bpf_rust_mem::entrypoint::process_instruction;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::Instruction, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+use {
+    solana_bpf_rust_mem::entrypoint::process_instruction,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::Instruction, pubkey::Pubkey, signature::Signer, transaction::Transaction,
+    },
 };
 
 #[tokio::test]

--- a/programs/bpf/rust/membuiltins/src/lib.rs
+++ b/programs/bpf/rust/membuiltins/src/lib.rs
@@ -4,8 +4,10 @@
 #![feature(rustc_private)]
 
 extern crate compiler_builtins;
-use solana_bpf_rust_mem::{run_mem_tests, MemOps};
-use solana_program::{custom_panic_default, entrypoint::SUCCESS};
+use {
+    solana_bpf_rust_mem::{run_mem_tests, MemOps},
+    solana_program::{custom_panic_default, entrypoint::SUCCESS},
+};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -1,11 +1,9 @@
 //! Example Rust-based BPF noop program
 
 extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -9,11 +9,9 @@ fn custom_panic(info: &core::panic::PanicInfo<'_>) {
 }
 
 extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -1,8 +1,10 @@
 //! Example Rust-based BPF program tests loop iteration
 
 extern crate solana_program;
-use solana_bpf_rust_param_passing_dep::{Data, TestDep};
-use solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64};
+use {
+    solana_bpf_rust_param_passing_dep::{Data, TestDep},
+    solana_program::{custom_panic_default, entrypoint::SUCCESS, log::sol_log_64},
+};
 
 #[no_mangle]
 pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {

--- a/programs/bpf/rust/rand/src/lib.rs
+++ b/programs/bpf/rust/rand/src/lib.rs
@@ -3,11 +3,9 @@
 #![allow(unreachable_code)]
 
 extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/realloc/src/processor.rs
+++ b/programs/bpf/rust/realloc/src/processor.rs
@@ -3,15 +3,20 @@
 #![cfg(feature = "program")]
 
 extern crate solana_program;
-use crate::instructions::*;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE, msg, program::invoke, pubkey::Pubkey,
-    system_instruction, system_program,
+use {
+    crate::instructions::*,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
+        msg,
+        program::invoke,
+        pubkey::Pubkey,
+        system_instruction, system_program,
+    },
+    std::convert::TryInto,
 };
-use std::convert::TryInto;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/realloc_invoke/src/processor.rs
+++ b/programs/bpf/rust/realloc_invoke/src/processor.rs
@@ -3,22 +3,22 @@
 #![cfg(feature = "program")]
 
 extern crate solana_program;
-use crate::instructions::*;
-use solana_bpf_rust_realloc::instructions::*;
-use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
-    entrypoint::ProgramResult,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    instruction::{AccountMeta, Instruction},
-    msg,
-    program::invoke,
-    pubkey::Pubkey,
-    system_instruction, system_program,
+use {
+    crate::instructions::*,
+    solana_bpf_rust_realloc::instructions::*,
+    solana_program::{
+        account_info::AccountInfo,
+        entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program::invoke,
+        pubkey::Pubkey,
+        system_instruction, system_program,
+    },
+    std::convert::TryInto,
 };
-use std::convert::TryInto;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/ro_account_modify/src/lib.rs
+++ b/programs/bpf/rust/ro_account_modify/src/lib.rs
@@ -1,6 +1,5 @@
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
@@ -15,7 +14,7 @@ const INSTRUCTION_INVOKE_MODIFY: u8 = 1;
 const INSTRUCTION_MODIFY_INVOKE: u8 = 2;
 const INSTRUCTION_VERIFY_MODIFIED: u8 = 3;
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/ro_modify/src/lib.rs
+++ b/programs/bpf/rust/ro_modify/src/lib.rs
@@ -1,5 +1,5 @@
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, program::invoke,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
     program_error::ProgramError, pubkey::Pubkey, system_instruction,
 };
 
@@ -116,7 +116,7 @@ fn check_preconditions(
     Ok(())
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -4,8 +4,7 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult, log::*, msg,
-    pubkey::Pubkey,
+    account_info::AccountInfo, bpf_loader, entrypoint::ProgramResult, log::*, msg, pubkey::Pubkey,
 };
 
 #[derive(Debug, PartialEq)]
@@ -20,7 +19,7 @@ fn return_sstruct() -> SStruct {
     SStruct { x: 1, y: 2, z: 3 }
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/sanity/tests/lib.rs
+++ b/programs/bpf/rust/sanity/tests/lib.rs
@@ -1,12 +1,14 @@
 #![cfg(feature = "test-bpf")]
 
-use solana_bpf_rust_sanity::process_instruction;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    transaction::Transaction,
+use {
+    solana_bpf_rust_sanity::process_instruction,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        transaction::Transaction,
+    },
 };
 
 #[tokio::test]

--- a/programs/bpf/rust/sibling_inner_instruction/src/lib.rs
+++ b/programs/bpf/rust/sibling_inner_instruction/src/lib.rs
@@ -4,7 +4,6 @@
 
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{
         get_processed_sibling_instruction, get_stack_height, AccountMeta, Instruction,
@@ -14,7 +13,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/sibling_instruction/src/lib.rs
+++ b/programs/bpf/rust/sibling_instruction/src/lib.rs
@@ -4,7 +4,6 @@
 
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{
         get_processed_sibling_instruction, get_stack_height, AccountMeta, Instruction,
@@ -15,7 +14,7 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/spoof1/src/lib.rs
+++ b/programs/bpf/rust/spoof1/src/lib.rs
@@ -1,6 +1,5 @@
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
@@ -10,7 +9,7 @@ use solana_program::{
     system_program,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/spoof1_system/src/lib.rs
+++ b/programs/bpf/rust/spoof1_system/src/lib.rs
@@ -1,8 +1,6 @@
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -5,7 +5,6 @@ extern crate solana_program;
 use solana_program::sysvar::recent_blockhashes::RecentBlockhashes;
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     instruction::{AccountMeta, Instruction},
     msg,
@@ -17,7 +16,7 @@ use solana_program::{
     },
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 pub fn process_instruction(
     program_id: &Pubkey,

--- a/programs/bpf/rust/sysvar/tests/lib.rs
+++ b/programs/bpf/rust/sysvar/tests/lib.rs
@@ -1,14 +1,16 @@
-use solana_bpf_rust_sysvar::process_instruction;
-use solana_program_test::*;
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::Signer,
-    sysvar::{
-        clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes, slot_history,
-        stake_history,
+use {
+    solana_bpf_rust_sysvar::process_instruction,
+    solana_program_test::*,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::Signer,
+        sysvar::{
+            clock, epoch_schedule, instructions, recent_blockhashes, rent, slot_hashes,
+            slot_history, stake_history,
+        },
+        transaction::Transaction,
     },
-    transaction::Transaction,
 };
 
 #[tokio::test]

--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -2,11 +2,10 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
-    sysvar::clock,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey, sysvar::clock,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -2,11 +2,10 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
-    sysvar::clock,
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey, sysvar::clock,
 };
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/scripts/cargo-fmt.sh
+++ b/scripts/cargo-fmt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+here="$(dirname "$0")"
+cargo="$(readlink -f "${here}/../cargo")"
+
+if [[ -z $cargo ]]; then
+  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
+  to gnu readlink with 'brew install coreutils' and then symlink greadlink as
+  /usr/local/bin/readlink."
+  exit 1
+fi
+
+set -ex
+
+"$cargo" nightly fmt --all
+(cd programs/bpf && "$cargo" nightly fmt --all)
+(cd sdk/cargo-build-bpf/tests/crates/fail && "$cargo" nightly fmt --all)
+(cd sdk/cargo-build-bpf/tests/crates/noop && "$cargo" nightly fmt --all)
+(cd storage-bigtable/build-proto && "$cargo" nightly fmt --all)
+(cd web3.js/test/fixtures/noop-program && "$cargo" nightly fmt --all)

--- a/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/fail/src/lib.rs
@@ -1,11 +1,8 @@
 //! Example Rust-based BPF noop program
 
-extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     _accounts: &[AccountInfo],

--- a/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
+++ b/sdk/cargo-build-bpf/tests/crates/noop/src/lib.rs
@@ -1,11 +1,8 @@
 //! Example Rust-based BPF noop program
 
-extern crate solana_program;
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
     _accounts: &[AccountInfo],

--- a/web3.js/test/fixtures/noop-program/src/lib.rs
+++ b/web3.js/test/fixtures/noop-program/src/lib.rs
@@ -1,8 +1,7 @@
 //! Example Rust-based BPF program that prints out the parameters passed to it
 
-
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, log::*, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, log::*, msg, pubkey::Pubkey,
 };
 
 #[derive(Debug, PartialEq)]
@@ -17,7 +16,7 @@ fn return_sstruct() -> SStruct {
     SStruct { x: 1, y: 2, z: 3 }
 }
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],


### PR DESCRIPTION
#### Problems
- The new rustfmt options added in https://github.com/solana-labs/solana/pull/23238 are still unstable so require nightly rustfmt
- CI doesn't use nightly rustfmt to enforce import formatting

#### Summary of Changes
- Added `./scripts/cargo-fmt.sh` for running nightly rustfmt the full monorepo
- Applied new rustfmt rules to all workspaces
- Updated CI to enforce new rustfmt rules

Fixes #
