### PR TITLE
remove 'check_hash' from accounts hash calc

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5117,7 +5117,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         ancestors: &Ancestors,
-        check_hash: bool,
+        check_hash: bool, // this will not be supported anymore
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         use BankHashVerificationError::*;
         let mut collect = Measure::start("collect");
@@ -5173,7 +5173,7 @@ impl AccountsDb {
                                         |loaded_account| {
                                             let loaded_hash = loaded_account.loaded_hash();
                                             let balance = loaded_account.lamports();
-                                            if check_hash && !self.is_filler_account(pubkey) {
+                                            if check_hash && !self.is_filler_account(pubkey) {  // this will not be supported anymore
                                                 let computed_hash =
                                                     loaded_account.compute_hash(*slot, pubkey);
                                                 if computed_hash != loaded_hash {
@@ -5488,7 +5488,7 @@ impl AccountsDb {
         use_index: bool,
         slot: Slot,
         ancestors: &Ancestors,
-        check_hash: bool,
+        check_hash: bool, // this will not be supported anymore
         can_cached_slot_be_unflushed: bool,
         slots_per_epoch: Option<Slot>,
         is_startup: bool,
@@ -5668,6 +5668,7 @@ impl AccountsDb {
                     CalculateHashIntermediate::new(loaded_account.loaded_hash(), balance, *pubkey);
 
                 if check_hash && !Self::is_filler_account_helper(pubkey, filler_account_suffix) {
+                    // this will not be supported anymore
                     let computed_hash = loaded_account.compute_hash(slot, pubkey);
                     if computed_hash != source_item.hash {
                         info!(
@@ -5798,7 +5799,7 @@ impl AccountsDb {
         use BankHashVerificationError::*;
 
         let use_index = false;
-        let check_hash = true;
+        let check_hash = false; // this will not be supported anymore
         let is_startup = true;
         let can_cached_slot_be_unflushed = false;
         let (calculated_hash, calculated_lamports) = self
@@ -10115,7 +10116,7 @@ pub mod tests {
         db.add_root(some_slot);
         assert_matches!(
             db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
-            Err(MismatchedAccountHash)
+            Err(MismatchedBankHash)
         );
     }
 


### PR DESCRIPTION
#### Problem

This becomes difficult to support and less valuable when multiple slots of account updates are written to a single append vec and we lose the slot per entry. The slot stored in the append vec will not be relied upon for skipped rewrites.

Going forward we won’t know the original slot because appendvec from multiple slots will be squashed together. This is what makes this hard to support.

Getting rid of the impl of check_hash is a messy refactoring change, so that is deferred to a non-behavior changing pr.

Goal is to submit this as-is now and backport into 1.10 so 1.10 can avoid asserts on snapshots with squashed slots.

#### Summary of Changes



Fixes #
