### PR TITLE
Fix builtin handling on epoch boundaries

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3198,6 +3198,11 @@ impl Bank {
 
     /// Add a precompiled program account
     pub fn add_precompiled_account(&self, program_id: &Pubkey) {
+        self.add_precompiled_account_with_owner(program_id, native_loader::id())
+    }
+
+    // Used by tests to simulate clusters with precompiles that aren't owned by the native loader
+    fn add_precompiled_account_with_owner(&self, program_id: &Pubkey, owner: Pubkey) {
         if let Some(account) = self.get_account_with_fixed_root(program_id) {
             if account.executable() {
                 // The account is already executable, that's all we need
@@ -3219,7 +3224,7 @@ impl Bank {
         let (lamports, rent_epoch) = self.inherit_specially_retained_account_fields(&None);
         let account = AccountSharedData::from(Account {
             lamports,
-            owner: native_loader::id(),
+            owner,
             data: vec![],
             executable: true,
             rent_epoch,
@@ -6494,12 +6499,12 @@ impl Bank {
 
     fn apply_builtin_program_feature_transitions(
         &mut self,
-        apply_transitions_for_new_features: bool,
+        only_apply_transitions_for_new_features: bool,
         new_feature_activations: &HashSet<Pubkey>,
     ) {
         let feature_set = self.feature_set.clone();
-        let should_apply_action_for_feature = |feature_id: &Pubkey| -> bool {
-            if apply_transitions_for_new_features {
+        let should_apply_action_for_feature_transition = |feature_id: &Pubkey| -> bool {
+            if only_apply_transitions_for_new_features {
                 new_feature_activations.contains(feature_id)
             } else {
                 feature_set.is_active(feature_id)
@@ -6508,7 +6513,9 @@ impl Bank {
 
         let builtin_feature_transitions = self.builtin_feature_transitions.clone();
         for transition in builtin_feature_transitions.iter() {
-            if let Some(builtin_action) = transition.to_action(&should_apply_action_for_feature) {
+            if let Some(builtin_action) =
+                transition.to_action(&should_apply_action_for_feature_transition)
+            {
                 match builtin_action {
                     BuiltinAction::Add(builtin) => self.add_builtin(
                         &builtin.name,
@@ -13000,25 +13007,25 @@ pub(crate) mod tests {
             if bank.slot == 0 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "HREoNvUAuqqGdJxYTgnFqjTxsuuBVUFFDNLGR2cdrtMf"
+                    "9tLrxkBoNE7zEUZ2g72ZwE4fTfhUQnhC8A4Xt4EmYhP1"
                 );
             }
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "J8kjxLMMrpEVQUbX54zDALkXidjdXyFSL5wD2d7xUaWL"
+                    "7qCbZN5WLT928VpsaLwLp6HfRDzZirmoU4JM4XBEyupu"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "yPCTEPtNi2DJb8KyqPKgBK7HCfiEpH2oS3Nn12LPBHm"
+                    "D3ypfQFreDaQhJuuYN8rWG1TVy9ApvTCx5CAiQ5i9d7A"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "2oG1rmA59tmr457oK4oF6C6TcM2gyy2ZAKeJoUhMNb1L"
+                    "67krqDMqjkkixdfypnCCgSyUm2FoqAE8KB1hgRAtCaBp"
                 );
                 break;
             }
@@ -13247,7 +13254,7 @@ pub(crate) mod tests {
         // No more slots should be shrunk
         assert_eq!(bank2.shrink_candidate_slots(), 0);
         // alive_counts represents the count of alive accounts in the three slots 0,1,2
-        assert_eq!(alive_counts, vec![11, 1, 7]);
+        assert_eq!(alive_counts, vec![9, 1, 7]);
     }
 
     #[test]
@@ -13295,7 +13302,7 @@ pub(crate) mod tests {
             .map(|_| bank.process_stale_slot_with_budget(0, force_to_return_alive_account))
             .sum();
         // consumed_budgets represents the count of alive accounts in the three slots 0,1,2
-        assert_eq!(consumed_budgets, 12);
+        assert_eq!(consumed_budgets, 10);
     }
 
     #[test]

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -6,6 +6,41 @@ mod tests {
     };
 
     #[test]
+    fn test_apply_builtin_program_feature_transitions_for_new_epoch() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        bank.feature_set = Arc::new(FeatureSet::all_enabled());
+        bank.finish_init(&genesis_config, None, false);
+
+        // Overwrite precompile accounts to simulate a cluster which already added precompiles.
+        for precompile in get_precompiles() {
+            bank.store_account(&precompile.program_id, &AccountSharedData::default());
+            // Simulate cluster which added ed25519 precompile with a system program owner
+            if precompile.program_id == ed25519_program::id() {
+                bank.add_precompiled_account_with_owner(
+                    &precompile.program_id,
+                    solana_sdk::system_program::id(),
+                );
+            } else {
+                bank.add_precompiled_account(&precompile.program_id);
+            }
+        }
+
+        // Normally feature transitions are applied to a bank that hasn't been
+        // frozen yet.  Freeze the bank early to ensure that no account changes
+        // are made.
+        bank.freeze();
+
+        // Simulate crossing an epoch boundary for a new bank
+        let only_apply_transitions_for_new_features = true;
+        bank.apply_builtin_program_feature_transitions(
+            only_apply_transitions_for_new_features,
+            &HashSet::new(),
+        );
+    }
+
+    #[test]
     fn test_startup_from_snapshot_after_precompile_transition() {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -26,7 +26,7 @@ pub fn bootstrap_validator_stake_lamports() -> u64 {
 
 // Number of lamports automatically used for genesis accounts
 pub const fn genesis_sysvar_and_builtin_program_lamports() -> u64 {
-    const NUM_BUILTIN_PROGRAMS: u64 = 6;
+    const NUM_BUILTIN_PROGRAMS: u64 = 4;
     const FEES_SYSVAR_MIN_BALANCE: u64 = 946_560;
     const STAKE_HISTORY_MIN_BALANCE: u64 = 114_979_200;
     const CLOCK_SYSVAR_MIN_BALANCE: u64 = 1_169_280;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -53,6 +53,10 @@ pub mod full_inflation {
     }
 }
 
+pub mod secp256k1_program_enabled {
+    solana_sdk::declare_id!("E3PHP7w8kB7np3CTQ1qQ2tW3KCtjRSXBQgW9vM2mWv2Y");
+}
+
 pub mod spl_token_v2_multisig_fix {
     solana_sdk::declare_id!("E5JiFDQCwyC6QfT9REFyMpfK2mHcmv1GUDySU1Ue7TYv");
 }
@@ -314,6 +318,7 @@ pub mod record_instruction_in_transaction_context_push {
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
+        (secp256k1_program_enabled::id(), "secp256k1 program"),
         (deprecate_rewards_sysvar::id(), "deprecate unused rewards sysvar"),
         (pico_inflation::id(), "pico inflation"),
         (full_inflation::devnet_and_testnet::id(), "full inflation on devnet and testnet"),


### PR DESCRIPTION
#### Problem
On epoch boundaries only newly activated features should lead to changes to builtin programs. But in https://github.com/solana-labs/solana/pull/23233, builtin addition/removal transitions were combined such that if the removal feature id was not activated, the builtin would be actively re-added instead of being skipped.

This repeated addition of a builtin can cause problems because on testnet when the built-in for ed25519 is re-added, the account becomes native loader owned and the "ed25519_program" string is stored in its data buffer. This results in a hash mismatch because on testnet, the ed25519 program id is a system owned account with an empty data buffer.

#### Summary of Changes
Ensure that builtins are only "re-added" on epoch boundaries if the feature used for adding the builtin was newly activated. Keep the behavior of re-adding builtins during snapshot loading to ensure that bank's have the correct list of builtin programs until a builtin is removed.

Fixes https://github.com/solana-labs/solana/issues/23253
