### PR TITLE
Update InvalidRentPayingAccount variant and message

### DIFF
--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -127,9 +127,7 @@ pub enum TransactionError {
     InvalidAddressLookupTableIndex,
 
     /// Transaction leaves an account with a lower balance than rent-exempt minimum
-    #[error(
-        "Transaction leaves an account with data with a lower balance than rent-exempt minimum"
-    )]
+    #[error("Transaction leaves an account with a lower balance than rent-exempt minimum")]
     InvalidRentPayingAccount,
 
     /// Transaction would exceed max Vote Cost Limit


### PR DESCRIPTION
#### Problem
InvalidRentPayingAccount error message is confusing because it still refers to accounts "with data", even though the implementation in  #22292 prevents all rent-paying accounts.


#### Summary of Changes
Update InvalidRentPayingAccount error message
~~Also include relevant account index to make it more helpful~~ (edit) actually, I removed this bit. Plumbing the account index into storage-protobuf types was a little annoying, and will make activation of `require_rent_exempt_accounts` dependent on this PR. Would rather not be adding another consensus-breaking change


Fixes #23670
