### PR TITLE
Use VoteAccountsHashMap type alias in all applicable spots

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -10,7 +10,7 @@ use {
     solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE,
-        vote_account::VoteAccount,
+        vote_account::VoteAccountsHashMap,
     },
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
@@ -253,7 +253,7 @@ impl Tower {
     pub(crate) fn collect_vote_lockouts(
         vote_account_pubkey: &Pubkey,
         bank_slot: Slot,
-        vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
+        vote_accounts: &VoteAccountsHashMap,
         ancestors: &HashMap<Slot, HashSet<Slot>>,
         get_frozen_hash: impl Fn(Slot) -> Option<Hash>,
         latest_validator_votes_for_frozen_banks: &mut LatestValidatorVotesForFrozenBanks,
@@ -636,7 +636,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+        epoch_vote_accounts: &VoteAccountsHashMap,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
         heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
@@ -929,7 +929,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+        epoch_vote_accounts: &VoteAccountsHashMap,
         latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
         heaviest_subtree_fork_choice: &HeaviestSubtreeForkChoice,
     ) -> SwitchForkDecision {
@@ -1377,7 +1377,7 @@ pub mod test {
         },
         itertools::Itertools,
         solana_ledger::{blockstore::make_slot_entries, get_tmp_ledger_path},
-        solana_runtime::bank::Bank,
+        solana_runtime::{bank::Bank, vote_account::VoteAccount},
         solana_sdk::{
             account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
             clock::Slot,
@@ -1398,7 +1398,7 @@ pub mod test {
         trees::tr,
     };
 
-    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> HashMap<Pubkey, (u64, VoteAccount)> {
+    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> VoteAccountsHashMap {
         stake_votes
             .iter()
             .map(|(lamports, votes)| {

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -7,7 +7,7 @@ use {
     },
     solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming},
     solana_program_runtime::timings::ExecuteTimingType,
-    solana_runtime::{bank::Bank, bank_forks::BankForks, vote_account::VoteAccount},
+    solana_runtime::{bank::Bank, bank_forks::BankForks, vote_account::VoteAccountsHashMap},
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
     std::{
         collections::{BTreeMap, HashMap, HashSet},
@@ -516,7 +516,7 @@ impl PropagatedStats {
         &mut self,
         node_pubkey: &Pubkey,
         vote_account_pubkeys: &[Pubkey],
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+        epoch_vote_accounts: &VoteAccountsHashMap,
     ) {
         self.propagated_node_ids.insert(*node_pubkey);
         for vote_account_pubkey in vote_account_pubkeys.iter() {
@@ -695,7 +695,7 @@ impl ProgressMap {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, solana_runtime::vote_account::VoteAccount};
 
     #[test]
     fn test_add_vote_pubkey() {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -34,7 +34,7 @@ use {
         snapshot_utils,
         transaction_batch::TransactionBatch,
         transaction_cost_metrics_sender::TransactionCostMetricsSender,
-        vote_account::VoteAccount,
+        vote_account::VoteAccountsHashMap,
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
@@ -1348,7 +1348,7 @@ fn supermajority_root(roots: &[(Slot, u64)], total_epoch_stake: u64) -> Option<S
 fn supermajority_root_from_vote_accounts(
     bank_slot: Slot,
     total_epoch_stake: u64,
-    vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
+    vote_accounts: &VoteAccountsHashMap,
 ) -> Option<Slot> {
     let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts
         .iter()
@@ -1550,8 +1550,11 @@ pub mod tests {
         matches::assert_matches,
         rand::{thread_rng, Rng},
         solana_entry::entry::{create_ticks, next_entry, next_entry_mut},
-        solana_runtime::genesis_utils::{
-            self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
+        solana_runtime::{
+            genesis_utils::{
+                self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
+            },
+            vote_account::VoteAccount,
         },
         solana_sdk::{
             account::{AccountSharedData, WritableAccount},
@@ -3797,27 +3800,23 @@ pub mod tests {
     #[test]
     #[allow(clippy::field_reassign_with_default)]
     fn test_supermajority_root_from_vote_accounts() {
-        let convert_to_vote_accounts =
-            |roots_stakes: Vec<(Slot, u64)>| -> HashMap<Pubkey, (u64, VoteAccount)> {
-                roots_stakes
-                    .into_iter()
-                    .map(|(root, stake)| {
-                        let mut vote_state = VoteState::default();
-                        vote_state.root_slot = Some(root);
-                        let mut vote_account = AccountSharedData::new(
-                            1,
-                            VoteState::size_of(),
-                            &solana_vote_program::id(),
-                        );
-                        let versioned = VoteStateVersions::new_current(vote_state);
-                        VoteState::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
-                        (
-                            solana_sdk::pubkey::new_rand(),
-                            (stake, VoteAccount::from(vote_account)),
-                        )
-                    })
-                    .collect()
-            };
+        let convert_to_vote_accounts = |roots_stakes: Vec<(Slot, u64)>| -> VoteAccountsHashMap {
+            roots_stakes
+                .into_iter()
+                .map(|(root, stake)| {
+                    let mut vote_state = VoteState::default();
+                    vote_state.root_slot = Some(root);
+                    let mut vote_account =
+                        AccountSharedData::new(1, VoteState::size_of(), &solana_vote_program::id());
+                    let versioned = VoteStateVersions::new_current(vote_state);
+                    VoteState::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
+                    (
+                        solana_sdk::pubkey::new_rand(),
+                        (stake, VoteAccount::from(vote_account)),
+                    )
+                })
+                .collect()
+        };
 
         let total_stake = 10;
         let slot = 100;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,7 +60,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         system_instruction_processor::{get_system_account_kind, SystemAccountKind},
         transaction_batch::TransactionBatch,
-        vote_account::VoteAccount,
+        vote_account::{VoteAccount, VoteAccountsHashMap},
         vote_parser,
     },
     byteorder::{ByteOrder, LittleEndian},
@@ -4492,7 +4492,7 @@ impl Bank {
     #[allow(clippy::needless_collect)]
     fn distribute_rent_to_validators(
         &self,
-        vote_accounts: &HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>,
+        vote_accounts: &VoteAccountsHashMap,
         rent_to_be_distributed: u64,
     ) {
         let mut total_staked = 0;
@@ -6123,7 +6123,7 @@ impl Bank {
 
     /// current vote accounts for this bank along with the stake
     ///   attributed to each account
-    pub fn vote_accounts(&self) -> Arc<HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>> {
+    pub fn vote_accounts(&self) -> Arc<VoteAccountsHashMap> {
         let stakes = self.stakes_cache.stakes();
         Arc::from(stakes.vote_accounts())
     }
@@ -6149,10 +6149,7 @@ impl Bank {
 
     /// vote accounts for the specific epoch along with the stake
     ///   attributed to each account
-    pub fn epoch_vote_accounts(
-        &self,
-        epoch: Epoch,
-    ) -> Option<&HashMap<Pubkey, (u64, VoteAccount)>> {
+    pub fn epoch_vote_accounts(&self, epoch: Epoch) -> Option<&VoteAccountsHashMap> {
         let epoch_stakes = self.epoch_stakes.get(&epoch)?.stakes();
         Some(epoch_stakes.vote_accounts().as_ref())
     }

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{stakes::Stakes, vote_account::VoteAccount},
+    crate::{stakes::Stakes, vote_account::VoteAccountsHashMap},
     serde::{Deserialize, Serialize},
     solana_sdk::{clock::Epoch, pubkey::Pubkey},
     std::{collections::HashMap, sync::Arc},
@@ -60,7 +60,7 @@ impl EpochStakes {
     }
 
     fn parse_epoch_vote_accounts(
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, VoteAccount)>,
+        epoch_vote_accounts: &VoteAccountsHashMap,
         leader_schedule_epoch: Epoch,
     ) -> (u64, NodeIdToVoteAccounts, EpochAuthorizedVoters) {
         let mut node_id_to_vote_accounts: NodeIdToVoteAccounts = HashMap::new();
@@ -119,7 +119,7 @@ impl EpochStakes {
 #[cfg(test)]
 pub(crate) mod tests {
     use {
-        super::*, solana_sdk::account::AccountSharedData,
+        super::*, crate::vote_account::VoteAccount, solana_sdk::account::AccountSharedData,
         solana_vote_program::vote_state::create_account_with_authorized, std::iter,
     };
 

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_vote_accounts_serialize() {
         let mut rng = rand::thread_rng();
-        let vote_accounts_hash_map: HashMap<Pubkey, (u64, VoteAccount)> =
+        let vote_accounts_hash_map: VoteAccountsHashMap =
             new_rand_vote_accounts(&mut rng, 64).take(1024).collect();
         let vote_accounts = VoteAccounts::from(Arc::new(vote_accounts_hash_map.clone()));
         assert!(vote_accounts.staked_nodes().len() > 32);
@@ -479,7 +479,7 @@ mod tests {
     #[test]
     fn test_vote_accounts_deserialize() {
         let mut rng = rand::thread_rng();
-        let vote_accounts_hash_map: HashMap<Pubkey, (u64, VoteAccount)> =
+        let vote_accounts_hash_map: VoteAccountsHashMap =
             new_rand_vote_accounts(&mut rng, 64).take(1024).collect();
         let data = bincode::serialize(&vote_accounts_hash_map).unwrap();
         let vote_accounts: VoteAccounts = bincode::deserialize(&data).unwrap();


### PR DESCRIPTION
#### Problem
I was poking around a little from https://github.com/solana-labs/solana/pull/23692 (and issue it aims to address) and found it inconvenient to find all instances `HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>`, given that some used `VoteAccountsHashMap` type alias, as well as there being a mix of including/excluding the `/*stake:*/` comment.


#### Summary of Changes
Use `VoteAccountsHashMap` type alias everywhere and appease clippy - no functional changes
