### PR TITLE
feat(connection.ts): implement getTransactions

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3305,6 +3305,34 @@ export class Connection {
   }
 
   /**
+   * Fetch transaction details for a batch of confirmed transactions.
+   * Similar to {@link getParsedTransactions} but returns a {@link TransactionResponse}.
+   */
+  async getTransactions(
+    signatures: TransactionSignature[],
+    commitment?: Finality,
+  ): Promise<(TransactionResponse | null)[]> {
+    const batch = signatures.map(signature => {
+      const args = this._buildArgsAtLeastConfirmed([signature], commitment);
+      return {
+        methodName: 'getTransaction',
+        args,
+      };
+    });
+
+    const unsafeRes = await this._rpcBatchRequest(batch);
+    const res = unsafeRes.map((unsafeRes: any) => {
+      const res = create(unsafeRes, GetTransactionRpcResult);
+      if ('error' in res) {
+        throw new Error('failed to get transactions: ' + res.error.message);
+      }
+      return res.result;
+    });
+
+    return res;
+  }
+
+  /**
    * Fetch a list of Transactions and transaction statuses from the cluster
    * for a confirmed block.
    *


### PR DESCRIPTION
implement getTransactions which retrieves **multiple transaction responses in a single RPC call**

#### Problem

currently `getParsedConfirmedTransactions` is the only method which lets you retrieve multiple txs in a single call, however the `ParsedTransactionWithMeta` structure is different from a `TransactionResponse` structure

#### Summary of Changes

implement getTransactions which retrieves multiple transaction responses in a single RPC call 

Fixes #
