### PR TITLE
(Validator) Add hidden `shred_storage` and `shred_storage_size` arguments for FIFO

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -36,7 +36,7 @@ use {
     solana_ledger::{
         bank_forks_utils,
         blockstore::{Blockstore, BlockstoreSignals, CompletedSlotsReceiver, PurgeType},
-        blockstore_db::{BlockstoreOptions, BlockstoreRecoveryMode},
+        blockstore_db::{BlockstoreOptions, BlockstoreRecoveryMode, ShredStorageType},
         blockstore_processor::{self, TransactionStatusSender},
         leader_schedule::FixedSchedule,
         leader_schedule_cache::LeaderScheduleCache,
@@ -165,6 +165,7 @@ pub struct ValidatorConfig {
     pub no_wait_for_vote_to_start_leader: bool,
     pub accounts_shrink_ratio: AccountShrinkThreshold,
     pub wait_to_vote_slot: Option<Slot>,
+    pub shred_storage_type: ShredStorageType,
 }
 
 impl Default for ValidatorConfig {
@@ -225,6 +226,7 @@ impl Default for ValidatorConfig {
             accounts_shrink_ratio: AccountShrinkThreshold::default(),
             accounts_db_config: None,
             wait_to_vote_slot: None,
+            shred_storage_type: ShredStorageType::RocksLevel,
         }
     }
 }
@@ -1256,6 +1258,7 @@ fn new_banks_from_ledger(
         BlockstoreOptions {
             recovery_mode: config.wal_recovery_mode.clone(),
             enforce_ulimit_nofile,
+            shred_storage_type: config.shred_storage_type.clone(),
             ..BlockstoreOptions::default()
         },
     )

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -35,6 +35,11 @@ use {
     thiserror::Error,
 };
 
+// The default storage size for storing shreds when `rocksdb-shred-compaction`
+// is set to `fifo` in the validator arguments.  This amount of storage size
+// in bytes will equally allocated to both data shreds and coding shreds.
+pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 * 1024;
+
 const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
 const FIFO_WRITE_BUFFER_SIZE: u64 = 2 * MAX_WRITE_BUFFER_SIZE;
 // Maximum size of cf::DataShred.  Used when `shred_storage_type`

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -62,6 +62,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_config: config.accounts_db_config.clone(),
         wait_to_vote_slot: config.wait_to_vote_slot,
+        shred_storage_type: config.shred_storage_type.clone(),
     }
 }
 


### PR DESCRIPTION
#### Summary of Changes
This PR adds two hidden arguments to the validator that allow users to use RocksDB's FIFO compaction for storing shreds.

        --shred-storage <SHRED_STORAGE>
            EXPERIMENTAL: Controls how RocksDB compacts shreds.  *WARNING*: You will lose your ledger data
            when you switch between options. Possible values are: 'level': stores shreds using RocksDB's default (level)
            compaction. 'fifo': stores shreds under RocksDB's FIFO compaction. This option is more efficient on
            disk-write-bytes of the ledger store. [default: level]  [possible values: level, fifo]

        --shred-storage-size <SHRED_STORAGE_SIZE_BYTES>
            The shred storage size in bytes. The suggested value is 50% of your ledger storage size in bytes. [default:
            268435456000]

Dependency: #23236


#### Test Plan
Run validators with the following arguments:
* without using any rocksdb-compaction-style arguments -- expect to see the existing behavior:
```
/mnt/disks/ledger/mainnet $ ls
admin.rpc  calculate_accounts_hash_cache  contact-info.bin  genesis.bin  genesis.tar.bz2  ledger.lock  rocksdb  tmp-genesis
/mnt/disks/ledger/mainnet $ cd rocksdb/
/mnt/disks/ledger/mainnet/rocksdb $ grep FIFO OPTIONS-000077
/mnt/disks/ledger/mainnet/rocksdb $
```
* run with `--rocksdb-shred-compaction fifo` and `--rocksdb-fifo-shred-storage-size 536870912000`:
  - saw `rocksdb_fifo` directory is created as expected, and FIFO compaction is used as expected as well.
```
/mnt/disks/ledger/mainnet$ ls
admin.rpc  calculate_accounts_hash_cache  contact-info.bin  genesis.bin  genesis.tar.bz2  ledger.lock  rocksdb_fifo  tmp-genesis
/mnt/disks/ledger/mainnet$  cd rocksdb_fifo/
/mnt/disks/ledger/mainnet/rocksdb_fifo $ grep FIFO OPTIONS-000077
  compaction_style=kCompactionStyleFIFO
  compaction_style=kCompactionStyleFIFO
/mnt/disks/ledger/mainnet/rocksdb_fifo $
```
* run with `--rocksdb-shred-compaction level` and expect to see the same behavior as the first one (default).