### PR TITLE
solana explorer: render program name, ix name, and account names from on chain idl for specific anchor programs

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -14,6 +14,7 @@
         "@cloudflare/stream-react": "^1.2.0",
         "@metamask/jazzicon": "^2.0.0",
         "@metaplex/js": "4.12.0",
+        "@project-serum/anchor": "^0.22.1",
         "@project-serum/serum": "^0.13.61",
         "@react-hook/debounce": "^4.0.0",
         "@sentry/react": "^6.16.1",
@@ -4488,17 +4489,18 @@
       }
     },
     "node_modules/@project-serum/anchor": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
-      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.22.1.tgz",
+      "integrity": "sha512-5pHeyvQhzLahIQ8aZymmDMZJAJFklN0joZdI+YIqFkK2uU/mlKr6rBLQjxysf/j1mLLiNG00tdyLfUtTAdQz7w==",
       "dependencies": {
-        "@project-serum/borsh": "^0.2.2",
+        "@project-serum/borsh": "^0.2.5",
         "@solana/web3.js": "^1.17.0",
         "base64-js": "^1.5.1",
         "bn.js": "^5.1.2",
         "bs58": "^4.0.1",
-        "buffer-layout": "^1.2.0",
+        "buffer-layout": "^1.2.2",
         "camelcase": "^5.3.1",
+        "cross-fetch": "^3.1.5",
         "crypto-hash": "^1.3.0",
         "eventemitter3": "^4.0.7",
         "find": "^0.3.0",
@@ -4544,6 +4546,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@project-serum/serum/node_modules/@project-serum/anchor": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
+      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "dependencies": {
+        "@project-serum/borsh": "^0.2.2",
+        "@solana/web3.js": "^1.17.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.0",
+        "camelcase": "^5.3.1",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "find": "^0.3.0",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
       }
     },
     "node_modules/@project-serum/serum/node_modules/@solana/spl-token": {
@@ -4592,6 +4618,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@project-serum/serum/node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/@project-serum/sol-wallet-adapter": {
       "version": "0.1.8",
@@ -30494,17 +30525,18 @@
       "peer": true
     },
     "@project-serum/anchor": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
-      "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.22.1.tgz",
+      "integrity": "sha512-5pHeyvQhzLahIQ8aZymmDMZJAJFklN0joZdI+YIqFkK2uU/mlKr6rBLQjxysf/j1mLLiNG00tdyLfUtTAdQz7w==",
       "requires": {
-        "@project-serum/borsh": "^0.2.2",
+        "@project-serum/borsh": "^0.2.5",
         "@solana/web3.js": "^1.17.0",
         "base64-js": "^1.5.1",
         "bn.js": "^5.1.2",
         "bs58": "^4.0.1",
-        "buffer-layout": "^1.2.0",
+        "buffer-layout": "^1.2.2",
         "camelcase": "^5.3.1",
+        "cross-fetch": "^3.1.5",
         "crypto-hash": "^1.3.0",
         "eventemitter3": "^4.0.7",
         "find": "^0.3.0",
@@ -30542,6 +30574,27 @@
         "buffer-layout": "^1.2.0"
       },
       "dependencies": {
+        "@project-serum/anchor": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.11.1.tgz",
+          "integrity": "sha512-oIdm4vTJkUy6GmE6JgqDAuQPKI7XM4TPJkjtoIzp69RZe0iAD9JP2XHx7lV1jLdYXeYHqDXfBt3zcq7W91K6PA==",
+          "requires": {
+            "@project-serum/borsh": "^0.2.2",
+            "@solana/web3.js": "^1.17.0",
+            "base64-js": "^1.5.1",
+            "bn.js": "^5.1.2",
+            "bs58": "^4.0.1",
+            "buffer-layout": "^1.2.0",
+            "camelcase": "^5.3.1",
+            "crypto-hash": "^1.3.0",
+            "eventemitter3": "^4.0.7",
+            "find": "^0.3.0",
+            "js-sha256": "^0.9.0",
+            "pako": "^2.0.3",
+            "snake-case": "^3.0.4",
+            "toml": "^3.0.0"
+          }
+        },
         "@solana/spl-token": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.6.tgz",
@@ -30568,6 +30621,11 @@
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
           "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        },
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
         }
       }
     },

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -9,6 +9,7 @@
     "@cloudflare/stream-react": "^1.2.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metaplex/js": "4.12.0",
+    "@project-serum/anchor": "^0.22.1",
     "@project-serum/serum": "^0.13.61",
     "@react-hook/debounce": "^4.0.0",
     "@sentry/react": "^6.16.1",

--- a/explorer/src/components/instruction/GenericAnchorDetails.tsx
+++ b/explorer/src/components/instruction/GenericAnchorDetails.tsx
@@ -1,0 +1,109 @@
+import {
+  Connection,
+  SignatureResult,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { InstructionCard } from "./InstructionCard";
+import {
+  BorshInstructionCoder,
+  Program,
+  Provider,
+} from "@project-serum/anchor";
+import React, { useEffect, useState } from "react";
+import { useCluster } from "../../providers/cluster";
+import { Address } from "../common/Address";
+import { snakeCase } from "snake-case";
+import { Idl } from "@project-serum/anchor";
+
+export function GenericAnchorDetailsCard(props: {
+  ix: TransactionInstruction;
+  index: number;
+  result: SignatureResult;
+  signature: string;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
+}) {
+  const { ix, index, result, innerCards, childIndex } = props;
+
+  const cluster = useCluster();
+
+  const [programName, setProgramName] = useState<string | null>(null);
+  const [ixTitle, setIxTitle] = useState<string | null>(null);
+  const [ixAccounts, setIxAccounts] = useState<
+    { name: string; isMut: boolean; isSigner: boolean; pda?: Object }[] | null
+  >(null);
+
+  useEffect(() => {
+    async function load() {
+      // fetch on chain idl
+      const idl: Idl | null = await Program.fetchIdl(ix.programId, {
+        connection: new Connection(cluster.url),
+      } as Provider);
+
+      if (!idl) {
+        return;
+      }
+
+      // e.g. voter_stake_registry -> voter stake registry
+      const programName = idl!.name.replaceAll("_", " ").trim();
+      setProgramName(programName);
+
+      const coder = new BorshInstructionCoder(idl!);
+      const decodedIx = coder.decode(ix.data)!;
+
+      // get ix title
+      setIxTitle(decodedIx.name);
+
+      // get ix accounts
+      const idlInstructions = idl.instructions.filter(
+        (ix) => ix.name === decodedIx.name
+      );
+      if (idlInstructions.length === 0) {
+        return;
+      }
+      const ixAccounts = idlInstructions[0].accounts;
+      setIxAccounts(
+        ixAccounts as {
+          // type coercing since anchor doesn't export the underlying type
+          name: string;
+          isMut: boolean;
+          isSigner: boolean;
+          pda?: Object;
+        }[]
+      );
+    }
+
+    load();
+  }, [ix.programId, ix.data, cluster]);
+
+  return (
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title={`${programName || "Unknown"}: ${snakeCase(ixTitle || "Unknown")}`}
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
+      {ixAccounts != null &&
+        ix.keys.map((am, keyIndex) => (
+          <tr>
+            <td>
+              <div className="me-2 d-md-inline">
+                {keyIndex + 1}) {snakeCase(ixAccounts![keyIndex].name)}
+              </div>
+              {am.isWritable && (
+                <span className="badge bg-info-soft me-1">Writable</span>
+              )}
+              {am.isSigner && (
+                <span className="badge bg-info-soft me-1">Signer</span>
+              )}
+            </td>
+            <td>
+              <Address pubkey={am.pubkey} alignRight link />
+            </td>
+          </tr>
+        ))}
+    </InstructionCard>
+  );
+}

--- a/explorer/src/components/instruction/GenericAnchorDetails.tsx
+++ b/explorer/src/components/instruction/GenericAnchorDetails.tsx
@@ -98,7 +98,7 @@ export function GenericAnchorDetailsCard(props: {
           <tr>
             <td>
               <div className="me-2 d-md-inline">
-                {keyIndex + 1}) {snakeCase(ixAccounts[keyIndex].name)}
+                {snakeCase(ixAccounts[keyIndex].name)}
               </div>
               {am.isWritable && (
                 <span className="badge bg-info-soft me-1">Writable</span>

--- a/explorer/src/components/instruction/GenericAnchorDetails.tsx
+++ b/explorer/src/components/instruction/GenericAnchorDetails.tsx
@@ -88,6 +88,11 @@ export function GenericAnchorDetailsCard(props: {
       innerCards={innerCards}
       childIndex={childIndex}
     >
+      <td>Program</td>
+      <td className="text-lg-end">
+        <Address pubkey={ix.programId} alignRight link />
+      </td>
+
       {ixAccounts != null &&
         ix.keys.map((am, keyIndex) => (
           <tr>

--- a/explorer/src/components/instruction/GenericAnchorDetails.tsx
+++ b/explorer/src/components/instruction/GenericAnchorDetails.tsx
@@ -45,11 +45,14 @@ export function GenericAnchorDetailsCard(props: {
       }
 
       // e.g. voter_stake_registry -> voter stake registry
-      const programName = idl!.name.replaceAll("_", " ").trim();
+      const programName = idl.name.replaceAll("_", " ").trim();
       setProgramName(programName);
 
-      const coder = new BorshInstructionCoder(idl!);
-      const decodedIx = coder.decode(ix.data)!;
+      const coder = new BorshInstructionCoder(idl);
+      const decodedIx = coder.decode(ix.data);
+      if (!decodedIx) {
+        return;
+      }
 
       // get ix title
       setIxTitle(decodedIx.name);
@@ -90,7 +93,7 @@ export function GenericAnchorDetailsCard(props: {
           <tr>
             <td>
               <div className="me-2 d-md-inline">
-                {keyIndex + 1}) {snakeCase(ixAccounts![keyIndex].name)}
+                {keyIndex + 1}) {snakeCase(ixAccounts[keyIndex].name)}
               </div>
               {am.isWritable && (
                 <span className="badge bg-info-soft me-1">Writable</span>

--- a/explorer/src/components/instruction/anchor/types.ts
+++ b/explorer/src/components/instruction/anchor/types.ts
@@ -4,7 +4,10 @@ import { TransactionInstruction } from "@solana/web3.js";
 // - should have idl on-chain for GenericAnchorDetailsCard to work out of the box
 // - before adding another program to this list, please make sure that the ix
 // are decoding without any errors
-const knownAnchorPrograms = ["4Q6WW2ouZ6V3iaNm56MTd5n2tnTm4C5fiH8miFHnAFHo"];
+const knownAnchorPrograms = [
+  // https://github.com/blockworks-foundation/voter-stake-registry
+  "4Q6WW2ouZ6V3iaNm56MTd5n2tnTm4C5fiH8miFHnAFHo",
+];
 
 export const isInstructionFromAnAnchorProgram = (
   instruction: TransactionInstruction

--- a/explorer/src/components/instruction/anchor/types.ts
+++ b/explorer/src/components/instruction/anchor/types.ts
@@ -1,0 +1,13 @@
+import { TransactionInstruction } from "@solana/web3.js";
+
+// list of programs written in anchor
+// - should have idl on-chain for GenericAnchorDetailsCard to work out of the box
+// - before adding another program to this list, please make sure that the ix
+// are decoding without any errors
+const knownAnchorPrograms = ["4Q6WW2ouZ6V3iaNm56MTd5n2tnTm4C5fiH8miFHnAFHo"];
+
+export const isInstructionFromAnAnchorProgram = (
+  instruction: TransactionInstruction
+) => {
+  return knownAnchorPrograms.includes(instruction.programId.toBase58());
+};

--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -21,8 +21,8 @@ import { WormholeDetailsCard } from "components/instruction/WormholeDetailsCard"
 import { UnknownDetailsCard } from "components/instruction/UnknownDetailsCard";
 import { BonfidaBotDetailsCard } from "components/instruction/BonfidaBotDetails";
 import {
-  SignatureProps,
   INNER_INSTRUCTIONS_START_SLOT,
+  SignatureProps,
 } from "pages/TransactionDetailsPage";
 import { intoTransactionInstruction } from "utils/tx";
 import { isSerumInstruction } from "components/instruction/serum/types";
@@ -39,8 +39,10 @@ import { BpfUpgradeableLoaderDetailsCard } from "components/instruction/bpf-upgr
 import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
 import { isWormholeInstruction } from "components/instruction/wormhole/types";
 import { AssociatedTokenDetailsCard } from "components/instruction/AssociatedTokenDetailsCard";
-import { isMangoInstruction } from "components/instruction/mango/types";
 import { MangoDetailsCard } from "components/instruction/MangoDetails";
+import { isInstructionFromAnAnchorProgram } from "../instruction/anchor/types";
+import { GenericAnchorDetailsCard } from "../instruction/GenericAnchorDetails";
+import { isMangoInstruction } from "../instruction/mango/types";
 
 export type InstructionDetailsProps = {
   tx: ParsedTransaction;
@@ -210,6 +212,8 @@ function renderInstructionCard({
 
   if (isBonfidaBotInstruction(transactionIx)) {
     return <BonfidaBotDetailsCard key={key} {...props} />;
+  } else if (isInstructionFromAnAnchorProgram(transactionIx)) {
+    return <GenericAnchorDetailsCard key={key} {...props} />;
   } else if (isMangoInstruction(transactionIx)) {
     return <MangoDetailsCard key={key} {...props} />;
   } else if (isSerumInstruction(transactionIx)) {


### PR DESCRIPTION
Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>

This patch renders program name, ix name, and account names from on chain idl for whitelisted anchor programs. Tested with https://github.com/blockworks-foundation/voter-stake-registry program ix

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/89031858/156872903-960f0787-ac9d-483c-8769-2262c5bc870b.png">
