### PR TITLE
Use Rent sysvar directly for stake split instruction

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1135,6 +1135,7 @@ pub fn mock_process_instruction(
     instruction_data: &[u8],
     transaction_accounts: Vec<TransactionAccount>,
     instruction_accounts: Vec<AccountMeta>,
+    sysvar_cache_override: Option<&SysvarCache>,
     expected_result: Result<(), InstructionError>,
     process_instruction: ProcessInstructionWithContext,
 ) -> Vec<AccountSharedData> {
@@ -1151,6 +1152,9 @@ pub fn mock_process_instruction(
         1,
     );
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
+    if let Some(sysvar_cache) = sysvar_cache_override {
+        invoke_context.sysvar_cache = Cow::Borrowed(sysvar_cache);
+    }
     let result = invoke_context
         .push(
             &preparation.instruction_accounts,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1333,6 +1333,7 @@ mod tests {
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            None,
             expected_result,
             super::process_instruction,
         )
@@ -1585,6 +1586,7 @@ mod tests {
             &[],
             vec![(program_id, program_account.clone())],
             Vec::new(),
+            None,
             Err(InstructionError::ProgramFailedToComplete),
             |first_instruction_account: usize,
              instruction_data: &[u8],
@@ -2855,6 +2857,7 @@ mod tests {
                 &instruction_data,
                 transaction_accounts,
                 instruction_accounts,
+                None,
                 expected_result,
                 super::process_instruction,
             )

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -166,6 +166,7 @@ mod tests {
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            None,
             expected_result,
             super::process_instruction,
         )

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -2373,10 +2373,11 @@ mod tests {
 
         // Define rent here so that it's used consistently for setting the rent exempt reserve
         // and in the sysvar cache used for mock instruction processing.
-        let mut rent = Rent::default();
-        rent.lamports_per_byte_year = 0;
         let mut sysvar_cache_override = SysvarCache::default();
-        sysvar_cache_override.set_rent(rent.clone());
+        sysvar_cache_override.set_rent(Rent {
+            lamports_per_byte_year: 0,
+            ..Rent::default()
+        });
 
         for state in [
             StakeState::Initialized(Meta::auto(&stake_address)),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -144,7 +144,7 @@ pub fn process_instruction(
             instruction_context.check_number_of_instruction_accounts(2)?;
             let split_stake =
                 &keyed_account_at_index(keyed_accounts, first_instruction_account + 1)?;
-            me.split(lamports, split_stake, &signers)
+            me.split(invoke_context, lamports, split_stake, &signers)
         }
         StakeInstruction::Merge => {
             instruction_context.check_number_of_instruction_accounts(2)?;

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -323,7 +323,9 @@ mod tests {
             Meta, Stake, StakeState,
         },
         bincode::serialize,
-        solana_program_runtime::invoke_context::mock_process_instruction,
+        solana_program_runtime::{
+            invoke_context::mock_process_instruction, sysvar_cache::SysvarCache,
+        },
         solana_sdk::{
             account::{self, AccountSharedData, ReadableAccount, WritableAccount},
             account_utils::StateMut,
@@ -374,12 +376,29 @@ mod tests {
         instruction_accounts: Vec<AccountMeta>,
         expected_result: Result<(), InstructionError>,
     ) -> Vec<AccountSharedData> {
+        process_instruction_with_sysvar_cache(
+            instruction_data,
+            transaction_accounts,
+            instruction_accounts,
+            None,
+            expected_result,
+        )
+    }
+
+    fn process_instruction_with_sysvar_cache(
+        instruction_data: &[u8],
+        transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
+        instruction_accounts: Vec<AccountMeta>,
+        sysvar_cache_override: Option<&SysvarCache>,
+        expected_result: Result<(), InstructionError>,
+    ) -> Vec<AccountSharedData> {
         mock_process_instruction(
             &id(),
             Vec::new(),
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            sysvar_cache_override,
             expected_result,
             super::process_instruction,
         )
@@ -2352,6 +2371,13 @@ mod tests {
             },
         ];
 
+        // Define rent here so that it's used consistently for setting the rent exempt reserve
+        // and in the sysvar cache used for mock instruction processing.
+        let mut rent = Rent::default();
+        rent.lamports_per_byte_year = 0;
+        let mut sysvar_cache_override = SysvarCache::default();
+        sysvar_cache_override.set_rent(rent.clone());
+
         for state in [
             StakeState::Initialized(Meta::auto(&stake_address)),
             just_stake(Meta::auto(&stake_address), stake_lamports),
@@ -2366,18 +2392,20 @@ mod tests {
             transaction_accounts[0] = (stake_address, stake_account);
 
             // should fail, split more than available
-            process_instruction(
+            process_instruction_with_sysvar_cache(
                 &serialize(&StakeInstruction::Split(stake_lamports + 1)).unwrap(),
                 transaction_accounts.clone(),
                 instruction_accounts.clone(),
+                Some(&sysvar_cache_override),
                 Err(InstructionError::InsufficientFunds),
             );
 
             // should pass
-            let accounts = process_instruction(
+            let accounts = process_instruction_with_sysvar_cache(
                 &serialize(&StakeInstruction::Split(stake_lamports / 2)).unwrap(),
                 transaction_accounts.clone(),
                 instruction_accounts.clone(),
+                Some(&sysvar_cache_override),
                 Ok(()),
             );
             // no lamport leakage

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -216,6 +216,7 @@ mod tests {
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            None,
             expected_result,
             super::process_instruction,
         )
@@ -233,6 +234,7 @@ mod tests {
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            None,
             expected_result,
             |first_instruction_account: usize,
              instruction_data: &[u8],

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -530,6 +530,7 @@ mod tests {
             instruction_data,
             transaction_accounts,
             instruction_accounts,
+            None,
             expected_result,
             process_instruction,
         )

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -48,10 +48,6 @@ impl Rent {
         (burned_portion, rent_collected - burned_portion)
     }
     /// minimum balance due for rent-exemption of a given size Account::data.len()
-    ///
-    /// Note: a stripped-down version of this calculation is used in
-    /// calculate_split_rent_exempt_reserve in the stake program. When this function is updated, --
-    /// eg. when making rent variable -- the stake program will need to be refactored
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
         (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year) as f64

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -48,6 +48,10 @@ impl Rent {
         (burned_portion, rent_collected - burned_portion)
     }
     /// minimum balance due for rent-exemption of a given size Account::data.len()
+    ///
+    /// Note: a stripped-down version of this calculation is used in
+    /// calculate_split_rent_exempt_reserve in the stake program. When this function is updated, --
+    /// eg. when making rent variable -- the stake program will need to be refactored
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
         (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year) as f64

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -335,6 +335,10 @@ pub mod check_slice_translation_size {
     solana_sdk::declare_id!("GmC19j9qLn2RFk5NduX6QXaDhVpGncVVBzyM8e9WMz2F");
 }
 
+pub mod stake_split_uses_rent_sysvar {
+    solana_sdk::declare_id!("FQnc7U4koHqWgRvFaBJjZnV8VPg6L6wWK33yJeDp4yvV");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -412,7 +416,8 @@ lazy_static! {
         (check_physical_overlapping::id(), "check physical overlapping regions"),
         (limit_secp256k1_recovery_id::id(), "limit secp256k1 recovery id"),
         (disable_deprecated_loader::id(), "disable the deprecated BPF loader"),
-        (check_slice_translation_size::id(), "check size when translating slices",)
+        (check_slice_translation_size::id(), "check size when translating slices"),
+        (stake_split_uses_rent_sysvar::id(), "stake split instruction uses rent sysvar"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The stake split instruction uses hard-coded rent exemption logic to determine the rent exemption balance of the new split stake account rather than using the Rent sysvar directly. This means that if Rent changes in the future, this hardcoded logic would break.

#### Feature Details
Added `stake_split_uses_rent_sysvar` feature with ID `FQnc7U4koHqWgRvFaBJjZnV8VPg6L6wWK33yJeDp4yvV` because if Rent fees change, this PR would break consensus without a feature gate.

#### Summary of Changes
Get the Rent sysvar dynamically from the invoke context and remove hard coded rent exemption calculation


Fixes #
