### PR TITLE
Support incremental snapshots and run turbine while blockstore processing at validator boot

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -433,6 +433,14 @@ impl ReplayStage {
                     last_print_time: Instant::now(),
                 };
 
+                Self::reset_poh_recorder(
+                    &my_pubkey,
+                    &blockstore,
+                    &bank_forks.read().unwrap().working_bank(),
+                    &poh_recorder,
+                    &leader_schedule_cache,
+                );
+
                 loop {
                     // Stop getting entries if we get exit signal
                     if exit.load(Ordering::Relaxed) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -346,7 +346,7 @@ pub struct ReplayStage {
 
 impl ReplayStage {
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<T: Into<Tower> + Sized>(
         config: ReplayStageConfig,
         blockstore: Arc<Blockstore>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -354,7 +354,7 @@ impl ReplayStage {
         ledger_signal_receiver: Receiver<bool>,
         duplicate_slots_receiver: DuplicateSlotReceiver,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        mut tower: Tower,
+        tower: T,
         vote_tracker: Arc<VoteTracker>,
         cluster_slots: Arc<ClusterSlots>,
         retransmit_slots_sender: RetransmitSlotsSender,
@@ -369,6 +369,9 @@ impl ReplayStage {
         block_metadata_notifier: Option<BlockMetadataNotifierLock>,
         transaction_cost_metrics_sender: Option<TransactionCostMetricsSender>,
     ) -> Self {
+        let mut tower = tower.into();
+        info!("Tower state: {:?}", tower);
+
         let ReplayStageConfig {
             vote_account,
             authorized_voter_keypairs,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -99,7 +99,7 @@ impl Tvu {
     /// * `sockets` - fetch, repair, and retransmit sockets
     /// * `blockstore` - the ledger itself
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new<T: Into<Tower> + Sized>(
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
         bank_forks: &Arc<RwLock<BankForks>>,
@@ -109,7 +109,7 @@ impl Tvu {
         ledger_signal_receiver: Receiver<bool>,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        tower: Tower,
+        tower: T,
         tower_storage: Arc<dyn TowerStorage>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         exit: &Arc<AtomicBool>,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -43,7 +43,6 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
-        snapshot_package::PendingAccountsPackage,
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -778,7 +777,6 @@ fn load_bank_forks(
         process_options,
         None,
         None,
-        PendingAccountsPackage::default(),
         None,
     )
     .map(|(bank_forks, .., starting_snapshot_hashes)| (bank_forks, starting_snapshot_hashes))

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -7,16 +7,13 @@ use {
         },
         leader_schedule_cache::LeaderScheduleCache,
     },
-    crossbeam_channel::bounded,
     log::*,
     solana_runtime::{
-        accounts_background_service::DroppedSlotsReceiver,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         bank_forks::BankForks,
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
-        snapshot_package::PendingAccountsPackage,
         snapshot_utils,
     },
     solana_sdk::genesis_config::GenesisConfig,
@@ -37,9 +34,6 @@ pub type LoadResult = result::Result<
     BlockstoreProcessorError,
 >;
 
-/// maximum drop bank signal queue length
-const MAX_DROP_BANK_SIGNAL_QUEUE_SIZE: usize = 10_000;
-
 /// Load the banks via genesis or a snapshot then processes all full blocks in blockstore
 ///
 /// If a snapshot config is given, and a snapshot is found, it will be loaded.  Otherwise, load
@@ -54,20 +48,18 @@ pub fn load(
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
-    pending_accounts_package: PendingAccountsPackage,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
 ) -> LoadResult {
-    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, pruned_banks_receiver) =
-        load_bank_forks(
-            genesis_config,
-            blockstore,
-            account_paths,
-            shrink_paths,
-            snapshot_config,
-            &process_options,
-            cache_block_meta_sender,
-            accounts_update_notifier,
-        );
+    let (bank_forks, leader_schedule_cache, starting_snapshot_hashes, ..) = load_bank_forks(
+        genesis_config,
+        blockstore,
+        account_paths,
+        shrink_paths,
+        snapshot_config,
+        &process_options,
+        cache_block_meta_sender,
+        accounts_update_notifier,
+    );
 
     blockstore_processor::process_blockstore_from_root(
         blockstore,
@@ -76,9 +68,7 @@ pub fn load(
         &process_options,
         transaction_status_sender,
         cache_block_meta_sender,
-        snapshot_config,
-        pending_accounts_package,
-        pruned_banks_receiver,
+        &solana_runtime::accounts_background_service::AbsRequestSender::default(),
     )
     .map(|_| (bank_forks, leader_schedule_cache, starting_snapshot_hashes))
 }
@@ -97,7 +87,6 @@ pub fn load_bank_forks(
     Arc<RwLock<BankForks>>,
     LeaderScheduleCache,
     Option<StartingSnapshotHashes>,
-    DroppedSlotsReceiver,
 ) {
     let snapshot_present = if let Some(snapshot_config) = snapshot_config {
         info!(
@@ -156,33 +145,11 @@ pub fn load_bank_forks(
         )
     };
 
-    // Before replay starts, set the callbacks in each of the banks in BankForks so that
-    // all dropped banks come through the `pruned_banks_receiver` channel. This way all bank
-    // drop behavior can be safely synchronized with any other ongoing accounts activity like
-    // cache flush, clean, shrink, as long as the same thread performing those activities also
-    // is processing the dropped banks from the `pruned_banks_receiver` channel.
-
-    // There should only be one bank, the root bank in BankForks. Thus all banks added to
-    // BankForks from now on will be descended from the root bank and thus will inherit
-    // the bank drop callback.
-    assert_eq!(bank_forks.read().unwrap().banks().len(), 1);
-    let (pruned_banks_sender, pruned_banks_receiver) = bounded(MAX_DROP_BANK_SIGNAL_QUEUE_SIZE);
-
-    let leader_schedule_cache = {
-        let root_bank = bank_forks.read().unwrap().root_bank();
-        let callback = root_bank
-            .rc
-            .accounts
-            .accounts_db
-            .create_drop_bank_callback(pruned_banks_sender);
-        root_bank.set_callback(Some(Box::new(callback)));
-
-        let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(&root_bank);
-        if process_options.full_leader_cache {
-            leader_schedule_cache.set_max_schedules(std::usize::MAX);
-        }
-        leader_schedule_cache
-    };
+    let mut leader_schedule_cache =
+        LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
+    if process_options.full_leader_cache {
+        leader_schedule_cache.set_max_schedules(std::usize::MAX);
+    }
 
     if let Some(ref new_hard_forks) = process_options.new_hard_forks {
         let root_bank = bank_forks.read().unwrap().root_bank();
@@ -200,12 +167,7 @@ pub fn load_bank_forks(
         }
     }
 
-    (
-        bank_forks,
-        leader_schedule_cache,
-        starting_snapshot_hashes,
-        pruned_banks_receiver,
-    )
+    (bank_forks, leader_schedule_cache, starting_snapshot_hashes)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -362,7 +362,7 @@ impl SnapshotRequestHandler {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct AbsRequestSender {
     snapshot_request_sender: Option<SnapshotRequestSender>,
 }


### PR DESCRIPTION
The blockstore processor module that reads the ledger at validator boot has its own full snapshot handling, and no support for incremental snapshots.

Rather than plumbing incremental snapshots, rip out blockstore processor's snapshot handling entirely and start the real snapshot packager earlier in the boot chain.

Additionally, start gossip/turbine before blockstore processing so that new blocks can be ingested into rocksdb as early as possible during validator startup