### PR TITLE
add size check for from_raw_parts

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -331,6 +331,10 @@ pub mod disable_deprecated_loader {
     solana_sdk::declare_id!("GTUMCZ8LTNxVfxdrw7ZsDFTxXb7TutYkzJnFwinpE6dg");
 }
 
+pub mod check_slice_translation_size {
+    solana_sdk::declare_id!("GmC19j9qLn2RFk5NduX6QXaDhVpGncVVBzyM8e9WMz2F");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -408,6 +412,7 @@ lazy_static! {
         (check_physical_overlapping::id(), "check physical overlapping regions"),
         (limit_secp256k1_recovery_id::id(), "limit secp256k1 recovery id"),
         (disable_deprecated_loader::id(), "disable the deprecated BPF loader"),
+        (check_slice_translation_size::id(), "check size when translating slices",)
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

From the docs for `from_raw_parts`:

> The total size len * mem::size_of::<T>() of the slice must be no larger than isize::MAX

The current code does check to ensure the above but also does not violate this because a region cannot be this large.  But there is no guarantee that it stay true as the code evolves over time.

#### Summary of Changes

- Add a size check
- Check the feature once for all syscalls and route the info through the syscalls
- Also check whether alignment is forced once and route that info through all the syscalls as a bool, rather than looking up the loader id, passing around its pubkey, and comparing pubkeys for each address translation.

Fixes #23754
