### PR TITLE
AcctIdx: move write to disk outside in mem write lock

### DIFF
--- a/runtime/src/bucket_map_holder_stats.rs
+++ b/runtime/src/bucket_map_holder_stats.rs
@@ -43,7 +43,8 @@ pub struct BucketMapHolderStats {
     pub get_range_us: AtomicU64,
     last_age: AtomicU8,
     last_ages_flushed: AtomicU64,
-    pub flush_scan_update_us: AtomicU64,
+    pub flush_scan_us: AtomicU64,
+    pub flush_update_us: AtomicU64,
     pub flush_remove_us: AtomicU64,
     pub flush_grow_us: AtomicU64,
     last_was_startup: AtomicBool,
@@ -329,8 +330,13 @@ impl BucketMapHolderStats {
                 ("keys", self.keys.swap(0, Ordering::Relaxed), i64),
                 ("ms_per_age", ms_per_age, i64),
                 (
-                    "flush_scan_update_us",
-                    self.flush_scan_update_us.swap(0, Ordering::Relaxed),
+                    "flush_scan_us",
+                    self.flush_scan_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "flush_update_us",
+                    self.flush_update_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem

existing code holds read lock on in-mem index while write to disk idx is going on. This is inefficient.

#### Summary of Changes

only hold read lock while scanning.

Fixes #
