### PR TITLE
ledger-tool: Pin histogram crate version to fix cargo publish

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -15,7 +15,7 @@ clap = "2.33.1"
 crossbeam-channel = "0.5"
 csv = "1.1.6"
 dashmap = "4.0.2"
-histogram = "*"
+histogram = "0.6.9"
 itertools = "0.10.3"
 log = { version = "0.4.14" }
 regex = "1"


### PR DESCRIPTION
From https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies:
> As of January 22nd, 2016, [crates.io](https://crates.io/) rejects all packages (not just libraries) with wildcard dependency constraints.
