### PR TITLE
Use borrow instead of move in interfaces defined by TpuConnection 

### DIFF
--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -182,7 +182,7 @@ impl QuicClient {
         if buffers.is_empty() {
             return Ok(());
         }
-        let connection = self._send_buffer(&buffers[0][..]).await?;
+        let connection = self._send_buffer(&buffers[0]).await?;
 
         // Used to avoid dereferencing the Arc multiple times below
         // by just getting a reference to the NewConnection once
@@ -196,7 +196,7 @@ impl QuicClient {
             join_all(
                 buffs
                     .into_iter()
-                    .map(|buf| Self::_send_buffer_using_conn(&buf[..], connection_ref)),
+                    .map(|buf| Self::_send_buffer_using_conn(buf, connection_ref)),
             )
         });
 

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -65,21 +65,21 @@ impl TpuConnection for QuicTpuConnection {
         &self.client.addr
     }
 
-    fn send_wire_transaction(&self, data: Vec<u8>) -> TransportResult<()> {
+    fn send_wire_transaction(&self, data: &[u8]) -> TransportResult<()> {
         let _guard = self.client.runtime.enter();
-        let send_buffer = self.client.send_buffer(&data[..]);
+        let send_buffer = self.client.send_buffer(data);
         self.client.runtime.block_on(send_buffer)?;
         Ok(())
     }
 
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()> {
+    fn send_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
         let buffers = transactions
             .into_par_iter()
             .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
             .collect::<Vec<_>>();
 
         let _guard = self.client.runtime.enter();
-        let send_batch = self.client.send_batch(&buffers[..]);
+        let send_batch = self.client.send_batch(&buffers);
         self.client.runtime.block_on(send_batch)?;
         Ok(())
     }

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -606,7 +606,7 @@ impl<C: 'static + TpuConnection> AsyncClient for ThinClient<C> {
     }
 
     fn async_send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()> {
-        self.tpu_connection().send_batch(transactions)
+        self.tpu_connection().send_batch(&transactions)
     }
 
     fn async_send_message<T: Signers>(

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -12,10 +12,10 @@ pub trait TpuConnection {
 
     fn send_transaction(&self, tx: &Transaction) -> TransportResult<()> {
         let data = bincode::serialize(tx).expect("serialize Transaction in send_transaction");
-        self.send_wire_transaction(data)
+        self.send_wire_transaction(&data)
     }
 
-    fn send_wire_transaction(&self, data: Vec<u8>) -> TransportResult<()>;
+    fn send_wire_transaction(&self, data: &[u8]) -> TransportResult<()>;
 
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()>;
+    fn send_batch(&self, transactions: &[Transaction]) -> TransportResult<()>;
 }

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -34,7 +34,7 @@ impl TpuConnection for UdpTpuConnection {
             .iter()
             .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
             .try_for_each(|buff| -> TransportResult<()> {
-                self.socket.send_to(&buff[..], self.addr)?;
+                self.socket.send_to(&buff, self.addr)?;
                 Ok(())
             })?;
         Ok(())

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -24,14 +24,14 @@ impl TpuConnection for UdpTpuConnection {
         &self.addr
     }
 
-    fn send_wire_transaction(&self, data: Vec<u8>) -> TransportResult<()> {
-        self.socket.send_to(&data[..], self.addr)?;
+    fn send_wire_transaction(&self, data: &[u8]) -> TransportResult<()> {
+        self.socket.send_to(data, self.addr)?;
         Ok(())
     }
 
-    fn send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()> {
+    fn send_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
         transactions
-            .into_iter()
+            .iter()
             .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
             .try_for_each(|buff| -> TransportResult<()> {
                 self.socket.send_to(&buff[..], self.addr)?;


### PR DESCRIPTION
Use borrow instead of move in interfaces defined by TpuConnection to avoid data copy in callers

#### Problem



#### Summary of Changes



Fixes #
