### PR TITLE
Not exposing inner cost_table to encapsulating implementation details

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -134,10 +134,6 @@ impl CostUpdateService {
                 .upsert_instruction_cost(program_id, units);
             update_count += 1;
         }
-        debug!(
-           "after replayed into bank, updated cost model instruction cost table, current values: {:?}",
-           cost_model.read().unwrap().get_instruction_cost_table()
-        );
         update_count
     }
 }
@@ -150,9 +146,10 @@ mod tests {
     fn test_update_cost_model_with_empty_execute_timings() {
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
         let mut empty_execute_timings = ExecuteTimings::default();
+
         assert_eq!(
+            0,
             CostUpdateService::update_cost_model(&cost_model, &mut empty_execute_timings),
-            0
         );
     }
 
@@ -183,16 +180,15 @@ mod tests {
                 },
             );
             assert_eq!(
+                1,
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
-                1
             );
             assert_eq!(
-                Some(&expected_cost),
+                expected_cost,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -215,16 +211,15 @@ mod tests {
                 },
             );
             assert_eq!(
+                1,
                 CostUpdateService::update_cost_model(&cost_model, &mut execute_timings),
-                1
             );
             assert_eq!(
-                Some(&expected_cost),
+                expected_cost,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }
@@ -274,12 +269,11 @@ mod tests {
                 1
             );
             assert_eq!(
-                Some(&current_program_cost),
+                current_program_cost,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -307,12 +301,11 @@ mod tests {
                 1
             );
             assert_eq!(
-                Some(&expected_units),
+                expected_units,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
 
@@ -338,12 +331,11 @@ mod tests {
                 1
             );
             assert_eq!(
-                Some(&expected_units),
+                expected_units,
                 cost_model
                     .read()
                     .unwrap()
-                    .get_instruction_cost_table()
-                    .get(&program_key_1)
+                    .find_instruction_cost(&program_key_1)
             );
         }
     }

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -11,7 +11,6 @@ use {
         instruction::CompiledInstruction, program_utils::limited_deserialize, pubkey::Pubkey,
         system_instruction::SystemInstruction, system_program, transaction::SanitizedTransaction,
     },
-    std::collections::HashMap,
 };
 
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
@@ -81,10 +80,6 @@ impl CostModel {
             .for_each(|(program_id, cost)| {
                 self.upsert_instruction_cost(program_id, *cost);
             });
-        debug!(
-            "restored cost model instruction cost table from blockstore, current values: {:?}",
-            self.get_instruction_cost_table()
-        );
     }
 
     pub fn calculate_cost(&self, transaction: &SanitizedTransaction) -> TransactionCost {
@@ -103,10 +98,6 @@ impl CostModel {
     pub fn upsert_instruction_cost(&mut self, program_key: &Pubkey, cost: u64) {
         self.instruction_execution_cost_table
             .upsert(program_key, cost);
-    }
-
-    pub fn get_instruction_cost_table(&self) -> &HashMap<Pubkey, u64> {
-        self.instruction_execution_cost_table.get_cost_table()
     }
 
     pub fn find_instruction_cost(&self, program_key: &Pubkey) -> u64 {

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -39,10 +39,6 @@ impl ExecuteCostTable {
         }
     }
 
-    pub fn get_cost_table(&self) -> &HashMap<Pubkey, u64> {
-        &self.table
-    }
-
     pub fn get_count(&self) -> usize {
         self.table.len()
     }


### PR DESCRIPTION
#### Problem

The inner cost_table (a HashMap) was unnecessarily exposed. 

#### Summary of Changes

- removed the `pub fn` that exposed it, updated tests

Fixes #
