### PR TITLE
Revert voting service to use UDP instead of QUIC

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -1,7 +1,6 @@
 use {
     crate::tower_storage::{SavedTowerVersions, TowerStorage},
     crossbeam_channel::Receiver,
-    solana_client::connection_cache::send_wire_transaction,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_poh::poh_recorder::PohRecorder,
@@ -87,13 +86,7 @@ impl VotingService {
         } else {
             crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder)
         };
-
-        let mut measure = Measure::start("vote_tx_send-ms");
-        let target_address = target_address.unwrap_or_else(|| cluster_info.my_contact_info().tpu);
-        let wire_vote_tx = bincode::serialize(vote_op.tx()).expect("vote serialization failure");
-        let _ = send_wire_transaction(&wire_vote_tx, &target_address);
-        measure.stop();
-        inc_new_counter_info!("vote_tx_send-ms", measure.as_ms() as usize);
+        let _ = cluster_info.send_transaction(vote_op.tx(), target_address);
 
         match vote_op {
             VoteOp::PushVote {


### PR DESCRIPTION
#### Problem
Usage of QUIC in voting service is causing unnecessary latencies.

#### Summary of Changes
Revert voting service to use UDP for time being.