### PR TITLE
Update Version CrdsData on node identity changes

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -635,6 +635,10 @@ impl ClusterInfo {
         self.my_contact_info.write().unwrap().id = id;
 
         self.insert_self();
+        self.push_message(CrdsValue::new_signed(
+            CrdsData::Version(Version::new(self.id())),
+            &self.keypair(),
+        ));
         self.push_self(&HashMap::new(), None);
     }
 


### PR DESCRIPTION
When `solana-validator set-identity` is used to switch a validator's identity at runtime, the version advertised in gossip is not refreshed for the new identity

Fixes #23918