### PR TITLE
Test stake split: destination delegation is at least the minimum

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -6802,6 +6802,7 @@ mod tests {
                                 expected_destination_stake_delegation,
                                 destination_stake.delegation.stake
                             );
+                            assert!(destination_stake.delegation.stake >= MINIMUM_STAKE_DELEGATION,);
                         } else {
                             panic!("destination state must be StakeStake::Stake after successful split when source is also StakeState::Stake!");
                         }


### PR DESCRIPTION
#### Problem

There is a test gap in case the minimum stake delegation is raised, to ensure that the destination stake delegation ends up being at least the minimum.

Thanks to @joncinque for identifying this potential issue here: https://github.com/solana-labs/solana/pull/22663#discussion_r818061753

#### Summary of Changes

Update test to ensure the destination stake delegation is at least the minimum stake delegation after splitting.

Ran this locally after increasing `MINIMUM_STAKE_DELEGATION` and confirmed that the tests fail as expected. Fixing the future test failures is being tracked in #23458.

#### Miscellaneous

This is PR number 23456!