### PR TITLE
Skip initial clean/shrink if starting from a locally-produced snapshot #23452

### DIFF
--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -79,7 +79,7 @@ impl PartialOrd for FullSnapshotArchiveInfo {
     }
 }
 
-// Order `FullSnapshotArchiveInfo` by slot (ascending), which practially is sorting chronologically
+// Order `FullSnapshotArchiveInfo` by slot (ascending), which practically is sorting chronologically
 impl Ord for FullSnapshotArchiveInfo {
     fn cmp(&self, other: &Self) -> Ordering {
         self.slot().cmp(&other.slot())
@@ -141,7 +141,7 @@ impl PartialOrd for IncrementalSnapshotArchiveInfo {
 }
 
 // Order `IncrementalSnapshotArchiveInfo` by base slot (ascending), then slot (ascending), which
-// practially is sorting chronologically
+// practically is sorting chronologically
 impl Ord for IncrementalSnapshotArchiveInfo {
     fn cmp(&self, other: &Self) -> Ordering {
         self.base_slot()

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -130,13 +130,15 @@ pub struct SnapshotPackage {
 }
 
 impl SnapshotPackage {
-    pub fn is_full_snapshot(&self) -> bool {
-        self.path()
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .starts_with("snapshot")
+    pub fn get_snapshot_type(&self) -> Option<SnapshotType> {
+        let file_name = self.path().file_name().unwrap().to_str().unwrap();
+        if file_name.starts_with("snapshot") {
+            Some(SnapshotType::FullSnapshot)
+        } else if file_name.starts_with("incremental-snapshot") {
+            Some(SnapshotType::IncrementalSnapshot(0))
+        } else {
+            None
+        }
     }
 }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -129,6 +129,17 @@ pub struct SnapshotPackage {
     pub snapshot_type: SnapshotType,
 }
 
+impl SnapshotPackage {
+    pub fn is_full_snapshot(&self) -> bool {
+        self.path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("snapshot")
+    }
+}
+
 impl From<AccountsPackage> for SnapshotPackage {
     fn from(accounts_package: AccountsPackage) -> Self {
         assert!(

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -129,19 +129,6 @@ pub struct SnapshotPackage {
     pub snapshot_type: SnapshotType,
 }
 
-impl SnapshotPackage {
-    pub fn get_snapshot_type(&self) -> Option<SnapshotType> {
-        let file_name = self.path().file_name().unwrap().to_str().unwrap();
-        if file_name.starts_with("snapshot") {
-            Some(SnapshotType::FullSnapshot)
-        } else if file_name.starts_with("incremental-snapshot") {
-            Some(SnapshotType::IncrementalSnapshot(0))
-        } else {
-            None
-        }
-    }
-}
-
 impl From<AccountsPackage> for SnapshotPackage {
     fn from(accounts_package: AccountsPackage) -> Self {
         assert!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -397,16 +397,7 @@ pub fn archive_snapshot_package(
         ("size", metadata.len(), i64)
     );
 
-    if parse_full_snapshot_archive_filename(
-        snapshot_package
-            .path()
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap(),
-    )
-    .is_ok()
-    {
+    if snapshot_package.is_full_snapshot() {
         info!("Create snapshot local file in {:?}", tar_dir);
         create_local_snapshot_file(tar_dir)?;
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -54,8 +54,10 @@ pub const TMP_SNAPSHOT_ARCHIVE_PREFIX: &str = "tmp-snapshot-archive-";
 pub const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8; // Save some bank snapshots but not too many
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 2;
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = 4;
-pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^snapshot-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$";
-pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = r"^incremental-snapshot-(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$";
+pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_PREFIX: &str = r"snapshot-";
+pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_PREFIX: &str = r"incremental-snapshot-";
+pub const FULL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = concat!("^", FULL_SNAPSHOT_ARCHIVE_FILENAME_PREFIX, "(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$");
+pub const INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_REGEX: &str = concat!("^", INCREMENTAL_SNAPSHOT_ARCHIVE_FILENAME_PREFIX,"(?P<base>[[:digit:]]+)-(?P<slot>[[:digit:]]+)-(?P<hash>[[:alnum:]]+)\.(?P<ext>tar|tar\.bz2|tar\.zst|tar\.gz)$";
 pub const LOCAL_SNAPSHOT_FILE_NAME: &str = ".local_snapshot";
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
@@ -397,9 +399,11 @@ pub fn archive_snapshot_package(
         ("size", metadata.len(), i64)
     );
 
-    if snapshot_package.is_full_snapshot() {
-        info!("Create snapshot local file in {:?}", tar_dir);
-        create_local_snapshot_file(tar_dir)?;
+    if let Some(snapshot_type) = snapshot_package.get_snapshot_type() {
+        if snapshot_type.is_full_snapshot() {
+            info!("Create snapshot local file in {:?}", tar_dir);
+            create_local_snapshot_file(tar_dir)?;
+        }
     }
     Ok(())
 }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1437,6 +1437,10 @@ mod with_incremental_snapshots {
             }
         }
 
+        info!("Delete snapshot local file {:?}", snapshot_archives_dir);
+        if let Err(e) = snapshot_utils::delete_snapshot_local_file(snapshot_archives_dir) {
+            info!("Unable to delete local snapshot file: {:?}", e);
+        }
         Ok(())
     }
 

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1438,7 +1438,7 @@ mod with_incremental_snapshots {
         }
 
         info!("Delete snapshot local file {:?}", snapshot_archives_dir);
-        if let Err(e) = snapshot_utils::delete_snapshot_local_file(snapshot_archives_dir) {
+        if let Err(e) = snapshot_utils::delete_local_snapshot_file(snapshot_archives_dir) {
             info!("Unable to delete local snapshot file: {:?}", e);
         }
         Ok(())

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1437,9 +1437,12 @@ mod with_incremental_snapshots {
             }
         }
 
-        info!("Delete snapshot local file {:?}", snapshot_archives_dir);
+        info!(
+            "Delete snapshot local file {}",
+            snapshot_archives_dir.display()
+        );
         if let Err(e) = snapshot_utils::delete_local_snapshot_file(snapshot_archives_dir) {
-            info!("Unable to delete local snapshot file: {:?}", e);
+            info!("Unable to delete local snapshot file: {}", e);
         }
         Ok(())
     }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/23452

Accounts DB cleaning and shrinking takes up a significant portion of the start up time.

#### Summary of Changes

There are 3 places to change.
1. Accounts DB: When loading Accounts DB from snapshot, it will check if an empty file `.local_snapshot` exists to skip cleaning and shrinking.
2.  bootstrap: if we decide to download the snapshot from remote, it will delete `.local_snapshot` files. So that, Accounts DB will do cleaning and shrinking.
3. snapshot archiver: When it successfully archive a snapshot, it will also create the empty  `.local_snapshot` file.

Fixes #
N/A
