### PR TITLE
Specify if archive size datapoint is for full or incremental snapshots

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -373,11 +373,20 @@ pub fn archive_snapshot_package(
         timer.as_ms(),
         metadata.len()
     );
+
     datapoint_info!(
-        "snapshot-package",
+        "archive-snapshot-package",
         ("slot", snapshot_package.slot(), i64),
         ("duration_ms", timer.as_ms(), i64),
-        ("size", metadata.len(), i64)
+        (
+            if snapshot_package.snapshot_type.is_full_snapshot() {
+                "full-snapshot-archive-size"
+            } else {
+                "incremental-snapshot-archive-size"
+            },
+            metadata.len(),
+            i64
+        ),
     );
     Ok(())
 }


### PR DESCRIPTION
#### Problem

When look at metrics for snapshots, the archive size datapoint is for both full and incremental snapshots. This can make it hard to only look at one or the other.

#### Summary of Changes

Specify either full or incremental for the archiving snapshot packages datapoint.

Fixes #
