### PR TITLE
Change Blockstore TryPrimaryThenSecondary to Secondary only

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -582,7 +582,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let force_reupload = arg_matches.is_present("force_reupload");
             let blockstore = crate::open_blockstore(
                 &canonicalize_ledger_path(ledger_path),
-                AccessType::TryPrimaryThenSecondary,
+                AccessType::Secondary,
                 None,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -515,7 +515,7 @@ impl Blockstore {
     /// compaction.
     ///
     /// To disable RocksDB's background compaction, open the Blockstore
-    /// with AccessType::PrimaryOnlyForMaintenance.
+    /// with AccessType::PrimaryForMaintenance.
     pub fn set_no_compaction(&mut self, no_compaction: bool) {
         self.no_compaction = no_compaction;
     }
@@ -3198,6 +3198,7 @@ impl Blockstore {
         shred_code_cf.get_int_property(RocksProperties::TOTAL_SST_FILES_SIZE)
     }
 
+    /// Returns whether the blockstore has primary (read and write) access
     pub fn is_primary_access(&self) -> bool {
         self.db.is_primary_access()
     }
@@ -3796,7 +3797,7 @@ pub fn create_new_ledger(
     let blockstore = Blockstore::open_with_options(
         ledger_path,
         BlockstoreOptions {
-            access_type: AccessType::PrimaryOnly,
+            access_type: AccessType::Primary,
             recovery_mode: None,
             enforce_ulimit_nofile: false,
             column_options: column_options.clone(),

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -440,15 +440,15 @@ pub mod columns {
     // - Account for column in `analyze_storage()` in ledger-tool/src/main.rs
 }
 
+#[derive(Clone, Debug, PartialEq)]
 pub enum AccessType {
-    PrimaryOnly,
-    PrimaryOnlyForMaintenance, // this indicates no compaction
-    TryPrimaryThenSecondary,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum ActualAccessType {
+    /// Primary (read/write) access; only one process can have Primary access.
     Primary,
+    /// Primary (read/write) access with RocksDB automatic compaction disabled.
+    PrimaryForMaintenance,
+    /// Secondary (read) access; multiple processes can have Secondary access.
+    /// Additionally, Secondary access can be obtained while another process
+    /// already has Primary access.
     Secondary,
 }
 
@@ -514,73 +514,66 @@ impl OldestSlot {
 #[derive(Debug)]
 struct Rocks {
     db: rocksdb::DB,
-    actual_access_type: ActualAccessType,
+    access_type: AccessType,
     oldest_slot: OldestSlot,
     column_options: LedgerColumnOptions,
 }
 
 impl Rocks {
     fn open(path: &Path, options: BlockstoreOptions) -> Result<Rocks> {
-        let access_type = &options.access_type;
+        let access_type = options.access_type.clone();
         let recovery_mode = options.recovery_mode.clone();
 
         fs::create_dir_all(&path)?;
 
         // Use default database options
-        if should_disable_auto_compactions(access_type) {
-            warn!("Disabling rocksdb's auto compaction for maintenance bulk ledger update...");
+        if should_disable_auto_compactions(&access_type) {
+            info!("Disabling rocksdb's automatic compactions...");
         }
-        let mut db_options = get_db_options(access_type);
+        let mut db_options = get_db_options(&access_type);
         if let Some(recovery_mode) = recovery_mode {
             db_options.set_wal_recovery_mode(recovery_mode.into());
         }
-
         let oldest_slot = OldestSlot::default();
-        let cf_descriptors = Self::cf_descriptors(&options, &oldest_slot);
-        let cf_names = Self::columns();
         let column_options = options.column_options.clone();
 
         // Open the database
         let db = match access_type {
-            AccessType::PrimaryOnly | AccessType::PrimaryOnlyForMaintenance => Rocks {
-                db: DB::open_cf_descriptors(&db_options, path, cf_descriptors)?,
-                actual_access_type: ActualAccessType::Primary,
+            AccessType::Primary | AccessType::PrimaryForMaintenance => Rocks {
+                db: DB::open_cf_descriptors(
+                    &db_options,
+                    path,
+                    Self::cf_descriptors(&options, &oldest_slot),
+                )?,
+                access_type: access_type.clone(),
                 oldest_slot,
                 column_options,
             },
-            AccessType::TryPrimaryThenSecondary => {
-                match DB::open_cf_descriptors(&db_options, path, cf_descriptors) {
-                    Ok(db) => Rocks {
-                        db,
-                        actual_access_type: ActualAccessType::Primary,
-                        oldest_slot,
-                        column_options,
-                    },
-                    Err(err) => {
-                        let secondary_path = path.join("solana-secondary");
+            AccessType::Secondary => {
+                let secondary_path = path.join("solana-secondary");
 
-                        warn!("Error when opening as primary: {}", err);
-                        warn!("Trying as secondary at : {:?}", secondary_path);
-                        warn!("This active secondary db use may temporarily cause the performance of another db use (like by validator) to degrade");
+                info!(
+                    "Opening Rocks with secondary (read only) access at: {:?}",
+                    secondary_path
+                );
+                info!("This secondary access could temporarily degrade other accesses, such as by solana-validator");
 
-                        Rocks {
-                            db: DB::open_cf_as_secondary(
-                                &db_options,
-                                path,
-                                &secondary_path,
-                                cf_names.clone(),
-                            )?,
-                            actual_access_type: ActualAccessType::Secondary,
-                            oldest_slot,
-                            column_options,
-                        }
-                    }
+                Rocks {
+                    db: DB::open_cf_descriptors_as_secondary(
+                        &db_options,
+                        path,
+                        &secondary_path,
+                        Self::cf_descriptors(&options, &oldest_slot),
+                    )?,
+                    access_type: access_type.clone(),
+                    oldest_slot,
+                    column_options,
                 }
             }
         };
-        // this is only needed for LedgerCleanupService. so guard with PrimaryOnly (i.e. running solana-validator)
-        if matches!(access_type, AccessType::PrimaryOnly) {
-            for cf_name in cf_names {
+        // This is only needed by solana-validator for LedgerCleanupService so guard with AccessType::Primary
+        if matches!(access_type, AccessType::Primary) {
+            for cf_name in Self::columns() {
                 // these special column families must be excluded from LedgerCleanupService's rocksdb
                 // compactions
                 if should_exclude_from_compaction(cf_name) {
@@ -764,7 +757,8 @@ impl Rocks {
     }
 
     fn is_primary_access(&self) -> bool {
-        self.actual_access_type == ActualAccessType::Primary
+        self.access_type == AccessType::Primary
+            || self.access_type == AccessType::PrimaryForMaintenance
     }
 
     /// Retrieves the specified RocksDB integer property of the current
@@ -2013,7 +2007,7 @@ impl Default for LedgerColumnOptions {
 }
 
 pub struct BlockstoreOptions {
-    // The access type of blockstore. Default: PrimaryOnly
+    // The access type of blockstore. Default: Primary
     pub access_type: AccessType,
     // Whether to open a blockstore under a recovery mode. Default: None.
     pub recovery_mode: Option<BlockstoreRecoveryMode>,
@@ -2026,7 +2020,7 @@ impl Default for BlockstoreOptions {
     /// The default options are the values used by [`Blockstore::open`].
     fn default() -> Self {
         Self {
-            access_type: AccessType::PrimaryOnly,
+            access_type: AccessType::Primary,
             recovery_mode: None,
             enforce_ulimit_nofile: true,
             column_options: LedgerColumnOptions::default(),
@@ -2929,8 +2923,9 @@ fn get_db_options(access_type: &AccessType) -> Options {
 
 // Returns whether automatic compactions should be disabled based upon access type
 fn should_disable_auto_compactions(access_type: &AccessType) -> bool {
-    // Disable automatic compactions in maintenance mode to prevent accidental cleaning
-    matches!(access_type, AccessType::PrimaryOnlyForMaintenance)
+    // Leave automatic compactions enabled (do not disable) in Primary mode;
+    // disable in all other modes to prevent accidental cleaning
+    !matches!(access_type, AccessType::Primary)
 }
 
 // Returns whether the supplied column (name) should be excluded from compaction
@@ -3015,6 +3010,15 @@ pub mod tests {
             Rocks::columns().len(),
             Rocks::cf_descriptors(&options, &oldest_slot).len()
         );
+    }
+
+    #[test]
+    fn test_should_disable_auto_compactions() {
+        assert!(!should_disable_auto_compactions(&AccessType::Primary));
+        assert!(should_disable_auto_compactions(
+            &AccessType::PrimaryForMaintenance
+        ));
+        assert!(should_disable_auto_compactions(&AccessType::Secondary));
     }
 
     #[test]

--- a/local-cluster/tests/local_cluster_flakey.rs
+++ b/local-cluster/tests/local_cluster_flakey.rs
@@ -9,12 +9,7 @@ use {
     log::*,
     serial_test::serial,
     solana_core::validator::ValidatorConfig,
-    solana_ledger::{
-        ancestor_iterator::AncestorIterator,
-        blockstore::Blockstore,
-        blockstore_db::{AccessType, BlockstoreOptions},
-        leader_schedule::FixedSchedule,
-    },
+    solana_ledger::{ancestor_iterator::AncestorIterator, leader_schedule::FixedSchedule},
     solana_local_cluster::{
         cluster::Cluster,
         local_cluster::{ClusterConfig, LocalCluster},
@@ -334,16 +329,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
 
         if let Some((last_vote, _)) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
             a_votes.push(last_vote);
-            let blockstore = Blockstore::open_with_options(
-                &val_a_ledger_path,
-                BlockstoreOptions {
-                    access_type: AccessType::TryPrimaryThenSecondary,
-                    recovery_mode: None,
-                    enforce_ulimit_nofile: true,
-                    ..BlockstoreOptions::default()
-                },
-            )
-            .unwrap();
+            let blockstore = open_blockstore(&val_a_ledger_path);
             let mut ancestors = AncestorIterator::new(last_vote, &blockstore);
             if ancestors.any(|a| votes_on_c_fork.contains(&a)) {
                 bad_vote_detected = true;


### PR DESCRIPTION
#### Problem
The `AccessType` enum specifies different modes of opening RocksDB. As of right now, there are three values that function as follows
- `PrimaryOnly` ==> Gives read+write access, this is what a running validator process has/needs
- `PrimaryOnlyForMaintenance` ==> Gives read+write access, used by `ledger-tool purge` only
- `TryPrimaryThenSecondary` ==> Tries to open with primary access, but opens secondary if primary fails. Primary will fail if the ledger is already open (ie by the validator process), so this mode allows `ledger-tool` operations while the validator is still running.
   - If Primary succeeds, read+write access is obtained
   - If Primary fails and Secondary succeeds, only read access is obtained (Secondary is inherently read-only)

If a use case is fine with secondary, we shouldn't give that use case primary access ever. Furthermore, restricting primary access will prevent unintended changes to the blockstore. For example, running `solana-ledger-tool verify` could result in slots being marked dead; this could be confusing to a user, especially if it could only happen some of the time (when the validator is running such that `verify` would get secondary access).

#### Summary of Changes
- Replace `TryPrimaryThenSecondary` with `Secondary` and use `Primary` in ledger-tool only when absolutely necessary
- Disable automatic compactions in `Secondary` (accomplished by passing cf_descriptors to open function)
- Guard more blockstore operations in blockstore_processor with `is_primary()`
   - Also demote some assertions to warnings such that `verify` can run in read-only mode without asserting

~~This PR is based upon https://github.com/solana-labs/solana/pull/23390 right now.~~

Fixes #19952 
