### PR TITLE
refactor cost_update code path

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3113,6 +3113,10 @@ mod tests {
             ..
         } = create_slow_genesis_config(lamports);
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        // set cost tracker limits to MAX so it will not filter out TXs
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
 
         // Transfer more than the balance of the mint keypair, should cause a
         // InstructionError::InsufficientFunds that is then committed. Needs to be
@@ -3169,6 +3173,10 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Arc::new(Bank::new_no_wallclock_throttle_for_tests(&genesis_config));
+        // set cost tracker limits to MAX so it will not filter out TXs
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
 
         // Make all repetitive transactions that conflict on the `mint_keypair`, so only 1 should be executed
         let mut transactions = vec![

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -7,16 +7,12 @@ use {
     crossbeam_channel::Receiver,
     solana_ledger::blockstore::Blockstore,
     solana_measure::measure::Measure,
-    solana_program_runtime::timings::ExecuteTimings,
+    solana_program_runtime::timings::{ExecuteTimings, ProgramTiming},
     solana_runtime::{bank::Bank, cost_model::CostModel},
-    solana_sdk::timing::timestamp,
+    solana_sdk::{pubkey::Pubkey, timing::timestamp},
     std::{
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc, RwLock,
-        },
+        sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
-        time::Duration,
     },
 };
 
@@ -29,15 +25,18 @@ pub struct CostUpdateServiceTiming {
 
 impl CostUpdateServiceTiming {
     fn update(&mut self, update_cost_model_count: u64, update_cost_model_elapsed: u64) {
-        self.update_cost_model_count += update_cost_model_count;
-        self.update_cost_model_elapsed += update_cost_model_elapsed;
+        self.update_cost_model_count = self
+            .update_cost_model_count
+            .saturating_add(update_cost_model_count);
+        self.update_cost_model_elapsed = self
+            .update_cost_model_elapsed
+            .saturating_add(update_cost_model_elapsed);
 
         let now = timestamp();
         let elapsed_ms = now - self.last_print;
         if elapsed_ms > 1000 {
             datapoint_info!(
                 "cost-update-service-stats",
-                ("total_elapsed_us", elapsed_ms * 1000, i64),
                 (
                     "update_cost_model_count",
                     self.update_cost_model_count as i64,
@@ -74,7 +73,6 @@ pub struct CostUpdateService {
 impl CostUpdateService {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
-        exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         cost_model: Arc<RwLock<CostModel>>,
         cost_update_receiver: CostUpdateReceiver,
@@ -82,7 +80,7 @@ impl CostUpdateService {
         let thread_hdl = Builder::new()
             .name("solana-cost-update-service".to_string())
             .spawn(move || {
-                Self::service_loop(exit, blockstore, cost_model, cost_update_receiver);
+                Self::service_loop(blockstore, cost_model, cost_update_receiver);
             })
             .unwrap();
 
@@ -94,105 +92,109 @@ impl CostUpdateService {
     }
 
     fn service_loop(
-        exit: Arc<AtomicBool>,
         _blockstore: Arc<Blockstore>,
         cost_model: Arc<RwLock<CostModel>>,
         cost_update_receiver: CostUpdateReceiver,
     ) {
         let mut cost_update_service_timing = CostUpdateServiceTiming::default();
-        let mut update_count: u64;
-        let wait_timer = Duration::from_millis(100);
+        let mut update_count = 0_u64;
 
-        loop {
-            if exit.load(Ordering::Relaxed) {
-                break;
-            }
-
-            update_count = 0_u64;
-            let mut update_cost_model_time = Measure::start("update_cost_model_time");
-            for cost_update in cost_update_receiver.try_iter() {
-                match cost_update {
-                    CostUpdate::FrozenBank { bank } => {
-                        bank.read_cost_tracker().unwrap().report_stats(bank.slot());
-                    }
-                    CostUpdate::ExecuteTiming {
-                        mut execute_timings,
-                    } => {
-                        Self::update_cost_model(&cost_model, &mut execute_timings);
-                        update_count += 1;
-                    }
+        for cost_update in cost_update_receiver.iter() {
+            match cost_update {
+                CostUpdate::FrozenBank { bank } => {
+                    bank.read_cost_tracker().unwrap().report_stats(bank.slot());
+                }
+                CostUpdate::ExecuteTiming {
+                    mut execute_timings,
+                } => {
+                    let mut update_cost_model_time = Measure::start("update_cost_model_time");
+                    update_count += Self::update_cost_model(&cost_model, &mut execute_timings);
+                    update_cost_model_time.stop();
+                    cost_update_service_timing.update(update_count, update_cost_model_time.as_us());
                 }
             }
-            update_cost_model_time.stop();
-
-            cost_update_service_timing.update(update_count, update_cost_model_time.as_us());
-
-            thread::sleep(wait_timer);
         }
     }
 
     fn update_cost_model(
         cost_model: &RwLock<CostModel>,
         execute_timings: &mut ExecuteTimings,
-    ) -> bool {
-        let mut dirty = false;
-        {
-            for (program_id, program_timings) in &mut execute_timings.details.per_program_timings {
-                let current_estimated_program_cost =
-                    cost_model.read().unwrap().find_instruction_cost(program_id);
-                program_timings.coalesce_error_timings(current_estimated_program_cost);
+    ) -> u64 {
+        let mut update_count = 0_u64;
+        for (program_id, program_timings) in &mut execute_timings.details.per_program_timings {
+            let current_estimated_program_cost =
+                cost_model.read().unwrap().find_instruction_cost(program_id);
+            program_timings.coalesce_error_timings(current_estimated_program_cost);
 
-                if program_timings.count < 1 {
-                    continue;
-                }
+            if program_timings.count < 1 {
+                continue;
+            }
 
-                let units = program_timings.accumulated_units / program_timings.count as u64;
-                match cost_model
-                    .write()
-                    .unwrap()
-                    .upsert_instruction_cost(program_id, units)
-                {
-                    Ok(c) => {
-                        debug!(
-                            "after replayed into bank, instruction {:?} has averaged cost {}",
-                            program_id, c
-                        );
-                        dirty = true;
-                    }
-                    Err(err) => {
-                        debug!(
-                        "after replayed into bank, instruction {:?} failed to update cost, err: {}",
-                        program_id, err
-                    );
-                    }
-                }
+            let units = program_timings.accumulated_units / program_timings.count as u64;
+            cost_model
+                .write()
+                .unwrap()
+                .upsert_instruction_cost(program_id, units);
+            update_count += 1;
+
+            let updated_estimated_program_cost =
+                cost_model.read().unwrap().find_instruction_cost(program_id);
+            if Self::is_large_change_in_cost_calculation(
+                units as i64,
+                updated_estimated_program_cost as i64,
+            ) {
+                Self::report_large_change_in_cost(
+                    program_id,
+                    program_timings,
+                    updated_estimated_program_cost,
+                );
             }
         }
-        debug!(
-           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
-           cost_model.read().unwrap().get_instruction_cost_table()
+        update_count
+    }
+
+    // Using historical data, it seems reasonable to consider large change if updated_cost
+    // is more than double of input_data;
+    // Compare updated_cost against input_cost instead of previous calculated cost captures
+    // how far apart between single data point and calculated value, which is a good indicator
+    // of potential issues.
+    fn is_large_change_in_cost_calculation(input_cost: i64, updated_cost: i64) -> bool {
+        (updated_cost - input_cost).abs() > input_cost
+    }
+
+    fn report_large_change_in_cost(
+        program_id: &Pubkey,
+        program_timing: &ProgramTiming,
+        calculated_units: u64,
+    ) {
+        datapoint_info!(
+            "large_change_in_cost",
+            ("pubkey", program_id.to_string(), String),
+            ("execute_us", program_timing.accumulated_us, i64),
+            ("accumulated_units", program_timing.accumulated_units, i64),
+            ("count", program_timing.count, i64),
+            ("errored_units", program_timing.total_errored_units, i64),
+            (
+                "errored_count",
+                program_timing.errored_txs_compute_consumed.len(),
+                i64
+            ),
+            ("calculated_units", calculated_units as i64, i64),
         );
-        dirty
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_program_runtime::timings::ProgramTiming, solana_sdk::pubkey::Pubkey};
+    use {super::*, solana_program_runtime::timings::ProgramTiming};
 
     #[test]
     fn test_update_cost_model_with_empty_execute_timings() {
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
         let mut empty_execute_timings = ExecuteTimings::default();
-        CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings);
-
         assert_eq!(
-            0,
-            cost_model
-                .read()
-                .unwrap()
-                .get_instruction_cost_table()
-                .len()
+            CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings),
+            0
         );
     }
 
@@ -222,22 +224,15 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            let update_count =
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            assert_eq!(1, update_count);
             assert_eq!(
-                1,
+                expected_cost,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
-            );
-            assert_eq!(
-                Some(&expected_cost),
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -259,22 +254,15 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            let update_count =
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            assert_eq!(1, update_count);
             assert_eq!(
-                1,
+                expected_cost,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
-            );
-            assert_eq!(
-                Some(&expected_cost),
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }
@@ -298,14 +286,37 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             // If both the `errored_txs_compute_consumed` is empty and `count == 0`, then
             // nothing should be inserted into the cost model
-            assert!(cost_model
-                .read()
-                .unwrap()
-                .get_instruction_cost_table()
-                .is_empty());
+            assert_eq!(
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                0
+            );
+        }
+
+        // set up current instruction cost to 100
+        let current_program_cost = 100;
+        {
+            execute_timings.details.per_program_timings.insert(
+                program_key_1,
+                ProgramTiming {
+                    accumulated_us: 1000,
+                    accumulated_units: current_program_cost,
+                    count: 1,
+                    errored_txs_compute_consumed: vec![],
+                    total_errored_units: 0,
+                },
+            );
+            let update_count =
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            assert_eq!(1, update_count);
+            assert_eq!(
+                current_program_cost,
+                cost_model
+                    .read()
+                    .unwrap()
+                    .find_instruction_cost(&program_key_1)
+            );
         }
 
         // Test updating cost model with only erroring compute costs where the `cost_per_error` is
@@ -325,22 +336,15 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            let update_count =
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            assert_eq!(1, update_count);
             assert_eq!(
-                1,
+                cost_per_error,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
-            );
-            assert_eq!(
-                Some(&cost_per_error),
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -361,22 +365,15 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            let update_count =
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
+            assert_eq!(1, update_count);
             assert_eq!(
-                1,
+                cost_per_error,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
-            );
-            assert_eq!(
-                Some(&cost_per_error),
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -309,12 +309,8 @@ impl Tvu {
         );
 
         let (cost_update_sender, cost_update_receiver) = unbounded();
-        let cost_update_service = CostUpdateService::new(
-            exit.clone(),
-            blockstore.clone(),
-            cost_model.clone(),
-            cost_update_receiver,
-        );
+        let cost_update_service =
+            CostUpdateService::new(blockstore.clone(), cost_model.clone(), cost_update_receiver);
 
         let (drop_bank_sender, drop_bank_receiver) = unbounded();
 

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -73,13 +73,8 @@ impl Default for ComputeBudget {
 
 impl ComputeBudget {
     pub fn new(use_max_units_default: bool) -> Self {
-        let max_units = if use_max_units_default {
-            MAX_UNITS
-        } else {
-            200_000
-        } as u64;
         ComputeBudget {
-            max_units,
+            max_units: ComputeBudget::get_max_units(use_max_units_default),
             log_64_units: 100,
             create_program_address_units: 1500,
             invoke_units: 1000,
@@ -99,6 +94,14 @@ impl ComputeBudget {
             heap_size: None,
             heap_cost: 8,
             mem_op_base_cost: 10,
+        }
+    }
+
+    pub fn get_max_units(use_max_units_default: bool) -> u64 {
+        if use_max_units_default {
+            MAX_UNITS as u64
+        } else {
+            200_000
         }
     }
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -11,7 +11,6 @@ use {
         instruction::CompiledInstruction, program_utils::limited_deserialize, pubkey::Pubkey,
         system_instruction::SystemInstruction, system_program, transaction::SanitizedTransaction,
     },
-    std::collections::HashMap,
 };
 
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
@@ -79,28 +78,9 @@ impl CostModel {
             .map(|(key, cost)| (key, cost))
             .chain(BUILT_IN_INSTRUCTION_COSTS.iter())
             .for_each(|(program_id, cost)| {
-                match self
-                    .instruction_execution_cost_table
-                    .upsert(program_id, *cost)
-                {
-                    Some(c) => {
-                        debug!(
-                            "initiating cost table, instruction {:?} has cost {}",
-                            program_id, c
-                        );
-                    }
-                    None => {
-                        debug!(
-                            "initiating cost table, failed for instruction {:?}",
-                            program_id
-                        );
-                    }
-                }
+                self.instruction_execution_cost_table
+                    .upsert(program_id, *cost);
             });
-        debug!(
-            "restored cost model instruction cost table from blockstore, current values: {:?}",
-            self.get_instruction_cost_table()
-        );
     }
 
     pub fn calculate_cost(&self, transaction: &SanitizedTransaction) -> TransactionCost {
@@ -116,35 +96,29 @@ impl CostModel {
         tx_cost
     }
 
-    pub fn upsert_instruction_cost(
-        &mut self,
-        program_key: &Pubkey,
-        cost: u64,
-    ) -> Result<u64, &'static str> {
+    // update-or-insert should be infallible. The result of upsert, which often
+    // requires additional calculation, should be lazy.
+    pub fn upsert_instruction_cost(&mut self, program_key: &Pubkey, cost: u64) {
         self.instruction_execution_cost_table
             .upsert(program_key, cost);
-        match self.instruction_execution_cost_table.get_cost(program_key) {
-            Some(cost) => Ok(*cost),
-            None => Err("failed to upsert to ExecuteCostTable"),
-        }
-    }
-
-    pub fn get_instruction_cost_table(&self) -> &HashMap<Pubkey, u64> {
-        self.instruction_execution_cost_table.get_cost_table()
     }
 
     pub fn find_instruction_cost(&self, program_key: &Pubkey) -> u64 {
         match self.instruction_execution_cost_table.get_cost(program_key) {
             Some(cost) => *cost,
             None => {
-                let default_value = self.instruction_execution_cost_table.get_mode();
+                let default_value = self.instruction_execution_cost_table.get_default_cost();
                 debug!(
-                    "Program key {:?} does not have assigned cost, using mode {}",
+                    "Instruction {:?} does not have aggregated cost, using default value {}",
                     program_key, default_value
                 );
                 default_value
             }
         }
+    }
+
+    pub fn get_program_keys(&self) -> Vec<&Pubkey> {
+        self.instruction_execution_cost_table.get_program_keys()
     }
 
     fn get_signature_cost(&self, transaction: &SanitizedTransaction) -> u64 {
@@ -270,6 +244,7 @@ mod tests {
             transaction::Transaction,
         },
         std::{
+            collections::HashMap,
             str::FromStr,
             sync::{Arc, RwLock},
             thread::{self, JoinHandle},
@@ -293,22 +268,49 @@ mod tests {
         let mut testee = CostModel::default();
 
         let known_key = Pubkey::from_str("known11111111111111111111111111111111111111").unwrap();
-        testee.upsert_instruction_cost(&known_key, 100).unwrap();
+        testee.upsert_instruction_cost(&known_key, 100);
         // find cost for known programs
         assert_eq!(100, testee.find_instruction_cost(&known_key));
 
-        testee
-            .upsert_instruction_cost(&bpf_loader::id(), 1999)
-            .unwrap();
+        testee.upsert_instruction_cost(&bpf_loader::id(), 1999);
         assert_eq!(1999, testee.find_instruction_cost(&bpf_loader::id()));
 
         // unknown program is assigned with default cost
         assert_eq!(
-            testee.instruction_execution_cost_table.get_mode(),
+            testee.instruction_execution_cost_table.get_default_cost(),
             testee.find_instruction_cost(
                 &Pubkey::from_str("unknown111111111111111111111111111111111111").unwrap()
             )
         );
+    }
+
+    #[test]
+    fn test_iterating_instruction_cost_by_program_keys() {
+        solana_logger::setup();
+        let mut testee = CostModel::default();
+
+        let mut test_key_and_cost = HashMap::<Pubkey, u64>::new();
+        (0u64..10u64).for_each(|n| {
+            test_key_and_cost.insert(Pubkey::new_unique(), n);
+        });
+
+        test_key_and_cost.iter().for_each(|(key, cost)| {
+            testee.upsert_instruction_cost(key, *cost);
+            info!("key {:?} cost {}", key, cost);
+        });
+
+        let keys = testee.get_program_keys();
+        // verify each key has pre-set value
+        keys.iter().for_each(|key| {
+            let expected_cost = test_key_and_cost.get(key).unwrap();
+            info!(
+                "check key {:?} expect {} find {}",
+                key,
+                expected_cost,
+                testee.find_instruction_cost(key)
+            );
+            assert_eq!(*expected_cost, testee.find_instruction_cost(key));
+        });
     }
 
     #[test]
@@ -376,8 +378,7 @@ mod tests {
 
         let mut testee = CostModel::default();
         testee
-            .upsert_instruction_cost(&system_program::id(), expected_cost)
-            .unwrap();
+            .upsert_instruction_cost(&system_program::id(), expected_cost);
         assert_eq!(
             expected_cost,
             testee.get_transaction_cost(&simple_transaction)
@@ -405,9 +406,7 @@ mod tests {
         let expected_cost = program_cost * 2;
 
         let mut testee = CostModel::default();
-        testee
-            .upsert_instruction_cost(&system_program::id(), program_cost)
-            .unwrap();
+        testee.upsert_instruction_cost(&system_program::id(), program_cost);
         assert_eq!(expected_cost, testee.get_transaction_cost(&tx));
     }
 
@@ -439,7 +438,7 @@ mod tests {
         let result = testee.get_transaction_cost(&tx);
 
         // expected cost for two random/unknown program is
-        let expected_cost = testee.instruction_execution_cost_table.get_mode() * 2;
+        let expected_cost = testee.instruction_execution_cost_table.get_default_cost() * 2;
         assert_eq!(expected_cost, result);
     }
 
@@ -483,14 +482,16 @@ mod tests {
         let mut cost_model = CostModel::default();
         // Using default cost for unknown instruction
         assert_eq!(
-            cost_model.instruction_execution_cost_table.get_mode(),
+            cost_model
+                .instruction_execution_cost_table
+                .get_default_cost(),
             cost_model.find_instruction_cost(&key1)
         );
 
         // insert instruction cost to table
-        assert!(cost_model.upsert_instruction_cost(&key1, cost1).is_ok());
+        cost_model.upsert_instruction_cost(&key1, cost1);
 
-        // now it is known insturction with known cost
+        // now it is known instruction with known cost
         assert_eq!(cost1, cost_model.find_instruction_cost(&key1));
     }
 
@@ -508,9 +509,7 @@ mod tests {
         let expected_execution_cost = 8;
 
         let mut cost_model = CostModel::default();
-        cost_model
-            .upsert_instruction_cost(&system_program::id(), expected_execution_cost)
-            .unwrap();
+        cost_model.upsert_instruction_cost(&system_program::id(), expected_execution_cost);
         let tx_cost = cost_model.calculate_cost(&tx);
         assert_eq!(expected_account_cost, tx_cost.write_lock_cost);
         assert_eq!(expected_execution_cost, tx_cost.execution_cost);
@@ -527,11 +526,11 @@ mod tests {
         let mut cost_model = CostModel::default();
 
         // insert instruction cost to table
-        assert!(cost_model.upsert_instruction_cost(&key1, cost1).is_ok());
+        cost_model.upsert_instruction_cost(&key1, cost1);
         assert_eq!(cost1, cost_model.find_instruction_cost(&key1));
 
         // update instruction cost
-        assert!(cost_model.upsert_instruction_cost(&key1, cost2).is_ok());
+        cost_model.upsert_instruction_cost(&key1, cost2);
         assert_eq!(updated_cost, cost_model.find_instruction_cost(&key1));
     }
 
@@ -573,8 +572,8 @@ mod tests {
                 if i == 5 {
                     thread::spawn(move || {
                         let mut cost_model = cost_model.write().unwrap();
-                        assert!(cost_model.upsert_instruction_cost(&prog1, cost1).is_ok());
-                        assert!(cost_model.upsert_instruction_cost(&prog2, cost2).is_ok());
+                        cost_model.upsert_instruction_cost(&prog1, cost1);
+                        cost_model.upsert_instruction_cost(&prog2, cost2);
                     })
                 } else {
                     thread::spawn(move || {

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -3,8 +3,10 @@
 /// unchecked.
 /// When its capacity limit is reached, it prunes old and less-used programs
 /// to make room for new ones.
-use log::*;
-use {solana_sdk::pubkey::Pubkey, std::collections::HashMap};
+use {
+    log::*, solana_program_runtime::compute_budget::ComputeBudget, solana_sdk::pubkey::Pubkey,
+    std::collections::HashMap,
+};
 
 // prune is rather expensive op, free up bulk space in each operation
 // would be more efficient. PRUNE_RATIO defines the after prune table
@@ -37,27 +39,30 @@ impl ExecuteCostTable {
         }
     }
 
-    pub fn get_cost_table(&self) -> &HashMap<Pubkey, u64> {
-        &self.table
-    }
-
+    // number of programs in table
     pub fn get_count(&self) -> usize {
         self.table.len()
     }
 
-    // instead of assigning unknown program with a configured/hard-coded cost
-    // use average or mode function to make a educated guess.
-    pub fn get_average(&self) -> u64 {
+    // default program cost to max_units
+    pub fn get_default_cost(&self) -> u64 {
+        let use_max_units_default = false;
+        ComputeBudget::get_max_units(use_max_units_default)
+    }
+
+    // average cost of all recorded programs
+    pub fn get_average_cost(&self) -> u64 {
         if self.table.is_empty() {
-            0
+            self.get_default_cost()
         } else {
             self.table.iter().map(|(_, value)| value).sum::<u64>() / self.get_count() as u64
         }
     }
 
-    pub fn get_mode(&self) -> u64 {
+    // mode - the most frequently occurring program's value
+    pub fn get_mode_cost(&self) -> u64 {
         if self.occurrences.is_empty() {
-            0
+            self.get_default_cost()
         } else {
             let key = self
                 .occurrences
@@ -71,14 +76,16 @@ impl ExecuteCostTable {
     }
 
     // returns None if program doesn't exist in table. In this case,
-    // client is advised to call `get_average()` or `get_mode()` to
-    // assign a 'default' value for new program.
+    // `get_default_cost()`, `get_average_cost()` or `get_mode_cost()`
+    // can be used to assign a value to new program.
     pub fn get_cost(&self, key: &Pubkey) -> Option<&u64> {
         self.table.get(key)
     }
 
-    pub fn upsert(&mut self, key: &Pubkey, value: u64) -> Option<u64> {
-        let need_to_add = self.table.get(key).is_none();
+    // update-or-insert should be infallible. The result of upsert, which often
+    // requires additional calculation, should be lazy at time of query.
+    pub fn upsert(&mut self, key: &Pubkey, value: u64) {
+        let need_to_add = !self.table.contains_key(key);
         let current_size = self.get_count();
         if current_size == self.capacity && need_to_add {
             self.prune_to(&((current_size as f64 * PRUNE_RATIO) as usize));
@@ -93,8 +100,10 @@ impl ExecuteCostTable {
             .or_insert((0, Self::micros_since_epoch()));
         *count += 1;
         *timestamp = Self::micros_since_epoch();
+    }
 
-        Some(*program_cost)
+    pub fn get_program_keys(&self) -> Vec<&Pubkey> {
+        self.table.keys().collect()
     }
 
     // prune the old programs so the table contains `new_size` of records,
@@ -184,9 +193,9 @@ mod tests {
         let key2 = Pubkey::new_unique();
         let key3 = Pubkey::new_unique();
 
-        // simulate a lot of occurences to key1, so even there're longer than
+        // simulate a lot of occurrences to key1, so even there're longer than
         // usual delay between upsert(key1..) and upsert(key2, ..), test
-        // would still satisfy as key1 has enough occurences to compensate
+        // would still satisfy as key1 has enough occurrences to compensate
         // its age.
         for i in 0..1000 {
             testee.upsert(&key1, i);
@@ -219,23 +228,23 @@ mod tests {
         // insert one record
         testee.upsert(&key1, cost1);
         assert_eq!(1, testee.get_count());
-        assert_eq!(cost1, testee.get_average());
-        assert_eq!(cost1, testee.get_mode());
+        assert_eq!(cost1, testee.get_average_cost());
+        assert_eq!(cost1, testee.get_mode_cost());
         assert_eq!(&cost1, testee.get_cost(&key1).unwrap());
 
         // insert 2nd record
         testee.upsert(&key2, cost2);
         assert_eq!(2, testee.get_count());
-        assert_eq!((cost1 + cost2) / 2_u64, testee.get_average());
-        assert_eq!(cost2, testee.get_mode());
+        assert_eq!((cost1 + cost2) / 2_u64, testee.get_average_cost());
+        assert_eq!(cost2, testee.get_mode_cost());
         assert_eq!(&cost1, testee.get_cost(&key1).unwrap());
         assert_eq!(&cost2, testee.get_cost(&key2).unwrap());
 
         // update 1st record
         testee.upsert(&key1, cost2);
         assert_eq!(2, testee.get_count());
-        assert_eq!(((cost1 + cost2) / 2 + cost2) / 2, testee.get_average());
-        assert_eq!((cost1 + cost2) / 2, testee.get_mode());
+        assert_eq!(((cost1 + cost2) / 2 + cost2) / 2, testee.get_average_cost());
+        assert_eq!((cost1 + cost2) / 2, testee.get_mode_cost());
         assert_eq!(&((cost1 + cost2) / 2), testee.get_cost(&key1).unwrap());
         assert_eq!(&cost2, testee.get_cost(&key2).unwrap());
     }
@@ -269,8 +278,8 @@ mod tests {
         // insert 3rd record, pushes out the oldest (eg 1st) record
         testee.upsert(&key3, cost3);
         assert_eq!(2, testee.get_count());
-        assert_eq!((cost2 + cost3) / 2_u64, testee.get_average());
-        assert_eq!(cost3, testee.get_mode());
+        assert_eq!((cost2 + cost3) / 2_u64, testee.get_average_cost());
+        assert_eq!(cost3, testee.get_mode_cost());
         assert!(testee.get_cost(&key1).is_none());
         assert_eq!(&cost2, testee.get_cost(&key2).unwrap());
         assert_eq!(&cost3, testee.get_cost(&key3).unwrap());
@@ -279,8 +288,11 @@ mod tests {
         // add 4th record, pushes out 3rd key
         testee.upsert(&key2, cost1);
         testee.upsert(&key4, cost4);
-        assert_eq!(((cost1 + cost2) / 2 + cost4) / 2_u64, testee.get_average());
-        assert_eq!((cost1 + cost2) / 2, testee.get_mode());
+        assert_eq!(
+            ((cost1 + cost2) / 2 + cost4) / 2_u64,
+            testee.get_average_cost()
+        );
+        assert_eq!((cost1 + cost2) / 2, testee.get_mode_cost());
         assert_eq!(2, testee.get_count());
         assert!(testee.get_cost(&key1).is_none());
         assert_eq!(&((cost1 + cost2) / 2), testee.get_cost(&key2).unwrap());


### PR DESCRIPTION
#### Problem
Before add back EMA cost calculation, want to clean up the code path.


#### Summary of Changes
- code refactoring
- using receiver.iter instead of `try_iter` to remove the need of passing `exit` flag;
- make `upsert...` ops infallible
- add trigger to report large changes in cost calculation 

Fixes #
