### PR TITLE
fix(explorer): retry should trigger loading state

### DIFF
--- a/explorer/src/providers/stats/SolanaPingProvider.tsx
+++ b/explorer/src/providers/stats/SolanaPingProvider.tsx
@@ -82,15 +82,15 @@ export function SolanaPingProvider({ children }: Props) {
   React.useEffect(() => {
     const url = getPingUrl(cluster);
 
-    setRollup({
-      status: PingStatus.Loading,
-    });
-
     if (!url) {
       return;
     }
 
     const fetchPingMetrics = () => {
+      setRollup({
+        status: PingStatus.Loading,
+      });
+
       fetch(url)
         .then((res) => {
           return res.json();


### PR DESCRIPTION
#### Problem
The retry button on the solana ping stats widget does not re-enter loading state.

#### Summary of Changes
Make loading state happen on retry.

Fixes #
