### PR TITLE
Reduce metric write log level

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -80,7 +80,7 @@ impl InfluxDbMetricsWriter {
 impl MetricsWriter for InfluxDbMetricsWriter {
     fn write(&self, points: Vec<DataPoint>) {
         if let Some(ref write_url) = self.write_url {
-            info!("submitting {} points", points.len());
+            debug!("submitting {} points", points.len());
 
             let host_id = HOST_ID.read().unwrap();
 


### PR DESCRIPTION
#### Problem

solana_metric submitting points log, like below, is showing up very frequently in the INFO log. It seems that it doesn't contain much useful information and is distracting.
  
```
[2022-03-23T04:04:36.771498106Z INFO  solana_metrics::metrics] submitting 1192 points
```

Could we reduce it to trace or debug level, like other metric logging?

```
Err(RecvTimeoutError::Timeout) => {
                    trace!("run: receive timeout");
                }
                Err(RecvTimeoutError::Disconnected) => {
                    debug!("run: sender disconnected");
                    break;
                }
```

#### Summary of Changes
Reduce metric write log of point submitting from info level to debug. 


Fixes #
