### PR TITLE
wip: Add StakeProgramConfig sysvar

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -15,7 +15,7 @@ use {
     solana_banks_interface::{BanksRequest, BanksResponse, BanksTransactionResultWithSimulation},
     solana_program::{
         clock::Slot, fee_calculator::FeeCalculator, hash::Hash, program_pack::Pack, pubkey::Pubkey,
-        rent::Rent, sysvar::Sysvar,
+        rent::Rent, sysvar::LegacySysvar,
     },
     solana_sdk::{
         account::{from_account, Account},
@@ -173,8 +173,9 @@ impl BanksClient {
         self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::default())
     }
 
+    // bprumo TODO: Will this only work for sysvars that are accounts?
     /// Return the cluster Sysvar
-    pub fn get_sysvar<T: Sysvar>(
+    pub fn get_sysvar<T: LegacySysvar>(
         &mut self,
     ) -> impl Future<Output = Result<T, BanksClientError>> + '_ {
         self.get_account(T::id()).map(|result| {

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -239,6 +239,7 @@ impl<'a> InvokeContext<'a> {
         builtin_programs: &'a [BuiltinProgram],
     ) -> Self {
         let mut sysvar_cache = SysvarCache::default();
+        // bprumo TODO: does this expect Sysvars are accounts?
         sysvar_cache.fill_missing_entries(|pubkey| {
             (0..transaction_context.get_number_of_accounts()).find_map(|index| {
                 if transaction_context
@@ -258,6 +259,13 @@ impl<'a> InvokeContext<'a> {
                 }
             })
         });
+        sysvar_cache.set_stake_program_config(
+            // bprumo TODO: can I get a more real value here?
+            solana_sdk::sysvar::stake_program_config::StakeProgramConfig::new(
+                solana_sdk::stake::MINIMUM_STAKE_DELEGATION,
+            ),
+        );
+        // bprumo TODO: add in StakeProgramConfig sysvar here?
         Self::new(
             transaction_context,
             Rent::default(),

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -1,9 +1,17 @@
 use {
     solana_program_test::{processor, ProgramTest},
     solana_sdk::{
-        account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
-        epoch_schedule::EpochSchedule, instruction::Instruction, msg, pubkey::Pubkey, rent::Rent,
-        signature::Signer, sysvar::Sysvar, transaction::Transaction,
+        account_info::AccountInfo,
+        clock::Clock,
+        entrypoint::ProgramResult,
+        epoch_schedule::EpochSchedule,
+        instruction::Instruction,
+        msg,
+        pubkey::Pubkey,
+        rent::Rent,
+        signature::Signer,
+        sysvar::{stake_program_config::StakeProgramConfig, LegacySysvar, Sysvar},
+        transaction::Transaction,
     },
 };
 
@@ -23,6 +31,10 @@ fn sysvar_getter_process_instruction(
 
     let rent = Rent::get()?;
     assert_eq!(rent, Rent::default());
+
+    let stake_program_config = StakeProgramConfig::get()?;
+    log::error!("bprumo DEBUG: {stake_program_config:?}");
+    assert_eq!(stake_program_config, StakeProgramConfig::new(123_456_789));
 
     Ok(())
 }

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -22,7 +22,7 @@ use {
         sysvar::{
             clock,
             stake_history::{self, StakeHistory},
-            Sysvar,
+            LegacySysvar,
         },
         transaction::{Transaction, TransactionError},
     },

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -125,7 +125,7 @@ use {
         slot_hashes::SlotHashes,
         slot_history::SlotHistory,
         system_transaction,
-        sysvar::{self, Sysvar, SysvarId},
+        sysvar::{self, LegacySysvar, SysvarId},
         timing::years_as_slots,
         transaction::{
             MessageHash, Result, SanitizedTransaction, Transaction, TransactionError,
@@ -2286,7 +2286,7 @@ impl Bank {
 
     pub fn set_sysvar_for_tests<T>(&self, sysvar: &T)
     where
-        T: Sysvar + SysvarId,
+        T: LegacySysvar + SysvarId,
     {
         self.update_sysvar_account(&T::id(), |account| {
             create_account(
@@ -6491,6 +6491,18 @@ impl Bank {
         if new_feature_activations.contains(&feature_set::cap_accounts_data_len::id()) {
             const ACCOUNTS_DATA_LEN: u64 = 50_000_000_000;
             self.store_accounts_data_len(ACCOUNTS_DATA_LEN);
+        }
+
+        if new_feature_activations.contains(&feature_set::add_stake_program_config_sysvar::id()) {
+            self.sysvar_cache.write().unwrap().set_stake_program_config(
+                sysvar::stake_program_config::StakeProgramConfig::new(
+                    solana_sdk::stake::MINIMUM_STAKE_DELEGATION,
+                ),
+            );
+            error!(
+                "bprumo DEBUG: bank activate stake program config sysvar! {:?}",
+                self.sysvar_cache.read().unwrap().get_stake_program_config()
+            );
         }
     }
 

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -50,6 +50,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_rent_sysvar(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_get_stake_program_config_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -145,6 +148,13 @@ pub(crate) fn sol_get_fees_sysvar(_var_addr: *mut u8) -> u64 {
 
 pub(crate) fn sol_get_rent_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_rent_sysvar(var_addr)
+}
+
+pub(crate) fn sol_get_stake_program_config_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_stake_program_config_sysvar(var_addr)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -1,10 +1,10 @@
 //! This account contains the clock slot, epoch, and leader_schedule_epoch
 //!
 pub use crate::clock::Clock;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::LegacySysvar};
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 
-impl Sysvar for Clock {
+impl LegacySysvar for Clock {
     impl_sysvar_get!(sol_get_clock_sysvar);
 }

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -1,10 +1,10 @@
 //! This account contains the current cluster rent
 //!
 pub use crate::epoch_schedule::EpochSchedule;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::LegacySysvar};
 
 crate::declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);
 
-impl Sysvar for EpochSchedule {
+impl LegacySysvar for EpochSchedule {
     impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
 }

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -3,7 +3,8 @@
 #![allow(deprecated)]
 
 use crate::{
-    fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
+    fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError,
+    sysvar::LegacySysvar,
 };
 
 crate::declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
@@ -26,6 +27,6 @@ impl Fees {
     }
 }
 
-impl Sysvar for Fees {
+impl LegacySysvar for Fees {
     impl_sysvar_get!(sol_get_fees_sysvar);
 }

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -5,7 +5,7 @@ use {
         declare_deprecated_sysvar_id,
         fee_calculator::FeeCalculator,
         hash::{hash, Hash},
-        sysvar::Sysvar,
+        sysvar::LegacySysvar,
     },
     std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref},
 };
@@ -131,7 +131,7 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
     }
 }
 
-impl Sysvar for RecentBlockhashes {
+impl LegacySysvar for RecentBlockhashes {
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
         6008 // golden, update if MAX_ENTRIES changes

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -1,10 +1,10 @@
 //! This account contains the current cluster rent
 //!
 pub use crate::rent::Rent;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::LegacySysvar};
 
 crate::declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);
 
-impl Sysvar for Rent {
+impl LegacySysvar for Rent {
     impl_sysvar_get!(sol_get_rent_sysvar);
 }

--- a/sdk/program/src/sysvar/rewards.rs
+++ b/sdk/program/src/sysvar/rewards.rs
@@ -1,6 +1,6 @@
 //! DEPRECATED: This sysvar can be removed once the pico-inflation feature is enabled
 //!
-use crate::sysvar::Sysvar;
+use crate::sysvar::LegacySysvar;
 
 crate::declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);
 
@@ -19,4 +19,4 @@ impl Rewards {
     }
 }
 
-impl Sysvar for Rewards {}
+impl LegacySysvar for Rewards {}

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -3,11 +3,11 @@
 //! this account carries the Bank's most recent bank hashes for some N parents
 //!
 pub use crate::slot_hashes::SlotHashes;
-use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::Sysvar};
+use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::LegacySysvar};
 
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
 
-impl Sysvar for SlotHashes {
+impl LegacySysvar for SlotHashes {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -3,14 +3,14 @@
 //! this account carries a bitvector of slots present over the past
 //! epoch
 //!
-use crate::sysvar::Sysvar;
+use crate::sysvar::LegacySysvar;
 pub use crate::{
     account_info::AccountInfo, program_error::ProgramError, slot_history::SlotHistory,
 };
 
 crate::declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
 
-impl Sysvar for SlotHistory {
+impl LegacySysvar for SlotHistory {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -3,11 +3,11 @@
 //! this account carries history about stake activations and de-activations
 //!
 pub use crate::stake_history::StakeHistory;
-use crate::sysvar::Sysvar;
+use crate::sysvar::LegacySysvar;
 
 crate::declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
 
-impl Sysvar for StakeHistory {
+impl LegacySysvar for StakeHistory {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/program/src/sysvar/stake_program_config.rs
+++ b/sdk/program/src/sysvar/stake_program_config.rs
@@ -1,0 +1,38 @@
+//! Sysvar for the stake program's configuration parameters
+use crate::{
+    impl_sysvar_get,
+    sysvar::{ProgramError, Sysvar},
+};
+
+crate::declare_sysvar_id!(
+    "SysvarStakeProgramConfig1111111111111111111",
+    StakeProgramConfig
+);
+
+type Lamports = u64;
+
+// bprumo TODO: should I add a frozen abi hash here?
+/// Configuration parameters for the stake program.
+#[repr(C)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, AbiExample)]
+pub struct StakeProgramConfig {
+    /// The minimum stake delegation amount, in lamports
+    minimum_delegation: Lamports,
+}
+
+impl StakeProgramConfig {
+    /// Create a new StakeProgramConfig with `minimum_delegation`
+    #[must_use]
+    pub fn new(minimum_delegation: Lamports) -> Self {
+        Self { minimum_delegation }
+    }
+
+    /// Get the minimum stake delegation amount, in lamports
+    pub fn minimum_delegation(&self) -> Lamports {
+        self.minimum_delegation
+    }
+}
+
+impl Sysvar for StakeProgramConfig {
+    impl_sysvar_get!(sol_get_stake_program_config_sysvar);
+}

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -5,7 +5,7 @@ use {
         pubkey::Pubkey,
     },
     serde::ser::{Serialize, Serializer},
-    solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::Sysvar},
+    solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::LegacySysvar},
     std::{
         cell::{Ref, RefCell},
         fmt,
@@ -600,11 +600,11 @@ pub const DUMMY_INHERITABLE_ACCOUNT_FIELDS: InheritableAccountFields = (1, INITI
     since = "1.5.17",
     note = "Please use `create_account_for_test` instead"
 )]
-pub fn create_account<S: Sysvar>(sysvar: &S, lamports: u64) -> Account {
+pub fn create_account<S: LegacySysvar>(sysvar: &S, lamports: u64) -> Account {
     create_account_with_fields(sysvar, (lamports, INITIAL_RENT_EPOCH))
 }
 
-pub fn create_account_with_fields<S: Sysvar>(
+pub fn create_account_with_fields<S: LegacySysvar>(
     sysvar: &S,
     (lamports, rent_epoch): InheritableAccountFields,
 ) -> Account {
@@ -615,7 +615,7 @@ pub fn create_account_with_fields<S: Sysvar>(
     account
 }
 
-pub fn create_account_for_test<S: Sysvar>(sysvar: &S) -> Account {
+pub fn create_account_for_test<S: LegacySysvar>(sysvar: &S) -> Account {
     create_account_with_fields(sysvar, DUMMY_INHERITABLE_ACCOUNT_FIELDS)
 }
 
@@ -624,21 +624,21 @@ pub fn create_account_for_test<S: Sysvar>(sysvar: &S) -> Account {
     since = "1.5.17",
     note = "Please use `create_account_shared_data_for_test` instead"
 )]
-pub fn create_account_shared_data<S: Sysvar>(sysvar: &S, lamports: u64) -> AccountSharedData {
+pub fn create_account_shared_data<S: LegacySysvar>(sysvar: &S, lamports: u64) -> AccountSharedData {
     AccountSharedData::from(create_account_with_fields(
         sysvar,
         (lamports, INITIAL_RENT_EPOCH),
     ))
 }
 
-pub fn create_account_shared_data_with_fields<S: Sysvar>(
+pub fn create_account_shared_data_with_fields<S: LegacySysvar>(
     sysvar: &S,
     fields: InheritableAccountFields,
 ) -> AccountSharedData {
     AccountSharedData::from(create_account_with_fields(sysvar, fields))
 }
 
-pub fn create_account_shared_data_for_test<S: Sysvar>(sysvar: &S) -> AccountSharedData {
+pub fn create_account_shared_data_for_test<S: LegacySysvar>(sysvar: &S) -> AccountSharedData {
     AccountSharedData::from(create_account_with_fields(
         sysvar,
         DUMMY_INHERITABLE_ACCOUNT_FIELDS,
@@ -646,12 +646,12 @@ pub fn create_account_shared_data_for_test<S: Sysvar>(sysvar: &S) -> AccountShar
 }
 
 /// Create a `Sysvar` from an `Account`'s data.
-pub fn from_account<S: Sysvar, T: ReadableAccount>(account: &T) -> Option<S> {
+pub fn from_account<S: LegacySysvar, T: ReadableAccount>(account: &T) -> Option<S> {
     bincode::deserialize(account.data()).ok()
 }
 
 /// Serialize a `Sysvar` into an `Account`'s data.
-pub fn to_account<S: Sysvar, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
+pub fn to_account<S: LegacySysvar, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
     bincode::serialize_into(account.data_as_mut_slice(), sysvar).ok()
 }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -335,6 +335,10 @@ pub mod check_slice_translation_size {
     solana_sdk::declare_id!("GmC19j9qLn2RFk5NduX6QXaDhVpGncVVBzyM8e9WMz2F");
 }
 
+pub mod add_stake_program_config_sysvar {
+    solana_sdk::declare_id!("9zmnLKx6F55cNhwxwANZP1aT4GGqgYhvyoSfmfG5Zjr9");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -412,7 +416,8 @@ lazy_static! {
         (check_physical_overlapping::id(), "check physical overlapping regions"),
         (limit_secp256k1_recovery_id::id(), "limit secp256k1 recovery id"),
         (disable_deprecated_loader::id(), "disable the deprecated BPF loader"),
-        (check_slice_translation_size::id(), "check size when translating slices",)
+        (check_slice_translation_size::id(), "check size when translating slices"),
+        (add_stake_program_config_sysvar::id(), "add StakeProgramConfig sysvar"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -259,7 +259,7 @@ mod tests {
         crate::{
             account::{create_account_for_test, from_account, to_account},
             pubkey::Pubkey,
-            sysvar::Sysvar,
+            sysvar::LegacySysvar,
         },
     };
 
@@ -277,7 +277,7 @@ mod tests {
             check_id(pubkey)
         }
     }
-    impl Sysvar for TestSysvar {}
+    impl LegacySysvar for TestSysvar {}
 
     #[test]
     fn test_sysvar_keyed_account_to_from() {


### PR DESCRIPTION
#### Problem

There is not a way to query the minimum stake delegation amount from a program.

#### Summary of Changes

- add StakeProgramConfig sysvar
- add feature-gate for sysvar
- set StakeProgramConfig in Bank::apply_feature_activations()
- add StakeProgramConfig to sysvar cache
- rename the Sysvar trait to LegacySysvar
- impl new Sysvar trait for StakeProgramConfig
- pass in StakeProgramConfig into stake_state via stake_instruction
- fixup tests

#### Outstanding Issue/Questions

- Versioning has not been implemented yet.
- How should programs get access to this sysvar? Since it is not an account, there may need to be a new api to handle fetching these new-style sysvars.
- Is it worthwhile to _not_ put this sysvar in an account? I don't want to waste a lot of time coming up with a new api if it won't end up being worth it.