### PR TITLE
Add get_confirmed_blocks_with_data method

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -683,14 +683,14 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
     pub async fn get_protobuf_or_bincode_cells<B, P>(
         &mut self,
         table: &str,
-        row_keys: Vec<RowKey>,
+        row_keys: &[RowKey],
     ) -> Result<Vec<(RowKey, CellData<B, P>)>>
     where
         B: serde::de::DeserializeOwned,
         P: prost::Message + Default,
     {
         Ok(self
-            .get_multi_row_data(table, row_keys.as_slice())
+            .get_multi_row_data(table, row_keys)
             .await?
             .into_iter()
             .map(|(key, row_data)| {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -683,14 +683,17 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
     pub async fn get_protobuf_or_bincode_cells<'a, B, P>(
         &mut self,
         table: &'a str,
-        row_keys: impl Iterator<Item = String>,
+        row_keys: impl IntoIterator<Item = RowKey>,
     ) -> Result<impl Iterator<Item = (RowKey, CellData<B, P>)> + 'a>
     where
         B: serde::de::DeserializeOwned,
         P: prost::Message + Default,
     {
         Ok(self
-            .get_multi_row_data(table, row_keys.collect::<Vec<RowKey>>().as_slice())
+            .get_multi_row_data(
+                table,
+                row_keys.into_iter().collect::<Vec<RowKey>>().as_slice(),
+            )
             .await?
             .into_iter()
             .map(|(key, row_data)| {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -465,7 +465,7 @@ impl LedgerStorage {
         );
         inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
-        let row_keys: Vec<RowKey> = slots.into_iter().map(|s| slot_to_blocks_key(s)).collect();
+        let row_keys: Vec<RowKey> = slots.into_iter().map(slot_to_blocks_key).collect();
         let data: Vec<(Slot, ConfirmedBlock)> = bigtable
             .get_protobuf_or_bincode_cells::<StoredConfirmedBlock, generated::ConfirmedBlock>(
                 "blocks",
@@ -478,7 +478,7 @@ impl LedgerStorage {
                     bigtable::CellData::Bincode(block) => block.into(),
                     bigtable::CellData::Protobuf(block) => block.try_into().ok()?,
                 };
-                Some((key_to_slot(&(row_key.to_string())).unwrap(), block))
+                Some((key_to_slot(&row_key).unwrap(), block))
             })
             .collect();
         Ok(data)

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -465,21 +465,22 @@ impl LedgerStorage {
         );
         inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
-        let row_keys: Vec<RowKey> = slots.iter().copied().map(slot_to_blocks_key).collect();
+        let row_keys = slots.iter().copied().map(slot_to_blocks_key);
         let data: Vec<(Slot, ConfirmedBlock)> = bigtable
-            .get_protobuf_or_bincode_cells::<StoredConfirmedBlock, generated::ConfirmedBlock>(
-                "blocks",
-                row_keys.as_slice(),
-            )
+            .get_protobuf_or_bincode_cells("blocks", row_keys)
             .await?
-            .into_iter()
-            .filter_map(|(row_key, block_cell_data)| {
-                let block = match block_cell_data {
-                    bigtable::CellData::Bincode(block) => block.into(),
-                    bigtable::CellData::Protobuf(block) => block.try_into().ok()?,
-                };
-                Some((key_to_slot(&row_key).unwrap(), block))
-            })
+            .filter_map(
+                |(row_key, block_cell_data): (
+                    RowKey,
+                    bigtable::CellData<StoredConfirmedBlock, generated::ConfirmedBlock>,
+                )| {
+                    let block = match block_cell_data {
+                        bigtable::CellData::Bincode(block) => block.into(),
+                        bigtable::CellData::Protobuf(block) => block.try_into().ok()?,
+                    };
+                    Some((key_to_slot(&row_key).unwrap(), block))
+                },
+            )
             .collect();
         Ok(data)
     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -455,10 +455,10 @@ impl LedgerStorage {
     }
 
     // Fetches and gets a vector of confirmed blocks via a multirow fetch
-    pub async fn get_confirmed_blocks_with_data(
+    pub async fn get_confirmed_blocks_with_data<'a>(
         &self,
-        slots: &[Slot],
-    ) -> Result<Vec<(Slot, ConfirmedBlock)>> {
+        slots: &'a [Slot],
+    ) -> Result<impl Iterator<Item = (Slot, ConfirmedBlock)> + 'a> {
         debug!(
             "LedgerStorage::get_confirmed_blocks_with_data request received: {:?}",
             slots
@@ -466,7 +466,7 @@ impl LedgerStorage {
         inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
         let row_keys = slots.iter().copied().map(slot_to_blocks_key);
-        let data: Vec<(Slot, ConfirmedBlock)> = bigtable
+        let data = bigtable
             .get_protobuf_or_bincode_cells("blocks", row_keys)
             .await?
             .filter_map(
@@ -480,8 +480,7 @@ impl LedgerStorage {
                     };
                     Some((key_to_slot(&row_key).unwrap(), block))
                 },
-            )
-            .collect();
+            );
         Ok(data)
     }
 

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -457,7 +457,7 @@ impl LedgerStorage {
     // Fetches and gets a vector of confirmed blocks via a multirow fetch
     pub async fn get_confirmed_blocks_with_data(
         &self,
-        slots: Vec<Slot>,
+        slots: &[Slot],
     ) -> Result<Vec<(Slot, ConfirmedBlock)>> {
         debug!(
             "LedgerStorage::get_confirmed_blocks_with_data request received: {:?}",
@@ -465,11 +465,11 @@ impl LedgerStorage {
         );
         inc_new_counter_debug!("storage-bigtable-query", 1);
         let mut bigtable = self.connection.client();
-        let row_keys: Vec<RowKey> = slots.into_iter().map(slot_to_blocks_key).collect();
+        let row_keys: Vec<RowKey> = slots.iter().copied().map(slot_to_blocks_key).collect();
         let data: Vec<(Slot, ConfirmedBlock)> = bigtable
             .get_protobuf_or_bincode_cells::<StoredConfirmedBlock, generated::ConfirmedBlock>(
                 "blocks",
-                row_keys.clone(),
+                row_keys.as_slice(),
             )
             .await?
             .into_iter()

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 use {
+    crate::bigtable::RowKey,
     log::*,
     serde::{Deserialize, Serialize},
     solana_metrics::inc_new_counter_debug,
@@ -451,6 +452,36 @@ impl LedgerStorage {
             )
             .await?;
         Ok(blocks.into_iter().filter_map(|s| key_to_slot(&s)).collect())
+    }
+
+    // Fetches and gets a vector of confirmed blocks via a multirow fetch
+    pub async fn get_confirmed_blocks_with_data(
+        &self,
+        slots: Vec<Slot>,
+    ) -> Result<Vec<(Slot, ConfirmedBlock)>> {
+        debug!(
+            "LedgerStorage::get_confirmed_blocks_with_data request received: {:?}",
+            slots
+        );
+        inc_new_counter_debug!("storage-bigtable-query", 1);
+        let mut bigtable = self.connection.client();
+        let row_keys: Vec<RowKey> = slots.into_iter().map(|s| slot_to_blocks_key(s)).collect();
+        let data: Vec<(Slot, ConfirmedBlock)> = bigtable
+            .get_protobuf_or_bincode_cells::<StoredConfirmedBlock, generated::ConfirmedBlock>(
+                "blocks",
+                row_keys.clone(),
+            )
+            .await?
+            .into_iter()
+            .filter_map(|(row_key, block_cell_data)| {
+                let block = match block_cell_data {
+                    bigtable::CellData::Bincode(block) => block.into(),
+                    bigtable::CellData::Protobuf(block) => block.try_into().ok()?,
+                };
+                Some((key_to_slot(&(row_key.to_string())).unwrap(), block))
+            })
+            .collect();
+        Ok(data)
     }
 
     /// Fetch the confirmed block from the desired slot


### PR DESCRIPTION
#### Problem
Analytics apps would like to query multi-row block data from Bigtable. Currently the only way to do this is to use many single-row fetches, which is [not performant](https://cloud.google.com/bigtable/docs/reads)


#### Summary of Changes
- add `get_confirmed_blocks_with_data`, which uses a multi-row fetch to get block data from Bigtable


**benchmarks:**
using Jito's GCP bigtable instance: 

```
Benchmarking performance of get_confirmed_blocks_with_data for 100 blocks
results [tasks=64, chunk=100, returned=5983, elapsed=19.02, blocks/s=314.61054382260795]
Benchmarking performance of get_confirmed_blocks_with_data for 250 blocks
results [tasks=64, chunk=250, returned=14007, elapsed=30.35, blocks/s=461.48676735656943]
Benchmarking performance of get_confirmed_blocks_with_data for 500 blocks
results [tasks=64, chunk=500, returned=28533, elapsed=59.78, blocks/s=477.26459687979406]
```

for reference, we were getting 8 blocks / s using single fetches