### PR TITLE
uses first_coding_index for erasure meta obtained from coding shreds

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1108,10 +1108,9 @@ impl Blockstore {
     }
 
     fn erasure_mismatch(shred1: &Shred, shred2: &Shred) -> bool {
-        // TODO should also compare first-coding-index once position field is
-        // populated across cluster.
         shred1.coding_header.num_coding_shreds != shred2.coding_header.num_coding_shreds
             || shred1.coding_header.num_data_shreds != shred2.coding_header.num_data_shreds
+            || shred1.first_coding_index() != shred2.first_coding_index()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -6094,7 +6093,7 @@ pub mod tests {
             );
             coding_shred.common_header.fec_set_index = std::u32::MAX - 1;
             coding_shred.coding_header.num_data_shreds = 2;
-            coding_shred.coding_header.num_coding_shreds = 3;
+            coding_shred.coding_header.num_coding_shreds = 4;
             coding_shred.coding_header.position = 1;
             coding_shred.common_header.index = std::u32::MAX - 1;
             assert!(!Blockstore::should_insert_coding_shred(

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -257,10 +257,6 @@ impl ErasureMeta {
             None => return false,
         };
         other.__unused_size = self.__unused_size;
-        // Ignore first_coding_index field for now to be backward compatible.
-        // TODO remove this once cluster is upgraded to always populate
-        // first_coding_index field.
-        other.first_coding_index = self.first_coding_index;
         self == &other
     }
 
@@ -275,16 +271,7 @@ impl ErasureMeta {
 
     pub(crate) fn coding_shreds_indices(&self) -> Range<u64> {
         let num_coding = self.config.num_coding() as u64;
-        // first_coding_index == 0 may imply that the field is not populated.
-        // self.set_index to be backward compatible.
-        // TODO remove this once cluster is upgraded to always populate
-        // first_coding_index field.
-        let first_coding_index = if self.first_coding_index == 0 {
-            self.set_index
-        } else {
-            self.first_coding_index
-        };
-        first_coding_index..first_coding_index + num_coding
+        self.first_coding_index..self.first_coding_index + num_coding
     }
 
     pub(crate) fn status(&self, index: &Index) -> ErasureMetaStatus {


### PR DESCRIPTION
#### Problem
Now that nodes correctly populate position field in coding shreds, and
first_coding_index in erasure meta, the old code to maintain backward
compatibility can be removed.

This change is working towards changing erasure coding schema to 32:64.

#### Summary of Changes
* use `first_coding_index` for erasure meta obtained from coding shreds