### PR TITLE
Remove injection of exit signal into cost_update_service

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -309,12 +309,8 @@ impl Tvu {
         );
 
         let (cost_update_sender, cost_update_receiver) = unbounded();
-        let cost_update_service = CostUpdateService::new(
-            exit.clone(),
-            blockstore.clone(),
-            cost_model.clone(),
-            cost_update_receiver,
-        );
+        let cost_update_service =
+            CostUpdateService::new(blockstore.clone(), cost_model.clone(), cost_update_receiver);
 
         let (drop_bank_sender, drop_bank_receiver) = unbounded();
 


### PR DESCRIPTION
#### Problem

Injecting `exit` signal from `tvu` to `cost_update_service` is redundant. 

#### Summary of Changes

- using `iter` instead of `try_iter` to control receiving loop without need of `exit`, streamline the process.  

Fixes #
