### PR TITLE
cargo-build-sbf, cargo-test-sbf: add --arch option

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -33,6 +33,7 @@ struct Config<'a> {
     verbose: bool,
     workspace: bool,
     jobs: Option<String>,
+    arch: &'a str,
 }
 
 impl Default for Config<'_> {
@@ -57,6 +58,7 @@ impl Default for Config<'_> {
             verbose: false,
             workspace: false,
             jobs: None,
+            arch: "sbf",
         }
     }
 }
@@ -539,6 +541,17 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
         env::remove_var("RUSTC")
     }
 
+    let mut target_rustflags = env::var("CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS")
+        .ok()
+        .unwrap_or_default();
+    if config.arch == "sbfv2" {
+        target_rustflags = format!("{} {}", "-C target_cpu=sbfv2", target_rustflags);
+        env::set_var(
+            "CARGO_TARGET_SBF_SOLANA_SOLANA_RUSTFLAGS",
+            &target_rustflags,
+        );
+    }
+
     let cargo_build = PathBuf::from("cargo");
     let mut cargo_build_args = vec![
         "+sbf",
@@ -547,6 +560,9 @@ fn build_sbf_package(config: &Config, target_directory: &Path, package: &cargo_m
         "sbf-solana-solana",
         "--release",
     ];
+    if config.arch == "sbfv2" {
+        cargo_build_args.push("-Zbuild-std=std,panic_abort");
+    }
     if config.no_default_features {
         cargo_build_args.push("--no-default-features");
     }
@@ -830,6 +846,13 @@ fn main() {
                 .validator(|val| val.parse::<usize>().map_err(|e| e.to_string()))
                 .help("Number of parallel jobs, defaults to # of CPUs"),
         )
+        .arg(
+            Arg::new("arch")
+                .long("arch")
+                .possible_values(&["sbf", "sbfv2"])
+                .default_value("sbf")
+                .help("Build for the given SBF version"),
+        )
         .get_matches_from(args);
 
     let sbf_sdk: PathBuf = matches.value_of_t_or_exit("sbf_sdk");
@@ -866,6 +889,7 @@ fn main() {
         verbose: matches.is_present("verbose"),
         workspace: matches.is_present("workspace"),
         jobs: matches.value_of_t("jobs").ok(),
+        arch: matches.value_of("arch").unwrap(),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
     if config.verbose {

--- a/sdk/cargo-test-sbf/src/main.rs
+++ b/sdk/cargo-test-sbf/src/main.rs
@@ -10,7 +10,7 @@ use {
     },
 };
 
-struct Config {
+struct Config<'a> {
     sbf_sdk: Option<String>,
     sbf_out_dir: Option<String>,
     cargo: PathBuf,
@@ -25,9 +25,10 @@ struct Config {
     verbose: bool,
     workspace: bool,
     jobs: Option<String>,
+    arch: &'a str,
 }
 
-impl Default for Config {
+impl Default for Config<'_> {
     fn default() -> Self {
         Self {
             sbf_sdk: None,
@@ -44,6 +45,7 @@ impl Default for Config {
             verbose: false,
             workspace: false,
             jobs: None,
+            arch: "sbf",
         }
     }
 }
@@ -128,6 +130,9 @@ fn test_sbf_package(config: &Config, target_directory: &Path, package: &cargo_me
     }
     build_sbf_args.push("--sbf-out-dir");
     build_sbf_args.push(&sbf_out_dir);
+
+    build_sbf_args.push("--arch");
+    build_sbf_args.push(config.arch);
 
     spawn(
         &config.cargo_build_sbf,
@@ -312,6 +317,13 @@ fn main() {
                 .help("Number of parallel jobs, defaults to # of CPUs"),
         )
         .arg(
+            Arg::new("arch")
+                .long("arch")
+                .possible_values(&["sbf", "sbfv2"])
+                .default_value("sbf")
+                .help("Build for the given SBF version"),
+        )
+        .arg(
             Arg::new("extra_cargo_test_args")
                 .value_name("extra args for cargo test and the test binary")
                 .index(1)
@@ -337,6 +349,7 @@ fn main() {
         verbose: matches.is_present("verbose"),
         workspace: matches.is_present("workspace"),
         jobs: matches.value_of_t("jobs").ok(),
+        arch: matches.value_of("arch").unwrap(),
         ..Config::default()
     };
 


### PR DESCRIPTION
#### Problem

As we evolve SBF, there needs to be a way to select which version to build for.

#### Summary of Changes

Add `--arch` option that can be used to select SBF version. Currently `sbf` and `sbfv2` are supported.

See https://github.com/solana-labs/llvm-project/pull/26
