### PR TITLE
Fix example mock Signer API in solana-program

### DIFF
--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -77,15 +77,17 @@ pub mod solana_sdk {
             pub fn new() -> Keypair {
                 Keypair
             }
+        }
 
-            pub fn pubkey(&self) -> Pubkey {
+        impl Signer for Keypair {
+            fn pubkey(&self) -> Pubkey {
                 Pubkey::default()
             }
         }
 
-        impl Signer for Keypair {}
-
-        pub trait Signer {}
+        pub trait Signer {
+            fn pubkey(&self) -> Pubkey;
+        }
     }
 
     pub mod signers {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -164,7 +164,7 @@ impl Message {
     ///      instruction::Instruction,
     ///      message::Message,
     ///      pubkey::Pubkey,
-    ///      signature::Keypair,
+    ///      signature::{Keypair, Signer},
     ///      transaction::Transaction,
     /// };
     ///
@@ -235,7 +235,7 @@ impl Message {
     ///      instruction::Instruction,
     ///      message::Message,
     ///      pubkey::Pubkey,
-    ///      signature::Keypair,
+    ///      signature::{Keypair, Signer},
     ///      transaction::Transaction,
     /// };
     ///
@@ -333,7 +333,7 @@ impl Message {
     ///      message::Message,
     ///      nonce,
     ///      pubkey::Pubkey,
-    ///      signature::Keypair,
+    ///      signature::{Keypair, Signer},
     ///      system_instruction,
     ///      transaction::Transaction,
     /// };


### PR DESCRIPTION
#### Problem

`pubkey` is part of `Signer`, not ` Keypair`.
