### PR TITLE
Revert: `KeyedAccount` refactoings in builtin programs

### DIFF
--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -5,29 +5,33 @@ use {
     bincode::deserialize,
     solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
-        feature_set, instruction::InstructionError, program_utils::limited_deserialize,
+        account::{ReadableAccount, WritableAccount},
+        feature_set,
+        instruction::InstructionError,
+        keyed_account::keyed_account_at_index,
+        program_utils::limited_deserialize,
         pubkey::Pubkey,
     },
     std::collections::BTreeSet,
 };
 
 pub fn process_instruction(
-    _first_instruction_account: usize,
+    first_instruction_account: usize,
     data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    let transaction_context = &invoke_context.transaction_context;
-    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
+    let config_keyed_account =
+        &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
     let current_data: ConfigKeys = {
-        let config_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        if config_account.get_owner() != &crate::id() {
+        let config_account = config_keyed_account.try_account_ref_mut()?;
+        if config_account.owner() != &crate::id() {
             return Err(InstructionError::InvalidAccountOwner);
         }
 
-        deserialize(config_account.get_data()).map_err(|err| {
+        deserialize(config_account.data()).map_err(|err| {
             ic_msg!(
                 invoke_context,
                 "Unable to deserialize config account: {}",
@@ -46,7 +50,7 @@ pub fn process_instruction(
     if current_signer_keys.is_empty() {
         // Config account keypair must be a signer on account initialization,
         // or when no signers specified in Config data
-        if !instruction_context.is_signer(instruction_context.get_number_of_program_accounts())? {
+        if config_keyed_account.signer_key().is_none() {
             return Err(InstructionError::MissingRequiredSignature);
         }
     }
@@ -54,10 +58,9 @@ pub fn process_instruction(
     let mut counter = 0;
     for (signer, _) in key_list.keys.iter().filter(|(_, is_signer)| *is_signer) {
         counter += 1;
-        if signer != instruction_context.get_instruction_account_key(transaction_context, 0)? {
-            let is_signer = instruction_context
-                .is_signer(instruction_context.get_number_of_program_accounts() + counter)
-                .map_err(|_| {
+        if signer != config_keyed_account.unsigned_key() {
+            let signer_account =
+                keyed_account_at_index(keyed_accounts, counter + 1).map_err(|_| {
                     ic_msg!(
                         invoke_context,
                         "account {:?} is not in account list",
@@ -65,7 +68,8 @@ pub fn process_instruction(
                     );
                     InstructionError::MissingRequiredSignature
                 })?;
-            if !is_signer {
+            let signer_key = signer_account.signer_key();
+            if signer_key.is_none() {
                 ic_msg!(
                     invoke_context,
                     "account {:?} signer_key().is_none()",
@@ -73,9 +77,7 @@ pub fn process_instruction(
                 );
                 return Err(InstructionError::MissingRequiredSignature);
             }
-            if instruction_context.get_instruction_account_key(transaction_context, counter)?
-                != signer
-            {
+            if signer_key.unwrap() != signer {
                 ic_msg!(
                     invoke_context,
                     "account[{:?}].signer_key() does not match Config data)",
@@ -94,9 +96,7 @@ pub fn process_instruction(
                 );
                 return Err(InstructionError::MissingRequiredSignature);
             }
-        } else if !instruction_context
-            .is_signer(instruction_context.get_number_of_program_accounts())?
-        {
+        } else if config_keyed_account.signer_key().is_none() {
             ic_msg!(invoke_context, "account[0].signer_key().is_none()");
             return Err(InstructionError::MissingRequiredSignature);
         }
@@ -125,13 +125,15 @@ pub fn process_instruction(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    let mut config_account =
-        instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-    if config_account.get_data().len() < data.len() {
+    if config_keyed_account.data_len()? < data.len() {
         ic_msg!(invoke_context, "instruction data too large");
         return Err(InstructionError::InvalidInstructionData);
     }
-    config_account.get_data_mut()[..data.len()].copy_from_slice(data);
+
+    config_keyed_account
+        .try_account_ref_mut()?
+        .data_as_mut_slice()[..data.len()]
+        .copy_from_slice(data);
     Ok(())
 }
 
@@ -144,7 +146,7 @@ mod tests {
         serde_derive::{Deserialize, Serialize},
         solana_program_runtime::invoke_context::mock_process_instruction,
         solana_sdk::{
-            account::{AccountSharedData, ReadableAccount},
+            account::AccountSharedData,
             instruction::AccountMeta,
             pubkey::Pubkey,
             signature::{Keypair, Signer},

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -7,12 +7,12 @@ use {
     crate::{config, stake_state::StakeAccount},
     log::*,
     solana_program_runtime::{
-        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
+        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         feature_set,
         instruction::InstructionError,
-        keyed_account::keyed_account_at_index,
+        keyed_account::{get_signers, keyed_account_at_index},
         program_utils::limited_deserialize,
         stake::{
             instruction::StakeInstruction,
@@ -23,140 +23,46 @@ use {
     },
 };
 
-pub mod instruction_account_indices {
-    pub enum Initialize {
-        StakeAccount = 0,
-        Rent = 1,
-    }
-
-    pub enum Authorize {
-        StakeAccount = 0,
-        Clock = 1,
-        // CurrentAuthority = 2,
-        Custodian = 3,
-    }
-
-    pub enum AuthorizeWithSeed {
-        StakeAccount = 0,
-        AuthorityBase = 1,
-        Clock = 2,
-        Custodian = 3,
-    }
-
-    pub enum DelegateStake {
-        StakeAccount = 0,
-        VoteAccount = 1,
-        Clock = 2,
-        StakeHistory = 3,
-        ConfigAccount = 4,
-    }
-
-    pub enum Split {
-        StakeAccount = 0,
-        SplitTo = 1,
-    }
-
-    pub enum Merge {
-        StakeAccount = 0,
-        MergeFrom = 1,
-        Clock = 2,
-        StakeHistory = 3,
-    }
-
-    pub enum Withdraw {
-        StakeAccount = 0,
-        Recipient = 1,
-        Clock = 2,
-        StakeHistory = 3,
-        WithdrawAuthority = 4,
-        Custodian = 5,
-    }
-
-    pub enum Deactivate {
-        StakeAccount = 0,
-        Clock = 1,
-    }
-
-    pub enum SetLockup {
-        StakeAccount = 0,
-        // Clock = 1,
-    }
-
-    pub enum InitializeChecked {
-        StakeAccount = 0,
-        Rent = 1,
-        AuthorizedStaker = 2,
-        AuthorizedWithdrawer = 3,
-    }
-
-    pub enum AuthorizeChecked {
-        StakeAccount = 0,
-        Clock = 1,
-        // CurrentAuthority = 2,
-        Authorized = 3,
-        Custodian = 4,
-    }
-
-    pub enum AuthorizeCheckedWithSeed {
-        StakeAccount = 0,
-        AuthorityBase = 1,
-        Clock = 2,
-        Authorized = 3,
-        Custodian = 4,
-    }
-
-    pub enum SetLockupChecked {
-        StakeAccount = 0,
-        // Clock = 1,
-        Custodian = 2,
-    }
-}
-
 pub fn process_instruction(
     first_instruction_account: usize,
     data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    let transaction_context = &invoke_context.transaction_context;
-    let instruction_context = transaction_context.get_current_instruction_context()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);
+    trace!("keyed_accounts: {:?}", keyed_accounts);
 
     let me = &keyed_account_at_index(keyed_accounts, first_instruction_account)?;
     if me.owner()? != id() {
         return Err(InstructionError::InvalidAccountOwner);
     }
 
-    let signers = instruction_context.get_signers(transaction_context);
+    let signers = get_signers(&keyed_accounts[first_instruction_account..]);
     match limited_deserialize(data)? {
         StakeInstruction::Initialize(authorized, lockup) => {
-            let rent = get_sysvar_with_account_check2::rent(
+            let rent = get_sysvar_with_account_check::rent(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Initialize::Rent as usize,
             )?;
             me.initialize(&authorized, &lockup, &rent)
         }
         StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
-            instruction_context.check_number_of_instruction_accounts(3)?;
             let require_custodian_for_locked_stake_authorize = invoke_context
                 .feature_set
                 .is_active(&feature_set::require_custodian_for_locked_stake_authorize::id());
 
             if require_custodian_for_locked_stake_authorize {
-                let clock = get_sysvar_with_account_check2::clock(
+                let clock = get_sysvar_with_account_check::clock(
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
                     invoke_context,
-                    instruction_context,
-                    instruction_account_indices::Authorize::Clock as usize,
                 )?;
-                let custodian = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::Authorize::Custodian as usize,
-                )
-                .ok()
-                .map(|ka| ka.unsigned_key());
+                let _current_authority =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
+                let custodian =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 3)
+                        .ok()
+                        .map(|ka| ka.unsigned_key());
 
                 me.authorize(
                     &signers,
@@ -178,29 +84,21 @@ pub fn process_instruction(
             }
         }
         StakeInstruction::AuthorizeWithSeed(args) => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let authority_base = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account
-                    + instruction_account_indices::AuthorizeWithSeed::AuthorityBase as usize,
-            )?;
+            let authority_base =
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let require_custodian_for_locked_stake_authorize = invoke_context
                 .feature_set
                 .is_active(&feature_set::require_custodian_for_locked_stake_authorize::id());
 
             if require_custodian_for_locked_stake_authorize {
-                let clock = get_sysvar_with_account_check2::clock(
+                let clock = get_sysvar_with_account_check::clock(
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
                     invoke_context,
-                    instruction_context,
-                    instruction_account_indices::AuthorizeWithSeed::Clock as usize,
                 )?;
-                let custodian = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeWithSeed::Custodian as usize,
-                )
-                .ok()
-                .map(|ka| ka.unsigned_key());
+                let custodian =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 3)
+                        .ok()
+                        .map(|ka| ka.unsigned_key());
 
                 me.authorize_with_seed(
                     authority_base,
@@ -226,28 +124,17 @@ pub fn process_instruction(
             }
         }
         StakeInstruction::DelegateStake => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let vote = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account
-                    + instruction_account_indices::DelegateStake::VoteAccount as usize,
-            )?;
-            let clock = get_sysvar_with_account_check2::clock(
+            let vote = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let clock = get_sysvar_with_account_check::clock(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::DelegateStake::Clock as usize,
             )?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+            let stake_history = get_sysvar_with_account_check::stake_history(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::DelegateStake::StakeHistory as usize,
             )?;
-            instruction_context.check_number_of_instruction_accounts(5)?;
-            let config_account = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account
-                    + instruction_account_indices::DelegateStake::ConfigAccount as usize,
-            )?;
+            let config_account =
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 4)?;
             if !config::check_id(config_account.unsigned_key()) {
                 return Err(InstructionError::InvalidArgument);
             }
@@ -256,28 +143,20 @@ pub fn process_instruction(
             me.delegate(vote, &clock, &stake_history, &config, &signers)
         }
         StakeInstruction::Split(lamports) => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let split_stake = &keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account + instruction_account_indices::Split::SplitTo as usize,
-            )?;
+            let split_stake =
+                &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             me.split(lamports, split_stake, &signers)
         }
         StakeInstruction::Merge => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let source_stake = &keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account + instruction_account_indices::Merge::MergeFrom as usize,
-            )?;
-            let clock = get_sysvar_with_account_check2::clock(
+            let source_stake =
+                &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let clock = get_sysvar_with_account_check::clock(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Merge::Clock as usize,
             )?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+            let stake_history = get_sysvar_with_account_check::stake_history(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Merge::StakeHistory as usize,
             )?;
             me.merge(
                 invoke_context,
@@ -288,46 +167,28 @@ pub fn process_instruction(
             )
         }
         StakeInstruction::Withdraw(lamports) => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let to = &keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account
-                    + instruction_account_indices::Withdraw::Recipient as usize,
-            )?;
-            let clock = get_sysvar_with_account_check2::clock(
+            let to = &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let clock = get_sysvar_with_account_check::clock(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Withdraw::Clock as usize,
             )?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+            let stake_history = get_sysvar_with_account_check::stake_history(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Withdraw::StakeHistory as usize,
             )?;
-            instruction_context.check_number_of_instruction_accounts(5)?;
             me.withdraw(
                 lamports,
                 to,
                 &clock,
                 &stake_history,
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::Withdraw::WithdrawAuthority as usize,
-                )?,
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::Withdraw::Custodian as usize,
-                )
-                .ok(),
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 4)?,
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 5).ok(),
             )
         }
         StakeInstruction::Deactivate => {
-            let clock = get_sysvar_with_account_check2::clock(
+            let clock = get_sysvar_with_account_check::clock(
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
                 invoke_context,
-                instruction_context,
-                instruction_account_indices::Deactivate::Clock as usize,
             )?;
             me.deactivate(&clock, &signers)
         }
@@ -340,29 +201,20 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
-                instruction_context.check_number_of_instruction_accounts(4)?;
                 let authorized = Authorized {
-                    staker: *keyed_account_at_index(
-                        keyed_accounts,
-                        first_instruction_account
-                            + instruction_account_indices::InitializeChecked::AuthorizedStaker
-                                as usize,
-                    )?
-                    .unsigned_key(),
+                    staker: *keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?
+                        .unsigned_key(),
                     withdrawer: *keyed_account_at_index(
                         keyed_accounts,
-                        first_instruction_account
-                            + instruction_account_indices::InitializeChecked::AuthorizedWithdrawer
-                                as usize,
+                        first_instruction_account + 3,
                     )?
                     .signer_key()
                     .ok_or(InstructionError::MissingRequiredSignature)?,
                 };
 
-                let rent = get_sysvar_with_account_check2::rent(
+                let rent = get_sysvar_with_account_check::rent(
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
                     invoke_context,
-                    instruction_context,
-                    instruction_account_indices::InitializeChecked::Rent as usize,
                 )?;
                 me.initialize(&authorized, &Lockup::default(), &rent)
             } else {
@@ -374,26 +226,20 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
-                let clock = get_sysvar_with_account_check2::clock(
+                let clock = get_sysvar_with_account_check::clock(
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
                     invoke_context,
-                    instruction_context,
-                    instruction_account_indices::AuthorizeChecked::Clock as usize,
                 )?;
-                instruction_context.check_number_of_instruction_accounts(4)?;
-                let authorized_pubkey = &keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeChecked::Authorized as usize,
-                )?
-                .signer_key()
-                .ok_or(InstructionError::MissingRequiredSignature)?;
-                let custodian = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeChecked::Custodian as usize,
-                )
-                .ok()
-                .map(|ka| ka.unsigned_key());
+                let _current_authority =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
+                let authorized_pubkey =
+                    &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
+                        .signer_key()
+                        .ok_or(InstructionError::MissingRequiredSignature)?;
+                let custodian =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 4)
+                        .ok()
+                        .map(|ka| ka.unsigned_key());
 
                 me.authorize(
                     &signers,
@@ -412,34 +258,20 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
-                instruction_context.check_number_of_instruction_accounts(2)?;
-                let authority_base = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeCheckedWithSeed::AuthorityBase
-                            as usize,
-                )?;
-                let clock = get_sysvar_with_account_check2::clock(
+                let authority_base =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+                let clock = get_sysvar_with_account_check::clock(
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
                     invoke_context,
-                    instruction_context,
-                    instruction_account_indices::AuthorizeCheckedWithSeed::Clock as usize,
                 )?;
-                instruction_context.check_number_of_instruction_accounts(4)?;
-                let authorized_pubkey = &keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeCheckedWithSeed::Authorized
-                            as usize,
-                )?
-                .signer_key()
-                .ok_or(InstructionError::MissingRequiredSignature)?;
-                let custodian = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::AuthorizeCheckedWithSeed::Custodian as usize,
-                )
-                .ok()
-                .map(|ka| ka.unsigned_key());
+                let authorized_pubkey =
+                    &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
+                        .signer_key()
+                        .ok_or(InstructionError::MissingRequiredSignature)?;
+                let custodian =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 4)
+                        .ok()
+                        .map(|ka| ka.unsigned_key());
 
                 me.authorize_with_seed(
                     authority_base,
@@ -460,11 +292,9 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
-                let custodian = if let Ok(custodian) = keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account
-                        + instruction_account_indices::SetLockupChecked::Custodian as usize,
-                ) {
+                let custodian = if let Ok(custodian) =
+                    keyed_account_at_index(keyed_accounts, first_instruction_account + 2)
+                {
                     Some(
                         *custodian
                             .signer_key()

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -5,19 +5,19 @@ use {
     bincode::{deserialize, serialize_into, serialized_size, ErrorKind},
     log::*,
     serde_derive::{Deserialize, Serialize},
-    solana_program_runtime::invoke_context::InvokeContext,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
+        account_utils::State,
         clock::{Epoch, Slot, UnixTimestamp},
         epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
         feature_set::{self, filter_votes_outside_slot_hashes, FeatureSet},
         hash::Hash,
         instruction::InstructionError,
+        keyed_account::KeyedAccount,
         pubkey::Pubkey,
         rent::Rent,
         slot_hashes::SlotHash,
         sysvar::clock::Clock,
-        transaction_context::{BorrowedAccount, InstructionContext},
     },
     std::{
         cmp::Ordering,
@@ -1165,24 +1165,19 @@ impl VoteState {
 /// but will implicitly withdraw authorization from the previously authorized
 /// key
 pub fn authorize<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
     authorized: &Pubkey,
     vote_authorize: VoteAuthorize,
+    signers: &HashSet<Pubkey, S>,
+    clock: &Clock,
+    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let clock = invoke_context.get_sysvar_cache().get_clock()?;
-    let mut vote_state: VoteState = vote_account
-        .get_state::<VoteStateVersions>()?
-        .convert_to_current();
+    let mut vote_state: VoteState =
+        State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
     match vote_authorize {
         VoteAuthorize::Voter => {
-            let authorized_withdrawer_signer = if invoke_context
-                .feature_set
+            let authorized_withdrawer_signer = if feature_set
                 .is_active(&feature_set::vote_withdraw_authority_may_change_authorized_voter::id())
             {
                 verify_authorized_signer(&vote_state.authorized_withdrawer, signers).is_ok()
@@ -1216,17 +1211,12 @@ pub fn authorize<S: std::hash::BuildHasher>(
 
 /// Update the node_pubkey, requires signature of the authorized voter
 pub fn update_validator_identity<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
     node_pubkey: &Pubkey,
+    signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let mut vote_state: VoteState = vote_account
-        .get_state::<VoteStateVersions>()?
-        .convert_to_current();
+    let mut vote_state: VoteState =
+        State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
     // current authorized withdrawer must say "yay"
     verify_authorized_signer(&vote_state.authorized_withdrawer, signers)?;
@@ -1241,17 +1231,12 @@ pub fn update_validator_identity<S: std::hash::BuildHasher>(
 
 /// Update the vote account's commission
 pub fn update_commission<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
     commission: u8,
+    signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let mut vote_state: VoteState = vote_account
-        .get_state::<VoteStateVersions>()?
-        .convert_to_current();
+    let mut vote_state: VoteState =
+        State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
     // current authorized withdrawer must say "yay"
     verify_authorized_signer(&vote_state.authorized_withdrawer, signers)?;
@@ -1274,42 +1259,20 @@ fn verify_authorized_signer<S: std::hash::BuildHasher>(
 
 /// Withdraw funds from the vote account
 pub fn withdraw<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
-    recipient_account_index: usize,
+    vote_account: &KeyedAccount,
     lamports: u64,
+    to_account: &KeyedAccount,
+    signers: &HashSet<Pubkey, S>,
+    rent_sysvar: Option<&Rent>,
+    clock: Option<&Clock>,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-
-    let rent_sysvar = if invoke_context
-        .feature_set
-        .is_active(&feature_set::reject_non_rent_exempt_vote_withdraws::id())
-    {
-        Some(invoke_context.get_sysvar_cache().get_rent()?)
-    } else {
-        None
-    };
-
-    let clock = if invoke_context
-        .feature_set
-        .is_active(&feature_set::reject_vote_account_close_unless_zero_credit_epoch::id())
-    {
-        Some(invoke_context.get_sysvar_cache().get_clock()?)
-    } else {
-        None
-    };
-
-    let vote_state: VoteState = vote_account
-        .get_state::<VoteStateVersions>()?
-        .convert_to_current();
+    let vote_state: VoteState =
+        State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
     verify_authorized_signer(&vote_state.authorized_withdrawer, signers)?;
 
     let remaining_balance = vote_account
-        .get_lamports()
+        .lamports()?
         .checked_sub(lamports)
         .ok_or(InstructionError::InsufficientFunds)?;
 
@@ -1332,19 +1295,18 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             vote_account.set_state(&VoteStateVersions::new_current(VoteState::default()))?;
         }
     } else if let Some(rent_sysvar) = rent_sysvar {
-        let min_rent_exempt_balance = rent_sysvar.minimum_balance(vote_account.get_data().len());
+        let min_rent_exempt_balance = rent_sysvar.minimum_balance(vote_account.data_len()?);
         if remaining_balance < min_rent_exempt_balance {
             return Err(InstructionError::InsufficientFunds);
         }
     }
 
-    vote_account.checked_sub_lamports(lamports)?;
-    drop(vote_account);
-    let mut recipient_account = instruction_context.try_borrow_instruction_account(
-        invoke_context.transaction_context,
-        recipient_account_index,
-    )?;
-    recipient_account.checked_add_lamports(lamports)?;
+    vote_account
+        .try_account_ref_mut()?
+        .checked_sub_lamports(lamports)?;
+    to_account
+        .try_account_ref_mut()?
+        .checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -1352,19 +1314,15 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 /// Assumes that the account is being init as part of a account creation or balance transfer and
 /// that the transaction must be signed by the staker's keys
 pub fn initialize_account<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
     vote_init: &VoteInit,
+    signers: &HashSet<Pubkey, S>,
+    clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let clock = invoke_context.get_sysvar_cache().get_clock()?;
-    if vote_account.get_data().len() != VoteState::size_of() {
+    if vote_account.data_len()? != VoteState::size_of() {
         return Err(InstructionError::InvalidAccountData);
     }
-    let versioned = vote_account.get_state::<VoteStateVersions>()?;
+    let versioned = State::<VoteStateVersions>::state(vote_account)?;
 
     if !versioned.is_uninitialized() {
         return Err(InstructionError::AccountAlreadyInitialized);
@@ -1374,16 +1332,16 @@ pub fn initialize_account<S: std::hash::BuildHasher>(
     verify_authorized_signer(&vote_init.node_pubkey, signers)?;
 
     vote_account.set_state(&VoteStateVersions::new_current(VoteState::new(
-        vote_init, &clock,
+        vote_init, clock,
     )))
 }
 
 fn verify_and_get_vote_state<S: std::hash::BuildHasher>(
-    vote_account: &BorrowedAccount,
+    vote_account: &KeyedAccount,
     clock: &Clock,
     signers: &HashSet<Pubkey, S>,
 ) -> Result<VoteState, InstructionError> {
-    let versioned = vote_account.get_state::<VoteStateVersions>()?;
+    let versioned = State::<VoteStateVersions>::state(vote_account)?;
 
     if versioned.is_uninitialized() {
         return Err(InstructionError::UninitializedAccount);
@@ -1397,25 +1355,16 @@ fn verify_and_get_vote_state<S: std::hash::BuildHasher>(
 }
 
 pub fn process_vote<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
+    slot_hashes: &[SlotHash],
+    clock: &Clock,
     vote: &Vote,
+    signers: &HashSet<Pubkey, S>,
+    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let sysvar_cache = invoke_context.get_sysvar_cache();
-    let slot_hashes = sysvar_cache.get_slot_hashes()?;
-    let clock = sysvar_cache.get_clock()?;
-    let mut vote_state = verify_and_get_vote_state(&vote_account, &clock, signers)?;
+    let mut vote_state = verify_and_get_vote_state(vote_account, clock, signers)?;
 
-    vote_state.process_vote(
-        vote,
-        slot_hashes.slot_hashes(),
-        clock.epoch,
-        Some(&invoke_context.feature_set),
-    )?;
+    vote_state.process_vote(vote, slot_hashes, clock.epoch, Some(feature_set))?;
     if let Some(timestamp) = vote.timestamp {
         vote.slots
             .iter()
@@ -1427,19 +1376,14 @@ pub fn process_vote<S: std::hash::BuildHasher>(
 }
 
 pub fn process_vote_state_update<S: std::hash::BuildHasher>(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey, S>,
-    vote_account_index: usize,
+    vote_account: &KeyedAccount,
+    slot_hashes: &[SlotHash],
+    clock: &Clock,
     mut vote_state_update: VoteStateUpdate,
+    signers: &HashSet<Pubkey, S>,
 ) -> Result<(), InstructionError> {
-    let mut vote_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, vote_account_index)?;
-    let sysvar_cache = invoke_context.get_sysvar_cache();
-    let slot_hashes = sysvar_cache.get_slot_hashes()?;
-    let clock = sysvar_cache.get_clock()?;
-    let mut vote_state = verify_and_get_vote_state(&vote_account, &clock, signers)?;
-    vote_state.check_update_vote_state_slots_are_valid(&mut vote_state_update, &slot_hashes)?;
+    let mut vote_state = verify_and_get_vote_state(vote_account, clock, signers)?;
+    vote_state.check_update_vote_state_slots_are_valid(&mut vote_state_update, slot_hashes)?;
     vote_state.process_new_vote_state(
         vote_state_update.lockouts,
         vote_state_update.root,

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -1,292 +1,314 @@
 use {
     solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
+        account::{ReadableAccount, WritableAccount},
+        account_utils::State as AccountUtilsState,
         feature_set::{self, nonce_must_be_writable},
         instruction::{checked_add, InstructionError},
+        keyed_account::KeyedAccount,
         nonce::{self, state::Versions, State},
         pubkey::Pubkey,
         system_instruction::{nonce_to_instruction_error, NonceError},
         sysvar::rent::Rent,
-        transaction_context::InstructionContext,
     },
     std::collections::HashSet,
 };
 
-pub const NONCE_ACCOUNT_INDEX: usize = 0;
-pub const WITHDRAW_TO_ACCOUNT_INDEX: usize = 1;
-
-pub fn advance_nonce_account(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey>,
-    nonce_account_index: usize,
-) -> Result<(), InstructionError> {
-    let mut account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, nonce_account_index)?;
-    let merge_nonce_error_into_system_error = invoke_context
-        .feature_set
-        .is_active(&feature_set::merge_nonce_error_into_system_error::id());
-
-    if invoke_context
-        .feature_set
-        .is_active(&nonce_must_be_writable::id())
-        && !account.is_writable()
-    {
-        ic_msg!(
-            invoke_context,
-            "Advance nonce account: Account {} must be writeable",
-            account.get_key()
-        );
-        return Err(InstructionError::InvalidArgument);
-    }
-
-    let state = account.get_state::<Versions>()?.convert_to_current();
-    match state {
-        State::Initialized(data) => {
-            if !signers.contains(&data.authority) {
-                ic_msg!(
-                    invoke_context,
-                    "Advance nonce account: Account {} must be a signer",
-                    data.authority
-                );
-                return Err(InstructionError::MissingRequiredSignature);
-            }
-            let recent_blockhash = invoke_context.blockhash;
-            if data.blockhash == recent_blockhash {
-                ic_msg!(
-                    invoke_context,
-                    "Advance nonce account: nonce can only advance once per slot"
-                );
-                return Err(nonce_to_instruction_error(
-                    NonceError::NotExpired,
-                    merge_nonce_error_into_system_error,
-                ));
-            }
-
-            let new_data = nonce::state::Data::new(
-                data.authority,
-                recent_blockhash,
-                invoke_context.lamports_per_signature,
-            );
-            account.set_state(&Versions::new_current(State::Initialized(new_data)))
-        }
-        _ => {
-            ic_msg!(
-                invoke_context,
-                "Advance nonce account: Account {} state is invalid",
-                account.get_key()
-            );
-            Err(nonce_to_instruction_error(
-                NonceError::BadAccountState,
-                merge_nonce_error_into_system_error,
-            ))
-        }
-    }
+pub trait NonceKeyedAccount {
+    fn advance_nonce_account(
+        &self,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError>;
+    fn withdraw_nonce_account(
+        &self,
+        lamports: u64,
+        to: &KeyedAccount,
+        rent: &Rent,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError>;
+    fn initialize_nonce_account(
+        &self,
+        nonce_authority: &Pubkey,
+        rent: &Rent,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError>;
+    fn authorize_nonce_account(
+        &self,
+        nonce_authority: &Pubkey,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError>;
 }
 
-pub fn withdraw_nonce_account(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey>,
-    nonce_account_index: usize,
-    withdraw_to_account_index: usize,
-    lamports: u64,
-    rent: &Rent,
-) -> Result<(), InstructionError> {
-    let mut nonce_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, nonce_account_index)?;
-    let merge_nonce_error_into_system_error = invoke_context
-        .feature_set
-        .is_active(&feature_set::merge_nonce_error_into_system_error::id());
+impl<'a> NonceKeyedAccount for KeyedAccount<'a> {
+    fn advance_nonce_account(
+        &self,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError> {
+        let merge_nonce_error_into_system_error = invoke_context
+            .feature_set
+            .is_active(&feature_set::merge_nonce_error_into_system_error::id());
 
-    if invoke_context
-        .feature_set
-        .is_active(&nonce_must_be_writable::id())
-        && !nonce_account.is_writable()
-    {
-        ic_msg!(
-            invoke_context,
-            "Withdraw nonce account: Account {} must be writeable",
-            nonce_account.get_key()
-        );
-        return Err(InstructionError::InvalidArgument);
-    }
-
-    let signer = match nonce_account.get_state::<Versions>()?.convert_to_current() {
-        State::Uninitialized => {
-            if lamports > nonce_account.get_lamports() {
-                ic_msg!(
-                    invoke_context,
-                    "Withdraw nonce account: insufficient lamports {}, need {}",
-                    nonce_account.get_lamports(),
-                    lamports,
-                );
-                return Err(InstructionError::InsufficientFunds);
-            }
-            *nonce_account.get_key()
+        if invoke_context
+            .feature_set
+            .is_active(&nonce_must_be_writable::id())
+            && !self.is_writable()
+        {
+            ic_msg!(
+                invoke_context,
+                "Advance nonce account: Account {} must be writeable",
+                self.unsigned_key()
+            );
+            return Err(InstructionError::InvalidArgument);
         }
-        State::Initialized(ref data) => {
-            if lamports == nonce_account.get_lamports() {
-                if data.blockhash == invoke_context.blockhash {
+
+        let state = AccountUtilsState::<Versions>::state(self)?.convert_to_current();
+        match state {
+            State::Initialized(data) => {
+                if !signers.contains(&data.authority) {
                     ic_msg!(
                         invoke_context,
-                        "Withdraw nonce account: nonce can only advance once per slot"
+                        "Advance nonce account: Account {} must be a signer",
+                        data.authority
+                    );
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+                let recent_blockhash = invoke_context.blockhash;
+                if data.blockhash == recent_blockhash {
+                    ic_msg!(
+                        invoke_context,
+                        "Advance nonce account: nonce can only advance once per slot"
                     );
                     return Err(nonce_to_instruction_error(
                         NonceError::NotExpired,
                         merge_nonce_error_into_system_error,
                     ));
                 }
-                nonce_account.set_state(&Versions::new_current(State::Uninitialized))?;
-            } else {
-                let min_balance = rent.minimum_balance(nonce_account.get_data().len());
-                let amount = checked_add(lamports, min_balance)?;
-                if amount > nonce_account.get_lamports() {
+
+                let new_data = nonce::state::Data::new(
+                    data.authority,
+                    recent_blockhash,
+                    invoke_context.lamports_per_signature,
+                );
+                self.set_state(&Versions::new_current(State::Initialized(new_data)))
+            }
+            _ => {
+                ic_msg!(
+                    invoke_context,
+                    "Advance nonce account: Account {} state is invalid",
+                    self.unsigned_key()
+                );
+                Err(nonce_to_instruction_error(
+                    NonceError::BadAccountState,
+                    merge_nonce_error_into_system_error,
+                ))
+            }
+        }
+    }
+
+    fn withdraw_nonce_account(
+        &self,
+        lamports: u64,
+        to: &KeyedAccount,
+        rent: &Rent,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError> {
+        let merge_nonce_error_into_system_error = invoke_context
+            .feature_set
+            .is_active(&feature_set::merge_nonce_error_into_system_error::id());
+
+        if invoke_context
+            .feature_set
+            .is_active(&nonce_must_be_writable::id())
+            && !self.is_writable()
+        {
+            ic_msg!(
+                invoke_context,
+                "Withdraw nonce account: Account {} must be writeable",
+                self.unsigned_key()
+            );
+            return Err(InstructionError::InvalidArgument);
+        }
+
+        let signer = match AccountUtilsState::<Versions>::state(self)?.convert_to_current() {
+            State::Uninitialized => {
+                if lamports > self.lamports()? {
                     ic_msg!(
                         invoke_context,
                         "Withdraw nonce account: insufficient lamports {}, need {}",
-                        nonce_account.get_lamports(),
-                        amount,
+                        self.lamports()?,
+                        lamports,
                     );
                     return Err(InstructionError::InsufficientFunds);
                 }
+                *self.unsigned_key()
             }
-            data.authority
-        }
-    };
-
-    if !signers.contains(&signer) {
-        ic_msg!(
-            invoke_context,
-            "Withdraw nonce account: Account {} must sign",
-            signer
-        );
-        return Err(InstructionError::MissingRequiredSignature);
-    }
-
-    nonce_account.checked_sub_lamports(lamports)?;
-    drop(nonce_account);
-    let mut withdraw_to_account = instruction_context.try_borrow_instruction_account(
-        invoke_context.transaction_context,
-        withdraw_to_account_index,
-    )?;
-    withdraw_to_account.checked_add_lamports(lamports)?;
-
-    Ok(())
-}
-
-pub fn initialize_nonce_account(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    nonce_account_index: usize,
-    nonce_authority: &Pubkey,
-    rent: &Rent,
-) -> Result<(), InstructionError> {
-    let mut account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, nonce_account_index)?;
-    let merge_nonce_error_into_system_error = invoke_context
-        .feature_set
-        .is_active(&feature_set::merge_nonce_error_into_system_error::id());
-
-    if invoke_context
-        .feature_set
-        .is_active(&nonce_must_be_writable::id())
-        && !account.is_writable()
-    {
-        ic_msg!(
-            invoke_context,
-            "Initialize nonce account: Account {} must be writeable",
-            account.get_key()
-        );
-        return Err(InstructionError::InvalidArgument);
-    }
-
-    match account.get_state::<Versions>()?.convert_to_current() {
-        State::Uninitialized => {
-            let min_balance = rent.minimum_balance(account.get_data().len());
-            if account.get_lamports() < min_balance {
-                ic_msg!(
-                    invoke_context,
-                    "Initialize nonce account: insufficient lamports {}, need {}",
-                    account.get_lamports(),
-                    min_balance
-                );
-                return Err(InstructionError::InsufficientFunds);
+            State::Initialized(ref data) => {
+                if lamports == self.lamports()? {
+                    if data.blockhash == invoke_context.blockhash {
+                        ic_msg!(
+                            invoke_context,
+                            "Withdraw nonce account: nonce can only advance once per slot"
+                        );
+                        return Err(nonce_to_instruction_error(
+                            NonceError::NotExpired,
+                            merge_nonce_error_into_system_error,
+                        ));
+                    }
+                    self.set_state(&Versions::new_current(State::Uninitialized))?;
+                } else {
+                    let min_balance = rent.minimum_balance(self.data_len()?);
+                    let amount = checked_add(lamports, min_balance)?;
+                    if amount > self.lamports()? {
+                        ic_msg!(
+                            invoke_context,
+                            "Withdraw nonce account: insufficient lamports {}, need {}",
+                            self.lamports()?,
+                            amount,
+                        );
+                        return Err(InstructionError::InsufficientFunds);
+                    }
+                }
+                data.authority
             }
-            let data = nonce::state::Data::new(
-                *nonce_authority,
-                invoke_context.blockhash,
-                invoke_context.lamports_per_signature,
-            );
-            account.set_state(&Versions::new_current(State::Initialized(data)))
-        }
-        _ => {
+        };
+
+        if !signers.contains(&signer) {
             ic_msg!(
                 invoke_context,
-                "Initialize nonce account: Account {} state is invalid",
-                account.get_key()
+                "Withdraw nonce account: Account {} must sign",
+                signer
             );
-            Err(nonce_to_instruction_error(
-                NonceError::BadAccountState,
-                merge_nonce_error_into_system_error,
-            ))
+            return Err(InstructionError::MissingRequiredSignature);
         }
-    }
-}
 
-pub fn authorize_nonce_account(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey>,
-    nonce_account_index: usize,
-    nonce_authority: &Pubkey,
-) -> Result<(), InstructionError> {
-    let mut account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, nonce_account_index)?;
-    let merge_nonce_error_into_system_error = invoke_context
-        .feature_set
-        .is_active(&feature_set::merge_nonce_error_into_system_error::id());
-
-    if invoke_context
-        .feature_set
-        .is_active(&nonce_must_be_writable::id())
-        && !account.is_writable()
-    {
-        ic_msg!(
-            invoke_context,
-            "Authorize nonce account: Account {} must be writeable",
-            account.get_key()
+        let nonce_balance = self.try_account_ref_mut()?.lamports();
+        self.try_account_ref_mut()?.set_lamports(
+            nonce_balance
+                .checked_sub(lamports)
+                .ok_or(InstructionError::ArithmeticOverflow)?,
         );
-        return Err(InstructionError::InvalidArgument);
+        let to_balance = to.try_account_ref_mut()?.lamports();
+        to.try_account_ref_mut()?.set_lamports(
+            to_balance
+                .checked_add(lamports)
+                .ok_or(InstructionError::ArithmeticOverflow)?,
+        );
+
+        Ok(())
     }
 
-    match account.get_state::<Versions>()?.convert_to_current() {
-        State::Initialized(data) => {
-            if !signers.contains(&data.authority) {
-                ic_msg!(
-                    invoke_context,
-                    "Authorize nonce account: Account {} must sign",
-                    data.authority
-                );
-                return Err(InstructionError::MissingRequiredSignature);
-            }
-            let new_data = nonce::state::Data::new(
-                *nonce_authority,
-                data.blockhash,
-                data.get_lamports_per_signature(),
-            );
-            account.set_state(&Versions::new_current(State::Initialized(new_data)))
-        }
-        _ => {
+    fn initialize_nonce_account(
+        &self,
+        nonce_authority: &Pubkey,
+        rent: &Rent,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError> {
+        let merge_nonce_error_into_system_error = invoke_context
+            .feature_set
+            .is_active(&feature_set::merge_nonce_error_into_system_error::id());
+
+        if invoke_context
+            .feature_set
+            .is_active(&nonce_must_be_writable::id())
+            && !self.is_writable()
+        {
             ic_msg!(
                 invoke_context,
-                "Authorize nonce account: Account {} state is invalid",
-                account.get_key()
+                "Initialize nonce account: Account {} must be writeable",
+                self.unsigned_key()
             );
-            Err(nonce_to_instruction_error(
-                NonceError::BadAccountState,
-                merge_nonce_error_into_system_error,
-            ))
+            return Err(InstructionError::InvalidArgument);
+        }
+
+        match AccountUtilsState::<Versions>::state(self)?.convert_to_current() {
+            State::Uninitialized => {
+                let min_balance = rent.minimum_balance(self.data_len()?);
+                if self.lamports()? < min_balance {
+                    ic_msg!(
+                        invoke_context,
+                        "Initialize nonce account: insufficient lamports {}, need {}",
+                        self.lamports()?,
+                        min_balance
+                    );
+                    return Err(InstructionError::InsufficientFunds);
+                }
+                let data = nonce::state::Data::new(
+                    *nonce_authority,
+                    invoke_context.blockhash,
+                    invoke_context.lamports_per_signature,
+                );
+                self.set_state(&Versions::new_current(State::Initialized(data)))
+            }
+            _ => {
+                ic_msg!(
+                    invoke_context,
+                    "Initialize nonce account: Account {} state is invalid",
+                    self.unsigned_key()
+                );
+                Err(nonce_to_instruction_error(
+                    NonceError::BadAccountState,
+                    merge_nonce_error_into_system_error,
+                ))
+            }
+        }
+    }
+
+    fn authorize_nonce_account(
+        &self,
+        nonce_authority: &Pubkey,
+        signers: &HashSet<Pubkey>,
+        invoke_context: &InvokeContext,
+    ) -> Result<(), InstructionError> {
+        let merge_nonce_error_into_system_error = invoke_context
+            .feature_set
+            .is_active(&feature_set::merge_nonce_error_into_system_error::id());
+
+        if invoke_context
+            .feature_set
+            .is_active(&nonce_must_be_writable::id())
+            && !self.is_writable()
+        {
+            ic_msg!(
+                invoke_context,
+                "Authorize nonce account: Account {} must be writeable",
+                self.unsigned_key()
+            );
+            return Err(InstructionError::InvalidArgument);
+        }
+
+        match AccountUtilsState::<Versions>::state(self)?.convert_to_current() {
+            State::Initialized(data) => {
+                if !signers.contains(&data.authority) {
+                    ic_msg!(
+                        invoke_context,
+                        "Authorize nonce account: Account {} must sign",
+                        data.authority
+                    );
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+                let new_data = nonce::state::Data::new(
+                    *nonce_authority,
+                    data.blockhash,
+                    data.get_lamports_per_signature(),
+                );
+                self.set_state(&Versions::new_current(State::Initialized(new_data)))
+            }
+            _ => {
+                ic_msg!(
+                    invoke_context,
+                    "Authorize nonce account: Account {} state is invalid",
+                    self.unsigned_key()
+                );
+                Err(nonce_to_instruction_error(
+                    NonceError::BadAccountState,
+                    merge_nonce_error_into_system_error,
+                ))
+            }
         }
     }
 }
@@ -306,6 +328,9 @@ mod test {
             transaction_context::{InstructionAccount, TransactionContext},
         },
     };
+
+    pub const NONCE_ACCOUNT_INDEX: usize = 0;
+    pub const WITHDRAW_TO_ACCOUNT_INDEX: usize = 1;
 
     macro_rules! push_instruction_context {
         ($invoke_context:expr, $transaction_context:ident, $instruction_context:ident, $instruction_accounts:ident) => {
@@ -392,14 +417,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 95);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -416,13 +436,9 @@ mod test {
         assert_eq!(state, State::Initialized(data.clone()));
         set_invoke_context_blockhash!(invoke_context, 63);
         drop(nonce_account);
-        advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -439,13 +455,9 @@ mod test {
         assert_eq!(state, State::Initialized(data.clone()));
         set_invoke_context_blockhash!(invoke_context, 31);
         drop(nonce_account);
-        advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -470,16 +482,15 @@ mod test {
         let expect_to_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -513,14 +524,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 31);
         let authority = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authority,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authority, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -538,12 +544,8 @@ mod test {
         // Nonce account did not sign
         let signers = HashSet::new();
         set_invoke_context_blockhash!(invoke_context, 0);
-        let result = advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context);
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
     }
 
@@ -564,20 +566,11 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 63);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
-        let result = advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        );
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context);
         assert_eq!(result, Err(SystemError::NonceBlockhashNotExpired.into()));
     }
 
@@ -597,12 +590,8 @@ mod test {
         signers.insert(*nonce_account.get_key());
         set_invoke_context_blockhash!(invoke_context, 63);
         drop(nonce_account);
-        let result = advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context);
         assert_eq!(result, Err(InstructionError::InvalidAccountData));
     }
 
@@ -627,23 +616,14 @@ mod test {
         let authorized = *nonce_authority.get_key();
         drop(nonce_account);
         drop(nonce_authority);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let mut signers = HashSet::new();
         signers.insert(authorized);
         set_invoke_context_blockhash!(invoke_context, 31);
-        let result = advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context);
         assert_eq!(result, Ok(()));
     }
 
@@ -668,20 +648,11 @@ mod test {
         let authorized = *nonce_authority.get_key();
         drop(nonce_account);
         drop(nonce_authority);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
-        let result = advance_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-        );
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .advance_nonce_account(&signers, &invoke_context);
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
     }
 
@@ -713,16 +684,15 @@ mod test {
         let expect_to_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -763,15 +733,14 @@ mod test {
         let withdraw_lamports = nonce_account.get_lamports();
         drop(nonce_account);
         drop(to_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
     }
 
@@ -797,15 +766,14 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 0);
         let withdraw_lamports = nonce_account.get_lamports() + 1;
         drop(nonce_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(InstructionError::InsufficientFunds));
     }
 
@@ -832,16 +800,15 @@ mod test {
         let to_expect_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -860,16 +827,15 @@ mod test {
         let to_expect_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -906,14 +872,9 @@ mod test {
         let authority = *nonce_account.get_key();
         drop(nonce_account);
         drop(to_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authority,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authority, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -935,16 +896,15 @@ mod test {
         let to_expect_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -969,16 +929,15 @@ mod test {
         let to_expect_lamports = to_account.get_lamports() + withdraw_lamports;
         drop(nonce_account);
         drop(to_account);
-        withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            )
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1013,14 +972,9 @@ mod test {
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
         drop(to_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1028,15 +982,14 @@ mod test {
         signers.insert(*nonce_account.get_key());
         let withdraw_lamports = nonce_account.get_lamports();
         drop(nonce_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(SystemError::NonceBlockhashNotExpired.into()));
     }
 
@@ -1055,14 +1008,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 95);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         set_invoke_context_blockhash!(invoke_context, 63);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
@@ -1071,15 +1019,14 @@ mod test {
         signers.insert(*nonce_account.get_key());
         let withdraw_lamports = nonce_account.get_lamports() + 1;
         drop(nonce_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(InstructionError::InsufficientFunds));
     }
 
@@ -1098,14 +1045,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 95);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1114,15 +1056,14 @@ mod test {
         signers.insert(*nonce_account.get_key());
         let withdraw_lamports = 42 + 1;
         drop(nonce_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(InstructionError::InsufficientFunds));
     }
 
@@ -1141,14 +1082,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 95);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1157,15 +1093,14 @@ mod test {
         signers.insert(*nonce_account.get_key());
         let withdraw_lamports = u64::MAX - 54;
         drop(nonce_account);
-        let result = withdraw_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            WITHDRAW_TO_ACCOUNT_INDEX,
-            withdraw_lamports,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .withdraw_nonce_account(
+                withdraw_lamports,
+                &invoke_context.get_keyed_accounts().unwrap()[1 + WITHDRAW_TO_ACCOUNT_INDEX],
+                &rent,
+                &signers,
+                &invoke_context,
+            );
         assert_eq!(result, Err(InstructionError::InsufficientFunds));
     }
 
@@ -1191,13 +1126,8 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 0);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        let result = initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context);
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1229,22 +1159,12 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 31);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         set_invoke_context_blockhash!(invoke_context, 0);
-        let result = initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context);
         assert_eq!(result, Err(InstructionError::InvalidAccountData));
     }
 
@@ -1264,13 +1184,8 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 63);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        let result = initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context);
         assert_eq!(result, Err(InstructionError::InsufficientFunds));
     }
 
@@ -1291,28 +1206,18 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 31);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         let authority = Pubkey::default();
         let data = nonce::state::Data::new(
             authority,
             invoke_context.blockhash,
             invoke_context.lamports_per_signature,
         );
-        authorize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            &authority,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .authorize_nonce_account(&authority, &signers, &invoke_context)
+            .unwrap();
         let nonce_account = instruction_context
             .try_borrow_instruction_account(transaction_context, NONCE_ACCOUNT_INDEX)
             .unwrap();
@@ -1338,13 +1243,8 @@ mod test {
         let mut signers = HashSet::new();
         signers.insert(*nonce_account.get_key());
         drop(nonce_account);
-        let result = authorize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            &Pubkey::default(),
-        );
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .authorize_nonce_account(&Pubkey::default(), &signers, &invoke_context);
         assert_eq!(result, Err(InstructionError::InvalidAccountData));
     }
 
@@ -1365,21 +1265,11 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 31);
         let authorized = Pubkey::default();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
-        let result = authorize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            &signers,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-        );
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
+        let result = invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .authorize_nonce_account(&authorized, &signers, &invoke_context);
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
     }
 
@@ -1403,14 +1293,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 0);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &rent,
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &rent, &invoke_context)
+            .unwrap();
         assert!(verify_nonce_account(
             &transaction_context
                 .get_account_at_index(NONCE_ACCOUNT_INDEX)
@@ -1458,14 +1343,9 @@ mod test {
         set_invoke_context_blockhash!(invoke_context, 0);
         let authorized = *nonce_account.get_key();
         drop(nonce_account);
-        initialize_nonce_account(
-            &invoke_context,
-            instruction_context,
-            NONCE_ACCOUNT_INDEX,
-            &authorized,
-            &Rent::free(),
-        )
-        .unwrap();
+        invoke_context.get_keyed_accounts().unwrap()[1 + NONCE_ACCOUNT_INDEX]
+            .initialize_nonce_account(&authorized, &Rent::free(), &invoke_context)
+            .unwrap();
         set_invoke_context_blockhash!(invoke_context, 1);
         assert!(!verify_nonce_account(
             &transaction_context

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -12,6 +12,9 @@ use {
     std::collections::HashSet,
 };
 
+pub const NONCE_ACCOUNT_INDEX: usize = 0;
+pub const WITHDRAW_TO_ACCOUNT_INDEX: usize = 1;
+
 pub fn advance_nonce_account(
     invoke_context: &InvokeContext,
     instruction_context: &InstructionContext,
@@ -349,9 +352,6 @@ mod test {
             let mut $invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         };
     }
-
-    const NONCE_ACCOUNT_INDEX: usize = 0;
-    const WITHDRAW_TO_ACCOUNT_INDEX: usize = 1;
 
     macro_rules! set_invoke_context_blockhash {
         ($invoke_context:expr, $seed:expr) => {

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1,17 +1,18 @@
 use {
     crate::nonce_keyed_account::{
         advance_nonce_account, authorize_nonce_account, initialize_nonce_account,
-        withdraw_nonce_account,
+        withdraw_nonce_account, NONCE_ACCOUNT_INDEX, WITHDRAW_TO_ACCOUNT_INDEX,
     },
     log::*,
     solana_program_runtime::{
         ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
     },
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,
         feature_set,
         instruction::InstructionError,
+        keyed_account::{keyed_account_at_index, KeyedAccount},
         nonce,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
@@ -19,7 +20,6 @@ use {
             NonceError, SystemError, SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
         },
         system_program,
-        transaction_context::{BorrowedAccount, InstructionContext},
     },
     std::collections::HashSet,
 };
@@ -70,11 +70,11 @@ impl Address {
 }
 
 fn allocate(
-    invoke_context: &InvokeContext,
-    signers: &HashSet<Pubkey>,
-    account: &mut BorrowedAccount,
+    account: &mut AccountSharedData,
     address: &Address,
     space: u64,
+    signers: &HashSet<Pubkey>,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
     if !address.is_signer(signers) {
         ic_msg!(
@@ -87,7 +87,7 @@ fn allocate(
 
     // if it looks like the `to` account is already in use, bail
     //   (note that the id check is also enforced by message_processor)
-    if !account.get_data().is_empty() || !system_program::check_id(account.get_owner()) {
+    if !account.data().is_empty() || !system_program::check_id(account.owner()) {
         ic_msg!(
             invoke_context,
             "Allocate: account {:?} already in use",
@@ -106,20 +106,20 @@ fn allocate(
         return Err(SystemError::InvalidAccountDataLength.into());
     }
 
-    account.set_data(vec![0; space as usize].as_slice());
+    account.set_data(vec![0; space as usize]);
 
     Ok(())
 }
 
 fn assign(
-    invoke_context: &InvokeContext,
-    signers: &HashSet<Pubkey>,
-    account: &mut BorrowedAccount,
+    account: &mut AccountSharedData,
     address: &Address,
     owner: &Pubkey,
+    signers: &HashSet<Pubkey>,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
     // no work to do, just return
-    if account.get_owner() == owner {
+    if account.owner() == owner {
         return Ok(());
     }
 
@@ -128,38 +128,36 @@ fn assign(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    account.set_owner(&owner.to_bytes());
+    account.set_owner(*owner);
     Ok(())
 }
 
 fn allocate_and_assign(
-    invoke_context: &InvokeContext,
-    signers: &HashSet<Pubkey>,
-    to_account: &mut BorrowedAccount,
+    to: &mut AccountSharedData,
     to_address: &Address,
     space: u64,
     owner: &Pubkey,
+    signers: &HashSet<Pubkey>,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
-    allocate(invoke_context, signers, to_account, to_address, space)?;
-    assign(invoke_context, signers, to_account, to_address, owner)
+    allocate(to, to_address, space, signers, invoke_context)?;
+    assign(to, to_address, owner, signers, invoke_context)
 }
 
 fn create_account(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    signers: &HashSet<Pubkey>,
-    from_account_index: usize,
-    to_account_index: usize,
+    from: &KeyedAccount,
+    to: &KeyedAccount,
     to_address: &Address,
     lamports: u64,
     space: u64,
     owner: &Pubkey,
+    signers: &HashSet<Pubkey>,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
     // if it looks like the `to` account is already in use, bail
     {
-        let mut to_account = instruction_context
-            .try_borrow_instruction_account(invoke_context.transaction_context, to_account_index)?;
-        if to_account.get_lamports() > 0 {
+        let to = &mut to.try_account_ref_mut()?;
+        if to.lamports() > 0 {
             ic_msg!(
                 invoke_context,
                 "Create Account: account {:?} already in use",
@@ -167,60 +165,42 @@ fn create_account(
             );
             return Err(SystemError::AccountAlreadyInUse.into());
         }
-        allocate_and_assign(
-            invoke_context,
-            signers,
-            &mut to_account,
-            to_address,
-            space,
-            owner,
-        )?;
+
+        allocate_and_assign(to, to_address, space, owner, signers, invoke_context)?;
     }
-    transfer(
-        invoke_context,
-        instruction_context,
-        from_account_index,
-        to_account_index,
-        lamports,
-    )
+    transfer(from, to, lamports, invoke_context)
 }
 
 fn transfer_verified(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    from_account_index: usize,
-    to_account_index: usize,
+    from: &KeyedAccount,
+    to: &KeyedAccount,
     lamports: u64,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
-    let mut from_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, from_account_index)?;
-    if !from_account.get_data().is_empty() {
+    if !from.data_is_empty()? {
         ic_msg!(invoke_context, "Transfer: `from` must not carry data");
         return Err(InstructionError::InvalidArgument);
     }
-    if lamports > from_account.get_lamports() {
+    if lamports > from.lamports()? {
         ic_msg!(
             invoke_context,
             "Transfer: insufficient lamports {}, need {}",
-            from_account.get_lamports(),
+            from.lamports()?,
             lamports
         );
         return Err(SystemError::ResultWithNegativeLamports.into());
     }
-    from_account.checked_sub_lamports(lamports)?;
-    drop(from_account);
-    let mut to_account = instruction_context
-        .try_borrow_instruction_account(invoke_context.transaction_context, to_account_index)?;
-    to_account.checked_add_lamports(lamports)?;
+
+    from.try_account_ref_mut()?.checked_sub_lamports(lamports)?;
+    to.try_account_ref_mut()?.checked_add_lamports(lamports)?;
     Ok(())
 }
 
 fn transfer(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    from_account_index: usize,
-    to_account_index: usize,
+    from: &KeyedAccount,
+    to: &KeyedAccount,
     lamports: u64,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
     if !invoke_context
         .feature_set
@@ -230,38 +210,26 @@ fn transfer(
         return Ok(());
     }
 
-    if !instruction_context
-        .is_signer(instruction_context.get_number_of_program_accounts() + from_account_index)?
-    {
+    if from.signer_key().is_none() {
         ic_msg!(
             invoke_context,
             "Transfer: `from` account {} must sign",
-            instruction_context.get_instruction_account_key(
-                invoke_context.transaction_context,
-                from_account_index
-            )?,
+            from.unsigned_key()
         );
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    transfer_verified(
-        invoke_context,
-        instruction_context,
-        from_account_index,
-        to_account_index,
-        lamports,
-    )
+    transfer_verified(from, to, lamports, invoke_context)
 }
 
 fn transfer_with_seed(
-    invoke_context: &InvokeContext,
-    instruction_context: &InstructionContext,
-    from_account_index: usize,
-    from_base_account_index: usize,
-    to_account_index: usize,
+    from: &KeyedAccount,
+    from_base: &KeyedAccount,
     from_seed: &str,
     from_owner: &Pubkey,
+    to: &KeyedAccount,
     lamports: u64,
+    invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError> {
     if !invoke_context
         .feature_set
@@ -271,112 +239,42 @@ fn transfer_with_seed(
         return Ok(());
     }
 
-    let from_base_key = instruction_context
-        .get_instruction_account_key(invoke_context.transaction_context, from_base_account_index)?;
-    if !instruction_context
-        .is_signer(instruction_context.get_number_of_program_accounts() + from_base_account_index)?
-    {
+    if from_base.signer_key().is_none() {
         ic_msg!(
             invoke_context,
             "Transfer: 'from' account {:?} must sign",
-            from_base_key,
+            from_base
         );
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    let from_key = instruction_context
-        .get_instruction_account_key(invoke_context.transaction_context, from_account_index)?;
-    let address_from_seed = Pubkey::create_with_seed(from_base_key, from_seed, from_owner)?;
-    if *from_key != address_from_seed {
+    let address_from_seed =
+        Pubkey::create_with_seed(from_base.unsigned_key(), from_seed, from_owner)?;
+    if *from.unsigned_key() != address_from_seed {
         ic_msg!(
             invoke_context,
             "Transfer: 'from' address {} does not match derived address {}",
-            from_key,
-            address_from_seed,
+            from.unsigned_key(),
+            address_from_seed
         );
         return Err(SystemError::AddressWithSeedMismatch.into());
     }
 
-    transfer_verified(
-        invoke_context,
-        instruction_context,
-        from_account_index,
-        to_account_index,
-        lamports,
-    )
-}
-
-pub mod instruction_account_indices {
-    pub enum CreateAccount {
-        From = 0,
-        To = 1,
-    }
-
-    pub enum CreateAccountWithSeed {
-        From = 0,
-        To = 1,
-    }
-
-    pub enum Assign {
-        Account = 0,
-    }
-
-    pub enum Transfer {
-        From = 0,
-        To = 1,
-    }
-
-    pub enum TransferWithSeed {
-        From = 0,
-        Base = 1,
-        To = 2,
-    }
-
-    pub enum AdvanceNonceAccount {
-        Nonce = 0,
-        RecentBlockhashes = 1,
-    }
-
-    pub enum WithdrawNonceAccount {
-        From = 0,
-        To = 1,
-        RecentBlockhashes = 2,
-        Rent = 3,
-    }
-
-    pub enum InitializeNonceAccount {
-        Nonce = 0,
-        RecentBlockhashes = 1,
-        Rent = 2,
-    }
-
-    pub enum AuthorizeNonceAccount {
-        Nonce = 0,
-    }
-
-    pub enum Allocate {
-        Account = 0,
-    }
-
-    pub enum AllocateWithSeed {
-        Account = 0,
-    }
-
-    pub enum AssignWithSeed {
-        Account = 0,
-    }
+    transfer_verified(from, to, lamports, invoke_context)
 }
 
 pub fn process_instruction(
-    _first_instruction_account: usize,
+    first_instruction_account: usize,
     instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let instruction = limited_deserialize(instruction_data)?;
 
     trace!("process_instruction: {:?}", instruction);
+    trace!("keyed_accounts: {:?}", keyed_accounts);
 
     let signers = instruction_context.get_signers(transaction_context);
     match instruction {
@@ -385,22 +283,18 @@ pub fn process_instruction(
             space,
             owner,
         } => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let to_key = instruction_context.get_instruction_account_key(
-                invoke_context.transaction_context,
-                instruction_account_indices::CreateAccount::To as usize,
-            )?;
-            let to_address = Address::create(to_key, None, invoke_context)?;
+            let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let to_address = Address::create(to.unsigned_key(), None, invoke_context)?;
             create_account(
-                invoke_context,
-                instruction_context,
-                &signers,
-                instruction_account_indices::CreateAccount::From as usize,
-                instruction_account_indices::CreateAccount::To as usize,
+                from,
+                to,
                 &to_address,
                 lamports,
                 space,
                 &owner,
+                &signers,
+                invoke_context,
             )
         }
         SystemInstruction::CreateAccountWithSeed {
@@ -410,66 +304,60 @@ pub fn process_instruction(
             space,
             owner,
         } => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            let to_key = instruction_context.get_instruction_account_key(
-                invoke_context.transaction_context,
-                instruction_account_indices::CreateAccountWithSeed::To as usize,
-            )?;
-            let to_address = Address::create(to_key, Some((&base, &seed, &owner)), invoke_context)?;
-            create_account(
+            let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let to_address = Address::create(
+                to.unsigned_key(),
+                Some((&base, &seed, &owner)),
                 invoke_context,
-                instruction_context,
-                &signers,
-                instruction_account_indices::CreateAccountWithSeed::From as usize,
-                instruction_account_indices::CreateAccountWithSeed::To as usize,
+            )?;
+            create_account(
+                from,
+                to,
                 &to_address,
                 lamports,
                 space,
                 &owner,
+                &signers,
+                invoke_context,
             )
         }
         SystemInstruction::Assign { owner } => {
-            let mut account = instruction_context.try_borrow_instruction_account(
-                invoke_context.transaction_context,
-                instruction_account_indices::Assign::Account as usize,
-            )?;
-            let address = Address::create(account.get_key(), None, invoke_context)?;
-            assign(invoke_context, &signers, &mut account, &address, &owner)
+            let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let mut account = keyed_account.try_account_ref_mut()?;
+            let address = Address::create(keyed_account.unsigned_key(), None, invoke_context)?;
+            assign(&mut account, &address, &owner, &signers, invoke_context)
         }
         SystemInstruction::Transfer { lamports } => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
-            transfer(
-                invoke_context,
-                instruction_context,
-                instruction_account_indices::Transfer::From as usize,
-                instruction_account_indices::Transfer::To as usize,
-                lamports,
-            )
+            let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            transfer(from, to, lamports, invoke_context)
         }
         SystemInstruction::TransferWithSeed {
             lamports,
             from_seed,
             from_owner,
         } => {
-            instruction_context.check_number_of_instruction_accounts(3)?;
+            let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let base = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
+            let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
             transfer_with_seed(
-                invoke_context,
-                instruction_context,
-                instruction_account_indices::TransferWithSeed::From as usize,
-                instruction_account_indices::TransferWithSeed::Base as usize,
-                instruction_account_indices::TransferWithSeed::To as usize,
+                from,
+                base,
                 &from_seed,
                 &from_owner,
+                to,
                 lamports,
+                invoke_context,
             )
         }
         SystemInstruction::AdvanceNonceAccount => {
-            instruction_context.check_number_of_instruction_accounts(1)?;
+            let _me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
             let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::AdvanceNonceAccount::RecentBlockhashes as usize,
+                first_instruction_account + 1,
             )?;
             if recent_blockhashes.is_empty() {
                 ic_msg!(
@@ -482,39 +370,40 @@ pub fn process_instruction(
                 invoke_context,
                 instruction_context,
                 &signers,
-                instruction_account_indices::AdvanceNonceAccount::Nonce as usize,
+                NONCE_ACCOUNT_INDEX,
             )
         }
         SystemInstruction::WithdrawNonceAccount(lamports) => {
-            instruction_context.check_number_of_instruction_accounts(2)?;
+            let _me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let _to = &mut keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             #[allow(deprecated)]
             let _recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::WithdrawNonceAccount::RecentBlockhashes as usize,
+                first_instruction_account + 2,
             )?;
             let rent = get_sysvar_with_account_check2::rent(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::WithdrawNonceAccount::Rent as usize,
+                first_instruction_account + 3,
             )?;
             withdraw_nonce_account(
                 invoke_context,
                 instruction_context,
                 &signers,
-                instruction_account_indices::WithdrawNonceAccount::From as usize,
-                instruction_account_indices::WithdrawNonceAccount::To as usize,
+                NONCE_ACCOUNT_INDEX,
+                WITHDRAW_TO_ACCOUNT_INDEX,
                 lamports,
                 &rent,
             )
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
-            instruction_context.check_number_of_instruction_accounts(1)?;
+            let _me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
             let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::InitializeNonceAccount::RecentBlockhashes as usize,
+                first_instruction_account + 1,
             )?;
             if recent_blockhashes.is_empty() {
                 ic_msg!(
@@ -526,33 +415,31 @@ pub fn process_instruction(
             let rent = get_sysvar_with_account_check2::rent(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::InitializeNonceAccount::Rent as usize,
+                first_instruction_account + 2,
             )?;
             initialize_nonce_account(
                 invoke_context,
                 instruction_context,
-                instruction_account_indices::InitializeNonceAccount::Nonce as usize,
+                NONCE_ACCOUNT_INDEX,
                 &authorized,
                 &rent,
             )
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {
-            instruction_context.check_number_of_instruction_accounts(1)?;
+            let _me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             authorize_nonce_account(
                 invoke_context,
                 instruction_context,
                 &signers,
-                instruction_account_indices::AuthorizeNonceAccount::Nonce as usize,
+                NONCE_ACCOUNT_INDEX,
                 &nonce_authority,
             )
         }
         SystemInstruction::Allocate { space } => {
-            let mut account = instruction_context.try_borrow_instruction_account(
-                invoke_context.transaction_context,
-                instruction_account_indices::Allocate::Account as usize,
-            )?;
-            let address = Address::create(account.get_key(), None, invoke_context)?;
-            allocate(invoke_context, &signers, &mut account, &address, space)
+            let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let mut account = keyed_account.try_account_ref_mut()?;
+            let address = Address::create(keyed_account.unsigned_key(), None, invoke_context)?;
+            allocate(&mut account, &address, space, &signers, invoke_context)
         }
         SystemInstruction::AllocateWithSeed {
             base,
@@ -560,35 +447,31 @@ pub fn process_instruction(
             space,
             owner,
         } => {
-            let mut account = instruction_context.try_borrow_instruction_account(
-                invoke_context.transaction_context,
-                instruction_account_indices::AllocateWithSeed::Account as usize,
-            )?;
+            let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(
-                account.get_key(),
+                keyed_account.unsigned_key(),
                 Some((&base, &seed, &owner)),
                 invoke_context,
             )?;
             allocate_and_assign(
-                invoke_context,
-                &signers,
                 &mut account,
                 &address,
                 space,
                 &owner,
+                &signers,
+                invoke_context,
             )
         }
         SystemInstruction::AssignWithSeed { base, seed, owner } => {
-            let mut account = instruction_context.try_borrow_instruction_account(
-                invoke_context.transaction_context,
-                instruction_account_indices::AssignWithSeed::Account as usize,
-            )?;
+            let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(
-                account.get_key(),
+                keyed_account.unsigned_key(),
                 Some((&base, &seed, &owner)),
                 invoke_context,
             )?;
-            assign(invoke_context, &signers, &mut account, &address, &owner)
+            assign(&mut account, &address, &owner, &signers, invoke_context)
         }
     }
 }


### PR DESCRIPTION
#### Problem

@jackcmay and me came to the conclusion that the recent refactoings in builtin programs are too hard to review.
So we decided to revert them so that we can reapply them in a structured and clean way.

#### Summary of Changes

Reverts #23375, #23348, #23302, #23214, #23217, #23056.
Some conflicts occurred and had to be resolved because of changes in the meantime (such as checked integer arithmetic and checked array accesses which were added).

Fixes #
