### PR TITLE
Made connection cache configurable.

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -24,7 +24,7 @@ use {
         transaction::{self, SanitizedTransaction, Transaction},
     },
     solana_send_transaction_service::{
-        send_transaction_service::{SendTransactionService, TransactionInfo},
+        send_transaction_service::{SendTransactionService, TransactionInfo, DEFAULT_TPU_USE_QUIC},
         tpu_info::NullTpuInfo,
     },
     std::{
@@ -399,6 +399,7 @@ pub async fn start_tcp_server(
                 receiver,
                 5_000,
                 0,
+                DEFAULT_TPU_USE_QUIC,
             );
 
             let server = BanksServer::new(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -75,7 +75,7 @@ use {
         },
     },
     solana_send_transaction_service::{
-        send_transaction_service::{SendTransactionService, TransactionInfo},
+        send_transaction_service::{SendTransactionService, TransactionInfo, DEFAULT_TPU_USE_QUIC},
         tpu_info::NullTpuInfo,
     },
     solana_storage_bigtable::Error as StorageError,
@@ -323,6 +323,7 @@ impl JsonRpcRequestProcessor {
             receiver,
             1000,
             1,
+            DEFAULT_TPU_USE_QUIC,
         );
 
         Self {
@@ -6087,6 +6088,7 @@ pub mod tests {
             receiver,
             1000,
             1,
+            DEFAULT_TPU_USE_QUIC,
         );
 
         let mut bad_transaction = system_transaction::transfer(
@@ -6352,6 +6354,7 @@ pub mod tests {
             receiver,
             1000,
             1,
+            DEFAULT_TPU_USE_QUIC,
         );
         assert_eq!(
             request_processor.get_block_commitment(0),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -65,12 +65,15 @@ struct ProcessTransactionsResult {
     retained: u64,
 }
 
+pub const DEFAULT_TPU_USE_QUIC: bool = false;
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub retry_rate_ms: u64,
     pub leader_forward_count: u64,
     pub default_max_retries: Option<usize>,
     pub service_max_retries: usize,
+    pub use_quic: bool,
 }
 
 impl Default for Config {
@@ -80,6 +83,7 @@ impl Default for Config {
             leader_forward_count: DEFAULT_LEADER_FORWARD_COUNT,
             default_max_retries: None,
             service_max_retries: DEFAULT_SERVICE_MAX_RETRIES,
+            use_quic: DEFAULT_TPU_USE_QUIC,
         }
     }
 }
@@ -92,10 +96,12 @@ impl SendTransactionService {
         receiver: Receiver<TransactionInfo>,
         retry_rate_ms: u64,
         leader_forward_count: u64,
+        use_quic: bool,
     ) -> Self {
         let config = Config {
             retry_rate_ms,
             leader_forward_count,
+            use_quic,
             ..Config::default()
         };
         Self::new_with_config(tpu_address, bank_forks, leader_info, receiver, config)
@@ -352,6 +358,7 @@ mod test {
             receiver,
             1000,
             1,
+            DEFAULT_TPU_USE_QUIC,
         );
 
         drop(sender);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -9,6 +9,7 @@ use {
     console::style,
     log::*,
     rand::{seq::SliceRandom, thread_rng},
+    send_transaction_service::DEFAULT_TPU_USE_QUIC,
     solana_clap_utils::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
         input_validators::{
@@ -456,6 +457,7 @@ pub fn main() {
     let default_accounts_shrink_ratio = &DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string();
     let default_rocksdb_fifo_shred_storage_size =
         &DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES.to_string();
+    let default_tpu_use_quic = &DEFAULT_TPU_USE_QUIC.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1142,6 +1144,14 @@ pub fn main() {
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .help("Milliseconds to wait in the TPU receiver for packet coalescing."),
+        )
+        .arg(
+            Arg::with_name("tpu_use_quic")
+                .long("tpu-use-quic")
+                .takes_value(true)
+                .value_name("BOOLEAN")
+                .default_value(default_tpu_use_quic)
+                .help("When this is set to true, the system will use QUIC to send transactions."),
         )
         .arg(
             Arg::with_name("rocksdb_max_compaction_jitter")
@@ -2094,6 +2104,8 @@ pub fn main() {
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
+    let tpu_use_quic = value_t_or_exit!(matches, "tpu_use_quic", bool);
+
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {
         eprintln!(
@@ -2365,6 +2377,7 @@ pub fn main() {
                 "rpc_send_transaction_service_max_retries",
                 usize
             ),
+            use_quic: tpu_use_quic,
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),


### PR DESCRIPTION
#### Problem
We need an option to allow the validator to use QUIC protocol for TPU transaction. Default is false.


#### Summary of Changes

Added command-line argument tpu-use-quic argument.
Changed connection cache to return different connections based on the config.

Fixes #
