### PR TITLE
Add CLI support for versioned transactions

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -28,7 +28,7 @@ use {
         signature::Signature,
         stake::state::{Authorized, Lockup},
         stake_history::StakeHistoryEntry,
-        transaction::{Transaction, TransactionError},
+        transaction::{Transaction, TransactionError, VersionedTransaction},
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedTransaction, TransactionConfirmationStatus,
@@ -2218,7 +2218,7 @@ pub enum CliSignatureVerificationStatus {
 }
 
 impl CliSignatureVerificationStatus {
-    pub fn verify_transaction(tx: &Transaction) -> Vec<Self> {
+    pub fn verify_transaction(tx: &VersionedTransaction) -> Vec<Self> {
         tx.verify_with_results()
             .iter()
             .zip(&tx.signatures)
@@ -2354,7 +2354,7 @@ pub struct CliTransaction {
     #[serde(skip_serializing)]
     pub slot: Option<Slot>,
     #[serde(skip_serializing)]
-    pub decoded_transaction: Transaction,
+    pub decoded_transaction: VersionedTransaction,
     #[serde(skip_serializing)]
     pub prefix: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -30,7 +30,7 @@ use {
         pubkey::Pubkey,
         signature::{Signature, Signer, SignerError},
         stake::{instruction::LockupArgs, state::Lockup},
-        transaction::{Transaction, TransactionError},
+        transaction::{TransactionError, VersionedTransaction},
     },
     solana_vote_program::vote_state::VoteAuthorize,
     std::{collections::HashMap, error, io::stdout, str::FromStr, sync::Arc, time::Duration},
@@ -385,7 +385,7 @@ pub enum CliCommand {
         seed: String,
         program_id: Pubkey,
     },
-    DecodeTransaction(Transaction),
+    DecodeTransaction(VersionedTransaction),
     ResolveSigner(Option<String>),
     ShowAccount {
         pubkey: Pubkey,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1058,6 +1058,7 @@ pub fn process_get_block(
             RpcBlockConfig {
                 encoding: Some(UiTransactionEncoding::Base64),
                 commitment: Some(CommitmentConfig::confirmed()),
+                max_supported_transaction_version: Some(0),
                 ..RpcBlockConfig::default()
             },
         )?
@@ -2042,7 +2043,7 @@ pub fn process_transaction_history(
                     RpcTransactionConfig {
                         encoding: Some(UiTransactionEncoding::Base64),
                         commitment: Some(CommitmentConfig::confirmed()),
-                        max_supported_transaction_version: None,
+                        max_supported_transaction_version: Some(0),
                     },
                 ) {
                     Ok(confirmed_transaction) => {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 use {
+    crate::{bigtable::*, ledger_path::*},
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
@@ -63,6 +64,7 @@ use {
         transaction::{MessageHash, SanitizedTransaction, SimpleAddressLoader},
     },
     solana_stake_program::stake_state::{self, PointValue},
+    solana_transaction_status::VersionedTransactionWithStatusMeta,
     solana_vote_program::{
         self,
         vote_state::{self, VoteState},
@@ -83,9 +85,7 @@ use {
 };
 
 mod bigtable;
-use bigtable::*;
 mod ledger_path;
-use ledger_path::*;
 
 #[derive(PartialEq)]
 enum LedgerOutputMethod {
@@ -147,7 +147,7 @@ fn output_entry(
             for (transactions_index, transaction) in entry.transactions.into_iter().enumerate() {
                 println!("    Transaction {}", transactions_index);
                 let tx_signature = transaction.signatures[0];
-                let tx_status = blockstore
+                let tx_with_meta = blockstore
                     .read_transaction_status((tx_signature, slot))
                     .unwrap_or_else(|err| {
                         eprintln!(
@@ -156,20 +156,16 @@ fn output_entry(
                         );
                         None
                     })
-                    .map(|transaction_status| transaction_status.into());
+                    .map(|meta| VersionedTransactionWithStatusMeta { transaction, meta });
 
-                if let Some(legacy_tx) = transaction.into_legacy_transaction() {
+                if let Some(tx_with_meta) = tx_with_meta {
+                    let status = tx_with_meta.meta.into();
                     solana_cli_output::display::println_transaction(
-                        &legacy_tx,
-                        tx_status.as_ref(),
+                        &tx_with_meta.transaction,
+                        Some(&status),
                         "      ",
                         None,
                         None,
-                    );
-                } else {
-                    eprintln!(
-                        "Failed to print unsupported transaction for {} at slot {}",
-                        tx_signature, slot
                     );
                 }
             }


### PR DESCRIPTION
#### Problem
No CLI support for versioned transactions

#### Summary of Changes
- Add support for fetching and displaying versioned transactions from Bigtable
- Add support for fetching and displaying versioned transactions from RPC
- Add support for printing versioned transactions with the ledger tool
- Remove unused legacy transaction types

Fixes #
