### PR TITLE
core: partial versioned transaction support for voting service

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2001,7 +2001,7 @@ impl ReplayStage {
             );
             voting_sender
                 .send(VoteOp::RefreshVote {
-                    tx: vote_tx,
+                    tx: vote_tx.into(),
                     last_voted_slot,
                 })
                 .unwrap_or_else(|err| warn!("Error: {:?}", err));
@@ -2044,7 +2044,7 @@ impl ReplayStage {
             let tower_slots = tower.tower_slots();
             voting_sender
                 .send(VoteOp::PushVote {
-                    tx: vote_tx,
+                    tx: vote_tx.into(),
                     tower_slots,
                     saved_tower: SavedTowerVersions::from(saved_tower),
                 })

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -6,7 +6,7 @@ use {
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::bank_forks::BankForks,
-    solana_sdk::{clock::Slot, transaction::Transaction},
+    solana_sdk::{clock::Slot, transaction::VersionedTransaction},
     std::{
         sync::{Arc, Mutex, RwLock},
         thread::{self, Builder, JoinHandle},
@@ -15,18 +15,18 @@ use {
 
 pub enum VoteOp {
     PushVote {
-        tx: Transaction,
+        tx: VersionedTransaction,
         tower_slots: Vec<Slot>,
         saved_tower: SavedTowerVersions,
     },
     RefreshVote {
-        tx: Transaction,
+        tx: VersionedTransaction,
         last_voted_slot: Slot,
     },
 }
 
 impl VoteOp {
-    fn tx(&self) -> &Transaction {
+    fn tx(&self) -> &VersionedTransaction {
         match self {
             VoteOp::PushVote { tx, .. } => tx,
             VoteOp::RefreshVote { tx, .. } => tx,
@@ -90,7 +90,7 @@ impl VotingService {
 
         let mut measure = Measure::start("vote_tx_send-ms");
         let target_address = target_address.unwrap_or_else(|| cluster_info.my_contact_info().tpu);
-        let _ = get_connection(&target_address).send_transaction(vote_op.tx());
+        let _ = get_connection(&target_address).serialize_and_send_transaction(vote_op.tx());
         measure.stop();
         inc_new_counter_info!("vote_tx_send-ms", measure.as_ms() as usize);
 
@@ -98,12 +98,18 @@ impl VotingService {
             VoteOp::PushVote {
                 tx, tower_slots, ..
             } => {
+                // we can safely unwrap here because the vote tx is constructed
+                // from a legacy transaction in replay stage
+                let tx = tx.into_legacy_transaction().unwrap();
                 cluster_info.push_vote(&tower_slots, tx);
             }
             VoteOp::RefreshVote {
                 tx,
                 last_voted_slot,
             } => {
+                // we can safely unwrap here because the vote tx is constructed
+                // from a legacy transaction in replay stage
+                let tx = tx.into_legacy_transaction().unwrap();
                 cluster_info.refresh_vote(tx, last_voted_slot);
             }
         }


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/23713 and https://github.com/solana-labs/solana/pull/23760 missed each other so now `VotingService` supports `TpuConnection`, `TpuConnection` only supports `VersionedTransaction`s and `VotingService` only works with legacy `Transaction`s

tldr;  master CI is red

#### Summary of Changes

Add partial support for `VersionedTransaction`s in `VotingService`

Fixes #23824
cc/ @jeffwashington 