### PR TITLE
calculate_accounts_hash_without_index takes &self

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5545,7 +5545,7 @@ impl AccountsDb {
             } else {
                 Some(&self.thread_pool_clean)
             };
-            Self::calculate_accounts_hash_without_index(
+            self.calculate_accounts_hash_without_index(
                 &self.accounts_hash_cache_path,
                 &storages,
                 thread_pool,
@@ -5749,6 +5749,7 @@ impl AccountsDb {
     // modeled after get_accounts_delta_hash
     // intended to be faster than calculate_accounts_hash
     pub fn calculate_accounts_hash_without_index(
+        &self,
         accounts_hash_cache_path: &Path,
         storages: &SortedStorages,
         thread_pool: Option<&ThreadPool>,
@@ -7930,17 +7931,19 @@ pub mod tests {
         solana_logger::setup();
 
         let (storages, _size, _slot_expected) = sample_storage();
-        let result = AccountsDb::calculate_accounts_hash_without_index(
-            TempDir::new().unwrap().path(),
-            &get_storage_refs(&storages),
-            None,
-            HashStats::default(),
-            false,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+        let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
+        let result = db
+            .calculate_accounts_hash_without_index(
+                TempDir::new().unwrap().path(),
+                &get_storage_refs(&storages),
+                None,
+                HashStats::default(),
+                false,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         assert_eq!(result, (expected_hash, 0));
     }
@@ -7955,17 +7958,19 @@ pub mod tests {
                 item.hash
             });
         let sum = raw_expected.iter().map(|item| item.lamports).sum();
-        let result = AccountsDb::calculate_accounts_hash_without_index(
-            TempDir::new().unwrap().path(),
-            &get_storage_refs(&storages),
-            None,
-            HashStats::default(),
-            false,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+        let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
+        let result = db
+            .calculate_accounts_hash_without_index(
+                TempDir::new().unwrap().path(),
+                &get_storage_refs(&storages),
+                None,
+                HashStats::default(),
+                false,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
 
         assert_eq!(result, (expected_hash, sum));
     }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -117,7 +117,7 @@ impl AccountsPackage {
             hash_for_testing,
             cluster_type: bank.cluster_type(),
             snapshot_type,
-            accounts: Arc::clone(&bank.accounts()),
+            accounts: bank.accounts(),
         })
     }
 }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        accounts::Accounts,
         accounts_db::SnapshotStorages,
         bank::{Bank, BankSlotDelta},
         snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter},
@@ -47,6 +48,7 @@ pub struct AccountsPackage {
     pub hash_for_testing: Option<Hash>,
     pub cluster_type: ClusterType,
     pub snapshot_type: Option<SnapshotType>,
+    pub accounts: Arc<Accounts>,
 }
 
 impl AccountsPackage {
@@ -115,6 +117,7 @@ impl AccountsPackage {
             hash_for_testing,
             cluster_type: bank.cluster_type(),
             snapshot_type,
+            accounts: Arc::clone(&bank.accounts()),
         })
     }
 }


### PR DESCRIPTION
#### Problem

original refactoring/creation of `calculate_accounts_hash_without_index `  was concerned with not having a `bank`. `AccountsDb` lives forever, and we have needed data from it (like thread pools) and will need more data from it. So, give it a '&self', and let the background code have an arc to `accounts`.

#### Summary of Changes



Fixes #
