### PR TITLE
Please Ignore - using PR to force Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: minimal
 jobs:
   include:
     - name: "Export Github Repositories"
-      if: type IN (push, cron) AND branch = master
+      if: type IN (push, cron, pull_request) AND branch = master
       language: python
       git:
         depth: false


### PR DESCRIPTION
Travis doesn't support building arbitrary commits... so creating PRs as a work-around while debugging.