### PR TITLE
clippy

### DIFF
--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -130,7 +130,7 @@ impl BlockhashQueue {
     )]
     #[allow(deprecated)]
     pub fn get_recent_blockhashes(&self) -> impl Iterator<Item = recent_blockhashes::IterItem> {
-        (&self.ages).iter().map(|(k, v)| {
+        (self.ages).iter().map(|(k, v)| {
             recent_blockhashes::IterItem(v.hash_height, k, v.fee_calculator.lamports_per_signature)
         })
     }


### PR DESCRIPTION
#### Problem

```
> cargo clippy -Zunstable-options -p solana-runtime -- --deny=warnings --deny=clippy::integer_arithmetic --no-deps
    Blocking waiting for file lock on build directory
   Compiling solana-runtime v1.10.1 (D:\mydoc\git\hy_solana\runtime)
error: this expression borrows a value the compiler would automatically borrow
   --> runtime\src\blockhash_queue.rs:133:9
    |
133 |         (&self.ages).iter().map(|(k, v)| {
    |         ^^^^^^^^^^^^ help: change this to: `self.ages`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `solana-runtime` due to previous error

#### Summary of Changes

Fixes #
