### PR TITLE
chore: increase ledger size for validator in tests

### DIFF
--- a/web3.js/.travis/script.sh
+++ b/web3.js/.travis/script.sh
@@ -12,4 +12,4 @@ test -r lib/index.esm.js
 npm run doc
 npm run lint
 npm run codecov
-npm run test:live-with-test-validator
+DEBUG=start-server-and-test npm run test:live-with-test-validator

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -55,7 +55,7 @@
     "test": "mocha -r ts-node/register './test/**/*.test.ts'",
     "test:cover": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' nyc --reporter=lcov mocha -r ts-node/register './test/**/*.test.ts'",
     "test:live": "TEST_LIVE=1 npm run test",
-    "test:live-with-test-validator": "start-server-and-test 'solana-test-validator --limit-ledger-size 1000000 --reset --quiet' http://localhost:8899/health test:live"
+    "test:live-with-test-validator": "start-server-and-test 'solana-test-validator --limit-ledger-size 100000 --reset --quiet' http://localhost:8899/health test:live"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -55,7 +55,7 @@
     "test": "mocha -r ts-node/register './test/**/*.test.ts'",
     "test:cover": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' nyc --reporter=lcov mocha -r ts-node/register './test/**/*.test.ts'",
     "test:live": "TEST_LIVE=1 npm run test",
-    "test:live-with-test-validator": "start-server-and-test 'solana-test-validator --reset --quiet' http://localhost:8899/health test:live"
+    "test:live-with-test-validator": "start-server-and-test 'solana-test-validator --limit-ledger-size 1000000 --reset --quiet' http://localhost:8899/health test:live"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",


### PR DESCRIPTION
#### Problem

During web3.js tests, sometimes data isn't found because it's been purged from the ledger.

#### Summary of Changes

Increase the test validator ledger size from the default of 10,000 to 1,000,000.

Fixes #23615
