### PR TITLE
ci: don't allow mergify to add automerge label to merged PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -93,6 +93,7 @@ pull_request_rules:
       - author=mergify[bot]
       - head~=^mergify/bp/
       - "#status-failure=0"
+      - "-merged"
     actions:
       label:
         add:


### PR DESCRIPTION
#### Problem

mergify went off its rails in https://github.com/solana-labs/solana/pull/23813, stuck in a loop adding and removing the automerge label.

#### Summary of Changes

explicitly disallow adding automerge to merged PRs