### PR TITLE
feat(explorer): solana ping set minBarHeight

### DIFF
--- a/explorer/src/components/SolanaPingCard.tsx
+++ b/explorer/src/components/SolanaPingCard.tsx
@@ -192,6 +192,7 @@ function PingBarChart({ pingInfo }: { pingInfo: PingRollupInfo }) {
     }),
     datasets: [
       {
+        minBarLength: 2,
         backgroundColor: seriesData.map((val) =>
           val.loss > 0.5 ? "#f00" : "#00D192"
         ),


### PR DESCRIPTION
#### Problem
For pings with 0 confirmations, there is zero height on the bar

#### Summary of Changes
Set the bar height to 2px


Fixes #
