### PR TITLE
Various blockstore processor API cleanup

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -550,9 +550,9 @@ mod tests {
             full_leader_cache: true,
             ..ProcessOptions::default()
         };
-        let (bank_forks, cached_leader_schedule, _) =
+        let (bank_forks, leader_schedule_cache) =
             test_process_blockstore(&genesis_config, &blockstore, opts);
-        let leader_schedule_cache = Arc::new(cached_leader_schedule);
+        let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         let mut me = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -550,11 +550,8 @@ mod tests {
             full_leader_cache: true,
             ..ProcessOptions::default()
         };
-        let (bank_forks, cached_leader_schedule, _) = test_process_blockstore(
-            &genesis_config,
-            &blockstore,
-            opts,
-        );
+        let (bank_forks, cached_leader_schedule, _) =
+            test_process_blockstore(&genesis_config, &blockstore, opts);
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -529,7 +529,7 @@ mod tests {
         super::*,
         solana_gossip::contact_info::ContactInfo,
         solana_ledger::{
-            blockstore_processor::{process_blockstore, ProcessOptions},
+            blockstore_processor::{test_process_blockstore, ProcessOptions},
             create_new_tmp_ledger,
             genesis_utils::{create_genesis_config, GenesisConfigInfo},
         },
@@ -550,18 +550,11 @@ mod tests {
             full_leader_cache: true,
             ..ProcessOptions::default()
         };
-        let (accounts_package_sender, _) = unbounded();
-        let (bank_forks, cached_leader_schedule, _) = process_blockstore(
+        let (bank_forks, cached_leader_schedule, _) = test_process_blockstore(
             &genesis_config,
             &blockstore,
-            Vec::new(),
             opts,
-            None,
-            None,
-            accounts_package_sender,
-            None,
-        )
-        .unwrap();
+        );
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -481,11 +481,8 @@ impl Validator {
             vote_account,
             config,
             ledger_path,
-            config.poh_verify,
             &exit,
-            config.enforce_ulimit_nofile,
             &start_progress,
-            config.no_poh_speed_test,
             accounts_package_channel.0.clone(),
             accounts_update_notifier,
             transaction_notifier,
@@ -1197,17 +1194,14 @@ fn post_process_restored_tower(
         })
 }
 
-#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
 fn new_banks_from_ledger(
     validator_identity: &Pubkey,
     vote_account: &Pubkey,
     config: &ValidatorConfig,
     ledger_path: &Path,
-    poh_verify: bool,
     exit: &Arc<AtomicBool>,
-    enforce_ulimit_nofile: bool,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
-    no_poh_speed_test: bool,
     accounts_package_sender: AccountsPackageSender,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     transaction_notifier: Option<TransactionNotifierLock>,
@@ -1245,7 +1239,7 @@ fn new_banks_from_ledger(
         }
     }
 
-    if !no_poh_speed_test {
+    if !config.no_poh_speed_test {
         check_poh_speed(&genesis_config, None);
     }
 
@@ -1258,7 +1252,6 @@ fn new_banks_from_ledger(
         ledger_path,
         BlockstoreOptions {
             recovery_mode: config.wal_recovery_mode.clone(),
-            enforce_ulimit_nofile,
             advanced_options: config.blockstore_advanced_options.clone(),
             ..BlockstoreOptions::default()
         },
@@ -1293,7 +1286,7 @@ fn new_banks_from_ledger(
 
     let process_options = blockstore_processor::ProcessOptions {
         bpf_jit: config.bpf_jit,
-        poh_verify,
+        poh_verify: config.poh_verify,
         dev_halt_at_slot: config.dev_halt_at_slot,
         new_hard_forks: config.new_hard_forks.clone(),
         debug_keys: config.debug_keys.clone(),

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         blockstore::Blockstore,
         blockstore_processor::{
-            self, BlockstoreProcessorError, BlockstoreProcessorResult, CacheBlockMetaSender,
+            self, BlockstoreProcessorError, CacheBlockMetaSender,
             ProcessOptions, TransactionStatusSender,
         },
         leader_schedule_cache::LeaderScheduleCache,
@@ -30,22 +30,6 @@ pub type LoadResult = result::Result<
     ),
     BlockstoreProcessorError,
 >;
-
-fn to_loadresult(
-    bpr: BlockstoreProcessorResult,
-    starting_snapshot_hashes: Option<StartingSnapshotHashes>,
-) -> LoadResult {
-    bpr.map(
-        |(bank_forks, leader_schedule_cache, last_full_snapshot_slot)| {
-            (
-                bank_forks,
-                leader_schedule_cache,
-                last_full_snapshot_slot,
-                starting_snapshot_hashes,
-            )
-        },
-    )
-}
 
 /// Load the banks and accounts
 ///
@@ -123,18 +107,25 @@ pub fn load(
         )
     };
 
-    to_loadresult(
-        blockstore_processor::process_blockstore_from_root(
-            blockstore,
-            bank_forks,
-            &process_options,
-            transaction_status_sender,
-            cache_block_meta_sender,
-            snapshot_config,
-            accounts_package_sender,
-            last_full_snapshot_slot,
-        ),
-        starting_snapshot_hashes,
+    blockstore_processor::process_blockstore_from_root(
+        blockstore,
+        bank_forks,
+        &process_options,
+        transaction_status_sender,
+        cache_block_meta_sender,
+        snapshot_config,
+        accounts_package_sender,
+        last_full_snapshot_slot,
+    )
+    .map(
+        |(bank_forks, leader_schedule_cache, last_full_snapshot_slot)| {
+            (
+                bank_forks,
+                leader_schedule_cache,
+                last_full_snapshot_slot,
+                starting_snapshot_hashes,
+            )
+        },
     )
 }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -8,7 +8,6 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
     },
     log::*,
-    solana_entry::entry::VerifyRecyclers,
     solana_runtime::{
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank_forks::BankForks,
@@ -194,7 +193,6 @@ fn load_from_snapshot(
             blockstore,
             bank_forks,
             &process_options,
-            &VerifyRecyclers::default(),
             transaction_status_sender,
             cache_block_meta_sender,
             Some(snapshot_config),

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -108,16 +108,25 @@ pub fn load(
     }
 
     info!("Processing ledger from genesis");
+
+    let bank_forks = blockstore_processor::process_blockstore_for_bank_0(
+        genesis_config,
+        blockstore,
+        account_paths,
+        &process_options,
+        cache_block_meta_sender,
+        accounts_update_notifier,
+    );
     to_loadresult(
-        blockstore_processor::process_blockstore(
-            genesis_config,
+        blockstore_processor::process_blockstore_from_root(
             blockstore,
-            account_paths,
-            process_options,
+            bank_forks,
+            &process_options,
+            transaction_status_sender,
             cache_block_meta_sender,
             snapshot_config,
             accounts_package_sender,
-            accounts_update_notifier,
+            None,
         ),
         None,
     )
@@ -197,7 +206,7 @@ fn load_from_snapshot(
             cache_block_meta_sender,
             Some(snapshot_config),
             accounts_package_sender,
-            full_snapshot_archive_info.slot(),
+            Some(full_snapshot_archive_info.slot()),
         ),
         Some(starting_snapshot_hashes),
     )

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -630,7 +630,7 @@ pub(crate) fn process_blockstore_for_bank_0(
 
 /// Process blockstore from a known root bank
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn process_blockstore_from_root(
+pub fn process_blockstore_from_root(
     blockstore: &Blockstore,
     mut bank_forks: BankForks,
     opts: &ProcessOptions,
@@ -3170,7 +3170,6 @@ pub mod tests {
             None,
             None,
             accounts_package_sender,
-            None,
         )
         .unwrap();
 
@@ -3278,7 +3277,6 @@ pub mod tests {
             None,
             Some(&snapshot_config),
             accounts_package_sender.clone(),
-            None,
         )
         .unwrap();
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -571,9 +571,17 @@ pub fn test_process_blockstore(
     blockstore: &Blockstore,
     opts: ProcessOptions,
 ) -> BlockstoreProcessorInner {
+    let (bank_forks, ..) = crate::bank_forks_utils::load_bank_forks(
+        genesis_config,
+        blockstore,
+        Vec::new(),
+        None,
+        None,
+        &opts,
+        None,
+        None,
+    );
     let (accounts_package_sender, _) = unbounded();
-    let bank_forks =
-        process_blockstore_for_bank_0(genesis_config, blockstore, Vec::new(), &opts, None, None);
     process_blockstore_from_root(
         blockstore,
         bank_forks,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -590,7 +590,6 @@ pub fn test_process_blockstore(
         None,
         None,
         accounts_package_sender,
-        None,
     )
     .unwrap()
 }
@@ -639,7 +638,6 @@ pub(crate) fn process_blockstore_from_root(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     snapshot_config: Option<&SnapshotConfig>,
     accounts_package_sender: AccountsPackageSender,
-    mut last_full_snapshot_slot: Option<Slot>,
 ) -> BlockstoreProcessorResult {
     if let Some(num_threads) = opts.override_num_threads {
         PAR_THREAD_POOL.with(|pool| {
@@ -698,6 +696,8 @@ pub(crate) fn process_blockstore_from_root(
     if opts.full_leader_cache {
         leader_schedule_cache.set_max_schedules(std::usize::MAX);
     }
+
+    let mut last_full_snapshot_slot = None;
 
     if let Some(start_slot_meta) = blockstore
         .meta(start_slot)


### PR DESCRIPTION
The functions used for blockstore processing at validator startup are starting to show rot from years of incremental work. Clean up some of the rough edges.

Generally the goal of this work is to make the separation between blockstore initialization and processing more crisp. Future work will hopefully allow blockstore processing to occur after most services have been booted, so the validator can start ingesting turbine and serve repair much sooner in the boot process than it currently does