### PR TITLE
simulation: Run preflight transaction on new bank

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
     ancestors.push(0);
     for i in 1..num_slots {
         ancestors.push(i as u64);
-        accounts.add_root(i as u64);
+        accounts.add_root(i as u64).unwrap();
     }
     let ancestors = Ancestors::from(ancestors);
     let mut elapsed = vec![0; iterations];
@@ -115,7 +115,7 @@ fn main() {
             println!("{}", time);
             for slot in 0..num_slots {
                 update_accounts_bench(&accounts, &pubkeys, ((x + 1) * num_slots + slot) as u64);
-                accounts.add_root((x * num_slots + slot) as u64);
+                accounts.add_root((x * num_slots + slot) as u64).unwrap();
             }
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1598,7 +1598,10 @@ impl ReplayStage {
                 root_slot,
                 my_pubkey,
                 rpc_subscriptions,
-                NewBankOptions { vote_only_bank },
+                NewBankOptions {
+                    vote_only_bank,
+                    simulation_bank: false,
+                },
             );
 
             let tpu_bank = bank_forks.write().unwrap().insert(tpu_bank);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1298,11 +1298,11 @@ fn load_frozen_forks(
                     for (pruned_slot, pruned_bank_id) in pruned_banks_receiver.try_iter() {
                         // Simulate this purge being from the AccountsBackgroundService
                         let is_from_abs = true;
-                        new_root_bank.rc.accounts.purge_slot(
-                            pruned_slot,
-                            pruned_bank_id,
-                            is_from_abs,
-                        );
+                        new_root_bank
+                            .rc
+                            .accounts
+                            .purge_slot(pruned_slot, pruned_bank_id, is_from_abs)
+                            .unwrap();
                     }
 
                     // Must be called after `squash()`, so that AccountsDb knows what

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -83,6 +83,7 @@ members = [
     "rust/sha",
     "rust/sibling_inner_instruction",
     "rust/sibling_instruction",
+    "rust/simulation",
     "rust/spoof1",
     "rust/spoof1_system",
     "rust/sysvar",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -93,6 +93,7 @@ fn main() {
             "sha",
             "sibling_inner_instruction",
             "sibling_instruction",
+            "simulation",
             "spoof1",
             "spoof1_system",
             "upgradeable",

--- a/programs/bpf/rust/simulation/Cargo.toml
+++ b/programs/bpf/rust/simulation/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "solana-bpf-rust-simulation"
+version = "1.11.0"
+description = "Solana BPF Program Simulation Differences"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-simulation"
+edition = "2021"
+
+[features]
+test-bpf = []
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.11.0" }
+
+[dev-dependencies]
+solana-logger = { path = "../../../../logger", version = "=1.11.0" }
+solana-program-test = { path = "../../../../program-test", version = "=1.11.0" }
+solana-sdk = { path = "../../../../sdk", version = "=1.11.0" }
+solana-validator = { path = "../../../../validator", version = "=1.11.0" }
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/simulation/src/lib.rs
+++ b/programs/bpf/rust/simulation/src/lib.rs
@@ -1,0 +1,41 @@
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        declare_id,
+        entrypoint::{self, ProgramResult},
+        msg,
+        pubkey::Pubkey,
+        sysvar::Sysvar,
+    },
+    std::convert::TryInto,
+};
+
+declare_id!("Sim1jD5C35odT8mzctm8BWnjic8xW5xgeb5MbcbErTo");
+
+entrypoint!(process_instruction);
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let slot_account = next_account_info(account_info_iter)?;
+
+    // Slot is an u64 at the end of the structure
+    let data = slot_account.data.borrow();
+    let slot: u64 = u64::from_le_bytes(data[data.len() - 8..].try_into().unwrap());
+
+    let clock = Clock::get().unwrap();
+
+    msg!("next_slot is {:?} ", slot);
+    msg!("clock is in slot {:?} ", clock.slot);
+    if clock.slot >= slot {
+        msg!("On-chain");
+    } else {
+        panic!("Simulation");
+    }
+
+    Ok(())
+}

--- a/programs/bpf/rust/simulation/tests/lib.rs
+++ b/programs/bpf/rust/simulation/tests/lib.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "test-bpf")]
+
+use {
+    solana_bpf_rust_simulation::process_instruction,
+    solana_program_test::{processor, tokio, ProgramTest},
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::Signer,
+        sysvar,
+        transaction::Transaction,
+    },
+};
+
+#[tokio::test]
+async fn no_panic() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new(
+        "solana_bpf_rust_simulation",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction {
+            program_id,
+            accounts: vec![AccountMeta::new_readonly(sysvar::slot_history::id(), false)],
+            data: vec![],
+        }],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction_with_preflight(transaction)
+        .await
+        .unwrap();
+}

--- a/programs/bpf/rust/simulation/tests/validator.rs
+++ b/programs/bpf/rust/simulation/tests/validator.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "test-bpf")]
+
+use {
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        sysvar,
+    },
+    solana_sdk::{signature::Signer, transaction::Transaction},
+    solana_validator::test_validator::*,
+};
+
+#[test]
+fn no_panic() {
+    solana_logger::setup_with_default("solana_program_runtime=debug");
+    let program_id = Pubkey::new_unique();
+
+    let (test_validator, payer) = TestValidatorGenesis::default()
+        .add_program("solana_bpf_rust_simulation", program_id)
+        .start();
+    let rpc_client = test_validator.get_rpc_client();
+    let blockhash = rpc_client.get_latest_blockhash().unwrap();
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction {
+            program_id,
+            accounts: vec![AccountMeta::new_readonly(sysvar::slot_history::id(), false)],
+            data: vec![],
+        }],
+        Some(&payer.pubkey()),
+        &[&payer],
+        blockhash,
+    );
+
+    rpc_client
+        .send_and_confirm_transaction(&transaction)
+        .unwrap();
+}

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3484,7 +3484,10 @@ mod tests {
     use solana_sdk::sysvar::fees::Fees;
     use {
         super::*,
-        solana_program_runtime::{invoke_context::InvokeContext, sysvar_cache::SysvarCache},
+        solana_program_runtime::{
+            invoke_context::InvokeContext,
+            sysvar_cache::{SysvarCache, SysvarWithLamports},
+        },
         solana_rbpf::{
             ebpf::HOST_ALIGN, memory_region::MemoryRegion, user_error::UserError, vm::Config,
         },
@@ -4440,10 +4443,10 @@ mod tests {
         };
 
         let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.set_clock(src_clock.clone());
-        sysvar_cache.set_epoch_schedule(src_epochschedule);
-        sysvar_cache.set_fees(src_fees.clone());
-        sysvar_cache.set_rent(src_rent);
+        sysvar_cache.set_clock(SysvarWithLamports::new(src_clock.clone(), 0));
+        sysvar_cache.set_epoch_schedule(SysvarWithLamports::new(src_epochschedule, 0));
+        sysvar_cache.set_fees(SysvarWithLamports::new(src_fees.clone(), 0));
+        sysvar_cache.set_rent(SysvarWithLamports::new(src_rent, 0));
 
         prepare_mockup!(
             invoke_context,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -437,7 +437,8 @@ mod tests {
         },
         bincode::serialize,
         solana_program_runtime::{
-            invoke_context::mock_process_instruction, sysvar_cache::SysvarCache,
+            invoke_context::mock_process_instruction,
+            sysvar_cache::{SysvarCache, SysvarWithLamports},
         },
         solana_sdk::{
             account::{self, AccountSharedData, ReadableAccount, WritableAccount},
@@ -2495,10 +2496,13 @@ mod tests {
         // Define rent here so that it's used consistently for setting the rent exempt reserve
         // and in the sysvar cache used for mock instruction processing.
         let mut sysvar_cache_override = SysvarCache::default();
-        sysvar_cache_override.set_rent(Rent {
-            lamports_per_byte_year: 0,
-            ..Rent::default()
-        });
+        sysvar_cache_override.set_rent(SysvarWithLamports::new(
+            Rent {
+                lamports_per_byte_year: 0,
+                ..Rent::default()
+            },
+            0,
+        ));
 
         for state in [
             StakeState::Initialized(Meta::auto(&stake_address)),

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3499,8 +3499,8 @@ pub mod rpc_full {
             let preflight_commitment = config
                 .preflight_commitment
                 .map(|commitment| CommitmentConfig { commitment });
-            let preflight_bank = &*meta.bank(preflight_commitment);
-            let transaction = sanitize_transaction(unsanitized_tx, preflight_bank)?;
+            let preflight_bank = meta.bank(preflight_commitment);
+            let transaction = sanitize_transaction(unsanitized_tx, preflight_bank.as_ref())?;
             let signature = *transaction.signature();
 
             let mut last_valid_block_height = preflight_bank
@@ -3604,7 +3604,7 @@ pub mod rpc_full {
             let (_, mut unsanitized_tx) =
                 decode_and_deserialize::<VersionedTransaction>(data, binary_encoding)?;
 
-            let bank = &*meta.bank(config.commitment);
+            let bank = meta.bank(config.commitment);
             if config.replace_recent_blockhash {
                 if config.sig_verify {
                     return Err(Error::invalid_params(
@@ -3616,7 +3616,7 @@ pub mod rpc_full {
                     .set_recent_blockhash(bank.last_blockhash());
             }
 
-            let transaction = sanitize_transaction(unsanitized_tx, bank)?;
+            let transaction = sanitize_transaction(unsanitized_tx, bank.as_ref())?;
             if config.sig_verify {
                 verify_transaction(&transaction, &bank.feature_set)?;
             }
@@ -3673,7 +3673,7 @@ pub mod rpc_full {
             };
 
             Ok(new_response(
-                bank,
+                &bank,
                 RpcSimulateTransactionResult {
                     err: result.err(),
                     logs: Some(logs),

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -184,10 +184,12 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         let pubkey = solana_sdk::pubkey::new_rand();
         let account =
             AccountSharedData::new((i + 1) as u64, 0, AccountSharedData::default().owner());
-        accounts.store_slow_uncached(i, &pubkey, &account);
-        accounts.store_slow_uncached(i, &old_pubkey, &zero_account);
+        accounts.store_slow_uncached(i, &pubkey, &account).unwrap();
+        accounts
+            .store_slow_uncached(i, &old_pubkey, &zero_account)
+            .unwrap();
         old_pubkey = pubkey;
-        accounts.add_root(i);
+        accounts.add_root(i).unwrap();
     }
     bencher.iter(|| {
         accounts.accounts_db.clean_accounts(None, false, None);
@@ -214,13 +216,15 @@ fn store_accounts_with_possible_contention<F: 'static>(
     ));
     let num_keys = 1000;
     let slot = 0;
-    accounts.add_root(slot);
+    accounts.add_root(slot).unwrap();
     let pubkeys: Arc<Vec<_>> = Arc::new(
         (0..num_keys)
             .map(|_| {
                 let pubkey = solana_sdk::pubkey::new_rand();
                 let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
-                accounts.store_slow_uncached(slot, &pubkey, &account);
+                accounts
+                    .store_slow_uncached(slot, &pubkey, &account)
+                    .unwrap();
                 pubkey
             })
             .collect(),
@@ -246,7 +250,9 @@ fn store_accounts_with_possible_contention<F: 'static>(
             // Write to a different slot than the one being read from. Because
             // there's a new account pubkey being written to every time, will
             // compete for the accounts index lock on every store
-            accounts.store_slow_uncached(slot + 1, &solana_sdk::pubkey::new_rand(), account);
+            accounts
+                .store_slow_uncached(slot + 1, &solana_sdk::pubkey::new_rand(), account)
+                .unwrap();
         }
     })
 }
@@ -409,7 +415,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         let lamports = rng.gen();
         let pubkey = Pubkey::new_unique();
         let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
-        accounts.store_slow_uncached(0, &pubkey, &account);
+        accounts.store_slow_uncached(0, &pubkey, &account).unwrap();
     }
     let ancestors = Ancestors::from(vec![0]);
     let bank_id = 0;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -198,9 +198,16 @@ impl Accounts {
         }
     }
 
-    pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot) -> Self {
+    pub fn new_from_parent(
+        parent: &Accounts,
+        slot: Slot,
+        parent_slot: Slot,
+        simulation_bank: bool,
+    ) -> Self {
         let accounts_db = parent.accounts_db.clone();
-        accounts_db.set_hash(slot, parent_slot);
+        if !simulation_bank {
+            accounts_db.set_hash(slot, parent_slot);
+        }
         Self {
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -348,7 +348,8 @@ impl AbsRequestHandler {
             count += 1;
             bank.rc
                 .accounts
-                .purge_slot(pruned_slot, pruned_bank_id, is_from_abs);
+                .purge_slot(pruned_slot, pruned_bank_id, is_from_abs)
+                .unwrap();
         }
 
         count

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -143,6 +143,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
 
 pub type BinnedHashData = Vec<Vec<CalculateHashIntermediate>>;
 
+#[derive(Debug, PartialEq)]
 pub struct AccountsAddRootTiming {
     pub index_us: u64,
     pub cache_us: u64,

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -20,7 +20,17 @@ impl Bank {
 mod tests {
     use {
         super::*,
-        solana_sdk::{genesis_config::create_genesis_config, pubkey::Pubkey},
+        crate::{bank::ErrorCounters, genesis_utils::activate_all_features},
+        solana_sdk::{
+            account::ReadableAccount,
+            genesis_config::create_genesis_config,
+            instruction::{AccountMeta, Instruction},
+            pubkey::Pubkey,
+            signature::Signer,
+            signer::keypair::Keypair,
+            system_program, sysvar,
+            transaction::{SanitizedTransaction, Transaction},
+        },
         std::sync::Arc,
     };
 
@@ -134,5 +144,81 @@ mod tests {
             bank1_sysvar_cache.get_slot_hashes(),
             bank1_cached_slot_hashes
         );
+    }
+
+    fn check_transaction_loaded_sysvars_match(bank: &Bank, payer: &Keypair) {
+        let program_id = system_program::id();
+        for sysvar_id in sysvar::ALL_IDS.iter() {
+            let instruction = Instruction {
+                program_id,
+                accounts: vec![AccountMeta::new(*sysvar_id, false)],
+                data: vec![],
+            };
+            let tx = Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&payer.pubkey()),
+                &[payer],
+                bank.blockhash_queue.read().unwrap().last_hash(),
+            );
+            let tx = SanitizedTransaction::from_transaction_for_tests(tx);
+            let mut error_counters = ErrorCounters::default();
+            let loaded_transactions = bank.rc.accounts.load_accounts(
+                &bank.ancestors,
+                &[tx],
+                vec![(Ok(()), None)],
+                &bank.blockhash_queue.read().unwrap(),
+                &mut error_counters,
+                &bank.rent_collector,
+                &bank.feature_set,
+                &bank.fee_structure,
+                &bank.sysvar_cache.read().unwrap(),
+            );
+            assert_eq!(loaded_transactions.len(), 1);
+            let transaction = &loaded_transactions[0].0.as_ref().unwrap();
+            let (loaded_sysvar_id, loaded_sysvar_account) = &transaction.accounts[1];
+            assert_eq!(loaded_sysvar_id, sysvar_id);
+            let bank_sysvar_account = bank.get_account_with_fixed_root(sysvar_id);
+
+            // rewards are deprecated and not available in the cache
+            if *sysvar_id == sysvar::rewards::id() {
+                assert_eq!(*loaded_sysvar_account.owner(), system_program::id());
+                assert!(bank_sysvar_account.is_none());
+            } else {
+                assert_eq!(*loaded_sysvar_account.owner(), sysvar::id());
+                // instructions can't be loaded as a normal account
+                if *sysvar_id == sysvar::instructions::id() {
+                    assert!(bank_sysvar_account.is_none());
+                } else {
+                    assert_eq!(&bank_sysvar_account.unwrap(), loaded_sysvar_account);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_load_sysvar_from_filled_cache() {
+        let (mut genesis_config, mint_keypair) = create_genesis_config(100_000);
+        activate_all_features(&mut genesis_config);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank = Arc::new(Bank::new_from_parent(
+            &bank,
+            &Pubkey::default(),
+            bank.slot() + 1,
+        ));
+        check_transaction_loaded_sysvars_match(&bank, &mint_keypair);
+    }
+
+    #[test]
+    fn sanity_test_load_sysvar_from_empty_cache() {
+        let (mut genesis_config, mint_keypair) = create_genesis_config(100_000);
+        activate_all_features(&mut genesis_config);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let bank = Arc::new(Bank::new_from_parent(
+            &bank,
+            &Pubkey::default(),
+            bank.slot() + 1,
+        ));
+        bank.reset_sysvar_cache();
+        check_transaction_loaded_sysvars_match(&bank, &mint_keypair);
     }
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -144,7 +144,7 @@ fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100, 0);
     check_accounts(&accounts, &pubkeys, 100);
-    accounts.add_root(0);
+    accounts.add_root(0).unwrap();
 
     let mut writer = Cursor::new(vec![]);
     accountsdb_to_stream(

--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -29,7 +29,7 @@ pub fn set_entries_for_tests_only(entries: usize) {
 pub type SlotHash = (Slot, Hash);
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Default)]
 pub struct SlotHashes(Vec<SlotHash>);
 
 impl SlotHashes {


### PR DESCRIPTION
#### Problem

As pointed out in #22880, it's possible for a program to detect if it's in a simulation.  The main idea of that PR was to create a new "simulation bank" which is used to simulation transactions only.

Unfortunately, that had unintended consequences, causing a validator panic, as reported in #23260.  Although we weren't able to figure out the root cause, it's most likely due to a race condition while updating sysvar accounts in the db during bank creation.

#### Summary of Changes

Simulation banks shouldn't need to update the account db, so do the same overall thing as #22880, but without updating the sysvar account in the db.  This builds on #24033, which allows transactions to load sysvar accounts from the cache rather than the db.

Fixes #23260