### PR TITLE
add deterministic default cost

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -33,7 +33,7 @@ use {
         rpc_request::DELINQUENT_VALIDATOR_SLOT_DISTANCE,
         rpc_response::SlotInfo,
     },
-    solana_program_runtime::compute_budget::ComputeBudget,
+    solana_program_runtime::compute_budget,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_sdk::{
         account::from_account,
@@ -1409,7 +1409,7 @@ pub fn process_ping(
             )];
             if let Some(additional_fee) = additional_fee {
                 ixs.push(ComputeBudgetInstruction::request_units(
-                    ComputeBudget::new(false).max_units as u32,
+                    compute_budget::DEFAULT_UNITS,
                     *additional_fee,
                 ));
             }

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -150,15 +150,9 @@ mod tests {
     fn test_update_cost_model_with_empty_execute_timings() {
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
         let mut empty_execute_timings = ExecuteTimings::default();
-        CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings);
-
         assert_eq!(
-            0,
-            cost_model
-                .read()
-                .unwrap()
-                .get_instruction_cost_table()
-                .len()
+            CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings),
+            0
         );
     }
 
@@ -188,14 +182,9 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             assert_eq!(
-                1,
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                1
             );
             assert_eq!(
                 Some(&expected_cost),
@@ -225,14 +214,9 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             assert_eq!(
-                1,
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                1
             );
             assert_eq!(
                 Some(&expected_cost),
@@ -264,20 +248,47 @@ mod tests {
                     total_errored_units: 0,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             // If both the `errored_txs_compute_consumed` is empty and `count == 0`, then
             // nothing should be inserted into the cost model
-            assert!(cost_model
-                .read()
-                .unwrap()
-                .get_instruction_cost_table()
-                .is_empty());
+            assert_eq!(
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                0
+            );
+        }
+
+        // set up current instruction cost to 100
+        let current_program_cost = 100;
+        {
+            execute_timings.details.per_program_timings.insert(
+                program_key_1,
+                ProgramTiming {
+                    accumulated_us: 1000,
+                    accumulated_units: current_program_cost,
+                    count: 1,
+                    errored_txs_compute_consumed: vec![],
+                    total_errored_units: 0,
+                },
+            );
+            assert_eq!(
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                1
+            );
+            assert_eq!(
+                Some(&current_program_cost),
+                cost_model
+                    .read()
+                    .unwrap()
+                    .get_instruction_cost_table()
+                    .get(&program_key_1)
+            );
         }
 
         // Test updating cost model with only erroring compute costs where the `cost_per_error` is
         // greater than the current instruction cost for the program. Should update with the
         // new erroring compute costs
         let cost_per_error = 1000;
+        // the expect cost is (previous_cost + new_cost)/2 = (100 + 1000)/2 = 550
+        let expect_units = 550;
         {
             let errored_txs_compute_consumed = vec![cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -291,17 +302,12 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             assert_eq!(
-                1,
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                1
             );
             assert_eq!(
-                Some(&cost_per_error),
+                Some(&expect_units),
                 cost_model
                     .read()
                     .unwrap()
@@ -313,7 +319,7 @@ mod tests {
         // Test updating cost model with only erroring compute costs where the error cost is
         // `smaller_cost_per_error`, less than the current instruction cost for the program.
         // The cost should not decrease for these new lesser errors
-        let smaller_cost_per_error = cost_per_error - 10;
+        let smaller_cost_per_error = expect_units - 10;
         {
             let errored_txs_compute_consumed = vec![smaller_cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -327,17 +333,12 @@ mod tests {
                     total_errored_units,
                 },
             );
-            CostUpdateService::update_cost_model(&cost_model, &mut execute_timings);
             assert_eq!(
-                1,
-                cost_model
-                    .read()
-                    .unwrap()
-                    .get_instruction_cost_table()
-                    .len()
+                CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
+                1
             );
             assert_eq!(
-                Some(&cost_per_error),
+                Some(&expect_units),
                 cost_model
                     .read()
                     .unwrap()

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -288,7 +288,7 @@ mod tests {
         // new erroring compute costs
         let cost_per_error = 1000;
         // the expect cost is (previous_cost + new_cost)/2 = (100 + 1000)/2 = 550
-        let expect_units = 550;
+        let expected_units = 550;
         {
             let errored_txs_compute_consumed = vec![cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -307,7 +307,7 @@ mod tests {
                 1
             );
             assert_eq!(
-                Some(&expect_units),
+                Some(&expected_units),
                 cost_model
                     .read()
                     .unwrap()
@@ -319,7 +319,7 @@ mod tests {
         // Test updating cost model with only erroring compute costs where the error cost is
         // `smaller_cost_per_error`, less than the current instruction cost for the program.
         // The cost should not decrease for these new lesser errors
-        let smaller_cost_per_error = expect_units - 10;
+        let smaller_cost_per_error = expected_units - 10;
         {
             let errored_txs_compute_consumed = vec![smaller_cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
@@ -338,7 +338,7 @@ mod tests {
                 1
             );
             assert_eq!(
-                Some(&expect_units),
+                Some(&expected_units),
                 cost_model
                     .read()
                     .unwrap()

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -73,13 +73,8 @@ impl Default for ComputeBudget {
 
 impl ComputeBudget {
     pub fn new(use_max_units_default: bool) -> Self {
-        let max_units = if use_max_units_default {
-            MAX_UNITS
-        } else {
-            200_000
-        } as u64;
         ComputeBudget {
-            max_units,
+            max_units: ComputeBudget::get_max_units(use_max_units_default),
             log_64_units: 100,
             create_program_address_units: 1500,
             invoke_units: 1000,
@@ -99,6 +94,14 @@ impl ComputeBudget {
             heap_size: None,
             heap_cost: 8,
             mem_op_base_cost: 10,
+        }
+    }
+
+    pub fn get_max_units(use_max_units_default: bool) -> u64 {
+        if use_max_units_default {
+            MAX_UNITS as u64
+        } else {
+            200_000
         }
     }
 

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -7,7 +7,8 @@ use solana_sdk::{
     transaction::TransactionError,
 };
 
-const MAX_UNITS: u32 = 1_400_000;
+pub const DEFAULT_UNITS: u32 = 200_000;
+pub const MAX_UNITS: u32 = 1_400_000;
 const MAX_HEAP_FRAME_BYTES: u32 = 256 * 1024;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
@@ -67,14 +68,14 @@ pub struct ComputeBudget {
 
 impl Default for ComputeBudget {
     fn default() -> Self {
-        Self::new(true)
+        Self::new(MAX_UNITS)
     }
 }
 
 impl ComputeBudget {
-    pub fn new(use_max_units_default: bool) -> Self {
+    pub fn new(max_units: u32) -> Self {
         ComputeBudget {
-            max_units: ComputeBudget::get_max_units(use_max_units_default),
+            max_units: max_units as u64,
             log_64_units: 100,
             create_program_address_units: 1500,
             invoke_units: 1000,
@@ -94,14 +95,6 @@ impl ComputeBudget {
             heap_size: None,
             heap_cost: 8,
             mem_op_base_cost: 10,
-        }
-    }
-
-    pub fn get_max_units(use_max_units_default: bool) -> u64 {
-        if use_max_units_default {
-            MAX_UNITS as u64
-        } else {
-            200_000
         }
     }
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1193,6 +1193,7 @@ pub fn visit_each_account_once<E>(
 mod tests {
     use {
         super::*,
+        crate::compute_budget,
         serde::{Deserialize, Serialize},
         solana_sdk::account::{ReadableAccount, WritableAccount},
     };
@@ -1674,12 +1675,12 @@ mod tests {
         let mut transaction_context = TransactionContext::new(accounts, 1, 3);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context.feature_set = Arc::new(feature_set);
-        invoke_context.compute_budget = ComputeBudget::new(false);
+        invoke_context.compute_budget = ComputeBudget::new(compute_budget::DEFAULT_UNITS);
 
         invoke_context.push(&[], &[0], &[]).unwrap();
         assert_eq!(
             *invoke_context.get_compute_budget(),
-            ComputeBudget::new(false)
+            ComputeBudget::new(compute_budget::DEFAULT_UNITS)
         );
         invoke_context.pop().unwrap();
 
@@ -1687,7 +1688,7 @@ mod tests {
         let expected_compute_budget = ComputeBudget {
             max_units: 500_000,
             heap_size: Some(256_usize.saturating_mul(1024)),
-            ..ComputeBudget::new(false)
+            ..ComputeBudget::new(compute_budget::DEFAULT_UNITS)
         };
         assert_eq!(
             *invoke_context.get_compute_budget(),
@@ -1698,7 +1699,7 @@ mod tests {
         invoke_context.push(&[], &[0], &[]).unwrap();
         assert_eq!(
             *invoke_context.get_compute_budget(),
-            ComputeBudget::new(false)
+            ComputeBudget::new(compute_budget::DEFAULT_UNITS)
         );
         invoke_context.pop().unwrap();
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,7 @@ use {
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
     solana_program_runtime::{
         accounts_data_meter::MAX_ACCOUNTS_DATA_LEN,
-        compute_budget::ComputeBudget,
+        compute_budget::{self, ComputeBudget},
         invoke_context::{
             BuiltinProgram, Executor, Executors, ProcessInstructionWithContext, TransactionExecutor,
         },
@@ -4036,9 +4036,14 @@ impl Bank {
                     signature_count += u64::from(tx.message().header().num_required_signatures);
 
                     let tx_wide_compute_cap = feature_set.is_active(&tx_wide_compute_cap::id());
+                    let compute_budget_max_units = if tx_wide_compute_cap {
+                        compute_budget::MAX_UNITS
+                    } else {
+                        compute_budget::DEFAULT_UNITS
+                    };
                     let mut compute_budget = self
                         .compute_budget
-                        .unwrap_or_else(|| ComputeBudget::new(tx_wide_compute_cap));
+                        .unwrap_or_else(|| ComputeBudget::new(compute_budget_max_units));
                     if tx_wide_compute_cap {
                         let mut compute_budget_process_transaction_time =
                             Measure::start("compute_budget_process_transaction_time");
@@ -16908,7 +16913,7 @@ pub(crate) mod tests {
 
         let compute_budget = bank
             .compute_budget
-            .unwrap_or_else(|| ComputeBudget::new(false));
+            .unwrap_or_else(|| ComputeBudget::new(compute_budget::DEFAULT_UNITS));
         let transaction_context = TransactionContext::new(
             loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
             compute_budget.max_invoke_depth.saturating_add(1),

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -113,9 +113,9 @@ impl CostModel {
         match self.instruction_execution_cost_table.get_cost(program_key) {
             Some(cost) => *cost,
             None => {
-                let default_value = self.instruction_execution_cost_table.get_mode();
+                let default_value = self.instruction_execution_cost_table.get_default_units();
                 debug!(
-                    "Program key {:?} does not have assigned cost, using mode {}",
+                    "Instruction {:?} does not have aggregated cost, using default value {}",
                     program_key, default_value
                 );
                 default_value
@@ -278,7 +278,7 @@ mod tests {
 
         // unknown program is assigned with default cost
         assert_eq!(
-            testee.instruction_execution_cost_table.get_mode(),
+            testee.instruction_execution_cost_table.get_default_units(),
             testee.find_instruction_cost(
                 &Pubkey::from_str("unknown111111111111111111111111111111111111").unwrap()
             )
@@ -409,7 +409,7 @@ mod tests {
         let result = testee.get_transaction_cost(&tx);
 
         // expected cost for two random/unknown program is
-        let expected_cost = testee.instruction_execution_cost_table.get_mode() * 2;
+        let expected_cost = testee.instruction_execution_cost_table.get_default_units() * 2;
         assert_eq!(expected_cost, result);
     }
 
@@ -453,7 +453,9 @@ mod tests {
         let mut cost_model = CostModel::default();
         // Using default cost for unknown instruction
         assert_eq!(
-            cost_model.instruction_execution_cost_table.get_mode(),
+            cost_model
+                .instruction_execution_cost_table
+                .get_default_units(),
             cost_model.find_instruction_cost(&key1)
         );
 

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -115,7 +115,7 @@ impl CostModel {
             None => {
                 let default_value = self.instruction_execution_cost_table.get_default_units();
                 debug!(
-                    "Instruction {:?} does not have aggregated cost, using default value {}",
+                    "Program {:?} does not have aggregated cost, using default value {}",
                     program_key, default_value
                 );
                 default_value


### PR DESCRIPTION
#### Problem

Default instruction cost to `ComputeBudget::get_max_units()` is safer than defaulting to `0`.

#### Summary of Changes

- Add `get_default_units()`, use it instead of `0` as default cost units for unknown instructions

Fixes #
