### PR TITLE
(LedgerStore) Rename BlockstoreAdvancedOptions to LedgerColumnOptions

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -38,7 +38,7 @@ use {
         blockstore::{
             Blockstore, BlockstoreError, BlockstoreSignals, CompletedSlotsReceiver, PurgeType,
         },
-        blockstore_db::{BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRecoveryMode},
+        blockstore_db::{BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions},
         blockstore_processor::{self, TransactionStatusSender},
         leader_schedule::FixedSchedule,
         leader_schedule_cache::LeaderScheduleCache,
@@ -168,7 +168,7 @@ pub struct ValidatorConfig {
     pub no_wait_for_vote_to_start_leader: bool,
     pub accounts_shrink_ratio: AccountShrinkThreshold,
     pub wait_to_vote_slot: Option<Slot>,
-    pub blockstore_advanced_options: BlockstoreAdvancedOptions,
+    pub ledger_column_options: LedgerColumnOptions,
 }
 
 impl Default for ValidatorConfig {
@@ -230,7 +230,7 @@ impl Default for ValidatorConfig {
             accounts_shrink_ratio: AccountShrinkThreshold::default(),
             accounts_db_config: None,
             wait_to_vote_slot: None,
-            blockstore_advanced_options: BlockstoreAdvancedOptions::default(),
+            ledger_column_options: LedgerColumnOptions::default(),
         }
     }
 }
@@ -1297,7 +1297,7 @@ fn load_blockstore(
         ledger_path,
         BlockstoreOptions {
             recovery_mode: config.wal_recovery_mode.clone(),
-            advanced_options: config.blockstore_advanced_options.clone(),
+            column_options: config.ledger_column_options.clone(),
             ..BlockstoreOptions::default()
         },
     )

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -10,7 +10,7 @@ mod tests {
         solana_ledger::{
             blockstore::{make_many_slot_shreds, Blockstore},
             blockstore_db::{
-                BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRocksFifoOptions,
+                BlockstoreOptions, BlockstoreRocksFifoOptions, LedgerColumnOptions,
                 ShredStorageType,
             },
             get_tmp_ledger_path,
@@ -351,7 +351,7 @@ mod tests {
             &ledger_path,
             if config.fifo_compaction {
                 BlockstoreOptions {
-                    advanced_options: BlockstoreAdvancedOptions {
+                    column_options: LedgerColumnOptions {
                         shred_storage_type: ShredStorageType::RocksFifo(
                             BlockstoreRocksFifoOptions {
                                 shred_data_cf_size: config.shred_data_cf_size,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_entry::poh::compute_hashes_per_tick,
     solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account},
-    solana_ledger::{blockstore::create_new_ledger, blockstore_db::BlockstoreAdvancedOptions},
+    solana_ledger::{blockstore::create_new_ledger, blockstore_db::LedgerColumnOptions},
     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
@@ -629,7 +629,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         &ledger_path,
         &genesis_config,
         max_genesis_archive_unpacked_size,
-        BlockstoreAdvancedOptions::default(),
+        LedgerColumnOptions::default(),
     )?;
 
     println!("{}", genesis_config);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -25,8 +25,8 @@ use {
         bank_forks_utils,
         blockstore::{create_new_ledger, Blockstore, PurgeType},
         blockstore_db::{
-            self, AccessType, BlockstoreAdvancedOptions, BlockstoreOptions, BlockstoreRecoveryMode,
-            Database,
+            self, AccessType, BlockstoreOptions, BlockstoreRecoveryMode, Database,
+            LedgerColumnOptions,
         },
         blockstore_processor::{BlockstoreProcessorError, ProcessOptions},
         shred::Shred,
@@ -1719,7 +1719,7 @@ fn main() {
                     &output_directory,
                     &genesis_config,
                     solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-                    BlockstoreAdvancedOptions::default(),
+                    LedgerColumnOptions::default(),
                 )
                 .unwrap_or_else(|err| {
                     eprintln!("Failed to write genesis config: {:?}", err);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -991,16 +991,16 @@ impl Default for ShredStorageType {
     }
 }
 
-/// Advanced options for blockstore.
-/// The each advanced option might also be used as a tag that supports
-/// group-by operation when reporting Blockstore metrics.
+/// Options for LedgerColumn.
+/// Each field might also be used as a tag that supports group-by operation when
+/// reporting metrics.
 #[derive(Clone)]
-pub struct BlockstoreAdvancedOptions {
+pub struct LedgerColumnOptions {
     // Determine how to store both data and coding shreds. Default: RocksLevel.
     pub shred_storage_type: ShredStorageType,
 }
 
-impl Default for BlockstoreAdvancedOptions {
+impl Default for LedgerColumnOptions {
     fn default() -> Self {
         Self {
             shred_storage_type: ShredStorageType::RocksLevel,
@@ -1015,7 +1015,7 @@ pub struct BlockstoreOptions {
     pub recovery_mode: Option<BlockstoreRecoveryMode>,
     // Whether to allow unlimited number of open files. Default: true.
     pub enforce_ulimit_nofile: bool,
-    pub advanced_options: BlockstoreAdvancedOptions,
+    pub column_options: LedgerColumnOptions,
 }
 
 impl Default for BlockstoreOptions {
@@ -1025,7 +1025,7 @@ impl Default for BlockstoreOptions {
             access_type: AccessType::PrimaryOnly,
             recovery_mode: None,
             enforce_ulimit_nofile: true,
-            advanced_options: BlockstoreAdvancedOptions::default(),
+            column_options: LedgerColumnOptions::default(),
         }
     }
 }
@@ -1459,7 +1459,7 @@ fn new_cf_descriptor_pair_shreds<
     options: &BlockstoreOptions,
     oldest_slot: &OldestSlot,
 ) -> (ColumnFamilyDescriptor, ColumnFamilyDescriptor) {
-    match &options.advanced_options.shred_storage_type {
+    match &options.column_options.shred_storage_type {
         ShredStorageType::RocksLevel => (
             new_cf_descriptor::<D>(options, oldest_slot),
             new_cf_descriptor::<C>(options, oldest_slot),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -63,7 +63,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         accounts_shrink_ratio: config.accounts_shrink_ratio,
         accounts_db_config: config.accounts_db_config.clone(),
         wait_to_vote_slot: config.wait_to_vote_slot,
-        blockstore_advanced_options: config.blockstore_advanced_options.clone(),
+        ledger_column_options: config.ledger_column_options.clone(),
     }
 }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -13,8 +13,7 @@ use {
         socketaddr,
     },
     solana_ledger::{
-        blockstore::create_new_ledger, blockstore_db::BlockstoreAdvancedOptions,
-        create_new_tmp_ledger,
+        blockstore::create_new_ledger, blockstore_db::LedgerColumnOptions, create_new_tmp_ledger,
     },
     solana_net_utils::PortRange,
     solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
@@ -582,7 +581,7 @@ impl TestValidator {
                     config
                         .max_genesis_archive_unpacked_size
                         .unwrap_or(MAX_GENESIS_ARCHIVE_UNPACKED_SIZE),
-                    BlockstoreAdvancedOptions::default(),
+                    LedgerColumnOptions::default(),
                 )
                 .map_err(|err| {
                     format!(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -33,8 +33,8 @@ use {
         contact_info::ContactInfo,
     },
     solana_ledger::blockstore_db::{
-        BlockstoreAdvancedOptions, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-        ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+        BlockstoreRecoveryMode, BlockstoreRocksFifoOptions, LedgerColumnOptions, ShredStorageType,
+        DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
@@ -2566,7 +2566,7 @@ pub fn main() {
         validator_config.max_ledger_shreds = Some(limit_ledger_size);
     }
 
-    validator_config.blockstore_advanced_options = BlockstoreAdvancedOptions {
+    validator_config.ledger_column_options = LedgerColumnOptions {
         shred_storage_type: match matches.value_of("rocksdb_shred_compaction") {
             None => ShredStorageType::default(),
             Some(shred_compaction_string) => match shred_compaction_string {


### PR DESCRIPTION
#### Summary of Changes
This PR renames BlockstoreAdvancedOptions to LedgerColumnOptions, as we will
pass-down this struct to LedgerColumn to allow it to perform metric reporting. 
