### PR TITLE
(LedgerStore) Enables group-by operation on storage type in blockstore_rocksdb_cfs metrics

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -36,7 +36,7 @@ use {
     solana_ledger::{
         bank_forks_utils,
         blockstore::{Blockstore, BlockstoreSignals, CompletedSlotsReceiver, PurgeType},
-        blockstore_db::{BlockstoreOptions, BlockstoreRecoveryMode, ShredStorageType},
+        blockstore_db::{BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRecoveryMode},
         blockstore_processor::{self, TransactionStatusSender},
         leader_schedule::FixedSchedule,
         leader_schedule_cache::LeaderScheduleCache,
@@ -165,7 +165,7 @@ pub struct ValidatorConfig {
     pub no_wait_for_vote_to_start_leader: bool,
     pub accounts_shrink_ratio: AccountShrinkThreshold,
     pub wait_to_vote_slot: Option<Slot>,
-    pub shred_storage_type: ShredStorageType,
+    pub blockstore_advanced_options: BlockstoreAdvancedOptions,
 }
 
 impl Default for ValidatorConfig {
@@ -226,7 +226,7 @@ impl Default for ValidatorConfig {
             accounts_shrink_ratio: AccountShrinkThreshold::default(),
             accounts_db_config: None,
             wait_to_vote_slot: None,
-            shred_storage_type: ShredStorageType::RocksLevel,
+            blockstore_advanced_options: BlockstoreAdvancedOptions::default(),
         }
     }
 }
@@ -1259,7 +1259,7 @@ fn new_banks_from_ledger(
         BlockstoreOptions {
             recovery_mode: config.wal_recovery_mode.clone(),
             enforce_ulimit_nofile,
-            shred_storage_type: config.shred_storage_type.clone(),
+            advanced_options: config.blockstore_advanced_options.clone(),
             ..BlockstoreOptions::default()
         },
     )

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -9,7 +9,10 @@ mod tests {
         solana_core::ledger_cleanup_service::LedgerCleanupService,
         solana_ledger::{
             blockstore::{make_many_slot_shreds, Blockstore},
-            blockstore_db::{BlockstoreOptions, BlockstoreRocksFifoOptions, ShredStorageType},
+            blockstore_db::{
+                BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRocksFifoOptions,
+                ShredStorageType,
+            },
             get_tmp_ledger_path,
         },
         solana_measure::measure::Measure,
@@ -348,10 +351,14 @@ mod tests {
             &ledger_path,
             if config.fifo_compaction {
                 BlockstoreOptions {
-                    shred_storage_type: ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
-                        shred_data_cf_size: config.shred_data_cf_size,
-                        ..BlockstoreRocksFifoOptions::default()
-                    }),
+                    advanced_options: BlockstoreAdvancedOptions {
+                        shred_storage_type: ShredStorageType::RocksFifo(
+                            BlockstoreRocksFifoOptions {
+                                shred_data_cf_size: config.shred_data_cf_size,
+                                ..BlockstoreRocksFifoOptions::default()
+                            },
+                        ),
+                    },
                     ..BlockstoreOptions::default()
                 }
             } else {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -15,7 +15,7 @@ use {
     solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account},
     solana_ledger::{
         blockstore::create_new_ledger,
-        blockstore_db::{AccessType, ShredStorageType},
+        blockstore_db::{AccessType, BlockstoreAdvancedOptions},
     },
     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_sdk::{
@@ -633,7 +633,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &genesis_config,
         max_genesis_archive_unpacked_size,
         AccessType::PrimaryOnly,
-        ShredStorageType::default(),
+        BlockstoreAdvancedOptions::default(),
     )?;
 
     println!("{}", genesis_config);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -24,7 +24,8 @@ use {
         bank_forks_utils,
         blockstore::{create_new_ledger, Blockstore, PurgeType},
         blockstore_db::{
-            self, AccessType, BlockstoreOptions, BlockstoreRecoveryMode, Database, ShredStorageType,
+            self, AccessType, BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRecoveryMode,
+            Database,
         },
         blockstore_processor::ProcessOptions,
         shred::Shred,
@@ -1721,7 +1722,7 @@ fn main() {
                     &genesis_config,
                     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
                     AccessType::PrimaryOnly,
-                    ShredStorageType::default(),
+                    BlockstoreAdvancedOptions::default(),
                 )
                 .unwrap_or_else(|err| {
                     eprintln!("Failed to write genesis config: {:?}", err);

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -62,7 +62,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_config: config.accounts_db_config.clone(),
         wait_to_vote_slot: config.wait_to_vote_slot,
-        shred_storage_type: config.shred_storage_type.clone(),
+        blockstore_advanced_options: config.blockstore_advanced_options.clone(),
     }
 }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -13,7 +13,8 @@ use {
         socketaddr,
     },
     solana_ledger::{
-        blockstore::create_new_ledger, blockstore_db::ShredStorageType, create_new_tmp_ledger,
+        blockstore::create_new_ledger, blockstore_db::BlockstoreAdvancedOptions,
+        create_new_tmp_ledger,
     },
     solana_net_utils::PortRange,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
@@ -582,7 +583,7 @@ impl TestValidator {
                         .max_genesis_archive_unpacked_size
                         .unwrap_or(MAX_GENESIS_ARCHIVE_UNPACKED_SIZE),
                     solana_ledger::blockstore_db::AccessType::PrimaryOnly,
-                    ShredStorageType::default(),
+                    BlockstoreAdvancedOptions::default(),
                 )
                 .map_err(|err| {
                     format!(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -33,8 +33,8 @@ use {
         contact_info::ContactInfo,
     },
     solana_ledger::blockstore_db::{
-        BlockstoreRecoveryMode, BlockstoreRocksFifoOptions, ShredStorageType,
-        DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+        BlockstoreAdvancedOptions, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
+        ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
@@ -2553,22 +2553,24 @@ pub fn main() {
         validator_config.max_ledger_shreds = Some(limit_ledger_size);
     }
 
-    validator_config.shred_storage_type = match matches.value_of("rocksdb_shred_compaction") {
-        None => ShredStorageType::default(),
-        Some(shred_compaction_string) => match shred_compaction_string {
-            "level" => ShredStorageType::RocksLevel,
-            "fifo" => {
-                let shred_storage_size =
-                    value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);
-                ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
-                    shred_data_cf_size: shred_storage_size / 2,
-                    shred_code_cf_size: shred_storage_size / 2,
-                })
-            }
-            _ => panic!(
-                "Unrecognized rocksdb-shred-compaction: {}",
-                shred_compaction_string
-            ),
+    validator_config.blockstore_advanced_options = BlockstoreAdvancedOptions {
+        shred_storage_type: match matches.value_of("rocksdb_shred_compaction") {
+            None => ShredStorageType::default(),
+            Some(shred_compaction_string) => match shred_compaction_string {
+                "level" => ShredStorageType::RocksLevel,
+                "fifo" => {
+                    let shred_storage_size =
+                        value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);
+                    ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
+                        shred_data_cf_size: shred_storage_size / 2,
+                        shred_code_cf_size: shred_storage_size / 2,
+                    })
+                }
+                _ => panic!(
+                    "Unrecognized rocksdb-shred-compaction: {}",
+                    shred_compaction_string
+                ),
+            },
         },
     };
 


### PR DESCRIPTION
#### Summary of Changes
This PR further enables group by operation on storage type in blockstore_rocksdb_cfs metrics.
Such group-by allows us to further compare the performance metrics between rocks-level and
rocks-fifo.

Here is an [example query](https://metrics.solana.com:8888/sources/1/chronograf/data-explorer?query=SELECT%20mean%28%22total_sst_files_size%22%29%20AS%20%22mean_total_sst_files_size%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22blockstore_rocksdb_cfs%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%2C%20%22cf_name%22%2C%20%22storage%22%20FILL%28null%29).

To make things extensible, this PR introduces BlockstoreAdvancedOptions and move shred_storage_type. 
All fields in BlockstoreAdvancedOptions will support group-by operation in blockstore_rocksdb_cfs.

Dependency: #23580