### PR TITLE
Remove BankFromArchiveTimings from ledger/

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -108,28 +108,6 @@ pub fn load(
         panic!("filler accounts specified, but not loading from snapshot");
     }
 
-    load_from_genesis(
-        genesis_config,
-        blockstore,
-        account_paths,
-        process_options,
-        cache_block_meta_sender,
-        snapshot_config,
-        accounts_package_sender,
-        accounts_update_notifier,
-    )
-}
-
-fn load_from_genesis(
-    genesis_config: &GenesisConfig,
-    blockstore: &Blockstore,
-    account_paths: Vec<PathBuf>,
-    process_options: ProcessOptions,
-    cache_block_meta_sender: Option<&CacheBlockMetaSender>,
-    snapshot_config: Option<&SnapshotConfig>,
-    accounts_package_sender: AccountsPackageSender,
-    accounts_update_notifier: Option<AccountsUpdateNotifier>,
-) -> LoadResult {
     info!("Processing ledger from genesis");
     to_loadresult(
         blockstore_processor::process_blockstore(

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -143,7 +143,7 @@ fn load_from_snapshot(
         process::exit(1);
     }
 
-    let (deserialized_bank, timings, full_snapshot_archive_info, incremental_snapshot_archive_info) =
+    let (deserialized_bank, full_snapshot_archive_info, incremental_snapshot_archive_info) =
         snapshot_utils::bank_from_latest_snapshot_archives(
             &snapshot_config.bank_snapshots_dir,
             &snapshot_config.snapshot_archives_dir,
@@ -199,7 +199,6 @@ fn load_from_snapshot(
             cache_block_meta_sender,
             Some(snapshot_config),
             accounts_package_sender,
-            timings,
             full_snapshot_archive_info.slot(),
         ),
         Some(starting_snapshot_hashes),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -31,7 +31,7 @@ use {
         cost_model::CostModel,
         snapshot_config::SnapshotConfig,
         snapshot_package::{AccountsPackageSender, SnapshotType},
-        snapshot_utils::{self, BankFromArchiveTimings},
+        snapshot_utils,
         transaction_batch::TransactionBatch,
         transaction_cost_metrics_sender::TransactionCostMetricsSender,
         vote_account::VoteAccount,
@@ -610,7 +610,6 @@ pub fn process_blockstore(
         cache_block_meta_sender,
         snapshot_config,
         accounts_package_sender,
-        BankFromArchiveTimings::default(),
         None,
     )
 }
@@ -626,7 +625,6 @@ pub(crate) fn process_blockstore_from_root(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     snapshot_config: Option<&SnapshotConfig>,
     accounts_package_sender: AccountsPackageSender,
-    timings: BankFromArchiveTimings,
     last_full_snapshot_slot: Slot,
 ) -> BlockstoreProcessorResult {
     do_process_blockstore_from_root(
@@ -638,7 +636,6 @@ pub(crate) fn process_blockstore_from_root(
         cache_block_meta_sender,
         snapshot_config,
         accounts_package_sender,
-        timings,
         Some(last_full_snapshot_slot),
     )
 }
@@ -653,7 +650,6 @@ fn do_process_blockstore_from_root(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     snapshot_config: Option<&SnapshotConfig>,
     accounts_package_sender: AccountsPackageSender,
-    timings: BankFromArchiveTimings,
     mut last_full_snapshot_slot: Option<Slot>,
 ) -> BlockstoreProcessorResult {
     // Starting slot must be a root, and thus has no parents
@@ -754,26 +750,6 @@ fn do_process_blockstore_from_root(
         ("slot", bank_forks.root(), i64),
         ("forks", bank_forks.banks().len(), i64),
         ("calculate_capitalization_us", time_cap.as_us(), i64),
-        (
-            "full_snapshot_untar_us",
-            timings.full_snapshot_untar_us,
-            i64
-        ),
-        (
-            "incremental_snapshot_untar_us",
-            timings.incremental_snapshot_untar_us,
-            i64
-        ),
-        (
-            "rebuild_bank_from_snapshots_us",
-            timings.rebuild_bank_from_snapshots_us,
-            i64
-        ),
-        (
-            "verify_snapshot_bank_us",
-            timings.verify_snapshot_bank_us,
-            i64
-        ),
     );
 
     info!("ledger processing timing: {:?}", timing);
@@ -3194,7 +3170,6 @@ pub mod tests {
             None,
             None,
             accounts_package_sender,
-            BankFromArchiveTimings::default(),
             None,
         )
         .unwrap();
@@ -3304,7 +3279,6 @@ pub mod tests {
             None,
             Some(&snapshot_config),
             accounts_package_sender.clone(),
-            BankFromArchiveTimings::default(),
             None,
         )
         .unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -847,7 +847,6 @@ pub fn bank_from_latest_snapshot_archives(
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
 ) -> Result<(
     Bank,
-    BankFromArchiveTimings,
     FullSnapshotArchiveInfo,
     Option<IncrementalSnapshotArchiveInfo>,
 )> {
@@ -890,6 +889,30 @@ pub fn bank_from_latest_snapshot_archives(
         accounts_update_notifier,
     )?;
 
+    datapoint_info!(
+        "bank_from_snapshot_archives",
+        (
+            "full_snapshot_untar_us",
+            timings.full_snapshot_untar_us,
+            i64
+        ),
+        (
+            "incremental_snapshot_untar_us",
+            timings.incremental_snapshot_untar_us,
+            i64
+        ),
+        (
+            "rebuild_bank_from_snapshots_us",
+            timings.rebuild_bank_from_snapshots_us,
+            i64
+        ),
+        (
+            "verify_snapshot_bank_us",
+            timings.verify_snapshot_bank_us,
+            i64
+        ),
+    );
+
     verify_bank_against_expected_slot_hash(
         &bank,
         incremental_snapshot_archive_info.as_ref().map_or(
@@ -904,7 +927,6 @@ pub fn bank_from_latest_snapshot_archives(
 
     Ok((
         bank,
-        timings,
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,
     ))


### PR DESCRIPTION
` ledger/` pulls in `BankFromArchiveTimings` for the sole purpose of emitting a datapoint. Upstream the datapoint emission in `runtime/` instead.

@brooksprumo - hey this patch affects the `process_blockstore_from_root` datapoint, will any metrics dashboards need to change?