### PR TITLE
Replaces keyed_account get_signers() by InstructionContext::get_signers()

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -12,7 +12,7 @@ use {
     solana_sdk::{
         feature_set,
         instruction::InstructionError,
-        keyed_account::{get_signers, keyed_account_at_index},
+        keyed_account::keyed_account_at_index,
         program_utils::limited_deserialize,
         stake::{
             instruction::StakeInstruction,
@@ -28,6 +28,8 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);
@@ -38,7 +40,7 @@ pub fn process_instruction(
         return Err(InstructionError::InvalidAccountOwner);
     }
 
-    let signers = get_signers(&keyed_accounts[first_instruction_account..]);
+    let signers = instruction_context.get_signers(transaction_context);
     match limited_deserialize(data)? {
         StakeInstruction::Initialize(authorized, lockup) => {
             let rent = get_sysvar_with_account_check::rent(

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -12,7 +12,7 @@ use {
         account_utils::StateMut,
         feature_set,
         instruction::InstructionError,
-        keyed_account::{get_signers, keyed_account_at_index, KeyedAccount},
+        keyed_account::{keyed_account_at_index, KeyedAccount},
         nonce,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
@@ -268,6 +268,8 @@ pub fn process_instruction(
     instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let instruction = limited_deserialize(instruction_data)?;
 
@@ -275,7 +277,7 @@ pub fn process_instruction(
     trace!("keyed_accounts: {:?}", keyed_accounts);
 
     let _ = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
-    let signers = get_signers(&keyed_accounts[first_instruction_account..]);
+    let signers = instruction_context.get_signers(transaction_context);
     match instruction {
         SystemInstruction::CreateAccount {
             lamports,

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -198,6 +198,10 @@ pub fn create_keyed_accounts_unified<'a>(
         .collect()
 }
 
+#[deprecated(
+    since = "1.11.0",
+    note = "Please use InstructionContext::get_signers() instead"
+)]
 /// Return all the signers from a set of KeyedAccounts
 pub fn get_signers<A>(keyed_accounts: &[KeyedAccount]) -> A
 where


### PR DESCRIPTION
#### Problem
The signer set uses `KeyedAccount`s, which are going to be deprecated.

#### Summary of Changes
Replaces keyed_account `get_signers()` by `InstructionContext::get_signers()`.

Fixes #
