### PR TITLE
transaction-status: Add return data to meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "ed25519-dalek",
  "humantime",
  "indicatif",
+ "pretty-hex",
  "serde",
  "serde_json",
  "solana-account-decoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
 name = "solana-program-test"
 version = "1.10.4"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "base64 0.13.0",
  "bincode",

--- a/banks-client/src/error.rs
+++ b/banks-client/src/error.rs
@@ -1,5 +1,8 @@
 use {
-    solana_sdk::{transaction::TransactionError, transport::TransportError},
+    solana_sdk::{
+        transaction::TransactionError, transaction_context::TransactionReturnData,
+        transport::TransportError,
+    },
     std::io,
     tarpc::client::RpcError,
     thiserror::Error,
@@ -25,6 +28,7 @@ pub enum BanksClientError {
         err: TransactionError,
         logs: Vec<String>,
         units_consumed: u64,
+        return_data: Option<TransactionReturnData>,
     },
 }
 

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -247,6 +247,7 @@ impl BanksClient {
                 err,
                 logs: simulation_details.logs,
                 units_consumed: simulation_details.units_consumed,
+                return_data: simulation_details.return_data,
             }),
             BanksTransactionResultWithSimulation {
                 result: Some(result),

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -12,6 +12,7 @@ use {
         pubkey::Pubkey,
         signature::Signature,
         transaction::{self, Transaction, TransactionError},
+        transaction_context::TransactionReturnData,
     },
 };
 
@@ -35,6 +36,7 @@ pub struct TransactionStatus {
 pub struct TransactionSimulationDetails {
     pub logs: Vec<String>,
     pub units_consumed: u64,
+    pub return_data: Option<TransactionReturnData>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -266,6 +266,7 @@ impl Banks for BanksServer {
             logs,
             post_simulation_accounts: _,
             units_consumed,
+            return_data,
         } = self
             .bank(commitment)
             .simulate_transaction_unchecked(sanitized_transaction)
@@ -275,6 +276,7 @@ impl Banks for BanksServer {
                 simulation_details: Some(TransactionSimulationDetails {
                     logs,
                     units_consumed,
+                    return_data,
                 }),
             };
         }

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -17,6 +17,7 @@ clap = "2.33.0"
 console = "0.15.0"
 humantime = "2.0.1"
 indicatif = "0.16.2"
+pretty-hex = "0.2.1"
 serde = "1.0.136"
 serde_json = "1.0.79"
 solana-account-decoder = { path = "../account-decoder", version = "=1.10.4" }

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -14,6 +14,7 @@ use {
         signature::Signature,
         stake,
         transaction::{TransactionError, TransactionVersion, VersionedTransaction},
+        transaction_context::TransactionReturnData,
     },
     solana_transaction_status::{Rewards, UiTransactionStatusMeta},
     spl_memo::{id as spl_memo_id, v1::id as spl_memo_v1_id},
@@ -246,6 +247,7 @@ fn write_transaction<W: io::Write>(
         write_fees(w, transaction_status.fee, prefix)?;
         write_balances(w, transaction_status, prefix)?;
         write_log_messages(w, transaction_status.log_messages.as_ref(), prefix)?;
+        write_return_data(w, transaction_status.return_data.as_ref(), prefix)?;
         write_rewards(w, transaction_status.rewards.as_ref(), prefix)?;
     } else {
         writeln!(w, "{}Status: Unavailable", prefix)?;
@@ -576,6 +578,21 @@ fn write_balances<W: io::Write>(
     Ok(())
 }
 
+fn write_return_data<W: io::Write>(
+    w: &mut W,
+    return_data: Option<&TransactionReturnData>,
+    prefix: &str,
+) -> io::Result<()> {
+    if let Some(return_data) = return_data {
+        if !return_data.data.is_empty() {
+            writeln!(w, "{}Return Data:", prefix)?;
+            writeln!(w, "{}  Program: {}", prefix, return_data.program_id)?;
+            writeln!(w, "{}  Data: {:?}", prefix, return_data.data)?;
+        }
+    }
+    Ok(())
+}
+
 fn write_log_messages<W: io::Write>(
     w: &mut W,
     log_messages: Option<&Vec<String>>,
@@ -750,6 +767,10 @@ mod test {
                 commission: None,
             }]),
             loaded_addresses: LoadedAddresses::default(),
+            return_data: Some(TransactionReturnData {
+                program_id: Pubkey::new_from_array([2u8; 32]),
+                data: vec![1, 2, 3],
+            }),
         };
 
         let output = {
@@ -786,6 +807,9 @@ Status: Ok
   Account 1 balance: ◎0.00001 -> ◎0.0000099
 Log Messages:
   Test message
+Return Data:
+  Program: 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR
+  Data: [1, 2, 3]
 Rewards:
   Address                                            Type        Amount            New Balance         \0
   4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi        rent        -◎0.000000100     ◎0.000009900       \0

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -585,9 +585,13 @@ fn write_return_data<W: io::Write>(
 ) -> io::Result<()> {
     if let Some(return_data) = return_data {
         if !return_data.data.is_empty() {
-            writeln!(w, "{}Return Data:", prefix)?;
-            writeln!(w, "{}  Program: {}", prefix, return_data.program_id)?;
-            writeln!(w, "{}  Data: {:?}", prefix, return_data.data)?;
+            use pretty_hex::*;
+            writeln!(
+                w,
+                "{}Return Data from Program {}:",
+                prefix, return_data.program_id
+            )?;
+            writeln!(w, "{}  {:?}", prefix, return_data.data.hex_dump())?;
         }
     }
     Ok(())
@@ -807,9 +811,9 @@ Status: Ok
   Account 1 balance: ◎0.00001 -> ◎0.0000099
 Log Messages:
   Test message
-Return Data:
-  Program: 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR
-  Data: [1, 2, 3]
+Return Data from Program 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR:
+  Length: 3 (0x3) bytes
+0000:   01 02 03                                             ...
 Rewards:
   Address                                            Type        Amount            New Balance         \0
   4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi        rent        -◎0.000000100     ◎0.000009900       \0
@@ -844,6 +848,10 @@ Rewards:
                 commission: None,
             }]),
             loaded_addresses,
+            return_data: Some(TransactionReturnData {
+                program_id: Pubkey::new_from_array([2u8; 32]),
+                data: vec![1, 2, 3],
+            }),
         };
 
         let output = {
@@ -889,6 +897,9 @@ Status: Ok
   Account 3 balance: ◎0.00002
 Log Messages:
   Test message
+Return Data from Program 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR:
+  Length: 3 (0x3) bytes
+0000:   01 02 03                                             ...
 Rewards:
   Address                                            Type        Amount            New Balance         \0
   CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8        rent        -◎0.000000100     ◎0.000014900       \0

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -341,6 +341,7 @@ impl RpcSender for MockSender {
                     logs: None,
                     accounts: None,
                     units_consumed: None,
+                    return_data: None,
                 },
             })?,
             "getMinimumBalanceForRentExemption" => json![20],

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -229,6 +229,7 @@ impl RpcSender for MockSender {
                             post_token_balances: None,
                             rewards: None,
                             loaded_addresses: None,
+                            return_data: None,
                         }),
                 },
                 block_time: Some(1628633791),

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -7,6 +7,7 @@ use {
         hash::Hash,
         inflation::Inflation,
         transaction::{Result, TransactionError},
+        transaction_context::TransactionReturnData,
     },
     solana_transaction_status::{
         ConfirmedTransactionStatusWithSignature, TransactionConfirmationStatus, UiConfirmedBlock,
@@ -347,6 +348,7 @@ pub struct RpcSimulateTransactionResult {
     pub logs: Option<Vec<String>>,
     pub accounts: Option<Vec<Option<UiAccount>>>,
     pub units_consumed: Option<u64>,
+    pub return_data: Option<TransactionReturnData>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1183,6 +1183,7 @@ impl BankingStage {
                     MAX_PROCESSING_AGE,
                     transaction_status_sender.is_some(),
                     transaction_status_sender.is_some(),
+                    transaction_status_sender.is_some(),
                     &mut execute_and_commit_timings.execute_timings,
                 )
             },
@@ -2156,6 +2157,7 @@ mod tests {
             log_messages: None,
             inner_instructions: None,
             durable_nonce_fee: None,
+            return_data: None,
         })
     }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1331,7 +1331,7 @@ fn load_blockstore(
                 blockstore.clone(),
                 exit,
                 enable_rpc_transaction_history,
-                config.rpc_config.enable_cpi_and_log_storage,
+                config.rpc_config.enable_cpi_and_log_and_return_data_storage,
                 transaction_notifier,
             )
         } else {
@@ -1538,7 +1538,7 @@ fn initialize_rpc_transaction_history_services(
     blockstore: Arc<Blockstore>,
     exit: &Arc<AtomicBool>,
     enable_rpc_transaction_history: bool,
-    enable_cpi_and_log_storage: bool,
+    enable_cpi_and_log_and_return_data_storage: bool,
     transaction_notifier: Option<TransactionNotifierLock>,
 ) -> TransactionHistoryServices {
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
@@ -1552,7 +1552,7 @@ fn initialize_rpc_transaction_history_services(
         enable_rpc_transaction_history,
         transaction_notifier.clone(),
         blockstore.clone(),
-        enable_cpi_and_log_storage,
+        enable_cpi_and_log_and_return_data_storage,
         exit,
     ));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1331,7 +1331,7 @@ fn load_blockstore(
                 blockstore.clone(),
                 exit,
                 enable_rpc_transaction_history,
-                config.rpc_config.enable_cpi_and_log_and_return_data_storage,
+                config.rpc_config.enable_extended_tx_metadata_storage,
                 transaction_notifier,
             )
         } else {
@@ -1538,7 +1538,7 @@ fn initialize_rpc_transaction_history_services(
     blockstore: Arc<Blockstore>,
     exit: &Arc<AtomicBool>,
     enable_rpc_transaction_history: bool,
-    enable_cpi_and_log_and_return_data_storage: bool,
+    enable_extended_tx_metadata_storage: bool,
     transaction_notifier: Option<TransactionNotifierLock>,
 ) -> TransactionHistoryServices {
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(blockstore.max_root()));
@@ -1552,7 +1552,7 @@ fn initialize_rpc_transaction_history_services(
         enable_rpc_transaction_history,
         transaction_notifier.clone(),
         blockstore.clone(),
-        enable_cpi_and_log_and_return_data_storage,
+        enable_extended_tx_metadata_storage,
         exit,
     ));
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4666,6 +4666,7 @@ pub mod tests {
             pubkey::Pubkey,
             signature::Signature,
             transaction::{Transaction, TransactionError},
+            transaction_context::TransactionReturnData,
         },
         solana_storage_proto::convert::generated,
         solana_transaction_status::{InnerInstructions, Reward, Rewards, TransactionTokenBalance},
@@ -6826,6 +6827,7 @@ pub mod tests {
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
                     loaded_addresses: LoadedAddresses::default(),
+                    return_data: Some(TransactionReturnData::default()),
                 }
                 .into();
                 blockstore
@@ -6843,6 +6845,7 @@ pub mod tests {
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
                     loaded_addresses: LoadedAddresses::default(),
+                    return_data: Some(TransactionReturnData::default()),
                 }
                 .into();
                 blockstore
@@ -6860,6 +6863,7 @@ pub mod tests {
                     post_token_balances: Some(vec![]),
                     rewards: Some(vec![]),
                     loaded_addresses: LoadedAddresses::default(),
+                    return_data: Some(TransactionReturnData::default()),
                 }
                 .into();
                 blockstore
@@ -6879,6 +6883,7 @@ pub mod tests {
                         post_token_balances: Some(vec![]),
                         rewards: Some(vec![]),
                         loaded_addresses: LoadedAddresses::default(),
+                        return_data: Some(TransactionReturnData::default()),
                     },
                 }
             })
@@ -6991,6 +6996,10 @@ pub mod tests {
             writable: vec![Pubkey::new_unique()],
             readonly: vec![Pubkey::new_unique()],
         };
+        let test_return_data = TransactionReturnData {
+            program_id: Pubkey::new_unique(),
+            data: vec![1, 2, 3],
+        };
 
         // result not found
         assert!(transaction_status_cf
@@ -7010,6 +7019,7 @@ pub mod tests {
             post_token_balances: Some(post_token_balances_vec.clone()),
             rewards: Some(rewards_vec.clone()),
             loaded_addresses: test_loaded_addresses.clone(),
+            return_data: Some(test_return_data.clone()),
         }
         .into();
         assert!(transaction_status_cf
@@ -7028,6 +7038,7 @@ pub mod tests {
             post_token_balances,
             rewards,
             loaded_addresses,
+            return_data,
         } = transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((0, Signature::default(), 0))
             .unwrap()
@@ -7044,6 +7055,7 @@ pub mod tests {
         assert_eq!(post_token_balances.unwrap(), post_token_balances_vec);
         assert_eq!(rewards.unwrap(), rewards_vec);
         assert_eq!(loaded_addresses, test_loaded_addresses);
+        assert_eq!(return_data.unwrap(), test_return_data);
 
         // insert value
         let status = TransactionStatusMeta {
@@ -7057,6 +7069,7 @@ pub mod tests {
             post_token_balances: Some(post_token_balances_vec.clone()),
             rewards: Some(rewards_vec.clone()),
             loaded_addresses: test_loaded_addresses.clone(),
+            return_data: Some(test_return_data.clone()),
         }
         .into();
         assert!(transaction_status_cf
@@ -7075,6 +7088,7 @@ pub mod tests {
             post_token_balances,
             rewards,
             loaded_addresses,
+            return_data,
         } = transaction_status_cf
             .get_protobuf_or_bincode::<StoredTransactionStatusMeta>((
                 0,
@@ -7097,6 +7111,7 @@ pub mod tests {
         assert_eq!(post_token_balances.unwrap(), post_token_balances_vec);
         assert_eq!(rewards.unwrap(), rewards_vec);
         assert_eq!(loaded_addresses, test_loaded_addresses);
+        assert_eq!(return_data.unwrap(), test_return_data);
     }
 
     #[test]
@@ -7325,6 +7340,7 @@ pub mod tests {
             post_token_balances: Some(vec![]),
             rewards: Some(vec![]),
             loaded_addresses: LoadedAddresses::default(),
+            return_data: Some(TransactionReturnData::default()),
         }
         .into();
 
@@ -7520,6 +7536,7 @@ pub mod tests {
             post_token_balances: Some(vec![]),
             rewards: Some(vec![]),
             loaded_addresses: LoadedAddresses::default(),
+            return_data: Some(TransactionReturnData::default()),
         }
         .into();
 
@@ -7691,6 +7708,10 @@ pub mod tests {
                 let post_token_balances = Some(vec![]);
                 let rewards = Some(vec![]);
                 let signature = transaction.signatures[0];
+                let return_data = Some(TransactionReturnData {
+                    program_id: Pubkey::new_unique(),
+                    data: vec![1, 2, 3],
+                });
                 let status = TransactionStatusMeta {
                     status: Ok(()),
                     fee: 42,
@@ -7702,6 +7723,7 @@ pub mod tests {
                     post_token_balances: post_token_balances.clone(),
                     rewards: rewards.clone(),
                     loaded_addresses: LoadedAddresses::default(),
+                    return_data: return_data.clone(),
                 }
                 .into();
                 blockstore
@@ -7721,6 +7743,7 @@ pub mod tests {
                         post_token_balances,
                         rewards,
                         loaded_addresses: LoadedAddresses::default(),
+                        return_data,
                     },
                 }
             })
@@ -7792,6 +7815,10 @@ pub mod tests {
                 let pre_token_balances = Some(vec![]);
                 let post_token_balances = Some(vec![]);
                 let rewards = Some(vec![]);
+                let return_data = Some(TransactionReturnData {
+                    program_id: Pubkey::new_unique(),
+                    data: vec![1, 2, 3],
+                });
                 let signature = transaction.signatures[0];
                 let status = TransactionStatusMeta {
                     status: Ok(()),
@@ -7804,6 +7831,7 @@ pub mod tests {
                     post_token_balances: post_token_balances.clone(),
                     rewards: rewards.clone(),
                     loaded_addresses: LoadedAddresses::default(),
+                    return_data: return_data.clone(),
                 }
                 .into();
                 blockstore
@@ -7823,6 +7851,7 @@ pub mod tests {
                         post_token_balances,
                         rewards,
                         loaded_addresses: LoadedAddresses::default(),
+                        return_data,
                     },
                 }
             })
@@ -8582,6 +8611,7 @@ pub mod tests {
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
                 loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
             }
             .into();
             transaction_status_cf
@@ -9139,6 +9169,10 @@ pub mod tests {
                 commission: None,
             }]),
             loaded_addresses: LoadedAddresses::default(),
+            return_data: Some(TransactionReturnData {
+                program_id: Pubkey::new_unique(),
+                data: vec![1, 2, 3],
+            }),
         };
         let deprecated_status: StoredTransactionStatusMeta = status.clone().try_into().unwrap();
         let protobuf_status: generated::TransactionStatusMeta = status.into();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -181,6 +181,7 @@ fn execute_batch(
         transaction_status_sender.is_some(),
         transaction_status_sender.is_some(),
         transaction_status_sender.is_some(),
+        transaction_status_sender.is_some(),
         timings,
     );
 
@@ -3507,6 +3508,7 @@ pub mod tests {
         ) = batch.bank().load_execute_and_commit_transactions(
             &batch,
             MAX_PROCESSING_AGE,
+            false,
             false,
             false,
             false,

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -55,6 +55,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-cpi-and-log-storage ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --enable-extended-tx-metadata-storage ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -141,6 +141,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-cpi-and-log-storage ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --enable-extended-tx-metadata-storage ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -280,7 +280,7 @@ EOF
 
     if $maybeFullRpc; then
       args+=(--enable-rpc-transaction-history)
-      args+=(--enable-cpi-and-log-storage)
+      args+=(--enable-extended-tx-metadata-storage)
     fi
 
     if [[ $airdropsEnabled = true ]]; then
@@ -408,7 +408,7 @@ EOF
 
     if $maybeFullRpc; then
       args+=(--enable-rpc-transaction-history)
-      args+=(--enable-cpi-and-log-storage)
+      args+=(--enable-extended-tx-metadata-storage)
     fi
 
 cat >> ~/solana/on-reboot <<EOF

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/solana-labs/solana"
 version = "1.10.4"
 
 [dependencies]
+assert_matches = "1.5.0"
 async-trait = "0.1.52"
 base64 = "0.13.0"
 bincode = "1.3.3"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
 name = "solana-program-test"
 version = "1.10.4"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "base64 0.13.0",
  "bincode",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1997,6 +1997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
+name = "pretty-hex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3244,7 @@ dependencies = [
  "console",
  "humantime",
  "indicatif",
+ "pretty-hex",
  "serde",
  "serde_json",
  "solana-account-decoder",

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -323,6 +323,7 @@ fn process_transaction_and_record_inner(
             false,
             true,
             false,
+            false,
             &mut ExecuteTimings::default(),
         )
         .0;
@@ -364,6 +365,7 @@ fn execute_transactions(
         true,
         true,
         true,
+        true,
         &mut timings,
     );
     let tx_post_token_balances = collect_token_balances(&bank, &batch, &mut mint_decimals);
@@ -392,6 +394,7 @@ fn execute_transactions(
                         log_messages,
                         inner_instructions,
                         durable_nonce_fee,
+                        return_data,
                     } = details;
 
                     let lamports_per_signature = match durable_nonce_fee {
@@ -432,6 +435,7 @@ fn execute_transactions(
                         log_messages,
                         rewards: None,
                         loaded_addresses: LoadedAddresses::default(),
+                        return_data,
                     };
 
                     Ok(ConfirmedTransactionWithStatusMeta {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3551,6 +3551,7 @@ pub mod rpc_full {
                     logs,
                     post_simulation_accounts: _,
                     units_consumed,
+                    return_data,
                 } = preflight_bank.simulate_transaction(transaction)
                 {
                     match err {
@@ -3568,6 +3569,7 @@ pub mod rpc_full {
                             logs: Some(logs),
                             accounts: None,
                             units_consumed: Some(units_consumed),
+                            return_data,
                         },
                     }
                     .into());
@@ -3625,6 +3627,7 @@ pub mod rpc_full {
                 logs,
                 post_simulation_accounts,
                 units_consumed,
+                return_data,
             } = bank.simulate_transaction(transaction);
 
             let accounts = if let Some(config_accounts) = config.accounts {
@@ -3676,6 +3679,7 @@ pub mod rpc_full {
                     logs: Some(logs),
                     accounts,
                     units_consumed: Some(units_consumed),
+                    return_data,
                 },
             ))
         }
@@ -5574,6 +5578,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "returnData":null,
                     "unitsConsumed":0
                 }
             },
@@ -5660,6 +5665,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "returnData":null,
                     "unitsConsumed":0
                 }
             },
@@ -5688,6 +5694,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "returnData":null,
                     "unitsConsumed":0
                 }
             },
@@ -5737,6 +5744,7 @@ pub mod tests {
                     "err":"BlockhashNotFound",
                     "accounts":null,
                     "logs":[],
+                    "returnData":null,
                     "unitsConsumed":0
                 }
             },
@@ -5766,6 +5774,7 @@ pub mod tests {
                         "Program 11111111111111111111111111111111 invoke [1]",
                         "Program 11111111111111111111111111111111 success"
                     ],
+                    "returnData":null,
                     "unitsConsumed":0
                 }
             },
@@ -6123,7 +6132,7 @@ pub mod tests {
         assert_eq!(
             res,
             Some(
-                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","logs":[],"unitsConsumed":0}},"id":1}"#.to_string(),
+                r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Blockhash not found","data":{"accounts":null,"err":"BlockhashNotFound","logs":[],"returnData":null,"unitsConsumed":0}},"id":1}"#.to_string(),
             )
         );
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -143,7 +143,7 @@ fn is_finalized(
 #[derive(Debug, Default, Clone)]
 pub struct JsonRpcConfig {
     pub enable_rpc_transaction_history: bool,
-    pub enable_cpi_and_log_storage: bool,
+    pub enable_cpi_and_log_and_return_data_storage: bool,
     pub faucet_addr: Option<SocketAddr>,
     pub health_check_slot_distance: u64,
     pub rpc_bigtable_config: Option<RpcBigtableConfig>,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -143,7 +143,7 @@ fn is_finalized(
 #[derive(Debug, Default, Clone)]
 pub struct JsonRpcConfig {
     pub enable_rpc_transaction_history: bool,
-    pub enable_cpi_and_log_and_return_data_storage: bool,
+    pub enable_extended_tx_metadata_storage: bool,
     pub faucet_addr: Option<SocketAddr>,
     pub health_check_slot_distance: u64,
     pub rpc_bigtable_config: Option<RpcBigtableConfig>,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -34,7 +34,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: Arc<Blockstore>,
-        enable_cpi_and_log_and_return_data_storage: bool,
+        enable_extended_tx_metadata_storage: bool,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let exit = exit.clone();
@@ -51,7 +51,7 @@ impl TransactionStatusService {
                     enable_rpc_transaction_history,
                     transaction_notifier.clone(),
                     &blockstore,
-                    enable_cpi_and_log_and_return_data_storage,
+                    enable_extended_tx_metadata_storage,
                 ) {
                     break;
                 }
@@ -66,7 +66,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: &Arc<Blockstore>,
-        enable_cpi_and_log_and_return_data_storage: bool,
+        enable_extended_tx_metadata_storage: bool,
     ) -> Result<(), RecvTimeoutError> {
         match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))? {
             TransactionStatusMessage::Batch(TransactionStatusBatch {
@@ -169,8 +169,7 @@ impl TransactionStatusService {
                             );
                         }
 
-                        if !(enable_cpi_and_log_and_return_data_storage
-                            || transaction_notifier.is_some())
+                        if !(enable_extended_tx_metadata_storage || transaction_notifier.is_some())
                         {
                             transaction_status_meta.log_messages.take();
                             transaction_status_meta.inner_instructions.take();

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -34,7 +34,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: Arc<Blockstore>,
-        enable_cpi_and_log_storage: bool,
+        enable_cpi_and_log_and_return_data_storage: bool,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let exit = exit.clone();
@@ -51,7 +51,7 @@ impl TransactionStatusService {
                     enable_rpc_transaction_history,
                     transaction_notifier.clone(),
                     &blockstore,
-                    enable_cpi_and_log_storage,
+                    enable_cpi_and_log_and_return_data_storage,
                 ) {
                     break;
                 }
@@ -66,7 +66,7 @@ impl TransactionStatusService {
         enable_rpc_transaction_history: bool,
         transaction_notifier: Option<TransactionNotifierLock>,
         blockstore: &Arc<Blockstore>,
-        enable_cpi_and_log_storage: bool,
+        enable_cpi_and_log_and_return_data_storage: bool,
     ) -> Result<(), RecvTimeoutError> {
         match write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))? {
             TransactionStatusMessage::Batch(TransactionStatusBatch {
@@ -101,6 +101,7 @@ impl TransactionStatusService {
                             log_messages,
                             inner_instructions,
                             durable_nonce_fee,
+                            return_data,
                         } = details;
                         let lamports_per_signature = match durable_nonce_fee {
                             Some(DurableNonceFee::Valid(lamports_per_signature)) => {
@@ -156,6 +157,7 @@ impl TransactionStatusService {
                             post_token_balances,
                             rewards,
                             loaded_addresses,
+                            return_data,
                         };
 
                         if let Some(transaction_notifier) = transaction_notifier.as_ref() {
@@ -167,9 +169,12 @@ impl TransactionStatusService {
                             );
                         }
 
-                        if !(enable_cpi_and_log_storage || transaction_notifier.is_some()) {
+                        if !(enable_cpi_and_log_and_return_data_storage
+                            || transaction_notifier.is_some())
+                        {
                             transaction_status_meta.log_messages.take();
                             transaction_status_meta.inner_instructions.take();
+                            transaction_status_meta.return_data.take();
                         }
 
                         if enable_rpc_transaction_history {
@@ -347,6 +352,7 @@ pub(crate) mod tests {
                     )
                     .unwrap(),
                 )),
+                return_data: None,
             });
 
         let balances = TransactionBalancesSet {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1374,6 +1374,7 @@ mod tests {
             log_messages: None,
             inner_instructions: None,
             durable_nonce_fee: nonce.map(DurableNonceFee::from),
+            return_data: None,
         })
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -131,7 +131,8 @@ use {
             TransactionVerificationMode, VersionedTransaction,
         },
         transaction_context::{
-            InstructionTrace, TransactionAccount, TransactionContext, TransactionReturnData,
+            InstructionTrace, TransactionAccount, TransactionContext, TransactionRecord,
+            TransactionReturnData,
         },
     },
     solana_stake_program::stake_state::{
@@ -3970,7 +3971,11 @@ impl Bank {
                     .ok()
             });
 
-        let (accounts, instruction_trace, mut return_data) = transaction_context.deconstruct();
+        let TransactionRecord {
+            accounts,
+            instruction_trace,
+            mut return_data,
+        } = transaction_context.into();
         loaded_transaction.accounts = accounts;
 
         let inner_instructions = if enable_cpi_recording {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -130,7 +130,9 @@ use {
             MessageHash, Result, SanitizedTransaction, Transaction, TransactionError,
             TransactionVerificationMode, VersionedTransaction,
         },
-        transaction_context::{InstructionTrace, TransactionAccount, TransactionContext},
+        transaction_context::{
+            InstructionTrace, TransactionAccount, TransactionContext, TransactionReturnData,
+        },
     },
     solana_stake_program::stake_state::{
         self, InflationPointCalculationEvent, PointValue, StakeState,
@@ -579,6 +581,7 @@ pub struct TransactionExecutionDetails {
     pub log_messages: Option<Vec<String>>,
     pub inner_instructions: Option<InnerInstructionsList>,
     pub durable_nonce_fee: Option<DurableNonceFee>,
+    pub return_data: Option<TransactionReturnData>,
 }
 
 /// Type safe representation of a transaction execution attempt which
@@ -3541,6 +3544,7 @@ impl Bank {
             MAX_PROCESSING_AGE - MAX_TRANSACTION_FORWARDING_DELAY,
             false,
             true,
+            true,
             &mut timings,
         );
 
@@ -3858,6 +3862,7 @@ impl Bank {
 
     /// Execute a transaction using the provided loaded accounts and update
     /// the executors cache if the transaction was successful.
+    #[allow(clippy::too_many_arguments)]
     fn execute_loaded_transaction(
         &self,
         tx: &SanitizedTransaction,
@@ -3866,6 +3871,7 @@ impl Bank {
         durable_nonce_fee: Option<DurableNonceFee>,
         enable_cpi_recording: bool,
         enable_log_recording: bool,
+        enable_return_data_recording: bool,
         timings: &mut ExecuteTimings,
         error_counters: &mut ErrorCounters,
     ) -> TransactionExecutionResult {
@@ -3960,7 +3966,7 @@ impl Bank {
                     .ok()
             });
 
-        let (accounts, instruction_trace) = transaction_context.deconstruct();
+        let (accounts, instruction_trace, mut return_data) = transaction_context.deconstruct();
         loaded_transaction.accounts = accounts;
 
         let inner_instructions = if enable_cpi_recording {
@@ -3971,11 +3977,25 @@ impl Bank {
             None
         };
 
+        let return_data = if enable_return_data_recording {
+            if let Some(end_index) = return_data.data.iter().rposition(|&x| x != 0) {
+                let end_index = end_index.saturating_add(1);
+                error!("end index {}", end_index);
+                return_data.data.truncate(end_index);
+                Some(return_data)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         TransactionExecutionResult::Executed(TransactionExecutionDetails {
             status,
             log_messages,
             inner_instructions,
             durable_nonce_fee,
+            return_data,
         })
     }
 
@@ -3986,6 +4006,7 @@ impl Bank {
         max_age: usize,
         enable_cpi_recording: bool,
         enable_log_recording: bool,
+        enable_return_data_recording: bool,
         timings: &mut ExecuteTimings,
     ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
@@ -4089,6 +4110,7 @@ impl Bank {
                         durable_nonce_fee,
                         enable_cpi_recording,
                         enable_log_recording,
+                        enable_return_data_recording,
                         timings,
                         &mut error_counters,
                     )
@@ -5240,6 +5262,7 @@ impl Bank {
         collect_balances: bool,
         enable_cpi_recording: bool,
         enable_log_recording: bool,
+        enable_return_data_recording: bool,
         timings: &mut ExecuteTimings,
     ) -> (TransactionResults, TransactionBalancesSet) {
         let pre_balances = if collect_balances {
@@ -5260,6 +5283,7 @@ impl Bank {
             max_age,
             enable_cpi_recording,
             enable_log_recording,
+            enable_return_data_recording,
             timings,
         );
 
@@ -5343,6 +5367,7 @@ impl Bank {
         self.load_execute_and_commit_transactions(
             batch,
             MAX_PROCESSING_AGE,
+            false,
             false,
             false,
             false,
@@ -6774,6 +6799,7 @@ pub(crate) mod tests {
             message::{Message, MessageHeader},
             nonce,
             poh_config::PohConfig,
+            program::MAX_RETURN_DATA,
             rent::Rent,
             signature::{keypair_from_seed, Keypair, Signer},
             stake::{
@@ -6813,6 +6839,7 @@ pub(crate) mod tests {
             log_messages: None,
             inner_instructions: None,
             durable_nonce_fee: nonce.map(DurableNonceFee::from),
+            return_data: None,
         })
     }
 
@@ -9949,6 +9976,7 @@ pub(crate) mod tests {
                 false,
                 false,
                 false,
+                false,
                 &mut ExecuteTimings::default(),
             )
             .0
@@ -12480,6 +12508,7 @@ pub(crate) mod tests {
                 &lock_result,
                 MAX_PROCESSING_AGE,
                 true,
+                false,
                 false,
                 false,
                 &mut ExecuteTimings::default(),
@@ -15407,6 +15436,7 @@ pub(crate) mod tests {
                 false,
                 false,
                 true,
+                false,
                 &mut ExecuteTimings::default(),
             )
             .0
@@ -15447,6 +15477,91 @@ pub(crate) mod tests {
         assert!(failure_log_info.result.is_err());
         let failure_log = failure_log_info.log_messages.clone().pop().unwrap();
         assert!(failure_log.contains(&"failed".to_string()));
+    }
+
+    #[test]
+    fn test_tx_return_data() {
+        solana_logger::setup();
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(
+            1_000_000_000_000_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        );
+        let mut bank = Bank::new_for_tests(&genesis_config);
+
+        let mock_program_id = Pubkey::new(&[2u8; 32]);
+        fn mock_process_instruction(
+            _first_instruction_account: usize,
+            data: &[u8],
+            invoke_context: &mut InvokeContext,
+        ) -> result::Result<(), InstructionError> {
+            let mock_program_id = Pubkey::new(&[2u8; 32]);
+            let transaction_context = &mut invoke_context.transaction_context;
+            let mut return_data = [0u8; MAX_RETURN_DATA];
+            if !data.is_empty() {
+                let index = usize::from_le_bytes(data.try_into().unwrap());
+                return_data[index] = 1;
+                transaction_context
+                    .set_return_data(mock_program_id, return_data.to_vec())
+                    .unwrap();
+            }
+            Ok(())
+        }
+        let blockhash = bank.last_blockhash();
+        bank.add_builtin("mock_program", &mock_program_id, mock_process_instruction);
+
+        for index in [
+            None,
+            Some(0),
+            Some(MAX_RETURN_DATA / 2),
+            Some(MAX_RETURN_DATA - 1),
+        ] {
+            let data = if let Some(index) = index {
+                usize::to_le_bytes(index).to_vec()
+            } else {
+                Vec::new()
+            };
+            let txs = vec![Transaction::new_signed_with_payer(
+                &[Instruction {
+                    program_id: mock_program_id,
+                    data,
+                    accounts: vec![AccountMeta::new(Pubkey::new_unique(), false)],
+                }],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                blockhash,
+            )];
+            let batch = bank.prepare_batch_for_tests(txs);
+            let return_data = bank
+                .load_execute_and_commit_transactions(
+                    &batch,
+                    MAX_PROCESSING_AGE,
+                    false,
+                    false,
+                    false,
+                    true,
+                    &mut ExecuteTimings::default(),
+                )
+                .0
+                .execution_results[0]
+                .details()
+                .unwrap()
+                .return_data
+                .clone();
+            if let Some(index) = index {
+                let return_data = return_data.unwrap();
+                assert_eq!(return_data.program_id, mock_program_id);
+                let mut expected_data = vec![0u8; index];
+                expected_data.push(1u8);
+                assert_eq!(return_data.data, expected_data);
+            } else {
+                assert!(return_data.is_none());
+            }
+        }
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -131,7 +131,7 @@ use {
             TransactionVerificationMode, VersionedTransaction,
         },
         transaction_context::{
-            InstructionTrace, TransactionAccount, TransactionContext, TransactionRecord,
+            ExecutionRecord, InstructionTrace, TransactionAccount, TransactionContext,
             TransactionReturnData,
         },
     },
@@ -3971,7 +3971,7 @@ impl Bank {
                     .ok()
             });
 
-        let TransactionRecord {
+        let ExecutionRecord {
             accounts,
             instruction_trace,
             mut return_data,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -673,6 +673,7 @@ pub struct TransactionSimulationResult {
     pub logs: TransactionLogMessages,
     pub post_simulation_accounts: Vec<TransactionAccount>,
     pub units_consumed: u64,
+    pub return_data: Option<TransactionReturnData>,
 }
 pub struct TransactionBalancesSet {
     pub pre_balances: TransactionBalances,
@@ -3575,17 +3576,20 @@ impl Bank {
 
         let execution_result = execution_results.pop().unwrap();
         let flattened_result = execution_result.flattened_result();
-        let logs = match execution_result {
-            TransactionExecutionResult::Executed(details) => details.log_messages,
-            TransactionExecutionResult::NotExecuted(_) => None,
-        }
-        .unwrap_or_default();
+        let (logs, return_data) = match execution_result {
+            TransactionExecutionResult::Executed(details) => {
+                (details.log_messages, details.return_data)
+            }
+            TransactionExecutionResult::NotExecuted(_) => (None, None),
+        };
+        let logs = logs.unwrap_or_default();
 
         TransactionSimulationResult {
             result: flattened_result,
             logs,
             post_simulation_accounts,
             units_consumed,
+            return_data,
         }
     }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -108,7 +108,7 @@ args=(
   --rpc-faucet-address 127.0.0.1:9900
   --log -
   --enable-rpc-transaction-history
-  --enable-cpi-and-log-storage
+  --enable-extended-tx-metadata-storage
   --init-complete-file "$dataDir"/init-completed
   --snapshot-compression none
   --require-tower

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -622,13 +622,13 @@ impl<'a> BorrowedAccount<'a> {
 }
 
 /// Everything that needs to be recorded from a TransactionContext after execution
-pub struct TransactionRecord {
+pub struct ExecutionRecord {
     pub accounts: Vec<TransactionAccount>,
     pub instruction_trace: InstructionTrace,
     pub return_data: TransactionReturnData,
 }
 /// Used by the bank in the runtime to write back the processed accounts and recorded instructions
-impl From<TransactionContext> for TransactionRecord {
+impl From<TransactionContext> for ExecutionRecord {
     fn from(context: TransactionContext) -> Self {
         Self {
             accounts: Vec::from(Pin::into_inner(context.account_keys))

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -792,7 +792,7 @@ mod tests {
         prost::Message,
         solana_sdk::{
             hash::Hash, message::v0::LoadedAddresses, signature::Keypair, system_transaction,
-            transaction::VersionedTransaction,
+            transaction::VersionedTransaction, transaction_context::TransactionReturnData,
         },
         solana_storage_proto::convert::generated,
         solana_transaction_status::{
@@ -842,6 +842,7 @@ mod tests {
                 post_token_balances: Some(vec![]),
                 rewards: Some(vec![]),
                 loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
             },
         });
         let expected_block = ConfirmedBlock {
@@ -899,6 +900,7 @@ mod tests {
                 meta.pre_token_balances = None; // Legacy bincode implementation does not support token balances
                 meta.post_token_balances = None; // Legacy bincode implementation does not support token balances
                 meta.rewards = None; // Legacy bincode implementation does not support rewards
+                meta.return_data = None; // Legacy bincode implementation does not support return data
             }
             assert_eq!(block, bincode_block.into());
         } else {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -237,6 +237,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             post_token_balances: None,
             rewards: None,
             loaded_addresses: LoadedAddresses::default(),
+            return_data: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -57,6 +57,8 @@ message TransactionStatusMeta {
     repeated Reward rewards = 9;
     repeated bytes loaded_writable_addresses = 12;
     repeated bytes loaded_readonly_addresses = 13;
+    ReturnData return_data = 14;
+    bool return_data_none = 15;
 }
 
 message TransactionError {
@@ -86,6 +88,11 @@ message UiTokenAmount {
     uint32 decimals = 2;
     string amount = 3;
     string ui_amount_string = 4;
+}
+
+message ReturnData {
+    bytes program_id = 1;
+    bytes data = 2;
 }
 
 enum RewardType {

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -6,6 +6,7 @@ use {
     },
     solana_sdk::{
         deserialize_utils::default_on_eof, message::v0::LoadedAddresses, transaction::Result,
+        transaction_context::TransactionReturnData,
     },
     solana_transaction_status::{
         InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
@@ -167,6 +168,8 @@ pub struct StoredTransactionStatusMeta {
     pub post_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
     #[serde(deserialize_with = "default_on_eof")]
     pub rewards: Option<Vec<StoredExtendedReward>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub return_data: Option<TransactionReturnData>,
 }
 
 impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
@@ -181,6 +184,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             pre_token_balances,
             post_token_balances,
             rewards,
+            return_data,
         } = value;
         Self {
             status,
@@ -196,6 +200,7 @@ impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
             rewards: rewards
                 .map(|rewards| rewards.into_iter().map(|reward| reward.into()).collect()),
             loaded_addresses: LoadedAddresses::default(),
+            return_data,
         }
     }
 }
@@ -214,6 +219,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
             post_token_balances,
             rewards,
             loaded_addresses,
+            return_data,
         } = value;
 
         if !loaded_addresses.is_empty() {
@@ -237,6 +243,7 @@ impl TryFrom<TransactionStatusMeta> for StoredTransactionStatusMeta {
                 .map(|balances| balances.into_iter().map(|balance| balance.into()).collect()),
             rewards: rewards
                 .map(|rewards| rewards.into_iter().map(|reward| reward.into()).collect()),
+            return_data,
         })
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -22,6 +22,7 @@ use {
             Result as TransactionResult, Transaction, TransactionError, TransactionVersion,
             VersionedTransaction,
         },
+        transaction_context::TransactionReturnData,
     },
     std::fmt,
     thiserror::Error,
@@ -279,6 +280,7 @@ pub struct TransactionStatusMeta {
     pub post_token_balances: Option<Vec<TransactionTokenBalance>>,
     pub rewards: Option<Rewards>,
     pub loaded_addresses: LoadedAddresses,
+    pub return_data: Option<TransactionReturnData>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -294,6 +296,7 @@ impl Default for TransactionStatusMeta {
             post_token_balances: None,
             rewards: None,
             loaded_addresses: LoadedAddresses::default(),
+            return_data: None,
         }
     }
 }
@@ -314,6 +317,7 @@ pub struct UiTransactionStatusMeta {
     pub rewards: Option<Rewards>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub loaded_addresses: Option<UiLoadedAddresses>,
+    pub return_data: Option<TransactionReturnData>,
 }
 
 /// A duplicate representation of LoadedAddresses
@@ -364,6 +368,7 @@ impl UiTransactionStatusMeta {
                 .map(|balance| balance.into_iter().map(Into::into).collect()),
             rewards: meta.rewards,
             loaded_addresses: Some(UiLoadedAddresses::from(&meta.loaded_addresses)),
+            return_data: meta.return_data,
         }
     }
 }
@@ -388,6 +393,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
                 .map(|balance| balance.into_iter().map(Into::into).collect()),
             rewards: meta.rewards,
             loaded_addresses: Some(UiLoadedAddresses::from(&meta.loaded_addresses)),
+            return_data: meta.return_data,
         }
     }
 }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -657,7 +657,7 @@ fn main() {
         )
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,
-            enable_cpi_and_log_storage: true,
+            enable_cpi_and_log_and_return_data_storage: true,
             rpc_bigtable_config,
             faucet_addr,
             ..JsonRpcConfig::default_for_test()

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -657,7 +657,7 @@ fn main() {
         )
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,
-            enable_cpi_and_log_and_return_data_storage: true,
+            enable_extended_tx_metadata_storage: true,
             rpc_bigtable_config,
             faucet_addr,
             ..JsonRpcConfig::default_for_test()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -656,8 +656,18 @@ pub fn main() {
                 .long("enable-cpi-and-log-storage")
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
-                .help("Include CPI inner instructions and logs in the \
-                        historical transaction info stored"),
+                .hidden(true)
+                .help("Deprecated, please use \"enable-cpi-and-log-and-return-data-storage\". \
+                       Include CPI inner instructions, logs and return data in \
+                       the historical transaction info stored"),
+        )
+        .arg(
+            Arg::with_name("enable_cpi_and_log_and_return_data_storage")
+                .long("enable-cpi-and-log-and-return-data-storage")
+                .requires("enable_rpc_transaction_history")
+                .takes_value(false)
+                .help("Include CPI inner instructions, logs, and return data in \
+                       the historical transaction info stored"),
         )
         .arg(
             Arg::with_name("rpc_max_multiple_accounts")
@@ -2282,7 +2292,11 @@ pub fn main() {
     };
 
     if matches.is_present("minimal_rpc_api") {
-        warn!("--minimal-rpc-api is now the default behavior. This flag is deprecated and can be removed from the launch args")
+        warn!("--minimal-rpc-api is now the default behavior. This flag is deprecated and can be removed from the launch args");
+    }
+
+    if matches.is_present("enable_cpi_and_log_storage") {
+        warn!("--enable-cpi-and-log-storage is deprecated. Please update the launch args to use --enable-cpi-and-log-and-return-data-storage and remove --enable-cpi-and-log-storage");
     }
 
     let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
@@ -2313,7 +2327,9 @@ pub fn main() {
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
-            enable_cpi_and_log_storage: matches.is_present("enable_cpi_and_log_storage"),
+            enable_cpi_and_log_and_return_data_storage: matches
+                .is_present("enable_cpi_and_log_storage")
+                || matches.is_present("enable_cpi_and_log_and_return_data_storage"),
             rpc_bigtable_config,
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -657,13 +657,13 @@ pub fn main() {
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
                 .hidden(true)
-                .help("Deprecated, please use \"enable-cpi-and-log-and-return-data-storage\". \
+                .help("Deprecated, please use \"enable-extended-tx-metadata-storage\". \
                        Include CPI inner instructions, logs and return data in \
                        the historical transaction info stored"),
         )
         .arg(
-            Arg::with_name("enable_cpi_and_log_and_return_data_storage")
-                .long("enable-cpi-and-log-and-return-data-storage")
+            Arg::with_name("enable_extended_tx_metadata_storage")
+                .long("enable-extended-tx-metadata-storage")
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
                 .help("Include CPI inner instructions, logs, and return data in \
@@ -2296,7 +2296,11 @@ pub fn main() {
     }
 
     if matches.is_present("enable_cpi_and_log_storage") {
-        warn!("--enable-cpi-and-log-storage is deprecated. Please update the launch args to use --enable-cpi-and-log-and-return-data-storage and remove --enable-cpi-and-log-storage");
+        warn!(
+            "--enable-cpi-and-log-storage is deprecated. Please update the \
+            launch args to use --enable-extended-tx-metadata-storage and remove \
+            --enable-cpi-and-log-storage"
+        );
     }
 
     let rpc_bigtable_config = if matches.is_present("enable_rpc_bigtable_ledger_storage")
@@ -2327,9 +2331,8 @@ pub fn main() {
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
-            enable_cpi_and_log_and_return_data_storage: matches
-                .is_present("enable_cpi_and_log_storage")
-                || matches.is_present("enable_cpi_and_log_and_return_data_storage"),
+            enable_extended_tx_metadata_storage: matches.is_present("enable_cpi_and_log_storage")
+                || matches.is_present("enable_extended_tx_metadata_storage"),
             rpc_bigtable_config,
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")


### PR DESCRIPTION
#### Problem

Programs can set return data, but that information isn't propagated outside of programs.

#### Summary of Changes

Expose all return data information by adding it in `TransactionStatusMeta` and `TransactionSimulationResults`.  For (slightly?) easier review, the first commit is just adding all of the wiring everywhere to expose in the meta, and the second commit is all about adding it to simulations.

The bank only propagates return data if it's not all 0, and cuts off at the first non-zero byte starting from the end.

Fixes #
