### PR TITLE
`u8` alignment is assumed to be 1 but not checked

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -4906,5 +4906,7 @@ mod tests {
     fn test_check_type_assumptions() {
         // Code in this file assumes that u64 and usize are the same
         assert_eq!(size_of::<u64>(), size_of::<usize>());
+        // Code in this file assumes that u8 is byte aligned
+        assert_eq!(1, align_of::<u8>());
     }
 }


### PR DESCRIPTION
#### Problem

`u8` alignment is assumed to be 1 but not checked

#### Summary of Changes

Check

Fixes #23753
