### PR TITLE
Add ability to get the latest incremental snapshot via RPC

### DIFF
--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -227,16 +227,31 @@ impl RequestMiddleware for RpcRequestMiddleware {
         trace!("request uri: {}", request.uri());
 
         if let Some(ref snapshot_config) = self.snapshot_config {
-            if request.uri().path() == "/snapshot.tar.bz2" {
+            if request.uri().path() == "/snapshot.tar.bz2" || request.uri().path() == "/incremental-snapshot.tar.bz2" {
                 // Convenience redirect to the latest snapshot
-                return if let Some(full_snapshot_archive_info) =
-                    snapshot_utils::get_highest_full_snapshot_archive_info(
-                        &snapshot_config.snapshot_archives_dir,
-                    ) {
+                let full_snapshot_archive_info = snapshot_utils::get_highest_full_snapshot_archive_info(&snapshot_config.snapshot_archives_dir);
+                let snapshot_archive_info = if let Some(full_snapshot_archive_info) = full_snapshot_archive_info {
+                    if request.uri().path() == "/snapshot.tar.bz2" {
+                        Some(full_snapshot_archive_info.snapshot_archive_info().clone())
+                    } else {
+                        if let Some(incremental_snapshot_archive_info) =
+                        snapshot_utils::get_highest_incremental_snapshot_archive_info(
+                            &snapshot_config.snapshot_archives_dir,
+                            full_snapshot_archive_info.slot(),
+                        ) {
+                            Some(incremental_snapshot_archive_info.snapshot_archive_info().clone())
+                        } else {
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                return if let Some(snapshot_archive_info) = snapshot_archive_info {
                     RpcRequestMiddleware::redirect(&format!(
                         "/{}",
-                        full_snapshot_archive_info
-                            .path()
+                        snapshot_archive_info
+                            .path
                             .file_name()
                             .unwrap_or_else(|| std::ffi::OsStr::new(""))
                             .to_str()

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -50,6 +50,8 @@ use {
     tokio_util::codec::{BytesCodec, FramedRead},
 };
 
+const FULL_SNAPSHOT_REQUEST_PATH: &str = "/snapshot.tar.bz2";
+const INCREMENTAL_SNAPSHOT_REQUEST_PATH: &str = "/incremental-snapshot.tar.bz2";
 const LARGEST_ACCOUNTS_CACHE_DURATION: u64 = 60 * 60 * 2;
 
 pub struct JsonRpcService {
@@ -227,8 +229,8 @@ impl RequestMiddleware for RpcRequestMiddleware {
         trace!("request uri: {}", request.uri());
 
         if let Some(ref snapshot_config) = self.snapshot_config {
-            if request.uri().path() == "/snapshot.tar.bz2"
-                || request.uri().path() == "/incremental-snapshot.tar.bz2"
+            if request.uri().path() == FULL_SNAPSHOT_REQUEST_PATH
+                || request.uri().path() == INCREMENTAL_SNAPSHOT_REQUEST_PATH
             {
                 // Convenience redirect to the latest snapshot
                 let full_snapshot_archive_info =
@@ -237,7 +239,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                     );
                 let snapshot_archive_info =
                     if let Some(full_snapshot_archive_info) = full_snapshot_archive_info {
-                        if request.uri().path() == "/snapshot.tar.bz2" {
+                        if request.uri().path() == FULL_SNAPSHOT_REQUEST_PATH {
                             Some(full_snapshot_archive_info.snapshot_archive_info().clone())
                         } else {
                             snapshot_utils::get_highest_incremental_snapshot_archive_info(


### PR DESCRIPTION
#### Problem

There is no ability to download latest incremental snapshot through rpc without knowing it full name with hash.

#### Summary of Changes

Added ability to download latest incremental snapshot using "/incremental-snapshot.tar.bz2" path

