### PR TITLE
Continue making it possible to implement RpcSender

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -18,7 +18,7 @@ pub mod rpc_deprecated_config;
 pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;
-pub(crate) mod rpc_sender;
+pub mod rpc_sender;
 pub mod spinner;
 pub mod thin_client;
 pub mod tpu_client;

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -148,7 +148,7 @@ impl RpcClient {
     /// `RpcSender`. Most applications should use one of the other constructors,
     /// such as [`new`] and [`new_mock`], which create an `RpcClient`
     /// encapsulating an [`HttpSender`] and [`MockSender`] respectively.
-    pub(crate) fn new_sender<T: RpcSender + Send + Sync + 'static>(
+    pub fn new_sender<T: RpcSender + Send + Sync + 'static>(
         sender: T,
         config: RpcClientConfig,
     ) -> Self {


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/issues/17631 and https://github.com/solana-labs/solana/pull/23383 it was decided to allow users to implement `RpcSender` and call `RpcClient::new_sender`.

There remain two issues preventing this:

- The `rpc_sender` module is not public and `RpcSender` is not reexported anywhere, so it cannot be named and implemented.
- The nonblocking version of `RpcSender::new_sender` is not public, only the blocking version.

#### Summary of Changes

- Make `rpc_sender` pub
- Make the nonblocking `RpcSender::new_sender` pub

cc @CriesofCarrots @t-nelson 