### PR TITLE
wip: don't update rent epoch for exempt accts

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1637,6 +1637,7 @@ mod tests {
                 lamports_per_byte_year: 42,
                 ..Rent::default()
             },
+            true,
         );
         let min_balance = rent_collector.rent.minimum_balance(NonceState::size());
         let nonce = Keypair::new();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6913,11 +6913,13 @@ impl AccountsDb {
         }
         let max_slot = slots.last().cloned().unwrap_or_default();
         let schedule = genesis_config.epoch_schedule;
+        let update_rent_epoch_on_exempt = true; // depends on feature activation
         let rent_collector = RentCollector::new(
             schedule.get_epoch(max_slot),
             &schedule,
             genesis_config.slots_per_year(),
             &genesis_config.rent,
+            update_rent_epoch_on_exempt,
         );
         let accounts_data_len = AtomicU64::new(0);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1165,6 +1165,8 @@ pub struct Bank {
     /// initialized from genesis
     epoch_schedule: EpochSchedule,
 
+    update_rent_epoch_on_exempt: bool,
+
     /// inflation specs
     inflation: Arc<RwLock<Inflation>>,
 
@@ -1316,6 +1318,7 @@ impl Bank {
 
     fn default_with_accounts(accounts: Accounts) -> Self {
         let bank = Self {
+            update_rent_epoch_on_exempt: true, // feature activation
             rc: BankRc::new(accounts, Slot::default()),
             src: StatusCacheRc::default(),
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
@@ -1631,6 +1634,7 @@ impl Bank {
             Measure::this(|_| parent.feature_set.clone(), (), "feature_set_creation");
 
         let mut new = Bank {
+            update_rent_epoch_on_exempt: true, // feature activation
             rc,
             src,
             slot,
@@ -1927,6 +1931,7 @@ impl Bank {
             T::default()
         }
         let mut bank = Self {
+            update_rent_epoch_on_exempt: true, // feature activation
             rc: bank_rc,
             src: new(),
             blockhash_queue: RwLock::new(fields.blockhash_queue),
@@ -3100,6 +3105,7 @@ impl Bank {
             &self.epoch_schedule,
             self.slots_per_year,
             &genesis_config.rent,
+            self.update_rent_epoch_on_exempt,
         );
 
         // Add additional builtin programs specified in the genesis config

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -305,7 +305,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "HVyzePMkma8T54PymRW32FAgDXpSdom59K6RnPsCNJjj")]
+    #[frozen_abi(digest = "B7AcgRQV6M4YookAYogeF4SVffdpwBjYeWrFD4EnuunH")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem
The goal is to stop updating rent epoch each epoch for rent exempt accounts. There is some complexity to when rent_exempt is updated during the slots of an epoch. Since exempt accounts never set rent_epoch to epoch+1, the epoch remains at the current epoch during each epoch. rent_epoch is always either (0, epoch-1, epoch) for exempt accounts. If we just treat everything that is not epoch+1 as 'epoch' and assume we could at most be 1 epoch away from the last time we collected rent, then we can simplify the states.
#### Summary of Changes

Fixes #
