### PR TITLE
calculate program cost by EMA

### DIFF
--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -206,8 +206,8 @@ mod tests {
             let accumulated_units: u64 = 200;
             let count: u32 = 10;
             // the theta = 200/10 - 100/10 = 10
-            let expected_average_cost = 11u64;
-            let expected_inflated_cost = 13u64;
+            let expected_average_cost = 10u64;
+            let expected_inflated_cost = 10u64;
 
             execute_timings.details.per_program_timings.insert(
                 program_key_1,
@@ -354,7 +354,7 @@ mod tests {
             - 10;
         {
             let expected_average_cost = 109u64;
-            let expected_inflated_cost = 288u64;
+            let expected_inflated_cost = 289u64;
             let errored_txs_compute_consumed = vec![smaller_cost_per_error; 3];
             let total_errored_units = errored_txs_compute_consumed.iter().sum();
             execute_timings.details.per_program_timings.insert(

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -511,7 +511,7 @@ mod tests {
         let key1 = Pubkey::new_unique();
         let cost1 = 100;
         let cost2 = 200;
-        let updated_cost = (cost1 + cost2) / 2;
+        let updated_cost = 121; // by spreadsheet
 
         let mut cost_model = CostModel::default();
 

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -108,7 +108,8 @@ impl ExecuteCostTable {
                 .iter()
                 .map(|(_, value)| value.get_ema())
                 .sum::<u64>()
-                / self.get_count() as u64
+                .checked_div(self.get_count() as u64)
+                .unwrap_or_else(|| self.get_default_units())
         }
     }
 

--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -32,6 +32,12 @@ struct AggregatedVarianceStats {
     ema_var: f64,
 }
 
+impl AggregatedVarianceStats {
+    fn get_ema_as_u64(&self) -> u64 {
+        self.ema.ceil() as u64
+    }
+}
+
 #[derive(Debug)]
 pub struct ExecuteCostTable {
     capacity: usize,
@@ -70,7 +76,7 @@ impl ExecuteCostTable {
         } else {
             self.table
                 .iter()
-                .map(|(_, value)| value.ema.ceil() as u64)
+                .map(|(_, value)| value.get_ema_as_u64())
                 .sum::<u64>()
                 / self.get_count() as u64
         }
@@ -88,14 +94,14 @@ impl ExecuteCostTable {
                 .map(|(key, _)| key)
                 .expect("cannot find mode from cost table");
 
-            self.table.get(key).unwrap().ema.ceil() as u64
+            self.table.get(key).unwrap().get_ema_as_u64()
         }
     }
 
     /// return program average cost units, or None if program doesn't exist in table.
     pub fn get_average_program_units(&self, key: &Pubkey) -> Option<u64> {
         let aggregated_variance_stats = self.table.get(key)?;
-        Some(aggregated_variance_stats.ema.ceil() as u64)
+        Some(aggregated_variance_stats.get_ema_as_u64())
     }
 
     /// returns inflated program cost units, which is `ema + 2*stddev`, or None


### PR DESCRIPTION
#### Problem

Currently program cost is average as `(new_cost + last_averaged_cost)/2`, which can be unstable. EMA described [here](https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation) is a better algo without requiring large cache or count data points.

#### Summary of Changes

- updated `execute_cost_table::upsert(...)` implementing EMA algo.
- added `cost_model::get_average_program_units()` to expose `ema` before inflated by stddev
- renamed functions to better describe their purposes.

Fixes #
