### PR TITLE
disk acct idx on by default on validators and ledger-tool

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2065,6 +2065,9 @@ fn main() {
                     accounts_index_config.index_limit_mb = Some(limit);
                 } else if arg_matches.is_present("disable_accounts_disk_index") {
                     accounts_index_config.index_limit_mb = None;
+                } else {
+                    // disk acct idx on by default
+                    accounts_index_config.index_limit_mb = Some(10_000);
                 }
 
                 {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2238,6 +2238,9 @@ pub fn main() {
         accounts_index_config.index_limit_mb = Some(limit);
     } else if matches.is_present("disable_accounts_disk_index") {
         accounts_index_config.index_limit_mb = None;
+    } else {
+        // disk acct idx on by default
+        accounts_index_config.index_limit_mb = Some(10_000);
     }
 
     {


### PR DESCRIPTION
#### Problem

cancel with --disable-disk-accounts-index
override size with --accounts-index-memory-limit-mb

#24251
#### Summary of Changes

Fixes #
