### PR TITLE
Expose rpcEndpoint in Connection for web3.js

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2231,6 +2231,13 @@ export class Connection {
   }
 
   /**
+   * The RPC endpoint
+   */
+  get rpcEndpoint(): string {
+    return this._rpcEndpoint;
+  }
+
+  /**
    * Fetch the balance for the specified public key, return with context
    */
   async getBalanceAndContext(


### PR DESCRIPTION
Adds a getter to the connection class to expose the rpcEndpoint property.

#### Problem
The rpc endpoint is not exposed. Makes it slightly annoying to have to pass around the endpoint while its just sitting there hidden in the connection object


#### Summary of Changes
Exposes the RPC endpoint.


Fixes #
