### PR TITLE
add metric to report large change in cost calculation

### DIFF
--- a/runtime/src/cost_calculation_metrics.rs
+++ b/runtime/src/cost_calculation_metrics.rs
@@ -1,0 +1,103 @@
+use {
+    solana_program_runtime::timings::ProgramTiming,
+    solana_sdk::pubkey::Pubkey,
+    std::time::{Duration, Instant},
+};
+
+/// To prevent too many writes to influx too often, MetricsMeter meters
+/// up to `max_number_of_writes` of writes within `time_window_duration`.
+/// New time window starts from the first write attempt outside of previous
+/// time window. See tests for examples.
+#[derive(Debug)]
+struct MetricsMeter {
+    max_number_of_writes: usize,
+    time_window_duration: Duration,
+    accumulated_number_of_writes: usize,
+    time_window_start: Instant,
+}
+
+impl MetricsMeter {
+    pub fn new(max_number_of_writes: usize, time_window_duration: Duration) -> Self {
+        Self {
+            max_number_of_writes,
+            time_window_duration,
+            accumulated_number_of_writes: 0,
+            time_window_start: Instant::now(),
+        }
+    }
+
+    pub fn take(&mut self) -> bool {
+        if self.time_window_start.elapsed() > self.time_window_duration {
+            // To start a new window, reset counters
+            self.accumulated_number_of_writes = 0;
+            self.time_window_start = Instant::now();
+        }
+        self.accumulated_number_of_writes = self.accumulated_number_of_writes.saturating_add(1);
+        self.accumulated_number_of_writes <= self.max_number_of_writes
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CostCalculationMetrics {
+    metrics_meter: MetricsMeter,
+}
+
+impl CostCalculationMetrics {
+    pub fn new(max_number_of_writes: usize, time_window_duration: Duration) -> Self {
+        Self {
+            metrics_meter: MetricsMeter::new(max_number_of_writes, time_window_duration),
+        }
+    }
+
+    pub fn report(
+        &mut self,
+        program_id: &Pubkey,
+        program_timing: &ProgramTiming,
+        calculated_units: u64,
+    ) {
+        if self.metrics_meter.take() {
+            datapoint_info!(
+                "large_change_in_cost_calculation",
+                ("pubkey", program_id.to_string(), String),
+                ("execute_us", program_timing.accumulated_us, i64),
+                ("accumulated_units", program_timing.accumulated_units, i64),
+                ("count", program_timing.count, i64),
+                ("errored_units", program_timing.total_errored_units, i64),
+                (
+                    "errored_count",
+                    program_timing.errored_txs_compute_consumed.len(),
+                    i64
+                ),
+                ("calculated_units", calculated_units as i64, i64),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::thread};
+
+    #[test]
+    fn test_metrics_meter() {
+        let limit = 2;
+        let duration = Duration::from_millis(250);
+
+        // start first window, can take up to `limit` writes
+        let mut metrics_meter = MetricsMeter::new(limit, duration);
+        assert!(metrics_meter.take());
+        assert!(metrics_meter.take());
+        assert!(!metrics_meter.take());
+
+        // start second window
+        thread::sleep(duration);
+        // can write again in second time_window
+        assert!(metrics_meter.take());
+
+        // start another new window, can take up to `limit` writes
+        thread::sleep(duration);
+        assert!(metrics_meter.take());
+        assert!(metrics_meter.take());
+        assert!(!metrics_meter.take());
+    }
+}

--- a/runtime/src/cost_calculation_metrics.rs
+++ b/runtime/src/cost_calculation_metrics.rs
@@ -26,7 +26,7 @@ impl MetricsMeter {
         }
     }
 
-    pub fn take(&mut self) -> bool {
+    pub fn should_submit(&mut self) -> bool {
         if self.time_window_start.elapsed() > self.time_window_duration {
             // To start a new window, reset counters
             self.accumulated_number_of_writes = 0;
@@ -55,7 +55,7 @@ impl CostCalculationMetrics {
         program_timing: &ProgramTiming,
         calculated_units: u64,
     ) {
-        if self.metrics_meter.take() {
+        if self.metrics_meter.should_submit() {
             datapoint_info!(
                 "large_change_in_cost_calculation",
                 ("pubkey", program_id.to_string(), String),
@@ -85,19 +85,19 @@ mod tests {
 
         // start first window, can take up to `limit` writes
         let mut metrics_meter = MetricsMeter::new(limit, duration);
-        assert!(metrics_meter.take());
-        assert!(metrics_meter.take());
-        assert!(!metrics_meter.take());
+        assert!(metrics_meter.should_submit());
+        assert!(metrics_meter.should_submit());
+        assert!(!metrics_meter.should_submit());
 
         // start second window
         thread::sleep(duration);
         // can write again in second time_window
-        assert!(metrics_meter.take());
+        assert!(metrics_meter.should_submit());
 
         // start another new window, can take up to `limit` writes
         thread::sleep(duration);
-        assert!(metrics_meter.take());
-        assert!(metrics_meter.take());
-        assert!(!metrics_meter.take());
+        assert!(metrics_meter.should_submit());
+        assert!(metrics_meter.should_submit());
+        assert!(!metrics_meter.should_submit());
     }
 }

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -22,7 +22,7 @@ const PRUNE_RATIO: f64 = 0.75;
 const OCCURRENCES_WEIGHT: i64 = 100;
 
 const DEFAULT_CAPACITY: usize = 1024;
-const MAX_METRICS_REPORT_PER_SEC: usize = 100;
+const MAX_METRICS_REPORT_PER_SEC: usize = 10;
 
 #[derive(Debug)]
 pub struct ExecuteCostTable {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -26,6 +26,7 @@ pub mod cache_hash_data;
 pub mod cache_hash_data_stats;
 pub mod commitment;
 pub mod contains;
+pub mod cost_calculation_metrics;
 pub mod cost_model;
 pub mod cost_tracker;
 pub mod epoch_stakes;


### PR DESCRIPTION
#### Problem

Large change in cost calculation is an indicator of potential issues. Need a datapoint for monitoring and troubleshooting.

#### Summary of Changes

- Check calculation anomaly within `ExecuteCostTable::Upsert()`, where new data point is processed. This allows data aggregation algo encapsulates anomaly check;
- Passing `ProgrmaTiming` instead of `cost: u64` to calculation, allow to report input data details to metric;
- Add `MetricsMeter` to limit up to `max_number_of_writes` within `time_window_duration`. 

Fixes #
