### PR TITLE
(LedgerStore) Add validator argument for compressing TransactionStatus

### DIFF
--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -358,6 +358,7 @@ mod tests {
                                 ..BlockstoreRocksFifoOptions::default()
                             },
                         ),
+                        ..LedgerColumnOptions::default()
                     },
                     ..BlockstoreOptions::default()
                 }


### PR DESCRIPTION
#### Summary of Changes
This PR adds `--rocksdb-ledger-compression` as a hidden argument to the validator
for specifying the compression algorithm for TransactionStatus.  Available compression
algorithms include `lz4`, `snappy`, `zlib`. The default value is `none`.

Experimental results show that with lz4 compression, we can achieve ~37% size-reduction
on the TransactionStatus column family, or ~8% size-reduction of the ledger store size.
