### PR TITLE
Refactor: Remove `KeyedAccount` in bpf_loader helper functions

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -201,10 +201,11 @@ fn write_program_data(
     bytes: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
-    let program = keyed_account_at_index(keyed_accounts, program_account_index)?;
-    let mut account = program.try_account_ref_mut()?;
-    let data = &mut account.data_as_mut_slice();
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let mut program =
+        instruction_context.try_borrow_account(transaction_context, program_account_index)?;
+    let data = program.get_data_mut();
     let write_offset = program_data_offset.saturating_add(bytes.len());
     if data.len() < write_offset {
         ic_msg!(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -205,17 +205,17 @@ fn write_program_data(
     let program = keyed_account_at_index(keyed_accounts, program_account_index)?;
     let mut account = program.try_account_ref_mut()?;
     let data = &mut account.data_as_mut_slice();
-    let len = bytes.len();
-    if data.len() < program_data_offset.saturating_add(len) {
+    let write_offset = program_data_offset.saturating_add(bytes.len());
+    if data.len() < write_offset {
         ic_msg!(
             invoke_context,
             "Write overflow: {} < {}",
             data.len(),
-            program_data_offset.saturating_add(len),
+            write_offset,
         );
         return Err(InstructionError::AccountDataTooSmall);
     }
-    data.get_mut(program_data_offset..program_data_offset.saturating_add(len))
+    data.get_mut(program_data_offset..write_offset)
         .ok_or(InstructionError::AccountDataTooSmall)?
         .copy_from_slice(bytes);
     Ok(())

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -303,7 +303,7 @@ fn process_instruction_common(
     let first_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
     let second_account =
         keyed_account_at_index(keyed_accounts, first_instruction_account.saturating_add(1));
-    let (program, next_first_instruction_account) = if first_account_key == program_id {
+    let (program, program_account_index) = if first_account_key == program_id {
         (first_account, first_instruction_account)
     } else if second_account_key
         .map(|key| key == program_id)
@@ -389,11 +389,7 @@ fn process_instruction_common(
             get_or_create_executor_time.as_us()
         );
 
-        executor.execute(
-            next_first_instruction_account,
-            instruction_data,
-            invoke_context,
-        )
+        executor.execute(program_account_index, instruction_data, invoke_context)
     } else {
         debug_assert_eq!(first_instruction_account, 1);
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -301,21 +301,19 @@ fn process_instruction_common(
 
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let first_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
-    let second_account =
-        keyed_account_at_index(keyed_accounts, first_instruction_account.saturating_add(1));
-    let (_program, program_account_index) = if first_account_key == program_id {
-        (first_account, first_instruction_account)
+    let program_account_index = if first_account_key == program_id {
+        first_instruction_account
     } else if second_account_key
         .map(|key| key == program_id)
         .unwrap_or(false)
     {
-        (second_account?, first_instruction_account.saturating_add(1))
+        first_instruction_account.saturating_add(1)
     } else {
         if first_account.executable()? {
             ic_logger_msg!(log_collector, "BPF loader is executable");
             return Err(InstructionError::IncorrectProgramId);
         }
-        (first_account, first_instruction_account)
+        first_instruction_account
     };
 
     let program =


### PR DESCRIPTION
#### Problem
The usage of `KeyedAccount` in helper functions is independent from the actual process_instruction functions so it should be removed separately.

#### Summary of Changes
Removes `KeyedAccount` in helper functions of bpf_loader.rs

Fixes #
