### PR TITLE
Restore solana-test-validator informational output

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -113,7 +113,7 @@ pub fn format_name_value(name: &str, value: &str) -> String {
 }
 /// Pretty print a "name value"
 pub fn println_name_value(name: &str, value: &str) {
-    format_name_value(name, value);
+    println!("{}", format_name_value(name, value));
 }
 
 /// Creates a new process bar for processing that will take an unknown amount of time


### PR DESCRIPTION
b44f40ee3af8e8711ddfbe37cb70d750abbcc572 broke the solana-test-validator informational output, fix it