### PR TITLE
Document APIs related to durable transaction nonces.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
 name = "solana-client"
 version = "1.11.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "async-mutex",
  "async-trait",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -53,6 +53,7 @@ tungstenite = { version = "0.17.2", features = ["rustls-tls-webpki-roots"] }
 url = "2.2.2"
 
 [dev-dependencies]
+anyhow = "1.0.45"
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"
 solana-logger = { path = "../logger", version = "=1.11.0" }

--- a/client/src/nonce_utils.rs
+++ b/client/src/nonce_utils.rs
@@ -1,3 +1,5 @@
+//! Durable transaction nonce helpers.
+
 use {
     crate::rpc_client::RpcClient,
     solana_sdk::{
@@ -32,10 +34,23 @@ pub enum Error {
     Client(String),
 }
 
+/// Get a nonce account from the network.
+///
+/// This is like [`RpcClient::get_account`] except:
+///
+/// - it returns this module's [`Error`] type,
+/// - it returns an error if any of the checks from [`account_identity_ok`] fail.
 pub fn get_account(rpc_client: &RpcClient, nonce_pubkey: &Pubkey) -> Result<Account, Error> {
     get_account_with_commitment(rpc_client, nonce_pubkey, CommitmentConfig::default())
 }
 
+/// Get a nonce account from the network.
+///
+/// This is like [`RpcClient::get_account_with_commitment`] except:
+///
+/// - it returns this module's [`Error`] type,
+/// - it returns an error if the account does not exist,
+/// - it returns an error if any of the checks from [`account_identity_ok`] fail.
 pub fn get_account_with_commitment(
     rpc_client: &RpcClient,
     nonce_pubkey: &Pubkey,
@@ -52,6 +67,13 @@ pub fn get_account_with_commitment(
         .and_then(|a| account_identity_ok(&a).map(|()| a))
 }
 
+/// Perform basic checks that an account has nonce-like properties.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidAccountOwner`] if the account is not owned by the
+/// system program. Returns [`Error::UnexpectedDataSize`] if the account
+/// contains no data.
 pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), Error> {
     if account.owner() != &system_program::id() {
         Err(Error::InvalidAccountOwner)
@@ -62,6 +84,47 @@ pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), Error>
     }
 }
 
+/// Deserialize the state of a durable transaction nonce account.
+///
+/// # Errors
+///
+/// Returns an error if the account is not owned by the system program or
+/// contains no data.
+///
+/// # Examples
+///
+/// Determine if a nonce account is initialized:
+///
+/// ```no_run
+/// use solana_client::{
+///     rpc_client::RpcClient,
+///     nonce_utils,
+/// };
+/// use solana_sdk::{
+///     nonce::State,
+///     pubkey::Pubkey,
+/// };
+/// use anyhow::Result;
+///
+/// fn is_nonce_initialized(
+///     client: &RpcClient,
+///     nonce_account_pubkey: &Pubkey,
+/// ) -> Result<bool> {
+///
+///     // Sign the tx with nonce_account's `blockhash` instead of the
+///     // network's latest blockhash.
+///     let nonce_account = client.get_account(&nonce_account_pubkey)?;
+///     let nonce_state = nonce_utils::state_from_account(&nonce_account)?;
+///
+///     Ok(!matches!(nonce_state, State::Uninitialized))
+/// }
+/// #
+/// # let client = RpcClient::new(String::new());
+/// # let nonce_account_pubkey = Pubkey::new_unique();
+/// # is_nonce_initialized(&client, &nonce_account_pubkey)?;
+/// #
+/// # Ok::<(), anyhow::Error>(())
+/// ```
 pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,
 ) -> Result<State, Error> {
@@ -71,6 +134,93 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
         .map(|v| v.convert_to_current())
 }
 
+/// Deserialize the state data of a durable transaction nonce account.
+///
+/// # Errors
+///
+/// Returns an error if the account is not owned by the system program or
+/// contains no data. Returns an error if the account state is uninitialized or
+/// fails to deserialize.
+///
+/// # Examples
+///
+/// Create and sign a transaction with a durable nonce:
+///
+/// ```no_run
+/// use solana_client::{
+///     rpc_client::RpcClient,
+///     nonce_utils,
+/// };
+/// use solana_sdk::{
+///     message::Message,
+///     pubkey::Pubkey,
+///     signature::{Keypair, Signer},
+///     system_instruction,
+///     transaction::Transaction,
+/// };
+/// use std::path::Path;
+/// use anyhow::Result;
+/// # use anyhow::anyhow;
+///
+/// fn create_transfer_tx_with_nonce(
+///     client: &RpcClient,
+///     nonce_account_pubkey: &Pubkey,
+///     payer: &Keypair,
+///     receiver: &Pubkey,
+///     amount: u64,
+///     tx_path: &Path,
+/// ) -> Result<()> {
+///
+///     let instr_transfer = system_instruction::transfer(
+///         &payer.pubkey(),
+///         receiver,
+///         amount,
+///     );
+///
+///     // In this example, `payer` is `nonce_account_pubkey`'s authority
+///     let instr_advance_nonce_account = system_instruction::advance_nonce_account(
+///         nonce_account_pubkey,
+///         &payer.pubkey(),
+///     );
+///
+///     // The `advance_nonce_account` instruction must be the first issued in
+///     // the transaction.
+///     let message = Message::new(
+///         &[
+///             instr_advance_nonce_account,
+///             instr_transfer
+///         ],
+///         Some(&payer.pubkey()),
+///     );
+///
+///     let mut tx = Transaction::new_unsigned(message);
+///
+///     // Sign the tx with nonce_account's `blockhash` instead of the
+///     // network's latest blockhash.
+///     let nonce_account = client.get_account(&nonce_account_pubkey)?;
+///     let nonce_data = nonce_utils::data_from_account(&nonce_account)?;
+///     let blockhash = nonce_data.blockhash;
+///
+///     tx.try_sign(&[payer], blockhash)?;
+///
+///     // Save the signed transaction locally for later submission.
+///     save_tx_to_file(&tx_path, &tx)?;
+///
+///     Ok(())
+/// }
+/// #
+/// # fn save_tx_to_file(path: &Path, tx: &Transaction) -> Result<()> {
+/// #     Ok(())
+/// # }
+/// #
+/// # let client = RpcClient::new(String::new());
+/// # let nonce_account_pubkey = Pubkey::new_unique();
+/// # let payer = Keypair::new();
+/// # let receiver = Pubkey::new_unique();
+/// # create_transfer_tx_with_nonce(&client, &nonce_account_pubkey, &payer, &receiver, 1024, Path::new("new_tx"))?;
+/// #
+/// # Ok::<(), anyhow::Error>(())
+/// ```
 pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
     account: &T,
 ) -> Result<Data, Error> {
@@ -78,6 +228,12 @@ pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
     state_from_account(account).and_then(|ref s| data_from_state(s).map(|d| d.clone()))
 }
 
+/// Get the nonce data from its [`State`] value.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidStateForOperation`] if `state` is
+/// [`State::Uninitialized`].
 pub fn data_from_state(state: &State) -> Result<&Data, Error> {
     match state {
         State::Uninitialized => Err(Error::InvalidStateForOperation),

--- a/sdk/program/src/nonce/mod.rs
+++ b/sdk/program/src/nonce/mod.rs
@@ -1,3 +1,5 @@
+//! Durable transaction nonces.
+
 pub mod state;
 pub use state::State;
 

--- a/sdk/program/src/nonce/state/current.rs
+++ b/sdk/program/src/nonce/state/current.rs
@@ -4,14 +4,21 @@ use {
     serde_derive::{Deserialize, Serialize},
 };
 
+/// Initialized data of a durable transaction nonce account.
+///
+/// This is stored within [`State`] for initialized nonce accounts.
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Data {
+    /// Address of the account that signs transactions using the nonce account.
     pub authority: Pubkey,
+    /// A valid previous blockhash.
     pub blockhash: Hash,
+    /// The fee calculator associated with the blockhash.
     pub fee_calculator: FeeCalculator,
 }
 
 impl Data {
+    /// Create new durable transaction nonce data.
     pub fn new(authority: Pubkey, blockhash: Hash, lamports_per_signature: u64) -> Self {
         Data {
             authority,
@@ -19,11 +26,17 @@ impl Data {
             fee_calculator: FeeCalculator::new(lamports_per_signature),
         }
     }
+
+    /// Get the cost per signature for the next transaction to use this nonce.
     pub fn get_lamports_per_signature(&self) -> u64 {
         self.fee_calculator.lamports_per_signature
     }
 }
 
+/// The state of a durable transaction nonce account.
+///
+/// When created in memory with [`State::default`] or when deserialized from an
+/// uninitialized account, a nonce account will be [`State::Uninitialized`].
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub enum State {
     Uninitialized,
@@ -37,6 +50,7 @@ impl Default for State {
 }
 
 impl State {
+    /// Create new durable transaction nonce state.
     pub fn new_initialized(
         authority: &Pubkey,
         blockhash: &Hash,
@@ -44,6 +58,8 @@ impl State {
     ) -> Self {
         Self::Initialized(Data::new(*authority, *blockhash, lamports_per_signature))
     }
+
+    /// Get the serialized size of the nonce state.
     pub fn size() -> usize {
         let data = Versions::new_current(State::Initialized(Data::default()));
         bincode::serialized_size(&data).unwrap() as usize

--- a/sdk/program/src/nonce/state/mod.rs
+++ b/sdk/program/src/nonce/state/mod.rs
@@ -1,3 +1,5 @@
+//! State for durable transaction nonces.
+
 mod current;
 pub use current::{Data, State};
 use serde_derive::{Deserialize, Serialize};


### PR DESCRIPTION
#### Summary of Changes

This documents system instruction constructors, state values, and client helpers related to durable transaction nonces.

I have not documented the create_nonce_account_with_seed constructor as I have not yet understood derived accounts. I will do that in the future.

For the system instruction constructors I have added a "Required signers" section, as figuring out which accounts needed to sign any particular instruction was a great difficulty for me as a beginner.

I put some effort into considering error scenarios for the system instructions but they are so varied and often not specific to a particular instruction that it is overwhelming and I have punted on attempting to document them.