### PR TITLE
Bump bytemuck_derive from 1.0.1 to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
+checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",


### PR DESCRIPTION
#### Problem
An update (v1.9.0) to the `bytemuck` crate was just released which requires version `1.1.0` of `bytemuck_derive` (this should be explicit in `bytemuck`'s dependencies but they messed this up). Our crates don't rely on v1.9.0 but since [cargo dependency resolution picks the highest version of a package](https://doc.rust-lang.org/cargo/reference/resolver.html) which satisfies dependency semver requirements, the downstream projects step picks up the update for `bytemuck` but not for `bytemuck_derive`.


#### Summary of Changes
Update `bytemuck_derive` so that when `bytemuck` v1.9.0 is used, downstream projects still build


Fixes #
