### PR TITLE
Refactor: Use `InstructionContext::get_instruction_data()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -34,7 +34,7 @@ use {
 };
 
 pub type ProcessInstructionWithContext =
-    fn(usize, &[u8], &mut InvokeContext) -> Result<(), InstructionError>;
+    fn(usize, &mut InvokeContext) -> Result<(), InstructionError>;
 
 #[derive(Clone)]
 pub struct BuiltinProgram {
@@ -45,11 +45,8 @@ pub struct BuiltinProgram {
 impl std::fmt::Debug for BuiltinProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // These are just type aliases for work around of Debug-ing above pointers
-        type ErasedProcessInstructionWithContext = fn(
-            usize,
-            &'static [u8],
-            &'static mut InvokeContext<'static>,
-        ) -> Result<(), InstructionError>;
+        type ErasedProcessInstructionWithContext =
+            fn(usize, &'static mut InvokeContext<'static>) -> Result<(), InstructionError>;
 
         // rustc doesn't compile due to bug without this work around
         // https://github.com/rust-lang/rust/issues/50280
@@ -892,7 +889,7 @@ impl<'a> InvokeContext<'a> {
                 self.transaction_context
                     .set_return_data(program_id, Vec::new())?;
                 let pre_remaining_units = self.compute_meter.borrow().get_remaining();
-                let execution_result = self.process_executable_chain(instruction_data);
+                let execution_result = self.process_executable_chain();
                 let post_remaining_units = self.compute_meter.borrow().get_remaining();
                 *compute_units_consumed = pre_remaining_units.saturating_sub(post_remaining_units);
                 process_executable_chain_time.stop();
@@ -932,10 +929,7 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Calls the instruction's program entrypoint method
-    fn process_executable_chain(
-        &mut self,
-        instruction_data: &[u8],
-    ) -> Result<(), InstructionError> {
+    fn process_executable_chain(&mut self) -> Result<(), InstructionError> {
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
         let borrowed_root_account = instruction_context
             .try_borrow_account(self.transaction_context, 0)
@@ -949,7 +943,6 @@ impl<'a> InvokeContext<'a> {
                     // Call the builtin program
                     return (entry.process_instruction)(
                         1, // root_id to be skipped
-                        instruction_data,
                         self,
                     );
                 }
@@ -958,7 +951,7 @@ impl<'a> InvokeContext<'a> {
                 drop(borrowed_root_account);
                 let native_loader = NativeLoader::default();
                 // Call the program via the native loader
-                return native_loader.process_instruction(0, instruction_data, self);
+                return native_loader.process_instruction(0, self);
             }
         } else {
             for entry in self.builtin_programs {
@@ -967,7 +960,6 @@ impl<'a> InvokeContext<'a> {
                     // Call the program via a builtin loader
                     return (entry.process_instruction)(
                         0, // no root_id was provided
-                        instruction_data,
                         self,
                     );
                 }
@@ -1160,7 +1152,7 @@ pub fn mock_process_instruction(
             &program_indices,
             instruction_data,
         )
-        .and_then(|_| process_instruction(1, instruction_data, &mut invoke_context));
+        .and_then(|_| process_instruction(1, &mut invoke_context));
     invoke_context.pop().unwrap();
     assert_eq!(result, expected_result);
     let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();
@@ -1271,7 +1263,6 @@ mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Ok(())
@@ -1279,8 +1270,7 @@ mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
-            _context: &mut InvokeContext,
+            _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Ok(())
         }
@@ -1300,7 +1290,6 @@ mod tests {
     #[allow(clippy::integer_arithmetic)]
     fn mock_process_instruction(
         _first_instruction_account: usize,
-        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1301,11 +1301,12 @@ mod tests {
     #[allow(clippy::integer_arithmetic)]
     fn mock_process_instruction(
         _first_instruction_account: usize,
-        data: &[u8],
+        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
+        let instruction_data = instruction_context.get_instruction_data();
         let program_id = instruction_context.get_program_key(transaction_context)?;
         assert_eq!(
             program_id,
@@ -1322,7 +1323,7 @@ mod tests {
                 .get_key()
         );
 
-        if let Ok(instruction) = bincode::deserialize(data) {
+        if let Ok(instruction) = bincode::deserialize(instruction_data) {
             match instruction {
                 MockInstruction::NoopSuccess => (),
                 MockInstruction::NoopFail => return Err(InstructionError::GenericError),

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -62,11 +62,10 @@ impl std::fmt::Debug for BuiltinProgram {
 /// Program executor
 pub trait Executor: Debug + Send + Sync {
     /// Execute the program
-    fn execute<'a, 'b>(
+    fn execute(
         &self,
         first_instruction_account: usize,
-        instruction_data: &[u8],
-        invoke_context: &'a mut InvokeContext<'b>,
+        invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError>;
 }
 

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -34,7 +34,7 @@ use {
 /// invoke_context: Invocation context
 pub type LoaderEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError>;
 
@@ -166,7 +166,7 @@ impl NativeLoader {
     pub fn process_instruction(
         &self,
         first_instruction_account: usize,
-        instruction_data: &[u8],
+        _instruction_data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
@@ -206,6 +206,9 @@ impl NativeLoader {
         trace!("Call native {:?}", name);
         #[allow(deprecated)]
         invoke_context.remove_first_keyed_account()?;
+        let transaction_context = &invoke_context.transaction_context;
+        let instruction_context = transaction_context.get_current_instruction_context()?;
+        let instruction_data = instruction_context.get_instruction_data();
         if name.ends_with("loader_program") {
             let entrypoint =
                 Self::get_entrypoint::<LoaderEntrypoint>(name, &self.loader_symbol_cache)?;

--- a/program-runtime/src/native_loader.rs
+++ b/program-runtime/src/native_loader.rs
@@ -34,7 +34,6 @@ use {
 /// invoke_context: Invocation context
 pub type LoaderEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
-    _instruction_data: &[u8],
     invoke_context: &InvokeContext,
 ) -> Result<(), InstructionError>;
 
@@ -166,7 +165,6 @@ impl NativeLoader {
     pub fn process_instruction(
         &self,
         first_instruction_account: usize,
-        _instruction_data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
@@ -212,7 +210,7 @@ impl NativeLoader {
         if name.ends_with("loader_program") {
             let entrypoint =
                 Self::get_entrypoint::<LoaderEntrypoint>(name, &self.loader_symbol_cache)?;
-            unsafe { entrypoint(&program_id, instruction_data, invoke_context) }
+            unsafe { entrypoint(&program_id, invoke_context) }
         } else {
             let entrypoint =
                 Self::get_entrypoint::<ProgramEntrypoint>(name, &self.program_symbol_cache)?;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -94,13 +94,14 @@ fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     _first_instruction_account: usize,
-    input: &[u8],
+    _input: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
     let indices_in_instruction = instruction_context.get_number_of_program_accounts()
         ..instruction_context.get_number_of_accounts();
 
@@ -167,7 +168,7 @@ pub fn builtin_process_instruction(
         .collect::<Result<Vec<AccountInfo>, InstructionError>>()?;
 
     // Execute the program
-    process_instruction(program_id, &account_infos, input).map_err(|err| {
+    process_instruction(program_id, &account_infos, instruction_data).map_err(|err| {
         let err = u64::from(err);
         stable_log::program_failure(&log_collector, program_id, &err.into());
         err
@@ -197,12 +198,12 @@ macro_rules! processor {
     ($process_instruction:expr) => {
         Some(
             |first_instruction_account: usize,
-             input: &[u8],
+             _input: &[u8],
              invoke_context: &mut solana_program_test::InvokeContext| {
                 $crate::builtin_process_instruction(
                     $process_instruction,
                     first_instruction_account,
-                    input,
+                    _input,
                     invoke_context,
                 )
             },

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -94,7 +94,6 @@ fn get_invoke_context<'a, 'b>() -> &'a mut InvokeContext<'b> {
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     _first_instruction_account: usize,
-    _input: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
@@ -198,12 +197,10 @@ macro_rules! processor {
     ($process_instruction:expr) => {
         Some(
             |first_instruction_account: usize,
-             _input: &[u8],
              invoke_context: &mut solana_program_test::InvokeContext| {
                 $crate::builtin_process_instruction(
                     $process_instruction,
                     first_instruction_account,
-                    _input,
                     invoke_context,
                 )
             },

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -22,9 +22,12 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
     match limited_deserialize(instruction_data)? {
         ProgramInstruction::CreateLookupTable {
             recent_slot,

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -62,6 +62,8 @@ impl Processor {
         untrusted_recent_slot: Slot,
         bump_seed: u8,
     ) -> Result<(), InstructionError> {
+        let transaction_context = &invoke_context.transaction_context;
+        let _instruction_context = transaction_context.get_current_instruction_context()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
         let lookup_table_account =
@@ -158,6 +160,8 @@ impl Processor {
         invoke_context: &mut InvokeContext,
         first_instruction_account: usize,
     ) -> Result<(), InstructionError> {
+        let transaction_context = &invoke_context.transaction_context;
+        let _instruction_context = transaction_context.get_current_instruction_context()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
         let lookup_table_account =
@@ -211,6 +215,8 @@ impl Processor {
         first_instruction_account: usize,
         new_addresses: Vec<Pubkey>,
     ) -> Result<(), InstructionError> {
+        let transaction_context = &invoke_context.transaction_context;
+        let _instruction_context = transaction_context.get_current_instruction_context()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
         let lookup_table_account =
@@ -328,6 +334,8 @@ impl Processor {
         invoke_context: &mut InvokeContext,
         first_instruction_account: usize,
     ) -> Result<(), InstructionError> {
+        let transaction_context = &invoke_context.transaction_context;
+        let _instruction_context = transaction_context.get_current_instruction_context()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
         let lookup_table_account =
@@ -378,6 +386,8 @@ impl Processor {
         invoke_context: &mut InvokeContext,
         first_instruction_account: usize,
     ) -> Result<(), InstructionError> {
+        let transaction_context = &invoke_context.transaction_context;
+        let _instruction_context = transaction_context.get_current_instruction_context()?;
         let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
         let lookup_table_account =

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -22,7 +22,6 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -257,33 +257,20 @@ pub fn create_vm<'a, 'b>(
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    process_instruction_common(
-        first_instruction_account,
-        _instruction_data,
-        invoke_context,
-        false,
-    )
+    process_instruction_common(first_instruction_account, invoke_context, false)
 }
 
 pub fn process_instruction_jit(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
-    process_instruction_common(
-        first_instruction_account,
-        _instruction_data,
-        invoke_context,
-        true,
-    )
+    process_instruction_common(first_instruction_account, invoke_context, true)
 }
 
 fn process_instruction_common(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -404,19 +391,13 @@ fn process_instruction_common(
         if bpf_loader_upgradeable::check_id(program_id) {
             process_loader_upgradeable_instruction(
                 first_instruction_account,
-                _instruction_data,
                 invoke_context,
                 use_jit,
             )
         } else if bpf_loader::check_id(program_id)
             || (!disable_deprecated_loader && bpf_loader_deprecated::check_id(program_id))
         {
-            process_loader_instruction(
-                first_instruction_account,
-                _instruction_data,
-                invoke_context,
-                use_jit,
-            )
+            process_loader_instruction(first_instruction_account, invoke_context, use_jit)
         } else if disable_deprecated_loader && bpf_loader_deprecated::check_id(program_id) {
             ic_logger_msg!(log_collector, "Deprecated loader is no longer supported");
             Err(InstructionError::UnsupportedProgramId)
@@ -429,7 +410,6 @@ fn process_instruction_common(
 
 fn process_loader_upgradeable_instruction(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -1063,7 +1043,6 @@ fn common_close_account(
 
 fn process_loader_instruction(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -1589,18 +1568,12 @@ mod tests {
             Vec::new(),
             None,
             Err(InstructionError::ProgramFailedToComplete),
-            |first_instruction_account: usize,
-             _instruction_data: &[u8],
-             invoke_context: &mut InvokeContext| {
+            |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
                 invoke_context
                     .get_compute_meter()
                     .borrow_mut()
                     .mock_set_remaining(0);
-                super::process_instruction(
-                    first_instruction_account,
-                    _instruction_data,
-                    invoke_context,
-                )
+                super::process_instruction(first_instruction_account, invoke_context)
             },
         );
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -394,7 +394,7 @@ fn process_instruction_common(
             get_or_create_executor_time.as_us()
         );
 
-        executor.execute(program_account_index, _instruction_data, invoke_context)
+        executor.execute(program_account_index, invoke_context)
     } else {
         drop(program);
         debug_assert_eq!(first_instruction_account, 1);
@@ -1150,11 +1150,10 @@ impl Debug for BpfExecutor {
 }
 
 impl Executor for BpfExecutor {
-    fn execute<'a, 'b>(
+    fn execute(
         &self,
         _first_instruction_account: usize,
-        _instruction_data: &[u8],
-        invoke_context: &'a mut InvokeContext<'b>,
+        invoke_context: &mut InvokeContext,
     ) -> Result<(), InstructionError> {
         let log_collector = invoke_context.get_log_collector();
         let compute_meter = invoke_context.get_compute_meter();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -257,12 +257,12 @@ pub fn create_vm<'a, 'b>(
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
         first_instruction_account,
-        instruction_data,
+        _instruction_data,
         invoke_context,
         false,
     )
@@ -270,12 +270,12 @@ pub fn process_instruction(
 
 pub fn process_instruction_jit(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     process_instruction_common(
         first_instruction_account,
-        instruction_data,
+        _instruction_data,
         invoke_context,
         true,
     )
@@ -283,7 +283,7 @@ pub fn process_instruction_jit(
 
 fn process_instruction_common(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
@@ -394,7 +394,7 @@ fn process_instruction_common(
             get_or_create_executor_time.as_us()
         );
 
-        executor.execute(program_account_index, instruction_data, invoke_context)
+        executor.execute(program_account_index, _instruction_data, invoke_context)
     } else {
         drop(program);
         debug_assert_eq!(first_instruction_account, 1);
@@ -404,7 +404,7 @@ fn process_instruction_common(
         if bpf_loader_upgradeable::check_id(program_id) {
             process_loader_upgradeable_instruction(
                 first_instruction_account,
-                instruction_data,
+                _instruction_data,
                 invoke_context,
                 use_jit,
             )
@@ -413,7 +413,7 @@ fn process_instruction_common(
         {
             process_loader_instruction(
                 first_instruction_account,
-                instruction_data,
+                _instruction_data,
                 invoke_context,
                 use_jit,
             )
@@ -429,13 +429,14 @@ fn process_instruction_common(
 
 fn process_loader_upgradeable_instruction(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let log_collector = invoke_context.get_log_collector();
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
     let program_id = instruction_context.get_program_key(transaction_context)?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
@@ -1062,12 +1063,13 @@ fn common_close_account(
 
 fn process_loader_instruction(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
     let program_id = instruction_context.get_program_key(transaction_context)?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let program = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
@@ -1589,7 +1591,7 @@ mod tests {
             None,
             Err(InstructionError::ProgramFailedToComplete),
             |first_instruction_account: usize,
-             instruction_data: &[u8],
+             _instruction_data: &[u8],
              invoke_context: &mut InvokeContext| {
                 invoke_context
                     .get_compute_meter()
@@ -1597,7 +1599,7 @@ mod tests {
                     .mock_set_remaining(0);
                 super::process_instruction(
                     first_instruction_account,
-                    instruction_data,
+                    _instruction_data,
                     invoke_context,
                 )
             },

--- a/programs/compute-budget/src/lib.rs
+++ b/programs/compute-budget/src/lib.rs
@@ -5,7 +5,6 @@ use {
 
 pub fn process_instruction(
     _first_instruction_account: usize,
-    _data: &[u8],
     _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     // Do nothing, compute budget instructions handled by the runtime

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -20,6 +20,8 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let _instruction_context = transaction_context.get_current_instruction_context()?;
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let key_list: ConfigKeys = limited_deserialize(data)?;

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -17,11 +17,12 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    data: &[u8],
+    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
-    let _instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let data = instruction_context.get_instruction_data();
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let key_list: ConfigKeys = limited_deserialize(data)?;

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -17,7 +17,6 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -25,7 +25,6 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -25,11 +25,12 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    data: &[u8],
+    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let data = instruction_context.get_instruction_data();
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -111,12 +111,10 @@ fn bench_process_vote_instruction(
         invoke_context
             .push(&instruction_accounts, &[0], &instruction_data)
             .unwrap();
-        assert!(solana_vote_program::vote_processor::process_instruction(
-            1,
-            &instruction_data,
-            &mut invoke_context
-        )
-        .is_ok());
+        assert!(
+            solana_vote_program::vote_processor::process_instruction(1, &mut invoke_context)
+                .is_ok()
+        );
         invoke_context.pop().unwrap();
     });
 }

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -18,11 +18,12 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    data: &[u8],
+    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
+    let data = instruction_context.get_instruction_data();
     let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);
@@ -237,12 +238,12 @@ mod tests {
             None,
             expected_result,
             |first_instruction_account: usize,
-             instruction_data: &[u8],
+             _instruction_data: &[u8],
              invoke_context: &mut InvokeContext| {
                 invoke_context.feature_set = std::sync::Arc::new(FeatureSet::default());
                 super::process_instruction(
                     first_instruction_account,
-                    instruction_data,
+                    _instruction_data,
                     invoke_context,
                 )
             },

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -18,7 +18,6 @@ use {
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
@@ -237,15 +236,9 @@ mod tests {
             instruction_accounts,
             None,
             expected_result,
-            |first_instruction_account: usize,
-             _instruction_data: &[u8],
-             invoke_context: &mut InvokeContext| {
+            |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
                 invoke_context.feature_set = std::sync::Arc::new(FeatureSet::default());
-                super::process_instruction(
-                    first_instruction_account,
-                    _instruction_data,
-                    invoke_context,
-                )
+                super::process_instruction(first_instruction_account, invoke_context)
             },
         )
     }

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -27,7 +27,6 @@ fn verify<T: Pod + Verifiable>(invoke_context: &mut InvokeContext) -> Result<(),
 
 pub fn process_instruction(
     _first_instruction_account: usize,
-    _input: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -8,11 +8,13 @@ use {
     std::result::Result,
 };
 
-fn verify<T: Pod + Verifiable>(
-    input: &[u8],
-    invoke_context: &mut InvokeContext,
-) -> Result<(), InstructionError> {
-    let proof = ProofInstruction::decode_data::<T>(input).ok_or_else(|| {
+fn verify<T: Pod + Verifiable>(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+    let instruction = ProofInstruction::decode_data::<T>(instruction_data);
+
+    let proof = instruction.ok_or_else(|| {
         ic_msg!(invoke_context, "invalid proof data");
         InstructionError::InvalidInstructionData
     })?;
@@ -25,7 +27,7 @@ fn verify<T: Pod + Verifiable>(
 
 pub fn process_instruction(
     _first_instruction_account: usize,
-    input: &[u8],
+    _input: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     if invoke_context.get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
@@ -40,26 +42,31 @@ pub fn process_instruction(
         compute_meter.borrow_mut().consume(100_000)?;
     }
 
-    match ProofInstruction::decode_type(input).ok_or(InstructionError::InvalidInstructionData)? {
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let instruction_data = instruction_context.get_instruction_data();
+    let instruction = ProofInstruction::decode_type(instruction_data);
+
+    match instruction.ok_or(InstructionError::InvalidInstructionData)? {
         ProofInstruction::VerifyCloseAccount => {
             ic_msg!(invoke_context, "VerifyCloseAccount");
-            verify::<CloseAccountData>(input, invoke_context)
+            verify::<CloseAccountData>(invoke_context)
         }
         ProofInstruction::VerifyWithdraw => {
             ic_msg!(invoke_context, "VerifyWithdraw");
-            verify::<WithdrawData>(input, invoke_context)
+            verify::<WithdrawData>(invoke_context)
         }
         ProofInstruction::VerifyWithdrawWithheldTokens => {
             ic_msg!(invoke_context, "VerifyWithdraw");
-            verify::<WithdrawData>(input, invoke_context)
+            verify::<WithdrawData>(invoke_context)
         }
         ProofInstruction::VerifyTransfer => {
             ic_msg!(invoke_context, "VerifyTransfer");
-            verify::<TransferData>(input, invoke_context)
+            verify::<TransferData>(invoke_context)
         }
         ProofInstruction::VerifyTransferWithFee => {
             ic_msg!(invoke_context, "VerifyTransferWithFee");
-            verify::<TransferWithFeeData>(input, invoke_context)
+            verify::<TransferWithFeeData>(invoke_context)
         }
     }
 }

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -34,7 +34,6 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _first_instruction_account: usize,
-    _data: &[u8],
     _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     Ok(())

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7820,12 +7820,13 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            data: &[u8],
+            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
-            if let Ok(instruction) = bincode::deserialize(data) {
+            let instruction_data = instruction_context.get_instruction_data();
+            if let Ok(instruction) = bincode::deserialize(instruction_data) {
                 match instruction {
                     MockInstruction::Deduction => {
                         instruction_context
@@ -12565,12 +12566,13 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            data: &[u8],
+            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
-            let lamports = data[0] as u64;
+            let instruction_data = instruction_context.get_instruction_data();
+            let lamports = instruction_data[0] as u64;
             instruction_context
                 .try_borrow_instruction_account(transaction_context, 2)?
                 .checked_sub_lamports(lamports)?;
@@ -15508,14 +15510,16 @@ pub(crate) mod tests {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            data: &[u8],
+            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let mock_program_id = Pubkey::new(&[2u8; 32]);
             let transaction_context = &mut invoke_context.transaction_context;
+            let instruction_context = transaction_context.get_current_instruction_context()?;
+            let instruction_data = instruction_context.get_instruction_data();
             let mut return_data = [0u8; MAX_RETURN_DATA];
-            if !data.is_empty() {
-                let index = usize::from_le_bytes(data.try_into().unwrap());
+            if !instruction_data.is_empty() {
+                let index = usize::from_le_bytes(instruction_data.try_into().unwrap());
                 return_data[index] = 1;
                 transaction_context
                     .set_return_data(mock_program_id, return_data.to_vec())
@@ -16383,12 +16387,13 @@ pub(crate) mod tests {
 
     fn mock_transfer_process_instruction(
         _first_instruction_account: usize,
-        data: &[u8],
+        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        if let Ok(instruction) = bincode::deserialize(data) {
+        let instruction_data = instruction_context.get_instruction_data();
+        if let Ok(instruction) = bincode::deserialize(instruction_data) {
             match instruction {
                 MockTransferInstruction::Transfer(amount) => {
                     instruction_context
@@ -17151,12 +17156,13 @@ pub(crate) mod tests {
 
     fn mock_realloc_process_instruction(
         _first_instruction_account: usize,
-        data: &[u8],
+        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
-        if let Ok(instruction) = bincode::deserialize(data) {
+        let instruction_data = instruction_context.get_instruction_data();
+        if let Ok(instruction) = bincode::deserialize(instruction_data) {
             match instruction {
                 MockReallocInstruction::Realloc(new_size, new_balance, _) => {
                     // Set data length

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7820,7 +7820,6 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -11261,7 +11260,6 @@ pub(crate) mod tests {
         }
         fn mock_vote_processor(
             _first_instruction_account: usize,
-            _instruction_data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -11321,7 +11319,6 @@ pub(crate) mod tests {
 
         fn mock_vote_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Err(InstructionError::Custom(42))
@@ -11371,7 +11368,6 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Err(InstructionError::Custom(42))
@@ -12566,7 +12562,6 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -12626,7 +12621,6 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             Ok(())
@@ -12849,7 +12843,6 @@ pub(crate) mod tests {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ok_vote_processor(
         _first_instruction_account: usize,
-        _data: &[u8],
         _invoke_context: &mut InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
         Ok(())
@@ -13099,7 +13092,6 @@ pub(crate) mod tests {
     fn test_same_program_id_uses_unqiue_executable_accounts() {
         fn nested_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -13374,7 +13366,6 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
@@ -13413,7 +13404,6 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             _context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
@@ -15509,7 +15499,6 @@ pub(crate) mod tests {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let mock_program_id = Pubkey::new(&[2u8; 32]);
@@ -15707,7 +15696,6 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -15918,7 +15906,6 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let compute_budget = invoke_context.get_compute_budget();
@@ -15963,7 +15950,6 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             let compute_budget = invoke_context.get_compute_budget();
@@ -16386,7 +16372,6 @@ pub(crate) mod tests {
 
     fn mock_transfer_process_instruction(
         _first_instruction_account: usize,
-        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -17155,7 +17140,6 @@ pub(crate) mod tests {
 
     fn mock_realloc_process_instruction(
         _first_instruction_account: usize,
-        _data: &[u8],
         invoke_context: &mut InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13791,11 +13791,10 @@ pub(crate) mod tests {
     #[derive(Debug)]
     struct TestExecutor {}
     impl Executor for TestExecutor {
-        fn execute<'a, 'b>(
+        fn execute(
             &self,
             _first_instruction_account: usize,
-            _instruction_data: &[u8],
-            _invoke_context: &'a mut InvokeContext<'b>,
+            _invoke_context: &mut InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
         }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -18,7 +18,7 @@ use {
 fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
@@ -27,7 +27,7 @@ fn process_instruction_with_program_logging(
     let program_id = instruction_context.get_program_key(transaction_context)?;
     stable_log::program_invoke(&logger, program_id, invoke_context.get_stack_height());
 
-    let result = process_instruction(first_instruction_account, instruction_data, invoke_context);
+    let result = process_instruction(first_instruction_account, _instruction_data, invoke_context);
 
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -42,12 +42,12 @@ fn process_instruction_with_program_logging(
 macro_rules! with_program_logging {
     ($process_instruction:expr) => {
         |first_instruction_account: usize,
-         instruction_data: &[u8],
+         _instruction_data: &[u8],
          invoke_context: &mut InvokeContext| {
             process_instruction_with_program_logging(
                 $process_instruction,
                 first_instruction_account,
-                instruction_data,
+                _instruction_data,
                 invoke_context,
             )
         }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -18,7 +18,6 @@ use {
 fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_log_collector();
@@ -27,7 +26,7 @@ fn process_instruction_with_program_logging(
     let program_id = instruction_context.get_program_key(transaction_context)?;
     stable_log::program_invoke(&logger, program_id, invoke_context.get_stack_height());
 
-    let result = process_instruction(first_instruction_account, _instruction_data, invoke_context);
+    let result = process_instruction(first_instruction_account, invoke_context);
 
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
@@ -41,13 +40,10 @@ fn process_instruction_with_program_logging(
 
 macro_rules! with_program_logging {
     ($process_instruction:expr) => {
-        |first_instruction_account: usize,
-         _instruction_data: &[u8],
-         invoke_context: &mut InvokeContext| {
+        |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
             process_instruction_with_program_logging(
                 $process_instruction,
                 first_instruction_account,
-                _instruction_data,
                 invoke_context,
             )
         }
@@ -87,7 +83,7 @@ impl AbiExample for Builtin {
         Self {
             name: String::default(),
             id: Pubkey::default(),
-            process_instruction_with_context: |_, _, _| Ok(()),
+            process_instruction_with_context: |_, _| Ok(()),
         }
     }
 }
@@ -214,7 +210,6 @@ fn genesis_builtins() -> Vec<Builtin> {
 /// place holder for precompile programs, remove when the precompile program is deactivated via feature activation
 fn dummy_process_instruction(
     _first_instruction_account: usize,
-    _data: &[u8],
     _invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     Ok(())

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -190,12 +190,13 @@ mod tests {
 
         fn mock_system_process_instruction(
             _first_instruction_account: usize,
-            data: &[u8],
+            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
-            if let Ok(instruction) = bincode::deserialize(data) {
+            let instruction_data = instruction_context.get_instruction_data();
+            if let Ok(instruction) = bincode::deserialize(instruction_data) {
                 match instruction {
                     MockSystemInstruction::Correct => Ok(()),
                     MockSystemInstruction::TransferLamports { lamports } => {
@@ -389,14 +390,15 @@ mod tests {
 
         fn mock_system_process_instruction(
             _first_instruction_account: usize,
-            data: &[u8],
+            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
+            let instruction_data = instruction_context.get_instruction_data();
             let mut to_account =
                 instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
-            if let Ok(instruction) = bincode::deserialize(data) {
+            if let Ok(instruction) = bincode::deserialize(instruction_data) {
                 match instruction {
                     MockSystemInstruction::BorrowFail => {
                         let from_account = instruction_context

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -190,7 +190,6 @@ mod tests {
 
         fn mock_system_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -390,7 +389,6 @@ mod tests {
 
         fn mock_system_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             let transaction_context = &invoke_context.transaction_context;
@@ -601,7 +599,6 @@ mod tests {
         let mock_program_id = Pubkey::new_unique();
         fn mock_process_instruction(
             _first_instruction_account: usize,
-            _data: &[u8],
             _invoke_context: &mut InvokeContext,
         ) -> Result<(), InstructionError> {
             Err(InstructionError::Custom(0xbabb1e))

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -265,7 +265,6 @@ fn transfer_with_seed(
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
@@ -1738,15 +1737,9 @@ mod tests {
                 },
             ],
             Ok(()),
-            |first_instruction_account: usize,
-             _instruction_data: &[u8],
-             invoke_context: &mut InvokeContext| {
+            |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                super::process_instruction(
-                    first_instruction_account,
-                    _instruction_data,
-                    invoke_context,
-                )
+                super::process_instruction(first_instruction_account, invoke_context)
             },
         );
     }
@@ -2106,15 +2099,9 @@ mod tests {
                 },
             ],
             Err(NonceError::NoRecentBlockhashes.into()),
-            |first_instruction_account: usize,
-             _instruction_data: &[u8],
-             invoke_context: &mut InvokeContext| {
+            |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
-                super::process_instruction(
-                    first_instruction_account,
-                    _instruction_data,
-                    invoke_context,
-                )
+                super::process_instruction(first_instruction_account, invoke_context)
             },
         );
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -265,13 +265,14 @@ fn transfer_with_seed(
 
 pub fn process_instruction(
     first_instruction_account: usize,
-    instruction_data: &[u8],
+    _instruction_data: &[u8],
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
+    let instruction_data = instruction_context.get_instruction_data();
     let instruction = limited_deserialize(instruction_data)?;
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", instruction);
     trace!("keyed_accounts: {:?}", keyed_accounts);
@@ -1738,12 +1739,12 @@ mod tests {
             ],
             Ok(()),
             |first_instruction_account: usize,
-             instruction_data: &[u8],
+             _instruction_data: &[u8],
              invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
                 super::process_instruction(
                     first_instruction_account,
-                    instruction_data,
+                    _instruction_data,
                     invoke_context,
                 )
             },
@@ -2106,12 +2107,12 @@ mod tests {
             ],
             Err(NonceError::NoRecentBlockhashes.into()),
             |first_instruction_account: usize,
-             instruction_data: &[u8],
+             _instruction_data: &[u8],
              invoke_context: &mut InvokeContext| {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
                 super::process_instruction(
                     first_instruction_account,
-                    instruction_data,
+                    _instruction_data,
                     invoke_context,
                 )
             },

--- a/sdk/src/builtins.rs
+++ b/sdk/src/builtins.rs
@@ -81,7 +81,6 @@ macro_rules! declare_builtin_name {
 /// fn my_process_instruction(
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
-///     _instruction_data: &[u8],
 /// ) -> Result<(), InstructionError> {
 ///   // Process an instruction
 ///   Ok(())
@@ -112,7 +111,6 @@ macro_rules! declare_builtin_name {
 /// fn my_process_instruction(
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
-///     _instruction_data: &[u8],
 /// ) -> Result<(), InstructionError> {
 ///   // Process an instruction
 ///   Ok(())

--- a/sdk/src/builtins.rs
+++ b/sdk/src/builtins.rs
@@ -81,7 +81,7 @@ macro_rules! declare_builtin_name {
 /// fn my_process_instruction(
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
-///     instruction_data: &[u8],
+///     _instruction_data: &[u8],
 /// ) -> Result<(), InstructionError> {
 ///   // Process an instruction
 ///   Ok(())
@@ -112,7 +112,7 @@ macro_rules! declare_builtin_name {
 /// fn my_process_instruction(
 ///     first_instruction_account: usize,
 ///     keyed_accounts: &[KeyedAccount],
-///     instruction_data: &[u8],
+///     _instruction_data: &[u8],
 /// ) -> Result<(), InstructionError> {
 ///   // Process an instruction
 ///   Ok(())


### PR DESCRIPTION
#### Problem
The `instruction_data` parameter is redundant as it can also be acquired from InvokeContext -> TransactionContext -> InstructionContext -> get_instruction_data().

#### Summary of Changes
- Use `instruction_context.get_instruction_data()` instead of an explicit parameter.
- Removes `instruction_data` parameter from `Executor::execute()`.
- Removes `instruction_data` parameter from `ProcessInstructionWithContext`.

Fixes #
