### PR TITLE
fix(explorer): can't convert too large of stake to JS number

### DIFF
--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -296,11 +296,11 @@ function isFullyInactivated(
     return false;
   }
 
-  const delegatedStake = stake.delegation.stake.toNumber();
-  const inactiveStake = activation.inactive;
+  const delegatedStake = stake.delegation.stake;
+  const inactiveStake = new BN(activation.inactive);
 
   return (
     !stake.delegation.deactivationEpoch.eq(MAX_EPOCH) &&
-    delegatedStake === inactiveStake
+    delegatedStake.eq(inactiveStake)
   );
 }


### PR DESCRIPTION
#### Problem
Converting a stake amount that is too large to fit in a JS number

#### Summary of Changes
Convert to BN and perform comparison using .eq

Note: We may need to make adjustments in web3.js to parse stake amounts as BigNums.

Fixes #
