### PR TITLE
avoid data copies in writing to cache

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -57,7 +57,7 @@ use {
     solana_measure::measure::Measure,
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::{BankId, Epoch, Slot, SlotCount},
         epoch_schedule::EpochSchedule,
         genesis_config::{ClusterType, GenesisConfig},
@@ -564,6 +564,19 @@ impl<'a> ReadableAccount for LoadedAccount<'a> {
                 stored_account_meta.account_meta.rent_epoch
             }
             LoadedAccount::Cached(cached_account) => cached_account.account.rent_epoch(),
+        }
+    }
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        match self {
+            LoadedAccount::Stored(_stored_account_meta) => AccountSharedData::create(
+                self.lamports(),
+                self.data().to_vec(),
+                *self.owner(),
+                self.executable(),
+                self.rent_epoch(),
+            ),
+            // clone here to prevent data copy
+            LoadedAccount::Cached(cached_account) => cached_account.account.clone(),
         }
     }
 }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -253,6 +253,10 @@ impl ReadableAccount for AccountSharedData {
     fn rent_epoch(&self) -> Epoch {
         self.rent_epoch
     }
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        // avoid data copy here
+        self.clone()
+    }
 }
 
 impl ReadableAccount for Ref<'_, AccountSharedData> {
@@ -270,6 +274,16 @@ impl ReadableAccount for Ref<'_, AccountSharedData> {
     }
     fn rent_epoch(&self) -> Epoch {
         self.rent_epoch
+    }
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        AccountSharedData {
+            lamports: self.lamports(),
+            // avoid data copy here
+            data: Arc::clone(&self.data),
+            owner: *self.owner(),
+            executable: self.executable(),
+            rent_epoch: self.rent_epoch(),
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem

Avoid allocation of new vec when effectively cloning an `AccountSharedData` instance. This will show up when writable accounts are written to the accounts cache.

#### Summary of Changes

If trait method `to_account_shared_data` is called on AccountSharedData (or ref), clone the data field instead of reallocating it.

Fixes #
