### PR TITLE
append_vec: correct lifetime bound

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -421,7 +421,7 @@ impl AppendVec {
     /// Return a reference to the type at `offset` if its data doesn't overrun the internal buffer.
     /// Otherwise return None. Also return the offset of the first byte after the requested data
     /// that falls on a 64-byte boundary.
-    fn get_type<'a, T>(&self, offset: usize) -> Option<(&'a T, usize)> {
+    fn get_type<T>(&self, offset: usize) -> Option<(&T, usize)> {
         let (data, next) = self.get_slice(offset, mem::size_of::<T>())?;
         let ptr: *const T = data.as_ptr() as *const T;
         //UNSAFE: The cast is safe because the slice is aligned and fits into the memory

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -377,12 +377,7 @@ impl AppendVec {
         let data = &self.map[offset..next];
         let next = u64_align!(next);
 
-        Some((
-            //UNSAFE: This unsafe creates a slice that represents a chunk of self.map memory
-            //The lifetime of this slice is tied to &self, since it points to self.map memory
-            unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, size) },
-            next,
-        ))
+        Some((data, next))
     }
 
     /// Copy `len` bytes from `src` to the first 64-byte boundary after position `offset` of


### PR DESCRIPTION
#### Problem

Unsafe appears to be unnecessary, the code compiles fine without unsafe. Also the lifetime bound was unbounded and not limited to `self`.

#### Summary of Changes

- remove unsafe
- correclty bound lifetime to `self`

Fixes #
