### PR TITLE
Patch validator from loading persisted program costs

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -811,7 +811,8 @@ impl Validator {
 
         let vote_tracker = Arc::<VoteTracker>::default();
         let mut cost_model = CostModel::default();
-        cost_model.initialize_cost_table(&blockstore.read_program_costs().unwrap());
+        // initialize cost model with built-in instruction costs only
+        cost_model.initialize_cost_table(&[]);
         let cost_model = Arc::new(RwLock::new(cost_model));
 
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();


### PR DESCRIPTION
#### Problem
Bad number in persisted cost_table, to temporally prevent calculate transaction cost using these bad numbers, update validator to not load/write to blockstore. 
 
#### Summary of Changes
- not to load persisted costs from blockstore during validator restart
- not to write cost snapshots to blockstore
- additional log to capture EMA calculation 
- 
Fixes #
