### PR TITLE
Make tpu_use_quic a flag only without argument

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -9,7 +9,6 @@ use {
     console::style,
     log::*,
     rand::{seq::SliceRandom, thread_rng},
-    send_transaction_service::DEFAULT_TPU_USE_QUIC,
     solana_clap_utils::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
         input_validators::{
@@ -460,7 +459,6 @@ pub fn main() {
     let default_accounts_shrink_ratio = &DEFAULT_ACCOUNTS_SHRINK_RATIO.to_string();
     let default_rocksdb_fifo_shred_storage_size =
         &DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES.to_string();
-    let default_tpu_use_quic = &DEFAULT_TPU_USE_QUIC.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1174,9 +1172,7 @@ pub fn main() {
         .arg(
             Arg::with_name("tpu_use_quic")
                 .long("tpu-use-quic")
-                .takes_value(true)
-                .value_name("BOOLEAN")
-                .default_value(default_tpu_use_quic)
+                .takes_value(false)
                 .help("When this is set to true, the system will use QUIC to send transactions."),
         )
         .arg(
@@ -2140,7 +2136,7 @@ pub fn main() {
     let restricted_repair_only_mode = matches.is_present("restricted_repair_only_mode");
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
-    let tpu_use_quic = value_t_or_exit!(matches, "tpu_use_quic", bool);
+    let tpu_use_quic = matches.is_present("tpu_use_quic");
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {


### PR DESCRIPTION
#### Problem
The flag tpu_use_quic asks for a Boolean variable and when not specified, it is default to 'false' which is not intuitive.

#### Summary of Changes
Make tpu_use_quic a flag only without argument



Fixes #
