### PR TITLE
Fix intermittent validator_exit test failure

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1794,12 +1794,14 @@ pub fn is_snapshot_config_valid(
 mod tests {
     use {
         super::*,
+        serial_test::serial,
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
         std::fs::remove_dir_all,
     };
 
     #[test]
+    #[serial]
     fn validator_exit() {
         solana_logger::setup();
         let leader_keypair = Keypair::new();
@@ -1880,6 +1882,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn validator_parallel_exit() {
         let leader_keypair = Keypair::new();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1876,8 +1876,6 @@ mod tests {
         );
         validator.close();
         remove_dir_all(validator_ledger_path).unwrap();
-
-        thread::sleep(time::Duration::from_millis(10));
     }
 
     fn validator_parallel_exit() {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1797,11 +1797,11 @@ mod tests {
         serial_test::serial,
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
-        std::fs::remove_dir_all,
+        std::{fs::remove_dir_all, thread, time},
     };
 
     #[test]
-    #[serial]
+    #[serial(serial_run_validator_exit)]
     fn validator_exit() {
         solana_logger::setup();
         let leader_keypair = Keypair::new();
@@ -1838,6 +1838,8 @@ mod tests {
         );
         validator.close();
         remove_dir_all(validator_ledger_path).unwrap();
+
+        thread::sleep(time::Duration::from_millis(10));
     }
 
     #[test]
@@ -1882,7 +1884,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
+    #[serial(serial_run_validator_exit)]
     fn validator_parallel_exit() {
         let leader_keypair = Keypair::new();
         let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
@@ -1928,6 +1930,8 @@ mod tests {
         for path in ledger_paths {
             remove_dir_all(path).unwrap();
         }
+
+        thread::sleep(time::Duration::from_millis(10));
     }
 
     #[test]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1799,6 +1799,44 @@ mod tests {
         std::fs::remove_dir_all,
     };
 
+    fn validator_exit() {
+        solana_logger::setup();
+        let leader_keypair = Keypair::new();
+        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
+
+        let validator_keypair = Keypair::new();
+        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
+        let genesis_config =
+            create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
+                .genesis_config;
+        let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
+
+        let voting_keypair = Arc::new(Keypair::new());
+        let config = ValidatorConfig {
+            rpc_addrs: Some((validator_node.info.rpc, validator_node.info.rpc_pubsub)),
+            ..ValidatorConfig::default_for_test()
+        };
+        let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
+        let validator = Validator::new(
+            validator_node,
+            Arc::new(validator_keypair),
+            &validator_ledger_path,
+            &voting_keypair.pubkey(),
+            Arc::new(RwLock::new(vec![voting_keypair.clone()])),
+            vec![leader_node.info],
+            &config,
+            true, // should_check_duplicate_instance
+            start_progress.clone(),
+            SocketAddrSpace::Unspecified,
+        );
+        assert_eq!(
+            *start_progress.read().unwrap(),
+            ValidatorStartProgress::Running
+        );
+        validator.close();
+        remove_dir_all(validator_ledger_path).unwrap();
+    }
+
     #[test]
     fn test_backup_and_clear_blockstore() {
         use std::time::Instant;
@@ -1838,44 +1876,6 @@ mod tests {
                     .is_empty());
             }
         }
-    }
-
-    fn validator_single_exit() {
-        solana_logger::setup();
-        let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
-
-        let validator_keypair = Keypair::new();
-        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
-        let genesis_config =
-            create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
-                .genesis_config;
-        let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
-
-        let voting_keypair = Arc::new(Keypair::new());
-        let config = ValidatorConfig {
-            rpc_addrs: Some((validator_node.info.rpc, validator_node.info.rpc_pubsub)),
-            ..ValidatorConfig::default_for_test()
-        };
-        let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
-        let validator = Validator::new(
-            validator_node,
-            Arc::new(validator_keypair),
-            &validator_ledger_path,
-            &voting_keypair.pubkey(),
-            Arc::new(RwLock::new(vec![voting_keypair.clone()])),
-            vec![leader_node.info],
-            &config,
-            true, // should_check_duplicate_instance
-            start_progress.clone(),
-            SocketAddrSpace::Unspecified,
-        );
-        assert_eq!(
-            *start_progress.read().unwrap(),
-            ValidatorStartProgress::Running
-        );
-        validator.close();
-        remove_dir_all(validator_ledger_path).unwrap();
     }
 
     fn validator_parallel_exit() {
@@ -1927,7 +1927,7 @@ mod tests {
 
     #[test]
     fn test_validator_exit() {
-        validator_single_exit();
+        validator_exit();
         validator_parallel_exit();
     }
 


### PR DESCRIPTION
#### Problem
Due to shared resources between `validator_exit` and `validator_parallel_exit`, when they are executed in parallel by the rust test executor, these tests hangs. 



#### Summary of Changes
Use one test function to run both tests.




Fixes #
