### PR TITLE
Refactor: Replaces KeyedAccount in_get_sysvar_with_account_check

### DIFF
--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -5,7 +5,6 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
         instruction::InstructionError,
-        keyed_account::KeyedAccount,
         pubkey::Pubkey,
         sysvar::{
             clock::Clock, epoch_schedule::EpochSchedule, rent::Rent, slot_hashes::SlotHashes,
@@ -179,60 +178,6 @@ impl SysvarCache {
 /// order to keep consistent behavior, they continue to enforce the same checks
 /// as `solana_sdk::keyed_account::from_keyed_account` despite dynamically
 /// loading them instead of deserializing from account data.
-pub mod get_sysvar_with_account_check {
-    use super::*;
-
-    fn check_sysvar_keyed_account<S: Sysvar>(
-        keyed_account: &KeyedAccount,
-    ) -> Result<(), InstructionError> {
-        if !S::check_id(keyed_account.unsigned_key()) {
-            return Err(InstructionError::InvalidArgument);
-        }
-        Ok(())
-    }
-
-    pub fn clock(
-        keyed_account: &KeyedAccount,
-        invoke_context: &InvokeContext,
-    ) -> Result<Arc<Clock>, InstructionError> {
-        check_sysvar_keyed_account::<Clock>(keyed_account)?;
-        invoke_context.get_sysvar_cache().get_clock()
-    }
-
-    pub fn rent(
-        keyed_account: &KeyedAccount,
-        invoke_context: &InvokeContext,
-    ) -> Result<Arc<Rent>, InstructionError> {
-        check_sysvar_keyed_account::<Rent>(keyed_account)?;
-        invoke_context.get_sysvar_cache().get_rent()
-    }
-
-    pub fn slot_hashes(
-        keyed_account: &KeyedAccount,
-        invoke_context: &InvokeContext,
-    ) -> Result<Arc<SlotHashes>, InstructionError> {
-        check_sysvar_keyed_account::<SlotHashes>(keyed_account)?;
-        invoke_context.get_sysvar_cache().get_slot_hashes()
-    }
-
-    #[allow(deprecated)]
-    pub fn recent_blockhashes(
-        keyed_account: &KeyedAccount,
-        invoke_context: &InvokeContext,
-    ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
-        check_sysvar_keyed_account::<RecentBlockhashes>(keyed_account)?;
-        invoke_context.get_sysvar_cache().get_recent_blockhashes()
-    }
-
-    pub fn stake_history(
-        keyed_account: &KeyedAccount,
-        invoke_context: &InvokeContext,
-    ) -> Result<Arc<StakeHistory>, InstructionError> {
-        check_sysvar_keyed_account::<StakeHistory>(keyed_account)?;
-        invoke_context.get_sysvar_cache().get_stake_history()
-    }
-}
-
 pub mod get_sysvar_with_account_check2 {
     use super::*;
 

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -178,7 +178,7 @@ impl SysvarCache {
 /// order to keep consistent behavior, they continue to enforce the same checks
 /// as `solana_sdk::keyed_account::from_keyed_account` despite dynamically
 /// loading them instead of deserializing from account data.
-pub mod get_sysvar_with_account_check2 {
+pub mod get_sysvar_with_account_check {
     use super::*;
 
     fn check_sysvar_account<S: Sysvar>(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -25,7 +25,7 @@ use {
         invoke_context::{ComputeMeter, Executor, InvokeContext},
         log_collector::LogCollector,
         stable_log,
-        sysvar_cache::get_sysvar_with_account_check,
+        sysvar_cache::get_sysvar_with_account_check2,
     },
     solana_rbpf::{
         aligned_memory::AlignedMemory,
@@ -492,20 +492,10 @@ fn process_loader_upgradeable_instruction(
                 keyed_accounts,
                 first_instruction_account.saturating_add(3),
             )?;
-            let rent = get_sysvar_with_account_check::rent(
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account.saturating_add(4),
-                )?,
-                invoke_context,
-            )?;
-            let clock = get_sysvar_with_account_check::clock(
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account.saturating_add(5),
-                )?,
-                invoke_context,
-            )?;
+            let rent =
+                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 4)?;
+            let clock =
+                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 5)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
                 first_instruction_account.saturating_add(7),
@@ -683,20 +673,9 @@ fn process_loader_upgradeable_instruction(
                 keyed_accounts,
                 first_instruction_account.saturating_add(2),
             )?;
-            let rent = get_sysvar_with_account_check::rent(
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account.saturating_add(4),
-                )?,
-                invoke_context,
-            )?;
-            let clock = get_sysvar_with_account_check::clock(
-                keyed_account_at_index(
-                    keyed_accounts,
-                    first_instruction_account.saturating_add(5),
-                )?,
-                invoke_context,
-            )?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 4)?;
+            let clock =
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 5)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
                 first_instruction_account.saturating_add(6),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -25,7 +25,7 @@ use {
         invoke_context::{ComputeMeter, Executor, InvokeContext},
         log_collector::LogCollector,
         stable_log,
-        sysvar_cache::get_sysvar_with_account_check2,
+        sysvar_cache::get_sysvar_with_account_check,
     },
     solana_rbpf::{
         aligned_memory::AlignedMemory,
@@ -492,10 +492,9 @@ fn process_loader_upgradeable_instruction(
                 keyed_accounts,
                 first_instruction_account.saturating_add(3),
             )?;
-            let rent =
-                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 4)?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 4)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 5)?;
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 5)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
                 first_instruction_account.saturating_add(7),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -7,7 +7,7 @@ use {
     crate::{config, stake_state::StakeAccount},
     log::*,
     solana_program_runtime::{
-        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
+        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         feature_set,
@@ -43,8 +43,7 @@ pub fn process_instruction(
     let signers = instruction_context.get_signers(transaction_context);
     match limited_deserialize(data)? {
         StakeInstruction::Initialize(authorized, lockup) => {
-            let rent =
-                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 1)?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             me.initialize(&authorized, &lockup, &rent)
         }
         StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
@@ -54,7 +53,7 @@ pub fn process_instruction(
 
             if require_custodian_for_locked_stake_authorize {
                 let clock =
-                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
+                    get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
                 let _current_authority =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
                 let custodian =
@@ -90,7 +89,7 @@ pub fn process_instruction(
 
             if require_custodian_for_locked_stake_authorize {
                 let clock =
-                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
+                    get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
                 let custodian =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 3)
                         .ok()
@@ -122,8 +121,8 @@ pub fn process_instruction(
         StakeInstruction::DelegateStake => {
             let vote = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
+            let stake_history = get_sysvar_with_account_check::stake_history(
                 invoke_context,
                 instruction_context,
                 3,
@@ -146,8 +145,8 @@ pub fn process_instruction(
             let source_stake =
                 &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
+            let stake_history = get_sysvar_with_account_check::stake_history(
                 invoke_context,
                 instruction_context,
                 3,
@@ -163,8 +162,8 @@ pub fn process_instruction(
         StakeInstruction::Withdraw(lamports) => {
             let to = &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
-            let stake_history = get_sysvar_with_account_check2::stake_history(
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
+            let stake_history = get_sysvar_with_account_check::stake_history(
                 invoke_context,
                 instruction_context,
                 3,
@@ -180,7 +179,7 @@ pub fn process_instruction(
         }
         StakeInstruction::Deactivate => {
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
             me.deactivate(&clock, &signers)
         }
         StakeInstruction::SetLockup(lockup) => {
@@ -204,7 +203,7 @@ pub fn process_instruction(
                 };
 
                 let rent =
-                    get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 1)?;
+                    get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
                 me.initialize(&authorized, &Lockup::default(), &rent)
             } else {
                 Err(InstructionError::InvalidInstructionData)
@@ -216,7 +215,7 @@ pub fn process_instruction(
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
                 let clock =
-                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
+                    get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
                 let _current_authority =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
                 let authorized_pubkey =
@@ -248,7 +247,7 @@ pub fn process_instruction(
                 let authority_base =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
                 let clock =
-                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
+                    get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
                 let authorized_pubkey =
                     &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
                         .signer_key()

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -5,7 +5,7 @@ use {
     log::*,
     solana_metrics::inc_new_counter_info,
     solana_program_runtime::{
-        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
+        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         feature_set,
@@ -36,16 +36,15 @@ pub fn process_instruction(
     let signers = instruction_context.get_signers(transaction_context);
     match limited_deserialize(data)? {
         VoteInstruction::InitializeAccount(vote_init) => {
-            let rent =
-                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 1)?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
             verify_rent_exemption(me, &rent)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
             vote_state::initialize_account(me, &vote_init, &signers, &clock)
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
             vote_state::authorize(
                 me,
                 &voter_pubkey,
@@ -65,13 +64,10 @@ pub fn process_instruction(
         }
         VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
             inc_new_counter_info!("vote-native", 1);
-            let slot_hashes = get_sysvar_with_account_check2::slot_hashes(
-                invoke_context,
-                instruction_context,
-                1,
-            )?;
+            let slot_hashes =
+                get_sysvar_with_account_check::slot_hashes(invoke_context, instruction_context, 1)?;
             let clock =
-                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
+                get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
             vote_state::process_vote(
                 me,
                 &slot_hashes,
@@ -141,7 +137,7 @@ pub fn process_instruction(
                         .signer_key()
                         .ok_or(InstructionError::MissingRequiredSignature)?;
                 let clock =
-                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
+                    get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
                 vote_state::authorize(
                     me,
                     voter_pubkey,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -5,7 +5,7 @@ use {
     log::*,
     solana_metrics::inc_new_counter_info,
     solana_program_runtime::{
-        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
+        invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
     },
     solana_sdk::{
         feature_set,
@@ -36,22 +36,16 @@ pub fn process_instruction(
     let signers = instruction_context.get_signers(transaction_context);
     match limited_deserialize(data)? {
         VoteInstruction::InitializeAccount(vote_init) => {
-            let rent = get_sysvar_with_account_check::rent(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
-                invoke_context,
-            )?;
+            let rent =
+                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 1)?;
             verify_rent_exemption(me, &rent)?;
-            let clock = get_sysvar_with_account_check::clock(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
-                invoke_context,
-            )?;
+            let clock =
+                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
             vote_state::initialize_account(me, &vote_init, &signers, &clock)
         }
         VoteInstruction::Authorize(voter_pubkey, vote_authorize) => {
-            let clock = get_sysvar_with_account_check::clock(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
-                invoke_context,
-            )?;
+            let clock =
+                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
             vote_state::authorize(
                 me,
                 &voter_pubkey,
@@ -71,14 +65,13 @@ pub fn process_instruction(
         }
         VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
             inc_new_counter_info!("vote-native", 1);
-            let slot_hashes = get_sysvar_with_account_check::slot_hashes(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
+            let slot_hashes = get_sysvar_with_account_check2::slot_hashes(
                 invoke_context,
+                instruction_context,
+                1,
             )?;
-            let clock = get_sysvar_with_account_check::clock(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
-                invoke_context,
-            )?;
+            let clock =
+                get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 2)?;
             vote_state::process_vote(
                 me,
                 &slot_hashes,
@@ -147,10 +140,8 @@ pub fn process_instruction(
                     &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
                         .signer_key()
                         .ok_or(InstructionError::MissingRequiredSignature)?;
-                let clock = get_sysvar_with_account_check::clock(
-                    keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
-                    invoke_context,
-                )?;
+                let clock =
+                    get_sysvar_with_account_check2::clock(invoke_context, instruction_context, 1)?;
                 vote_state::authorize(
                     me,
                     voter_pubkey,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -5,7 +5,7 @@ use {
     },
     log::*,
     solana_program_runtime::{
-        ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
+        ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -355,9 +355,10 @@ pub fn process_instruction(
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
-            let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
+            let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
+                instruction_context,
+                1,
             )?;
             if recent_blockhashes.is_empty() {
                 ic_msg!(
@@ -372,22 +373,22 @@ pub fn process_instruction(
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = &mut keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             #[allow(deprecated)]
-            let _recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
+            let _recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
+                instruction_context,
+                2,
             )?;
-            let rent = get_sysvar_with_account_check::rent(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?,
-                invoke_context,
-            )?;
+            let rent =
+                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 3)?;
             withdraw_nonce_account(me, lamports, to, &rent, &signers, invoke_context)
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
-            let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?,
+            let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
                 invoke_context,
+                instruction_context,
+                1,
             )?;
             if recent_blockhashes.is_empty() {
                 ic_msg!(
@@ -396,10 +397,8 @@ pub fn process_instruction(
                 );
                 return Err(NonceError::NoRecentBlockhashes.into());
             }
-            let rent = get_sysvar_with_account_check::rent(
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?,
-                invoke_context,
-            )?;
+            let rent =
+                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 2)?;
             initialize_nonce_account(me, &authorized, &rent, invoke_context)
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -5,7 +5,7 @@ use {
     },
     log::*,
     solana_program_runtime::{
-        ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check2,
+        ic_msg, invoke_context::InvokeContext, sysvar_cache::get_sysvar_with_account_check,
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
@@ -355,7 +355,7 @@ pub fn process_instruction(
         SystemInstruction::AdvanceNonceAccount => {
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
-            let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
+            let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
                 invoke_context,
                 instruction_context,
                 1,
@@ -373,19 +373,18 @@ pub fn process_instruction(
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = &mut keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             #[allow(deprecated)]
-            let _recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
+            let _recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
                 invoke_context,
                 instruction_context,
                 2,
             )?;
-            let rent =
-                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 3)?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 3)?;
             withdraw_nonce_account(me, lamports, to, &rent, &signers, invoke_context)
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
-            let recent_blockhashes = get_sysvar_with_account_check2::recent_blockhashes(
+            let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
                 invoke_context,
                 instruction_context,
                 1,
@@ -397,8 +396,7 @@ pub fn process_instruction(
                 );
                 return Err(NonceError::NoRecentBlockhashes.into());
             }
-            let rent =
-                get_sysvar_with_account_check2::rent(invoke_context, instruction_context, 2)?;
+            let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 2)?;
             initialize_nonce_account(me, &authorized, &rent, invoke_context)
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {


### PR DESCRIPTION
#### Problem
`in_get_sysvar_with_account_check` still uses `KeyedAccount`s, and an alternative `in_get_sysvar_with_account_check2` which uses the `InstructionContext` instead exists already but is unused.

#### Summary of Changes
- Replaces all use sites of `get_sysvar_with_account_check` by `in_get_sysvar_with_account_check2`.
- Removes `get_sysvar_with_account_check`.
- Renames `get_sysvar_with_account_check2` to `get_sysvar_with_account_check`.

Fixes #
