### PR TITLE
Set ordering flushing_active.swap() to AcqRel

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -864,7 +864,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
     }
 
     pub(crate) fn flush(&self) {
-        let flushing = self.flushing_active.swap(true, Ordering::Acquire);
+        let flushing = self.flushing_active.swap(true, Ordering::AcqRel);
         if flushing {
             // already flushing in another thread
             return;


### PR DESCRIPTION
#### Problem

Consider `InMemAccountsIndex::flush()`:

https://github.com/solana-labs/solana/blob/e60c9b97c9ab8b4975aa6bde30d831df28941845/runtime/src/in_mem_accounts_index.rs#L866-L876

If two threads run `flush()` and execute the `swap()` at the same time, it is possible that both threads would see `false`, and then both run `flush_internal()`.

Since only the load (of the swap) has ordering constraints, it will sequence with the "unlock" (since that store is Release), but not the Relaxed store (of the swap) (which can be thought of as the "lock").

#### Summary of Changes

Make the `flushing_active.swap()` AcqRel.
