### PR TITLE
added more intuitive error message

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2142,7 +2142,7 @@ impl Blockstore {
         w_active_transaction_status_index: &RwLockWriteGuard<Slot>,
     ) -> Result<u64> {
         let i = **w_active_transaction_status_index;
-        let mut index_meta = self.transaction_status_index_cf.get(i)?.unwrap();
+        let mut index_meta = self.transaction_status_index_cf.get(i)?.unwrap().expect("No local snapshots or ledger state available.");
         if slot > index_meta.max_slot {
             assert!(!index_meta.frozen);
             index_meta.max_slot = slot;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2142,7 +2142,7 @@ impl Blockstore {
         w_active_transaction_status_index: &RwLockWriteGuard<Slot>,
     ) -> Result<u64> {
         let i = **w_active_transaction_status_index;
-        let mut index_meta = self.transaction_status_index_cf.get(i)?.unwrap().expect("No local snapshots or ledger state available.");
+        let mut index_meta = self.transaction_status_index_cf.get(i)?.expect("No local snapshots or ledger state available.");
         if slot > index_meta.max_slot {
             assert!(!index_meta.frozen);
             index_meta.max_slot = slot;


### PR DESCRIPTION
#### Problem
confusing error description from blockstore.rs  running a validator with `--no-snapshot-fetch`, but no local snapshots or ledger state.
#### Summary of Changes
added a more intuitive error message

Fixes #
