### PR TITLE
Manually serialize and use `send_wire_transaction` for votes

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2001,7 +2001,7 @@ impl ReplayStage {
             );
             voting_sender
                 .send(VoteOp::RefreshVote {
-                    tx: vote_tx.into(),
+                    tx: vote_tx,
                     last_voted_slot,
                 })
                 .unwrap_or_else(|err| warn!("Error: {:?}", err));
@@ -2044,7 +2044,7 @@ impl ReplayStage {
             let tower_slots = tower.tower_slots();
             voting_sender
                 .send(VoteOp::PushVote {
-                    tx: vote_tx.into(),
+                    tx: vote_tx,
                     tower_slots,
                     saved_tower: SavedTowerVersions::from(saved_tower),
                 })

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -6,7 +6,7 @@ use {
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
     solana_runtime::bank_forks::BankForks,
-    solana_sdk::{clock::Slot, transaction::VersionedTransaction},
+    solana_sdk::{clock::Slot, transaction::Transaction},
     std::{
         sync::{Arc, Mutex, RwLock},
         thread::{self, Builder, JoinHandle},
@@ -15,18 +15,18 @@ use {
 
 pub enum VoteOp {
     PushVote {
-        tx: VersionedTransaction,
+        tx: Transaction,
         tower_slots: Vec<Slot>,
         saved_tower: SavedTowerVersions,
     },
     RefreshVote {
-        tx: VersionedTransaction,
+        tx: Transaction,
         last_voted_slot: Slot,
     },
 }
 
 impl VoteOp {
-    fn tx(&self) -> &VersionedTransaction {
+    fn tx(&self) -> &Transaction {
         match self {
             VoteOp::PushVote { tx, .. } => tx,
             VoteOp::RefreshVote { tx, .. } => tx,
@@ -90,7 +90,7 @@ impl VotingService {
 
         let mut measure = Measure::start("vote_tx_send-ms");
         let target_address = target_address.unwrap_or_else(|| cluster_info.my_contact_info().tpu);
-        let _ = get_connection(&target_address).serialize_and_send_transaction(vote_op.tx());
+        let _ = get_connection(&target_address).send_transaction(vote_op.tx());
         measure.stop();
         inc_new_counter_info!("vote_tx_send-ms", measure.as_ms() as usize);
 
@@ -98,18 +98,12 @@ impl VotingService {
             VoteOp::PushVote {
                 tx, tower_slots, ..
             } => {
-                // we can safely unwrap here because the vote tx is constructed
-                // from a legacy transaction in replay stage
-                let tx = tx.into_legacy_transaction().unwrap();
                 cluster_info.push_vote(&tower_slots, tx);
             }
             VoteOp::RefreshVote {
                 tx,
                 last_voted_slot,
             } => {
-                // we can safely unwrap here because the vote tx is constructed
-                // from a legacy transaction in replay stage
-                let tx = tx.into_legacy_transaction().unwrap();
                 cluster_info.refresh_vote(tx, last_voted_slot);
             }
         }

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -90,7 +90,8 @@ impl VotingService {
 
         let mut measure = Measure::start("vote_tx_send-ms");
         let target_address = target_address.unwrap_or_else(|| cluster_info.my_contact_info().tpu);
-        let _ = get_connection(&target_address).send_transaction(vote_op.tx());
+        let wire_vote_tx = bincode::serialize(vote_op.tx()).expect("vote serialization failure");
+        let _ = get_connection(&target_address).send_wire_transaction(&wire_vote_tx);
         measure.stop();
         inc_new_counter_info!("vote_tx_send-ms", measure.as_ms() as usize);
 


### PR DESCRIPTION
#### Problem
I think it's better to keep vote transactions as `Transaction` for now to avoid the `into_legacy_transaction` unwrap.

#### Summary of Changes
Manually serialize and use `send_wire_transaction` directly here



Fixes #
