### PR TITLE
Bump bytemuck version in solana-program for consistency

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -16,7 +16,7 @@ blake3 = { version = "1.2.0", features = ["traits-preview"] }
 borsh = "0.9.1"
 borsh-derive = "0.9.1"
 bs58 = "0.4.0"
-bytemuck = { version = "1.7.2", features = ["derive"] }
+bytemuck = { version = "1.8.0", features = ["derive"] }
 bv = { version = "0.11.1", features = ["serde"] }
 itertools =  "0.10.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Make `bytemuck` dependency version consistent for all monorepo crates