### PR TITLE
add roots_original to roots tracker

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5513,7 +5513,7 @@ impl AccountsDb {
             };
             timings.calc_storage_size_quartiles(&combined_maps);
 
-            self.calculate_accounts_hash_without_index(
+            let result = self.calculate_accounts_hash_without_index(
                 &CalcAccountsHashConfig {
                     storages: &storages,
                     use_bg_thread_pool: !is_startup,
@@ -5521,7 +5521,11 @@ impl AccountsDb {
                     ancestors: can_cached_slot_be_unflushed.then(|| ancestors),
                 },
                 timings,
-            )
+            );
+            // now that calculate_accounts_hash_without_index is complete, we can remove old roots
+            self.remove_old_roots(slot);
+
+            result
         } else {
             self.calculate_accounts_hash(slot, ancestors, check_hash)
         }
@@ -5777,6 +5781,18 @@ impl AccountsDb {
             self.thread_pool_clean.install(scan_and_hash)
         } else {
             scan_and_hash()
+        }
+    }
+
+    /// get rid of old original_roots
+    fn remove_old_roots(&self, slot: Slot) {
+        // epoch_schedule::DEFAULT_SLOTS_PER_EPOCH is a sufficient approximation for now
+        let width = solana_sdk::epoch_schedule::DEFAULT_SLOTS_PER_EPOCH * 11 / 10; // a buffer
+        if slot > width {
+            let min_root = slot - width;
+            let valid_slots = HashSet::default();
+            self.accounts_index
+                .remove_old_original_roots(min_root, &valid_slots);
         }
     }
 

--- a/runtime/src/ancestors.rs
+++ b/runtime/src/ancestors.rs
@@ -85,6 +85,10 @@ impl Ancestors {
         self.len() == 0
     }
 
+    pub fn min_slot(&self) -> Slot {
+        self.ancestors.min().unwrap_or_default()
+    }
+
     pub fn max_slot(&self) -> Slot {
         self.ancestors.max_exclusive().saturating_sub(1)
     }

--- a/runtime/src/rolling_bit_field.rs
+++ b/runtime/src/rolling_bit_field.rs
@@ -240,7 +240,6 @@ impl RollingBitField {
     }
 
     /// return all items < 'max_slot_exclusive'
-    #[allow(dead_code)] // temporary
     pub fn get_all_less_than(&self, max_slot_exclusive: Slot) -> Vec<u64> {
         let mut all = Vec::with_capacity(self.count);
         self.excess.iter().for_each(|slot| {


### PR DESCRIPTION
#### Problem

This work is preparation for smashing multiple slots into a single slot and allowing ancient append vecs. This data structure needs to be saved/loaded to/from snapshots. It is unused in its current form. Other PRs will soon begin using this.

#### Summary of Changes



Fixes #
