### PR TITLE
Wrap CostTracker limits in an Option

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -178,7 +178,7 @@ fn main() {
     // set cost tracker limits to MAX so it will not filter out TXs
     bank.write_cost_tracker()
         .unwrap()
-        .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
+        .set_limits(None, None, None);
 
     info!("threads: {} txs: {}", num_threads, total_num_transactions);
 
@@ -341,11 +341,9 @@ fn main() {
                 insert_time.stop();
 
                 // set cost tracker limits to MAX so it will not filter out TXs
-                bank.write_cost_tracker().unwrap().set_limits(
-                    std::u64::MAX,
-                    std::u64::MAX,
-                    std::u64::MAX,
-                );
+                bank.write_cost_tracker()
+                    .unwrap()
+                    .set_limits(None, None, None);
 
                 poh_recorder.lock().unwrap().set_bank(&bank);
                 assert!(poh_recorder.lock().unwrap().bank().is_some());

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -180,7 +180,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     // set cost tracker limits to MAX so it will not filter out TXs
     bank.write_cost_tracker()
         .unwrap()
-        .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
+        .set_limits(None, None, None);
 
     debug!("threads: {} txs: {}", num_threads, txes);
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -3179,7 +3179,7 @@ mod tests {
         // set cost tracker limits to MAX so it will not filter out TXs
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
+            .set_limits(None, None, None);
 
         // Transfer more than the balance of the mint keypair, should cause a
         // InstructionError::InsufficientFunds that is then committed. Needs to be
@@ -3239,7 +3239,7 @@ mod tests {
         // set cost tracker limits to MAX so it will not filter out TXs
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
+            .set_limits(None, None, None);
 
         // Make all repetitive transactions that conflict on the `mint_keypair`, so only 1 should be executed
         let mut transactions = vec![

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -556,9 +556,11 @@ mod tests {
 
         // set cost tracker limit to fit 1 transfer tx and 1 vote tx
         let cost_limit = transfer_tx_cost + vote_tx_cost;
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(cost_limit, cost_limit, cost_limit);
+        bank.write_cost_tracker().unwrap().set_limits(
+            Some(cost_limit),
+            Some(cost_limit),
+            Some(cost_limit),
+        );
         let (results, num_selected) =
             qos_service.select_transactions_per_cost(txs.iter(), txs_costs.iter(), &bank);
         assert_eq!(num_selected, 2);


### PR DESCRIPTION
#### Problem
`CostTracker` limit fields were being set to `u64::MAX` to represent "no limit". 

#### Summary of Changes
This wraps the limit fields in an `Option` type, so we can represent this as `Option::None`.

cc @brooksprumo 

Fixes #
[#23612](https://github.com/solana-labs/solana/issues/23612)