### PR TITLE
fix deadlink in doc

### DIFF
--- a/docs/src/developing/runtime-facilities/programs.md
+++ b/docs/src/developing/runtime-facilities/programs.md
@@ -21,7 +21,7 @@ Create new accounts, allocate account data, assign accounts to owning programs,
 transfer lamports from System Program owned accounts and pay transaction fees.
 
 - Program id: `11111111111111111111111111111111`
-- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_sdk/system_instruction/enum.SystemInstruction.html)
+- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_program/system_instruction/enum.SystemInstruction.html)
 
 ## Config Program
 

--- a/docs/src/developing/runtime-facilities/programs.md
+++ b/docs/src/developing/runtime-facilities/programs.md
@@ -21,7 +21,7 @@ Create new accounts, allocate account data, assign accounts to owning programs,
 transfer lamports from System Program owned accounts and pay transaction fees.
 
 - Program id: `11111111111111111111111111111111`
-- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_program/system_instruction/enum.SystemInstruction.html)
+- Instructions: [SystemInstruction](https://docs.rs/solana-program/VERSION_FOR_DOCS_RS/solana_program/system_instruction/enum.SystemInstruction.html)
 
 ## Config Program
 


### PR DESCRIPTION
#### Problem

In section [System Program](https://docs.solana.com/developing/runtime-facilities/programs#system-program) link is dead.

#### Summary of Changes

Fixes #1
`https://docs.rs/solana-sdk/1.9.11/solana_sdk/system_instruction/enum.SystemInstruction.html` -> `https://docs.rs/solana-program/1.9.11/solana_program/system_instruction/enum.SystemInstruction.html`
