### PR TITLE
Improve correctness of Rust-side type definitions for C invoke syscall

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2345,9 +2345,21 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, loader_id)?;
 
-        assert_eq!(std::mem::size_of_val(&ix_c.accounts_len), std::mem::size_of::<usize>(), "non-64-bit host");
-        assert_eq!(std::mem::size_of_val(&ix_c.data_len), std::mem::size_of::<usize>(), "non-64-bit host");
-        check_instruction_size(ix_c.accounts_len as usize, ix_c.data_len as usize, invoke_context)?;
+        assert_eq!(
+            std::mem::size_of_val(&ix_c.accounts_len),
+            std::mem::size_of::<usize>(),
+            "non-64-bit host"
+        );
+        assert_eq!(
+            std::mem::size_of_val(&ix_c.data_len),
+            std::mem::size_of::<usize>(),
+            "non-64-bit host"
+        );
+        check_instruction_size(
+            ix_c.accounts_len as usize,
+            ix_c.data_len as usize,
+            invoke_context,
+        )?;
         let program_id = translate_type::<Pubkey>(memory_mapping, ix_c.program_id_addr, loader_id)?;
         let meta_cs = translate_slice::<SolAccountMeta>(
             memory_mapping,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2320,9 +2320,7 @@ struct SolSignerSeedC {
 #[derive(Debug)]
 #[repr(C)]
 struct SolSignerSeedsC {
-    #[allow(dead_code)]
     addr: u64,
-    #[allow(dead_code)]
     len: u64,
 }
 
@@ -2494,7 +2492,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
         memory_mapping: &MemoryMapping,
     ) -> Result<Vec<Pubkey>, EbpfError<BpfError>> {
         if signers_seeds_len > 0 {
-            let signers_seeds = translate_slice::<SolSignerSeedC>(
+            let signers_seeds = translate_slice::<SolSignerSeedsC>(
                 memory_mapping,
                 signers_seeds_addr,
                 signers_seeds_len,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2345,12 +2345,12 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, loader_id)?;
 
-        assert_eq!(
+        debug_assert_eq!(
             std::mem::size_of_val(&ix_c.accounts_len),
             std::mem::size_of::<usize>(),
             "non-64-bit host"
         );
-        assert_eq!(
+        debug_assert_eq!(
             std::mem::size_of_val(&ix_c.data_len),
             std::mem::size_of::<usize>(),
             "non-64-bit host"

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2277,9 +2277,9 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a, 'b> {
 struct SolInstruction {
     program_id_addr: u64,
     accounts_addr: u64,
-    accounts_len: usize,
+    accounts_len: u64,
     data_addr: u64,
-    data_len: usize,
+    data_len: u64,
 }
 
 /// Rust representation of C's SolAccountMeta
@@ -2347,7 +2347,9 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, loader_id)?;
 
-        check_instruction_size(ix_c.accounts_len, ix_c.data_len, invoke_context)?;
+        assert_eq!(std::mem::size_of_val(&ix_c.accounts_len), std::mem::size_of::<usize>(), "non-64-bit host");
+        assert_eq!(std::mem::size_of_val(&ix_c.data_len), std::mem::size_of::<usize>(), "non-64-bit host");
+        check_instruction_size(ix_c.accounts_len as usize, ix_c.data_len as usize, invoke_context)?;
         let program_id = translate_type::<Pubkey>(memory_mapping, ix_c.program_id_addr, loader_id)?;
         let meta_cs = translate_slice::<SolAccountMeta>(
             memory_mapping,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2273,6 +2273,7 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a, 'b> {
 
 /// Rust representation of C's SolInstruction
 #[derive(Debug)]
+#[repr(C)]
 struct SolInstruction {
     program_id_addr: u64,
     accounts_addr: u64,
@@ -2283,6 +2284,7 @@ struct SolInstruction {
 
 /// Rust representation of C's SolAccountMeta
 #[derive(Debug)]
+#[repr(C)]
 struct SolAccountMeta {
     pubkey_addr: u64,
     is_writable: bool,
@@ -2291,6 +2293,7 @@ struct SolAccountMeta {
 
 /// Rust representation of C's SolAccountInfo
 #[derive(Debug)]
+#[repr(C)]
 struct SolAccountInfo {
     key_addr: u64,
     lamports_addr: u64,
@@ -2307,6 +2310,7 @@ struct SolAccountInfo {
 
 /// Rust representation of C's SolSignerSeed
 #[derive(Debug)]
+#[repr(C)]
 struct SolSignerSeedC {
     addr: u64,
     len: u64,
@@ -2314,6 +2318,7 @@ struct SolSignerSeedC {
 
 /// Rust representation of C's SolSignerSeeds
 #[derive(Debug)]
+#[repr(C)]
 struct SolSignerSeedsC {
     #[allow(dead_code)]
     addr: u64,


### PR DESCRIPTION
#### Problem

There are several places in the implementation of `SyscallInvokeSignedC` where types are defined or used incorrectly. There is no practical impact today, but this improves correctness in ways that may help in the future.

#### Summary of Changes

- Add `#[repr(C)]` to several structs that are intended to have the same representation as C structs.
- Make the length fields of `SolInstruction` u64, as they are in C
- Use the `SolSignerSeedsC` type instead of `SolSignerSeedC` type when mapping the array of `SolSignerSeeds` - these two types happen to have the same Rust-side definition so it worked, but `SolSignerSeedsC` was suspiciously unused.

Changing the fields of `SolInstruction` forces the host to do a cast to `usize`. As I'm not sure exactly what should happen for 32-bit hosts, and since Solana doesn't currently support 32-bit hosts, I just asserted that u64 and usize are the same size. The code looks worse like this but I think is more correct and futureproof than leaving usizes in the struct definition.

I was not able to complete the test suite locally for unrelated reasons, and have not done any manual testing that these changes are correct, though I think they introduce no observable change. I hope that CI has good coverage of C programs.