### PR TITLE
Code cleanup: In vote and stake processor

### DIFF
--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -11,8 +11,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         genesis_config::GenesisConfig,
-        instruction::InstructionError,
-        keyed_account::KeyedAccount,
         stake::config::{self, Config},
     },
 };
@@ -21,13 +19,6 @@ pub fn from<T: ReadableAccount>(account: &T) -> Option<Config> {
     get_config_data(account.data())
         .ok()
         .and_then(|data| deserialize(data).ok())
-}
-
-pub fn from_keyed_account(account: &KeyedAccount) -> Result<Config, InstructionError> {
-    if !config::check_id(account.unsigned_key()) {
-        return Err(InstructionError::InvalidArgument);
-    }
-    from(&*account.try_account_ref()?).ok_or(InstructionError::InvalidArgument)
 }
 
 pub fn create_account(lamports: u64, config: &Config) -> AccountSharedData {
@@ -47,15 +38,11 @@ pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_sdk::pubkey::Pubkey, std::cell::RefCell};
+    use {super::*, std::cell::RefCell};
 
     #[test]
     fn test() {
         let account = RefCell::new(create_account(0, &Config::default()));
         assert_eq!(from(&account.borrow()), Some(Config::default()));
-        assert_eq!(
-            from_keyed_account(&KeyedAccount::new(&Pubkey::default(), false, &account)),
-            Err(InstructionError::InvalidArgument)
-        );
     }
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -133,16 +133,14 @@ pub fn process_instruction(
                 keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?,
                 invoke_context,
             )?;
-            me.delegate(
-                vote,
-                &clock,
-                &stake_history,
-                &config::from_keyed_account(keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account + 4,
-                )?)?,
-                &signers,
-            )
+            let config_account =
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 4)?;
+            if !config::check_id(config_account.unsigned_key()) {
+                return Err(InstructionError::InvalidArgument);
+            }
+            let config = config::from(&*config_account.try_account_ref()?)
+                .ok_or(InstructionError::InvalidArgument)?;
+            me.delegate(vote, &clock, &stake_history, &config, &signers)
         }
         StakeInstruction::Split(lamports) => {
             let split_stake =

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -122,7 +122,6 @@ fn bench_process_vote_instruction(
 }
 
 #[bench]
-#[ignore]
 fn bench_process_vote(bencher: &mut Bencher) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_accounts) =
         create_accounts();
@@ -151,7 +150,6 @@ fn bench_process_vote(bencher: &mut Bencher) {
 }
 
 #[bench]
-#[ignore]
 fn bench_process_vote_state_update(bencher: &mut Bencher) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_accounts) =
         create_accounts();


### PR DESCRIPTION
#### Problem
Some left over TODOs from other PRs.

#### Summary of Changes
- (Re)enable benchmarks of vote processor.
- Inline `from_keyed_account()` in stake instruction.

Fixes #
