### PR TITLE
Make solana-address-lookup-table-program crate bpf compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,6 +4243,7 @@ dependencies = [
  "serde",
  "solana-frozen-abi 1.10.3",
  "solana-frozen-abi-macro 1.10.3",
+ "solana-program 1.10.3",
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",

--- a/programs/address-lookup-table/Cargo.toml
+++ b/programs/address-lookup-table/Cargo.toml
@@ -18,9 +18,12 @@ num-traits = "0.2"
 serde = { version = "1.0.136", features = ["derive"] }
 solana-frozen-abi = { path = "../../frozen-abi", version = "=1.10.3" }
 solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "=1.10.3" }
+solana-program = { path = "../../sdk/program", version = "=1.10.3" }
+thiserror = "1.0"
+
+[target.'cfg(not(target_arch = "bpf"))'.dependencies]
 solana-program-runtime = { path = "../../program-runtime", version = "=1.10.3" }
 solana-sdk = { path = "../../sdk", version = "=1.10.3" }
-thiserror = "1.0"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/address-lookup-table/src/error.rs
+++ b/programs/address-lookup-table/src/error.rs
@@ -1,0 +1,34 @@
+#[cfg(not(target_arch = "bpf"))]
+use solana_sdk::transaction::TransactionError;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum AddressLookupError {
+    /// Attempted to lookup addresses from a table that does not exist
+    #[error("Attempted to lookup addresses from a table that does not exist")]
+    LookupTableAccountNotFound,
+
+    /// Attempted to lookup addresses from an account owned by the wrong program
+    #[error("Attempted to lookup addresses from an account owned by the wrong program")]
+    InvalidAccountOwner,
+
+    /// Attempted to lookup addresses from an invalid account
+    #[error("Attempted to lookup addresses from an invalid account")]
+    InvalidAccountData,
+
+    /// Address lookup contains an invalid index
+    #[error("Address lookup contains an invalid index")]
+    InvalidLookupIndex,
+}
+
+#[cfg(not(target_arch = "bpf"))]
+impl From<AddressLookupError> for TransactionError {
+    fn from(err: AddressLookupError) -> Self {
+        match err {
+            AddressLookupError::LookupTableAccountNotFound => Self::AddressLookupTableNotFound,
+            AddressLookupError::InvalidAccountOwner => Self::InvalidAddressLookupTableOwner,
+            AddressLookupError::InvalidAccountData => Self::InvalidAddressLookupTableData,
+            AddressLookupError::InvalidLookupIndex => Self::InvalidAddressLookupTableIndex,
+        }
+    }
+}

--- a/programs/address-lookup-table/src/instruction.rs
+++ b/programs/address-lookup-table/src/instruction.rs
@@ -1,7 +1,7 @@
 use {
     crate::id,
     serde::{Deserialize, Serialize},
-    solana_sdk::{
+    solana_program::{
         clock::Slot,
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,

--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -2,9 +2,11 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
-use solana_sdk::declare_id;
+use solana_program::declare_id;
 
+pub mod error;
 pub mod instruction;
+#[cfg(not(target_arch = "bpf"))]
 pub mod processor;
 pub mod state;
 

--- a/programs/address-lookup-table/src/state.rs
+++ b/programs/address-lookup-table/src/state.rs
@@ -1,12 +1,12 @@
 use {
+    crate::error::AddressLookupError,
     serde::{Deserialize, Serialize},
     solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample},
-    solana_sdk::{
+    solana_program::{
         clock::Slot,
         instruction::InstructionError,
         pubkey::Pubkey,
         slot_hashes::{SlotHashes, MAX_ENTRIES},
-        transaction::AddressLookupError,
     },
     std::borrow::Cow,
 };

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "serde",
  "solana-frozen-abi 1.10.3",
  "solana-frozen-abi-macro 1.10.3",
+ "solana-program 1.10.3",
  "solana-program-runtime",
  "solana-sdk",
  "thiserror",
@@ -2857,6 +2858,7 @@ name = "solana-bpf-rust-dep-crate"
 version = "1.10.3"
 dependencies = [
  "byteorder 1.4.3",
+ "solana-address-lookup-table-program",
  "solana-program 1.10.3",
 ]
 

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2021"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 solana-program = { path = "../../../../sdk/program", version = "=1.10.3" }
+# list of crates which must be buildable for bpf programs
+solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.10.3" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -23,7 +23,7 @@ use {
     },
     log::*,
     rand::{thread_rng, Rng},
-    solana_address_lookup_table_program::state::AddressLookupTable,
+    solana_address_lookup_table_program::{error::AddressLookupError, state::AddressLookupTable},
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,
@@ -43,10 +43,7 @@ use {
         slot_hashes::SlotHashes,
         system_program,
         sysvar::{self, instructions::construct_instructions_data},
-        transaction::{
-            AddressLookupError, Result, SanitizedTransaction, TransactionAccountLocks,
-            TransactionError,
-        },
+        transaction::{Result, SanitizedTransaction, TransactionAccountLocks, TransactionError},
         transaction_context::TransactionAccount,
     },
     std::{

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -1,10 +1,9 @@
 use {
     super::Bank,
+    solana_address_lookup_table_program::error::AddressLookupError,
     solana_sdk::{
         message::v0::{LoadedAddresses, MessageAddressTableLookup},
-        transaction::{
-            AddressLoader, AddressLookupError, Result as TransactionResult, TransactionError,
-        },
+        transaction::{AddressLoader, Result as TransactionResult, TransactionError},
     },
 };
 

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -150,33 +150,3 @@ impl From<SanitizeMessageError> for TransactionError {
         Self::SanitizeFailure
     }
 }
-
-#[derive(Debug, Error, PartialEq, Eq, Clone)]
-pub enum AddressLookupError {
-    /// Attempted to lookup addresses from a table that does not exist
-    #[error("Attempted to lookup addresses from a table that does not exist")]
-    LookupTableAccountNotFound,
-
-    /// Attempted to lookup addresses from an account owned by the wrong program
-    #[error("Attempted to lookup addresses from an account owned by the wrong program")]
-    InvalidAccountOwner,
-
-    /// Attempted to lookup addresses from an invalid account
-    #[error("Attempted to lookup addresses from an invalid account")]
-    InvalidAccountData,
-
-    /// Address lookup contains an invalid index
-    #[error("Address lookup contains an invalid index")]
-    InvalidLookupIndex,
-}
-
-impl From<AddressLookupError> for TransactionError {
-    fn from(err: AddressLookupError) -> Self {
-        match err {
-            AddressLookupError::LookupTableAccountNotFound => Self::AddressLookupTableNotFound,
-            AddressLookupError::InvalidAccountOwner => Self::InvalidAddressLookupTableOwner,
-            AddressLookupError::InvalidAccountData => Self::InvalidAddressLookupTableData,
-            AddressLookupError::InvalidLookupIndex => Self::InvalidAddressLookupTableIndex,
-        }
-    }
-}


### PR DESCRIPTION
#### Problem
The `solana-address-lookup-table-program` crate cannot be used as a dependency when building bpf programs

#### Summary of Changes
- Use `cfg` attributes to disable BPF incompatible dependencies and instruction processing
- Moved `AddressLookupError` to the `solana-address-lookup-table-program` to make state types usable without a `solana-sdk` dependency.
- Added `solana-address-lookup-table-program` as a dependency for the `dep-crate` test program to ensure that compatibility is preserved in the future


Fixes https://github.com/solana-labs/solana/issues/23410
