### PR TITLE
Add GetMinimumDelegation stake program instruction

### DIFF
--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
-use solana_sdk::genesis_config::GenesisConfig;
 #[deprecated(
     since = "1.8.0",
     note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` instead"
 )]
 pub use solana_sdk::stake::program::{check_id, id};
+use solana_sdk::{feature_set::FeatureSet, genesis_config::GenesisConfig};
 
 pub mod config;
 pub mod stake_instruction;
@@ -13,4 +13,16 @@ pub mod stake_state;
 
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
     config::add_genesis_account(genesis_config)
+}
+
+/// The minimum stake amount that can be delegated, in lamports.
+/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
+/// rent exempt reserve _plus_ the minimum stake delegation.
+#[inline(always)]
+pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
+    // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
+    // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
+    // removed, use it here as to not duplicate magic constants.
+    #[allow(deprecated)]
+    solana_sdk::stake::MINIMUM_STAKE_DELEGATION
 }

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -222,6 +222,15 @@ pub enum StakeInstruction {
     ///   1. `[SIGNER]` Lockup authority or withdraw authority
     ///   2. Optional: `[SIGNER]` New lockup authority
     SetLockupChecked(LockupCheckedArgs),
+
+    /// Get the minimum stake delegation, in lamports
+    ///
+    /// # Account references
+    ///   None
+    ///
+    /// The minimum delegation will be returned via the transaction context's returndata.
+    /// Use `get_return_data()` to retrieve the result.
+    GetMinimumDelegation,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -675,6 +684,14 @@ pub fn set_lockup_checked(
         id(),
         &StakeInstruction::SetLockupChecked(lockup_checked),
         account_metas,
+    )
+}
+
+pub fn get_minimum_delegation() -> Instruction {
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::GetMinimumDelegation,
+        Vec::default(),
     )
 }
 

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -6,7 +6,8 @@ pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
-/// The minimum stake amount that can be delegated, in lamports.
-/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
-/// rent exempt reserve _plus_ the minimum stake delegation.
+#[deprecated(
+    since = "1.10.6",
+    note = "This constant may be outdated, please use `solana_stake_program::get_minimum_delegation` instead"
+)]
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -339,6 +339,10 @@ pub mod stake_split_uses_rent_sysvar {
     solana_sdk::declare_id!("FQnc7U4koHqWgRvFaBJjZnV8VPg6L6wWK33yJeDp4yvV");
 }
 
+pub mod add_get_minimum_delegation_instruction_to_stake_program {
+    solana_sdk::declare_id!("St8k9dVXP97xT6faW24YmRSYConLbhsMJA4TJTBLmMT");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -418,6 +422,7 @@ lazy_static! {
         (disable_deprecated_loader::id(), "disable the deprecated BPF loader"),
         (check_slice_translation_size::id(), "check size when translating slices"),
         (stake_split_uses_rent_sysvar::id(), "stake split instruction uses rent sysvar"),
+        (add_get_minimum_delegation_instruction_to_stake_program::id(), "add GetMinimumDelegation instruction to stake program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -3,7 +3,7 @@ use {
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
     bincode::deserialize,
-    serde_json::{json, Map},
+    serde_json::{json, Map, Value},
     solana_sdk::{
         instruction::CompiledInstruction, message::AccountKeys,
         stake::instruction::StakeInstruction,
@@ -269,6 +269,10 @@ pub fn parse_stake(
                 }),
             })
         }
+        StakeInstruction::GetMinimumDelegation => Ok(ParsedInstructionEnum {
+            instruction_type: "getMinimumDelegation".to_string(),
+            info: Value::default(),
+        }),
     }
 }
 


### PR DESCRIPTION
#### Problem

There is not a way to query the minimum stake delegation.

#### Summary of Changes

* Add new GetMinimumDelegation instruction to the stake program (and feature-gate)
* Add `get_minimum_delegation()` helper function
* Deprecate `MINIMUM_STAKE_DELEGATION` constant and update clients to use `get_minimum_delegation()` instead

Feature gate issue: #24057