### PR TITLE
Fix race: Enable the bank-drop-callback *after* setting the callback

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1156,13 +1156,6 @@ impl Accounts {
         self.accounts_db.store_cached(slot, &accounts_to_store);
     }
 
-    /// Purge a slot if it is not a root
-    /// Root slots cannot be purged
-    /// `is_from_abs` is true if the caller is the AccountsBackgroundService
-    pub fn purge_slot(&self, slot: Slot, bank_id: BankId, is_from_abs: bool) {
-        self.accounts_db.purge_slot(slot, bank_id, is_from_abs);
-    }
-
     /// Add a slot to root.  Root slots cannot be purged
     pub fn add_root(&self, slot: Slot) -> AccountsAddRootTiming {
         self.accounts_db.add_root(slot)

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -342,6 +342,7 @@ impl AbsRequestHandler {
             count += 1;
             bank.rc
                 .accounts
+                .accounts_db
                 .purge_slot(pruned_slot, pruned_bank_id, is_from_abs);
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1901,7 +1901,7 @@ impl Bank {
             .filter(move |slot| *slot != self.slot)
     }
 
-    pub fn set_callback(&self, callback: Option<Box<dyn DropCallback + Send + Sync>>) {
+    pub fn set_drop_callback(&self, callback: Option<Box<dyn DropCallback + Send + Sync>>) {
         *self.drop_callback.write().unwrap() = OptionalDropCallback(callback);
     }
 
@@ -6759,6 +6759,7 @@ impl Drop for Bank {
             // AccountsBackgroundService to perform cleanups yet.
             self.rc
                 .accounts
+                .accounts_db
                 .purge_slot(self.slot(), self.bank_id(), false);
         }
     }
@@ -14497,7 +14498,7 @@ pub(crate) mod tests {
             accounts_db_caching_enabled,
             AccountShrinkThreshold::default(),
         ));
-        bank0.set_callback(drop_callback);
+        bank0.set_drop_callback(drop_callback);
 
         // Set up pubkeys to write to
         let total_pubkeys = ITER_BATCH_SIZE * 10;


### PR DESCRIPTION
#### Problem

There is a possible race between enabling the bank-drop-callback flag and setting the callback itself.

- `Bank::drop()` decides to use the drop-callback or not based on if it has a drop-callback
    - If the drop-callback is not set, then `Bank::drop()` will call `AccountsDb::purge_slot()` directly, passing `false` for the `is_abs` parameter
- `AccountsDb::purge_slot()` checks the `is_bank_drop_callback_enabled` flag, and panics if it is set _and not_ called from AccountsBackgroundService
- `Tvu::new()` does:
    1. Creates the bank-drop-callback (`SendDroppedBankCallback::new(pruned_banks_sender)`)
    2. Sets the `AccountsDb::is_bank_drop_callback_enabled` flag to true
 <-- possible bank drop here -->
    3. Sets the drop-callback on all the banks

So if a bank gets dropped between 2 and 3, then the bank will not have its drop-callback set _but_ the `is_bank_drop_callback_enabled` flag is set, so `Bank::drop()` will call `AccountsDb::purge_slot()` directly, and that will trigger a panic since `is_bank_drop_callback_enabled` is true and `is_abs` is false.

##### Additional Questions

- Can banks get dropped between 2 and 3? There are many concurrent threads that hold an `Arc<Bank>`, but which could be running when `Tvu::new()` is in flight?
- Before, the banks had their drop-callback set while iterating through BankForks with a read lock; is there any code that could've been messing with the banks, not in `Tvu::new()`, but that could've been running at the same time?

#### Summary of Changes

Set the bank drop callback for all the banks *before* enabling the flag.