### PR TITLE
Fix: instruction_account_indices in builtin programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -525,7 +525,7 @@ fn process_loader_upgradeable_instruction(
             )?;
         }
         UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
-            instruction_context.check_number_of_instruction_accounts(1)?;
+            instruction_context.check_number_of_instruction_accounts(4)?;
             let programdata_address = *instruction_context.get_instruction_account_key(
                 transaction_context,
                 upgradeable_ins_acc_idx::DeployWithMaxDataLen::ProgramData as usize,
@@ -717,7 +717,7 @@ fn process_loader_upgradeable_instruction(
             ic_logger_msg!(log_collector, "Deployed program {:?}", new_program_id);
         }
         UpgradeableLoaderInstruction::Upgrade => {
-            instruction_context.check_number_of_instruction_accounts(1)?;
+            instruction_context.check_number_of_instruction_accounts(3)?;
             let current_programdata_address = *instruction_context.get_instruction_account_key(
                 transaction_context,
                 upgradeable_ins_acc_idx::Upgrade::ProgramData as usize,


### PR DESCRIPTION
#### Problem
The review of #23056 found some incorrect assertions about the number of instruction accounts.

#### Summary of Changes
- Increases `check_number_of_instruction_accounts()` in BPF loader.

Fixes #
