### PR TITLE
Update derivation path integer sign specification

### DIFF
--- a/docs/src/wallet-guide/hardware-wallets.md
+++ b/docs/src/wallet-guide/hardware-wallets.md
@@ -37,7 +37,7 @@ usb://<MANUFACTURER>[/<WALLET_ID>][?key=<DERIVATION_PATH>]
 
 `DERVIATION_PATH` is used to navigate to Solana keys within your hardware wallet.
 The path has the form `<ACCOUNT>[/<CHANGE>]`, where each `ACCOUNT` and `CHANGE`
-are positive integers.
+are nonnegative integers.
 
 For example, a fully qualified URL for a Ledger device might be:
 


### PR DESCRIPTION
#### Problem

Previously, `ACCOUNT` and `CHANGE` were specified as being positive integers, but since both can assume a value of 0 (as in the given example), they should be specified as nonnegative integers

#### Summary of Changes

Change the word "positive" to "nonnegative"

Fixes #
