### PR TITLE
Add accounts arg to genesis command to dump genesis account info

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -326,6 +326,26 @@ fn output_ledger(
     }
 }
 
+fn output_account(
+    pubkey: &Pubkey,
+    account: &AccountSharedData,
+    modified_slot: Option<Slot>,
+    print_account_data: bool,
+) {
+    println!("{}", pubkey);
+    println!("  balance: {} SOL", lamports_to_sol(account.lamports()));
+    println!("  owner: '{}'", account.owner());
+    println!("  executable: {}", account.executable());
+    if let Some(slot) = modified_slot {
+        println!("  slot: {}", slot);
+    }
+    println!("  rent_epoch: {}", account.rent_epoch());
+    println!("  data_len: {}", account.data().len());
+    if print_account_data {
+        println!("  data: '{}'", bs58::encode(account.data()).into_string());
+    }
+}
+
 fn render_dot(dot: String, output_file: &str, output_format: &str) -> io::Result<()> {
     let mut child = Command::new("dot")
         .arg(format!("-T{}", output_format))
@@ -1162,6 +1182,24 @@ fn main() {
             SubCommand::with_name("genesis")
             .about("Prints the ledger's genesis config")
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(
+                Arg::with_name("accounts")
+                    .long("accounts")
+                    .takes_value(false)
+                    .help("Print the ledger's genesis accounts"),
+            )
+            .arg(
+                Arg::with_name("no_account_data")
+                    .long("no-account-data")
+                    .takes_value(false)
+                    .requires("accounts")
+                    .help("Do not print account data when printing account contents."),
+            )
+        )
+        .subcommand(
+            SubCommand::with_name("genesis-hash")
+            .about("Prints the ledger's genesis hash")
+            .arg(&max_genesis_archive_unpacked_size_arg)
         )
         .subcommand(
             SubCommand::with_name("parse_full_frozen")
@@ -1176,11 +1214,6 @@ fn main() {
                     .takes_value(true)
                     .help("path to log file to parse"),
             )
-        )
-        .subcommand(
-            SubCommand::with_name("genesis-hash")
-            .about("Prints the ledger's genesis hash")
-            .arg(&max_genesis_archive_unpacked_size_arg)
         )
         .subcommand(
             SubCommand::with_name("modify-genesis")
@@ -1457,11 +1490,10 @@ fn main() {
                     .takes_value(false)
                     .help("Do not print contents of each account, which is very slow with lots of accounts."),
             )
-            .arg(
-                Arg::with_name("no_account_data")
-                    .long("no-account-data")
-                    .takes_value(false)
-                    .help("Do not print account data when printing account contents."),
+            .arg(Arg::with_name("no_account_data")
+                .long("no-account-data")
+                .takes_value(false)
+                .help("Do not print account data when printing account contents."),
             )
             .arg(&max_genesis_archive_unpacked_size_arg)
         ).subcommand(
@@ -1690,7 +1722,21 @@ fn main() {
                 }
             }
             ("genesis", Some(arg_matches)) => {
-                println!("{}", open_genesis_config_by(&ledger_path, arg_matches));
+                let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
+                let print_accouunts = arg_matches.is_present("accounts");
+                if print_accouunts {
+                    let print_account_data = !arg_matches.is_present("no_account_data");
+                    for (pubkey, account) in genesis_config.accounts {
+                        output_account(
+                            &pubkey,
+                            &AccountSharedData::from(account),
+                            None,
+                            print_account_data,
+                        );
+                    }
+                } else {
+                    println!("{}", genesis_config);
+                }
             }
             ("genesis-hash", Some(arg_matches)) => {
                 println!(
@@ -2560,17 +2606,7 @@ fn main() {
                     let print_account_data = !arg_matches.is_present("no_account_data");
                     let mut measure = Measure::start("printing account contents");
                     for (pubkey, (account, slot)) in accounts.into_iter() {
-                        let data_len = account.data().len();
-                        println!("{}:", pubkey);
-                        println!("  - balance: {} SOL", lamports_to_sol(account.lamports()));
-                        println!("  - owner: '{}'", account.owner());
-                        println!("  - executable: {}", account.executable());
-                        println!("  - slot: {}", slot);
-                        println!("  - rent_epoch: {}", account.rent_epoch());
-                        if print_account_data {
-                            println!("  - data: '{}'", bs58::encode(account.data()).into_string());
-                        }
-                        println!("  - data_len: {}", data_len);
+                        output_account(&pubkey, &account, Some(slot), print_account_data);
                     }
                     measure.stop();
                     info!("{}", measure);


### PR DESCRIPTION
#### Summary of Changes
Add accounts arg to genesis command to dump genesis account info

Sample output:
```
$ cargo run -- solana-ledger-tool genesis --accounts --no-account-data --ledger ~/path/to/mainnet/genesis/bin
...
13LeFbG6m2EP1fqCj9k66fcXsoTHMMtgr7c78AivUrYD
  balance: 153333633.3909091 SOL
  owner: 'Stake11111111111111111111111111111111111111'
  executable: false
  rent_epoch: 0
  data_len: 200
14FUT96s9swbmH7ZjpDvfEDywnAYy9zaNhv4xvezySGu
  balance: 4999999.98090912 SOL
  owner: 'Stake11111111111111111111111111111111111111'
  executable: false
  rent_epoch: 0
  data_len: 200
...
```