### PR TITLE
Threads for discrete log

### DIFF
--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -59,9 +59,6 @@ lazy_static::lazy_static! {
             include_bytes!("decode_u32_precomputation_for_G.bincode");
         bincode::deserialize(DECODE_PRECOMPUTATION_FOR_G_BINCODE).unwrap_or_default()
     };
-
-    // pub static ref ITERATOR_G: RistrettoPoint = Scalar::from(NUM_THREADS as u64) * G;
-    // pub static ref THREAD_RANGE_BOUND: usize = (TWO16 as usize) / NUM_THREADS;
 }
 
 /// Solves the discrete log instance using a 16/16 bit offline/online split
@@ -79,8 +76,8 @@ impl DiscreteLog {
         }
     }
 
-    /// Adjusts number of threads ina  discrete log isntance.
-    pub fn set_number_threads(&mut self, num_threads: usize) -> Result<(), ProofError> {
+    /// Adjusts number of threads in a discrete log instance.
+    pub fn num_threads(&mut self, num_threads: usize) -> Result<(), ProofError> {
         // number of threads must be a positive power-of-two integer
         if num_threads == 0 || (num_threads & (num_threads - 1)) != 0 {
             return Err(ProofError::DiscreteLogThreads);

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -261,4 +261,3 @@ mod tests {
         assert_eq!(amount, decoded.unwrap());
     }
 }
-

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -10,7 +10,7 @@ use {
 };
 
 const TWO16: u64 = 65536; // 2^16
-const NUM_THREADS: usize = 8;
+const NUM_THREADS: usize = 1;
 
 /// Type that captures a discrete log challenge.
 ///

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -219,7 +219,7 @@ mod tests {
         let amount: u64 = 55;
 
         let mut instance = DiscreteLog::new(G, Scalar::from(amount) * G);
-        instance.set_number_threads(4).unwrap();
+        instance.num_threads(4).unwrap();
 
         // Very informal measurements for now
         let start_computation = Instant::now();

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -1,18 +1,16 @@
 #![cfg(not(target_arch = "bpf"))]
 
 use {
-    curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::Identity},
+    curve25519_dalek::{
+        constants::RISTRETTO_BASEPOINT_POINT as G, ristretto::RistrettoPoint, scalar::Scalar,
+        traits::Identity,
+    },
     serde::{Deserialize, Serialize},
-    std::collections::HashMap,
+    std::{collections::HashMap, sync::mpsc, thread},
 };
 
-#[allow(dead_code)]
-const TWO15: u64 = 32768;
-#[allow(dead_code)]
-const TWO14: u64 = 16384; // 2^14
 const TWO16: u64 = 65536; // 2^16
-#[allow(dead_code)]
-const TWO18: u64 = 262144; // 2^18
+const NUM_THREADS: usize = 8;
 
 /// Type that captures a discrete log challenge.
 ///
@@ -38,11 +36,11 @@ fn decode_u32_precomputation(generator: RistrettoPoint) -> DecodePrecomputation 
     let generator = two16_scalar * generator; // 2^16 * G
 
     // iterator for 2^12*0G , 2^12*1G, 2^12*2G, ...
-    let ristretto_iter = RistrettoIterator::new(identity, generator);
-    ristretto_iter.zip(0..TWO16).for_each(|(elem, x_hi)| {
-        let key = elem.compress().to_bytes();
+    let ristretto_iter = RistrettoIterator::new((identity, 0), (generator, 1));
+    for (point, x_hi) in ristretto_iter.take(TWO16 as usize) {
+        let key = point.compress().to_bytes();
         hashmap.insert(key, x_hi as u16);
-    });
+    }
 
     DecodePrecomputation(hashmap)
 }
@@ -54,6 +52,9 @@ lazy_static::lazy_static! {
             include_bytes!("decode_u32_precomputation_for_G.bincode");
         bincode::deserialize(DECODE_PRECOMPUTATION_FOR_G_BINCODE).unwrap_or_default()
     };
+
+    pub static ref ITERATOR_G: RistrettoPoint = Scalar::from(NUM_THREADS as u64) * G;
+    pub static ref THREAD_RANGE_BOUND: usize = (TWO16 as usize) / NUM_THREADS;
 }
 
 /// Solves the discrete log instance using a 16/16 bit offline/online split
@@ -61,23 +62,51 @@ impl DiscreteLog {
     /// Solves the discrete log problem under the assumption that the solution
     /// is a 32-bit number.
     pub(crate) fn decode_u32(self) -> Option<u64> {
-        self.decode_online(&DECODE_PRECOMPUTATION_FOR_G, TWO16)
+        let ristretto_iterator = RistrettoIterator::new(
+            (self.target, 0),
+            (-self.generator, 1),
+        );
+        self.decode_range(ristretto_iterator, TWO16 as usize)
     }
 
-    pub fn decode_online(self, hashmap: &DecodePrecomputation, solution_bound: u64) -> Option<u64> {
-        // iterator for 0G, -1G, -2G, ...
-        let ristretto_iter = RistrettoIterator::new(self.target, -self.generator);
+    pub(crate) fn decode_u32_threaded(self) -> Option<u64> {
+        let mut starting_point = self.target;
+        let (tx, rx) = mpsc::channel();
 
-        let mut decoded = None;
-        ristretto_iter
-            .zip(0..solution_bound)
-            .for_each(|(elem, x_lo)| {
-                let key = elem.compress().to_bytes();
-                if hashmap.0.contains_key(&key) {
-                    let x_hi = hashmap.0[&key];
-                    decoded = Some(x_lo + solution_bound * x_hi as u64);
+        for i in 0..NUM_THREADS {
+            let tx = tx.clone();
+            let ristretto_iterator = RistrettoIterator::new(
+                (starting_point, i as u64),
+                (-(*ITERATOR_G), NUM_THREADS as u64),
+            );
+
+            thread::spawn(move || {
+                let decoded = self.decode_range(ristretto_iterator, *THREAD_RANGE_BOUND);
+                if decoded.is_some() {
+                    tx.send(decoded.unwrap());
                 }
             });
+            starting_point -= G;
+        }
+
+        drop(tx);
+        for received in rx {
+            return Some(received);
+        }
+
+        None
+    }
+
+    fn decode_range(self, ristretto_iterator: RistrettoIterator, range_bound: usize) -> Option<u64> {
+        let hashmap = &DECODE_PRECOMPUTATION_FOR_G;
+        let mut decoded = None;
+        for (point, x_lo) in ristretto_iterator.take(range_bound) {
+            let key = point.compress().to_bytes();
+            if hashmap.0.contains_key(&key) {
+                let x_hi = hashmap.0[&key];
+                decoded = Some(x_lo + TWO16 * x_hi as u64);
+            }
+        }
         decoded
     }
 }
@@ -87,31 +116,29 @@ impl DiscreteLog {
 /// Given an initial point X and a stepping point P, the iterator iterates through
 /// X + 0*P, X + 1*P, X + 2*P, X + 3*P, ...
 struct RistrettoIterator {
-    pub curr: RistrettoPoint,
-    pub step: RistrettoPoint,
+    pub current: (RistrettoPoint, u64),
+    pub step: (RistrettoPoint, u64),
 }
 
 impl RistrettoIterator {
-    fn new(curr: RistrettoPoint, step: RistrettoPoint) -> Self {
-        RistrettoIterator { curr, step }
+    fn new(current: (RistrettoPoint, u64), step: (RistrettoPoint, u64)) -> Self {
+        RistrettoIterator { current, step }
     }
 }
 
 impl Iterator for RistrettoIterator {
-    type Item = RistrettoPoint;
+    type Item = (RistrettoPoint, u64);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let r = self.curr;
-        self.curr += self.step;
+        let r = self.current;
+        self.current = (self.current.0 + self.step.0, self.current.1 + self.step.1);
         Some(r)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT as G, std::time::Instant,
-    };
+    use {super::*, std::time::Instant};
 
     #[test]
     #[allow(non_snake_case)]
@@ -132,7 +159,8 @@ mod tests {
 
     #[test]
     fn test_decode_correctness() {
-        let amount: u64 = 65545;
+        // general case
+        let amount: u64 = 55;
 
         let instance = DiscreteLog {
             generator: G,
@@ -140,17 +168,90 @@ mod tests {
         };
 
         // Very informal measurements for now
-        let start_precomputation = Instant::now();
-        let precomputed_hashmap = decode_u32_precomputation(G);
-        let precomputation_secs = start_precomputation.elapsed().as_secs_f64();
+        let start_computation = Instant::now();
+        let decoded = instance.decode_u32();
+        let computation_secs = start_computation.elapsed().as_secs_f64();
 
-        let start_online = Instant::now();
-        let computed_amount = instance.decode_online(&precomputed_hashmap, TWO16).unwrap();
-        let online_secs = start_online.elapsed().as_secs_f64();
+        assert_eq!(amount, decoded.unwrap());
 
-        assert_eq!(amount, computed_amount);
+        println!("computation secs: {:?} sec", computation_secs);
+    }
 
-        println!("16/16 Split precomputation: {:?} sec", precomputation_secs);
-        println!("16/16 Split online computation: {:?} sec", online_secs);
+    #[test]
+    fn test_decode_correctness_threaded() {
+        // general case
+        let amount: u64 = 55;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        // Very informal measurements for now
+        let start_computation = Instant::now();
+        let decoded = instance.decode_u32_threaded();
+        let computation_secs = start_computation.elapsed().as_secs_f64();
+
+        assert_eq!(amount, decoded.unwrap());
+
+        println!("computation secs: {:?} sec", computation_secs);
+
+        // amount 0
+        let amount: u64 = 0;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        let decoded = instance.decode_u32_threaded();
+        assert_eq!(amount, decoded.unwrap());
+
+        // amount 1
+        let amount: u64 = 1;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        let decoded = instance.decode_u32_threaded();
+        assert_eq!(amount, decoded.unwrap());
+
+        // amount 2
+        let amount: u64 = 2;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        let decoded = instance.decode_u32_threaded();
+        assert_eq!(amount, decoded.unwrap());
+
+        // amount 3
+        let amount: u64 = 3;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        let decoded = instance.decode_u32_threaded();
+        assert_eq!(amount, decoded.unwrap());
+
+        // max amount
+        let amount: u64 = ((1_u64 << 32) - 1) as u64;
+
+        let instance = DiscreteLog {
+            generator: G,
+            target: Scalar::from(amount) * G,
+        };
+
+        let decoded = instance.decode_u32_threaded();
+        assert_eq!(amount, decoded.unwrap());
     }
 }
+
+
+

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -99,22 +99,26 @@ impl DiscreteLog {
         let mut starting_point = self.target;
         let (tx, rx) = mpsc::channel();
 
-        for i in 0..self.num_threads {
+        let handles = (0..self.num_threads).into_iter().map(|i| {
             let tx = tx.clone();
             let ristretto_iterator = RistrettoIterator::new(
                 (starting_point, i as u64),
                 (-(&self.step_point), self.num_threads as u64),
             );
 
-            thread::spawn(move || {
+            let handle = thread::spawn(move || {
                 if let Some(decoded) = self.decode_range(ristretto_iterator, self.range_bound) {
                     tx.send(decoded).unwrap();
                 }
             });
-            starting_point -= G;
-        }
 
+            starting_point -= G;
+            handle
+        });
+
+        handles.for_each(|handle| handle.join().unwrap());
         drop(tx);
+
         let mut solution = None;
         for received in rx {
             solution = Some(received);

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -123,10 +123,10 @@ impl ElGamal {
     /// message, use `DiscreteLog::decode`.
     #[cfg(not(target_arch = "bpf"))]
     fn decrypt(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> DiscreteLog {
-        DiscreteLog {
-            generator: *G,
-            target: &ciphertext.commitment.0 - &(&secret.0 * &ciphertext.handle.0),
-        }
+        DiscreteLog::new(
+            *G,
+            &ciphertext.commitment.0 - &(&secret.0 * &ciphertext.handle.0),
+        )
     }
 
     /// On input a secret key and a ciphertext, the function returns the decrypted message
@@ -584,13 +584,21 @@ mod tests {
         let amount: u32 = 57;
         let ciphertext = ElGamal::encrypt(&public, amount);
 
-        let expected_instance = DiscreteLog {
-            generator: *G,
-            target: Scalar::from(amount) * &(*G),
-        };
+        let expected_instance = DiscreteLog::new(*G, Scalar::from(amount) * &(*G));
 
         assert_eq!(expected_instance, ElGamal::decrypt(&secret, &ciphertext));
         assert_eq!(57_u64, secret.decrypt_u32(&ciphertext).unwrap());
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_correctness_multithreaded() {
+        let ElGamalKeypair { public, secret } = ElGamalKeypair::new_rand();
+        let amount: u32 = 57;
+        let ciphertext = ElGamal::encrypt(&public, amount);
+
+        let mut instance = ElGamal::decrypt(&secret, &ciphertext);
+        instance.set_number_threads(4).unwrap();
+        assert_eq!(57_u64, instance.decode_u32().unwrap());
     }
 
     #[test]
@@ -619,10 +627,7 @@ mod tests {
             handle: handle_1,
         };
 
-        let expected_instance = DiscreteLog {
-            generator: *G,
-            target: Scalar::from(amount) * (*G),
-        };
+        let expected_instance = DiscreteLog::new(*G, Scalar::from(amount) * &(*G));
 
         assert_eq!(expected_instance, secret_0.decrypt(&ciphertext_0));
         assert_eq!(expected_instance, secret_1.decrypt(&ciphertext_1));

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -597,7 +597,7 @@ mod tests {
         let ciphertext = ElGamal::encrypt(&public, amount);
 
         let mut instance = ElGamal::decrypt(&secret, &ciphertext);
-        instance.set_number_threads(4).unwrap();
+        instance.num_threads(4).unwrap();
         assert_eq!(57_u64, instance.decode_u32().unwrap());
     }
 

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -28,6 +28,8 @@ pub enum ProofError {
     InconsistentCTData,
     #[error("failed to decrypt ciphertext from transfer data")]
     Decryption,
+    #[error("discrete log number of threads not power-of-two")]
+    DiscreteLogThreads,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
#### Summary of Changes

Discrete log computation for ElGamal decryption is a very parallelizable operation. I experimented with multithreading the computation and with 4 threads, decryption time seems to decrease by roughly 50~60% by very informal measurements.

I modified the discrete log code so that number of threads can be set as a static constant. I imagine the discrete log computation should be adjusted later for integration, but solving discrete log with 4/8 threads for now does seem to improve test times.