### PR TITLE
Revert dashmap 5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,13 +1004,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.1.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot 0.12.0",
  "rayon",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 bs58 = "0.4.0"
 chrono = { version = "0.4.11", features = ["serde"] }
 crossbeam-channel = "0.5"
-dashmap = { version = "5.1.0", features = ["rayon", "raw-api"] }
+dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 etcd-client = { version = "0.8.4", features = ["tls"]}
 fs_extra = "1.2.0"
 histogram = "0.6.9"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -14,7 +14,7 @@ bs58 = "0.4.0"
 clap = "2.33.1"
 crossbeam-channel = "0.5"
 csv = "1.1.6"
-dashmap = "5.1.0"
+dashmap = "4.0.2"
 histogram = "*"
 itertools = "0.10.3"
 log = { version = "0.4.14" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -641,13 +641,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.1.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
- "parking_lot",
  "rayon",
 ]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.12.3"
 bincode = "1.3.3"
 bs58 = "0.4.0"
 crossbeam-channel = "0.5"
-dashmap = "5.1.0"
+dashmap = "4.0.2"
 itertools = "0.10.3"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,7 @@ bv = { version = "0.11.1", features = ["serde"] }
 bytemuck = "1.8.0"
 byteorder = "1.4.3"
 bzip2 = "0.4.3"
-dashmap = { version = "5.1.0", features = ["rayon", "raw-api"] }
+dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 crossbeam-channel = "0.5"
 dir-diff = "0.3.2"
 flate2 = "1.0.22"


### PR DESCRIPTION
#### Problem

Dashmap 5.1.0 seems to hang the validator when secondary indexes are enabled.

#### Summary of Changes

Revert in favor of 4.0.2 which seems to work.

Fixes #
