### PR TITLE
separated text for versions <=1.9.6 and >= 1.9.7 (still missing link for >=1.9.7)

### DIFF
--- a/docs/src/developing/runtime-facilities/programs.md
+++ b/docs/src/developing/runtime-facilities/programs.md
@@ -21,7 +21,8 @@ Create new accounts, allocate account data, assign accounts to owning programs,
 transfer lamports from System Program owned accounts and pay transaction fees.
 
 - Program id: `11111111111111111111111111111111`
-- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_sdk/system_instruction/enum.SystemInstruction.html)
+- Instructions (1.9.6 and lower): [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_sdk/system_instruction/enum.SystemInstruction.html)
+- Instructions (1.9.7 and upper): LINK
 
 ## Config Program
 


### PR DESCRIPTION
#### Problem
broken link for version >=1.9.7 for the SystemInstruction docs
#### Summary of Changes
added separate text for both versions (<=1.9.6) and (>=1.9.7), but still missing link to docs for versions >=1.9.7
Fixes #
added separate text to differentiate both versions

**Please comment the link for the >=1.9.7 versions so I can finish this issue**