### PR TITLE
Report banking metrics even if slot begins and ends in process_buffered_packets()

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -812,7 +812,7 @@ impl BankingStage {
                         ),
                     )
                 };
-
+                slot_metrics_tracker.update_on_leader_slot_boundary(&bank_start);
                 Self::consume_or_forward_packets(
                     my_pubkey,
                     leader_at_slot_offset,


### PR DESCRIPTION
#### Problem
If the buffered queue is large enough, it's possible a banking thread spends the entire slot in one iteration of `process_buffered_packets()`, and never hits the `update_on_leader_slot_boundary()` later in the banking loop. This means it won't report metrics.

#### Summary of Changes
Add a check for the slot boundary for metrics inside `process_buffered_packets()` as well
Fixes #
