### PR TITLE
Narrow scope of client_targets build

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
      - master
+    paths:
+      - "client/**"
+      - "sdk/**"
+      - ".github/workflows/client-targets.yml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
As @CriesofCarrots points out [here](https://github.com/solana-labs/solana/pull/22931#issuecomment-1050366367), the client_targets build is a little to eager.  Only trigger it when files under `client/` or `sdk/` are changed.