### PR TITLE
Use `AsRef<Path>` instead of `PathBuf` for parameters

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -175,7 +175,7 @@ mod tests {
 
         let check_hash_calculation = false;
         let full_snapshot_archive_path = snapshot_utils::build_full_snapshot_archive_path(
-            snapshot_archives_dir.to_path_buf(),
+            snapshot_archives_dir,
             old_last_bank.slot(),
             &old_last_bank.get_accounts_hash(),
             ArchiveFormat::TarBzip2,
@@ -461,7 +461,7 @@ mod tests {
                 fs_extra::dir::copy(&last_snapshot_path, &saved_snapshots_dir, &options).unwrap();
 
                 saved_archive_path = Some(snapshot_utils::build_full_snapshot_archive_path(
-                    snapshot_archives_dir.to_path_buf(),
+                    snapshot_archives_dir,
                     slot,
                     &accounts_hash,
                     ArchiveFormat::TarBzip2,

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -276,14 +276,14 @@ pub fn download_snapshot_archive<'a, 'b>(
     ] {
         let destination_path = match snapshot_type {
             SnapshotType::FullSnapshot => snapshot_utils::build_full_snapshot_archive_path(
-                snapshot_archives_dir.to_path_buf(),
+                snapshot_archives_dir,
                 desired_snapshot_hash.0,
                 &desired_snapshot_hash.1,
                 archive_format,
             ),
             SnapshotType::IncrementalSnapshot(base_slot) => {
                 snapshot_utils::build_incremental_snapshot_archive_path(
-                    snapshot_archives_dir.to_path_buf(),
+                    snapshot_archives_dir,
                     base_slot,
                     desired_snapshot_hash.0,
                     &desired_snapshot_hash.1,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1330,8 +1330,7 @@ fn test_snapshot_restart_tower() {
     let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
         validator_snapshot_test_config
             .snapshot_archives_dir
-            .path()
-            .to_path_buf(),
+            .into_path(),
         full_snapshot_archive_info.slot(),
         full_snapshot_archive_info.hash(),
         full_snapshot_archive_info.archive_format(),
@@ -1403,8 +1402,7 @@ fn test_snapshots_blockstore_floor() {
     let validator_archive_path = snapshot_utils::build_full_snapshot_archive_path(
         validator_snapshot_test_config
             .snapshot_archives_dir
-            .path()
-            .to_path_buf(),
+            .into_path(),
         archive_info.slot(),
         archive_info.hash(),
         ArchiveFormat::TarBzip2,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1053,12 +1053,12 @@ pub fn path_to_file_name_str(path: &Path) -> Result<&str> {
 /// Build the full snapshot archive path from its components: the snapshot archives directory, the
 /// snapshot slot, the accounts hash, and the archive format.
 pub fn build_full_snapshot_archive_path(
-    snapshot_archives_dir: impl Into<PathBuf>,
+    snapshot_archives_dir: impl AsRef<Path>,
     slot: Slot,
     hash: &Hash,
     archive_format: ArchiveFormat,
 ) -> PathBuf {
-    snapshot_archives_dir.into().join(format!(
+    snapshot_archives_dir.as_ref().join(format!(
         "snapshot-{}-{}.{}",
         slot,
         hash,
@@ -1070,13 +1070,13 @@ pub fn build_full_snapshot_archive_path(
 /// directory, the snapshot base slot, the snapshot slot, the accounts hash, and the archive
 /// format.
 pub fn build_incremental_snapshot_archive_path(
-    snapshot_archives_dir: impl Into<PathBuf>,
+    snapshot_archives_dir: impl AsRef<Path>,
     base_slot: Slot,
     slot: Slot,
     hash: &Hash,
     archive_format: ArchiveFormat,
 ) -> PathBuf {
-    snapshot_archives_dir.into().join(format!(
+    snapshot_archives_dir.as_ref().join(format!(
         "incremental-snapshot-{}-{}-{}.{}",
         base_slot,
         slot,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1053,12 +1053,12 @@ pub fn path_to_file_name_str(path: &Path) -> Result<&str> {
 /// Build the full snapshot archive path from its components: the snapshot archives directory, the
 /// snapshot slot, the accounts hash, and the archive format.
 pub fn build_full_snapshot_archive_path(
-    snapshot_archives_dir: PathBuf,
+    snapshot_archives_dir: impl Into<PathBuf>,
     slot: Slot,
     hash: &Hash,
     archive_format: ArchiveFormat,
 ) -> PathBuf {
-    snapshot_archives_dir.join(format!(
+    snapshot_archives_dir.into().join(format!(
         "snapshot-{}-{}.{}",
         slot,
         hash,
@@ -1070,13 +1070,13 @@ pub fn build_full_snapshot_archive_path(
 /// directory, the snapshot base slot, the snapshot slot, the accounts hash, and the archive
 /// format.
 pub fn build_incremental_snapshot_archive_path(
-    snapshot_archives_dir: PathBuf,
+    snapshot_archives_dir: impl Into<PathBuf>,
     base_slot: Slot,
     slot: Slot,
     hash: &Hash,
     archive_format: ArchiveFormat,
 ) -> PathBuf {
-    snapshot_archives_dir.join(format!(
+    snapshot_archives_dir.into().join(format!(
         "incremental-snapshot-{}-{}-{}.{}",
         base_slot,
         slot,


### PR DESCRIPTION
#### Problem

Callers of `build_full_snapshot_archive_path()` and `build_incremental_snapshot_archive_path()` are required to pass a `PathBuf` for the `snapshot_archives_dir` parameter.

~Rust already has an ergonomic way to handle these kind of requirements, and it's with the `Into` trait.~

Since we call `.join()` immediately, we don't need to have an owned type from the beginning. For these cases, the idiomatic way to do this in Rust is with `AsRef`.

#### Summary of Changes

* Use `impl AsRef<Path>` for the `snapshot_archives_dir` parameter
* Update callers of these functions