### PR TITLE
fix(explorer): serum init open orders has optional openOrdersMarketAu…

### DIFF
--- a/explorer/src/components/instruction/serum/types.ts
+++ b/explorer/src/components/instruction/serum/types.ts
@@ -500,7 +500,7 @@ export function decodeInitOpenOrders(
       openOrders: ix.keys[0].pubkey,
       openOrdersOwner: ix.keys[1].pubkey,
       market: ix.keys[2].pubkey,
-      openOrdersMarketAuthority: ix.keys[4].pubkey,
+      openOrdersMarketAuthority: ix.keys[4]?.pubkey,
     },
   };
 }


### PR DESCRIPTION
…thority

#### Problem
openOrdersMarketAuthority is optional


#### Summary of Changes
When decoding InitOpenOrders, openOrdersMarketAuthority should be an optional account