### PR TITLE
Remove failure audit ignore

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -8,11 +8,6 @@ src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
 cargo_audit_ignores=(
-  # failure is officially deprecated/unmaintained
-  #
-  # Blocked on multiple upstream crates removing their `failure` dependency.
-  --ignore RUSTSEC-2020-0036
-
   # `net2` crate has been deprecated; use `socket2` instead
   #
   # Blocked on https://github.com/paritytech/jsonrpc/issues/575


### PR DESCRIPTION
https://github.com/solana-labs/solana/pull/23346 removed our last dependency on the unmaintained `failure` crate, so we can remove the `--ignore` from our CI audit job!
