### PR TITLE
Improve UX querying rpc for blocks at or before the snapshot from boot

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1944,9 +1944,13 @@ impl Blockstore {
         self.block_height_cf.put(slot, &block_height)
     }
 
+    /// The first complete block that is available in the Blockstore ledger
     pub fn get_first_available_block(&self) -> Result<Slot> {
         let mut root_iterator = self.rooted_slot_iterator(self.lowest_slot())?;
-        Ok(root_iterator.next().unwrap_or_default())
+        // The block at root-index 0 cannot be complete, because it is missing its parent
+        // blockhash. A parent blockhash must be calculated from the entries of the previous block.
+        // Therefore, the first available complete block is that at root-index 1.
+        Ok(root_iterator.nth(1).unwrap_or_default())
     }
 
     pub fn get_rooted_block(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7365,8 +7365,6 @@ pub mod tests {
                 )
                 .unwrap();
         }
-        // Purge to freeze index 0
-        blockstore.run_purge(0, 1, PurgeType::PrimaryIndex).unwrap();
         let slot1 = 20;
         for x in 5..9 {
             let signature = Signature::new(&[x; 64]);
@@ -7515,8 +7513,6 @@ pub mod tests {
                 )
                 .unwrap();
         }
-        // Purge to freeze index 0
-        blockstore.run_purge(0, 1, PurgeType::PrimaryIndex).unwrap();
         for x in 7..9 {
             let signature = Signature::new(&[x; 64]);
             blockstore
@@ -7574,6 +7570,9 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
+        let (shreds, _) = make_slot_entries(1, 0, 4);
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+
         fn make_slot_entries_with_transaction_addresses(addresses: &[Pubkey]) -> Vec<Entry> {
             let mut entries: Vec<Entry> = Vec::new();
             for address in addresses {
@@ -7601,11 +7600,7 @@ pub mod tests {
             let shreds = entries_to_test_shreds(&entries, slot, slot - 1, true, 0);
             blockstore.insert_shreds(shreds, None, false).unwrap();
 
-            for (i, entry) in entries.into_iter().enumerate() {
-                if slot == 4 && i == 2 {
-                    // Purge to freeze index 0 and write address-signatures in new primary index
-                    blockstore.run_purge(0, 1, PurgeType::PrimaryIndex).unwrap();
-                }
+            for entry in entries.into_iter() {
                 for transaction in entry.transactions {
                     assert_eq!(transaction.signatures.len(), 1);
                     blockstore


### PR DESCRIPTION
#### Problem
When an RPC node not backed by bigtable boots from a snapshot and fresh ledger, it initially reports `null` for `getBlock` requests for all slots <= snapshot slot + 1. This is because:
1. For the case of slots <= snapshot_slot: When a node starts from a snapshot and empty ledger, the `Blockstore::lowest_cleanup_slot` reports 0. This is the field that RPC checks for the `RpcCustomError::BlockCleanedUp` error, so it doesn't know that the snapshot slot and older slots aren't available. This persists until the first ledger prune occurs.
2. For the case of slot == snapshot_slot +1: RPC now requires that blocks queried from Blockstore be complete, including the parent_blockhash. Parent_blockhashes are figured from slot entries, so this value isn't available for the snapshot slot.

#### Summary of Changes
- Update `Blockstore::get_first_available_block` to be root at index 1, instead of index 0, so that the value reflects the first completely available block
- Use get_first_available_block in `JsonRpcRequestProcessor::check_slot_cleaned_up()` and return `RpcCustomError::BlockCleanedUp` when older blocks are queried. This new case needs to cover both Err and Ok cases to handle `Blockstore::get_complete_block` and `Blockstore::get_block_time` responses, respectively. Regarding the error message: technically these blocks haven't been cleaned up... they never existed on this node. But this seems most consistent with the spirit of the error to me, and less confusing than it would be to have the error message change after the first prune.

Note: these changes do not affect nodes with bigtable backing, since all methods query bigtable and return early before reaching `check_slot_cleaned_up()`
