### PR TITLE
Implement Sysvar Trait for Instruction introspection (Incomplete attempt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 /solana-metrics.tar.bz2
 /target/
 /test-ledger/
+/test-validator/
+/bin/
+
+.crates.toml
+.crates2.json
 
 **/*.rs.bk
 .cargo

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -353,6 +353,13 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         )
     }
 
+    fn sol_get_instructions_sysvar(&self, var_addr: *mut u8) -> u64 {
+        get_sysvar(
+            get_invoke_context().get_sysvar_cache().get_instructions(),
+            var_addr,
+        )
+    }
+
     fn sol_get_epoch_schedule_sysvar(&self, var_addr: *mut u8) -> u64 {
         get_sysvar(
             get_invoke_context().get_sysvar_cache().get_epoch_schedule(),

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -10,6 +10,7 @@ use solana_program::{
     program_error::ProgramError,
     pubkey::Pubkey,
     sysvar::instructions,
+    sysvar::instructions::Instructions,
 };
 
 solana_program::entrypoint!(process_instruction);
@@ -23,7 +24,9 @@ fn process_instruction(
     }
 
     let secp_instruction_index = instruction_data[0];
-    let instructions_account = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
+    //let instructions_account = accounts.last().ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let instructions_account = solana_program::sysvar::instructions::Instructions::get().unwrap();
+
     assert_eq!(*instructions_account.key, instructions::id());
     let data_len = instructions_account.try_borrow_data()?.len();
     if data_len < 2 {

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -20,6 +20,7 @@ use {
             state::{Authorized, Lockup},
         },
         sysvar::clock::Clock,
+        sysvar::instructions::Instructions,
     },
 };
 
@@ -310,6 +311,11 @@ pub fn process_instruction(
                     custodian,
                 };
                 let clock = invoke_context.get_sysvar_cache().get_clock()?;
+
+                // apparently working here?
+                //let instructions = invoke_context.get_sysvar_cache().get_instructions()?;
+                let abc = instructions;
+                let a = sysvar::instructions::Instructions;
                 me.set_lockup(&lockup, &signers, &clock)
             } else {
                 Err(InstructionError::InvalidInstructionData)

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -41,6 +41,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_clock_sysvar(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_get_instructions_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     fn sol_get_epoch_schedule_sysvar(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
@@ -130,6 +133,13 @@ pub(crate) fn sol_invoke_signed(
 
 pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_clock_sysvar(var_addr)
+}
+
+pub(crate) fn sol_get_instructions_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_instructions_sysvar(var_addr)
 }
 
 pub(crate) fn sol_get_epoch_schedule_sysvar(var_addr: *mut u8) -> u64 {

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -1,6 +1,7 @@
 //! This account contains the clock slot, epoch, and leader_schedule_epoch
 //!
 pub use crate::clock::Clock;
+
 use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);


### PR DESCRIPTION
## This is a WIP.
#### Problem
There are multiple issues opened about implementing the Sysvar trait for Instructions. 
- https://github.com/solana-labs/solana/issues/22911
- https://github.com/solana-labs/solana/issues/17017
- https://github.com/solana-labs/solana/issues/23617

Presently, this account must be passed in and was involved in the wormhole hack (was not checked properly), and is needed to check signatures with the Secp256k1 program (one reason why the Secp256k1 is hard to use).

Anchor also must use `UncheckedAccount` forcing an address=id() right now.


#### Stuck
From https://docs.solana.com/implemented-proposals/instruction_introspection:
"The runtime will recognize this special instruction, serialize the Message instruction data for it and also write the current instruction index and then the bpf program can extract the necessary information from there."

I've tried to follow along with replicating from `Clock::get()`, but I'm missing some key piece to do this. 

#### I can't wrap my head around how instruction introspection is working (apparently it does something extra at runtime?). It seems to be more complicated than implementing a trait to the dummy struct, because we use helper methods anyway.

## Update
The runtime checks the passed in accounts, and builds the `instruction sysvar` if it is passed in. However, it is not in anywhere global and is only stored in the accounts of `LoadedTransaction`.
Source: https://github.com/solana-labs/solana/blob/c08cfafd6c599abbf440fbac1974ac8d754e265f/runtime/src/accounts.rs#L265-L270

# Proposal
1. Create an Instruction Introspection struct inside `sdk/program/src` (where Clock and SlotHistory are)
2. when `load_accounts` is called in `bank.rs`, update Instruction Introspection (like how Clock or SlotHistory is updated) to always hold the transactions currently being processed. Help needed on whether this is exorbitant overhead (since this computation normally only happens if instruction sysvar is passed in)

Code for how the SlotHistory sysvar is updated
https://github.com/solana-labs/solana/blob/c08cfafd6c599abbf440fbac1974ac8d754e265f/runtime/src/bank.rs#L2303-L2315
4. Now implement the Sysvar Trait. Update the methods like `load_instruction_at_checked` to be methods of Instruction Introspection and not the sysvar as it is now. The struct now acts similar to Clock and can be "get()"d.

## Pros
- can be more organized and can clean up the hacky way Sysvar implements and deserializes the data
## Cons/Questions
- more overhead computation since called in every transaction even if not needed (unless there's another way to indicate the instruction needs it?). Maybe the runtime can detect if the instruction `gets()` on instruction sysvar?
- `load_accounts` in `accounts.rs` loads a batch of transactions, when is the right time to update the instruction sysvar to the current transaction?


Thoughts on this?

@armaniferrante @jarry-xiao 
