### PR TITLE
chore: remove console log from connection.js

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4048,11 +4048,6 @@ export class Connection {
       let logs;
       if ('data' in res.error) {
         logs = res.error.data.logs;
-        if (logs && Array.isArray(logs)) {
-          const traceIndent = '\n    ';
-          const logTrace = traceIndent + logs.join(traceIndent);
-          console.error(res.error.message, logTrace);
-        }
       }
       throw new SendTransactionError(
         'failed to send transaction: ' + res.error.message,


### PR DESCRIPTION
There is no need to log the error to the console. Developers can simply catch the error and handle it themselves without it cluttering production logs.

#### Problem

Clutter in my production server logs for no reason.

#### Summary of Changes

I am removing the console.log

Fixes #

Removal of the console.log will result in less production server clutter and still allow developers to catch the error and handle it they want to.
