### PR TITLE
(LedgerStore) Introduce experimental flag dynamic_size_with_fixed_level

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1030,6 +1030,19 @@ pub fn main() {
                        Turning on compression can save ~10% of the ledger size."),
         )
         .arg(
+            Arg::with_name("rocksdb_dynamic_size_with_fixed_level")
+                .hidden(true)
+                .long("rocksdb-dynamic-size-with-fixed-level")
+                .takes_value(false)
+                .help("EXPERIMENTAL: This setting allows the blockstore to \
+                       flexibly handle different workload by dynamically adapting \
+                       the size of each level over time to maintain the same read \
+                       amplification. \
+                       WARNING: based on the RocksDB's documentation, it is \
+                       suggested not to use this options to open an existing \
+                       rocksdb instance without this option enabled"),
+        )
+        .arg(
             Arg::with_name("skip_poh_verify")
                 .long("skip-poh-verify")
                 .takes_value(false)
@@ -2726,6 +2739,7 @@ pub fn main() {
                 ),
             },
         },
+        dynamic_size_with_fixed_level: matches.is_present("rocksdb_dynamic_size_with_fixed_level"),
     };
 
     if matches.is_present("halt_on_known_validators_accounts_hash_mismatch") {


### PR DESCRIPTION
#### Summary of Changes
This PR adds `dynamic_size_with_fixed_level`, an experimental setting that allows
the blockstore to flexibly handle different workloads by adapting the size of each level
while maintaining the same read amplification.

The setting internally turns on `level_compaction_dynamic_level_bytes`,
which option is also used in MyRocks (the Facebook's version of MySQL)
https://github.com/facebook/mysql-5.6/wiki/my.cnf-tuning.  Some details are described in 
https://smalldatum.blogspot.com/2018/09/5-things-to-set-when-configuring.html.

This PR depends on #23523, #23696, and #23834.