### PR TITLE
Allow sub-rent-exempt-minimum transfers to `1nc1nerator`

### DIFF
--- a/runtime/src/account_rent_state.rs
+++ b/runtime/src/account_rent_state.rs
@@ -79,7 +79,7 @@ pub(crate) fn check_rent_state_with_account(
     account_state: &AccountSharedData,
 ) -> Result<()> {
     submit_rent_state_metrics(pre_rent_state, post_rent_state);
-    if !post_rent_state.transition_allowed_from(pre_rent_state) {
+    if !is_incinerator(address) && !post_rent_state.transition_allowed_from(pre_rent_state) {
         debug!(
             "Account {} not rent exempt, state {:?}",
             address, account_state,
@@ -87,6 +87,10 @@ pub(crate) fn check_rent_state_with_account(
         return Err(TransactionError::InvalidRentPayingAccount);
     }
     Ok(())
+}
+
+fn is_incinerator(address: &Pubkey) -> bool {
+    address == &solana_sdk::incinerator::id()
 }
 
 #[cfg(test)]

--- a/runtime/src/account_rent_state.rs
+++ b/runtime/src/account_rent_state.rs
@@ -79,7 +79,9 @@ pub(crate) fn check_rent_state_with_account(
     account_state: &AccountSharedData,
 ) -> Result<()> {
     submit_rent_state_metrics(pre_rent_state, post_rent_state);
-    if !is_incinerator(address) && !post_rent_state.transition_allowed_from(pre_rent_state) {
+    if !solana_sdk::incinerator::check_id(address)
+        && !post_rent_state.transition_allowed_from(pre_rent_state)
+    {
         debug!(
             "Account {} not rent exempt, state {:?}",
             address, account_state,
@@ -87,10 +89,6 @@ pub(crate) fn check_rent_state_with_account(
         return Err(TransactionError::InvalidRentPayingAccount);
     }
     Ok(())
-}
-
-fn is_incinerator(address: &Pubkey) -> bool {
-    address == &solana_sdk::incinerator::id()
 }
 
 #[cfg(test)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -16725,6 +16725,28 @@ pub(crate) mod tests {
         ));
     }
 
+    // Ensure System transfers of any size can be made to the incinerator
+    #[test]
+    fn test_rent_state_incinerator() {
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(sol_to_lamports(100.), &Pubkey::new_unique(), 42);
+        genesis_config.rent = Rent::default();
+        let rent_exempt_minimum = genesis_config.rent.minimum_balance(0);
+
+        // Activate features, including require_rent_exempt_accounts
+        activate_all_features(&mut genesis_config);
+
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        for amount in [rent_exempt_minimum - 1, rent_exempt_minimum] {
+            bank.transfer(amount, &mint_keypair, &solana_sdk::incinerator::id())
+                .unwrap();
+        }
+    }
+
     #[test]
     fn test_rent_state_list_len() {
         let GenesisConfigInfo {


### PR DESCRIPTION
#### Problem
`require_rent_exempt_accounts` prevents most small transfers (< 0.00089088 SOL) to incinerator. This is because the incinerator is emptied every block, and so the first transfer is seen as creating a new account.

#### Summary of Changes
Special case `1nc1nerator11111111111111111111111111111111` to allow all transfers, regardless of size or rent-exempt status
