### PR TITLE
feat: the search bar now auto-focuses when you first visit the Explorer

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -42,6 +42,7 @@ export function SearchBar() {
       <div className="row align-items-center">
         <div className="col">
           <Select
+            autoFocus
             ref={(ref) => (selectRef.current = ref)}
             options={buildOptions(
               search,


### PR DESCRIPTION
Almost always, the first thing I want to do when I visit the Explorer is to paste in a pubkey. I have to focus the field first.

After this PR, the field auto focuses when you visit the site.

https://user-images.githubusercontent.com/13243/160228844-5fba894e-8f31-4c66-91a7-1828ee1b0f1e.mov