### PR TITLE
[Explorer] Adding Verified On-chain Collection Support

### DIFF
--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -30,6 +30,7 @@ export function NFTHeader({
               : "No NFT name was found"}
           </h2>
           {getEditionPill(nftData.editionInfo)}
+          {getIsVerifiedCollection(metadata.collection?.verified)}
         </div>
         <h4 className="header-pretitle ms-1 mt-1 no-overflow-with-ellipsis">
           {metadata.data.symbol !== ""
@@ -172,5 +173,18 @@ function getIsMutablePill(isMutable: boolean) {
     <span className="badge badge-pill bg-dark">{`${
       isMutable ? "Mutable" : "Immutable"
     }`}</span>
+  );
+}
+
+function getIsVerifiedCollection(isVerified?: boolean) {
+  const onchainVerifiedToolTip =
+    "This NFT has been verified as a member of an no-chain collection. This tag guarantees authenticity.";
+  return (
+    <div className={"d-inline-flex align-items-center ms-2"}>
+      <span className="badge badge-pill bg-dark">
+        {`${isVerified ? "Verified Collection" : "Not Verified"}`}
+      </span>
+      <InfoTooltip bottom text={onchainVerifiedToolTip} />
+    </div>
   );
 }

--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -1,11 +1,17 @@
+import React from "react";
 import "bootstrap/dist/js/bootstrap.min.js";
-import { NFTData } from "providers/accounts";
+import {
+  NFTData,
+  useFetchAccountInfo,
+  useMintAccountInfo,
+} from "providers/accounts";
 import { programs } from "@metaplex/js";
 import { ArtContent } from "components/common/NFTArt";
 import { InfoTooltip } from "components/common/InfoTooltip";
 import { clusterPath } from "utils/url";
 import { Link } from "react-router-dom";
 import { EditionInfo } from "providers/accounts/utils/getEditionInfo";
+import { PublicKey } from "@solana/web3.js";
 
 export function NFTHeader({
   nftData,
@@ -14,8 +20,22 @@ export function NFTHeader({
   nftData: NFTData;
   address: string;
 }) {
+  const collectionAddress = nftData.metadata.collection?.key;
+  const collectionMintInfo = useMintAccountInfo(collectionAddress);
+  const fetchAccountInfo = useFetchAccountInfo();
+
+  React.useEffect(() => {
+    if (collectionAddress && !collectionMintInfo) {
+      fetchAccountInfo(new PublicKey(collectionAddress));
+    }
+  }, [fetchAccountInfo, collectionAddress]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const metadata = nftData.metadata;
   const data = nftData.json;
+  const isVerifiedCollection =
+    metadata.collection != null &&
+    metadata.collection?.verified &&
+    collectionMintInfo !== undefined;
   return (
     <div className="row">
       <div className="col-auto ms-2 d-flex align-items-center">
@@ -30,7 +50,7 @@ export function NFTHeader({
               : "No NFT name was found"}
           </h2>
           {getEditionPill(nftData.editionInfo)}
-          {getIsVerifiedCollection(metadata.collection?.verified)}
+          {isVerifiedCollection && getVerifiedCollectionPill()}
         </div>
         <h4 className="header-pretitle ms-1 mt-1 no-overflow-with-ellipsis">
           {metadata.data.symbol !== ""
@@ -176,14 +196,12 @@ function getIsMutablePill(isMutable: boolean) {
   );
 }
 
-function getIsVerifiedCollection(isVerified?: boolean) {
+function getVerifiedCollectionPill() {
   const onchainVerifiedToolTip =
     "This NFT has been verified as a member of an on-chain collection. This tag guarantees authenticity.";
   return (
     <div className={"d-inline-flex align-items-center ms-2"}>
-      <span className="badge badge-pill bg-dark">
-        {`${isVerified ? "Verified Collection" : "Not Verified"}`}
-      </span>
+      <span className="badge badge-pill bg-dark">{"Verified Collection"}</span>
       <InfoTooltip bottom text={onchainVerifiedToolTip} />
     </div>
   );

--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -178,7 +178,7 @@ function getIsMutablePill(isMutable: boolean) {
 
 function getIsVerifiedCollection(isVerified?: boolean) {
   const onchainVerifiedToolTip =
-    "This NFT has been verified as member of an on-chain collection. This tag guarantees authenticity.";
+    "This NFT has been verified as a member of an on-chain collection. This tag guarantees authenticity.";
   return (
     <div className={"d-inline-flex align-items-center ms-2"}>
       <span className="badge badge-pill bg-dark">

--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -178,7 +178,7 @@ function getIsMutablePill(isMutable: boolean) {
 
 function getIsVerifiedCollection(isVerified?: boolean) {
   const onchainVerifiedToolTip =
-    "This NFT has been verified as a member of an no-chain collection. This tag guarantees authenticity.";
+    "This NFT has been verified as member of an on-chain collection. This tag guarantees authenticity.";
   return (
     <div className={"d-inline-flex align-items-center ms-2"}>
       <span className="badge badge-pill bg-dark">

--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -343,6 +343,18 @@ function NonFungibleTokenMintAccountCard({
             </td>
           </tr>
         )}
+        {nftData?.metadata.collection?.verified && (
+          <tr>
+            <td>Verified Collection Address</td>
+            <td className="text-lg-end">
+              <Address
+                pubkey={new PublicKey(nftData.metadata.collection.key)}
+                alignRight
+                link
+              />
+            </td>
+          </tr>
+        )}
         {mintInfo.mintAuthority && (
           <tr>
             <td>Mint Authority</td>


### PR DESCRIPTION
This change adds Verified On-chain Collection data to help consumers check if their NFTs are authentic. Note the new "Verified Collection" pill beside Master Edition and the "Verified Collection Address" addition to the Overview Section.

![Screen Shot 2022-03-04 at 3 29 20 PM](https://user-images.githubusercontent.com/3758645/156855777-3e9116dc-8b05-4baf-9f80-a51ec7d86eb9.png)

