### PR TITLE
Add accounts-filler-size command line option

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -798,7 +798,8 @@ impl Validator {
                 let enable_gossip_push = config
                     .accounts_db_config
                     .as_ref()
-                    .and_then(|config| config.filler_account_count)
+                    .and_then(|config| config.filler_accounts.as_ref())
+                    .and_then(|config| config.count)
                     .map(|count| count == 0)
                     .unwrap_or(true);
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -798,9 +798,7 @@ impl Validator {
                 let enable_gossip_push = config
                     .accounts_db_config
                     .as_ref()
-                    .and_then(|config| config.filler_accounts.as_ref())
-                    .and_then(|config| config.count)
-                    .map(|count| count == 0)
+                    .map(|config| config.filler_accounts_config.count == 0)
                     .unwrap_or(true);
 
                 let snapshot_packager_service = SnapshotPackagerService::new(

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -928,6 +928,7 @@ fn main() {
         .value_name("COUNT")
         .validator(is_parsable::<usize>)
         .takes_value(true)
+        .default_value("0")
         .help("How many accounts to add to stress the system. Accounts are ignored in operations related to correctness.");
     let accounts_filler_size = Arg::with_name("accounts_filler_size")
         .long("accounts-filler-size")
@@ -935,6 +936,7 @@ fn main() {
         .validator(is_parsable::<usize>)
         .takes_value(true)
         .default_value("0")
+        .requires("accounts_filler_count")
         .help("Size per filler account in bytes.");
     let account_paths_arg = Arg::with_name("account_paths")
         .long("accounts")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2077,8 +2077,8 @@ fn main() {
                 }
 
                 let filler_accounts_config = FillerAccountsConfig {
-                    count: value_t!(matches, "accounts_filler_count", usize).unwrap(),
-                    size: value_t!(matches, "accounts_filler_size", usize).unwrap(),
+                    count: value_t_or_exit!(matches, "accounts_filler_count", usize),
+                    size: value_t_or_exit!(matches, "accounts_filler_size", usize),
                 };
 
                 let accounts_db_config = Some(AccountsDbConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2077,8 +2077,8 @@ fn main() {
                 }
 
                 let filler_accounts_config = FillerAccountsConfig {
-                    count: value_t_or_exit!(matches, "accounts_filler_count", usize),
-                    size: value_t_or_exit!(matches, "accounts_filler_size", usize),
+                    count: value_t_or_exit!(arg_matches, "accounts_filler_count", usize),
+                    size: value_t_or_exit!(arg_matches, "accounts_filler_size", usize),
                 };
 
                 let accounts_db_config = Some(AccountsDbConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -934,7 +934,8 @@ fn main() {
         .value_name("BYTES")
         .validator(is_parsable::<usize>)
         .takes_value(true)
-        .help("Size per filler account in bytes. [default: 0]");
+        .default_value("0")
+        .help("Size per filler account in bytes.");
     let account_paths_arg = Arg::with_name("account_paths")
         .long("accounts")
         .value_name("PATHS")
@@ -2073,19 +2074,15 @@ fn main() {
                     accounts_index_config.drives = Some(accounts_index_paths);
                 }
 
-                let mut filler_accounts_config = FillerAccountsConfig::default();
-                if let Some(count) = value_t!(arg_matches, "accounts_filler_count", usize).ok() {
-                    filler_accounts_config.count = Some(count);
-                }
-
-                if let Some(size) = value_t!(arg_matches, "accounts_filler_size", usize).ok() {
-                    filler_accounts_config.size = Some(size);
-                }
+                let filler_accounts_config = FillerAccountsConfig {
+                    count: value_t!(matches, "accounts_filler_count", usize).unwrap(),
+                    size: value_t!(matches, "accounts_filler_size", usize).unwrap(),
+                };
 
                 let accounts_db_config = Some(AccountsDbConfig {
                     index: Some(accounts_index_config),
                     accounts_hash_cache_path: Some(ledger_path.clone()),
-                    filler_accounts: Some(filler_accounts_config),
+                    filler_accounts_config,
                     ..AccountsDbConfig::default()
                 });
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -128,7 +128,7 @@ pub fn load_bank_forks(
         if process_options
             .accounts_db_config
             .as_ref()
-            .and_then(|config| config.filler_account_count)
+            .and_then(|cfg| cfg.filler_accounts.as_ref().and_then(|facfg| facfg.count))
             .unwrap_or_default()
             > 0
         {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -125,12 +125,12 @@ pub fn load_bank_forks(
             accounts_update_notifier,
         )
     } else {
-        if process_options
+        let maybe_filler_accounts = process_options
             .accounts_db_config
             .as_ref()
-            .map(|config| config.filler_accounts_config.count > 0)
-            .unwrap()
-        {
+            .map(|config| config.filler_accounts_config.count > 0);
+
+        if let Some(true) = maybe_filler_accounts {
             panic!("filler accounts specified, but not loading from snapshot");
         }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -128,9 +128,8 @@ pub fn load_bank_forks(
         if process_options
             .accounts_db_config
             .as_ref()
-            .and_then(|cfg| cfg.filler_accounts.as_ref().and_then(|facfg| facfg.count))
-            .unwrap_or_default()
-            > 0
+            .map(|config| config.filler_accounts_config.count > 0)
+            .unwrap()
         {
             panic!("filler accounts specified, but not loading from snapshot");
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6876,8 +6876,8 @@ impl AccountsDb {
         let epoch = epoch_schedule.get_epoch(max_root_inclusive);
 
         info!(
-            "adding {} filler accounts",
-            self.filler_accounts_config.count
+            "adding {} filler accounts with size {}",
+            self.filler_accounts_config.count, self.filler_accounts_config.size,
         );
         // break this up to force the accounts out of memory after each pass
         let passes = 100;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -128,14 +128,14 @@ const CACHE_VIRTUAL_STORED_SIZE: StoredSize = 0;
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     accounts_hash_cache_path: None,
-    filler_accounts: None,
+    filler_accounts_config: FillerAccountsConfig { count: 0, size: 0 },
     hash_calc_num_passes: None,
     write_cache_limit_bytes: None,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     accounts_hash_cache_path: None,
-    filler_accounts: None,
+    filler_accounts_config: FillerAccountsConfig { count: 0, size: 0 },
     hash_calc_num_passes: None,
     write_cache_limit_bytes: None,
 };
@@ -148,17 +148,19 @@ pub struct AccountsAddRootTiming {
     pub store_us: u64,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct FillerAccountsConfig {
-    pub count: Option<usize>,
-    pub size: Option<usize>,
+    /// Number of filler accounts
+    pub count: usize,
+    /// Data size per account, in bytes
+    pub size: usize,
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct AccountsDbConfig {
     pub index: Option<AccountsIndexConfig>,
     pub accounts_hash_cache_path: Option<PathBuf>,
-    pub filler_accounts: Option<FillerAccountsConfig>,
+    pub filler_accounts_config: FillerAccountsConfig,
     pub hash_calc_num_passes: Option<usize>,
     pub write_cache_limit_bytes: Option<u64>,
 }
@@ -1096,8 +1098,7 @@ pub struct AccountsDb {
     /// GeyserPlugin accounts update notifier
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
 
-    filler_accounts_count: usize,
-    filler_accounts_size: usize,
+    filler_accounts_config: FillerAccountsConfig,
     pub filler_account_suffix: Option<Pubkey>,
 
     active_stats: ActiveStats,
@@ -1640,8 +1641,7 @@ impl AccountsDb {
             dirty_stores: DashMap::default(),
             zero_lamport_accounts_to_purge_after_full_snapshot: DashSet::default(),
             accounts_update_notifier: None,
-            filler_accounts_count: 0,
-            filler_accounts_size: 0,
+            filler_accounts_config: FillerAccountsConfig::default(),
             filler_account_suffix: None,
             num_hash_scan_passes,
         }
@@ -1685,17 +1685,13 @@ impl AccountsDb {
         let accounts_hash_cache_path = accounts_db_config
             .as_ref()
             .and_then(|x| x.accounts_hash_cache_path.clone());
-        let filler_accounts_count = accounts_db_config
+
+        let filler_accounts_config = accounts_db_config
             .as_ref()
-            .and_then(|cfg| cfg.filler_accounts.as_ref().and_then(|facfg| facfg.count))
+            .map(|config| config.filler_accounts_config)
             .unwrap_or_default();
 
-        let filler_accounts_size = accounts_db_config
-            .as_ref()
-            .and_then(|cfg| cfg.filler_accounts.as_ref().and_then(|facfg| facfg.size))
-            .unwrap_or_default();
-
-        let filler_account_suffix = if filler_accounts_count > 0 {
+        let filler_account_suffix = if filler_accounts_config.count > 0 {
             Some(solana_sdk::pubkey::new_rand())
         } else {
             None
@@ -1708,8 +1704,7 @@ impl AccountsDb {
             caching_enabled,
             shrink_ratio,
             accounts_update_notifier,
-            filler_accounts_count,
-            filler_accounts_size,
+            filler_accounts_config,
             filler_account_suffix,
             write_cache_limit_bytes: accounts_db_config
                 .as_ref()
@@ -5756,7 +5751,7 @@ impl AccountsDb {
                 };
 
                 let hash = AccountsHash {
-                    filler_account_suffix: if self.filler_account_count > 0 {
+                    filler_account_suffix: if self.filler_accounts_config.count > 0 {
                         self.filler_account_suffix
                     } else {
                         None
@@ -6873,14 +6868,17 @@ impl AccountsDb {
     /// The accounts added in a slot are setup to have pubkeys such that rent will be collected from them before (or when?) their slot becomes an epoch old.
     /// Thus, the filler accounts are rewritten by rent and the old slot can be thrown away successfully.
     pub fn maybe_add_filler_accounts(&self, epoch_schedule: &EpochSchedule) {
-        if self.filler_accounts_count == 0 {
+        if self.filler_accounts_config.count == 0 {
             return;
         }
 
         let max_root_inclusive = self.accounts_index.max_root_inclusive();
         let epoch = epoch_schedule.get_epoch(max_root_inclusive);
 
-        info!("adding {} filler accounts", self.filler_accounts_count);
+        info!(
+            "adding {} filler accounts",
+            self.filler_accounts_config.count
+        );
         // break this up to force the accounts out of memory after each pass
         let passes = 100;
         let mut roots = self.storage.all_slots();
@@ -6895,7 +6893,7 @@ impl AccountsDb {
         let hash = Hash::from_str(string).unwrap();
         let owner = Pubkey::from_str(string).unwrap();
         let lamports = 100_000_000;
-        let space = self.filler_accounts_count * self.filler_accounts_size;
+        let space = self.filler_accounts_config.size;
         let account = AccountSharedData::new(lamports, space, &owner);
         let added = AtomicUsize::default();
         for pass in 0..=passes {
@@ -6922,8 +6920,8 @@ impl AccountsDb {
                 let subrange = crate::bank::Bank::pubkey_range_from_partition(partition);
 
                 let idx = overall_index.fetch_add(1, Ordering::Relaxed);
-                let filler_entries = (idx + 1) * self.filler_accounts_count / root_count
-                    - idx * self.filler_accounts_count / root_count;
+                let filler_entries = (idx + 1) * self.filler_accounts_config.count / root_count
+                    - idx * self.filler_accounts_config.count / root_count;
                 let accounts = (0..filler_entries)
                     .map(|_| {
                         let my_id = added.fetch_add(1, Ordering::Relaxed);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -128,14 +128,14 @@ const CACHE_VIRTUAL_STORED_SIZE: StoredSize = 0;
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     accounts_hash_cache_path: None,
-    filler_accounts_config: FillerAccountsConfig { count: 0, size: 0 },
+    filler_accounts_config: FillerAccountsConfig::const_default(),
     hash_calc_num_passes: None,
     write_cache_limit_bytes: None,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
     accounts_hash_cache_path: None,
-    filler_accounts_config: FillerAccountsConfig { count: 0, size: 0 },
+    filler_accounts_config: FillerAccountsConfig::const_default(),
     hash_calc_num_passes: None,
     write_cache_limit_bytes: None,
 };
@@ -148,12 +148,24 @@ pub struct AccountsAddRootTiming {
     pub store_us: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct FillerAccountsConfig {
     /// Number of filler accounts
     pub count: usize,
     /// Data size per account, in bytes
     pub size: usize,
+}
+
+impl FillerAccountsConfig {
+    pub const fn const_default() -> Self {
+        Self { count: 0, size: 0 }
+    }
+}
+
+impl Default for FillerAccountsConfig {
+    fn default() -> Self {
+        Self::const_default()
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -642,7 +642,7 @@ where
         genesis_config,
     );
 
-    accounts_db.maybe_add_filler_accounts(&genesis_config.epoch_schedule);
+    accounts_db.maybe_add_filler_accounts(&genesis_config.epoch_schedule, &genesis_config.rent);
 
     handle.join().unwrap();
     measure_notify.stop();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1600,6 +1600,7 @@ pub fn main() {
             .value_name("COUNT")
             .validator(is_parsable::<usize>)
             .takes_value(true)
+            .default_value("0")
             .help("How many accounts to add to stress the system. Accounts are ignored in operations related to correctness."))
          .arg(Arg::with_name("accounts_filler_size")
             .long("accounts-filler-size")
@@ -1607,6 +1608,7 @@ pub fn main() {
             .validator(is_parsable::<usize>)
             .takes_value(true)
             .default_value("0")
+            .requires("accounts_filler_count")
             .help("Size per filler account in bytes."))
          .arg(
             Arg::with_name("accounts_db_test_hash_calculation")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1606,7 +1606,8 @@ pub fn main() {
             .value_name("BYTES")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Size per filler account in bytes. [default: 0]"))
+            .default_value("0")
+            .help("Size per filler account in bytes."))
          .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
@@ -2257,19 +2258,15 @@ pub fn main() {
             .ok()
             .map(|mb| mb * MB);
 
-    let mut filler_accounts_config = FillerAccountsConfig::default();
-    if let Some(count) = value_t!(matches, "accounts_filler_count", usize).ok() {
-        filler_accounts_config.count = Some(count);
-    }
-
-    if let Some(size) = value_t!(matches, "accounts_filler_size", usize).ok() {
-        filler_accounts_config.size = Some(size);
-    }
+    let filler_accounts_config = FillerAccountsConfig {
+        count: value_t!(matches, "accounts_filler_count", usize).unwrap(),
+        size: value_t!(matches, "accounts_filler_size", usize).unwrap(),
+    };
 
     let mut accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         accounts_hash_cache_path: Some(ledger_path.clone()),
-        filler_accounts: Some(filler_accounts_config),
+        filler_accounts_config,
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()
             .map(|mb| mb * MB as u64),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2261,8 +2261,8 @@ pub fn main() {
             .map(|mb| mb * MB);
 
     let filler_accounts_config = FillerAccountsConfig {
-        count: value_t!(matches, "accounts_filler_count", usize).unwrap(),
-        size: value_t!(matches, "accounts_filler_size", usize).unwrap(),
+        count: value_t_or_exit!(matches, "accounts_filler_count", usize),
+        size: value_t_or_exit!(matches, "accounts_filler_size", usize),
     };
 
     let mut accounts_db_config = AccountsDbConfig {


### PR DESCRIPTION
#### Problem
Filler accounts offer a great way to model and test the code with more accounts than actually exist. Currently, all the accounts are created without data, so their on-chain data size is all zero. It would be beneficial to exercise the code with additional on-chain data as well.

#### Summary of Changes
Added a new command line option to set the size for filler accounts' data to `solana-validator` and `solana-ledger-tool`

Fixes #23593