### PR TITLE
Add spacing in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
-#### Problem
+### Problem
 
 
 
-#### Proposed Solution
+### Proposed Solution
+
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
-### Problem
+#### Problem
 
 
 
-### Proposed Solution
+#### Proposed Solution
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
-#### Problem
+### Problem
 
-#### Summary of Changes
+
+
+### Summary of Changes
+
+
 
 Fixes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Problem
+#### Problem
 
 
 
-### Summary of Changes
+#### Summary of Changes
 
 
 


### PR DESCRIPTION
### Problem

The templates aren't as friendly to fill out, due to a lack of newlines. Specifically, with the old templates, I'd have to add new lines in every PR/Issue to ensure there was a newline between the sections.

### Summary of Changes

Add newlines to the templates.
