### PR TITLE
validator: adds `--no-incremental-snapshots` NOP arg for v1.10 forward compat

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -886,6 +886,13 @@ pub fn main() {
                        download from other validators"),
         )
         .arg(
+            // NOP arg for forward compatibility with ISS on-by-default in v1.10
+            Arg::with_name("no_incremental_snapshots")
+                .long("no-incremental-snapshots")
+                .hidden(true)
+                .conflicts_with("incremental_snapshots")
+        )
+        .arg(
             Arg::with_name("incremental_snapshots")
                 .long("incremental-snapshots")
                 .takes_value(false)


### PR DESCRIPTION
#### Problem

v1.10 will enable incremental snapshots by default, adding a `--no-incremental-snapshots` arg to manually disable.  v1.9 bins do not recognize this flag, preventing proactive configuration in situations where incremental snapshots are undesirable, such as  warehouse nodes

#### Summary of Changes

add `--no-incremental-snapshots` as a hidden, NOP arg for v1.9 `solana-validator`
