### PR TITLE
Fix stake state docs typo

### DIFF
--- a/docs/src/developing/clients/javascript-reference.md
+++ b/docs/src/developing/clients/javascript-reference.md
@@ -681,8 +681,8 @@ console.log(`Stake balance: ${stakeBalance}`)
 
 // We can verify the state of our stake. This may take some time to become active
 let stakeState = await connection.getStakeActivation(stakeAccount.publicKey);
-console.log(`Stake Stake: ${stakeState.state}`);
-// Stake State: inactive
+console.log(`Stake state: ${stakeState.state}`);
+// Stake state: inactive
 
 // To delegate our stake, we get the current vote accounts and choose the first
 let voteAccounts = await connection.getVoteAccounts();


### PR DESCRIPTION
#### Problem
There's a typo in the StakeProgram Web3 API Reference docs.

#### Summary of Changes
Fixed the typo: `Stake Stake` -> `Stake state`.