### PR TITLE
RPC Client: Use Tokio's RwLock instead of std

### DIFF
--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -52,10 +52,9 @@ use {
         cmp::min,
         net::SocketAddr,
         str::FromStr,
-        sync::RwLock,
         time::{Duration, Instant},
     },
-    tokio::time::sleep,
+    tokio::{sync::RwLock, time::sleep},
 };
 
 /// A client of a remote Solana node.
@@ -442,12 +441,12 @@ impl RpcClient {
     }
 
     async fn get_node_version(&self) -> Result<semver::Version, RpcError> {
-        let r_node_version = self.node_version.read().unwrap();
+        let r_node_version = self.node_version.read().await;
         if let Some(version) = &*r_node_version {
             Ok(version.clone())
         } else {
             drop(r_node_version);
-            let mut w_node_version = self.node_version.write().unwrap();
+            let mut w_node_version = self.node_version.write().await;
             let node_version = self.get_version().await.map_err(|e| {
                 RpcError::RpcRequestError(format!("cluster version query failed: {}", e))
             })?;


### PR DESCRIPTION
#### Problem
Recently, the `nonblocking` version of the RPC client was added, which is great!
However, its usage of std's RwLock prevents the client from being usable in async tasks in a multi-threaded context. For example, suppose one wants to spawn a Tokio task:
```
tokio::spawn(async move {
    client
        .get_transaction(&signature, UiTransactionEncoding::JsonParsed)
        .await
})
```
one is met with following `rustc` error:
```
generator cannot be sent between threads safely
within `impl futures::Future<Output = Result<EncodedConfirmedTransactionWithStatusMeta, solana_client::client_error::ClientError>>`, the trait `std::marker::Send` is not implemented for `std::sync::RwLockWriteGuard<'_, std::option::Option<semver::Version>>
```
because std's RwLock cannot be held across `await` boundary.
Tokio's RwLock exists to address this. After this change, the above snippet compiles.

#### Summary of Changes
Simple swap of `std::sync::RwLock` => `tokio::sync::RwLock`.
