### PR TITLE
ledger tool halt at slot verify hash

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1374,6 +1374,8 @@ fn load_frozen_forks(
             )?;
 
             if slot >= dev_halt_at_slot {
+                bank.force_flush_accounts_cache();
+                let _ = bank.verify_bank_hash(false);
                 break;
             }
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5777,7 +5777,7 @@ impl Bank {
     /// snapshot.
     /// Only called from startup or test code.
     #[must_use]
-    fn verify_bank_hash(&self, test_hash_calculation: bool) -> bool {
+    pub fn verify_bank_hash(&self, test_hash_calculation: bool) -> bool {
         self.rc.accounts.verify_bank_hash_and_lamports(
             self.slot(),
             &self.ancestors,


### PR DESCRIPTION
#### Problem
When --halt-at-slot is passed to ledger_tool, ledger processing stops at the specified slot. It is quite useful to get the hash of the final state of the accounts at that slot.
#### Summary of Changes
flush the cache and calculate the hash
Fixes #
