### PR TITLE
explorer: format Instructions title as singular/plural

### DIFF
--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -127,7 +127,9 @@ export function InstructionsSection({ signature }: SignatureProps) {
       <div className="container">
         <div className="header">
           <div className="header-body">
-            <h3 className="mb-0">Instruction(s)</h3>
+            <h3 className="mb-0">
+              {instructionDetails.length > 1 ? "Instructions" : "Instruction"}
+            </h3>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### Problem

The explorer shows `Instruction(s)` regardless if there are one, two, three or zero (?) instructions.

This triggers me and makes the explorer very hard to use. Devs pls fix.

<img width="717" alt="Screenshot 2022-03-09 at 11 42 51" src="https://user-images.githubusercontent.com/21371810/157426361-48a785ec-958e-410b-aaef-5c14ce322afd.png">

#### Summary of Changes

Context aware plural

Fixes #
