### PR TITLE
Feat: add getEstimatedFee to Transaction

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -2,6 +2,7 @@ import nacl from 'tweetnacl';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 
+import {Connection} from './connection';
 import {Message} from './message';
 import {PublicKey} from './publickey';
 import * as shortvec from './util/shortvec-encoding';
@@ -403,6 +404,13 @@ export class Transaction {
    */
   serializeMessage(): Buffer {
     return this._compile().serialize();
+  }
+
+  /**
+   * Get the estimated fee associated with a transaction
+   */
+  async getEstimatedFee(connection: Connection): Promise<number> {
+    return (await connection.getFeeForMessage(this.compileMessage())).value;
   }
 
   /**


### PR DESCRIPTION
#### Problem
From [#23491](https://github.com/solana-labs/solana/issues/23491)

> With the current way a `Transaction` object is constructed, the new `getFeeForMessage` RPC call has confused some devs because it isn't obvious how to get the message from a constructed Transaction.


#### Summary of Changes

This PR adds a method to the `Transaction` class that will allow developers to more easily get estimated fees for transactions by making the call to `getFeeForMessage` under the hood.

Fixes #

This addresses the first item of [#23491 ](https://github.com/solana-labs/solana/issues/23491). Additional PRs will follow to address the remaining items.