### PR TITLE
Make find_program_address client example runnable

### DIFF
--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -130,6 +130,16 @@ pub mod solana_sdk {
                 }
             }
 
+            pub fn new_signed_with_payer<T: Signers>(
+                instructions: &[Instruction],
+                payer: Option<&Pubkey>,
+                signing_keypairs: &T,
+                recent_blockhash: Hash,
+            ) -> Self {
+                let message = Message::new(instructions, payer);
+                Self::new(signing_keypairs, message, recent_blockhash)
+            }
+
             pub fn sign<T: Signers>(&mut self, _keypairs: &T, _recent_blockhash: Hash) {}
         }
     }


### PR DESCRIPTION
This uses `solana_program::example_mocks` to make the `Pubkey::find_program_address` client example testable.