### PR TITLE
Type alias to struct

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -37,7 +37,6 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     std::{
-        collections::VecDeque,
         sync::{atomic::Ordering, Arc, RwLock},
         time::{Duration, Instant},
     },
@@ -80,7 +79,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let len = 4096;
         let chunk_size = 1024;
         let batches = to_packet_batches(&vec![tx; len], chunk_size);
-        let mut packet_batches = VecDeque::new();
+        let mut packet_batches = UnprocessedPacketBatches::new();
         for batch in batches {
             let batch_len = batch.packets.len();
             packet_batches.push_back(DeserializedPacketBatch::new(

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -57,7 +57,7 @@ use {
     },
     std::{
         cmp,
-        collections::{HashMap, VecDeque},
+        collections::HashMap,
         env,
         net::{SocketAddr, UdpSocket},
         sync::{
@@ -943,7 +943,7 @@ impl BankingStage {
     ) {
         let recorder = poh_recorder.lock().unwrap().recorder();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let mut buffered_packet_batches = VecDeque::with_capacity(batch_limit);
+        let mut buffered_packet_batches = UnprocessedPacketBatches::with_capacity(batch_limit);
         let mut banking_stage_stats = BankingStageStats::new(id);
         let qos_service = QosService::new(cost_model, id);
         let mut slot_metrics_tracker = LeaderSlotMetricsTracker::new(id);

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -11,7 +11,7 @@ use {
     },
 };
 
-/// hold deserialized messages, as well as computed message_hash and other things needed to create
+/// Holds deserialized messages, as well as computed message_hash and other things needed to create
 /// SanitizedTransaction
 #[derive(Debug, Default)]
 pub struct DeserializedPacket {
@@ -25,14 +25,22 @@ pub struct DeserializedPacket {
     is_simple_vote: bool,
 }
 
+/// Defines the type of entry in `UnprocessedPacketBatches`, it holds original packet_batch
+/// for forwarding, as well as `forwarded` flag;
+/// Each packet in packet_batch are deserialized upon receiving, the result are stored in
+/// `DeserializedPacket` in the same order as packets in `packet_batch`.
 #[derive(Debug, Default)]
 pub struct DeserializedPacketBatch {
     pub packet_batch: PacketBatch,
     pub forwarded: bool,
-    // indexes of valid packets in batch, and their corrersponding deserialized_packet
+    // indexes of valid packets in batch, and their corresponding deserialized_packet
     pub unprocessed_packets: HashMap<usize, DeserializedPacket>,
 }
 
+/// Currently each banking_stage thread has a `UnprocessedPacketBatches` buffer to store
+/// PacketBatch's received from sigverify. Banking thread continuously scans the buffer
+/// to pick proper packets to add to the block.
+#[derive(Default)]
 pub struct UnprocessedPacketBatches(VecDeque<DeserializedPacketBatch>);
 
 impl std::ops::Deref for UnprocessedPacketBatches {
@@ -63,15 +71,9 @@ impl FromIterator<DeserializedPacketBatch> for UnprocessedPacketBatches {
     }
 }
 
-impl Default for UnprocessedPacketBatches {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl UnprocessedPacketBatches {
     pub fn new() -> Self {
-        UnprocessedPacketBatches(VecDeque::new())
+        Self::default()
     }
 
     pub fn with_capacity(capacity: usize) -> Self {


### PR DESCRIPTION
#### Problem
Would be nice to define UnprocessedPacketBatches as struct instead of type alias, to allow adding methods to it.

#### Summary of Changes
- replaced type alias with _newtype_, implemented necessary traits to back support existing code.


Fixes #
