### PR TITLE
Set drop callback on first root bank

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -446,6 +446,7 @@ pub mod tests {
         let tower = Tower::default();
         let accounts_package_channel = unbounded();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
+        let (_pruned_banks_sender, pruned_banks_receiver) = unbounded();
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
@@ -495,6 +496,7 @@ pub mod tests {
             None,
             None,
             None,
+            pruned_banks_receiver,
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -40,7 +40,8 @@ use {
     },
     solana_runtime::{
         accounts_background_service::{
-            AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, SnapshotRequestHandler,
+            AbsRequestHandler, AbsRequestSender, AccountsBackgroundService, DroppedSlotsReceiver,
+            SnapshotRequestHandler,
         },
         accounts_db::AccountShrinkThreshold,
         bank_forks::BankForks,
@@ -57,7 +58,6 @@ use {
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Keypair},
     std::{
-        boxed::Box,
         collections::HashSet,
         net::UdpSocket,
         sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
@@ -147,6 +147,7 @@ impl Tvu {
         last_full_snapshot_slot: Option<Slot>,
         block_metadata_notifier: Option<BlockMetadataNotifierLock>,
         wait_to_vote_slot: Option<Slot>,
+        pruned_banks_receiver: DroppedSlotsReceiver,
     ) -> Self {
         let TvuSockets {
             repair: repair_socket,
@@ -245,23 +246,6 @@ impl Tvu {
                 )
             }
         };
-
-        let (pruned_banks_sender, pruned_banks_receiver) = unbounded();
-
-        // Before replay starts, set the callbacks in each of the banks in BankForks
-        // Note after this callback is created, only the AccountsBackgroundService should be calling
-        // AccountsDb::purge_slot() to clean up dropped banks.
-        let callback = bank_forks
-            .read()
-            .unwrap()
-            .root_bank()
-            .rc
-            .accounts
-            .accounts_db
-            .create_drop_bank_callback(pruned_banks_sender);
-        for bank in bank_forks.read().unwrap().banks().values() {
-            bank.set_callback(Some(Box::new(callback.clone())));
-        }
 
         let accounts_background_request_sender = AbsRequestSender::new(snapshot_request_sender);
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -68,6 +68,7 @@ use {
         transaction_status_service::TransactionStatusService,
     },
     solana_runtime::{
+        accounts_background_service::DroppedSlotsReceiver,
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -507,6 +508,7 @@ impl Validator {
             },
             blockstore_process_options,
             blockstore_root_scan,
+            pruned_banks_receiver,
         ) = load_blockstore(
             config,
             ledger_path,
@@ -527,6 +529,7 @@ impl Validator {
             config.snapshot_config.as_ref(),
             accounts_package_channel.0.clone(),
             blockstore_root_scan,
+            pruned_banks_receiver.clone(),
         );
         let last_full_snapshot_slot =
             last_full_snapshot_slot.or_else(|| starting_snapshot_hashes.map(|x| x.full.hash.0));
@@ -934,6 +937,7 @@ impl Validator {
             last_full_snapshot_slot,
             block_metadata_notifier,
             config.wait_to_vote_slot,
+            pruned_banks_receiver,
         );
 
         let tpu = Tpu::new(
@@ -1274,6 +1278,7 @@ fn load_blockstore(
     TransactionHistoryServices,
     blockstore_processor::ProcessOptions,
     BlockstoreRootScan,
+    DroppedSlotsReceiver,
 ) {
     info!("loading ledger from {:?}...", ledger_path);
     *start_progress.write().unwrap() = ValidatorStartProgress::LoadingLedger;
@@ -1353,19 +1358,23 @@ fn load_blockstore(
             TransactionHistoryServices::default()
         };
 
-    let (mut bank_forks, mut leader_schedule_cache, starting_snapshot_hashes) =
-        bank_forks_utils::load_bank_forks(
-            &genesis_config,
-            &blockstore,
-            config.account_paths.clone(),
-            config.account_shrink_paths.clone(),
-            config.snapshot_config.as_ref(),
-            &process_options,
-            transaction_history_services
-                .cache_block_meta_sender
-                .as_ref(),
-            accounts_update_notifier,
-        );
+    let (
+        mut bank_forks,
+        mut leader_schedule_cache,
+        starting_snapshot_hashes,
+        pruned_banks_receiver,
+    ) = bank_forks_utils::load_bank_forks(
+        &genesis_config,
+        &blockstore,
+        config.account_paths.clone(),
+        config.account_shrink_paths.clone(),
+        config.snapshot_config.as_ref(),
+        &process_options,
+        transaction_history_services
+            .cache_block_meta_sender
+            .as_ref(),
+        accounts_update_notifier,
+    );
 
     leader_schedule_cache.set_fixed_leader_schedule(config.fixed_leader_schedule.clone());
     bank_forks.set_snapshot_config(config.snapshot_config.clone());
@@ -1387,9 +1396,11 @@ fn load_blockstore(
         transaction_history_services,
         process_options,
         blockstore_root_scan,
+        pruned_banks_receiver,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_blockstore(
     blockstore: &Blockstore,
     bank_forks: &mut BankForks,
@@ -1400,6 +1411,7 @@ fn process_blockstore(
     snapshot_config: Option<&SnapshotConfig>,
     accounts_package_sender: AccountsPackageSender,
     blockstore_root_scan: BlockstoreRootScan,
+    pruned_banks_receiver: DroppedSlotsReceiver,
 ) -> Option<Slot> {
     let last_full_snapshot_slot = blockstore_processor::process_blockstore_from_root(
         blockstore,
@@ -1410,6 +1422,7 @@ fn process_blockstore(
         cache_block_meta_sender,
         snapshot_config,
         accounts_package_sender,
+        pruned_banks_receiver,
     )
     .unwrap_or_else(|err| {
         error!("Failed to load ledger: {:?}", err);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -17,6 +17,7 @@ use {
     solana_program_runtime::timings::{ExecuteTimingType, ExecuteTimings},
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::{
+        accounts_background_service::DroppedSlotsReceiver,
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
         accounts_index::AccountSecondaryIndexes,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -567,16 +568,17 @@ pub fn test_process_blockstore(
     blockstore: &Blockstore,
     opts: ProcessOptions,
 ) -> (BankForks, LeaderScheduleCache) {
-    let (mut bank_forks, leader_schedule_cache, ..) = crate::bank_forks_utils::load_bank_forks(
-        genesis_config,
-        blockstore,
-        Vec::new(),
-        None,
-        None,
-        &opts,
-        None,
-        None,
-    );
+    let (mut bank_forks, leader_schedule_cache, .., pruned_banks_receiver) =
+        crate::bank_forks_utils::load_bank_forks(
+            genesis_config,
+            blockstore,
+            Vec::new(),
+            None,
+            None,
+            &opts,
+            None,
+            None,
+        );
     let (accounts_package_sender, _) = unbounded();
     process_blockstore_from_root(
         blockstore,
@@ -587,6 +589,7 @@ pub fn test_process_blockstore(
         None,
         None,
         accounts_package_sender,
+        pruned_banks_receiver,
     )
     .unwrap();
     (bank_forks, leader_schedule_cache)
@@ -637,6 +640,7 @@ pub fn process_blockstore_from_root(
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
     snapshot_config: Option<&SnapshotConfig>,
     accounts_package_sender: AccountsPackageSender,
+    pruned_banks_receiver: DroppedSlotsReceiver,
 ) -> result::Result<Option<Slot>, BlockstoreProcessorError> {
     if let Some(num_threads) = opts.override_num_threads {
         PAR_THREAD_POOL.with(|pool| {
@@ -696,6 +700,7 @@ pub fn process_blockstore_from_root(
             accounts_package_sender,
             &mut timing,
             &mut last_full_snapshot_slot,
+            pruned_banks_receiver,
         )?;
     } else {
         // If there's no meta for the input `start_slot`, then we started from a snapshot
@@ -1117,6 +1122,7 @@ fn load_frozen_forks(
     accounts_package_sender: AccountsPackageSender,
     timing: &mut ExecuteTimings,
     last_full_snapshot_slot: &mut Option<Slot>,
+    pruned_banks_receiver: DroppedSlotsReceiver,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let recyclers = VerifyRecyclers::default();
     let mut all_banks = HashMap::new();
@@ -1285,6 +1291,17 @@ fn load_frozen_forks(
                 }
 
                 if last_free.elapsed() > Duration::from_secs(10) {
+                    // Purge account state for all dropped banks
+                    for (pruned_slot, pruned_bank_id) in pruned_banks_receiver.try_iter() {
+                        // Simulate this purge being from the AccountsBackgroundService
+                        let is_from_abs = true;
+                        new_root_bank.rc.accounts.purge_slot(
+                            pruned_slot,
+                            pruned_bank_id,
+                            is_from_abs,
+                        );
+                    }
+
                     // Must be called after `squash()`, so that AccountsDb knows what
                     // the roots are for the cache flushing in exhaustively_free_unused_resource().
                     // This could take few secs; so update last_free later

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3164,6 +3164,7 @@ pub mod tests {
 
         // Test process_blockstore_from_root() from slot 1 onwards
         let (accounts_package_sender, _) = unbounded();
+        let (_pruned_banks_sender, pruned_banks_receiver) = unbounded();
         process_blockstore_from_root(
             &blockstore,
             &mut bank_forks,
@@ -3173,6 +3174,7 @@ pub mod tests {
             None,
             None,
             accounts_package_sender,
+            pruned_banks_receiver,
         )
         .unwrap();
 
@@ -3273,6 +3275,7 @@ pub mod tests {
         let (accounts_package_sender, accounts_package_receiver) = unbounded();
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
 
+        let (_pruned_banks_sender, pruned_banks_receiver) = unbounded();
         process_blockstore_from_root(
             &blockstore,
             &mut bank_forks,
@@ -3282,6 +3285,7 @@ pub mod tests {
             None,
             Some(&snapshot_config),
             accounts_package_sender.clone(),
+            pruned_banks_receiver,
         )
         .unwrap();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6753,10 +6753,7 @@ impl Drop for Bank {
         if let Some(drop_callback) = self.drop_callback.read().unwrap().0.as_ref() {
             drop_callback.callback(self);
         } else {
-            // Default case
-            // 1. Tests
-            // 2. At startup when replaying blockstore and there's no
-            // AccountsBackgroundService to perform cleanups yet.
+            // Default case for tests
             self.rc
                 .accounts
                 .purge_slot(self.slot(), self.bank_id(), false);


### PR DESCRIPTION
#### Problem
See comment here: https://github.com/solana-labs/solana/pull/23970#issuecomment-1081462476


#### Summary of Changes
1. Set the drop callback on the first bank after snapshot unpacking
2. `blockstore_processor::load_frozen_forks()` now handles the `Bank::drop() -> purge_slot()` call like `AccountsBackgroundService` would as part of its periodic cleanup


Fixes #
