### PR TITLE
client: expose creating `RpcClient`s with custom `RpcSender` impls

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -163,7 +163,7 @@ impl RpcClient {
     /// `RpcSender`. Most applications should use one of the other constructors,
     /// such as [`new`] and [`new_mock`], which create an `RpcClient`
     /// encapsulating an [`HttpSender`] and [`MockSender`] respectively.
-    fn new_sender<T: RpcSender + Send + Sync + 'static>(
+    pub fn new_sender<T: RpcSender + Send + Sync + 'static>(
         sender: T,
         config: RpcClientConfig,
     ) -> Self {

--- a/client/src/rpc_sender.rs
+++ b/client/src/rpc_sender.rs
@@ -29,7 +29,7 @@ pub struct RpcTransportStats {
 /// [`HttpSender`]: crate::http_sender::HttpSender
 /// [`MockSender`]: crate::mock_sender::MockSender
 #[async_trait]
-pub(crate) trait RpcSender {
+pub trait RpcSender {
     async fn send(
         &self,
         request: RpcRequest,


### PR DESCRIPTION
#### Problem

No way to instantiate an `RpcClient` with custom authentication logic

#### Summary of Changes

In lieu of https://github.com/solana-labs/solana/issues/17631, make `RpcClient::new_sender` pub
