### PR TITLE
Refactor: Add transaction binary encoding enum

### DIFF
--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -39,7 +39,9 @@ use {
         system_program,
         transaction::Transaction,
     },
-    solana_transaction_status::{Encodable, EncodedTransaction, UiTransactionEncoding},
+    solana_transaction_status::{
+        Encodable, EncodedTransaction, TransactionBinaryEncoding, UiTransactionEncoding,
+    },
     std::{fmt::Write as FmtWrite, fs::File, io::Write, sync::Arc},
 };
 
@@ -189,7 +191,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("encoding")
                         .index(2)
                         .value_name("ENCODING")
-                        .possible_values(&["base58", "base64"]) // Subset of `UiTransactionEncoding` enum
+                        .possible_values(&["base58", "base64"]) // Variants of `TransactionBinaryEncoding` enum
                         .default_value("base58")
                         .takes_value(true)
                         .required(true)
@@ -341,13 +343,13 @@ pub fn parse_balance(
 
 pub fn parse_decode_transaction(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let blob = value_t_or_exit!(matches, "transaction", String);
-    let encoding = match matches.value_of("encoding").unwrap() {
-        "base58" => UiTransactionEncoding::Base58,
-        "base64" => UiTransactionEncoding::Base64,
+    let binary_encoding = match matches.value_of("encoding").unwrap() {
+        "base58" => TransactionBinaryEncoding::Base58,
+        "base64" => TransactionBinaryEncoding::Base64,
         _ => unreachable!(),
     };
 
-    let encoded_transaction = EncodedTransaction::Binary(blob, encoding);
+    let encoded_transaction = EncodedTransaction::Binary(blob, binary_encoding);
     if let Some(transaction) = encoded_transaction.decode() {
         Ok(CliCommandInfo {
             command: CliCommand::DecodeTransaction(transaction),

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -32,9 +32,9 @@ use {
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
-        EncodedTransactionWithStatusMeta, Rewards, TransactionConfirmationStatus,
-        TransactionStatus, UiCompiledInstruction, UiMessage, UiRawMessage, UiTransaction,
-        UiTransactionEncoding, UiTransactionStatusMeta,
+        EncodedTransactionWithStatusMeta, Rewards, TransactionBinaryEncoding,
+        TransactionConfirmationStatus, TransactionStatus, UiCompiledInstruction, UiMessage,
+        UiRawMessage, UiTransaction, UiTransactionStatusMeta,
     },
     solana_version::Version,
     std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::RwLock},
@@ -381,7 +381,7 @@ impl RpcSender for MockSender {
                                  pLHxcaShD81xBNaFDgnA2nkkdHnKtZt4hVSfKAmw3VRZbjrZ7L2fKZBx21CwsG\
                                  hD6onjM2M3qZW5C8J6d1pj41MxKmZgPBSha3MyKkNLkAGFASK"
                             .to_string(),
-                        UiTransactionEncoding::Base58,
+                        TransactionBinaryEncoding::Base58,
                     ),
                     meta: None,
                     version: Some(TransactionVersion::LEGACY),


### PR DESCRIPTION
#### Problem
The `UiTransactionEncoding` enum is used in places where only `Base58` and `Base64` variants are used which means that extra unnecessary handling for the json variants needs to be considered when decoding transactions.

#### Summary of Changes
- Introduced `TransactionBinaryEncoding` which just includes the base58 and base64 variants of `UiTransactionEncoding`

Fixes #
