### PR TITLE
ignore heavy tests in dos

### DIFF
--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -542,6 +542,7 @@ pub mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_dos_local_cluster_transactions() {
         let num_nodes = 1;
         let cluster =


### PR DESCRIPTION
#### Problem

Some tests in DoS might take too much time to execute due to `LocalCluster`.
Since we have Timeout on CI running unit tests, it might be a good idea to ignore aforementioned tests for now and prepare a better unit tests (not using LocalCluster) in the following PRs.


#### Summary of Changes

Ignore these tests for now
