### PR TITLE
Deserialized banks get accounts data size from snapshot

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2012,7 +2012,7 @@ impl Bank {
                     .then(|| MAX_ACCOUNTS_DATA_LEN.saturating_sub(accounts_data_len)),
             )),
             sysvar_cache: RwLock::new(SysvarCache::default()),
-            accounts_data_len: AtomicU64::new(accounts_data_len),
+            accounts_data_len: AtomicU64::new(fields.accounts_data_len),
             fee_structure: FeeStructure::default(),
         };
         bank.finish_init(


### PR DESCRIPTION
#### Problem

When a new `Bank` is deserialized from a snapshot (i.e. `Bank::new_from_fields()`), its `accounts_data_len` field is populated by the value calculated from `generate_index()`. Since that way is not deterministic across the cluster, it cannot be used for the cap_accounts_data_len feature.

#### Summary of Changes

* When creating a new Bank from a snapshot, use `fields.accounts_data_len` for `Bank::accounts_data_len`

Part of #21604 



~~Do NOT merge this PR until #23714 has been released and live for a week or so. This should give sufficient time for nodes to start generating snapshots that include `accounts_data_len` from #23714. Otherwise, there's a risk of deserializing a bank from an old snapshot that did not include `accounts_data_len`.~~

~~Note that this is not a consensus/correctness issue, since _using_ the accounts data len is behind a feature gate; but it would impact metrics being gathered on approximate accounts data size.~~

Update: PR #23714 was released in v1.10.4 and v1.9.14
