### PR TITLE
Replace channel with Mutex<Option> for AccountsPackage

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -5,19 +5,18 @@
 // set and halt the node if a mismatch is detected.
 
 use {
-    crossbeam_channel::RecvTimeoutError,
     solana_gossip::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES},
     solana_measure::measure::Measure,
     solana_runtime::{
         accounts_hash::{CalcAccountsHashConfig, HashStats},
         snapshot_config::SnapshotConfig,
         snapshot_package::{
-            AccountsPackage, AccountsPackageReceiver, PendingSnapshotPackage, SnapshotPackage,
+            AccountsPackage, PendingAccountsPackage, PendingSnapshotPackage, SnapshotPackage,
             SnapshotType,
         },
         sorted_storages::SortedStorages,
     },
-    solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
+    solana_sdk::{clock::{Slot, SLOT_MS}, hash::Hash, pubkey::Pubkey},
     std::{
         collections::{HashMap, HashSet},
         sync::{
@@ -35,7 +34,7 @@ pub struct AccountsHashVerifier {
 
 impl AccountsHashVerifier {
     pub fn new(
-        accounts_package_receiver: AccountsPackageReceiver,
+        pending_accounts_package: PendingAccountsPackage,
         pending_snapshot_package: Option<PendingSnapshotPackage>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
@@ -55,23 +54,24 @@ impl AccountsHashVerifier {
                         break;
                     }
 
-                    match accounts_package_receiver.recv_timeout(Duration::from_secs(1)) {
-                        Ok(accounts_package) => {
-                            Self::process_accounts_package(
-                                accounts_package,
-                                &cluster_info,
-                                known_validators.as_ref(),
-                                halt_on_known_validators_accounts_hash_mismatch,
-                                pending_snapshot_package.as_ref(),
-                                &mut hashes,
-                                &exit,
-                                fault_injection_rate_slots,
-                                snapshot_config.as_ref(),
-                            );
-                        }
-                        Err(RecvTimeoutError::Disconnected) => break,
-                        Err(RecvTimeoutError::Timeout) => (),
+                    let accounts_package = pending_accounts_package.lock().unwrap().take();
+                    if accounts_package.is_none() {
+                        std::thread::sleep(Duration::from_millis(SLOT_MS));
+                        continue;
                     }
+                    let accounts_package = accounts_package.unwrap();
+
+                    Self::process_accounts_package(
+                        accounts_package,
+                        &cluster_info,
+                        known_validators.as_ref(),
+                        halt_on_known_validators_accounts_hash_mismatch,
+                        pending_snapshot_package.as_ref(),
+                        &mut hashes,
+                        &exit,
+                        fault_injection_rate_slots,
+                        snapshot_config.as_ref(),
+                    );
                 }
             })
             .unwrap();

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -16,7 +16,11 @@ use {
         },
         sorted_storages::SortedStorages,
     },
-    solana_sdk::{clock::{Slot, SLOT_MS}, hash::Hash, pubkey::Pubkey},
+    solana_sdk::{
+        clock::{Slot, SLOT_MS},
+        hash::Hash,
+        pubkey::Pubkey,
+    },
     std::{
         collections::{HashMap, HashSet},
         sync::{

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -5,7 +5,6 @@ use {
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
     },
-    crossbeam_channel::unbounded,
     dashmap::DashMap,
     itertools::Itertools,
     log::*,
@@ -43,6 +42,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
+        snapshot_package::PendingAccountsPackage,
         snapshot_utils::{
             self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
@@ -768,7 +768,6 @@ fn load_bank_forks(
         vec![non_primary_accounts_path]
     };
 
-    let (accounts_package_sender, _) = unbounded();
     bank_forks_utils::load(
         genesis_config,
         blockstore,
@@ -778,7 +777,7 @@ fn load_bank_forks(
         process_options,
         None,
         None,
-        accounts_package_sender,
+        PendingAccountsPackage::default(),
         None,
     )
     .map(|(bank_forks, .., starting_snapshot_hashes)| (bank_forks, starting_snapshot_hashes))

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -16,7 +16,7 @@ use {
         snapshot_archive_info::SnapshotArchiveInfoGetter,
         snapshot_config::SnapshotConfig,
         snapshot_hash::{FullSnapshotHash, IncrementalSnapshotHash, StartingSnapshotHashes},
-        snapshot_package::AccountsPackageSender,
+        snapshot_package::PendingAccountsPackage,
         snapshot_utils,
     },
     solana_sdk::genesis_config::GenesisConfig,
@@ -46,7 +46,7 @@ pub fn load(
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
-    accounts_package_sender: AccountsPackageSender,
+    pending_accounts_package: PendingAccountsPackage,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
 ) -> LoadResult {
     let (mut bank_forks, leader_schedule_cache, starting_snapshot_hashes, pruned_banks_receiver) =
@@ -69,7 +69,7 @@ pub fn load(
         transaction_status_sender,
         cache_block_meta_sender,
         snapshot_config,
-        accounts_package_sender,
+        pending_accounts_package,
         pruned_banks_receiver,
     )
     .map(|_| (bank_forks, leader_schedule_cache, starting_snapshot_hashes))

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -7,7 +7,7 @@ use {
         bank::{Bank, BankSlotDelta, DropCallback},
         bank_forks::BankForks,
         snapshot_config::SnapshotConfig,
-        snapshot_package::{AccountsPackageSender, SnapshotType},
+        snapshot_package::{PendingAccountsPackage, SnapshotType},
         snapshot_utils::{self, SnapshotError},
     },
     crossbeam_channel::{Receiver, SendError, Sender},
@@ -85,7 +85,7 @@ pub struct SnapshotRequest {
 pub struct SnapshotRequestHandler {
     pub snapshot_config: SnapshotConfig,
     pub snapshot_request_receiver: SnapshotRequestReceiver,
-    pub accounts_package_sender: AccountsPackageSender,
+    pub pending_accounts_package: PendingAccountsPackage,
 }
 
 impl SnapshotRequestHandler {
@@ -198,7 +198,7 @@ impl SnapshotRequestHandler {
                 let result = snapshot_utils::snapshot_bank(
                     &snapshot_root_bank,
                     status_cache_slot_deltas,
-                    &self.accounts_package_sender,
+                    &self.pending_accounts_package,
                     &self.snapshot_config.bank_snapshots_dir,
                     &self.snapshot_config.snapshot_archives_dir,
                     self.snapshot_config.snapshot_version,
@@ -269,7 +269,6 @@ impl SnapshotRequestHandler {
             SnapshotError::ArchiveGenerationFailure(..) => true,
             SnapshotError::StoragePathSymlinkInvalid => true,
             SnapshotError::UnpackError(..) => true,
-            SnapshotError::AccountsPackageSendError(..) => true,
             SnapshotError::IoWithSource(..) => true,
             SnapshotError::PathToFileNameError(..) => true,
             SnapshotError::FileNameToStrError(..) => true,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -10,7 +10,6 @@ use {
             TMP_BANK_SNAPSHOT_PREFIX,
         },
     },
-    crossbeam_channel::{Receiver, SendError, Sender},
     log::*,
     solana_sdk::{
         clock::Slot, genesis_config::ClusterType, hash::Hash, sysvar::epoch_schedule::EpochSchedule,
@@ -23,14 +22,9 @@ use {
     tempfile::TempDir,
 };
 
-/// The sender side of the AccountsPackage channel, used by AccountsBackgroundService
-pub type AccountsPackageSender = Sender<AccountsPackage>;
-
-/// The receiver side of the AccountsPackage channel, used by AccountsHashVerifier
-pub type AccountsPackageReceiver = Receiver<AccountsPackage>;
-
-/// The error type when sending an AccountsPackage over the channel fails
-pub type AccountsPackageSendError = SendError<AccountsPackage>;
+/// The PendingAccountsPackage passes an AccountsPackage from AccountsBackgroundService to
+/// AccountsHashVerifier for hashing
+pub type PendingAccountsPackage = Arc<Mutex<Option<AccountsPackage>>>;
 
 /// The PendingSnapshotPackage passes a SnapshotPackage from AccountsHashVerifier to
 /// SnapshotPackagerService for archiving


### PR DESCRIPTION
## Problem

If the accounts hash calculation is moved from AccountsBackgroundService (ABS) to AccountsHashVerifier (AHV), then the flow of `AccountsPackage`s between ABS and AHV may increase substantially, and also may not be serviced fast enough, resulting in the channel ever growing in size.

## Summary of Changes

Replace the channel with a `Mutex<Option<AccountsPackage>>`, so only a single `AccountsPackage` is ever pending between ABS and AHV.

## Background and Context

@jeffwashington is working on moving the hash calculation out of ABS and into AHV. The hash calculation takes a long time (around 10 seconds [^1]), which is blocking flush/clean/shrink in his accounts index work. Because `hash_calc()` is slow, the ABS loop for handling snapshot requests is also slow.

The dataflow is:

```
bank_forks::set_root() ===SnapshotRequest==> ABS::handle_snapshot_request() ===AccountsPackage==> AHV
```

- bank_forks::set_root() sends `SnapshotRequest`s to ABS on the `SnapshotRequest` channel at a rate of `accounts_hash_interval`, which is 100 blocks (so around 40-50 seconds)
- ABS processes the snapshot requests
    - each iteration, ABS pulls out *all* of the `SnapshotRequest`s in the channel and discards all but the last one
    - processing the snapshot request performs the hash calculation, and then sends the new `AccountsPackage` to AHV on the `AccountsPackage` channel
    - ABS has a sleep of 100 ms at the end of each loop, so at the absolute fastest, a `SnapshotRequest` could be processed once per 100 ms. But snapshot request handling takes around 13 seconds[^2].
- AHV processes *all* the `AccountsPackage`s in its channel

So
- Since ABS::handle_snapshot_request() is slow (mostly due to `hash_calc()`), new `AccountsPackage`s are pushed into the `AccountsPackage` channel at a slow rate
- If `hash_calc()` moves to AHV, then ABS::handle_snapshot_request() will be fast and AHV will be slow.
- If that happens, ABS will push more `AccountsPackage`s to the  channel.
- And now that AHV is slow, it likely cannot keep up. This will just balloon memory.

Can the `AccountsPackage` channel  just be a single item?
Is it OK if that item is ever overwritten?

I can only assume it's OK, since (1) today if ABS exceeds the 40-50 seconds (which the graphs show that it does happen) then AHV doesn't get all the banks that `set_root()` pushes, so this PR wouldn't change that, and (2) AHV already has a `fault_injection_rate` parameter:

https://github.com/solana-labs/solana/blob/51b37f0184b15c02306d3047770d00755ab9c764/core/src/accounts_hash_verifier.rs#L150-L174

But maybe there's some other failure mode I'm missing?

Lastly, I've also prioritized the overwritting:
- If the new AccountsPackage is destined to be a full snapshot archive, then it always overwrites the pending AccountsPackage
- If the new AccountsPackage is destined to be an incremental snapshot archive, then it overwrites the pending AccountsPackage as long as the pending AccountsPackage is *not* a full snapshot 
- If the new AccountsPackage is not going to become a snapshot archive, then only overwrite the pending AccountsPackage if it too is not going to become a snapshot archive.

### Footnotes

^1: [Hash calculation time, in us (log y-axis)](https://metrics.solana.com:8888/sources/1/chronograf/data-explorer?query=SELECT%20mean%28%22hash_time%22%29%20AS%20%22mean_hash_time%22%2C%20min%28%22hash_time%22%29%20AS%20%22min_hash_time%22%2C%20max%28%22hash_time%22%29%20AS%20%22max_hash_time%22%2C%20median%28%22hash_time%22%29%20AS%20%22median_hash_time%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22handle_snapshot_requests-timing%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29)
<img width="1467" alt="hash calculation time" src="https://user-images.githubusercontent.com/840349/161138236-6dcbf223-792e-43e9-889e-66d78ca849f2.png">

^2: [Handle snapshot request, total time in us (log y-axis)](https://metrics.solana.com:8888/sources/1/chronograf/data-explorer?query=SELECT%20mean%28%22total_us%22%29%20AS%20%22mean_total_us%22%2C%20median%28%22total_us%22%29%20AS%20%22median_total_us%22%2C%20min%28%22total_us%22%29%20AS%20%22min_total_us%22%2C%20max%28%22total_us%22%29%20AS%20%22max_total_us%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22handle_snapshot_requests-timing%22%20WHERE%20time%20%3E%20%3AdashboardTime%3A%20AND%20time%20%3C%20%3AupperDashboardTime%3A%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29)
<img width="1452" alt="handle snapshot request total time" src="https://user-images.githubusercontent.com/840349/161141482-91f37e4d-a0ef-44b5-ba77-47f80abbd224.png">

