### PR TITLE
Set accounts_data_len on feature activation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1936,7 +1936,6 @@ impl Bank {
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         additional_builtins: Option<&Builtins>,
         debug_do_not_add_builtins: bool,
-        // bprumo TODO: remove param vv and get accounts_data_len from fields
         accounts_data_len: u64,
     ) -> Self {
         fn new<T: Default>() -> T {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6428,6 +6428,13 @@ impl Bank {
             self.reconfigure_token2_native_mint();
         }
         self.ensure_no_storage_rewards_pool();
+
+        if new_feature_activations.contains(&feature_set::cap_accounts_data_len::id()) {
+            // bprumo TODO:
+            const BPRUMO_TODO_STARTING_ACCOUNTS_DATA_LEN: u64 = 50_000_000_000;
+            let accounts_data_len = BPRUMO_TODO_STARTING_ACCOUNTS_DATA_LEN;
+            self.store_accounts_data_len(accounts_data_len);
+        }
     }
 
     fn adjust_sysvar_balance_for_rent(&self, account: &mut AccountSharedData) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6431,14 +6431,8 @@ impl Bank {
         self.ensure_no_storage_rewards_pool();
 
         if new_feature_activations.contains(&feature_set::cap_accounts_data_len::id()) {
-            // bprumo TODO: get good starting numbers for the clusters
-            let accounts_data_len = match self.cluster_type() {
-                ClusterType::Testnet => todo!(),
-                ClusterType::MainnetBeta => 50_000_000_000,
-                ClusterType::Devnet => todo!(),
-                ClusterType::Development => todo!(),
-            };
-            self.store_accounts_data_len(accounts_data_len);
+            const ACCOUNTS_DATA_LEN: u64 = 50_000_000_000;
+            self.store_accounts_data_len(ACCOUNTS_DATA_LEN);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1936,6 +1936,7 @@ impl Bank {
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         additional_builtins: Option<&Builtins>,
         debug_do_not_add_builtins: bool,
+        // bprumo TODO: remove param vv and get accounts_data_len from fields
         accounts_data_len: u64,
     ) -> Self {
         fn new<T: Default>() -> T {
@@ -6430,9 +6431,13 @@ impl Bank {
         self.ensure_no_storage_rewards_pool();
 
         if new_feature_activations.contains(&feature_set::cap_accounts_data_len::id()) {
-            // bprumo TODO:
-            const BPRUMO_TODO_STARTING_ACCOUNTS_DATA_LEN: u64 = 50_000_000_000;
-            let accounts_data_len = BPRUMO_TODO_STARTING_ACCOUNTS_DATA_LEN;
+            // bprumo TODO: get good starting numbers for the clusters
+            let accounts_data_len = match self.cluster_type() {
+                ClusterType::Testnet => todo!(),
+                ClusterType::MainnetBeta => 50_000_000_000,
+                ClusterType::Devnet => todo!(),
+                ClusterType::Development => todo!(),
+            };
             self.store_accounts_data_len(accounts_data_len);
         }
     }


### PR DESCRIPTION
#### Problem

`Bank::accounts_data_len` does not have a cluster-wide deterministic starting value.

#### Summary of Changes

On feature activation, set the `Bank::accounts_data_len`.

Part of #21604 