### PR TITLE
zk-token-sdk: change variable names to use suffix rather than prefix

### DIFF
--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -37,25 +37,25 @@ const TRANSFER_AMOUNT_HI_BIT_LENGTH: usize = 32;
 #[cfg(not(target_arch = "bpf"))]
 pub struct TransferAmountEncryption {
     pub commitment: PedersenCommitment,
-    pub handle_source: DecryptHandle,
-    pub handle_dest: DecryptHandle,
-    pub handle_auditor: DecryptHandle,
+    pub source_handle: DecryptHandle,
+    pub destination_handle: DecryptHandle,
+    pub auditor_handle: DecryptHandle,
 }
 
 #[cfg(not(target_arch = "bpf"))]
 impl TransferAmountEncryption {
     pub fn new(
         amount: u32,
-        pubkey_source: &ElGamalPubkey,
-        pubkey_dest: &ElGamalPubkey,
-        pubkey_auditor: &ElGamalPubkey,
+        source_pubkey: &ElGamalPubkey,
+        destination_pubkey: &ElGamalPubkey,
+        auditor_pubkey: &ElGamalPubkey,
     ) -> (Self, PedersenOpening) {
         let (commitment, opening) = Pedersen::new(amount);
         let transfer_amount_encryption = Self {
             commitment,
-            handle_source: pubkey_source.decrypt_handle(&opening),
-            handle_dest: pubkey_dest.decrypt_handle(&opening),
-            handle_auditor: pubkey_auditor.decrypt_handle(&opening),
+            source_handle: source_pubkey.decrypt_handle(&opening),
+            destination_handle: destination_pubkey.decrypt_handle(&opening),
+            auditor_handle: auditor_pubkey.decrypt_handle(&opening),
         };
 
         (transfer_amount_encryption, opening)
@@ -64,9 +64,9 @@ impl TransferAmountEncryption {
     pub fn to_pod(&self) -> pod::TransferAmountEncryption {
         pod::TransferAmountEncryption {
             commitment: self.commitment.into(),
-            handle_source: self.handle_source.into(),
-            handle_dest: self.handle_dest.into(),
-            handle_auditor: self.handle_auditor.into(),
+            source_handle: self.source_handle.into(),
+            destination_handle: self.destination_handle.into(),
+            auditor_handle: self.auditor_handle.into(),
         }
     }
 }
@@ -84,7 +84,7 @@ pub struct TransferData {
     pub transfer_pubkeys: pod::TransferPubkeys,
 
     /// The final spendable ciphertext after the transfer
-    pub ciphertext_new_source: pod::ElGamalCiphertext,
+    pub new_source_ciphertext: pod::ElGamalCiphertext,
 
     /// Zero-knowledge proofs for Transfer
     pub proof: TransferProof,
@@ -96,23 +96,23 @@ impl TransferData {
     pub fn new(
         transfer_amount: u64,
         (spendable_balance, ciphertext_old_source): (u64, &ElGamalCiphertext),
-        keypair_source: &ElGamalKeypair,
-        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        source_keypair: &ElGamalKeypair,
+        (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
     ) -> Result<Self, ProofError> {
         // split and encrypt transfer amount
         let (amount_lo, amount_hi) = split_u64_into_u32(transfer_amount);
 
         let (ciphertext_lo, opening_lo) = TransferAmountEncryption::new(
             amount_lo,
-            &keypair_source.public,
-            pubkey_dest,
-            pubkey_auditor,
+            &source_keypair.public,
+            destination_pubkey,
+            auditor_pubkey,
         );
         let (ciphertext_hi, opening_hi) = TransferAmountEncryption::new(
             amount_hi,
-            &keypair_source.public,
-            pubkey_dest,
-            pubkey_auditor,
+            &source_keypair.public,
+            destination_pubkey,
+            auditor_pubkey,
         );
 
         // subtract transfer amount from the spendable ciphertext
@@ -122,41 +122,41 @@ impl TransferData {
 
         let transfer_amount_lo_source = ElGamalCiphertext {
             commitment: ciphertext_lo.commitment,
-            handle: ciphertext_lo.handle_source,
+            handle: ciphertext_lo.source_handle,
         };
 
         let transfer_amount_hi_source = ElGamalCiphertext {
             commitment: ciphertext_hi.commitment,
-            handle: ciphertext_hi.handle_source,
+            handle: ciphertext_hi.source_handle,
         };
 
-        let ciphertext_new_source = ciphertext_old_source
+        let new_source_ciphertext = ciphertext_old_source
             - combine_u32_ciphertexts(&transfer_amount_lo_source, &transfer_amount_hi_source);
 
         // generate transcript and append all public inputs
         let pod_transfer_pubkeys = pod::TransferPubkeys {
-            pubkey_source: keypair_source.public.into(),
-            pubkey_dest: (*pubkey_dest).into(),
-            pubkey_auditor: (*pubkey_auditor).into(),
+            source_pubkey: source_keypair.public.into(),
+            destination_pubkey: (*destination_pubkey).into(),
+            auditor_pubkey: (*auditor_pubkey).into(),
         };
         let pod_ciphertext_lo: pod::TransferAmountEncryption = ciphertext_lo.into();
         let pod_ciphertext_hi: pod::TransferAmountEncryption = ciphertext_hi.into();
-        let pod_ciphertext_new_source: pod::ElGamalCiphertext = ciphertext_new_source.into();
+        let pod_new_source_ciphertext: pod::ElGamalCiphertext = new_source_ciphertext.into();
 
         let mut transcript = TransferProof::transcript_new(
             &pod_transfer_pubkeys,
             &pod_ciphertext_lo,
             &pod_ciphertext_hi,
-            &pod_ciphertext_new_source,
+            &pod_new_source_ciphertext,
         );
 
         let proof = TransferProof::new(
             (amount_lo, amount_hi),
-            keypair_source,
-            (pubkey_dest, pubkey_auditor),
+            source_keypair,
+            (destination_pubkey, auditor_pubkey),
             &opening_lo,
             &opening_hi,
-            (new_spendable_balance, &ciphertext_new_source),
+            (new_spendable_balance, &new_source_ciphertext),
             &mut transcript,
         );
 
@@ -164,7 +164,7 @@ impl TransferData {
             ciphertext_lo: pod_ciphertext_lo,
             ciphertext_hi: pod_ciphertext_hi,
             transfer_pubkeys: pod_transfer_pubkeys,
-            ciphertext_new_source: pod_ciphertext_new_source,
+            new_source_ciphertext: pod_new_source_ciphertext,
             proof,
         })
     }
@@ -174,9 +174,9 @@ impl TransferData {
         let ciphertext_lo: TransferAmountEncryption = self.ciphertext_lo.try_into()?;
 
         let handle_lo = match role {
-            Role::Source => ciphertext_lo.handle_source,
-            Role::Dest => ciphertext_lo.handle_dest,
-            Role::Auditor => ciphertext_lo.handle_auditor,
+            Role::Source => ciphertext_lo.source_handle,
+            Role::Dest => ciphertext_lo.destination_handle,
+            Role::Auditor => ciphertext_lo.auditor_handle,
         };
 
         Ok(ElGamalCiphertext {
@@ -190,9 +190,9 @@ impl TransferData {
         let ciphertext_hi: TransferAmountEncryption = self.ciphertext_hi.try_into()?;
 
         let handle_hi = match role {
-            Role::Source => ciphertext_hi.handle_source,
-            Role::Dest => ciphertext_hi.handle_dest,
-            Role::Auditor => ciphertext_hi.handle_auditor,
+            Role::Source => ciphertext_hi.source_handle,
+            Role::Dest => ciphertext_hi.destination_handle,
+            Role::Auditor => ciphertext_hi.auditor_handle,
         };
 
         Ok(ElGamalCiphertext {
@@ -230,13 +230,13 @@ impl Verifiable for TransferData {
             &self.transfer_pubkeys,
             &self.ciphertext_lo,
             &self.ciphertext_hi,
-            &self.ciphertext_new_source,
+            &self.new_source_ciphertext,
         );
 
         let ciphertext_lo = self.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.ciphertext_hi.try_into()?;
         let transfer_pubkeys = self.transfer_pubkeys.try_into()?;
-        let new_spendable_ciphertext = self.ciphertext_new_source.try_into()?;
+        let new_spendable_ciphertext = self.new_source_ciphertext.try_into()?;
 
         self.proof.verify(
             &ciphertext_lo,
@@ -272,56 +272,56 @@ impl TransferProof {
         transfer_pubkeys: &pod::TransferPubkeys,
         ciphertext_lo: &pod::TransferAmountEncryption,
         ciphertext_hi: &pod::TransferAmountEncryption,
-        ciphertext_new_source: &pod::ElGamalCiphertext,
+        new_source_ciphertext: &pod::ElGamalCiphertext,
     ) -> Transcript {
         let mut transcript = Transcript::new(b"transfer-proof");
 
-        transcript.append_pubkey(b"pubkey-source", &transfer_pubkeys.pubkey_source);
-        transcript.append_pubkey(b"pubkey-dest", &transfer_pubkeys.pubkey_dest);
-        transcript.append_pubkey(b"pubkey-auditor", &transfer_pubkeys.pubkey_auditor);
+        transcript.append_pubkey(b"pubkey-source", &transfer_pubkeys.source_pubkey);
+        transcript.append_pubkey(b"pubkey-dest", &transfer_pubkeys.destination_pubkey);
+        transcript.append_pubkey(b"pubkey-auditor", &transfer_pubkeys.auditor_pubkey);
 
         transcript.append_commitment(b"comm-lo-amount", &ciphertext_lo.commitment);
-        transcript.append_handle(b"handle-lo-source", &ciphertext_lo.handle_source);
-        transcript.append_handle(b"handle-lo-dest", &ciphertext_lo.handle_dest);
-        transcript.append_handle(b"handle-lo-auditor", &ciphertext_lo.handle_auditor);
+        transcript.append_handle(b"handle-lo-source", &ciphertext_lo.source_handle);
+        transcript.append_handle(b"handle-lo-dest", &ciphertext_lo.destination_handle);
+        transcript.append_handle(b"handle-lo-auditor", &ciphertext_lo.auditor_handle);
 
         transcript.append_commitment(b"comm-hi-amount", &ciphertext_hi.commitment);
-        transcript.append_handle(b"handle-hi-source", &ciphertext_hi.handle_source);
-        transcript.append_handle(b"handle-hi-dest", &ciphertext_hi.handle_dest);
-        transcript.append_handle(b"handle-hi-auditor", &ciphertext_hi.handle_auditor);
+        transcript.append_handle(b"handle-hi-source", &ciphertext_hi.source_handle);
+        transcript.append_handle(b"handle-hi-dest", &ciphertext_hi.destination_handle);
+        transcript.append_handle(b"handle-hi-auditor", &ciphertext_hi.auditor_handle);
 
-        transcript.append_ciphertext(b"ciphertext-new-source", ciphertext_new_source);
+        transcript.append_ciphertext(b"ciphertext-new-source", new_source_ciphertext);
 
         transcript
     }
 
     pub fn new(
         (transfer_amount_lo, transfer_amount_hi): (u32, u32),
-        keypair_source: &ElGamalKeypair,
-        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        source_keypair: &ElGamalKeypair,
+        (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
         opening_lo: &PedersenOpening,
         opening_hi: &PedersenOpening,
-        (source_new_balance, ciphertext_new_source): (u64, &ElGamalCiphertext),
+        (source_new_balance, new_source_ciphertext): (u64, &ElGamalCiphertext),
         transcript: &mut Transcript,
     ) -> Self {
         // generate a Pedersen commitment for the remaining balance in source
-        let (commitment_new_source, opening_source) = Pedersen::new(source_new_balance);
+        let (commitment_new_source, source_opening) = Pedersen::new(source_new_balance);
 
         let pod_commitment_new_source: pod::PedersenCommitment = commitment_new_source.into();
         transcript.append_commitment(b"commitment-new-source", &pod_commitment_new_source);
 
         // generate equality_proof
         let equality_proof = CtxtCommEqualityProof::new(
-            keypair_source,
-            ciphertext_new_source,
+            source_keypair,
+            new_source_ciphertext,
             source_new_balance,
-            &opening_source,
+            &source_opening,
             transcript,
         );
 
         // generate ciphertext validity proof
         let validity_proof = AggregatedValidityProof::new(
-            (pubkey_dest, pubkey_auditor),
+            (destination_pubkey, auditor_pubkey),
             (transfer_amount_lo, transfer_amount_hi),
             (opening_lo, opening_hi),
             transcript,
@@ -339,7 +339,7 @@ impl TransferProof {
                 TRANSFER_AMOUNT_LO_BIT_LENGTH,
                 TRANSFER_AMOUNT_HI_BIT_LENGTH,
             ],
-            vec![&opening_source, opening_lo, opening_hi],
+            vec![&source_opening, opening_lo, opening_hi],
             transcript,
         );
 
@@ -370,7 +370,7 @@ impl TransferProof {
         //
         // TODO: we can also consider verifying equality and range proof in a batch
         equality_proof.verify(
-            &transfer_pubkeys.pubkey_source,
+            &transfer_pubkeys.source_pubkey,
             ciphertext_new_spendable,
             &commitment,
             transcript,
@@ -379,12 +379,12 @@ impl TransferProof {
         // verify validity proof
         aggregated_validity_proof.verify(
             (
-                &transfer_pubkeys.pubkey_dest,
-                &transfer_pubkeys.pubkey_auditor,
+                &transfer_pubkeys.destination_pubkey,
+                &transfer_pubkeys.auditor_pubkey,
             ),
             (&ciphertext_lo.commitment, &ciphertext_hi.commitment),
-            (&ciphertext_lo.handle_dest, &ciphertext_hi.handle_dest),
-            (&ciphertext_lo.handle_auditor, &ciphertext_hi.handle_auditor),
+            (&ciphertext_lo.destination_handle, &ciphertext_hi.destination_handle),
+            (&ciphertext_lo.auditor_handle, &ciphertext_hi.auditor_handle),
             transcript,
         )?;
 
@@ -409,9 +409,9 @@ impl TransferProof {
 #[repr(C)]
 #[cfg(not(target_arch = "bpf"))]
 pub struct TransferPubkeys {
-    pub pubkey_source: ElGamalPubkey,
-    pub pubkey_dest: ElGamalPubkey,
-    pub pubkey_auditor: ElGamalPubkey,
+    pub source_pubkey: ElGamalPubkey,
+    pub destination_pubkey: ElGamalPubkey,
+    pub auditor_pubkey: ElGamalPubkey,
 }
 
 #[cfg(not(target_arch = "bpf"))]
@@ -419,26 +419,26 @@ impl TransferPubkeys {
     // TODO: use constructor instead
     pub fn to_bytes(&self) -> [u8; 96] {
         let mut bytes = [0u8; 96];
-        bytes[..32].copy_from_slice(&self.pubkey_source.to_bytes());
-        bytes[32..64].copy_from_slice(&self.pubkey_dest.to_bytes());
-        bytes[64..96].copy_from_slice(&self.pubkey_auditor.to_bytes());
+        bytes[..32].copy_from_slice(&self.source_pubkey.to_bytes());
+        bytes[32..64].copy_from_slice(&self.destination_pubkey.to_bytes());
+        bytes[64..96].copy_from_slice(&self.auditor_pubkey.to_bytes());
         bytes
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
         let bytes = array_ref![bytes, 0, 96];
-        let (pubkey_source, pubkey_dest, pubkey_auditor) = array_refs![bytes, 32, 32, 32];
+        let (source_pubkey, destination_pubkey, auditor_pubkey) = array_refs![bytes, 32, 32, 32];
 
-        let pubkey_source =
-            ElGamalPubkey::from_bytes(pubkey_source).ok_or(ProofError::Verification)?;
-        let pubkey_dest = ElGamalPubkey::from_bytes(pubkey_dest).ok_or(ProofError::Verification)?;
-        let pubkey_auditor =
-            ElGamalPubkey::from_bytes(pubkey_auditor).ok_or(ProofError::Verification)?;
+        let source_pubkey =
+            ElGamalPubkey::from_bytes(source_pubkey).ok_or(ProofError::Verification)?;
+        let destination_pubkey = ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
+        let auditor_pubkey =
+            ElGamalPubkey::from_bytes(auditor_pubkey).ok_or(ProofError::Verification)?;
 
         Ok(Self {
-            pubkey_source,
-            pubkey_dest,
-            pubkey_auditor,
+            source_pubkey,
+            destination_pubkey,
+            auditor_pubkey,
         })
     }
 }

--- a/zk-token-sdk/src/instruction/transfer.rs
+++ b/zk-token-sdk/src/instruction/transfer.rs
@@ -383,7 +383,10 @@ impl TransferProof {
                 &transfer_pubkeys.auditor_pubkey,
             ),
             (&ciphertext_lo.commitment, &ciphertext_hi.commitment),
-            (&ciphertext_lo.destination_handle, &ciphertext_hi.destination_handle),
+            (
+                &ciphertext_lo.destination_handle,
+                &ciphertext_hi.destination_handle,
+            ),
             (&ciphertext_lo.auditor_handle, &ciphertext_hi.auditor_handle),
             transcript,
         )?;
@@ -431,7 +434,8 @@ impl TransferPubkeys {
 
         let source_pubkey =
             ElGamalPubkey::from_bytes(source_pubkey).ok_or(ProofError::Verification)?;
-        let destination_pubkey = ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
+        let destination_pubkey =
+            ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
         let auditor_pubkey =
             ElGamalPubkey::from_bytes(auditor_pubkey).ok_or(ProofError::Verification)?;
 

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -63,10 +63,10 @@ pub struct TransferWithFeeData {
     pub transfer_with_fee_pubkeys: pod::TransferWithFeePubkeys,
 
     /// The final spendable ciphertext after the transfer,
-    pub ciphertext_new_source: pod::ElGamalCiphertext,
+    pub new_source_ciphertext: pod::ElGamalCiphertext,
 
     // transfer fee encryption
-    pub ciphertext_fee: pod::FeeEncryption,
+    pub fee_ciphertext: pod::FeeEncryption,
 
     // fee parameters
     pub fee_parameters: pod::FeeParameters,
@@ -79,26 +79,26 @@ pub struct TransferWithFeeData {
 impl TransferWithFeeData {
     pub fn new(
         transfer_amount: u64,
-        (spendable_balance, ciphertext_old_source): (u64, &ElGamalCiphertext),
-        keypair_source: &ElGamalKeypair,
-        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
+        (spendable_balance, old_source_ciphertext): (u64, &ElGamalCiphertext),
+        source_keypair: &ElGamalKeypair,
+        (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
         fee_parameters: FeeParameters,
-        pubkey_withdraw_withheld_authority: &ElGamalPubkey,
+        withdraw_withheld_authority_pubkey: &ElGamalPubkey,
     ) -> Result<Self, ProofError> {
         // split and encrypt transfer amount
         let (amount_lo, amount_hi) = split_u64_into_u32(transfer_amount);
 
         let (ciphertext_lo, opening_lo) = TransferAmountEncryption::new(
             amount_lo,
-            &keypair_source.public,
-            pubkey_dest,
-            pubkey_auditor,
+            &source_keypair.public,
+            destination_pubkey,
+            auditor_pubkey,
         );
         let (ciphertext_hi, opening_hi) = TransferAmountEncryption::new(
             amount_hi,
-            &keypair_source.public,
-            pubkey_dest,
-            pubkey_auditor,
+            &source_keypair.public,
+            destination_pubkey,
+            auditor_pubkey,
         );
 
         // subtract transfer amount from the spendable ciphertext
@@ -108,15 +108,15 @@ impl TransferWithFeeData {
 
         let transfer_amount_lo_source = ElGamalCiphertext {
             commitment: ciphertext_lo.commitment,
-            handle: ciphertext_lo.handle_source,
+            handle: ciphertext_lo.source_handle,
         };
 
         let transfer_amount_hi_source = ElGamalCiphertext {
             commitment: ciphertext_hi.commitment,
-            handle: ciphertext_hi.handle_source,
+            handle: ciphertext_hi.source_handle,
         };
 
-        let ciphertext_new_source = ciphertext_old_source
+        let new_source_ciphertext = old_source_ciphertext
             - combine_u32_ciphertexts(&transfer_amount_lo_source, &transfer_amount_hi_source);
 
         // calculate and encrypt fee
@@ -126,43 +126,42 @@ impl TransferWithFeeData {
         let below_max = u64::ct_gt(&fee_parameters.maximum_fee, &fee_amount);
         let fee_to_encrypt =
             u64::conditional_select(&fee_parameters.maximum_fee, &fee_amount, below_max);
-        // u64::conditional_select(&fee_amount, &fee_parameters.maximum_fee, below_max);
 
-        let (ciphertext_fee, opening_fee) = FeeEncryption::new(
+        let (fee_ciphertext, opening_fee) = FeeEncryption::new(
             fee_to_encrypt,
-            pubkey_dest,
-            pubkey_withdraw_withheld_authority,
+            destination_pubkey,
+            withdraw_withheld_authority_pubkey,
         );
 
         // generate transcript and append all public inputs
         let pod_transfer_with_fee_pubkeys = pod::TransferWithFeePubkeys {
-            pubkey_source: keypair_source.public.into(),
-            pubkey_dest: (*pubkey_dest).into(),
-            pubkey_auditor: (*pubkey_auditor).into(),
-            pubkey_withdraw_withheld_authority: (*pubkey_withdraw_withheld_authority).into(),
+            source_pubkey: source_keypair.public.into(),
+            destination_pubkey: (*destination_pubkey).into(),
+            auditor_pubkey: (*auditor_pubkey).into(),
+            withdraw_withheld_authority_pubkey: (*withdraw_withheld_authority_pubkey).into(),
         };
         let pod_ciphertext_lo: pod::TransferAmountEncryption = ciphertext_lo.to_pod();
         let pod_ciphertext_hi: pod::TransferAmountEncryption = ciphertext_hi.to_pod();
-        let pod_ciphertext_new_source: pod::ElGamalCiphertext = ciphertext_new_source.into();
-        let pod_ciphertext_fee: pod::FeeEncryption = ciphertext_fee.to_pod();
+        let pod_new_source_ciphertext: pod::ElGamalCiphertext = new_source_ciphertext.into();
+        let pod_fee_ciphertext: pod::FeeEncryption = fee_ciphertext.to_pod();
 
         let mut transcript = TransferWithFeeProof::transcript_new(
             &pod_transfer_with_fee_pubkeys,
             &pod_ciphertext_lo,
             &pod_ciphertext_hi,
-            &pod_ciphertext_new_source,
-            &pod_ciphertext_fee,
+            &pod_new_source_ciphertext,
+            &pod_fee_ciphertext,
         );
 
         let proof = TransferWithFeeProof::new(
             (amount_lo, &ciphertext_lo, &opening_lo),
             (amount_hi, &ciphertext_hi, &opening_hi),
-            keypair_source,
-            (pubkey_dest, pubkey_auditor),
-            (new_spendable_balance, &ciphertext_new_source),
-            (fee_amount, &ciphertext_fee, &opening_fee),
+            source_keypair,
+            (destination_pubkey, auditor_pubkey),
+            (new_spendable_balance, &new_source_ciphertext),
+            (fee_to_encrypt, &fee_ciphertext, &opening_fee),
             delta_fee,
-            pubkey_withdraw_withheld_authority,
+            withdraw_withheld_authority_pubkey,
             fee_parameters,
             &mut transcript,
         );
@@ -171,8 +170,8 @@ impl TransferWithFeeData {
             ciphertext_lo: pod_ciphertext_lo,
             ciphertext_hi: pod_ciphertext_hi,
             transfer_with_fee_pubkeys: pod_transfer_with_fee_pubkeys,
-            ciphertext_new_source: pod_ciphertext_new_source,
-            ciphertext_fee: pod_ciphertext_fee,
+            new_source_ciphertext: pod_new_source_ciphertext,
+            fee_ciphertext: pod_fee_ciphertext,
             fee_parameters: fee_parameters.into(),
             proof,
         })
@@ -183,9 +182,9 @@ impl TransferWithFeeData {
         let ciphertext_lo: TransferAmountEncryption = self.ciphertext_lo.try_into()?;
 
         let handle_lo = match role {
-            Role::Source => ciphertext_lo.handle_source,
-            Role::Dest => ciphertext_lo.handle_dest,
-            Role::Auditor => ciphertext_lo.handle_auditor,
+            Role::Source => ciphertext_lo.source_handle,
+            Role::Dest => ciphertext_lo.destination_handle,
+            Role::Auditor => ciphertext_lo.auditor_handle,
         };
 
         Ok(ElGamalCiphertext {
@@ -199,9 +198,9 @@ impl TransferWithFeeData {
         let ciphertext_hi: TransferAmountEncryption = self.ciphertext_hi.try_into()?;
 
         let handle_hi = match role {
-            Role::Source => ciphertext_hi.handle_source,
-            Role::Dest => ciphertext_hi.handle_dest,
-            Role::Auditor => ciphertext_hi.handle_auditor,
+            Role::Source => ciphertext_hi.source_handle,
+            Role::Dest => ciphertext_hi.destination_handle,
+            Role::Auditor => ciphertext_hi.auditor_handle,
         };
 
         Ok(ElGamalCiphertext {
@@ -238,24 +237,24 @@ impl Verifiable for TransferWithFeeData {
             &self.transfer_with_fee_pubkeys,
             &self.ciphertext_lo,
             &self.ciphertext_hi,
-            &self.ciphertext_new_source,
-            &self.ciphertext_fee,
+            &self.new_source_ciphertext,
+            &self.fee_ciphertext,
         );
 
         let ciphertext_lo = self.ciphertext_lo.try_into()?;
         let ciphertext_hi = self.ciphertext_hi.try_into()?;
         let pubkeys_transfer_with_fee = self.transfer_with_fee_pubkeys.try_into()?;
-        let ciphertext_new_source = self.ciphertext_new_source.try_into()?;
+        let new_source_ciphertext = self.new_source_ciphertext.try_into()?;
 
-        let ciphertext_fee = self.ciphertext_fee.try_into()?;
+        let fee_ciphertext = self.fee_ciphertext.try_into()?;
         let fee_parameters = self.fee_parameters.into();
 
         self.proof.verify(
             &ciphertext_lo,
             &ciphertext_hi,
             &pubkeys_transfer_with_fee,
-            &ciphertext_new_source,
-            &ciphertext_fee,
+            &new_source_ciphertext,
+            &fee_ciphertext,
             fee_parameters,
             &mut transcript,
         )
@@ -266,12 +265,12 @@ impl Verifiable for TransferWithFeeData {
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 pub struct TransferWithFeeProof {
-    pub commitment_new_source: pod::PedersenCommitment,
-    pub commitment_claimed: pod::PedersenCommitment,
+    pub new_source_commitment: pod::PedersenCommitment,
+    pub claimed_commitment: pod::PedersenCommitment,
     pub equality_proof: pod::CtxtCommEqualityProof,
     pub ciphertext_amount_validity_proof: pod::AggregatedValidityProof,
     pub fee_sigma_proof: pod::FeeSigmaProof,
-    pub ciphertext_fee_validity_proof: pod::ValidityProof,
+    pub fee_ciphertext_validity_proof: pod::ValidityProof,
     pub range_proof: pod::RangeProof256,
 }
 
@@ -282,36 +281,36 @@ impl TransferWithFeeProof {
         transfer_with_fee_pubkeys: &pod::TransferWithFeePubkeys,
         ciphertext_lo: &pod::TransferAmountEncryption,
         ciphertext_hi: &pod::TransferAmountEncryption,
-        ciphertext_new_source: &pod::ElGamalCiphertext,
-        ciphertext_fee: &pod::FeeEncryption,
+        new_source_ciphertext: &pod::ElGamalCiphertext,
+        fee_ciphertext: &pod::FeeEncryption,
     ) -> Transcript {
         let mut transcript = Transcript::new(b"FeeProof");
 
-        transcript.append_pubkey(b"pubkey-source", &transfer_with_fee_pubkeys.pubkey_source);
-        transcript.append_pubkey(b"pubkey-dest", &transfer_with_fee_pubkeys.pubkey_dest);
-        transcript.append_pubkey(b"pubkey-auditor", &transfer_with_fee_pubkeys.pubkey_auditor);
+        transcript.append_pubkey(b"pubkey-source", &transfer_with_fee_pubkeys.source_pubkey);
+        transcript.append_pubkey(b"pubkey-dest", &transfer_with_fee_pubkeys.destination_pubkey);
+        transcript.append_pubkey(b"pubkey-auditor", &transfer_with_fee_pubkeys.auditor_pubkey);
         transcript.append_pubkey(
-            b"pubkey_withdraw_withheld_authority",
-            &transfer_with_fee_pubkeys.pubkey_withdraw_withheld_authority,
+            b"withdraw_withheld_authority_pubkey",
+            &transfer_with_fee_pubkeys.withdraw_withheld_authority_pubkey,
         );
 
         transcript.append_commitment(b"comm-lo-amount", &ciphertext_lo.commitment);
-        transcript.append_handle(b"handle-lo-source", &ciphertext_lo.handle_source);
-        transcript.append_handle(b"handle-lo-dest", &ciphertext_lo.handle_dest);
-        transcript.append_handle(b"handle-lo-auditor", &ciphertext_lo.handle_auditor);
+        transcript.append_handle(b"handle-lo-source", &ciphertext_lo.source_handle);
+        transcript.append_handle(b"handle-lo-dest", &ciphertext_lo.destination_handle);
+        transcript.append_handle(b"handle-lo-auditor", &ciphertext_lo.auditor_handle);
 
         transcript.append_commitment(b"comm-hi-amount", &ciphertext_hi.commitment);
-        transcript.append_handle(b"handle-hi-source", &ciphertext_hi.handle_source);
-        transcript.append_handle(b"handle-hi-dest", &ciphertext_hi.handle_dest);
-        transcript.append_handle(b"handle-hi-auditor", &ciphertext_hi.handle_auditor);
+        transcript.append_handle(b"handle-hi-source", &ciphertext_hi.source_handle);
+        transcript.append_handle(b"handle-hi-dest", &ciphertext_hi.destination_handle);
+        transcript.append_handle(b"handle-hi-auditor", &ciphertext_hi.auditor_handle);
 
-        transcript.append_ciphertext(b"ctxt-new-source", ciphertext_new_source);
+        transcript.append_ciphertext(b"ctxt-new-source", new_source_ciphertext);
 
-        transcript.append_commitment(b"comm-fee", &ciphertext_fee.commitment);
-        transcript.append_handle(b"fee-dest-handle", &ciphertext_fee.handle_dest);
+        transcript.append_commitment(b"comm-fee", &fee_ciphertext.commitment);
+        transcript.append_handle(b"fee-dest-handle", &fee_ciphertext.destination_handle);
         transcript.append_handle(
             b"handle-fee-auditor",
-            &ciphertext_fee.handle_withdraw_withheld_authority,
+            &fee_ciphertext.withdraw_withheld_authority_handle,
         );
 
         transcript
@@ -322,13 +321,13 @@ impl TransferWithFeeProof {
     pub fn new(
         transfer_amount_lo_data: (u32, &TransferAmountEncryption, &PedersenOpening),
         transfer_amount_hi_data: (u32, &TransferAmountEncryption, &PedersenOpening),
-        keypair_source: &ElGamalKeypair,
-        (pubkey_dest, pubkey_auditor): (&ElGamalPubkey, &ElGamalPubkey),
-        (source_new_balance, ciphertext_new_source): (u64, &ElGamalCiphertext),
+        source_keypair: &ElGamalKeypair,
+        (destination_pubkey, auditor_pubkey): (&ElGamalPubkey, &ElGamalPubkey),
+        (source_new_balance, new_source_ciphertext): (u64, &ElGamalCiphertext),
 
-        (fee_amount, ciphertext_fee, opening_fee): (u64, &FeeEncryption, &PedersenOpening),
+        (fee_amount, fee_ciphertext, opening_fee): (u64, &FeeEncryption, &PedersenOpening),
         delta_fee: u64,
-        pubkey_withdraw_withheld_authority: &ElGamalPubkey,
+        withdraw_withheld_authority_pubkey: &ElGamalPubkey,
         fee_parameters: FeeParameters,
         transcript: &mut Transcript,
     ) -> Self {
@@ -336,19 +335,19 @@ impl TransferWithFeeProof {
         let (transfer_amount_hi, ciphertext_hi, opening_hi) = transfer_amount_hi_data;
 
         // generate a Pedersen commitment for the remaining balance in source
-        let (commitment_new_source, opening_source) = Pedersen::new(source_new_balance);
-        let (commitment_claimed, opening_claimed) = Pedersen::new(delta_fee);
+        let (new_source_commitment, opening_source) = Pedersen::new(source_new_balance);
+        let (claimed_commitment, opening_claimed) = Pedersen::new(delta_fee);
 
-        let pod_commitment_new_source: pod::PedersenCommitment = commitment_new_source.into();
-        let pod_commitment_claimed: pod::PedersenCommitment = commitment_claimed.into();
+        let pod_new_source_commitment: pod::PedersenCommitment = new_source_commitment.into();
+        let pod_claimed_commitment: pod::PedersenCommitment = claimed_commitment.into();
 
-        transcript.append_commitment(b"commitment-new-source", &pod_commitment_new_source);
-        transcript.append_commitment(b"commitment-claimed", &pod_commitment_claimed);
+        transcript.append_commitment(b"commitment-new-source", &pod_new_source_commitment);
+        transcript.append_commitment(b"commitment-claimed", &pod_claimed_commitment);
 
         // generate equality_proof
         let equality_proof = CtxtCommEqualityProof::new(
-            keypair_source,
-            ciphertext_new_source,
+            source_keypair,
+            new_source_ciphertext,
             source_new_balance,
             &opening_source,
             transcript,
@@ -356,29 +355,29 @@ impl TransferWithFeeProof {
 
         // generate ciphertext validity proof
         let ciphertext_amount_validity_proof = AggregatedValidityProof::new(
-            (pubkey_dest, pubkey_auditor),
+            (destination_pubkey, auditor_pubkey),
             (transfer_amount_lo, transfer_amount_hi),
             (opening_lo, opening_hi),
             transcript,
         );
 
-        let (commitment_delta, opening_delta) = compute_delta_commitment_and_opening(
+        let (delta_commitment, opening_delta) = compute_delta_commitment_and_opening(
             (&ciphertext_lo.commitment, opening_lo),
             (&ciphertext_hi.commitment, opening_hi),
-            (&ciphertext_fee.commitment, opening_fee),
+            (&fee_ciphertext.commitment, opening_fee),
             fee_parameters.fee_rate_basis_points,
         );
 
         let fee_sigma_proof = FeeSigmaProof::new(
-            (fee_amount, &ciphertext_fee.commitment, opening_fee),
-            (delta_fee, &commitment_delta, &opening_delta),
-            (&commitment_claimed, &opening_claimed),
+            (fee_amount, &fee_ciphertext.commitment, opening_fee),
+            (delta_fee, &delta_commitment, &opening_delta),
+            (&claimed_commitment, &opening_claimed),
             fee_parameters.maximum_fee,
             transcript,
         );
 
-        let ciphertext_fee_validity_proof = ValidityProof::new(
-            (pubkey_dest, pubkey_withdraw_withheld_authority),
+        let fee_ciphertext_validity_proof = ValidityProof::new(
+            (destination_pubkey, withdraw_withheld_authority_pubkey),
             fee_amount,
             opening_fee,
             transcript,
@@ -411,12 +410,12 @@ impl TransferWithFeeProof {
         );
 
         Self {
-            commitment_new_source: pod_commitment_new_source,
-            commitment_claimed: pod_commitment_claimed,
+            new_source_commitment: pod_new_source_commitment,
+            claimed_commitment: pod_claimed_commitment,
             equality_proof: equality_proof.into(),
             ciphertext_amount_validity_proof: ciphertext_amount_validity_proof.into(),
             fee_sigma_proof: fee_sigma_proof.into(),
-            ciphertext_fee_validity_proof: ciphertext_fee_validity_proof.into(),
+            fee_ciphertext_validity_proof: fee_ciphertext_validity_proof.into(),
             range_proof: range_proof.try_into().expect("range proof: length error"),
         }
     }
@@ -428,81 +427,83 @@ impl TransferWithFeeProof {
         transfer_with_fee_pubkeys: &TransferWithFeePubkeys,
         new_spendable_ciphertext: &ElGamalCiphertext,
 
-        ciphertext_fee: &FeeEncryption,
+        fee_ciphertext: &FeeEncryption,
         fee_parameters: FeeParameters,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
-        transcript.append_commitment(b"commitment-new-source", &self.commitment_new_source);
-        transcript.append_commitment(b"commitment-claimed", &self.commitment_claimed);
+        transcript.append_commitment(b"commitment-new-source", &self.new_source_commitment);
+        transcript.append_commitment(b"commitment-claimed", &self.claimed_commitment);
 
-        let commitment_new_source: PedersenCommitment = self.commitment_new_source.try_into()?;
-        let commitment_claimed: PedersenCommitment = self.commitment_claimed.try_into()?;
+        let new_source_commitment: PedersenCommitment = self.new_source_commitment.try_into()?;
+        let claimed_commitment: PedersenCommitment = self.claimed_commitment.try_into()?;
 
         let equality_proof: CtxtCommEqualityProof = self.equality_proof.try_into()?;
         let ciphertext_amount_validity_proof: AggregatedValidityProof =
             self.ciphertext_amount_validity_proof.try_into()?;
         let fee_sigma_proof: FeeSigmaProof = self.fee_sigma_proof.try_into()?;
-        let ciphertext_fee_validity_proof: ValidityProof =
-            self.ciphertext_fee_validity_proof.try_into()?;
+        let fee_ciphertext_validity_proof: ValidityProof =
+            self.fee_ciphertext_validity_proof.try_into()?;
         let range_proof: RangeProof = self.range_proof.try_into()?;
 
         // verify equality proof
         equality_proof.verify(
-            &transfer_with_fee_pubkeys.pubkey_source,
+            &transfer_with_fee_pubkeys.source_pubkey,
             new_spendable_ciphertext,
-            &commitment_new_source,
+            &new_source_commitment,
             transcript,
         )?;
+
+        println!("here");
 
         // verify that the transfer amount is encrypted correctly
         ciphertext_amount_validity_proof.verify(
             (
-                &transfer_with_fee_pubkeys.pubkey_dest,
-                &transfer_with_fee_pubkeys.pubkey_auditor,
+                &transfer_with_fee_pubkeys.destination_pubkey,
+                &transfer_with_fee_pubkeys.auditor_pubkey,
             ),
             (&ciphertext_lo.commitment, &ciphertext_hi.commitment),
-            (&ciphertext_lo.handle_dest, &ciphertext_hi.handle_dest),
-            (&ciphertext_lo.handle_auditor, &ciphertext_hi.handle_auditor),
+            (&ciphertext_lo.destination_handle, &ciphertext_hi.destination_handle),
+            (&ciphertext_lo.auditor_handle, &ciphertext_hi.auditor_handle),
             transcript,
         )?;
 
         // verify fee sigma proof
-        let commitment_delta = compute_delta_commitment(
+        let delta_commitment = compute_delta_commitment(
             &ciphertext_lo.commitment,
             &ciphertext_hi.commitment,
-            &ciphertext_fee.commitment,
+            &fee_ciphertext.commitment,
             fee_parameters.fee_rate_basis_points,
         );
 
         fee_sigma_proof.verify(
-            &ciphertext_fee.commitment,
-            &commitment_delta,
-            &commitment_claimed,
+            &fee_ciphertext.commitment,
+            &delta_commitment,
+            &claimed_commitment,
             fee_parameters.maximum_fee,
             transcript,
         )?;
 
-        ciphertext_fee_validity_proof.verify(
-            &ciphertext_fee.commitment,
+        fee_ciphertext_validity_proof.verify(
+            &fee_ciphertext.commitment,
             (
-                &transfer_with_fee_pubkeys.pubkey_dest,
-                &transfer_with_fee_pubkeys.pubkey_withdraw_withheld_authority,
+                &transfer_with_fee_pubkeys.destination_pubkey,
+                &transfer_with_fee_pubkeys.withdraw_withheld_authority_pubkey,
             ),
             (
-                &ciphertext_fee.handle_dest,
-                &ciphertext_fee.handle_withdraw_withheld_authority,
+                &fee_ciphertext.destination_handle,
+                &fee_ciphertext.withdraw_withheld_authority_handle,
             ),
             transcript,
         )?;
 
-        let commitment_claimed_negated = &(*COMMITMENT_MAX_FEE_BASIS_POINTS) - &commitment_claimed;
+        let claimed_commitment_negated = &(*COMMITMENT_MAX_FEE_BASIS_POINTS) - &claimed_commitment;
         range_proof.verify(
             vec![
-                &commitment_new_source,
+                &new_source_commitment,
                 &ciphertext_lo.commitment,
                 &ciphertext_hi.commitment,
-                &commitment_claimed,
-                &commitment_claimed_negated,
+                &claimed_commitment,
+                &claimed_commitment_negated,
             ],
             vec![64, 32, 32, 64, 64],
             transcript,
@@ -517,42 +518,42 @@ impl TransferWithFeeProof {
 #[repr(C)]
 #[cfg(not(target_arch = "bpf"))]
 pub struct TransferWithFeePubkeys {
-    pub pubkey_source: ElGamalPubkey,
-    pub pubkey_dest: ElGamalPubkey,
-    pub pubkey_auditor: ElGamalPubkey,
-    pub pubkey_withdraw_withheld_authority: ElGamalPubkey,
+    pub source_pubkey: ElGamalPubkey,
+    pub destination_pubkey: ElGamalPubkey,
+    pub auditor_pubkey: ElGamalPubkey,
+    pub withdraw_withheld_authority_pubkey: ElGamalPubkey,
 }
 
 #[cfg(not(target_arch = "bpf"))]
 impl TransferWithFeePubkeys {
     pub fn to_bytes(&self) -> [u8; 128] {
         let mut bytes = [0u8; 128];
-        bytes[..32].copy_from_slice(&self.pubkey_source.to_bytes());
-        bytes[32..64].copy_from_slice(&self.pubkey_dest.to_bytes());
-        bytes[64..96].copy_from_slice(&self.pubkey_auditor.to_bytes());
-        bytes[96..128].copy_from_slice(&self.pubkey_withdraw_withheld_authority.to_bytes());
+        bytes[..32].copy_from_slice(&self.source_pubkey.to_bytes());
+        bytes[32..64].copy_from_slice(&self.destination_pubkey.to_bytes());
+        bytes[64..96].copy_from_slice(&self.auditor_pubkey.to_bytes());
+        bytes[96..128].copy_from_slice(&self.withdraw_withheld_authority_pubkey.to_bytes());
         bytes
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
         let bytes = array_ref![bytes, 0, 128];
-        let (pubkey_source, pubkey_dest, pubkey_auditor, pubkey_withdraw_withheld_authority) =
+        let (source_pubkey, destination_pubkey, auditor_pubkey, withdraw_withheld_authority_pubkey) =
             array_refs![bytes, 32, 32, 32, 32];
 
-        let pubkey_source =
-            ElGamalPubkey::from_bytes(pubkey_source).ok_or(ProofError::Verification)?;
-        let pubkey_dest = ElGamalPubkey::from_bytes(pubkey_dest).ok_or(ProofError::Verification)?;
-        let pubkey_auditor =
-            ElGamalPubkey::from_bytes(pubkey_auditor).ok_or(ProofError::Verification)?;
-        let pubkey_withdraw_withheld_authority =
-            ElGamalPubkey::from_bytes(pubkey_withdraw_withheld_authority)
+        let source_pubkey =
+            ElGamalPubkey::from_bytes(source_pubkey).ok_or(ProofError::Verification)?;
+        let destination_pubkey = ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
+        let auditor_pubkey =
+            ElGamalPubkey::from_bytes(auditor_pubkey).ok_or(ProofError::Verification)?;
+        let withdraw_withheld_authority_pubkey =
+            ElGamalPubkey::from_bytes(withdraw_withheld_authority_pubkey)
                 .ok_or(ProofError::Verification)?;
 
         Ok(Self {
-            pubkey_source,
-            pubkey_dest,
-            pubkey_auditor,
-            pubkey_withdraw_withheld_authority,
+            source_pubkey,
+            destination_pubkey,
+            auditor_pubkey,
+            withdraw_withheld_authority_pubkey,
         })
     }
 }
@@ -562,22 +563,22 @@ impl TransferWithFeePubkeys {
 #[cfg(not(target_arch = "bpf"))]
 pub struct FeeEncryption {
     pub commitment: PedersenCommitment,
-    pub handle_dest: DecryptHandle,
-    pub handle_withdraw_withheld_authority: DecryptHandle,
+    pub destination_handle: DecryptHandle,
+    pub withdraw_withheld_authority_handle: DecryptHandle,
 }
 
 #[cfg(not(target_arch = "bpf"))]
 impl FeeEncryption {
     pub fn new(
         amount: u64,
-        pubkey_dest: &ElGamalPubkey,
-        pubkey_withdraw_withheld: &ElGamalPubkey,
+        destination_pubkey: &ElGamalPubkey,
+        withdraw_withheld_authority_pubkey: &ElGamalPubkey,
     ) -> (Self, PedersenOpening) {
         let (commitment, opening) = Pedersen::new(amount);
         let fee_encryption = Self {
             commitment,
-            handle_dest: pubkey_dest.decrypt_handle(&opening),
-            handle_withdraw_withheld_authority: pubkey_withdraw_withheld.decrypt_handle(&opening),
+            destination_handle: destination_pubkey.decrypt_handle(&opening),
+            withdraw_withheld_authority_handle: withdraw_withheld_authority_pubkey.decrypt_handle(&opening),
         };
 
         (fee_encryption, opening)
@@ -586,8 +587,8 @@ impl FeeEncryption {
     pub fn to_pod(&self) -> pod::FeeEncryption {
         pod::FeeEncryption {
             commitment: self.commitment.into(),
-            handle_dest: self.handle_dest.into(),
-            handle_withdraw_withheld_authority: self.handle_withdraw_withheld_authority.into(),
+            destination_handle: self.destination_handle.into(),
+            withdraw_withheld_authority_handle: self.withdraw_withheld_authority_handle.into(),
         }
     }
 }
@@ -640,30 +641,30 @@ fn calculate_fee(transfer_amount: u64, fee_rate_basis_points: u16) -> (u64, u64)
 fn compute_delta_commitment_and_opening(
     (commitment_lo, opening_lo): (&PedersenCommitment, &PedersenOpening),
     (commitment_hi, opening_hi): (&PedersenCommitment, &PedersenOpening),
-    (commitment_fee, opening_fee): (&PedersenCommitment, &PedersenOpening),
+    (fee_commitment, opening_fee): (&PedersenCommitment, &PedersenOpening),
     fee_rate_basis_points: u16,
 ) -> (PedersenCommitment, PedersenOpening) {
     let fee_rate_scalar = Scalar::from(fee_rate_basis_points);
 
-    let commitment_delta = commitment_fee * Scalar::from(MAX_FEE_BASIS_POINTS)
+    let delta_commitment = fee_commitment * Scalar::from(MAX_FEE_BASIS_POINTS)
         - &(&combine_u32_commitments(commitment_lo, commitment_hi) * &fee_rate_scalar);
 
     let opening_delta = opening_fee * Scalar::from(MAX_FEE_BASIS_POINTS)
         - &(&combine_u32_openings(opening_lo, opening_hi) * &fee_rate_scalar);
 
-    (commitment_delta, opening_delta)
+    (delta_commitment, opening_delta)
 }
 
 #[cfg(not(target_arch = "bpf"))]
 fn compute_delta_commitment(
     commitment_lo: &PedersenCommitment,
     commitment_hi: &PedersenCommitment,
-    commitment_fee: &PedersenCommitment,
+    fee_commitment: &PedersenCommitment,
     fee_rate_basis_points: u16,
 ) -> PedersenCommitment {
     let fee_rate_scalar = Scalar::from(fee_rate_basis_points);
 
-    commitment_fee * Scalar::from(MAX_FEE_BASIS_POINTS)
+    fee_commitment * Scalar::from(MAX_FEE_BASIS_POINTS)
         - &(&combine_u32_commitments(commitment_lo, commitment_hi) * &fee_rate_scalar)
 }
 
@@ -673,28 +674,28 @@ mod test {
 
     #[test]
     fn test_fee_correctness() {
-        let keypair_source = ElGamalKeypair::new_rand();
-        let pubkey_dest = ElGamalKeypair::new_rand().public;
-        let pubkey_auditor = ElGamalKeypair::new_rand().public;
-        let pubkey_withdraw_withheld_authority = ElGamalKeypair::new_rand().public;
+        let source_keypair = ElGamalKeypair::new_rand();
+        let destination_pubkey = ElGamalKeypair::new_rand().public;
+        let auditor_pubkey = ElGamalKeypair::new_rand().public;
+        let withdraw_withheld_authority_pubkey = ElGamalKeypair::new_rand().public;
 
         let spendable_balance: u64 = 120;
-        let spendable_ciphertext = keypair_source.public.encrypt(spendable_balance);
+        let spendable_ciphertext = source_keypair.public.encrypt(spendable_balance);
 
         let transfer_amount: u64 = 100;
 
         let fee_parameters = FeeParameters {
-            fee_rate_basis_points: 100,
+            fee_rate_basis_points: 400,
             maximum_fee: 3,
         };
 
         let fee_data = TransferWithFeeData::new(
             transfer_amount,
             (spendable_balance, &spendable_ciphertext),
-            &keypair_source,
-            (&pubkey_dest, &pubkey_auditor),
+            &source_keypair,
+            (&destination_pubkey, &auditor_pubkey),
             fee_parameters,
-            &pubkey_withdraw_withheld_authority,
+            &withdraw_withheld_authority_pubkey,
         )
         .unwrap();
 

--- a/zk-token-sdk/src/instruction/transfer_with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer_with_fee.rs
@@ -287,7 +287,10 @@ impl TransferWithFeeProof {
         let mut transcript = Transcript::new(b"FeeProof");
 
         transcript.append_pubkey(b"pubkey-source", &transfer_with_fee_pubkeys.source_pubkey);
-        transcript.append_pubkey(b"pubkey-dest", &transfer_with_fee_pubkeys.destination_pubkey);
+        transcript.append_pubkey(
+            b"pubkey-dest",
+            &transfer_with_fee_pubkeys.destination_pubkey,
+        );
         transcript.append_pubkey(b"pubkey-auditor", &transfer_with_fee_pubkeys.auditor_pubkey);
         transcript.append_pubkey(
             b"withdraw_withheld_authority_pubkey",
@@ -462,7 +465,10 @@ impl TransferWithFeeProof {
                 &transfer_with_fee_pubkeys.auditor_pubkey,
             ),
             (&ciphertext_lo.commitment, &ciphertext_hi.commitment),
-            (&ciphertext_lo.destination_handle, &ciphertext_hi.destination_handle),
+            (
+                &ciphertext_lo.destination_handle,
+                &ciphertext_hi.destination_handle,
+            ),
             (&ciphertext_lo.auditor_handle, &ciphertext_hi.auditor_handle),
             transcript,
         )?;
@@ -542,7 +548,8 @@ impl TransferWithFeePubkeys {
 
         let source_pubkey =
             ElGamalPubkey::from_bytes(source_pubkey).ok_or(ProofError::Verification)?;
-        let destination_pubkey = ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
+        let destination_pubkey =
+            ElGamalPubkey::from_bytes(destination_pubkey).ok_or(ProofError::Verification)?;
         let auditor_pubkey =
             ElGamalPubkey::from_bytes(auditor_pubkey).ok_or(ProofError::Verification)?;
         let withdraw_withheld_authority_pubkey =
@@ -578,7 +585,8 @@ impl FeeEncryption {
         let fee_encryption = Self {
             commitment,
             destination_handle: destination_pubkey.decrypt_handle(&opening),
-            withdraw_withheld_authority_handle: withdraw_withheld_authority_pubkey.decrypt_handle(&opening),
+            withdraw_withheld_authority_handle: withdraw_withheld_authority_pubkey
+                .decrypt_handle(&opening),
         };
 
         (fee_encryption, opening)

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -172,17 +172,17 @@ impl CtxtCommEqualityProof {
                 &ww_negated,         // -ww
             ],
             vec![
-                P_source, // P_source
-                &(*H),    // H
-                &Y_0,     // Y_0
-                &(*G),    // G
-                D_source, // D_source
-                C_source, // C_source
-                &Y_1,     // Y_1
-                &(*G),    // G
-                &(*H),    // H
-                C_destination,   // C_destination
-                &Y_2,     // Y_2
+                P_source,      // P_source
+                &(*H),         // H
+                &Y_0,          // Y_0
+                &(*G),         // G
+                D_source,      // D_source
+                C_source,      // C_source
+                &Y_1,          // Y_1
+                &(*G),         // G
+                &(*H),         // H
+                C_destination, // C_destination
+                &Y_2,          // Y_2
             ],
         );
 
@@ -387,20 +387,20 @@ impl CtxtCtxtEqualityProof {
                 &www_negated,
             ],
             vec![
-                P_source, // P_source
-                &(*H),    // H
-                &Y_0,     // Y_0
-                &(*G),    // G
-                D_source, // D_source
-                C_source, // C_source
-                &Y_1,     // Y_1
-                &(*G),    // G
-                &(*H),    // H
-                C_destination,   // C_destination
-                &Y_2,     // Y_2
-                P_destination,   // P_destination
-                D_destination,   // D_destination
-                &Y_3,     // Y_3
+                P_source,      // P_source
+                &(*H),         // H
+                &Y_0,          // Y_0
+                &(*G),         // G
+                D_source,      // D_source
+                C_source,      // C_source
+                &Y_1,          // Y_1
+                &(*G),         // G
+                &(*H),         // H
+                C_destination, // C_destination
+                &Y_2,          // Y_2
+                P_destination, // P_destination
+                D_destination, // D_destination
+                &Y_3,          // Y_3
             ],
         );
 
@@ -642,7 +642,9 @@ mod test {
         let source_ciphertext = source_keypair.public.encrypt(message);
 
         let destination_opening = PedersenOpening::new_rand();
-        let destination_ciphertext = destination_keypair.public.encrypt_with(message, &destination_opening);
+        let destination_ciphertext = destination_keypair
+            .public
+            .encrypt_with(message, &destination_opening);
 
         let mut prover_transcript = Transcript::new(b"Test");
         let mut verifier_transcript = Transcript::new(b"Test");

--- a/zk-token-sdk/src/sigma_proofs/equality_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/equality_proof.rs
@@ -59,14 +59,14 @@ impl CtxtCommEqualityProof {
     /// Note that the proof constructor does not take the actual Pedersen commitment as input; it
     /// takes the associated Pedersen opening instead.
     ///
-    /// * `elgamal_keypair` - The ElGamal keypair associated with the ciphertext to be proved
-    /// * `ciphertext` - The main ElGamal ciphertext to be proved
+    /// * `source_keypair` - The ElGamal keypair associated with the first to be proved
+    /// * `source_ciphertext` - The main ElGamal ciphertext to be proved
     /// * `amount` - The message associated with the ElGamal ciphertext and Pedersen commitment
     /// * `opening` - The opening associated with the main Pedersen commitment to be proved
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn new(
-        keypair_source: &ElGamalKeypair,
-        ciphertext_source: &ElGamalCiphertext,
+        source_keypair: &ElGamalKeypair,
+        source_ciphertext: &ElGamalCiphertext,
         amount: u64,
         opening: &PedersenOpening,
         transcript: &mut Transcript,
@@ -74,10 +74,10 @@ impl CtxtCommEqualityProof {
         transcript.equality_proof_domain_sep();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = keypair_source.public.get_point();
-        let D_source = ciphertext_source.handle.get_point();
+        let P_source = source_keypair.public.get_point();
+        let D_source = source_ciphertext.handle.get_point();
 
-        let s = keypair_source.secret.get_scalar();
+        let s = source_keypair.secret.get_scalar();
         let x = Scalar::from(amount);
         let r = opening.get_scalar();
 
@@ -121,24 +121,24 @@ impl CtxtCommEqualityProof {
 
     /// Equality proof verifier. TODO: wrt commitment
     ///
-    /// * `elgamal_pubkey` - The ElGamal pubkey associated with the ciphertext to be proved
-    /// * `ciphertext` - The main ElGamal ciphertext to be proved
-    /// * `commitment` - The main Pedersen commitment to be proved
+    /// * `source_pubkey` - The ElGamal pubkey associated with the ciphertext to be proved
+    /// * `source_ciphertext` - The main ElGamal ciphertext to be proved
+    /// * `destination_commitment` - The main Pedersen commitment to be proved
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn verify(
         self,
-        pubkey_source: &ElGamalPubkey,
-        ciphertext_source: &ElGamalCiphertext,
-        commitment_dest: &PedersenCommitment,
+        source_pubkey: &ElGamalPubkey,
+        source_ciphertext: &ElGamalCiphertext,
+        destination_commitment: &PedersenCommitment,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
         transcript.equality_proof_domain_sep();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = pubkey_source.get_point();
-        let C_source = ciphertext_source.commitment.get_point();
-        let D_source = ciphertext_source.handle.get_point();
-        let C_dest = commitment_dest.get_point();
+        let P_source = source_pubkey.get_point();
+        let C_source = source_ciphertext.commitment.get_point();
+        let D_source = source_ciphertext.handle.get_point();
+        let C_destination = destination_commitment.get_point();
 
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
@@ -181,7 +181,7 @@ impl CtxtCommEqualityProof {
                 &Y_1,     // Y_1
                 &(*G),    // G
                 &(*H),    // H
-                C_dest,   // C_dest
+                C_destination,   // C_destination
                 &Y_2,     // Y_2
             ],
         );
@@ -256,29 +256,30 @@ impl CtxtCtxtEqualityProof {
     /// Note that the proof constructor does not take the actual Pedersen commitment as input; it
     /// takes the associated Pedersen opening instead.
     ///
-    /// * `elgamal_keypair` - The ElGamal keypair associated with the ciphertext to be proved
-    /// * `ciphertext` - The main ElGamal ciphertext to be proved
+    /// * `source_keypair` - The ElGamal keypair associated with the first ciphertext to be proved
+    /// * `destination_pubkey` - The ElGamal pubkey associated with the second ElGamal ciphertext
+    /// * `source_ciphertext` - The first ElGamal ciphertext
     /// * `amount` - The message associated with the ElGamal ciphertext and Pedersen commitment
-    /// * `opening` - The opening associated with the main Pedersen commitment to be proved
+    /// * `destination_opening` - The opening associated with the second ElGamal ciphertext
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn new(
-        keypair_source: &ElGamalKeypair,
-        pubkey_dest: &ElGamalPubkey,
-        ciphertext_source: &ElGamalCiphertext,
+        source_keypair: &ElGamalKeypair,
+        destination_pubkey: &ElGamalPubkey,
+        source_ciphertext: &ElGamalCiphertext,
         amount: u64,
-        opening_dest: &PedersenOpening,
+        destination_opening: &PedersenOpening,
         transcript: &mut Transcript,
     ) -> Self {
         transcript.equality_proof_domain_sep();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = keypair_source.public.get_point();
-        let D_source = ciphertext_source.handle.get_point();
-        let P_dest = pubkey_dest.get_point();
+        let P_source = source_keypair.public.get_point();
+        let D_source = source_ciphertext.handle.get_point();
+        let P_destination = destination_pubkey.get_point();
 
-        let s = keypair_source.secret.get_scalar();
+        let s = source_keypair.secret.get_scalar();
         let x = Scalar::from(amount);
-        let r = opening_dest.get_scalar();
+        let r = destination_opening.get_scalar();
 
         // generate random masking factors that also serves as nonces
         let mut y_s = Scalar::random(&mut OsRng);
@@ -289,7 +290,7 @@ impl CtxtCtxtEqualityProof {
         let Y_1 =
             RistrettoPoint::multiscalar_mul(vec![&y_x, &y_s], vec![&(*G), D_source]).compress();
         let Y_2 = RistrettoPoint::multiscalar_mul(vec![&y_x, &y_r], vec![&(*G), &(*H)]).compress();
-        let Y_3 = (&y_r * P_dest).compress();
+        let Y_3 = (&y_r * P_destination).compress();
 
         // record masking factors in the transcript
         transcript.append_point(b"Y_0", &Y_0);
@@ -321,30 +322,31 @@ impl CtxtCtxtEqualityProof {
         }
     }
 
-    /// Equality proof verifier. TODO: wrt commitment
+    /// Equality proof verifier.
     ///
-    /// * `elgamal_pubkey` - The ElGamal pubkey associated with the ciphertext to be proved
-    /// * `ciphertext` - The main ElGamal ciphertext to be proved
-    /// * `commitment` - The main Pedersen commitment to be proved
+    /// * `source_pubkey` - The ElGamal pubkey associated with the first ciphertext to be proved
+    /// * `destination_pubkey` - The ElGamal pubkey associated with the second ciphertext to be proved
+    /// * `source_ciphertext` - The first ElGamal ciphertext to be proved
+    /// * `destination_ciphertext` - The second ElGamal ciphertext to be proved
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic
     pub fn verify(
         self,
-        pubkey_source: &ElGamalPubkey,
-        pubkey_dest: &ElGamalPubkey,
-        ciphertext_source: &ElGamalCiphertext,
-        ciphertext_dest: &ElGamalCiphertext,
+        source_pubkey: &ElGamalPubkey,
+        destination_pubkey: &ElGamalPubkey,
+        source_ciphertext: &ElGamalCiphertext,
+        destination_ciphertext: &ElGamalCiphertext,
         transcript: &mut Transcript,
     ) -> Result<(), EqualityProofError> {
         transcript.equality_proof_domain_sep();
 
         // extract the relevant scalar and Ristretto points from the inputs
-        let P_source = pubkey_source.get_point();
-        let C_source = ciphertext_source.commitment.get_point();
-        let D_source = ciphertext_source.handle.get_point();
+        let P_source = source_pubkey.get_point();
+        let C_source = source_ciphertext.commitment.get_point();
+        let D_source = source_ciphertext.handle.get_point();
 
-        let P_dest = pubkey_dest.get_point();
-        let C_dest = ciphertext_dest.commitment.get_point();
-        let D_dest = ciphertext_dest.handle.get_point();
+        let P_destination = destination_pubkey.get_point();
+        let C_destination = destination_ciphertext.commitment.get_point();
+        let D_destination = destination_ciphertext.handle.get_point();
 
         // include Y_0, Y_1, Y_2 to transcript and extract challenges
         transcript.validate_and_append_point(b"Y_0", &self.Y_0)?;
@@ -394,10 +396,10 @@ impl CtxtCtxtEqualityProof {
                 &Y_1,     // Y_1
                 &(*G),    // G
                 &(*H),    // H
-                C_dest,   // C_dest
+                C_destination,   // C_destination
                 &Y_2,     // Y_2
-                P_dest,   // P_dest
-                D_dest,   // D_dest
+                P_destination,   // P_destination
+                D_destination,   // D_destination
                 &Y_3,     // Y_3
             ],
         );
@@ -456,57 +458,57 @@ mod test {
     #[test]
     fn test_ciphertext_commitment_equality_proof_correctness() {
         // success case
-        let keypair_source = ElGamalKeypair::new_rand();
+        let source_keypair = ElGamalKeypair::new_rand();
         let message: u64 = 55;
 
-        let ciphertext_source = keypair_source.public.encrypt(message);
-        let (commitment_dest, opening_dest) = Pedersen::new(message);
+        let source_ciphertext = source_keypair.public.encrypt(message);
+        let (destination_commitment, destination_opening) = Pedersen::new(message);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
-            &keypair_source,
-            &ciphertext_source,
+            &source_keypair,
+            &source_ciphertext,
             message,
-            &opening_dest,
-            &mut transcript_prover,
+            &destination_opening,
+            &mut prover_transcript,
         );
 
         assert!(proof
             .verify(
-                &keypair_source.public,
-                &ciphertext_source,
-                &commitment_dest,
-                &mut transcript_verifier
+                &source_keypair.public,
+                &source_ciphertext,
+                &destination_commitment,
+                &mut verifier_transcript
             )
             .is_ok());
 
         // fail case: encrypted and committed messages are different
-        let keypair_source = ElGamalKeypair::new_rand();
+        let source_keypair = ElGamalKeypair::new_rand();
         let encrypted_message: u64 = 55;
         let committed_message: u64 = 77;
 
-        let ciphertext_source = keypair_source.public.encrypt(encrypted_message);
-        let (commitment_dest, opening_dest) = Pedersen::new(committed_message);
+        let source_ciphertext = source_keypair.public.encrypt(encrypted_message);
+        let (destination_commitment, destination_opening) = Pedersen::new(committed_message);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
-            &keypair_source,
-            &ciphertext_source,
+            &source_keypair,
+            &source_ciphertext,
             message,
-            &opening_dest,
-            &mut transcript_prover,
+            &destination_opening,
+            &mut prover_transcript,
         );
 
         assert!(proof
             .verify(
-                &keypair_source.public,
-                &ciphertext_source,
-                &commitment_dest,
-                &mut transcript_verifier
+                &source_keypair.public,
+                &source_ciphertext,
+                &destination_commitment,
+                &mut verifier_transcript
             )
             .is_err());
     }
@@ -523,15 +525,15 @@ mod test {
         let ciphertext = elgamal_keypair.public.encrypt(message);
         let (commitment, opening) = Pedersen::new(message);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
             &elgamal_keypair,
             &ciphertext,
             message,
             &opening,
-            &mut transcript_prover,
+            &mut prover_transcript,
         );
 
         assert!(proof
@@ -539,7 +541,7 @@ mod test {
                 &elgamal_keypair.public,
                 &ciphertext,
                 &commitment,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_err());
 
@@ -552,15 +554,15 @@ mod test {
         let commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
         let opening = PedersenOpening::from_bytes(&[0u8; 32]).unwrap();
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
             &elgamal_keypair,
             &ciphertext,
             message,
             &opening,
-            &mut transcript_prover,
+            &mut prover_transcript,
         );
 
         assert!(proof
@@ -568,7 +570,7 @@ mod test {
                 &elgamal_keypair.public,
                 &ciphertext,
                 &commitment,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_ok());
 
@@ -581,15 +583,15 @@ mod test {
         let commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
         let opening = PedersenOpening::from_bytes(&[0u8; 32]).unwrap();
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
             &elgamal_keypair,
             &ciphertext,
             message,
             &opening,
-            &mut transcript_prover,
+            &mut prover_transcript,
         );
 
         assert!(proof
@@ -597,7 +599,7 @@ mod test {
                 &elgamal_keypair.public,
                 &ciphertext,
                 &commitment,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_ok());
 
@@ -609,15 +611,15 @@ mod test {
         let ciphertext = ElGamalCiphertext::from_bytes(&[0u8; 64]).unwrap();
         let (commitment, opening) = Pedersen::new(message);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCommEqualityProof::new(
             &elgamal_keypair,
             &ciphertext,
             message,
             &opening,
-            &mut transcript_prover,
+            &mut prover_transcript,
         );
 
         assert!(proof
@@ -625,7 +627,7 @@ mod test {
                 &elgamal_keypair.public,
                 &ciphertext,
                 &commitment,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_ok());
     }
@@ -633,67 +635,67 @@ mod test {
     #[test]
     fn test_ciphertext_ciphertext_equality_proof_correctness() {
         // success case
-        let keypair_source = ElGamalKeypair::new_rand();
-        let keypair_dest = ElGamalKeypair::new_rand();
+        let source_keypair = ElGamalKeypair::new_rand();
+        let destination_keypair = ElGamalKeypair::new_rand();
         let message: u64 = 55;
 
-        let ciphertext_source = keypair_source.public.encrypt(message);
+        let source_ciphertext = source_keypair.public.encrypt(message);
 
-        let opening_dest = PedersenOpening::new_rand();
-        let ciphertext_dest = keypair_dest.public.encrypt_with(message, &opening_dest);
+        let destination_opening = PedersenOpening::new_rand();
+        let destination_ciphertext = destination_keypair.public.encrypt_with(message, &destination_opening);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCtxtEqualityProof::new(
-            &keypair_source,
-            &keypair_dest.public,
-            &ciphertext_source,
+            &source_keypair,
+            &destination_keypair.public,
+            &source_ciphertext,
             message,
-            &opening_dest,
-            &mut transcript_prover,
+            &destination_opening,
+            &mut prover_transcript,
         );
 
         assert!(proof
             .verify(
-                &keypair_source.public,
-                &keypair_dest.public,
-                &ciphertext_source,
-                &ciphertext_dest,
-                &mut transcript_verifier
+                &source_keypair.public,
+                &destination_keypair.public,
+                &source_ciphertext,
+                &destination_ciphertext,
+                &mut verifier_transcript
             )
             .is_ok());
 
         // fail case: encrypted and committed messages are different
-        let message_source: u64 = 55;
-        let message_dest: u64 = 77;
+        let source_message: u64 = 55;
+        let destination_message: u64 = 77;
 
-        let ciphertext_source = keypair_source.public.encrypt(message_source);
+        let source_ciphertext = source_keypair.public.encrypt(source_message);
 
-        let opening_dest = PedersenOpening::new_rand();
-        let ciphertext_dest = keypair_dest
+        let destination_opening = PedersenOpening::new_rand();
+        let destination_ciphertext = destination_keypair
             .public
-            .encrypt_with(message_dest, &opening_dest);
+            .encrypt_with(destination_message, &destination_opening);
 
-        let mut transcript_prover = Transcript::new(b"Test");
-        let mut transcript_verifier = Transcript::new(b"Test");
+        let mut prover_transcript = Transcript::new(b"Test");
+        let mut verifier_transcript = Transcript::new(b"Test");
 
         let proof = CtxtCtxtEqualityProof::new(
-            &keypair_source,
-            &keypair_dest.public,
-            &ciphertext_source,
+            &source_keypair,
+            &destination_keypair.public,
+            &source_ciphertext,
             message,
-            &opening_dest,
-            &mut transcript_prover,
+            &destination_opening,
+            &mut prover_transcript,
         );
 
         assert!(proof
             .verify(
-                &keypair_source.public,
-                &keypair_dest.public,
-                &ciphertext_source,
-                &ciphertext_dest,
-                &mut transcript_verifier
+                &source_keypair.public,
+                &destination_keypair.public,
+                &source_ciphertext,
+                &destination_ciphertext,
+                &mut verifier_transcript
             )
             .is_err());
     }

--- a/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -178,30 +178,30 @@ mod test {
     fn test_zero_balance_proof_correctness() {
         let source_keypair = ElGamalKeypair::new_rand();
 
-        let mut transcript_prover = Transcript::new(b"test");
-        let mut transcript_verifier = Transcript::new(b"test");
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
 
         // general case: encryption of 0
         let elgamal_ciphertext = source_keypair.public.encrypt(0_u64);
         let proof =
-            ZeroBalanceProof::new(&source_keypair, &elgamal_ciphertext, &mut transcript_prover);
+            ZeroBalanceProof::new(&source_keypair, &elgamal_ciphertext, &mut prover_transcript);
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &elgamal_ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_ok());
 
         // general case: encryption of > 0
         let elgamal_ciphertext = source_keypair.public.encrypt(1_u64);
         let proof =
-            ZeroBalanceProof::new(&source_keypair, &elgamal_ciphertext, &mut transcript_prover);
+            ZeroBalanceProof::new(&source_keypair, &elgamal_ciphertext, &mut prover_transcript);
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &elgamal_ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_err());
     }
@@ -210,26 +210,26 @@ mod test {
     fn test_zero_balance_proof_edge_cases() {
         let source_keypair = ElGamalKeypair::new_rand();
 
-        let mut transcript_prover = Transcript::new(b"test");
-        let mut transcript_verifier = Transcript::new(b"test");
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
 
         // all zero ciphertext should always be a valid encryption of 0
         let ciphertext = ElGamalCiphertext::from_bytes(&[0u8; 64]).unwrap();
 
-        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut transcript_prover);
+        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_ok());
 
         // if only either commitment or handle is zero, the ciphertext is always invalid and proof
         // verification should always reject
-        let mut transcript_prover = Transcript::new(b"test");
-        let mut transcript_verifier = Transcript::new(b"test");
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
 
         let zeroed_commitment = PedersenCommitment::from_bytes(&[0u8; 32]).unwrap();
         let handle = source_keypair
@@ -241,18 +241,18 @@ mod test {
             handle,
         };
 
-        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut transcript_prover);
+        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_err());
 
-        let mut transcript_prover = Transcript::new(b"test");
-        let mut transcript_verifier = Transcript::new(b"test");
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
 
         let (zeroed_commitment, _) = Pedersen::new(0_u64);
         let ciphertext = ElGamalCiphertext {
@@ -260,19 +260,19 @@ mod test {
             handle: DecryptHandle::from_bytes(&[0u8; 32]).unwrap(),
         };
 
-        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut transcript_prover);
+        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_err());
 
         // if public key is always zero, then the proof should always reject
-        let mut transcript_prover = Transcript::new(b"test");
-        let mut transcript_verifier = Transcript::new(b"test");
+        let mut prover_transcript = Transcript::new(b"test");
+        let mut verifier_transcript = Transcript::new(b"test");
 
         let public = ElGamalPubkey::from_bytes(&[0u8; 32]).unwrap();
         let secret = ElGamalSecretKey::new_rand();
@@ -281,13 +281,13 @@ mod test {
 
         let ciphertext = elgamal_keypair.public.encrypt(0_u64);
 
-        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut transcript_prover);
+        let proof = ZeroBalanceProof::new(&source_keypair, &ciphertext, &mut prover_transcript);
 
         assert!(proof
             .verify(
                 &source_keypair.public,
                 &ciphertext,
-                &mut transcript_verifier
+                &mut verifier_transcript
             )
             .is_err());
     }

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -327,9 +327,9 @@ mod target_arch {
     impl From<TransferPubkeys> for pod::TransferPubkeys {
         fn from(keys: TransferPubkeys) -> Self {
             Self {
-                pubkey_source: keys.pubkey_source.into(),
-                pubkey_dest: keys.pubkey_dest.into(),
-                pubkey_auditor: keys.pubkey_auditor.into(),
+                source_pubkey: keys.source_pubkey.into(),
+                destination_pubkey: keys.destination_pubkey.into(),
+                auditor_pubkey: keys.auditor_pubkey.into(),
             }
         }
     }
@@ -339,9 +339,9 @@ mod target_arch {
 
         fn try_from(pod: pod::TransferPubkeys) -> Result<Self, Self::Error> {
             Ok(Self {
-                pubkey_source: pod.pubkey_source.try_into()?,
-                pubkey_dest: pod.pubkey_dest.try_into()?,
-                pubkey_auditor: pod.pubkey_auditor.try_into()?,
+                source_pubkey: pod.source_pubkey.try_into()?,
+                destination_pubkey: pod.destination_pubkey.try_into()?,
+                auditor_pubkey: pod.auditor_pubkey.try_into()?,
             })
         }
     }
@@ -349,10 +349,10 @@ mod target_arch {
     impl From<TransferWithFeePubkeys> for pod::TransferWithFeePubkeys {
         fn from(keys: TransferWithFeePubkeys) -> Self {
             Self {
-                pubkey_source: keys.pubkey_source.into(),
-                pubkey_dest: keys.pubkey_dest.into(),
-                pubkey_auditor: keys.pubkey_auditor.into(),
-                pubkey_withdraw_withheld_authority: keys.pubkey_withdraw_withheld_authority.into(),
+                source_pubkey: keys.source_pubkey.into(),
+                destination_pubkey: keys.destination_pubkey.into(),
+                auditor_pubkey: keys.auditor_pubkey.into(),
+                withdraw_withheld_authority_pubkey: keys.withdraw_withheld_authority_pubkey.into(),
             }
         }
     }
@@ -362,11 +362,11 @@ mod target_arch {
 
         fn try_from(pod: pod::TransferWithFeePubkeys) -> Result<Self, Self::Error> {
             Ok(Self {
-                pubkey_source: pod.pubkey_source.try_into()?,
-                pubkey_dest: pod.pubkey_dest.try_into()?,
-                pubkey_auditor: pod.pubkey_auditor.try_into()?,
-                pubkey_withdraw_withheld_authority: pod
-                    .pubkey_withdraw_withheld_authority
+                source_pubkey: pod.source_pubkey.try_into()?,
+                destination_pubkey: pod.destination_pubkey.try_into()?,
+                auditor_pubkey: pod.auditor_pubkey.try_into()?,
+                withdraw_withheld_authority_pubkey: pod
+                    .withdraw_withheld_authority_pubkey
                     .try_into()?,
             })
         }
@@ -376,9 +376,9 @@ mod target_arch {
         fn from(ciphertext: TransferAmountEncryption) -> Self {
             Self {
                 commitment: ciphertext.commitment.into(),
-                handle_source: ciphertext.handle_source.into(),
-                handle_dest: ciphertext.handle_dest.into(),
-                handle_auditor: ciphertext.handle_auditor.into(),
+                source_handle: ciphertext.source_handle.into(),
+                destination_handle: ciphertext.destination_handle.into(),
+                auditor_handle: ciphertext.auditor_handle.into(),
             }
         }
     }
@@ -389,9 +389,9 @@ mod target_arch {
         fn try_from(pod: pod::TransferAmountEncryption) -> Result<Self, Self::Error> {
             Ok(Self {
                 commitment: pod.commitment.try_into()?,
-                handle_source: pod.handle_source.try_into()?,
-                handle_dest: pod.handle_dest.try_into()?,
-                handle_auditor: pod.handle_auditor.try_into()?,
+                source_handle: pod.source_handle.try_into()?,
+                destination_handle: pod.destination_handle.try_into()?,
+                auditor_handle: pod.auditor_handle.try_into()?,
             })
         }
     }
@@ -400,9 +400,9 @@ mod target_arch {
         fn from(ciphertext: FeeEncryption) -> Self {
             Self {
                 commitment: ciphertext.commitment.into(),
-                handle_dest: ciphertext.handle_dest.into(),
-                handle_withdraw_withheld_authority: ciphertext
-                    .handle_withdraw_withheld_authority
+                destination_handle: ciphertext.destination_handle.into(),
+                withdraw_withheld_authority_handle: ciphertext
+                    .withdraw_withheld_authority_handle
                     .into(),
             }
         }
@@ -414,9 +414,9 @@ mod target_arch {
         fn try_from(pod: pod::FeeEncryption) -> Result<Self, Self::Error> {
             Ok(Self {
                 commitment: pod.commitment.try_into()?,
-                handle_dest: pod.handle_dest.try_into()?,
-                handle_withdraw_withheld_authority: pod
-                    .handle_withdraw_withheld_authority
+                destination_handle: pod.destination_handle.try_into()?,
+                withdraw_withheld_authority_handle: pod
+                    .withdraw_withheld_authority_handle
                     .try_into()?,
             })
         }

--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -194,35 +194,35 @@ impl Default for AeCiphertext {
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferPubkeys {
-    pub pubkey_source: ElGamalPubkey,
-    pub pubkey_dest: ElGamalPubkey,
-    pub pubkey_auditor: ElGamalPubkey,
+    pub source_pubkey: ElGamalPubkey,
+    pub destination_pubkey: ElGamalPubkey,
+    pub auditor_pubkey: ElGamalPubkey,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferWithFeePubkeys {
-    pub pubkey_source: ElGamalPubkey,
-    pub pubkey_dest: ElGamalPubkey,
-    pub pubkey_auditor: ElGamalPubkey,
-    pub pubkey_withdraw_withheld_authority: ElGamalPubkey,
+    pub source_pubkey: ElGamalPubkey,
+    pub destination_pubkey: ElGamalPubkey,
+    pub auditor_pubkey: ElGamalPubkey,
+    pub withdraw_withheld_authority_pubkey: ElGamalPubkey,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferAmountEncryption {
     pub commitment: PedersenCommitment,
-    pub handle_source: DecryptHandle,
-    pub handle_dest: DecryptHandle,
-    pub handle_auditor: DecryptHandle,
+    pub source_handle: DecryptHandle,
+    pub destination_handle: DecryptHandle,
+    pub auditor_handle: DecryptHandle,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct FeeEncryption {
     pub commitment: PedersenCommitment,
-    pub handle_dest: DecryptHandle,
-    pub handle_withdraw_withheld_authority: DecryptHandle,
+    pub destination_handle: DecryptHandle,
+    pub withdraw_withheld_authority_handle: DecryptHandle,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]


### PR DESCRIPTION
Changing variable names to use suffix rather than prefix on types for consistency with the rest of the monorepo.

Example: `pubkey_source` --> `source_pubkey`