### PR TITLE
Stalebot doesn't seem to be working anymore. Close stale PRs via mergify instead

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,32 @@
 #
 # https://doc.mergify.io/
 pull_request_rules:
+  - name: add stale label
+    conditions:
+      - label≠security
+      - label≠blocked
+      - label≠stale
+      - updated-at<7 days ago
+    actions:
+      label:
+        add:
+          - stale
+      comment:
+        message:
+          This pull request has been automatically marked as stale because it has not had
+          recent activity. It will be closed if no further activity occurs.
+          Remove the `stale` label to reset.
+  - name: close stale pull request
+    conditions:
+      - label≠security
+      - label≠blocked
+      - label=stale
+      - updated-at<7 days ago
+    actions:
+      close:
+        message:
+          This stale pull request has been automatically closed.
+          Thank you for your contributions.
   - name: label changes from community
     conditions:
       - author≠@core-contributors


### PR DESCRIPTION
This version is slightly different than the stalebot version: the user needs to remove the `stale` label themselves to prevent the PR from getting closed.

It was nice how stalebot automatically removed the stale label. but I don't see how this can be implemented with the current set of mergify [conditions](https://docs.mergify.com/conditions/).

Also stale issues aren't closed since mergify only deals with pull requests, so returning to stalebot in a future would be better if/when what's broken about it can be debugged