### PR TITLE
restore existing overlapping overflow

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1492,9 +1492,10 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallKeccak256<'a, 'b> {
 
 /// This function is incorrect due to arithmetic overflow and only exists for
 /// backwards compatibility. Instead use program_stubs::is_nonoverlapping.
+#[allow(clippy::integer_arithmetic)]
 fn check_overlapping_do_not_use(src_addr: u64, dst_addr: u64, n: u64) -> bool {
-    (src_addr <= dst_addr && src_addr.saturating_add(n) > dst_addr)
-        || (dst_addr <= src_addr && dst_addr.saturating_add(n) > src_addr)
+    (src_addr <= dst_addr && src_addr + n > dst_addr)
+        || (dst_addr <= src_addr && dst_addr + n > src_addr)
 }
 
 fn mem_op_consume<'a, 'b>(


### PR DESCRIPTION
#### Problem

Original behavior overflowed and was fixed via a feature.  A previous pr changed the original behavior

#### Summary of Changes

Return to previous behavior until the feature is activated

Fixes #
