### PR TITLE
Add space for keys in calculation for rent exempt in `process_set_validator_info`

### DIFF
--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -312,6 +312,7 @@ pub fn process_set_validator_info(
     };
 
     let build_message = |lamports| {
+        let keys = keys.clone();
         if balance == 0 {
             println!(
                 "Publishing info for Validator {:?}",
@@ -326,7 +327,7 @@ pub fn process_set_validator_info(
             instructions.extend_from_slice(&[config_instruction::store(
                 &info_pubkey,
                 true,
-                keys.clone(),
+                keys,
                 &validator_info,
             )]);
             Message::new(&instructions, Some(&config.signers[0].pubkey()))
@@ -339,7 +340,7 @@ pub fn process_set_validator_info(
             let instructions = vec![config_instruction::store(
                 &info_pubkey,
                 false,
-                keys.clone(),
+                keys,
                 &validator_info,
             )];
             Message::new(&instructions, Some(&config.signers[0].pubkey()))


### PR DESCRIPTION
#### Problem
`process_set_validator_info` does not work as intended, thus the client's command `validator-info publish` does not work: leaves an account with space greater than the minimum rent exempt balance.

#### Summary of Changes
Add space for keys in calculation for rent exempt in `process_set_validator_info`.
The space required for allocating the `(ConfigKeys, ValidatorInfo)` tuple only considered space for `ValidatorInfo`
but `config_instruction::create_account` also requires space for `n` keys.
