### PR TITLE
include version in typedoc for web3.js

### DIFF
--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -42,7 +42,7 @@
     "clean": "rimraf ./coverage ./lib",
     "codecov": "set -ex; npm run test:cover; cat ./coverage/lcov.info | codecov",
     "dev": "cross-env NODE_ENV=development rollup -c",
-    "doc": "set -ex; typedoc --treatWarningsAsErrors",
+    "doc": "set -ex; typedoc --treatWarningsAsErrors  --includeVersion",
     "flow:check": "flow check-contents < module.flow.js",
     "flow:gen": "flowgen lib/index.d.ts -o module.flow.js",
     "type:gen": "./scripts/typegen.sh",


### PR DESCRIPTION
#### Problem

I was referencing the docs and got pretty confused and it turns out I was on a different version

#### Summary of Changes

Add ` --includeVersion` to typedoc command