### PR TITLE
Leader qos

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -12,6 +12,7 @@ use {
         banking_stage::{BankingStage, BankingStageStats},
         leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
         qos_service::QosService,
+        unprocessed_packet_batches::*,
     },
     solana_entry::entry::{next_hash, Entry},
     solana_gossip::cluster_info::{ClusterInfo, Node},
@@ -82,7 +83,11 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let mut packet_batches = VecDeque::new();
         for batch in batches {
             let batch_len = batch.packets.len();
-            packet_batches.push_back((batch, vec![0usize; batch_len], false));
+            packet_batches.push_back(DeserializedPacketBatch::new(
+                batch,
+                vec![0usize; batch_len],
+                false,
+            ));
         }
         let (s, _r) = unbounded();
         // This tests the performance of buffering packets.

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -105,6 +105,8 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &recorder,
                 &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
                 &mut LeaderSlotMetricsTracker::new(0),
+                Some(bank.clone()),
+                None,
             );
         });
 

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -159,7 +159,7 @@ fn bench_sigverify_stage(bencher: &mut Bencher) {
         for _ in 0..batches.len() {
             if let Some(batch) = batches.pop() {
                 sent_len += batch.packets.len();
-                packet_s.send(batch).unwrap();
+                packet_s.send(vec![batch]).unwrap();
             }
         }
         let mut received = 0;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -77,9 +77,9 @@ pub const FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET: u64 = 2;
 pub const HOLD_TRANSACTIONS_SLOT_OFFSET: u64 = 20;
 
 // Fixed thread size seems to be fastest on GCP setup
-pub const NUM_THREADS: u32 = 4;
+pub const NUM_THREADS: u32 = 8;
 
-pub const TOTAL_BUFFERED_PACKETS: usize = 500_000;
+pub const TOTAL_BUFFERED_PACKETS: usize = 250_000;
 
 const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 128;
 
@@ -398,7 +398,7 @@ impl BankingStage {
         gossip_vote_sender: ReplayVoteSender,
         cost_model: Arc<RwLock<CostModel>>,
     ) -> Self {
-        let batch_limit = TOTAL_BUFFERED_PACKETS / ((num_threads - 1) as usize * PACKETS_PER_BATCH);
+        let batch_limit = TOTAL_BUFFERED_PACKETS / ((num_threads - 2) as usize * PACKETS_PER_BATCH);
         // Single thread to generate entries from many banks.
         // This thread talks to poh_service and broadcasts the entries once they have been recorded.
         // Once an entry has been recorded, its blockhash is registered with the bank.

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2082,28 +2082,17 @@ impl BankingStage {
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) {
         if Self::packet_has_more_unprocessed_transactions(&packet_indexes) {
-            if unprocessed_packet_batches.len() >= batch_limit {
-                *dropped_packet_batches_count += 1;
-                if let Some(dropped_batch) = unprocessed_packet_batches.pop_front() {
-                    *dropped_packets_count += dropped_batch.unprocessed_packets.len();
-                    slot_metrics_tracker.increment_exceeded_buffer_limit_dropped_packets_count(
-                        dropped_batch.unprocessed_packets.len() as u64,
-                    );
-                }
-            }
             let _ = banking_stage_stats
                 .batch_packet_indexes_len
                 .increment(packet_indexes.len() as u64);
 
             *newly_buffered_packets_count += packet_indexes.len();
-            slot_metrics_tracker
-                .increment_newly_buffered_packets_count(packet_indexes.len() as u64);
 
-            unprocessed_packet_batches.push_back(DeserializedPacketBatch::new(
-                packet_batch,
-                packet_indexes,
-                false,
-            ));
+            insert_or_swap_batch(
+                unprocessed_packet_batches,
+                DeserializedPacketBatch::new(packet_batch, packet_indexes, false),
+                batch_limit,
+            );
         }
     }
 
@@ -4086,8 +4075,9 @@ mod tests {
             1,
             Hash::new_unique(),
         );
-        let packet = Packet::from_data(None, &tx).unwrap();
-        let new_packet_batch = PacketBatch::new(vec![packet; 2]);
+        let mut heavy_packet = Packet::from_data(None, &tx).unwrap();
+        heavy_packet.meta.weight = 1_000_000u64;
+        let new_packet_batch = PacketBatch::new(vec![heavy_packet; 2]);
         let mut unprocessed_packets: UnprocessedPacketBatches = vec![DeserializedPacketBatch::new(
             new_packet_batch,
             vec![0, 1],
@@ -4101,7 +4091,10 @@ mod tests {
         // Set the limit to 2
         let batch_limit = 2;
         // Create new unprocessed packets and add to a batch
-        let new_packet_batch = PacketBatch::new(vec![Packet::default()]);
+        let mut light_packet =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9001))), 42).unwrap();
+        light_packet.meta.weight = 1u64;
+        let new_packet_batch = PacketBatch::new(vec![light_packet; 3]);
         let packet_indexes = vec![];
 
         let mut dropped_packet_batches_count = 0;
@@ -4128,11 +4121,11 @@ mod tests {
 
         // Because the set of unprocessed `packet_indexes` is non-empty, the
         // packets are added to the unprocessed queue
-        let packet_indexes = vec![0];
+        let packet_indexes = vec![0, 1, 2];
         BankingStage::push_unprocessed(
             &mut unprocessed_packets,
             new_packet_batch,
-            packet_indexes.clone(),
+            packet_indexes,
             &mut dropped_packet_batches_count,
             &mut dropped_packets_count,
             &mut newly_buffered_packets_count,
@@ -4143,15 +4136,15 @@ mod tests {
         assert_eq!(unprocessed_packets.len(), 2);
         assert_eq!(dropped_packet_batches_count, 0);
         assert_eq!(dropped_packets_count, 0);
-        assert_eq!(newly_buffered_packets_count, 1);
+        assert_eq!(newly_buffered_packets_count, 3);
 
-        // Because we've reached the batch limit, old unprocessed packets are
+        // Because we've reached the batch limit, the light_weight unprocessed packets are
         // dropped and the new one is appended to the end
-        let new_packet_batch = PacketBatch::new(vec![Packet::from_data(
-            Some(&SocketAddr::from(([127, 0, 0, 1], 8001))),
-            42,
-        )
-        .unwrap()]);
+        let mut also_heavy_packet =
+            Packet::from_data(Some(&SocketAddr::from(([127, 0, 0, 1], 8001))), 42).unwrap();
+        also_heavy_packet.meta.weight = 100_000_000u64;
+        let new_packet_batch = PacketBatch::new(vec![also_heavy_packet]);
+        let packet_indexes = vec![0];
         assert_eq!(unprocessed_packets.len(), batch_limit);
         BankingStage::push_unprocessed(
             &mut unprocessed_packets,
@@ -4170,8 +4163,8 @@ mod tests {
             new_packet_batch.packets[0]
         );
         assert_eq!(dropped_packet_batches_count, 1);
-        assert_eq!(dropped_packets_count, 2);
-        assert_eq!(newly_buffered_packets_count, 2);
+        assert_eq!(dropped_packets_count, 3);
+        assert_eq!(newly_buffered_packets_count, 4);
     }
 
     #[test]

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -640,6 +640,7 @@ impl LeaderSlotMetricsTracker {
     }
 
     // Processing packets timing metrics
+    #[allow(dead_code)]
     pub(crate) fn increment_transactions_from_packets_us(&mut self, us: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             saturating_add_assign!(
@@ -671,6 +672,30 @@ impl LeaderSlotMetricsTracker {
                     .timing_metrics
                     .process_packets_timings
                     .filter_retryable_packets_us,
+                us
+            );
+        }
+    }
+
+    pub(crate) fn increment_prioritize_packets_us(&mut self, us: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .timing_metrics
+                    .process_packets_timings
+                    .prioritize_packets_us,
+                us
+            );
+        }
+    }
+
+    pub(crate) fn increment_report_sender_info_us(&mut self, us: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            saturating_add_assign!(
+                leader_slot_metrics
+                    .timing_metrics
+                    .process_packets_timings
+                    .report_sender_info_us,
                 us
             );
         }

--- a/core/src/leader_slot_banking_stage_timing_metrics.rs
+++ b/core/src/leader_slot_banking_stage_timing_metrics.rs
@@ -261,6 +261,12 @@ pub(crate) struct ProcessPacketsTimings {
     // Time spent running the cost model in processing transactions before executing
     // transactions
     pub cost_model_us: u64,
+
+    // Time spent prioritizing packets, before sending to consuming process
+    pub prioritize_packets_us: u64,
+
+    // Time soent to collect and organize packet sender info.
+    pub report_sender_info_us: u64,
 }
 
 impl ProcessPacketsTimings {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,7 @@ pub mod tpu;
 pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;
+pub mod unprocessed_packet_batches;
 pub mod validator;
 pub mod verified_vote_packets;
 pub mod vote_simulator;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod leader_slot_banking_stage_timing_metrics;
 pub mod ledger_cleanup_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
+pub mod packet_forward_manager;
 pub mod packet_hasher;
 pub mod packet_sender_info;
 pub mod progress_map;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,6 +59,7 @@ pub mod system_monitor_service;
 mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;
+pub mod transaction_weighting_stage;
 pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ledger_cleanup_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
 pub mod packet_hasher;
+pub mod packet_sender_info;
 pub mod progress_map;
 pub mod qos_service;
 pub mod repair_generic_traversal;

--- a/core/src/packet_forward_manager.rs
+++ b/core/src/packet_forward_manager.rs
@@ -1,0 +1,435 @@
+use {
+    crate::{
+        banking_stage::TOTAL_BUFFERED_PACKETS, qos_service::QosService,
+        unprocessed_packet_batches::*,
+    },
+    solana_perf::packet::Packet,
+    solana_runtime::{bank::Bank, cost_model::TransactionCost, cost_tracker::CostTracker},
+    solana_sdk::transaction::SanitizedTransaction,
+    std::sync::Arc,
+};
+
+#[derive(Debug)]
+pub struct PacketForwardManager<'a> {
+    cost_trackers: Vec<CostTracker>,
+    forwardable_packets: Vec<Vec<&'a Packet>>,
+}
+
+impl<'a> PacketForwardManager<'a> {
+    pub fn new(max_forward_block_count: u64) -> Self {
+        Self {
+            cost_trackers: (0..max_forward_block_count)
+                .into_iter()
+                .map(|_| CostTracker::default())
+                .collect(),
+            forwardable_packets: (0..max_forward_block_count)
+                .into_iter()
+                .map(|_| Vec::<&'a Packet>::new())
+                .collect(),
+        }
+    }
+
+    pub fn take(
+        &mut self,
+        unprocessed_packet_batches: &'a UnprocessedPacketBatches,
+        working_bank: Arc<Bank>,
+        qos_service: &'a QosService,
+    ) -> Vec<&'a Packet> {
+        let prioritized_forwardable_packet_locators = Self::prioritize_unforwarded_packets_by_fee(
+            unprocessed_packet_batches,
+            Some(working_bank.clone()),
+        );
+
+        // if we have a bank to work with, then sort packets by write-account buckets
+        let (transactions, sanitized_locators) = sanitize_transactions(
+            unprocessed_packet_batches,
+            &prioritized_forwardable_packet_locators,
+            &working_bank.feature_set,
+            working_bank.vote_only_bank(),
+            working_bank.as_ref(),
+        );
+        let transactions_costs = qos_service.compute_transaction_costs(transactions.iter());
+
+        transactions
+            .iter()
+            .zip(transactions_costs.iter())
+            .zip(sanitized_locators.iter())
+            .for_each(|((tx, cost), packet_locator)| {
+                if let Some(packet) =
+                    Self::locate_packet(unprocessed_packet_batches, packet_locator)
+                {
+                    self.sort_into_buckets(tx, cost, packet)
+                }
+            });
+
+        let mut result = Vec::<&'a Packet>::new();
+        self.forwardable_packets
+            .iter()
+            .for_each(|v| result.extend(v));
+        result
+    }
+
+    // prioritize unforwarded, unprocessed packets in buffered packet_batches by its fee/CU
+    fn prioritize_unforwarded_packets_by_fee(
+        unprocessed_packet_batches: &'a UnprocessedPacketBatches,
+        working_bank: Option<Arc<Bank>>,
+    ) -> Vec<PacketLocator> {
+        let mut locators = Vec::<PacketLocator>::with_capacity(TOTAL_BUFFERED_PACKETS);
+        unprocessed_packet_batches.iter().enumerate().for_each(
+            |(batch_index, deserialized_packet_batch)| {
+                if !deserialized_packet_batch.forwarded {
+                    deserialized_packet_batch
+                        .unprocessed_packets
+                        .keys()
+                        .for_each(|packet_index| {
+                            locators.push(PacketLocator {
+                                batch_index,
+                                packet_index: *packet_index,
+                            });
+                        })
+                }
+            },
+        );
+
+        prioritize_by_fee(unprocessed_packet_batches, &locators, working_bank)
+    }
+
+    fn sort_into_buckets(
+        &mut self,
+        transaction: &SanitizedTransaction,
+        cost: &TransactionCost,
+        packet: &'a Packet,
+    ) {
+        // try to sort the `transaction` into one of outbound (virtual) blocks
+        for (cost_tracker, forwardable_packets) in self
+            .cost_trackers
+            .iter_mut()
+            .zip(self.forwardable_packets.iter_mut())
+        {
+            match cost_tracker.try_add(transaction, cost) {
+                Ok(_) => {
+                    forwardable_packets.push(packet);
+                    return;
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
+    fn locate_packet(
+        unprocessed_packet_batches: &'a UnprocessedPacketBatches,
+        locator: &PacketLocator,
+    ) -> Option<&'a Packet> {
+        let deserialized_packet_batch = unprocessed_packet_batches.get(locator.batch_index)?;
+        deserialized_packet_batch.get_packet(locator.packet_index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_perf::packet::{Packet, PacketBatch},
+        solana_runtime::{
+            bank::goto_end_of_slot,
+            block_cost_limits::MAX_WRITABLE_ACCOUNT_UNITS,
+            genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
+        },
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction,
+            hash::Hash,
+            message::Message,
+            signature::{Keypair, Signer},
+            system_instruction::{self},
+            system_transaction,
+            transaction::Transaction,
+        },
+        std::net::SocketAddr,
+    };
+
+    #[test]
+    fn test_prioritize_unforwarded_packets_by_fee() {
+        solana_logger::setup();
+        let leader = solana_sdk::pubkey::new_rand();
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(1_000_000, &leader, 3);
+        genesis_config
+            .fee_rate_governor
+            .target_lamports_per_signature = 1000;
+        genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
+
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+        goto_end_of_slot(&mut bank);
+
+        let key0 = Keypair::new();
+        let key1 = Keypair::new();
+        let ix0 = system_instruction::transfer(&key0.pubkey(), &key1.pubkey(), 1);
+        let ix1 = system_instruction::transfer(&key1.pubkey(), &key0.pubkey(), 1);
+        let ix_cb = ComputeBudgetInstruction::request_units(1000, 20000);
+
+        // build a buffer of 3 packet batches, 2nd bacth is forwarded
+        let unprocessed_packets = vec![
+            DeserializedPacketBatch::new(
+                PacketBatch::new(vec![Packet::from_data(
+                    None,
+                    &Transaction::new(
+                        &[&key0],
+                        Message::new(&[ix0.clone()], Some(&key0.pubkey())),
+                        bank.last_blockhash(),
+                    ),
+                )
+                .unwrap()]),
+                vec![0],
+                false,
+            ),
+            DeserializedPacketBatch::new(
+                PacketBatch::new(vec![Packet::from_data(
+                    None,
+                    &Transaction::new(
+                        &[&key1],
+                        Message::new(&[ix1.clone()], Some(&key1.pubkey())),
+                        bank.last_blockhash(),
+                    ),
+                )
+                .unwrap()]),
+                vec![0],
+                true, // forwarded
+            ),
+            // add a packet with 2 signatures to buffer that has doubled fee, and additional fee
+            DeserializedPacketBatch::new(
+                PacketBatch::new(vec![Packet::from_data(
+                    None,
+                    &Transaction::new(
+                        &[&key0, &key1],
+                        Message::new(&[ix0, ix1, ix_cb], Some(&key0.pubkey())),
+                        bank.last_blockhash(),
+                    ),
+                )
+                .unwrap()]),
+                vec![0],
+                false,
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        {
+            // If no bank is given, fee-per-cu won't calculate, should expect output is same as input
+            let locators = vec![
+                PacketLocator {
+                    batch_index: 0,
+                    packet_index: 0,
+                },
+                PacketLocator {
+                    batch_index: 2,
+                    packet_index: 0,
+                },
+            ];
+            let prioritized_locators = PacketForwardManager::prioritize_unforwarded_packets_by_fee(
+                &unprocessed_packets,
+                None,
+            );
+            assert_eq!(locators, prioritized_locators);
+        }
+
+        {
+            // If bank is given, fee-per-cu is calculated, should expect higher fee-per-cu come
+            // out first
+            let expected_locators = vec![
+                PacketLocator {
+                    batch_index: 2,
+                    packet_index: 0,
+                },
+                PacketLocator {
+                    batch_index: 0,
+                    packet_index: 0,
+                },
+            ];
+
+            let prioritized_locators = PacketForwardManager::prioritize_unforwarded_packets_by_fee(
+                &unprocessed_packets,
+                Some(Arc::new(bank)),
+            );
+            assert_eq!(expected_locators, prioritized_locators);
+        }
+    }
+
+    #[test]
+    fn test_locate_packet() {
+        solana_logger::setup();
+        let leader = solana_sdk::pubkey::new_rand();
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(1_000_000, &leader, 3);
+        genesis_config
+            .fee_rate_governor
+            .target_lamports_per_signature = 1000;
+        genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
+
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let mut bank = Bank::new_from_parent(&Arc::new(bank), &leader, 1);
+        goto_end_of_slot(&mut bank);
+
+        let key0 = Keypair::new();
+        let key1 = Keypair::new();
+        let ix0 = system_instruction::transfer(&key0.pubkey(), &key1.pubkey(), 1);
+        let ix1 = system_instruction::transfer(&key1.pubkey(), &key0.pubkey(), 1);
+        let ix_cb = ComputeBudgetInstruction::request_units(1000, 20000);
+
+        // build a buffer of 2 packet batches, 2nd bacth is forwarded
+        let unprocessed_packets = vec![
+            DeserializedPacketBatch::new(
+                PacketBatch::new(vec![Packet::from_data(
+                    None,
+                    &Transaction::new(
+                        &[&key0],
+                        Message::new(&[ix0.clone()], Some(&key0.pubkey())),
+                        bank.last_blockhash(),
+                    ),
+                )
+                .unwrap()]),
+                vec![0],
+                false,
+            ),
+            DeserializedPacketBatch::new(
+                PacketBatch::new(vec![Packet::from_data(
+                    None,
+                    &Transaction::new(
+                        &[&key1],
+                        Message::new(&[ix1.clone()], Some(&key1.pubkey())),
+                        bank.last_blockhash(),
+                    ),
+                )
+                .unwrap()]),
+                vec![0],
+                true, // forwarded
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        // locate packet succeffully
+        assert!(PacketForwardManager::locate_packet(
+            &unprocessed_packets,
+            &PacketLocator {
+                batch_index: 1,
+                packet_index: 0
+            }
+        )
+        .is_some());
+        // batch_index out of bound
+        assert!(PacketForwardManager::locate_packet(
+            &unprocessed_packets,
+            &PacketLocator {
+                batch_index: 9,
+                packet_index: 0
+            }
+        )
+        .is_none());
+        // packet_index out of bound
+        assert!(PacketForwardManager::locate_packet(
+            &unprocessed_packets,
+            &PacketLocator {
+                batch_index: 0,
+                packet_index: 9
+            }
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_sort_into_buckets() {
+        solana_logger::setup();
+        // a dummy transaction, it doesn't really matter.
+        let dummy_tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+            Hash::new_unique(),
+        );
+        let dummy_tx = SanitizedTransaction::from_transaction_for_tests(dummy_tx);
+        // 2 writable accounts
+        let account_a = solana_sdk::pubkey::new_rand();
+        let account_b = solana_sdk::pubkey::new_rand();
+        //
+        let tx_cost_large_a = TransactionCost {
+            writable_accounts: vec![account_a.clone()],
+            execution_cost: MAX_WRITABLE_ACCOUNT_UNITS,
+            ..TransactionCost::default()
+        };
+        let tx_cost_large_ab = TransactionCost {
+            writable_accounts: vec![account_a.clone(), account_b.clone()],
+            execution_cost: MAX_WRITABLE_ACCOUNT_UNITS,
+            ..TransactionCost::default()
+        };
+        let tx_cost_small_a = TransactionCost {
+            writable_accounts: vec![account_a.clone()],
+            execution_cost: 1,
+            ..TransactionCost::default()
+        };
+        let tx_cost_small_b = TransactionCost {
+            writable_accounts: vec![account_b.clone()],
+            execution_cost: 1,
+            ..TransactionCost::default()
+        };
+        // packets
+        let packet_1 =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9001))), &42).unwrap();
+        let packet_2 =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9002))), &42).unwrap();
+        let packet_3 =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9003))), &42).unwrap();
+        let packet_4 =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9004))), &42).unwrap();
+        let packet_5 =
+            Packet::from_data(Some(&SocketAddr::from(([10, 10, 10, 1], 9005))), &42).unwrap();
+
+        // setup 2 virtual blocks, which will have two account bucket: A and B
+        // fee-sorted packets are:
+        // (large, write A, packet_1)   - will fill up A in first block
+        // (small, write B, packet_2)   - will put into B in first block
+        // (large, write AB, packet_3)  - no room for it in first block's A nor B, will fill up A
+        //                                in 2nd block
+        // (small, write B, packet_4)   - will put into B in first block
+        // (small, write A, packet_5)   - both As are filled up, this one will not be placed
+        // where 'large' is account max limit cu, 'small' is just 1 cu
+        // Expected result:
+        // block 1
+        //     A: packet_1
+        //     B: packet_2, packet_4
+        // block 2
+        //     A: packet_3
+        //     B: nil
+        let mut forwarder = PacketForwardManager::new(2);
+        forwarder.sort_into_buckets(&dummy_tx, &tx_cost_large_a, &packet_1);
+        forwarder.sort_into_buckets(&dummy_tx, &tx_cost_small_b, &packet_2);
+        forwarder.sort_into_buckets(&dummy_tx, &tx_cost_large_ab, &packet_3);
+        forwarder.sort_into_buckets(&dummy_tx, &tx_cost_small_b, &packet_4);
+        forwarder.sort_into_buckets(&dummy_tx, &tx_cost_small_a, &packet_5);
+
+        assert_eq!(3, forwarder.forwardable_packets[0].len());
+        assert_eq!(1, forwarder.forwardable_packets[1].len());
+
+        assert_eq!(&packet_1, forwarder.forwardable_packets[0][0]);
+        assert_eq!(&packet_2, forwarder.forwardable_packets[0][1]);
+        assert_eq!(&packet_4, forwarder.forwardable_packets[0][2]);
+        assert_eq!(&packet_3, forwarder.forwardable_packets[1][0]);
+
+        let mut result = Vec::<&Packet>::new();
+        forwarder
+            .forwardable_packets
+            .iter()
+            .for_each(|v| result.extend(v));
+        assert_eq!(4, result.len());
+        assert_eq!(&packet_1, result[0]);
+        assert_eq!(&packet_2, result[1]);
+        assert_eq!(&packet_4, result[2]);
+        assert_eq!(&packet_3, result[3]);
+    }
+}

--- a/core/src/packet_sender_info.rs
+++ b/core/src/packet_sender_info.rs
@@ -1,0 +1,56 @@
+/// struct PacketSenderInfo contains sender information for pakcets in baning_stage's
+/// unprocessed_buffer. It provides metrics for stake weight block packing prioritization.
+///
+use std::{collections::HashMap, net::IpAddr};
+
+#[derive(Debug, Default)]
+pub struct SenderDetailInfo {
+    pub stake: u64,
+    pub packet_count: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct PacketSenderInfo {
+    // Vec of IP of packets in banking_stage buffer, one-to-one mapped, even after shuffling.
+    pub packet_senders_ip: Vec<IpAddr>,
+    // HashMap keyed by IP, with sender's detail info as Value
+    pub senders_detail: HashMap<IpAddr, SenderDetailInfo>,
+    // implied info are:
+    // 1. packet_senders_ip.len() is the number of buffered packets subjected to this round of
+    //    processing;
+    // 2. sender_detail.values.map(|info| info.stake).sum() is the total stakes presented in buffer
+}
+
+impl PacketSenderInfo {
+    pub fn report(&self, id: u32) {
+        let tot_buffered_packet_count = self.packet_senders_ip.len();
+        let tot_buffered_stakes: u64 = self.senders_detail.values().map(|info| info.stake).sum();
+
+        for (ip, sender_info) in self.senders_detail.iter() {
+            let stake_pct = match tot_buffered_stakes == 0 {
+                true => 0.0,
+                false => sender_info.stake as f64 / tot_buffered_stakes as f64,
+            };
+            let transaction_pct = match tot_buffered_packet_count == 0 {
+                true => 0.0,
+                false => sender_info.packet_count as f64 / tot_buffered_packet_count as f64,
+            };
+
+            datapoint_info!(
+                "banking_stage-packing_sender_info",
+                ("id", id as i64, i64),
+                ("ip", ip.to_string(), String),
+                ("stake", sender_info.stake as i64, i64),
+                ("tot_buffered_stakes", tot_buffered_stakes as i64, i64),
+                ("stake_pct", stake_pct, f64),
+                ("packet_count", sender_info.packet_count as i64, i64),
+                (
+                    "tot_buffered_packet_count",
+                    tot_buffered_packet_count as i64,
+                    i64
+                ),
+                ("packet_pct", transaction_pct, f64),
+            );
+        }
+    }
+}

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -445,7 +445,7 @@ mod tests {
         for _ in 0..batches.len() {
             if let Some(batch) = batches.pop() {
                 sent_len += batch.packets.len();
-                packet_s.send(batch).unwrap();
+                packet_s.send(vec![batch]).unwrap();
             }
         }
         let mut received = 0;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -12,6 +12,7 @@ use {
         fetch_stage::FetchStage,
         sigverify::TransactionSigVerifier,
         sigverify_stage::SigVerifyStage,
+        transaction_weighting_stage::TransactionWeightStage,
     },
     crossbeam_channel::{unbounded, Receiver},
     solana_gossip::cluster_info::ClusterInfo,
@@ -52,6 +53,8 @@ pub struct Tpu {
     cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
     tpu_quic_t: thread::JoinHandle<()>,
+    transaction_weight_stage: TransactionWeightStage,
+    vote_transaction_weight_stage: TransactionWeightStage,
 }
 
 impl Tpu {
@@ -100,6 +103,25 @@ impl Tpu {
             poh_recorder,
             tpu_coalesce_ms,
         );
+
+        let (weighted_sender, weighted_receiver) = unbounded();
+
+        let transaction_weight_stage = TransactionWeightStage::new(
+            packet_receiver,
+            weighted_sender,
+            bank_forks.clone(),
+            cluster_info.clone(),
+        );
+
+        let (vote_weighted_sender, vote_weighted_receiver) = unbounded();
+
+        let vote_transaction_weight_stage = TransactionWeightStage::new(
+            vote_packet_receiver,
+            vote_weighted_sender,
+            bank_forks.clone(),
+            cluster_info.clone(),
+        );
+
         let (verified_sender, verified_receiver) = unbounded();
 
         let tpu_quic_t = solana_streamer::quic::spawn_server(
@@ -113,7 +135,7 @@ impl Tpu {
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::default();
-            SigVerifyStage::new(packet_receiver, verified_sender, verifier)
+            SigVerifyStage::new(weighted_receiver, verified_sender, verifier)
         };
 
         let (verified_tpu_vote_packets_sender, verified_tpu_vote_packets_receiver) = unbounded();
@@ -121,7 +143,7 @@ impl Tpu {
         let vote_sigverify_stage = {
             let verifier = TransactionSigVerifier::new_reject_non_vote();
             SigVerifyStage::new(
-                vote_packet_receiver,
+                vote_weighted_receiver,
                 verified_tpu_vote_packets_sender,
                 verifier,
             )
@@ -175,6 +197,8 @@ impl Tpu {
             cluster_info_vote_listener,
             broadcast_stage,
             tpu_quic_t,
+            transaction_weight_stage,
+            vote_transaction_weight_stage,
         }
     }
 
@@ -185,6 +209,8 @@ impl Tpu {
             self.vote_sigverify_stage.join(),
             self.cluster_info_vote_listener.join(),
             self.banking_stage.join(),
+            self.transaction_weight_stage.join(),
+            self.vote_transaction_weight_stage.join(),
         ];
         self.tpu_quic_t.join()?;
         let broadcast_result = self.broadcast_stage.join();

--- a/core/src/transaction_weighting_stage.rs
+++ b/core/src/transaction_weighting_stage.rs
@@ -1,0 +1,77 @@
+use {
+    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    rayon::prelude::*,
+    solana_gossip::cluster_info::ClusterInfo,
+    solana_perf::packet::PacketBatch,
+    solana_runtime::bank_forks::BankForks,
+    solana_streamer::streamer::{self, StreamerError},
+    std::{
+        collections::HashMap,
+        net::IpAddr,
+        sync::{Arc, RwLock},
+        thread::{self, Builder, JoinHandle},
+        time::Instant,
+    },
+};
+
+pub struct TransactionWeightStage {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl TransactionWeightStage {
+    pub fn new(
+        packet_receiver: Receiver<PacketBatch>,
+        sender: Sender<Vec<PacketBatch>>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        cluster_info: Arc<ClusterInfo>,
+    ) -> Self {
+        let thread_hdl = Builder::new()
+            .name("sol-tx-weight".to_string())
+            .spawn(move || {
+                let mut last_stakes = Instant::now();
+                let mut ip_to_stake: HashMap<IpAddr, u64> = HashMap::new();
+                loop {
+                    if last_stakes.elapsed().as_millis() > 1000 {
+                        let root_bank = bank_forks.read().unwrap().root_bank();
+                        let staked_nodes = root_bank.staked_nodes();
+                        ip_to_stake = cluster_info
+                            .tvu_peers()
+                            .into_iter()
+                            .filter_map(|node| {
+                                let stake = staked_nodes.get(&node.id)?;
+                                Some((node.tvu.ip(), *stake))
+                            })
+                            .collect();
+                        last_stakes = Instant::now();
+                    }
+                    match streamer::recv_packet_batches(&packet_receiver) {
+                        Ok((mut batches, _num_packets, _recv_duration)) => {
+                            Self::apply_weights(&mut batches, &ip_to_stake);
+                            if let Err(e) = sender.send(batches) {
+                                info!("Sender error: {:?}", e);
+                            }
+                        }
+                        Err(e) => match e {
+                            StreamerError::RecvTimeout(RecvTimeoutError::Disconnected) => break,
+                            StreamerError::RecvTimeout(RecvTimeoutError::Timeout) => (),
+                            _ => error!("error: {:?}", e),
+                        },
+                    }
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    fn apply_weights(batches: &mut [PacketBatch], ip_to_stake: &HashMap<IpAddr, u64>) {
+        batches.into_par_iter().for_each(|batch| {
+            batch.packets.par_iter_mut().for_each(|packet| {
+                packet.meta.weight = *ip_to_stake.get(&packet.meta.addr().ip()).unwrap_or(&0);
+            });
+        });
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,0 +1,111 @@
+use {
+    solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
+    solana_sdk::{
+        hash::Hash, message::Message, short_vec::decode_shortu16_len, signature::Signature,
+        transaction::VersionedTransaction,
+    },
+    std::{
+        collections::{HashMap, VecDeque},
+        mem::size_of,
+    },
+};
+
+// hold deserialized messages, as well as computed message_hash and other things needed to create
+// SanitizedTransaction
+#[derive(Debug, Default)]
+pub struct DeserializedPacket {
+    #[allow(dead_code)]
+    versioned_transaction: VersionedTransaction,
+
+    #[allow(dead_code)]
+    message_hash: Hash,
+
+    #[allow(dead_code)]
+    is_simple_vote: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct DeserializedPacketBatch {
+    pub packet_batch: PacketBatch,
+    pub forwarded: bool,
+    // indexes of valid packets in batch, and their corrersponding deserialized_packet
+    pub unprocessed_packets: HashMap<usize, DeserializedPacket>,
+}
+
+impl DeserializedPacketBatch {
+    pub fn new(packet_batch: PacketBatch, packet_indexes: Vec<usize>, forwarded: bool) -> Self {
+        let unprocessed_packets = Self::deserialize_packets(&packet_batch, &packet_indexes);
+        Self {
+            packet_batch,
+            unprocessed_packets,
+            forwarded,
+        }
+    }
+
+    fn deserialize_packets(
+        packet_batch: &PacketBatch,
+        packet_indexes: &[usize],
+    ) -> HashMap<usize, DeserializedPacket> {
+        let mut unprocessed_packets =
+            HashMap::<usize, DeserializedPacket>::with_capacity(packet_indexes.len());
+        packet_indexes.iter().for_each(|packet_index| {
+            // only those packets can be deserialized are considered as valid.
+            if let Some(deserialized_packet) =
+                Self::deserialize_packet(&packet_batch.packets[*packet_index])
+            {
+                unprocessed_packets.insert(*packet_index, deserialized_packet);
+            }
+        });
+        unprocessed_packets
+    }
+
+    fn deserialize_packet(packet: &Packet) -> Option<DeserializedPacket> {
+        let versioned_transaction: VersionedTransaction =
+            match limited_deserialize(&packet.data[0..packet.meta.size]) {
+                Ok(tx) => tx,
+                Err(_) => return None,
+            };
+
+        if let Some(message_bytes) = Self::packet_message(packet) {
+            let message_hash = Message::hash_raw_message(message_bytes);
+            let is_simple_vote = packet.meta.is_simple_vote_tx();
+            Some(DeserializedPacket {
+                versioned_transaction,
+                message_hash,
+                is_simple_vote,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Read the transaction message from packet data
+    fn packet_message(packet: &Packet) -> Option<&[u8]> {
+        let (sig_len, sig_size) = decode_shortu16_len(&packet.data).ok()?;
+        let msg_start = sig_len
+            .checked_mul(size_of::<Signature>())
+            .and_then(|v| v.checked_add(sig_size))?;
+        let msg_end = packet.meta.size;
+        Some(&packet.data[msg_start..msg_end])
+    }
+
+    // Returns whether the given `PacketBatch` has any more remaining unprocessed
+    // transactions
+    pub fn update_buffered_packets_with_new_unprocessed(
+        &mut self,
+        _original_unprocessed_indexes: &[usize],
+        new_unprocessed_indexes: &[usize],
+    ) -> bool {
+        let has_more_unprocessed_transactions = !new_unprocessed_indexes.is_empty();
+        if has_more_unprocessed_transactions {
+            self.unprocessed_packets
+                .retain(|index, _| new_unprocessed_indexes.contains(index));
+        } else {
+            self.unprocessed_packets.clear();
+        }
+
+        has_more_unprocessed_transactions
+    }
+}
+
+pub type UnprocessedPacketBatches = VecDeque<DeserializedPacketBatch>;

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,4 +1,8 @@
 use {
+    crate::{
+        banking_stage::TOTAL_BUFFERED_PACKETS,
+        packet_sender_info::{PacketSenderInfo, SenderDetailInfo},
+    },
     solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
     solana_sdk::{
         hash::Hash, message::Message, short_vec::decode_shortu16_len, signature::Signature,
@@ -9,6 +13,15 @@ use {
         mem::size_of,
     },
 };
+
+// To locate a packet in banking_stage's buffered packet batches.
+#[derive(Debug, Default)]
+pub struct PacketLocator {
+    #[allow(dead_code)]
+    batch_index: usize,
+    #[allow(dead_code)]
+    packet_index: usize,
+}
 
 // hold deserialized messages, as well as computed message_hash and other things needed to create
 // SanitizedTransaction
@@ -108,4 +121,146 @@ impl DeserializedPacketBatch {
     }
 }
 
+// TODO TAO - refactor type into struct
 pub type UnprocessedPacketBatches = VecDeque<DeserializedPacketBatch>;
+
+// Iterates packets in buffered batches, returns all unprocessed packet's stake,
+// and its location (batch_index plus packet_index within batch)
+pub fn get_stakes_and_locators(
+    unprocessed_packet_batches: &UnprocessedPacketBatches,
+    packet_sender_info: &mut Option<PacketSenderInfo>,
+) -> (Vec<u64>, Vec<PacketLocator>) {
+    let mut stakes = Vec::<u64>::with_capacity(TOTAL_BUFFERED_PACKETS);
+    let mut locators = Vec::<PacketLocator>::with_capacity(TOTAL_BUFFERED_PACKETS);
+
+    unprocessed_packet_batches.iter().enumerate().for_each(
+        |(batch_index, deserialized_packet_batch)| {
+            let packet_batch = &deserialized_packet_batch.packet_batch;
+            deserialized_packet_batch
+                .unprocessed_packets
+                .keys()
+                //                    .cloned()
+                //                    .collect::<Vec<usize>>();
+                //                original_unprocessed_indexes
+                //                    .iter()
+                .for_each(|packet_index| {
+                    debug!("----- packet index {}", packet_index);
+                    let p = &packet_batch.packets[*packet_index];
+                    stakes.push(p.meta.weight);
+                    locators.push(PacketLocator {
+                        batch_index,
+                        packet_index: *packet_index,
+                    });
+
+                    if let Some(packet_sender_info) = packet_sender_info {
+                        update_packet_sender_info(packet_sender_info, p);
+                    }
+                });
+        },
+    );
+
+    (stakes, locators)
+}
+
+fn update_packet_sender_info(packet_sender_info: &mut PacketSenderInfo, packet: &Packet) {
+    let ip = packet.meta.addr;
+    packet_sender_info.packet_senders_ip.push(ip);
+    let sender_detail = packet_sender_info
+        .senders_detail
+        .entry(ip)
+        .or_insert(SenderDetailInfo {
+            stake: packet.meta.weight,
+            packet_count: 0u64,
+        });
+    sender_detail.packet_count = sender_detail.packet_count.saturating_add(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{signature::Keypair, system_transaction},
+        std::net::IpAddr,
+    };
+
+    fn packet_with_weight(weight: u64, ip: IpAddr) -> Packet {
+        let tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+            Hash::new_unique(),
+        );
+        let mut packet = Packet::from_data(None, &tx).unwrap();
+        packet.meta.weight = weight;
+        packet.meta.addr = ip;
+        packet
+    }
+
+    #[test]
+    fn test_get_stakes_and_locators_with_sender_info() {
+        solana_logger::setup();
+
+        // setup senders' addr and stake
+        let senders: Vec<(IpAddr, u64)> = vec![
+            (IpAddr::from([127, 0, 0, 1]), 1),
+            (IpAddr::from([127, 0, 0, 2]), 2),
+            (IpAddr::from([127, 0, 0, 3]), 3),
+        ];
+        // create a buffer with 3 batches, each has 2 packet from above sender.
+        // so: [1, 2] [3, 1] [2, 3]
+        let batch_size = 2usize;
+        let batch_count = 3usize;
+        let unprocessed_packets = (0..batch_count)
+            .map(|batch_index| {
+                DeserializedPacketBatch::new(
+                    PacketBatch::new(
+                        (0..batch_size)
+                            .map(|packet_index| {
+                                let n = (batch_index * batch_size + packet_index) % senders.len();
+                                packet_with_weight(senders[n].1, senders[n].0)
+                            })
+                            .collect(),
+                    ),
+                    (0..batch_size).collect(),
+                    false,
+                )
+            })
+            .collect();
+        debug!("unprocessed batches: {:?}", unprocessed_packets);
+
+        let mut packet_sender_info = Some(PacketSenderInfo::default());
+
+        let (stakes, locators) =
+            get_stakes_and_locators(&unprocessed_packets, &mut packet_sender_info);
+        debug!("stakes: {:?}, locators: {:?}", stakes, locators);
+        assert_eq!(batch_size * batch_count, stakes.len());
+        assert_eq!(batch_size * batch_count, locators.len());
+        locators.iter().enumerate().for_each(|(index, locator)| {
+            assert_eq!(
+                stakes[index],
+                senders[(locator.batch_index * batch_size + locator.packet_index) % senders.len()]
+                    .1
+            );
+        });
+
+        // verify the sender info are collected correctly
+        let packet_sender_info = packet_sender_info.unwrap();
+        assert_eq!(
+            batch_size * batch_count,
+            packet_sender_info.packet_senders_ip.len()
+        );
+        locators.iter().enumerate().for_each(|(index, locator)| {
+            assert_eq!(
+                packet_sender_info.packet_senders_ip[index],
+                senders[(locator.batch_index * batch_size + locator.packet_index) % senders.len()]
+                    .0
+            );
+        });
+        assert_eq!(senders.len(), packet_sender_info.senders_detail.len());
+        senders.into_iter().for_each(|(ip, stake)| {
+            let sender_detail = packet_sender_info.senders_detail.get(&ip).unwrap();
+            assert_eq!(stake, sender_detail.stake);
+            assert_eq!(2u64, sender_detail.packet_count);
+        });
+    }
+}

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -92,7 +92,6 @@ impl CostModel {
         tx_cost.execution_cost = self.get_transaction_cost(transaction);
         tx_cost.account_data_size = self.calculate_account_data_size(transaction);
 
-        debug!("transaction {:?} has cost {:?}", transaction, tx_cost);
         tx_cost
     }
 

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -32,6 +32,7 @@ pub struct Meta {
     pub addr: IpAddr,
     pub port: u16,
     pub flags: PacketFlags,
+    pub weight: u64,
 }
 
 #[derive(Clone)]
@@ -145,6 +146,7 @@ impl Default for Meta {
             addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             port: 0,
             flags: PacketFlags::empty(),
+            weight: 0,
         }
     }
 }


### PR DESCRIPTION
#### Problem
Leader to prioritize transactions with fee-per-cu and/or sender stake weights

#### Summary of Changes
- Refactor banking_stage buffer into its own model
- Deserialize packet upon receiving into VersionedTransaction, store in buffer;
- Add tx weighting stage
- Add function to get packet locators from buffer, as well as their sender stakes;
- Add weighted shuffle function
- Add function to sanitize VersionedTransactions in chunk, 
- To drop lowe-priority packets based on eviction strategy instead of fifo, to make room for new packet_batch
- Refactor `consume_buffered_packets` to prioritize SanitizedTransactions in fee-per-cu (still wip) then stake shuffled order, send to bank for processing in chunk.
- refactor forwarding with fee-per-cu prioritization, and per write accounts.

Fixes #23207 
