### PR TITLE
Made GenericTokenAccount public 

### DIFF
--- a/runtime/src/inline_spl_token.rs
+++ b/runtime/src/inline_spl_token.rs
@@ -23,7 +23,7 @@ pub const SPL_TOKEN_ACCOUNT_MINT_OFFSET: usize = 0;
 pub const SPL_TOKEN_ACCOUNT_OWNER_OFFSET: usize = 32;
 const SPL_TOKEN_ACCOUNT_LENGTH: usize = 165;
 
-pub(crate) trait GenericTokenAccount {
+pub trait GenericTokenAccount {
     fn valid_account_data(account_data: &[u8]) -> bool;
 
     // Call after account length has already been verified


### PR DESCRIPTION
Made GenericTokenAccount public so that plugin can use it instead of duplicating the same code.

#### Problem

#### Summary of Changes

Fixes #
