### PR TITLE
Remove unnecessary asserts

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2553,16 +2553,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
     ) -> Result<Instruction, EbpfError<BpfError>> {
         let ix_c = translate_type::<SolInstruction>(memory_mapping, addr, self.check_aligned)?;
 
-        debug_assert_eq!(
-            std::mem::size_of_val(&ix_c.accounts_len),
-            std::mem::size_of::<usize>(),
-            "non-64-bit host"
-        );
-        debug_assert_eq!(
-            std::mem::size_of_val(&ix_c.data_len),
-            std::mem::size_of::<usize>(),
-            "non-64-bit host"
-        );
         check_instruction_size(
             ix_c.accounts_len as usize,
             ix_c.data_len as usize,


### PR DESCRIPTION
#### Problem

These checks are checking that a ref to a u64 is the same size as a usize even though they were intended to check the size of usize vs u64.

#### Summary of Changes

Rely on type tests which already cover the intended case

Fixes #
