### PR TITLE
fix: thread `enforce_ulimit_nofile` config down when opening blockstore

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1298,6 +1298,7 @@ fn load_blockstore(
         BlockstoreOptions {
             recovery_mode: config.wal_recovery_mode.clone(),
             column_options: config.ledger_column_options.clone(),
+            enforce_ulimit_nofile: config.enforce_ulimit_nofile,
             ..BlockstoreOptions::default()
         },
     )


### PR DESCRIPTION
#### Problem

The web3.js test suite starts up a test validator in a CI environment (GitHub Actions workflows). That environment has a lower maximum allowable file descriptors than the validator would like.

https://github.com/solana-labs/solana/blob/c83c95b56b375afeea231b45cb4ced0cf07761e8/ledger/src/blockstore.rs#L4273-L4276

There's a config param that decides whether a shortfall in the file descriptor limit should log and panic, or just log and move on.

https://github.com/solana-labs/solana/blob/c83c95b56b375afeea231b45cb4ced0cf07761e8/ledger/src/blockstore.rs#L4304-L4306

That config param was not being threaded through when opening the blockstore, so no matter the value, the test validator would _always_ panic in the CI environment and the test suite would fail.

This blocks the release of new versions of web3.js.

#### Summary of Changes

Add  `enforce_ulimit_nofile` to the `BlockstoreOptions` when starting a validator.

Fixes #23615.

---
NOTE: I don't expect the CI run on this PR to actually pass. The CI run sources the `edge` test validator, rather than the version of the test validator _in this PR itself_. The web3.js tests will start passing once this PR is merged and hits `edge`.