### PR TITLE
Fix MetaplexNFTHeader for unverified collection

### DIFF
--- a/explorer/src/components/account/MetaplexNFTHeader.tsx
+++ b/explorer/src/components/account/MetaplexNFTHeader.tsx
@@ -50,7 +50,7 @@ export function NFTHeader({
               : "No NFT name was found"}
           </h2>
           {getEditionPill(nftData.editionInfo)}
-          {isVerifiedCollection && getVerifiedCollectionPill()}
+          {isVerifiedCollection ? getVerifiedCollectionPill() : null}
         </div>
         <h4 className="header-pretitle ms-1 mt-1 no-overflow-with-ellipsis">
           {metadata.data.symbol !== ""


### PR DESCRIPTION



#### Problem
When the NFT is in an unverified collection, the metaplex NFT header displays a 0.
Example : https://explorer.solana.com/address/ARA6zvFJZAydh6mdAgc7A6pMpZotCQj6eYugUMpEWKYh
#### Summary of Changes
The metaplex NFT header should display nothing
Fixes #
