### PR TITLE
fix: web3.js browser cjs build

### DIFF
--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -69,8 +69,34 @@ function generateConfig(configType, format) {
   switch (configType) {
     case 'browser':
       switch (format) {
-        case 'esm': {
+        case 'iife': {
+          config.external = ['http', 'https'];
+
           config.output = [
+            {
+              file: 'lib/index.iife.js',
+              format: 'iife',
+              name: 'solanaWeb3',
+              sourcemap: true,
+            },
+            {
+              file: 'lib/index.iife.min.js',
+              format: 'iife',
+              name: 'solanaWeb3',
+              sourcemap: true,
+              plugins: [terser({mangle: false, compress: false})],
+            },
+          ];
+
+          break;
+        }
+        default: {
+          config.output = [
+            {
+              file: 'lib/index.browser.cjs.js',
+              format: 'cjs',
+              sourcemap: true,
+            },
             {
               file: 'lib/index.browser.esm.js',
               format: 'es',
@@ -99,29 +125,6 @@ function generateConfig(configType, format) {
 
           break;
         }
-        case 'iife': {
-          config.external = ['http', 'https'];
-
-          config.output = [
-            {
-              file: 'lib/index.iife.js',
-              format: 'iife',
-              name: 'solanaWeb3',
-              sourcemap: true,
-            },
-            {
-              file: 'lib/index.iife.min.js',
-              format: 'iife',
-              name: 'solanaWeb3',
-              sourcemap: true,
-              plugins: [terser({mangle: false, compress: false})],
-            },
-          ];
-
-          break;
-        }
-        default:
-          throw new Error(`Unknown format: ${format}`);
       }
 
       // TODO: Find a workaround to avoid resolving the following JSON file:
@@ -152,6 +155,6 @@ function generateConfig(configType, format) {
 
 export default [
   generateConfig('node'),
-  generateConfig('browser', 'esm'),
+  generateConfig('browser'),
   generateConfig('browser', 'iife'),
 ];


### PR DESCRIPTION
#### Problem

Fixes an issue reported here: https://github.com/solana-labs/solana-web3.js/commit/dfda2cc5d0bb1a46b39e479108c6281b55a29306

This issue was introduced by https://github.com/solana-labs/solana/pull/21940 which attempted to fix an apparently incorrect reference to a CJS browser build output file. However, the real issue is that the CJS browser build wasn't happening, so this produced a dead file reference.

#### Summary of Changes

This PR adds the missing CJS browser build to the Rollup config, which should fix the issue.