### PR TITLE
fix logging: only walk remote dir if it exist

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1166,9 +1166,10 @@ where
     };
 
     let mut ret = walk_dir(snapshot_archives_dir);
-    ret.append(&mut walk_dir(
-        build_snapshot_archives_remote_dir(snapshot_archives_dir).as_ref(),
-    ));
+    let remote_dir = build_snapshot_archives_remote_dir(snapshot_archives_dir);
+    if remote_dir.exists() {
+        ret.append(&mut walk_dir(remote_dir.as_ref()));
+    }
     ret
 }
 


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/23662#issuecomment-1067352529

Fix unnecessary logging when remote snapshot directory is not found.


#### Summary of Changes



Fixes #
