### PR TITLE
Remove unused clippy attribute

### DIFF
--- a/sdk/program/src/native_token.rs
+++ b/sdk/program/src/native_token.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::integer_arithmetic)]
 /// There are 10^9 lamports in one SOL
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
 


### PR DESCRIPTION
This clippy lint is not triggered by anything in this module.
