### PR TITLE
Adds `check_number_of_instruction_accounts()` to all builtin programs

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -431,6 +431,7 @@ fn process_loader_upgradeable_instruction(
 
     match limited_deserialize(instruction_data)? {
         UpgradeableLoaderInstruction::InitializeBuffer => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let buffer = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
 
             if UpgradeableLoaderState::Uninitialized != buffer.state()? {
@@ -448,6 +449,7 @@ fn process_loader_upgradeable_instruction(
             })?;
         }
         UpgradeableLoaderInstruction::Write { offset, bytes } => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let buffer = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
@@ -479,6 +481,7 @@ fn process_loader_upgradeable_instruction(
             )?;
         }
         UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
+            instruction_context.check_number_of_instruction_accounts(4)?;
             let payer = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let programdata = keyed_account_at_index(
                 keyed_accounts,
@@ -495,6 +498,7 @@ fn process_loader_upgradeable_instruction(
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 4)?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 5)?;
+            instruction_context.check_number_of_instruction_accounts(8)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
                 first_instruction_account.saturating_add(7),
@@ -663,6 +667,7 @@ fn process_loader_upgradeable_instruction(
             ic_logger_msg!(log_collector, "Deployed program {:?}", new_program_id);
         }
         UpgradeableLoaderInstruction::Upgrade => {
+            instruction_context.check_number_of_instruction_accounts(3)?;
             let programdata = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let program = keyed_account_at_index(
                 keyed_accounts,
@@ -675,6 +680,7 @@ fn process_loader_upgradeable_instruction(
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 4)?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 5)?;
+            instruction_context.check_number_of_instruction_accounts(7)?;
             let authority = keyed_account_at_index(
                 keyed_accounts,
                 first_instruction_account.saturating_add(6),
@@ -843,6 +849,7 @@ fn process_loader_upgradeable_instruction(
             ic_logger_msg!(log_collector, "Upgraded program {:?}", new_program_id);
         }
         UpgradeableLoaderInstruction::SetAuthority => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let present_authority = keyed_account_at_index(
                 keyed_accounts,
@@ -905,6 +912,7 @@ fn process_loader_upgradeable_instruction(
             ic_logger_msg!(log_collector, "New authority {:?}", new_authority);
         }
         UpgradeableLoaderInstruction::Close => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let close_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let recipient_account = keyed_account_at_index(
                 keyed_accounts,
@@ -932,6 +940,7 @@ fn process_loader_upgradeable_instruction(
                     );
                 }
                 UpgradeableLoaderState::Buffer { authority_address } => {
+                    instruction_context.check_number_of_instruction_accounts(3)?;
                     let authority = keyed_account_at_index(
                         keyed_accounts,
                         first_instruction_account.saturating_add(2),
@@ -955,6 +964,7 @@ fn process_loader_upgradeable_instruction(
                     slot: _,
                     upgrade_authority_address: authority_address,
                 } => {
+                    instruction_context.check_number_of_instruction_accounts(4)?;
                     let program_account = keyed_account_at_index(
                         keyed_accounts,
                         first_instruction_account.saturating_add(3),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -47,6 +47,7 @@ pub fn process_instruction(
             me.initialize(&authorized, &lockup, &rent)
         }
         StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
+            instruction_context.check_number_of_instruction_accounts(3)?;
             let require_custodian_for_locked_stake_authorize = invoke_context
                 .feature_set
                 .is_active(&feature_set::require_custodian_for_locked_stake_authorize::id());
@@ -81,6 +82,7 @@ pub fn process_instruction(
             }
         }
         StakeInstruction::AuthorizeWithSeed(args) => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let authority_base =
                 keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let require_custodian_for_locked_stake_authorize = invoke_context
@@ -119,6 +121,7 @@ pub fn process_instruction(
             }
         }
         StakeInstruction::DelegateStake => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let vote = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
@@ -127,6 +130,7 @@ pub fn process_instruction(
                 instruction_context,
                 3,
             )?;
+            instruction_context.check_number_of_instruction_accounts(5)?;
             let config_account =
                 keyed_account_at_index(keyed_accounts, first_instruction_account + 4)?;
             if !config::check_id(config_account.unsigned_key()) {
@@ -137,11 +141,13 @@ pub fn process_instruction(
             me.delegate(vote, &clock, &stake_history, &config, &signers)
         }
         StakeInstruction::Split(lamports) => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let split_stake =
                 &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             me.split(lamports, split_stake, &signers)
         }
         StakeInstruction::Merge => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let source_stake =
                 &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
@@ -160,6 +166,7 @@ pub fn process_instruction(
             )
         }
         StakeInstruction::Withdraw(lamports) => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let to = &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
@@ -168,6 +175,7 @@ pub fn process_instruction(
                 instruction_context,
                 3,
             )?;
+            instruction_context.check_number_of_instruction_accounts(5)?;
             me.withdraw(
                 lamports,
                 to,
@@ -191,6 +199,7 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
+                instruction_context.check_number_of_instruction_accounts(4)?;
                 let authorized = Authorized {
                     staker: *keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?
                         .unsigned_key(),
@@ -216,6 +225,7 @@ pub fn process_instruction(
             {
                 let clock =
                     get_sysvar_with_account_check::clock(invoke_context, instruction_context, 1)?;
+                instruction_context.check_number_of_instruction_accounts(4)?;
                 let _current_authority =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
                 let authorized_pubkey =
@@ -244,10 +254,12 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
+                instruction_context.check_number_of_instruction_accounts(2)?;
                 let authority_base =
                     keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
                 let clock =
                     get_sysvar_with_account_check::clock(invoke_context, instruction_context, 2)?;
+                instruction_context.check_number_of_instruction_accounts(4)?;
                 let authorized_pubkey =
                     &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
                         .signer_key()

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -54,11 +54,15 @@ pub fn process_instruction(
                 &invoke_context.feature_set,
             )
         }
-        VoteInstruction::UpdateValidatorIdentity => vote_state::update_validator_identity(
-            me,
-            keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?.unsigned_key(),
-            &signers,
-        ),
+        VoteInstruction::UpdateValidatorIdentity => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
+            vote_state::update_validator_identity(
+                me,
+                keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?
+                    .unsigned_key(),
+                &signers,
+            )
+        }
         VoteInstruction::UpdateCommission(commission) => {
             vote_state::update_commission(me, commission, &signers)
         }
@@ -99,6 +103,7 @@ pub fn process_instruction(
             }
         }
         VoteInstruction::Withdraw(lamports) => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let rent_sysvar = if invoke_context
                 .feature_set
@@ -132,6 +137,7 @@ pub fn process_instruction(
                 .feature_set
                 .is_active(&feature_set::vote_stake_checked_instructions::id())
             {
+                instruction_context.check_number_of_instruction_accounts(4)?;
                 let voter_pubkey =
                     &keyed_account_at_index(keyed_accounts, first_instruction_account + 3)?
                         .signer_key()

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -284,6 +284,7 @@ pub fn process_instruction(
             space,
             owner,
         } => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let to_address = Address::create(to.unsigned_key(), None, invoke_context)?;
@@ -305,6 +306,7 @@ pub fn process_instruction(
             space,
             owner,
         } => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let to_address = Address::create(
@@ -324,12 +326,14 @@ pub fn process_instruction(
             )
         }
         SystemInstruction::Assign { owner } => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(keyed_account.unsigned_key(), None, invoke_context)?;
             assign(&mut account, &address, &owner, &signers, invoke_context)
         }
         SystemInstruction::Transfer { lamports } => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             transfer(from, to, lamports, invoke_context)
@@ -339,6 +343,7 @@ pub fn process_instruction(
             from_seed,
             from_owner,
         } => {
+            instruction_context.check_number_of_instruction_accounts(3)?;
             let from = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let base = keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             let to = keyed_account_at_index(keyed_accounts, first_instruction_account + 2)?;
@@ -353,6 +358,7 @@ pub fn process_instruction(
             )
         }
         SystemInstruction::AdvanceNonceAccount => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
             let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
@@ -370,6 +376,7 @@ pub fn process_instruction(
             advance_nonce_account(me, &signers, invoke_context)
         }
         SystemInstruction::WithdrawNonceAccount(lamports) => {
+            instruction_context.check_number_of_instruction_accounts(2)?;
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let to = &mut keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
             #[allow(deprecated)]
@@ -382,6 +389,7 @@ pub fn process_instruction(
             withdraw_nonce_account(me, lamports, to, &rent, &signers, invoke_context)
         }
         SystemInstruction::InitializeNonceAccount(authorized) => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             #[allow(deprecated)]
             let recent_blockhashes = get_sysvar_with_account_check::recent_blockhashes(
@@ -400,10 +408,12 @@ pub fn process_instruction(
             initialize_nonce_account(me, &authorized, &rent, invoke_context)
         }
         SystemInstruction::AuthorizeNonceAccount(nonce_authority) => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let me = &mut keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             authorize_nonce_account(me, &nonce_authority, &signers, invoke_context)
         }
         SystemInstruction::Allocate { space } => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(keyed_account.unsigned_key(), None, invoke_context)?;
@@ -415,6 +425,7 @@ pub fn process_instruction(
             space,
             owner,
         } => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(
@@ -432,6 +443,7 @@ pub fn process_instruction(
             )
         }
         SystemInstruction::AssignWithSeed { base, seed, owner } => {
+            instruction_context.check_number_of_instruction_accounts(1)?;
             let keyed_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
             let mut account = keyed_account.try_account_ref_mut()?;
             let address = Address::create(


### PR DESCRIPTION
#### Problem
Replacing `KeyedAccount` by `BorrowedAccount` can lead to a error ordering / priority divergence.
`check_number_of_instruction_accounts()` prevents that by asserting that each instruction is supplied with the number of non-optional accounts upfront.

#### Summary of Changes
Adds `check_number_of_instruction_accounts()` to all builtin programs except for the address-lookup-table.
Sysvars are not covered as they perform their own check and these can not be mixed.

Fixes #
