### PR TITLE
docs: Update CTA for tech support to have StackOverflow

### DIFF
--- a/docs/src/developing/on-chain-programs/faq.md
+++ b/docs/src/developing/on-chain-programs/faq.md
@@ -6,8 +6,7 @@ When writing or interacting with Solana programs, there are common questions or
 challenges that often come up. Below are resources to help answer these
 questions.
 
-If not addressed here, the Solana [#developers](https://discord.gg/RxeGBH)
-Discord channel is a great resource.
+If not addressed here, ask on [StackOverflow](https://stackoverflow.com/questions/tagged/solana) with the `solana` tag or check out the Solana [#developer-support](https://discord.gg/RxeGBH)
 
 ## `CallDepth` error
 

--- a/docs/src/wallet-guide/support.md
+++ b/docs/src/wallet-guide/support.md
@@ -11,6 +11,4 @@ with the latest available features.
 If you have questions after reading the docs, feel free to reach out to us on
 our [Telegram](https://t.me/solana).
 
-For **technical support**, reach out to us on
-[Discord](https://discordapp.com/invite/pquxPsq), using the #wallet-support
-channel in our Community section.
+For **technical support**, please ask a question on [StackOverflow](https://stackoverflow.com/questions/tagged/solana) and tag your questions with `solana`.


### PR DESCRIPTION
#### Problem

Docs currently push developers towards Discord for their problems. While Discord does give a personal touch it is not scalable or indexed on Google.

#### Summary of Changes

Add StackOverflow CTA to help populate more questions by devs there and have them indexed by Google over time. Will update to the Solana specific StackExchange once available.
