### PR TITLE
Use fee and sender_stake prioritization to add new packet_batch to ba…

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -507,16 +507,17 @@ impl Accounts {
                         .unwrap_or_else(|| {
                             hash_queue.get_lamports_per_signature(tx.message().recent_blockhash())
                         });
-                    let fee = if let Some(lamports_per_signature) = lamports_per_signature {
-                        Bank::calculate_fee(
-                            tx.message(),
-                            lamports_per_signature,
-                            fee_structure,
-                            feature_set.is_active(&tx_wide_compute_cap::id()),
-                        )
-                    } else {
-                        return (Err(TransactionError::BlockhashNotFound), None);
-                    };
+                    let (fee, _max_units) =
+                        if let Some(lamports_per_signature) = lamports_per_signature {
+                            Bank::calculate_fee(
+                                tx.message(),
+                                lamports_per_signature,
+                                fee_structure,
+                                feature_set.is_active(&tx_wide_compute_cap::id()),
+                            )
+                        } else {
+                            return (Err(TransactionError::BlockhashNotFound), None);
+                        };
 
                     let loaded_transaction = match self.load_transaction(
                         ancestors,
@@ -1589,7 +1590,7 @@ mod tests {
             instructions,
         );
 
-        let fee = Bank::calculate_fee(
+        let (fee, _max_units) = Bank::calculate_fee(
             &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
             10,
             &FeeStructure::default(),


### PR DESCRIPTION
#### Problem

Banking_stage currently using FIFO to drop buffered packet_batch to make room for received new batch. It could drop highly prioritized Transactions in old batch. It should instead to drop Transactions with lowest priority. 

Priority is determined by Transaction's fee-per-cu, and sender_stake if fee-per-cu is same.

#### Summary of Changes

- update `banking_stage::push_unprocessed()` to `UnprocessedPacketBatches::insert_or_swap_batch()` instead of fifo;
- `UnprocessedPacketBatches::prioritize_by_fee_per_cu()` to index Transaction by its fee/CU, which is calculated with `working_bank`
- Weight-shuffle locators with send_stakes
- `swap_packet_by_priority` implements the logic of dropping lower prioritized Transaction, indexed by `prioritize_by_fee_then_stakes`, find an empty patch_batch to swap with received new packet_batch.

Fixes #23369 
