### PR TITLE
Locking fixes for versions of Dashmap v5.1.0 and beyond

### DIFF
--- a/runtime/src/secondary_index.rs
+++ b/runtime/src/secondary_index.rs
@@ -129,18 +129,20 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
             pubkeys_map.insert_if_not_exists(inner_key, &self.stats.num_inner_keys);
         }
 
-        let outer_keys = self.reverse_index.get(inner_key).unwrap_or_else(|| {
-            self.reverse_index
-                .entry(*inner_key)
-                .or_insert(RwLock::new(Vec::with_capacity(1)))
-                .downgrade()
-        });
+        {
+            let outer_keys = self.reverse_index.get(inner_key).unwrap_or_else(|| {
+                self.reverse_index
+                    .entry(*inner_key)
+                    .or_insert(RwLock::new(Vec::with_capacity(1)))
+                    .downgrade()
+            });
 
-        let should_insert = !outer_keys.read().unwrap().contains(key);
-        if should_insert {
-            let mut w_outer_keys = outer_keys.write().unwrap();
-            if !w_outer_keys.contains(key) {
-                w_outer_keys.push(*key);
+            let should_insert = !outer_keys.read().unwrap().contains(key);
+            if should_insert {
+                let mut w_outer_keys = outer_keys.write().unwrap();
+                if !w_outer_keys.contains(key) {
+                    w_outer_keys.push(*key);
+                }
             }
         }
 


### PR DESCRIPTION
#### Problem
Bumping dashmap version to v5.1.0 caused validator with secondary indexes to stall, and thus had to be reverted: https://github.com/solana-labs/solana/pull/23592

Dashmap v5.1.0 switched over to using `parking_lot` RwLocks. Because these locks can be write-prioritized, this means that behavior like:

```
Thread 1:  Grabs and holds Read(A) lock, tries to grab Read(A) later while holding original Read(A)
Thread 2: Grabs Write(A)
```

can deadlock if Thread 2 grabs the write lock between the first and second attempts to grab `Read(A)` by Thread 1.

#### Summary of Changes
The attempt to grab read lock here: https://github.com/solana-labs/solana/blob/857576d76fa43e89985e55bec2edfca57aac4b63/runtime/src/secondary_index.rs#L132-L137, then later here https://github.com/solana-labs/solana/blob/857576d76fa43e89985e55bec2edfca57aac4b63/runtime/src/secondary_index.rs#L150 is an example of such a scenario where the deadlock described above can occur. We fix this by ensuring the first lock drops out of scope.


TODO: Check use cases across the rest of the code base


Fixes #
