### PR TITLE
Refactor fn to closure

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -346,7 +346,7 @@ fn retransmit(
                     let stats = acc.entry(slot).or_default();
                     *stats += RetransmitSlotStats {
                         num_shreds: 1,
-                        num_nodes: num_nodes,
+                        num_nodes,
                     };
                     acc
                 },


### PR DESCRIPTION
#### Problem
Small refactor to use closure instead of fn for merge hashmap counters.



#### Summary of Changes



Fixes #
