### PR TITLE
Separate remotely downloaded snapshot archives

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -271,7 +271,7 @@ pub fn download_snapshot_archive<'a, 'b>(
     let snapshot_archives_remote_dir = snapshot_archives_dir
         .to_path_buf()
         .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR);
-    fs::create_dir_all(snapshot_archives_remote_dir.to_path_buf()).unwrap();
+    fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
     for archive_format in [
         ArchiveFormat::TarZstd,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -268,9 +268,8 @@ pub fn download_snapshot_archive<'a, 'b>(
         maximum_incremental_snapshot_archives_to_retain,
     );
 
-    let snapshot_archives_remote_dir = snapshot_archives_dir
-        .to_path_buf()
-        .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR);
+    let snapshot_archives_remote_dir =
+        snapshot_utils::build_snapshot_archives_remote_dir(snapshot_archives_dir);
     fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
 
     for archive_format in [

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -274,16 +274,19 @@ pub fn download_snapshot_archive<'a, 'b>(
         ArchiveFormat::TarBzip2,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
+        let snapshot_archives_remote_dir = snapshot_archives_dir.to_path_buf().join("remote");
+        fs::create_dir_all(snapshot_archives_remote_dir.to_path_buf()).unwrap();
+
         let destination_path = match snapshot_type {
             SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                snapshot_archives_dir,
+                snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
             SnapshotType::IncrementalSnapshot(base_slot) => {
                 snapshot_utils::build_incremental_snapshot_archive_path(
-                    snapshot_archives_dir,
+                    snapshot_archives_remote_dir,
                     base_slot,
                     desired_snapshot_hash.0,
                     &desired_snapshot_hash.1,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -268,17 +268,17 @@ pub fn download_snapshot_archive<'a, 'b>(
         maximum_incremental_snapshot_archives_to_retain,
     );
 
+    let snapshot_archives_remote_dir = snapshot_archives_dir
+        .to_path_buf()
+        .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR);
+    fs::create_dir_all(snapshot_archives_remote_dir.to_path_buf()).unwrap();
+
     for archive_format in [
         ArchiveFormat::TarZstd,
         ArchiveFormat::TarGzip,
         ArchiveFormat::TarBzip2,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
-        let snapshot_archives_remote_dir = snapshot_archives_dir
-            .to_path_buf()
-            .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR);
-        fs::create_dir_all(snapshot_archives_remote_dir.to_path_buf()).unwrap();
-
         let destination_path = match snapshot_type {
             SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
                 snapshot_archives_remote_dir,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -280,14 +280,14 @@ pub fn download_snapshot_archive<'a, 'b>(
     ] {
         let destination_path = match snapshot_type {
             SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                snapshot_archives_remote_dir,
+                &snapshot_archives_remote_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
             SnapshotType::IncrementalSnapshot(base_slot) => {
                 snapshot_utils::build_incremental_snapshot_archive_path(
-                    snapshot_archives_remote_dir,
+                    &snapshot_archives_remote_dir,
                     base_slot,
                     desired_snapshot_hash.0,
                     &desired_snapshot_hash.1,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -274,7 +274,9 @@ pub fn download_snapshot_archive<'a, 'b>(
         ArchiveFormat::TarBzip2,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
-        let snapshot_archives_remote_dir = snapshot_archives_dir.to_path_buf().join("remote");
+        let snapshot_archives_remote_dir = snapshot_archives_dir
+            .to_path_buf()
+            .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR);
         fs::create_dir_all(snapshot_archives_remote_dir.to_path_buf()).unwrap();
 
         let destination_path = match snapshot_type {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1084,18 +1084,18 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let copy_files_with_remote = |from: &Path, to: &Path| {
         copy_files(from, to);
-        let _ = fs::create_dir_all(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
-        let _ = fs::create_dir_all(&to.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
-        copy_files(
-            &from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR),
-            &to.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR),
-        );
+        let remote_from = snapshot_utils::build_snapshot_archives_remote_dir(from);
+        let remote_to = snapshot_utils::build_snapshot_archives_remote_dir(to);
+        let _ = fs::create_dir_all(&remote_from);
+        let _ = fs::create_dir_all(&remote_to);
+        copy_files(&remote_from, &remote_to);
     };
 
     let delete_files_with_remote = |from: &Path| {
         delete_files(from);
-        let _ = fs::create_dir_all(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
-        delete_files(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
+        let remote_dir = snapshot_utils::build_snapshot_archives_remote_dir(from);
+        let _ = fs::create_dir_all(&remote_dir);
+        delete_files(&remote_dir);
     };
 
     // After downloading the snapshots, copy them over to a backup directory.  Later we'll need to

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1082,6 +1082,16 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         }
     };
 
+    let copy_files_with_remote = |from: &Path, to: &Path| {
+        copy_files(from, to);
+        copy_files(&from.join("remote"), &to.join("remote"));
+    };
+
+    let delete_files_with_remote = |from: &Path| {
+        delete_files(from);
+        delete_files(&from.join("remote"));
+    };
+
     // After downloading the snapshots, copy them over to a backup directory.  Later we'll need to
     // restart the node and guarantee that the only snapshots present are these initial ones.  So,
     // the easiest way to do that is create a backup now, delete the ones on the node before
@@ -1091,7 +1101,7 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         "Backing up validator snapshots to dir: {}...",
         backup_validator_snapshot_archives_dir.path().display()
     );
-    copy_files(
+    copy_files_with_remote(
         validator_snapshot_test_config.snapshot_archives_dir.path(),
         backup_validator_snapshot_archives_dir.path(),
     );
@@ -1169,8 +1179,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     trace!(
         "Delete all the snapshots on the validator and restore the originals from the backup..."
     );
-    delete_files(validator_snapshot_test_config.snapshot_archives_dir.path());
-    copy_files(
+    delete_files_with_remote(validator_snapshot_test_config.snapshot_archives_dir.path());
+    copy_files_with_remote(
         backup_validator_snapshot_archives_dir.path(),
         validator_snapshot_test_config.snapshot_archives_dir.path(),
     );

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1084,15 +1084,18 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let copy_files_with_remote = |from: &Path, to: &Path| {
         copy_files(from, to);
-        let _ = fs::create_dir_all(&from.join("remote"));
-        let _ = fs::create_dir_all(&to.join("remote"));
-        copy_files(&from.join("remote"), &to.join("remote"));
+        let _ = fs::create_dir_all(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
+        let _ = fs::create_dir_all(&to.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
+        copy_files(
+            &from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR),
+            &to.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR),
+        );
     };
 
     let delete_files_with_remote = |from: &Path| {
         delete_files(from);
-        let _ = fs::create_dir_all(&from.join("remote"));
-        delete_files(&from.join("remote"));
+        let _ = fs::create_dir_all(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
+        delete_files(&from.join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR));
     };
 
     // After downloading the snapshots, copy them over to a backup directory.  Later we'll need to

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1084,11 +1084,14 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let copy_files_with_remote = |from: &Path, to: &Path| {
         copy_files(from, to);
+        let _ = fs::create_dir_all(&from.join("remote"));
+        let _ = fs::create_dir_all(&to.join("remote"));
         copy_files(&from.join("remote"), &to.join("remote"));
     };
 
     let delete_files_with_remote = |from: &Path| {
         delete_files(from);
+        let _ = fs::create_dir_all(&from.join("remote"));
         delete_files(&from.join("remote"));
     };
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -153,14 +153,14 @@ impl RpcRequestMiddleware {
         tokio::fs::File::open(path).await
     }
 
-    fn find_snapshot_file(&self, stem: &Path) -> PathBuf {
+    fn find_snapshot_file(&self, stem: impl AsRef<Path>) -> PathBuf {
         let root = &self.snapshot_config.as_ref().unwrap().snapshot_archives_dir;
         let local_path = root.join(stem);
-        let remote_path = snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem);
         if local_path.exists() {
             local_path
         } else {
-            remote_path
+            // remote snapshot archive path
+            snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem);
         }
     }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -155,10 +155,10 @@ impl RpcRequestMiddleware {
 
     fn find_snapshot_file<P>(&self, stem: P) -> PathBuf
     where
-        P: AsRef<Path> + Copy,
+        P: AsRef<Path>,
     {
         let root = &self.snapshot_config.as_ref().unwrap().snapshot_archives_dir;
-        let local_path = root.join(stem);
+        let local_path = root.join(&stem);
         if local_path.exists() {
             local_path
         } else {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -156,10 +156,7 @@ impl RpcRequestMiddleware {
     fn find_snapshot_file(&self, stem: &Path) -> PathBuf {
         let root = &self.snapshot_config.as_ref().unwrap().snapshot_archives_dir;
         let local_path = root.join(stem);
-        let remote_path = root
-            .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
-            .join(stem);
-
+        let remote_path = snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem);
         if local_path.exists() {
             local_path
         } else {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -160,7 +160,7 @@ impl RpcRequestMiddleware {
             local_path
         } else {
             // remote snapshot archive path
-            snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem);
+            snapshot_utils::build_snapshot_archives_remote_dir(root).join(stem)
         }
     }
 
@@ -174,7 +174,7 @@ impl RpcRequestMiddleware {
                 }
                 _ => {
                     inc_new_counter_info!("rpc-get_snapshot", 1);
-                    self.find_snapshot_file(stem.as_ref())
+                    self.find_snapshot_file(stem)
                 }
             }
         };

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -153,7 +153,10 @@ impl RpcRequestMiddleware {
         tokio::fs::File::open(path).await
     }
 
-    fn find_snapshot_file(&self, stem: impl AsRef<Path>) -> PathBuf {
+    fn find_snapshot_file<P>(&self, stem: P) -> PathBuf
+    where
+        P: AsRef<Path> + Copy,
+    {
         let root = &self.snapshot_config.as_ref().unwrap().snapshot_archives_dir;
         let local_path = root.join(stem);
         if local_path.exists() {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -156,7 +156,9 @@ impl RpcRequestMiddleware {
     fn find_snapshot_file(&self, stem: &Path) -> PathBuf {
         let root = &self.snapshot_config.as_ref().unwrap().snapshot_archives_dir;
         let local_path = root.join(stem);
-        let remote_path = root.join("remote").join(stem);
+        let remote_path = root
+            .join(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
+            .join(stem);
 
         if local_path.exists() {
             local_path

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -65,6 +65,10 @@ impl FullSnapshotArchiveInfo {
     pub(crate) fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
         Self(snapshot_archive_info)
     }
+
+    pub fn is_remote(&self) -> bool {
+        self.path().parent().unwrap().ends_with("remote")
+    }
 }
 
 impl SnapshotArchiveInfoGetter for FullSnapshotArchiveInfo {

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -67,7 +67,10 @@ impl FullSnapshotArchiveInfo {
     }
 
     pub fn is_remote(&self) -> bool {
-        self.path().parent().unwrap().ends_with("remote")
+        self.path()
+            .parent()
+            .unwrap()
+            .ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
     }
 }
 
@@ -83,7 +86,7 @@ impl PartialOrd for FullSnapshotArchiveInfo {
     }
 }
 
-// Order `FullSnapshotArchiveInfo` by slot (ascending), which practially is sorting chronologically
+// Order `FullSnapshotArchiveInfo` by slot (ascending), which practically is sorting chronologically
 impl Ord for FullSnapshotArchiveInfo {
     fn cmp(&self, other: &Self) -> Ordering {
         self.slot().cmp(&other.slot())
@@ -145,7 +148,7 @@ impl PartialOrd for IncrementalSnapshotArchiveInfo {
 }
 
 // Order `IncrementalSnapshotArchiveInfo` by base slot (ascending), then slot (ascending), which
-// practially is sorting chronologically
+// practically is sorting chronologically
 impl Ord for IncrementalSnapshotArchiveInfo {
     fn cmp(&self, other: &Self) -> Ordering {
         self.base_slot()

--- a/runtime/src/snapshot_archive_info.rs
+++ b/runtime/src/snapshot_archive_info.rs
@@ -25,6 +25,15 @@ pub trait SnapshotArchiveInfoGetter {
     fn archive_format(&self) -> ArchiveFormat {
         self.snapshot_archive_info().archive_format
     }
+
+    fn is_remote(&self) -> bool {
+        self.snapshot_archive_info()
+            .path
+            .parent()
+            .map_or(false, |p| {
+                p.ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
+            })
+    }
 }
 
 /// Common information about a snapshot archive
@@ -64,13 +73,6 @@ impl FullSnapshotArchiveInfo {
 
     pub(crate) fn new(snapshot_archive_info: SnapshotArchiveInfo) -> Self {
         Self(snapshot_archive_info)
-    }
-
-    pub fn is_remote(&self) -> bool {
-        self.path()
-            .parent()
-            .unwrap()
-            .ends_with(snapshot_utils::SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
     }
 }
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -47,6 +47,7 @@ mod archive_format;
 pub use archive_format::*;
 
 pub const SNAPSHOT_STATUS_CACHE_FILENAME: &str = "status_cache";
+pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 25_000;
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: Slot = 100;
 const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1143,7 +1143,7 @@ pub(crate) fn parse_incremental_snapshot_archive_filename(
     })
 }
 
-/// Walk down the snapshot archive directory recursively to collect snapshot archive file info
+/// Walk down the snapshot archive to collect snapshot archive file info
 fn get_snapshot_archives<T, F>(snapshot_archives_dir: &Path, cb: F) -> Vec<T>
 where
     F: Fn(PathBuf) -> Result<T>,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1150,14 +1150,12 @@ fn get_snapshot_archives<T>(dir: &Path, cb: fn(PathBuf) -> Result<T>, output: &m
             return;
         }
 
-        for entry in entry_iter.unwrap() {
-            if let Ok(e) = entry {
-                let p = e.path();
-                if p.is_dir() && p.ends_with(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR) {
-                    get_snapshot_archives::<T>(&p, cb, output);
-                } else if let Ok(info) = cb(p) {
-                    output.push(info);
-                }
+        for entry in entry_iter.unwrap().flatten() {
+            let p = entry.path();
+            if p.is_dir() && p.ends_with(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR) {
+                get_snapshot_archives::<T>(&p, cb, output);
+            } else if let Ok(info) = cb(p) {
+                output.push(info);
             }
         }
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1154,7 +1154,7 @@ fn get_snapshot_archives<T>(dir: &Path, cb: fn(PathBuf) -> Result<T>, output: &m
             if entry.is_ok() {
                 let entry = entry.unwrap();
                 let path = entry.path();
-                if path.is_dir() {
+                if path.is_dir() && path.ends_with(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR) {
                     get_snapshot_archives::<T>(&path, cb, output);
                 } else {
                     if let Ok(info) = cb(entry.path()) {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1155,7 +1155,7 @@ where
                 info!(
                     "Unable to read snapshot archives directory: err: {}, path: {}",
                     err,
-                    snapshot_archives_dir.display()
+                    dir.display()
                 );
                 vec![]
             }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1151,15 +1151,12 @@ fn get_snapshot_archives<T>(dir: &Path, cb: fn(PathBuf) -> Result<T>, output: &m
         }
 
         for entry in entry_iter.unwrap() {
-            if entry.is_ok() {
-                let entry = entry.unwrap();
-                let path = entry.path();
-                if path.is_dir() && path.ends_with(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR) {
-                    get_snapshot_archives::<T>(&path, cb, output);
-                } else {
-                    if let Ok(info) = cb(entry.path()) {
-                        output.push(info);
-                    }
+            if let Ok(e) = entry {
+                let p = e.path();
+                if p.is_dir() && p.ends_with(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR) {
+                    get_snapshot_archives::<T>(&p, cb, output);
+                } else if let Ok(info) = cb(p) {
+                    output.push(info);
                 }
             }
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1034,6 +1034,12 @@ pub fn path_to_file_name_str(path: &Path) -> Result<&str> {
         .ok_or_else(|| SnapshotError::FileNameToStrError(path.to_path_buf()))
 }
 
+pub fn build_snapshot_archives_remote_dir(snapshot_archives_dir: impl AsRef<Path>) -> PathBuf {
+    snapshot_archives_dir
+        .as_ref()
+        .join(SNAPSHOT_ARCHIVE_DOWNLOAD_DIR)
+}
+
 /// Build the full snapshot archive path from its components: the snapshot archives directory, the
 /// snapshot slot, the accounts hash, and the archive format.
 pub fn build_full_snapshot_archive_path(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1148,7 +1148,7 @@ fn get_snapshot_archives<T, F>(snapshot_archives_dir: &Path, cb: F) -> Vec<T>
 where
     F: Fn(PathBuf) -> Result<T>,
 {
-    let walk_dir = |dir| -> Vec<T> {
+    let walk_dir = |dir: &Path| -> Vec<T> {
         let entry_iter = fs::read_dir(dir);
         match entry_iter {
             Err(err) => {


### PR DESCRIPTION
#### Problem

This is yet another approach, from https://github.com/solana-labs/solana/pull/23455, to address the https://github.com/solana-labs/solana/issues/23452

#### Summary of Changes
1. Remotely downloaded snapshot archives are stored in `remote` subdirectory.
2. skip cleaning and shrinking for local snapshot archives.

Fixes #