### PR TITLE
reserialize bank in ahv by first writing to temp file in abs

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -145,6 +145,10 @@ impl AccountsHashVerifier {
             assert_eq!(expected_hash, hash);
         };
         measure_hash.stop();
+        solana_runtime::serde_snapshot::reserialize_bank(
+            accounts_package.snapshot_links.path(),
+            accounts_package.slot,
+        );
         datapoint_info!(
             "accounts_hash_verifier",
             ("calculate_hash", measure_hash.as_us(), i64),

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -14,6 +14,7 @@ use {
         epoch_stakes::EpochStakes,
         hardened_unpack::UnpackedAppendVecMap,
         rent_collector::RentCollector,
+        snapshot_utils::{self, BANK_SNAPSHOT_PRE_FILENAME_EXTENSION},
         stakes::Stakes,
     },
     bincode::{self, config::Options, Error},
@@ -283,6 +284,21 @@ where
         warn!("bankrc_to_stream error: {:?}", err);
         err
     })
+}
+
+pub fn reserialize_bank(bank_snapshots_dir: impl AsRef<Path>, slot: Slot) {
+    let bank_post = snapshot_utils::get_bank_snapshots_dir(bank_snapshots_dir, slot);
+    let bank_post = bank_post.join(snapshot_utils::get_snapshot_file_name(slot));
+    let mut bank_pre = bank_post.clone();
+    bank_pre.set_extension(BANK_SNAPSHOT_PRE_FILENAME_EXTENSION);
+
+    // some tests don't create the file
+    if bank_pre.is_file() {
+        // replace the original file with the newly serialized one
+        // atm, this just copies the file and deletes the old one
+        std::fs::copy(&bank_pre, bank_post).unwrap();
+        std::fs::remove_file(bank_pre).unwrap();
+    }
 }
 
 struct SerializableBankAndStorage<'a, C> {


### PR DESCRIPTION
#### Problem

This prepares the way for moving hash calc to accounts hash verifier from accounts_background_service. By serializing the bank to a temp file in abs and then writing a new file (with a different name) when it is time to create a snapshot (and after we have calculated the accounts_hash), then we don't require the bank to remain in memory until after the hash calc is finished. With high account counts, hash calc can be slow.

#### Summary of Changes



Fixes #
