### PR TITLE
(Validator) Add argument dependency for rocksdb-fifo-shred-storage-size

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -998,6 +998,7 @@ pub fn main() {
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .default_value(default_rocksdb_fifo_shred_storage_size)
+                .requires("rocksdb_shred_compaction")
                 .help("The shred storage size in bytes. \
                        The suggested value is 50% of your ledger storage size in bytes."),
         )


### PR DESCRIPTION
#### Problem
Validator argument `--rocksdb-fifo-shred-storage-size` requires 
`--rocksdb-shred-compaction`.  Otherwise it has no-op.

#### Summary of Changes
List `--rocksdb-shred-compaction` as a required argument
for `--rocksdb-fifo-shred-storage-size`

