### PR TITLE
update_index uses ReadableAccount to reduce params

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -10,7 +10,7 @@ use {
             AccountSecondaryIndexes, AccountsIndex, ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS,
         },
     },
-    solana_sdk::pubkey::{self, Pubkey},
+    solana_sdk::{account::AccountSharedData, pubkey},
     test::Bencher,
 };
 
@@ -28,8 +28,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
             index.upsert(
                 f,
                 pubkey,
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 AccountInfo::default(),
                 &mut reclaims,
@@ -46,8 +45,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
             index.upsert(
                 fork,
                 &pubkeys[pubkey],
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 AccountInfo::default(),
                 &mut reclaims,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5962,8 +5962,7 @@ impl AccountsDb {
                     self.accounts_index.upsert(
                         slot,
                         pubkey,
-                        pubkey_account.1.owner(),
-                        pubkey_account.1.data(),
+                        pubkey_account.1,
                         &self.account_indexes,
                         *info,
                         &mut reclaims,
@@ -6722,8 +6721,7 @@ impl AccountsDb {
                 if secondary {
                     self.accounts_index.update_secondary_indexes(
                         &pubkey,
-                        &stored_account.account_meta.owner,
-                        stored_account.data,
+                        &stored_account,
                         &self.account_indexes,
                     );
                 }
@@ -11056,8 +11054,7 @@ pub mod tests {
         accounts_index.upsert(
             0,
             &key0,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info0,
             &mut reclaims,
@@ -11066,8 +11063,7 @@ pub mod tests {
         accounts_index.upsert(
             1,
             &key0,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info1,
             &mut reclaims,
@@ -11076,8 +11072,7 @@ pub mod tests {
         accounts_index.upsert(
             1,
             &key1,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info1,
             &mut reclaims,
@@ -11086,8 +11081,7 @@ pub mod tests {
         accounts_index.upsert(
             2,
             &key1,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info2,
             &mut reclaims,
@@ -11096,8 +11090,7 @@ pub mod tests {
         accounts_index.upsert(
             2,
             &key2,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info2,
             &mut reclaims,
@@ -11106,8 +11099,7 @@ pub mod tests {
         accounts_index.upsert(
             3,
             &key2,
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             info3,
             &mut reclaims,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -20,6 +20,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_sdk::{
+        account::ReadableAccount,
         clock::{BankId, Slot},
         pubkey::Pubkey,
     },
@@ -1602,13 +1603,15 @@ impl<T: IndexValue> AccountsIndex<T> {
     pub(crate) fn update_secondary_indexes(
         &self,
         pubkey: &Pubkey,
-        account_owner: &Pubkey,
-        account_data: &[u8],
+        account: &impl ReadableAccount,
         account_indexes: &AccountSecondaryIndexes,
     ) {
         if account_indexes.is_empty() {
             return;
         }
+
+        let account_owner = account.owner();
+        let account_data = account.data();
 
         if account_indexes.contains(&AccountIndex::ProgramId)
             && account_indexes.include_key(account_owner)
@@ -1741,8 +1744,7 @@ impl<T: IndexValue> AccountsIndex<T> {
         &self,
         slot: Slot,
         pubkey: &Pubkey,
-        account_owner: &Pubkey,
-        account_data: &[u8],
+        account: &impl ReadableAccount,
         account_indexes: &AccountSecondaryIndexes,
         account_info: T,
         reclaims: &mut SlotList<T>,
@@ -1770,7 +1772,7 @@ impl<T: IndexValue> AccountsIndex<T> {
             let r_account_maps = map.read().unwrap();
             r_account_maps.upsert(pubkey, new_item, reclaims, previous_slot_entry_was_cached);
         }
-        self.update_secondary_indexes(pubkey, account_owner, account_data, account_indexes);
+        self.update_secondary_indexes(pubkey, account, account_indexes);
     }
 
     pub fn unref_from_storage(&self, pubkey: &Pubkey) {
@@ -2030,6 +2032,7 @@ pub mod tests {
         super::*,
         crate::inline_spl_token::*,
         solana_sdk::{
+            account::{AccountSharedData, WritableAccount},
             pubkey::PUBKEY_BYTES,
             signature::{Keypair, Signer},
         },
@@ -2858,8 +2861,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3070,8 +3072,7 @@ pub mod tests {
             index.upsert(
                 slot0,
                 &key,
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 account_infos[0],
                 &mut gc,
@@ -3107,8 +3108,7 @@ pub mod tests {
             index.upsert(
                 slot1,
                 &key,
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 account_infos[1],
                 &mut gc,
@@ -3220,8 +3220,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3252,8 +3251,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3293,8 +3291,7 @@ pub mod tests {
             index.upsert(
                 root_slot,
                 &new_pubkey,
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 true,
                 &mut vec![],
@@ -3310,8 +3307,7 @@ pub mod tests {
             index.upsert(
                 root_slot,
                 &Pubkey::default(),
-                &Pubkey::default(),
-                &[],
+                &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
                 true,
                 &mut vec![],
@@ -3453,8 +3449,7 @@ pub mod tests {
         index.upsert(
             0,
             &solana_sdk::pubkey::new_rand(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3479,8 +3474,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3594,8 +3588,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3612,8 +3605,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
@@ -3636,8 +3628,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3647,8 +3638,7 @@ pub mod tests {
         index.upsert(
             1,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
@@ -3674,8 +3664,7 @@ pub mod tests {
         index.upsert(
             0,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3685,8 +3674,7 @@ pub mod tests {
         index.upsert(
             1,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             false,
             &mut gc,
@@ -3695,8 +3683,7 @@ pub mod tests {
         index.upsert(
             2,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3705,8 +3692,7 @@ pub mod tests {
         index.upsert(
             3,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3718,8 +3704,7 @@ pub mod tests {
         index.upsert(
             4,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             true,
             &mut gc,
@@ -3763,8 +3748,7 @@ pub mod tests {
         index.upsert(
             1,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             12,
             &mut gc,
@@ -3775,8 +3759,7 @@ pub mod tests {
         index.upsert(
             1,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             10,
             &mut gc,
@@ -3795,8 +3778,7 @@ pub mod tests {
         index.upsert(
             1,
             &key.pubkey(),
-            &Pubkey::default(),
-            &[],
+            &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
             9,
             &mut gc,
@@ -3871,8 +3853,13 @@ pub mod tests {
                 *slot,
                 &account_key,
                 // Make sure these accounts are added to secondary index
-                &inline_spl_token::id(),
-                &account_data,
+                &AccountSharedData::create(
+                    0,
+                    account_data.to_vec(),
+                    inline_spl_token::id(),
+                    false,
+                    0,
+                ),
                 secondary_indexes,
                 true,
                 &mut vec![],
@@ -4045,8 +4032,7 @@ pub mod tests {
         index.upsert(
             0,
             &account_key,
-            &Pubkey::default(),
-            &account_data,
+            &AccountSharedData::create(0, account_data.to_vec(), Pubkey::default(), false, 0),
             &secondary_indexes,
             true,
             &mut vec![],
@@ -4059,8 +4045,7 @@ pub mod tests {
         index.upsert(
             0,
             &account_key,
-            token_id,
-            &account_data[1..],
+            &AccountSharedData::create(0, account_data[1..].to_vec(), *token_id, false, 0),
             &secondary_indexes,
             true,
             &mut vec![],
@@ -4075,8 +4060,7 @@ pub mod tests {
         for _ in 0..2 {
             index.update_secondary_indexes(
                 &account_key,
-                token_id,
-                &account_data,
+                &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
                 &secondary_indexes,
             );
             check_secondary_index_mapping_correct(secondary_index, &[index_key], &account_key);
@@ -4092,7 +4076,11 @@ pub mod tests {
         });
         secondary_index.index.clear();
         secondary_index.reverse_index.clear();
-        index.update_secondary_indexes(&account_key, token_id, &account_data, &secondary_indexes);
+        index.update_secondary_indexes(
+            &account_key,
+            &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
+            &secondary_indexes,
+        );
         assert!(!secondary_index.index.is_empty());
         assert!(!secondary_index.reverse_index.is_empty());
         check_secondary_index_mapping_correct(secondary_index, &[index_key], &account_key);
@@ -4104,7 +4092,11 @@ pub mod tests {
         });
         secondary_index.index.clear();
         secondary_index.reverse_index.clear();
-        index.update_secondary_indexes(&account_key, token_id, &account_data, &secondary_indexes);
+        index.update_secondary_indexes(
+            &account_key,
+            &AccountSharedData::create(0, account_data.to_vec(), *token_id, false, 0),
+            &secondary_indexes,
+        );
         assert!(!secondary_index.index.is_empty());
         assert!(!secondary_index.reverse_index.is_empty());
         check_secondary_index_mapping_correct(secondary_index, &[index_key], &account_key);
@@ -4176,8 +4168,7 @@ pub mod tests {
         index.upsert(
             slot,
             &account_key,
-            token_id,
-            &account_data1,
+            &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
             &mut vec![],
@@ -4188,8 +4179,7 @@ pub mod tests {
         index.upsert(
             slot,
             &account_key,
-            token_id,
-            &account_data2,
+            &AccountSharedData::create(0, account_data2.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
             &mut vec![],
@@ -4208,8 +4198,7 @@ pub mod tests {
         index.upsert(
             later_slot,
             &account_key,
-            token_id,
-            &account_data1,
+            &AccountSharedData::create(0, account_data1.to_vec(), *token_id, false, 0),
             secondary_indexes,
             true,
             &mut vec![],


### PR DESCRIPTION
#### Problem
simplify api. update_index is about to get a new param and now have 'too many'. Other changes with traits and such have made it straightforward and efficient to pass through an account to update_index and update_secondary_index.
This seems like good api cleanup.
#### Summary of Changes

Fixes #
