### PR TITLE
Pin version for publish cargo-check

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -70,7 +70,7 @@ for Cargo_toml in $Cargo_tomls; do
         rm -rf crate-test
         "$cargo" stable init crate-test
         cd crate-test/
-        echo "${crate_name} = \"${expectedCrateVersion}\"" >> Cargo.toml
+        echo "${crate_name} = \"=${expectedCrateVersion}\"" >> Cargo.toml
         echo "[workspace]" >> Cargo.toml
         "$cargo" stable check
       ) && really_uploaded=1


### PR DESCRIPTION
#### Problem
The crate check in `ci/publish-crates.sh` can pull a newer release of the crate just uploaded, if such exists. This can break the job, if there are build conflicts/errors between the versions. Not sure if this could happen on a CI agent, but it definitely happens locally, which makes manually publishing a pain.


#### Summary of Changes
Pin the version in the generated Cargo.toml to prevent this
