### PR TITLE
validator: `--only-known-rpc` requires a `--known-validator ...`

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1099,6 +1099,7 @@ pub fn main() {
                 .alias("no-untrusted-rpc")
                 .long("only-known-rpc")
                 .takes_value(false)
+                .requires("known_validators")
                 .help("Use the RPC service of known validators only")
         )
         .arg(


### PR DESCRIPTION
#### Problem

`solana-validator` will accept `--only-known-rpc` without passing a `--known-validator ...`

#### Summary of Changes

`clap::Arg::requires` it