### PR TITLE
(Ledger-Tool) Add compaction-style arguments to ledger-tool

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -15,8 +15,9 @@ use {
         OutputFormat,
     },
     solana_ledger::{
-        bigtable_upload::ConfirmedBlockUploadConfig, blockstore::Blockstore,
-        blockstore_options::AccessType,
+        bigtable_upload::ConfirmedBlockUploadConfig,
+        blockstore::Blockstore,
+        blockstore_options::{AccessType, ShredStorageType},
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
     solana_storage_bigtable::CredentialType,
@@ -559,7 +560,11 @@ impl BigTableSubCommand for App<'_, '_> {
     }
 }
 
-pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+pub fn bigtable_process_command(
+    ledger_path: &Path,
+    matches: &ArgMatches<'_>,
+    shred_storage_type: &ShredStorageType,
+) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let verbose = matches.is_present("verbose");
@@ -595,6 +600,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 &canonicalize_ledger_path(ledger_path),
                 AccessType::Secondary,
                 None,
+                shred_storage_type,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,6 +1,8 @@
 use {
     assert_cmd::prelude::*,
-    solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config},
+    solana_ledger::{
+        create_new_tmp_ledger, create_new_tmp_ledger_fifo, genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete
+    },
     std::process::{Command, Output},
 };
 
@@ -27,27 +29,144 @@ fn bad_arguments() {
         .success());
 }
 
-#[test]
-fn nominal() {
-    let genesis_config = create_genesis_config(100).genesis_config;
-    let ticks_per_slot = genesis_config.ticks_per_slot;
+fn nominal_test_helper(
+    ledger_path: &str,
+    ticks: usize,
+    use_default_shred_compaction: bool,
+    compatible_shred_compaction: &str,
+    incompatible_shred_compaction: &str,
+) {
     let meta_lines = 2;
     let summary_lines = 1;
 
-    let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
-    let ticks = ticks_per_slot as usize;
-
-    let ledger_path = ledger_path.to_str().unwrap();
-
     // Basic validation
-    let output = run_ledger_tool(&["-l", ledger_path, "verify"]);
+    if use_default_shred_compaction {
+        let output = run_ledger_tool(&["-l", ledger_path, "verify"]);
+        assert!(output.status.success());
+    }
+
+    // Repeat by manually specifying rocksdb-shred-compaction
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        compatible_shred_compaction,
+        "verify",
+    ]);
     assert!(output.status.success());
+
+    // Repeat with an incompatible shred compaction setting and expect failure
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        incompatible_shred_compaction,
+        "verify",
+    ]);
+    assert!(!output.status.success());
 
     // Print everything
-    let output = run_ledger_tool(&["-l", ledger_path, "print", "-vvv"]);
+    if use_default_shred_compaction {
+        let output = run_ledger_tool(&["-l", ledger_path, "print", "-vvv"]);
+        assert!(output.status.success());
+        assert!(count_newlines(&output.stdout) >= meta_lines + summary_lines);
+        assert_eq!(
+            count_newlines(&output.stdout).saturating_sub(meta_lines + summary_lines),
+            ticks
+        );
+    }
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        compatible_shred_compaction,
+        "print",
+        "-vvv",
+    ]);
     assert!(output.status.success());
+    assert!(count_newlines(&output.stdout) >= meta_lines + summary_lines);
     assert_eq!(
-        count_newlines(&output.stdout),
-        ticks + meta_lines + summary_lines
+        count_newlines(&output.stdout).saturating_sub(meta_lines + summary_lines),
+        ticks
     );
+}
+
+#[test]
+fn nominal_default() {
+    let genesis_config = create_genesis_config(100).genesis_config;
+    let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
+    nominal_test_helper(
+        ledger_path.to_str().unwrap(),
+        genesis_config.ticks_per_slot as usize,
+        true, // use_default_shred_compaction
+        "level",
+        "fifo",
+    );
+}
+
+#[test]
+fn nominal_fifo() {
+    let genesis_config = create_genesis_config(100).genesis_config;
+    let (ledger_path, _blockhash) = create_new_tmp_ledger_fifo!(&genesis_config);
+    nominal_test_helper(
+        ledger_path.to_str().unwrap(),
+        genesis_config.ticks_per_slot as usize,
+        false, // use_default_shred_compaction
+        "fifo",
+        "level",
+    );
+}
+
+fn copy_test_helper(src_shred_compaction: &str, dst_shred_compaction: &str) {
+    let genesis_config = create_genesis_config(100).genesis_config;
+    let (ledger_path, _blockhash) = match src_shred_compaction {
+        "fifo" => create_new_tmp_ledger_fifo!(&genesis_config),
+        _ => create_new_tmp_ledger!(&genesis_config),
+    };
+    let ledger_path = ledger_path.to_str().unwrap();
+    let target_ledger_path = get_tmp_ledger_path_auto_delete!();
+    let target_ledger_path = target_ledger_path.path().to_str().unwrap();
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        src_shred_compaction,
+        "copy",
+        "--target-db",
+        target_ledger_path,
+        "--target-rocksdb-shred-compaction",
+        dst_shred_compaction,
+        "--ending-slot",
+        "1",
+    ]);
+    assert!(output.status.success());
+    let src_slot_output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        src_shred_compaction,
+        "slot",
+        "0",
+    ]);
+
+    let dst_slot_output = run_ledger_tool(&[
+        "-l",
+        target_ledger_path,
+        "--rocksdb-shred-compaction",
+        dst_shred_compaction,
+        "slot",
+        "0",
+    ]);
+    assert!(src_slot_output.status.success());
+    assert!(dst_slot_output.status.success());
+    assert!(!src_slot_output.stdout.is_empty());
+    assert_eq!(src_slot_output.stdout, dst_slot_output.stdout);
+}
+
+#[test]
+fn copy_test() {
+    copy_test_helper("level", "level");
+    copy_test_helper("level", "fifo");
+    copy_test_helper("fifo", "level");
+    copy_test_helper("fifo", "fifo");
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3919,6 +3919,22 @@ macro_rules! create_new_tmp_ledger {
 }
 
 #[macro_export]
+macro_rules! create_new_tmp_ledger_fifo {
+    ($genesis_config:expr) => {
+        $crate::blockstore::create_new_ledger_from_name(
+            $crate::tmp_ledger_name!(),
+            $genesis_config,
+            $crate::blockstore_options::LedgerColumnOptions {
+                shred_storage_type: $crate::blockstore_options::ShredStorageType::RocksFifo(
+                    $crate::blockstore_options::BlockstoreRocksFifoOptions::default(),
+                ),
+                ..$crate::blockstore_options::LedgerColumnOptions::default()
+            },
+        )
+    };
+}
+
+#[macro_export]
 macro_rules! create_new_tmp_ledger_auto_delete {
     ($genesis_config:expr) => {
         $crate::blockstore::create_new_ledger_from_name_auto_delete(

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -155,24 +155,18 @@ pub struct BlockstoreRocksFifoOptions {
     pub shred_code_cf_size: u64,
 }
 
-// Maximum size of cf::DataShred.  Used when `shred_storage_type`
-// is set to ShredStorageType::RocksFifo.  The default value is set
-// to 125GB, assuming 500GB total storage for ledger and 25% is
-// used by data shreds.
-const DEFAULT_FIFO_COMPACTION_DATA_CF_SIZE: u64 = 125 * 1024 * 1024 * 1024;
-// Maximum size of cf::CodeShred.  Used when `shred_storage_type`
-// is set to ShredStorageType::RocksFifo.  The default value is set
-// to 100GB, assuming 500GB total storage for ledger and 20% is
-// used by coding shreds.
-const DEFAULT_FIFO_COMPACTION_CODING_CF_SIZE: u64 = 100 * 1024 * 1024 * 1024;
+// The default storage size for storing shreds when `rocksdb-shred-compaction`
+// is set to `fifo` in the validator arguments.  This amount of storage size
+// in bytes will equally allocated to both data shreds and coding shreds.
+pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 * 1024;
 
 impl Default for BlockstoreRocksFifoOptions {
     fn default() -> Self {
         Self {
             // Maximum size of cf::ShredData.
-            shred_data_cf_size: DEFAULT_FIFO_COMPACTION_DATA_CF_SIZE,
+            shred_data_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
             // Maximum size of cf::ShredCode.
-            shred_code_cf_size: DEFAULT_FIFO_COMPACTION_CODING_CF_SIZE,
+            shred_code_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
         }
     }
 }

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -133,6 +133,15 @@ impl Default for ShredStorageType {
     }
 }
 
+impl ShredStorageType {
+    /// Returns ShredStorageType::RocksFifo where the specified
+    /// `shred_storage_size` is equally allocated to shred_data_cf_size
+    /// and shred_code_cf_size.
+    pub fn rocks_fifo(shred_storage_size: u64) -> ShredStorageType {
+        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::new(shred_storage_size))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BlockstoreRocksFifoOptions {
     // The maximum storage size for storing data shreds in column family
@@ -162,11 +171,15 @@ pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 *
 
 impl Default for BlockstoreRocksFifoOptions {
     fn default() -> Self {
+        BlockstoreRocksFifoOptions::new(DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES)
+    }
+}
+
+impl BlockstoreRocksFifoOptions {
+    fn new(shred_storage_size: u64) -> Self {
         Self {
-            // Maximum size of cf::ShredData.
-            shred_data_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
-            // Maximum size of cf::ShredCode.
-            shred_code_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
+            shred_data_cf_size: shred_storage_size / 2,
+            shred_code_cf_size: shred_storage_size / 2,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -30,12 +30,9 @@ use {
         validator::{is_snapshot_config_valid, Validator, ValidatorConfig, ValidatorStartProgress},
     },
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
-    solana_ledger::{
-        blockstore_db::DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
-        blockstore_options::{
-            BlockstoreCompressionType, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-            LedgerColumnOptions, ShredStorageType,
-        },
+    solana_ledger::blockstore_options::{
+        BlockstoreCompressionType, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
+        LedgerColumnOptions, ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_perf::recycler::enable_recycler_warming,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -31,8 +31,8 @@ use {
     },
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::blockstore_options::{
-        BlockstoreCompressionType, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-        LedgerColumnOptions, ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+        BlockstoreCompressionType, BlockstoreRecoveryMode, LedgerColumnOptions, ShredStorageType,
+        DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_perf::recycler::enable_recycler_warming,
@@ -2765,10 +2765,7 @@ pub fn main() {
                 "fifo" => {
                     let shred_storage_size =
                         value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);
-                    ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
-                        shred_data_cf_size: shred_storage_size / 2,
-                        shred_code_cf_size: shred_storage_size / 2,
-                    })
+                    ShredStorageType::rocks_fifo(shred_storage_size)
                 }
                 _ => panic!(
                     "Unrecognized rocksdb-shred-compaction: {}",


### PR DESCRIPTION
#### Summary of Changes
In #23236, specifying a different shred storage type of the ledger will store rocksdb in different directories.
This PR adds relevant arguments to the ledger-tool to enable specifying FIFO.

The `copy` tool also takes additional arguments to specify the shred storage type of the target db, allowing
users to migrate from one storage type to another.
