### PR TITLE
feat(explorer): reenable solana ping widget

### DIFF
--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -18,6 +18,7 @@ import { useVoteAccounts } from "providers/accounts/vote-accounts";
 import { CoingeckoStatus, useCoinGecko } from "utils/coingecko";
 import { Epoch } from "components/common/Epoch";
 import { TimestampToggle } from "components/common/TimestampToggle";
+import { SolanaPingCard } from "components/SolanaPingCard";
 
 const CLUSTER_STATS_TIMEOUT = 5000;
 
@@ -36,7 +37,7 @@ export function ClusterStatsPage() {
         <StatsCardBody />
       </div>
       <TpsCard />
-      {/* <SolanaPingCard /> */}
+      <SolanaPingCard />
     </div>
   );
 }

--- a/explorer/src/providers/stats/index.tsx
+++ b/explorer/src/providers/stats/index.tsx
@@ -1,7 +1,12 @@
+import { SolanaPingProvider } from "providers/stats/SolanaPingProvider";
 import React from "react";
 import { SolanaClusterStatsProvider } from "./solanaClusterStats";
 
 type Props = { children: React.ReactNode };
 export function StatsProvider({ children }: Props) {
-  return <SolanaClusterStatsProvider>{children}</SolanaClusterStatsProvider>;
+  return (
+    <SolanaClusterStatsProvider>
+      <SolanaPingProvider>{children}</SolanaPingProvider>
+    </SolanaClusterStatsProvider>
+  );
 }


### PR DESCRIPTION
#### Problem
We will reactivate the Solana Ping chart now that the server should be able to handle load.

#### Summary of Changes
* Reenable
* Query server only when cluster stats is actie

Fixes #
