### PR TITLE
Add solana-faucet to the list for version update in downstream projects

### DIFF
--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -16,6 +16,8 @@ update_solana_dependencies() {
   sed -i -e "s#\(solana-clap-utils = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-account-decoder = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-account-decoder = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-faucet = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-faucet = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
 }
 
 patch_crates_io_solana() {
@@ -29,5 +31,6 @@ solana-client = { path = "$solana_dir/client" }
 solana-program = { path = "$solana_dir/sdk/program" }
 solana-program-test = { path = "$solana_dir/program-test" }
 solana-sdk = { path = "$solana_dir/sdk" }
+solana-faucet = { path = "$solana_dir/faucet" }
 EOF
 }


### PR DESCRIPTION
#### Problem

CI downstream anchor projects step is failing to pick a suitable solana-sdk version. It's explicitly updated to the current target, but solana-faucet is not updated and looks for an earlier version of solana-sdk.

#### Solution 
Add solana-faucet to the list of dependencies whose version is updated in downstream dependencies

