### PR TITLE
accounts: Load sysvar accounts from cache instead of db during tx processing

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3486,7 +3486,7 @@ mod tests {
         super::*,
         solana_program_runtime::{
             invoke_context::InvokeContext,
-            sysvar_cache::{SysvarCache, SysvarWithLamports},
+            sysvar_cache::{SysvarCache, SysvarWithAccount},
         },
         solana_rbpf::{
             ebpf::HOST_ALIGN, memory_region::MemoryRegion, user_error::UserError, vm::Config,
@@ -4443,10 +4443,22 @@ mod tests {
         };
 
         let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.set_clock(SysvarWithLamports::new(src_clock.clone(), 0));
-        sysvar_cache.set_epoch_schedule(SysvarWithLamports::new(src_epochschedule, 0));
-        sysvar_cache.set_fees(SysvarWithLamports::new(src_fees.clone(), 0));
-        sysvar_cache.set_rent(SysvarWithLamports::new(src_rent, 0));
+        sysvar_cache.set_clock(SysvarWithAccount::new(
+            src_clock.clone(),
+            AccountSharedData::default(),
+        ));
+        sysvar_cache.set_epoch_schedule(SysvarWithAccount::new(
+            src_epochschedule,
+            AccountSharedData::default(),
+        ));
+        sysvar_cache.set_fees(SysvarWithAccount::new(
+            src_fees.clone(),
+            AccountSharedData::default(),
+        ));
+        sysvar_cache.set_rent(SysvarWithAccount::new(
+            src_rent,
+            AccountSharedData::default(),
+        ));
 
         prepare_mockup!(
             invoke_context,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3484,7 +3484,10 @@ mod tests {
     use solana_sdk::sysvar::fees::Fees;
     use {
         super::*,
-        solana_program_runtime::{invoke_context::InvokeContext, sysvar_cache::SysvarCache},
+        solana_program_runtime::{
+            invoke_context::InvokeContext,
+            sysvar_cache::{SysvarCache, SysvarWithLamports},
+        },
         solana_rbpf::{
             ebpf::HOST_ALIGN, memory_region::MemoryRegion, user_error::UserError, vm::Config,
         },
@@ -4440,10 +4443,10 @@ mod tests {
         };
 
         let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.set_clock(src_clock.clone());
-        sysvar_cache.set_epoch_schedule(src_epochschedule);
-        sysvar_cache.set_fees(src_fees.clone());
-        sysvar_cache.set_rent(src_rent);
+        sysvar_cache.set_clock(SysvarWithLamports::new(src_clock.clone(), 0));
+        sysvar_cache.set_epoch_schedule(SysvarWithLamports::new(src_epochschedule, 0));
+        sysvar_cache.set_fees(SysvarWithLamports::new(src_fees.clone(), 0));
+        sysvar_cache.set_rent(SysvarWithLamports::new(src_rent, 0));
 
         prepare_mockup!(
             invoke_context,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -438,7 +438,7 @@ mod tests {
         bincode::serialize,
         solana_program_runtime::{
             invoke_context::mock_process_instruction,
-            sysvar_cache::{SysvarCache, SysvarWithLamports},
+            sysvar_cache::{SysvarCache, SysvarWithAccount},
         },
         solana_sdk::{
             account::{self, AccountSharedData, ReadableAccount, WritableAccount},
@@ -2496,12 +2496,12 @@ mod tests {
         // Define rent here so that it's used consistently for setting the rent exempt reserve
         // and in the sysvar cache used for mock instruction processing.
         let mut sysvar_cache_override = SysvarCache::default();
-        sysvar_cache_override.set_rent(SysvarWithLamports::new(
+        sysvar_cache_override.set_rent(SysvarWithAccount::new(
             Rent {
                 lamports_per_byte_year: 0,
                 ..Rent::default()
             },
-            0,
+            AccountSharedData::default(),
         ));
 
         for state in [

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -437,7 +437,8 @@ mod tests {
         },
         bincode::serialize,
         solana_program_runtime::{
-            invoke_context::mock_process_instruction, sysvar_cache::SysvarCache,
+            invoke_context::mock_process_instruction,
+            sysvar_cache::{SysvarCache, SysvarWithLamports},
         },
         solana_sdk::{
             account::{self, AccountSharedData, ReadableAccount, WritableAccount},
@@ -2495,10 +2496,13 @@ mod tests {
         // Define rent here so that it's used consistently for setting the rent exempt reserve
         // and in the sysvar cache used for mock instruction processing.
         let mut sysvar_cache_override = SysvarCache::default();
-        sysvar_cache_override.set_rent(Rent {
-            lamports_per_byte_year: 0,
-            ..Rent::default()
-        });
+        sysvar_cache_override.set_rent(SysvarWithLamports::new(
+            Rent {
+                lamports_per_byte_year: 0,
+                ..Rent::default()
+            },
+            0,
+        ));
 
         for state in [
             StakeState::Initialized(Meta::auto(&stake_address)),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -240,12 +240,11 @@ impl Accounts {
         pubkey: &Pubkey,
         ancestors: &Ancestors,
         sysvar_cache: &SysvarCache,
-    ) -> AccountSharedData {
-        sysvar_cache.get_account(sysvar_type).unwrap_or_else(|_| {
+    ) -> Option<AccountSharedData> {
+        sysvar_cache.get_account(sysvar_type).ok().or_else(|| {
             self.accounts_db
                 .load_with_fixed_root(ancestors, pubkey)
                 .map(|(account, _)| account)
-                .unwrap_or_default()
         })
     }
 
@@ -291,7 +290,7 @@ impl Accounts {
                                 ),
                             )
                         } else {
-                            self.load_sysvar_account(&sysvar_type, key, ancestors, sysvar_cache)
+                            self.load_sysvar_account(&sysvar_type, key, ancestors, sysvar_cache).unwrap_or_default()
                         }
                     } else {
                         let (account, rent) = self

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -231,7 +231,7 @@ impl Accounts {
         })
     }
 
-    fn construct_sysvar_account(
+    fn load_sysvar_account(
         &self,
         pubkey: &Pubkey,
         ancestors: &Ancestors,
@@ -287,7 +287,7 @@ impl Accounts {
                                 ),
                             )
                         } else {
-                            self.construct_sysvar_account(key, ancestors, sysvar_cache)
+                            self.load_sysvar_account(key, ancestors, sysvar_cache)
                         }
                     } else {
                         let (account, rent) = self

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1725,7 +1725,7 @@ impl Bank {
                     .is_active(&feature_set::cap_accounts_data_len::id())
                     .then(|| MAX_ACCOUNTS_DATA_LEN.saturating_sub(accounts_data_len)),
             )),
-            sysvar_cache: RwLock::new(SysvarCache::new(epoch)),
+            sysvar_cache: RwLock::new(SysvarCache::default()),
             accounts_data_len: AtomicU64::new(accounts_data_len),
             fee_structure: parent.fee_structure.clone(),
         };
@@ -2045,7 +2045,7 @@ impl Bank {
                     .is_active(&feature_set::cap_accounts_data_len::id())
                     .then(|| MAX_ACCOUNTS_DATA_LEN.saturating_sub(accounts_data_len)),
             )),
-            sysvar_cache: RwLock::new(SysvarCache::new(fields.epoch)),
+            sysvar_cache: RwLock::new(SysvarCache::default()),
             accounts_data_len: AtomicU64::new(accounts_data_len),
             fee_structure: FeeStructure::default(),
         };
@@ -2228,7 +2228,7 @@ impl Bank {
             self.sysvar_cache
                 .write()
                 .unwrap()
-                .set_account(pubkey, &new_account)
+                .set_account(pubkey, new_account)
                 .unwrap();
         }
     }
@@ -10823,11 +10823,6 @@ pub(crate) mod tests {
                     },
                     true,
                 );
-                bank1
-                    .sysvar_cache
-                    .write()
-                    .unwrap()
-                    .set_rent_epoch(rent_epoch);
                 let current_account = bank1.get_account(&clock_id).unwrap();
                 assert_eq!(
                     expected_previous_slot,
@@ -10876,11 +10871,6 @@ pub(crate) mod tests {
             },
             true,
         );
-        bank2
-            .sysvar_cache
-            .write()
-            .unwrap()
-            .set_rent_epoch(rent_epoch);
         let current_account = bank2.get_account(&clock_id).unwrap();
         assert_eq!(
             expected_next_slot,

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -20,7 +20,17 @@ impl Bank {
 mod tests {
     use {
         super::*,
-        solana_sdk::{genesis_config::create_genesis_config, pubkey::Pubkey},
+        crate::{bank::ErrorCounters, genesis_utils::activate_all_features},
+        solana_sdk::{
+            account::ReadableAccount,
+            genesis_config::create_genesis_config,
+            instruction::{AccountMeta, Instruction},
+            pubkey::Pubkey,
+            signature::Signer,
+            signer::keypair::Keypair,
+            system_program, sysvar,
+            transaction::{SanitizedTransaction, Transaction},
+        },
         std::sync::Arc,
     };
 
@@ -134,5 +144,81 @@ mod tests {
             bank1_sysvar_cache.get_slot_hashes(),
             bank1_cached_slot_hashes
         );
+    }
+
+    fn check_transaction_loaded_sysvars_match(bank: &Bank, payer: &Keypair) {
+        let program_id = system_program::id();
+        for sysvar_id in sysvar::ALL_IDS.iter() {
+            let instruction = Instruction {
+                program_id,
+                accounts: vec![AccountMeta::new(*sysvar_id, false)],
+                data: vec![],
+            };
+            let tx = Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&payer.pubkey()),
+                &[payer],
+                bank.blockhash_queue.read().unwrap().last_hash(),
+            );
+            let tx = SanitizedTransaction::from_transaction_for_tests(tx);
+            let mut error_counters = ErrorCounters::default();
+            let loaded_transactions = bank.rc.accounts.load_accounts(
+                &bank.ancestors,
+                &[tx],
+                vec![(Ok(()), None)],
+                &bank.blockhash_queue.read().unwrap(),
+                &mut error_counters,
+                &bank.rent_collector,
+                &bank.feature_set,
+                &bank.fee_structure,
+                &bank.sysvar_cache.read().unwrap(),
+            );
+            assert_eq!(loaded_transactions.len(), 1);
+            let transaction = &loaded_transactions[0].0.as_ref().unwrap();
+            let (loaded_sysvar_id, loaded_sysvar_account) = &transaction.accounts[1];
+            assert_eq!(loaded_sysvar_id, sysvar_id);
+            let bank_sysvar_account = bank.get_account_with_fixed_root(sysvar_id);
+
+            // rewards are deprecated and not available in the cache
+            if *sysvar_id == sysvar::rewards::id() {
+                assert_eq!(*loaded_sysvar_account.owner(), system_program::id());
+                assert!(bank_sysvar_account.is_none());
+            } else {
+                assert_eq!(*loaded_sysvar_account.owner(), sysvar::id());
+                // instructions can't be loaded as a normal account
+                if *sysvar_id == sysvar::instructions::id() {
+                    assert!(bank_sysvar_account.is_none());
+                } else {
+                    assert_eq!(&bank_sysvar_account.unwrap(), loaded_sysvar_account);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_load_sysvar_from_filled_cache() {
+        let (mut genesis_config, mint_keypair) = create_genesis_config(100_000);
+        activate_all_features(&mut genesis_config);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank = Arc::new(Bank::new_from_parent(
+            &bank,
+            &Pubkey::default(),
+            bank.slot() + 1,
+        ));
+        check_transaction_loaded_sysvars_match(&bank, &mint_keypair);
+    }
+
+    #[test]
+    fn sanity_test_load_sysvar_from_empty_cache() {
+        let (mut genesis_config, mint_keypair) = create_genesis_config(100_000);
+        activate_all_features(&mut genesis_config);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank = Arc::new(Bank::new_from_parent(
+            &bank,
+            &Pubkey::default(),
+            bank.slot() + 1,
+        ));
+        bank.reset_sysvar_cache();
+        check_transaction_loaded_sysvars_match(&bank, &mint_keypair);
     }
 }

--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -29,7 +29,7 @@ pub fn set_entries_for_tests_only(entries: usize) {
 pub type SlotHash = (Slot, Hash);
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
 pub struct SlotHashes(Vec<SlotHash>);
 
 impl SlotHashes {

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -1,10 +1,15 @@
 //! This account contains the clock slot, epoch, and leader_schedule_epoch
 //!
 pub use crate::clock::Clock;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{
+    impl_sysvar_get,
+    program_error::ProgramError,
+    sysvar::{Sysvar, SysvarType},
+};
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 
 impl Sysvar for Clock {
+    const TYPE: SysvarType = SysvarType::Clock;
     impl_sysvar_get!(sol_get_clock_sysvar);
 }

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -1,10 +1,15 @@
 //! This account contains the current cluster rent
 //!
 pub use crate::epoch_schedule::EpochSchedule;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{
+    impl_sysvar_get,
+    program_error::ProgramError,
+    sysvar::{Sysvar, SysvarType},
+};
 
 crate::declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);
 
 impl Sysvar for EpochSchedule {
+    const TYPE: SysvarType = SysvarType::EpochSchedule;
     impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
 }

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -3,7 +3,10 @@
 #![allow(deprecated)]
 
 use crate::{
-    fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
+    fee_calculator::FeeCalculator,
+    impl_sysvar_get,
+    program_error::ProgramError,
+    sysvar::{Sysvar, SysvarType},
 };
 
 crate::declare_deprecated_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
@@ -27,5 +30,6 @@ impl Fees {
 }
 
 impl Sysvar for Fees {
+    const TYPE: SysvarType = SysvarType::Fees;
     impl_sysvar_get!(sol_get_fees_sysvar);
 }

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -5,7 +5,7 @@ use {
         declare_deprecated_sysvar_id,
         fee_calculator::FeeCalculator,
         hash::{hash, Hash},
-        sysvar::Sysvar,
+        sysvar::{Sysvar, SysvarType},
     },
     std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref},
 };
@@ -132,6 +132,7 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
 }
 
 impl Sysvar for RecentBlockhashes {
+    const TYPE: SysvarType = SysvarType::RecentBlockhashes;
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
         6008 // golden, update if MAX_ENTRIES changes

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -1,10 +1,15 @@
 //! This account contains the current cluster rent
 //!
 pub use crate::rent::Rent;
-use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
+use crate::{
+    impl_sysvar_get,
+    program_error::ProgramError,
+    sysvar::{Sysvar, SysvarType},
+};
 
 crate::declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);
 
 impl Sysvar for Rent {
+    const TYPE: SysvarType = SysvarType::Rent;
     impl_sysvar_get!(sol_get_rent_sysvar);
 }

--- a/sdk/program/src/sysvar/rewards.rs
+++ b/sdk/program/src/sysvar/rewards.rs
@@ -1,6 +1,6 @@
 //! DEPRECATED: This sysvar can be removed once the pico-inflation feature is enabled
 //!
-use crate::sysvar::Sysvar;
+use crate::sysvar::{Sysvar, SysvarType};
 
 crate::declare_sysvar_id!("SysvarRewards111111111111111111111111111111", Rewards);
 
@@ -19,4 +19,6 @@ impl Rewards {
     }
 }
 
-impl Sysvar for Rewards {}
+impl Sysvar for Rewards {
+    const TYPE: SysvarType = SysvarType::Rewards;
+}

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -3,11 +3,16 @@
 //! this account carries the Bank's most recent bank hashes for some N parents
 //!
 pub use crate::slot_hashes::SlotHashes;
-use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::Sysvar};
+use crate::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    sysvar::{Sysvar, SysvarType},
+};
 
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
 
 impl Sysvar for SlotHashes {
+    const TYPE: SysvarType = SysvarType::SlotHashes;
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/program/src/sysvar/slot_history.rs
+++ b/sdk/program/src/sysvar/slot_history.rs
@@ -3,7 +3,7 @@
 //! this account carries a bitvector of slots present over the past
 //! epoch
 //!
-use crate::sysvar::Sysvar;
+use crate::sysvar::{Sysvar, SysvarType};
 pub use crate::{
     account_info::AccountInfo, program_error::ProgramError, slot_history::SlotHistory,
 };
@@ -11,6 +11,7 @@ pub use crate::{
 crate::declare_sysvar_id!("SysvarS1otHistory11111111111111111111111111", SlotHistory);
 
 impl Sysvar for SlotHistory {
+    const TYPE: SysvarType = SysvarType::SlotHistory;
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -3,11 +3,12 @@
 //! this account carries history about stake activations and de-activations
 //!
 pub use crate::stake_history::StakeHistory;
-use crate::sysvar::Sysvar;
+use crate::sysvar::{Sysvar, SysvarType};
 
 crate::declare_sysvar_id!("SysvarStakeHistory1111111111111111111111111", StakeHistory);
 
 impl Sysvar for StakeHistory {
+    const TYPE: SysvarType = SysvarType::StakeHistory;
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -259,7 +259,7 @@ mod tests {
         crate::{
             account::{create_account_for_test, from_account, to_account},
             pubkey::Pubkey,
-            sysvar::Sysvar,
+            sysvar::{Sysvar, SysvarType},
         },
     };
 
@@ -277,7 +277,9 @@ mod tests {
             check_id(pubkey)
         }
     }
-    impl Sysvar for TestSysvar {}
+    impl Sysvar for TestSysvar {
+        const TYPE: SysvarType = SysvarType::Instructions;
+    }
 
     #[test]
     fn test_sysvar_keyed_account_to_from() {


### PR DESCRIPTION
#### Problem

As pointed out in #22880, it's possible for a program to detect if it's in a simulation.  The main idea of that PR was to create a new "simulation bank" which is used to simulate transactions only.

Unfortunately, that had unintended consequences, causing a validator panic, as reported in #23260.  Although we weren't able to figure out the exact root cause, it's most likely due to a race condition while updating sysvar accounts in the db during bank creation.

#### Summary of Changes

Simulation banks should never update accounts db, but it needs correct sysvars.  As part one of this change, this loads sysvar accounts from the cache rather than the db.

A few notes about this implementation:

* slot history is not considered, since it's only updated during bank freeze. A simulation bank can load this from the db
* `Rewards` are still not included because it's deprecated
* the tests cover lots of use-cases to be sure the accounts look exactly the same, but this will need to run against testnet or mainnet to make sure nothing bad is happening
* With this change, we actually save an additional account load for each sysvar in the cache!  Before, we were loading the old sysvar account, updating it, saving it, then loading it again to fill the sysvar cache.  Now, we also fill the sysvar cache during the saving portion.  Any unupdated ones are still filled later.