### PR TITLE
plumbing for 'other_slot' in 'update_index'

### DIFF
--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -27,6 +27,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
         for pubkey in pubkeys.iter().take(NUM_PUBKEYS) {
             index.upsert(
                 f,
+                f,
                 pubkey,
                 &AccountSharedData::default(),
                 &AccountSecondaryIndexes::default(),
@@ -43,6 +44,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
         for _p in 0..NUM_PUBKEYS {
             let pubkey = thread_rng().gen_range(0, NUM_PUBKEYS);
             index.upsert(
+                fork,
                 fork,
                 &pubkeys[pubkey],
                 &AccountSharedData::default(),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5969,6 +5969,7 @@ impl AccountsDb {
                     let pubkey = pubkey_account.0;
                     self.accounts_index.upsert(
                         slot,
+                        slot,
                         pubkey,
                         pubkey_account.1,
                         &self.account_indexes,
@@ -11060,6 +11061,7 @@ pub mod tests {
         let mut reclaims = vec![];
         accounts_index.upsert(
             0,
+            0,
             &key0,
             &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
@@ -11069,6 +11071,7 @@ pub mod tests {
         );
         accounts_index.upsert(
             1,
+            1,
             &key0,
             &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
@@ -11077,6 +11080,7 @@ pub mod tests {
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
         accounts_index.upsert(
+            1,
             1,
             &key1,
             &AccountSharedData::default(),
@@ -11087,6 +11091,7 @@ pub mod tests {
         );
         accounts_index.upsert(
             2,
+            2,
             &key1,
             &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
@@ -11096,6 +11101,7 @@ pub mod tests {
         );
         accounts_index.upsert(
             2,
+            2,
             &key2,
             &AccountSharedData::default(),
             &AccountSecondaryIndexes::default(),
@@ -11104,6 +11110,7 @@ pub mod tests {
             UPSERT_PREVIOUS_SLOT_ENTRY_WAS_CACHED_FALSE,
         );
         accounts_index.upsert(
+            3,
             3,
             &key2,
             &AccountSharedData::default(),

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -343,6 +343,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         &self,
         pubkey: &Pubkey,
         new_value: PreAllocatedAccountMapEntry<T>,
+        other_slot: Option<Slot>,
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,
     ) {
@@ -352,6 +353,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 Self::lock_and_update_slot_list(
                     entry,
                     new_value.into(),
+                    other_slot,
                     reclaims,
                     previous_slot_entry_was_cached,
                 );
@@ -368,6 +370,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         Self::lock_and_update_slot_list(
                             current,
                             new_value.into(),
+                            other_slot,
                             reclaims,
                             previous_slot_entry_was_cached,
                         );
@@ -401,6 +404,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                                 Self::lock_and_update_slot_list(
                                     &disk_entry,
                                     new_value.into(),
+                                    other_slot,
                                     reclaims,
                                     previous_slot_entry_was_cached,
                                 );
@@ -440,6 +444,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     pub fn lock_and_update_slot_list(
         current: &AccountMapEntryInner<T>,
         new_value: (Slot, T),
+        other_slot: Option<Slot>,
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,
     ) {
@@ -449,6 +454,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
             &mut slot_list,
             slot,
             new_entry,
+            other_slot,
             reclaims,
             previous_slot_entry_was_cached,
         );
@@ -466,6 +472,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         list: &mut SlotList<T>,
         slot: Slot,
         account_info: T,
+        _other_slot: Option<Slot>,
         reclaims: &mut SlotList<T>,
         previous_slot_entry_was_cached: bool,
     ) -> bool {
@@ -531,6 +538,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 InMemAccountsIndex::lock_and_update_slot_list(
                     occupied.get(),
                     (slot, account_info),
+                    None,
                     &mut Vec::default(),
                     false,
                 );
@@ -557,6 +565,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         InMemAccountsIndex::lock_and_update_slot_list(
                             &disk_entry,
                             (slot, account_info),
+                            None,
                             &mut Vec::default(),
                             false,
                         );
@@ -612,6 +621,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         &mut slot_list,
                         slot,
                         account_info,
+                        None,
                         reclaims,
                         previous_slot_entry_was_cached,
                     );


### PR DESCRIPTION
#### Problem
prep for #23311

this is used by ancient append vecs. Broken out here because of all the files and tests it touches.

#### Summary of Changes

Fixes #
