### PR TITLE
count discarded batches on sig. validation stage

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -45,13 +45,13 @@ impl SigVerifier for TransactionSigVerifier {
         mut batches: Vec<PacketBatch>,
         valid_packets: usize,
     ) -> (Vec<PacketBatch>, usize) {
-        let count_invalid_packages = sigverify::ed25519_verify(
+        let count_invalid_batches = sigverify::ed25519_verify(
             &mut batches,
             &self.recycler,
             &self.recycler_out,
             self.reject_non_vote,
             valid_packets,
         );
-        (batches, count_invalid_packages)
+        (batches, count_invalid_batches)
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -44,14 +44,14 @@ impl SigVerifier for TransactionSigVerifier {
         &self,
         mut batches: Vec<PacketBatch>,
         valid_packets: usize,
-    ) -> Vec<PacketBatch> {
-        sigverify::ed25519_verify(
+    ) -> (Vec<PacketBatch>, usize) {
+        let count_invalid_packages = sigverify::ed25519_verify(
             &mut batches,
             &self.recycler,
             &self.recycler_out,
             self.reject_non_vote,
             valid_packets,
         );
-        batches
+        (batches, count_invalid_packages)
     }
 }

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -45,7 +45,7 @@ impl SigVerifier for ShredSigVerifier {
         &self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
-    ) -> Vec<PacketBatch> {
+    ) -> (Vec<PacketBatch>, usize) {
         let r_bank = self.bank_forks.read().unwrap().working_bank();
         let slots: HashSet<u64> = Self::read_slots(&batches);
         let mut leader_slots: HashMap<u64, [u8; 32]> = slots
@@ -60,8 +60,8 @@ impl SigVerifier for ShredSigVerifier {
         leader_slots.insert(std::u64::MAX, [0u8; 32]);
 
         let r = verify_shreds_gpu(&batches, &leader_slots, &self.recycler_cache);
-        solana_perf::sigverify::mark_disabled(&mut batches, &r);
-        batches
+        let count_discarded = solana_perf::sigverify::mark_disabled(&mut batches, &r);
+        (batches, count_discarded)
     }
 }
 

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -166,7 +166,9 @@ pub mod tests {
         batches[0].packets[1].meta.size = shred.payload.len();
 
         let num_packets = solana_perf::sigverify::count_packets_in_batches(&batches);
-        let rv = verifier.verify_batches(batches, num_packets);
+        let (rv, count_discarded) = verifier.verify_batches(batches, num_packets);
+        assert_eq!(count_discarded, 1);
+
         assert!(!rv[0].packets[0].meta.discard());
         assert!(rv[0].packets[1].meta.discard());
     }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -268,7 +268,7 @@ impl SigVerifyStage {
         verify_batch_time.stop();
 
         debug!(
-            "discarded packages: {}, dedup failed packages: {}",
+            "discarded packets: {}, dedup failed packets: {}",
             count_discarded, dedup_fail
         );
 

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -42,7 +42,13 @@ pub struct SigVerifyStage {
 }
 
 pub trait SigVerifier {
-    fn verify_batches(&self, batches: Vec<PacketBatch>, valid_packets: usize) -> Vec<PacketBatch>;
+    /// Returns marked packets and number of discarded packets
+    /// a returned packet is marked as discarded if it fails verification
+    fn verify_batches(
+        &self,
+        batches: Vec<PacketBatch>,
+        valid_packets: usize,
+    ) -> (Vec<PacketBatch>, usize);
 }
 
 #[derive(Default, Clone)]
@@ -63,6 +69,7 @@ struct SigVerifierStats {
     total_shrink_time: usize,
     total_shrinks: usize,
     total_valid_packets: usize,
+    total_discarded: usize,
 }
 
 impl SigVerifierStats {
@@ -174,6 +181,7 @@ impl SigVerifierStats {
             ("total_shrink_time", self.total_shrink_time, i64),
             ("total_shrinks", self.total_shrinks, i64),
             ("total_valid_packets", self.total_valid_packets, i64),
+            ("total_discarded", self.total_discarded, i64),
         );
     }
 }
@@ -183,9 +191,9 @@ impl SigVerifier for DisabledSigVerifier {
         &self,
         mut batches: Vec<PacketBatch>,
         _valid_packets: usize,
-    ) -> Vec<PacketBatch> {
+    ) -> (Vec<PacketBatch>, usize) {
         sigverify::ed25519_verify_disabled(&mut batches);
-        batches
+        (batches, 0)
     }
 }
 
@@ -256,8 +264,13 @@ impl SigVerifyStage {
         discard_time.stop();
 
         let mut verify_batch_time = Measure::start("sigverify_batch_time");
-        let mut batches = verifier.verify_batches(batches, num_valid_packets);
+        let (mut batches, count_discarded) = verifier.verify_batches(batches, num_valid_packets);
         verify_batch_time.stop();
+
+        debug!(
+            "discarded packages: {}, dedup failed packages: {}",
+            count_discarded, dedup_fail
+        );
 
         let mut shrink_time = Measure::start("sigverify_shrink_time");
         let num_valid_packets = count_valid_packets(&batches);
@@ -307,6 +320,7 @@ impl SigVerifyStage {
         stats.total_excess_fail += excess_fail;
         stats.total_shrink_time += shrink_time.as_us() as usize;
         stats.total_shrinks += total_shrinks;
+        stats.total_discarded += count_discarded;
 
         Ok(())
     }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -543,18 +543,30 @@ pub fn shrink_batches(batches: &mut [PacketBatch]) -> usize {
     last_valid_batch
 }
 
-pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, packet_count: usize) {
+/// return number of packets that failed signature validation
+pub fn ed25519_verify_cpu(
+    batches: &mut [PacketBatch],
+    reject_non_vote: bool,
+    packet_count: usize,
+) -> usize {
     use rayon::prelude::*;
     debug!("CPU ECDSA for {}", packet_count);
-    PAR_THREAD_POOL.install(|| {
-        batches.into_par_iter().for_each(|batch| {
-            batch
-                .packets
-                .par_iter_mut()
-                .for_each(|p| verify_packet(p, reject_non_vote))
-        });
-    });
     inc_new_counter_debug!("ed25519_verify_cpu", packet_count);
+    PAR_THREAD_POOL.install(|| {
+        batches
+            .into_par_iter()
+            .map(|batch| {
+                batch
+                    .packets
+                    .par_iter_mut()
+                    .map(|p| {
+                        verify_packet(p, reject_non_vote);
+                        p.meta.discard() as usize
+                    })
+                    .sum::<usize>() as usize
+            })
+            .sum::<usize>()
+    })
 }
 
 pub fn ed25519_verify_disabled(batches: &mut [PacketBatch]) {
@@ -621,14 +633,17 @@ pub fn get_checked_scalar(scalar: &[u8; 32]) -> Result<[u8; 32], PacketError> {
     Ok(out)
 }
 
-pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
+pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) -> usize {
+    let mut count_discarded = 0;
     for (batch, v) in batches.iter_mut().zip(r) {
         for (pkt, f) in batch.packets.iter_mut().zip(v) {
             if !pkt.meta.discard() {
                 pkt.meta.set_discard(*f == 0);
+                count_discarded += pkt.meta.discard() as usize;
             }
         }
     }
+    count_discarded
 }
 
 pub fn ed25519_verify(
@@ -637,7 +652,7 @@ pub fn ed25519_verify(
     recycler_out: &Recycler<PinnedVec<u8>>,
     reject_non_vote: bool,
     valid_packet_count: usize,
-) {
+) -> usize {
     let api = perf_libs::api();
     if api.is_none() {
         return ed25519_verify_cpu(batches, reject_non_vote, valid_packet_count);
@@ -707,8 +722,8 @@ pub fn ed25519_verify(
     }
     trace!("done verify");
     copy_return_values(&sig_lens, &out, &mut rvs);
-    mark_disabled(batches, &rvs);
     inc_new_counter_debug!("ed25519_verify_gpu", valid_packet_count);
+    mark_disabled(batches, &rvs)
 }
 
 #[cfg(test)]

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -634,12 +634,12 @@ pub fn get_checked_scalar(scalar: &[u8; 32]) -> Result<[u8; 32], PacketError> {
 }
 
 pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) -> usize {
-    let mut count_discarded = 0;
+    let mut count_discarded: usize = 0;
     for (batch, v) in batches.iter_mut().zip(r) {
         for (pkt, f) in batch.packets.iter_mut().zip(v) {
             if !pkt.meta.discard() {
                 pkt.meta.set_discard(*f == 0);
-                count_discarded += pkt.meta.discard() as usize;
+                count_discarded = count_discarded.saturating_add(pkt.meta.discard() as usize);
             }
         }
     }


### PR DESCRIPTION
#### Problem

*I'm not sure that we really need these additional metrics so I don't merge right now.*

It seems that there is no way to distinguish transactions filtered due to de-dublicate filter and other filters on sifverify stage.

#### Summary of Changes

Added such a metric to influxDB, added to DEBUG level logs

Fixes #
