### PR TITLE
Update TpuConnection interface to be compatible with versioned txs

### DIFF
--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -215,10 +215,13 @@ impl<C: 'static + TpuConnection> ThinClient<C> {
             let mut num_confirmed = 0;
             let mut wait_time = MAX_PROCESSING_AGE;
             // resend the same transaction until the transaction has no chance of succeeding
+            let wire_transaction =
+                bincode::serialize(&transaction).expect("transaction serialization failed");
             while now.elapsed().as_secs() < wait_time as u64 {
                 if num_confirmed == 0 {
                     // Send the transaction if there has been no confirmation (e.g. the first time)
-                    self.tpu_connection().send_transaction(transaction)?;
+                    self.tpu_connection()
+                        .send_wire_transaction(&wire_transaction)?;
                 }
 
                 if let Ok(confirmed_blocks) = self.poll_for_signature_confirmation(
@@ -601,12 +604,20 @@ impl<C: 'static + TpuConnection> SyncClient for ThinClient<C> {
 
 impl<C: 'static + TpuConnection> AsyncClient for ThinClient<C> {
     fn async_send_transaction(&self, transaction: Transaction) -> TransportResult<Signature> {
-        self.tpu_connection().send_transaction(&transaction)?;
+        let wire_transaction =
+            bincode::serialize(&transaction).expect("transaction serialization failed");
+        self.tpu_connection()
+            .send_wire_transaction(&wire_transaction)?;
         Ok(transaction.signatures[0])
     }
 
     fn async_send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()> {
-        self.tpu_connection().send_batch(&transactions)
+        let batch: Vec<_> = transactions
+            .iter()
+            .map(|tx| bincode::serialize(&tx).expect("transaction serialization failed"))
+            .collect();
+        self.tpu_connection().send_wire_transaction_batch(&batch)?;
+        Ok(())
     }
 
     fn async_send_message<T: Signers>(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -24,7 +24,7 @@ use {
         signers::Signers,
         system_instruction,
         timing::duration_as_ms,
-        transaction::{self, Transaction},
+        transaction::{self, Transaction, VersionedTransaction},
         transport::Result as TransportResult,
     },
     std::{
@@ -612,11 +612,8 @@ impl<C: 'static + TpuConnection> AsyncClient for ThinClient<C> {
     }
 
     fn async_send_batch(&self, transactions: Vec<Transaction>) -> TransportResult<()> {
-        let batch: Vec<_> = transactions
-            .iter()
-            .map(|tx| bincode::serialize(&tx).expect("transaction serialization failed"))
-            .collect();
-        self.tpu_connection().send_wire_transaction_batch(&batch)?;
+        let batch: Vec<VersionedTransaction> = transactions.into_iter().map(Into::into).collect();
+        self.tpu_connection().send_transaction_batch(&batch)?;
         Ok(())
     }
 

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -1,5 +1,5 @@
 use {
-    solana_sdk::{transaction::Transaction, transport::Result as TransportResult},
+    solana_sdk::transport::Result as TransportResult,
     std::net::{SocketAddr, UdpSocket},
 };
 
@@ -10,12 +10,15 @@ pub trait TpuConnection {
 
     fn tpu_addr(&self) -> &SocketAddr;
 
-    fn send_transaction(&self, tx: &Transaction) -> TransportResult<()> {
-        let data = bincode::serialize(tx).expect("serialize Transaction in send_transaction");
-        self.send_wire_transaction(&data)
+    fn send_wire_transaction(&self, wire_transaction: &[u8]) -> TransportResult<()>;
+
+    fn send_wire_transaction_batch(
+        &self,
+        wire_transaction_batch: &[Vec<u8>],
+    ) -> TransportResult<()> {
+        for wire_transaction in wire_transaction_batch {
+            self.send_wire_transaction(wire_transaction)?;
+        }
+        Ok(())
     }
-
-    fn send_wire_transaction(&self, data: &[u8]) -> TransportResult<()>;
-
-    fn send_batch(&self, transactions: &[Transaction]) -> TransportResult<()>;
 }

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -1,5 +1,5 @@
 use {
-    solana_sdk::transport::Result as TransportResult,
+    solana_sdk::{transaction::VersionedTransaction, transport::Result as TransportResult},
     std::net::{SocketAddr, UdpSocket},
 };
 
@@ -11,6 +11,17 @@ pub trait TpuConnection {
     fn tpu_addr(&self) -> &SocketAddr;
 
     fn send_wire_transaction(&self, wire_transaction: &[u8]) -> TransportResult<()>;
+
+    fn send_transaction_batch(
+        &self,
+        transaction_batch: &[VersionedTransaction],
+    ) -> TransportResult<()> {
+        let wire_transaction_batch: Vec<_> = transaction_batch
+            .iter()
+            .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
+            .collect();
+        self.send_wire_transaction_batch(&wire_transaction_batch)
+    }
 
     fn send_wire_transaction_batch(
         &self,

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::tpu_connection::TpuConnection,
-    solana_sdk::{transaction::Transaction, transport::Result as TransportResult},
+    solana_sdk::transport::Result as TransportResult,
     std::net::{SocketAddr, UdpSocket},
 };
 
@@ -24,19 +24,8 @@ impl TpuConnection for UdpTpuConnection {
         &self.addr
     }
 
-    fn send_wire_transaction(&self, data: &[u8]) -> TransportResult<()> {
-        self.socket.send_to(data, self.addr)?;
-        Ok(())
-    }
-
-    fn send_batch(&self, transactions: &[Transaction]) -> TransportResult<()> {
-        transactions
-            .iter()
-            .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
-            .try_for_each(|buff| -> TransportResult<()> {
-                self.socket.send_to(&buff, self.addr)?;
-                Ok(())
-            })?;
+    fn send_wire_transaction(&self, wire_transaction: &[u8]) -> TransportResult<()> {
+        self.socket.send_to(wire_transaction, self.addr)?;
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem
`TpuConnection` trait only supports legacy transactions.


#### Summary of Changes
Update `TpuConnection` to operate over wire transactions so that any future transaction version will remain supported


Fixes #
