### PR TITLE
Refresh blockhash for fee calculations in solana-tokens

### DIFF
--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         args::{DistributeTokensArgs, SplTokenArgs},
-        commands::{Allocation, Error, FundingSource},
+        commands::{get_fees_for_messages, Allocation, Error, FundingSource},
     },
     console::style,
     solana_account_decoder::parse_token::{
@@ -93,14 +93,7 @@ pub fn check_spl_token_balances(
         .as_ref()
         .expect("spl_token_args must be some");
     let allocation_amount: u64 = allocations.iter().map(|x| x.amount).sum();
-
-    let fees: u64 = messages
-        .iter()
-        .map(|message| client.get_fee_for_message(message))
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap()
-        .iter()
-        .sum();
+    let fees = get_fees_for_messages(messages, client)?;
 
     let token_account_rent_exempt_balance =
         client.get_minimum_balance_for_rent_exemption(SplTokenAccount::LEN)?;


### PR DESCRIPTION
#### Problem
Solana-tokens balance checks can panic on invalid-blockhash. This could happen if (a) RPC is behind a load-balancer, and getLatestBlockhash and getFeeForMessage are routed to different nodes; or (b) the distribution list is so long that the blockhash expires mid-checks. This PR adds some improvement for (b).

#### Summary of Changes
Refresh blockhash on some interval while performing balance checks.
If it is ever desired to make solana-tokens perform fewer RPC requests, `send_messages()` could be updated to use a similar slower blockhash refresh.

Fixes #22900
