### PR TITLE
Refactor: Sanitized transaction creation

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1617,7 +1617,7 @@ impl BankingStage {
         transaction_indexes: &[usize],
         feature_set: &Arc<feature_set::FeatureSet>,
         votes_only: bool,
-        address_loader: &impl AddressLoader,
+        address_loader: impl AddressLoader,
     ) -> (Vec<SanitizedTransaction>, Vec<usize>) {
         transaction_indexes
             .iter()
@@ -1634,7 +1634,7 @@ impl BankingStage {
                     tx,
                     message_hash,
                     Some(p.meta.is_simple_vote_tx()),
-                    address_loader,
+                    address_loader.clone(),
                 )
                 .ok()?;
                 tx.verify_precompiles(feature_set).ok()?;
@@ -2065,7 +2065,7 @@ mod tests {
             signature::{Keypair, Signer},
             system_instruction::SystemError,
             system_transaction,
-            transaction::{DisabledAddressLoader, Transaction, TransactionError},
+            transaction::{MessageHash, SimpleAddressLoader, Transaction, TransactionError},
         },
         solana_streamer::{recvmmsg::recv_mmsg, socket::SocketAddrSpace},
         solana_transaction_status::{TransactionStatusMeta, VersionedTransactionWithStatusMeta},
@@ -4085,7 +4085,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(2, txs.len());
             assert_eq!(vec![0, 1], tx_packet_index);
@@ -4096,7 +4096,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(0, txs.len());
             assert_eq!(0, tx_packet_index.len());
@@ -4116,7 +4116,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(3, txs.len());
             assert_eq!(vec![0, 1, 2], tx_packet_index);
@@ -4127,7 +4127,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(2, txs.len());
             assert_eq!(vec![0, 2], tx_packet_index);
@@ -4147,7 +4147,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(3, txs.len());
             assert_eq!(vec![0, 1, 2], tx_packet_index);
@@ -4158,7 +4158,7 @@ mod tests {
                 &packet_indexes,
                 &Arc::new(FeatureSet::default()),
                 votes_only,
-                &DisabledAddressLoader,
+                SimpleAddressLoader::Disabled,
             );
             assert_eq!(3, txs.len());
             assert_eq!(vec![0, 1, 2], tx_packet_index);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3401,10 +3401,13 @@ mod tests {
         });
 
         let tx = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
-        let message_hash = tx.message.hash();
-        let sanitized_tx =
-            SanitizedTransaction::try_create(tx.clone(), message_hash, Some(false), bank.as_ref())
-                .unwrap();
+        let sanitized_tx = SanitizedTransaction::try_create(
+            tx.clone(),
+            MessageHash::Compute,
+            Some(false),
+            bank.as_ref(),
+        )
+        .unwrap();
 
         let entry = next_versioned_entry(&genesis_config.hash(), 1, vec![tx]);
         let entries = vec![entry];

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -6,7 +6,7 @@ use {
     solana_sdk::{
         hash::Hash,
         transaction::{
-            DisabledAddressLoader, Result, SanitizedTransaction, TransactionVerificationMode,
+            Result, SanitizedTransaction, SimpleAddressLoader, TransactionVerificationMode,
             VersionedTransaction,
         },
     },
@@ -39,7 +39,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                     versioned_tx,
                     message_hash,
                     None,
-                    &DisabledAddressLoader,
+                    SimpleAddressLoader::Disabled,
                 )
             }?;
 
@@ -80,7 +80,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     versioned_tx,
                     message_hash,
                     None,
-                    &DisabledAddressLoader,
+                    SimpleAddressLoader::Disabled,
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -933,7 +933,7 @@ mod tests {
             signature::{Keypair, Signer},
             system_transaction,
             transaction::{
-                DisabledAddressLoader, Result, SanitizedTransaction, VersionedTransaction,
+                Result, SanitizedTransaction, SimpleAddressLoader, VersionedTransaction,
             },
         },
     };
@@ -1022,7 +1022,7 @@ mod tests {
                         versioned_tx,
                         message_hash,
                         None,
-                        &DisabledAddressLoader,
+                        SimpleAddressLoader::Disabled,
                     )
                 }?;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -58,7 +58,7 @@ use {
         shred_version::compute_shred_version,
         stake::{self, state::StakeState},
         system_program,
-        transaction::{DisabledAddressLoader, MessageHash, SanitizedTransaction},
+        transaction::{MessageHash, SanitizedTransaction, SimpleAddressLoader},
     },
     solana_stake_program::stake_state::{self, PointValue},
     solana_vote_program::{
@@ -242,7 +242,7 @@ fn output_slot(
                     transaction,
                     MessageHash::Compute,
                     None,
-                    &DisabledAddressLoader,
+                    SimpleAddressLoader::Disabled,
                 );
 
                 match sanitize_result {
@@ -793,7 +793,7 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
                     transaction,
                     MessageHash::Compute,
                     None,
-                    &DisabledAddressLoader,
+                    SimpleAddressLoader::Disabled,
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {:?}", err);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -58,7 +58,7 @@ use {
         shred_version::compute_shred_version,
         stake::{self, state::StakeState},
         system_program,
-        transaction::{DisabledAddressLoader, SanitizedTransaction},
+        transaction::{DisabledAddressLoader, MessageHash, SanitizedTransaction},
     },
     solana_stake_program::stake_state::{self, PointValue},
     solana_vote_program::{
@@ -240,7 +240,7 @@ fn output_slot(
                 let tx_signature = transaction.signatures[0];
                 let sanitize_result = SanitizedTransaction::try_create(
                     transaction,
-                    Hash::default(),
+                    MessageHash::Compute,
                     None,
                     &DisabledAddressLoader,
                 );
@@ -791,7 +791,7 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
             .filter_map(|transaction| {
                 SanitizedTransaction::try_create(
                     transaction,
-                    Hash::default(),
+                    MessageHash::Compute,
                     None,
                     &DisabledAddressLoader,
                 )

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -70,7 +70,8 @@ use {
         system_instruction,
         sysvar::stake_history,
         transaction::{
-            self, AddressLoader, SanitizedTransaction, TransactionError, VersionedTransaction,
+            self, AddressLoader, MessageHash, SanitizedTransaction, TransactionError,
+            VersionedTransaction,
         },
     },
     solana_send_transaction_service::{
@@ -4279,8 +4280,7 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: &impl AddressLoader,
 ) -> Result<SanitizedTransaction> {
-    let message_hash = transaction.message.hash();
-    SanitizedTransaction::try_create(transaction, message_hash, None, address_loader)
+    SanitizedTransaction::try_create(transaction, MessageHash::Compute, None, address_loader)
         .map_err(|err| Error::invalid_params(format!("invalid transaction: {}", err)))
 }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4278,7 +4278,7 @@ where
 
 fn sanitize_transaction(
     transaction: VersionedTransaction,
-    address_loader: &impl AddressLoader,
+    address_loader: impl AddressLoader,
 ) -> Result<SanitizedTransaction> {
     SanitizedTransaction::try_create(transaction, MessageHash::Compute, None, address_loader)
         .map_err(|err| Error::invalid_params(format!("invalid transaction: {}", err)))
@@ -4420,7 +4420,7 @@ pub mod tests {
             system_program, system_transaction,
             timing::slot_duration_from_slots_per_year,
             transaction::{
-                self, DisabledAddressLoader, Transaction, TransactionError, TransactionVersion,
+                self, SimpleAddressLoader, Transaction, TransactionError, TransactionVersion,
             },
         },
         solana_transaction_status::{
@@ -7823,7 +7823,8 @@ pub mod tests {
                 .to_string(),
         );
         assert_eq!(
-            sanitize_transaction(unsanitary_versioned_tx, &DisabledAddressLoader).unwrap_err(),
+            sanitize_transaction(unsanitary_versioned_tx, SimpleAddressLoader::Disabled)
+                .unwrap_err(),
             expect58
         );
     }
@@ -7843,9 +7844,9 @@ pub mod tests {
         };
 
         assert_eq!(
-            sanitize_transaction(versioned_tx, &DisabledAddressLoader).unwrap_err(),
+            sanitize_transaction(versioned_tx, SimpleAddressLoader::Disabled).unwrap_err(),
             Error::invalid_params(
-                "invalid transaction: Transaction version is unsupported".to_string(),
+                "invalid transaction: Transaction loads an address table account that doesn't exist".to_string(),
             )
         );
     }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -225,7 +225,7 @@ pub(crate) mod tests {
             signature::{Keypair, Signature, Signer},
             system_transaction,
             transaction::{
-                DisabledAddressLoader, MessageHash, SanitizedTransaction, Transaction,
+                MessageHash, SanitizedTransaction, SimpleAddressLoader, Transaction,
                 VersionedTransaction,
             },
         },
@@ -311,7 +311,7 @@ pub(crate) mod tests {
             transaction,
             MessageHash::Compute,
             None,
-            &DisabledAddressLoader,
+            SimpleAddressLoader::Disabled,
         )
         .unwrap();
 

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -225,7 +225,8 @@ pub(crate) mod tests {
             signature::{Keypair, Signature, Signer},
             system_transaction,
             transaction::{
-                DisabledAddressLoader, SanitizedTransaction, Transaction, VersionedTransaction,
+                DisabledAddressLoader, MessageHash, SanitizedTransaction, Transaction,
+                VersionedTransaction,
             },
         },
         solana_transaction_status::{
@@ -304,13 +305,12 @@ pub(crate) mod tests {
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger");
         let blockstore = Arc::new(blockstore);
 
-        let message_hash = Hash::new_unique();
         let transaction = build_test_transaction_legacy();
         let transaction = VersionedTransaction::from(transaction);
         let transaction = SanitizedTransaction::try_create(
             transaction,
-            message_hash,
-            Some(true),
+            MessageHash::Compute,
+            None,
             &DisabledAddressLoader,
         )
         .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -126,7 +126,7 @@ use {
         sysvar::{self, Sysvar, SysvarId},
         timing::years_as_slots,
         transaction::{
-            Result, SanitizedTransaction, Transaction, TransactionError,
+            MessageHash, Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode, VersionedTransaction,
         },
         transaction_context::{InstructionTrace, TransactionAccount, TransactionContext},
@@ -3419,10 +3419,7 @@ impl Bank {
     pub fn prepare_entry_batch(&self, txs: Vec<VersionedTransaction>) -> Result<TransactionBatch> {
         let sanitized_txs = txs
             .into_iter()
-            .map(|tx| {
-                let message_hash = tx.message.hash();
-                SanitizedTransaction::try_create(tx, message_hash, None, self)
-            })
+            .map(|tx| SanitizedTransaction::try_create(tx, MessageHash::Compute, None, self))
             .collect::<Result<Vec<_>>>()?;
         let lock_results = self
             .rc

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -8,9 +8,9 @@ use {
     },
 };
 
-impl AddressLoader for Bank {
+impl AddressLoader for &Bank {
     fn load_addresses(
-        &self,
+        self,
         address_table_lookups: &[MessageAddressTableLookup],
     ) -> TransactionResult<LoadedAddresses> {
         if !self.versioned_tx_message_enabled() {

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -236,7 +236,7 @@ mod tests {
             hash::Hash,
             signature::{Keypair, Signer},
             system_transaction,
-            transaction::{DisabledAddressLoader, VersionedTransaction},
+            transaction::{DisabledAddressLoader, MessageHash, VersionedTransaction},
         },
         solana_vote_program::vote_transaction,
         std::{cmp, sync::Arc},
@@ -293,10 +293,9 @@ mod tests {
             &keypair,
             None,
         );
-        let message_hash = transaction.message.hash();
         let vote_transaction = SanitizedTransaction::try_create(
             VersionedTransaction::from(transaction),
-            message_hash,
+            MessageHash::Compute,
             Some(true),
             &DisabledAddressLoader,
         )

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -236,7 +236,7 @@ mod tests {
             hash::Hash,
             signature::{Keypair, Signer},
             system_transaction,
-            transaction::{DisabledAddressLoader, MessageHash, VersionedTransaction},
+            transaction::{MessageHash, SimpleAddressLoader, VersionedTransaction},
         },
         solana_vote_program::vote_transaction,
         std::{cmp, sync::Arc},
@@ -297,7 +297,7 @@ mod tests {
             VersionedTransaction::from(transaction),
             MessageHash::Compute,
             Some(true),
-            &DisabledAddressLoader,
+            SimpleAddressLoader::Disabled,
         )
         .unwrap();
         (vote_transaction, vec![mint_keypair.pubkey()], 10)


### PR DESCRIPTION
#### Problem
- In tests, it's inconvenient to have to precompute the message hash for sanitized transactions
- No way to load addresses from the `loaded_addresses` field in transaction meta

#### Summary of Changes
- Added `MessageHash` enum to indicate whether a transaction message hash still needs to be computed
- Replaced `DisabledAddressLoader` with `SimpleAddressLoader`

Fixes #
