### PR TITLE
snapshot code needs all storages for hash calc

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1636,7 +1636,7 @@ pub fn snapshot_bank(
     hash_for_testing: Option<Hash>,
     snapshot_type: Option<SnapshotType>,
 ) -> Result<()> {
-    let snapshot_storages = get_snapshot_storages(root_bank, snapshot_type);
+    let snapshot_storages = get_snapshot_storages(root_bank);
 
     let mut add_snapshot_time = Measure::start("add-snapshot-ms");
     let bank_snapshot_info = add_bank_snapshot(
@@ -1667,44 +1667,21 @@ pub fn snapshot_bank(
     Ok(())
 }
 
-/// Get the snapshot storages for this bank and snapshot_type
-fn get_snapshot_storages(bank: &Bank, snapshot_type: Option<SnapshotType>) -> SnapshotStorages {
+/// Get the snapshot storages for this bank
+fn get_snapshot_storages(bank: &Bank) -> SnapshotStorages {
     let mut measure_snapshot_storages = Measure::start("snapshot-storages");
-    let snapshot_storages = snapshot_type.map_or_else(SnapshotStorages::default, |snapshot_type| {
-        let incremental_snapshot_base_slot = match snapshot_type {
-            SnapshotType::IncrementalSnapshot(incremental_snapshot_base_slot) => {
-                Some(incremental_snapshot_base_slot)
-            }
-            _ => None,
-        };
-        bank.get_snapshot_storages(incremental_snapshot_base_slot)
-    });
+    let snapshot_storages = bank.get_snapshot_storages(None);
     measure_snapshot_storages.stop();
-
-    if let Some(snapshot_type) = snapshot_type {
-        let snapshot_storages_count_name;
-        let snapshot_storages_time_name;
-        match snapshot_type {
-            SnapshotType::FullSnapshot => {
-                snapshot_storages_count_name = "full-snapshot-storages-count";
-                snapshot_storages_time_name = "full-snapshot-storages-time-ms";
-            }
-            SnapshotType::IncrementalSnapshot(_) => {
-                snapshot_storages_count_name = "incremental-snapshot-storages-count";
-                snapshot_storages_time_name = "incremental-snapshot-storages-time-ms";
-            }
-        }
-        let snapshot_storages_count = snapshot_storages.iter().map(Vec::len).sum::<usize>();
-        datapoint_info!(
-            "get_snapshot_storages",
-            (snapshot_storages_count_name, snapshot_storages_count, i64),
-            (
-                snapshot_storages_time_name,
-                measure_snapshot_storages.as_ms(),
-                i64
-            ),
-        );
-    }
+    let snapshot_storages_count = snapshot_storages.iter().map(Vec::len).sum::<usize>();
+    datapoint_info!(
+        "get_snapshot_storages",
+        ("snapshot-storages-count", snapshot_storages_count, i64),
+        (
+            "snapshot-storages-time-ms",
+            measure_snapshot_storages.as_ms(),
+            i64
+        ),
+    );
 
     snapshot_storages
 }


### PR DESCRIPTION
#### Problem

Today, incremental snapshots do not work with verifying hash calc. This pr fixes that by allowing the caller to pass in ALL storages, not just the last N.
Tomorrow, incremental snapshots do not work when we move the hash calc to accounts hash verifier. This pr prepares to fix that.


#### Summary of Changes



Fixes #
