### PR TITLE
Take snapshot after processing bank 0

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -139,6 +139,7 @@ pub fn load_bank_forks(
                 process_options,
                 cache_block_meta_sender,
                 accounts_update_notifier,
+                snapshot_config,
             ),
             None,
         )


### PR DESCRIPTION
#### Problem

Without a full snapshot at slot 0, incremental snapshots cannot be taken until the next
full snapshot is taken.  This can be confusing when starting a new cluster from genesis and
restarting the node before crossing the first full snapshot interval.

#### Summary of Changes

Ensure that `process_bank_0` takes a full snapshot for bank 0 if a snapshot config has been passed in.
