### PR TITLE
docs: add web3 source docs copy

### DIFF
--- a/docs/src/developing/clients/javascript-api.md
+++ b/docs/src/developing/clients/javascript-api.md
@@ -6,6 +6,8 @@ title: Web3 JavaScript API
 
 The Solana-Web3.js library aims to provide complete coverage of Solana. The library was built on top of the [Solana JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api).
 
+You can find the full documentation for the `@solana/web3.js` library [here](https://solana-labs.github.io/solana-web3.js/).
+
 ## Common Terminology
 
 | Term | Definition |

--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -4,6 +4,10 @@ title: Web3 API Reference
 
 ## Web3 API Reference Guide
 
+The `@solana/web3.js` library is a package that has coverage over the [Solana JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api).
+
+You can find the full documentation for the `@solana/web3.js` library [here](https://solana-labs.github.io/solana-web3.js/).
+
 ## General
 
 ### Connection


### PR DESCRIPTION
#### Problem

There wasn't a direct link to the full typedocs for web3 on either of the javascript documentation pages

#### Summary of Changes

Added links + copy
