### PR TITLE
vote_account uses AccountSharedData to avoid copies

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -702,13 +702,17 @@ impl ProgressMap {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_runtime::vote_account::VoteAccount, solana_sdk::account::Account};
+    use {
+        super::*,
+        solana_runtime::vote_account::VoteAccount,
+        solana_sdk::account::{Account, AccountSharedData},
+    };
 
     fn new_test_vote_account() -> VoteAccount {
-        let account = Account {
+        let account = AccountSharedData::from(Account {
             owner: solana_vote_program::id(),
             ..Account::default()
-        };
+        });
         VoteAccount::try_from(account).unwrap()
     }
 

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -6,7 +6,7 @@ use {
     },
     serde::{
         ser::{Serialize, Serializer},
-        Deserialize, Deserializer,
+        Deserialize,
     },
     solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::Sysvar},
     std::{
@@ -97,7 +97,8 @@ impl Serialize for AccountSharedData {
 /// An Account with data that is stored on chain
 /// This will be the in-memory representation of the 'Account' struct data.
 /// The existing 'Account' structure cannot easily change due to downstream projects.
-#[derive(PartialEq, Eq, Clone, Default, AbiExample)]
+#[derive(PartialEq, Eq, Clone, Default, AbiExample, Deserialize)]
+#[serde(from = "Account")]
 pub struct AccountSharedData {
     /// lamports in the account
     lamports: u64,
@@ -470,15 +471,6 @@ fn shared_new_ref_data_with_space<T: serde::Serialize, U: WritableAccount>(
     Ok(RefCell::new(shared_new_data_with_space::<T, U>(
         lamports, state, space, owner,
     )?))
-}
-
-impl<'de> Deserialize<'de> for AccountSharedData {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(AccountSharedData::from(Account::deserialize(deserializer)?))
-    }
 }
 
 fn shared_deserialize_data<T: serde::de::DeserializeOwned, U: ReadableAccount>(

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -4,7 +4,10 @@ use {
         lamports::LamportsError,
         pubkey::Pubkey,
     },
-    serde::ser::{Serialize, Serializer},
+    serde::{
+        ser::{Serialize, Serializer},
+        Deserialize, Deserializer,
+    },
     solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::Sysvar},
     std::{
         cell::{Ref, RefCell},
@@ -467,6 +470,15 @@ fn shared_new_ref_data_with_space<T: serde::Serialize, U: WritableAccount>(
     Ok(RefCell::new(shared_new_data_with_space::<T, U>(
         lamports, state, space, owner,
     )?))
+}
+
+impl<'de> Deserialize<'de> for AccountSharedData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(AccountSharedData::from(Account::deserialize(deserializer)?))
+    }
 }
 
 fn shared_deserialize_data<T: serde::de::DeserializeOwned, U: ReadableAccount>(


### PR DESCRIPTION
#### Problem

converting `AccountSharedData` to `Account` causes a copy of data. We previously did this so we could serialize. We can now serialize `AccountSharedData` directly.

#### Summary of Changes



Fixes #
