### PR TITLE
Explorer: Add candy machine v2 to known program names

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -62,6 +62,7 @@ export enum PROGRAM_NAMES {
   METAPLEX = "Metaplex Program",
   NFT_AUCTION = "NFT Auction Program",
   NFT_CANDY_MACHINE = "NFT Candy Machine Program",
+  NFT_CANDY_MACHINE_V2 = "NFT Candy Machine Program V2",
   ORCA_SWAP_1 = "Orca Swap Program v1",
   ORCA_SWAP_2 = "Orca Swap Program v2",
   ORCA_AQUAFARM = "Orca Aquafarm Program",
@@ -245,6 +246,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
   },
   cndyAnrLdpjq1Ssp1z8xxDsB8dxe7u4HL5Nxi2K5WXZ: {
     name: PROGRAM_NAMES.NFT_CANDY_MACHINE,
+    deployments: LIVE_CLUSTERS,
+  },
+  cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ: {
+    name: PROGRAM_NAMES.NFT_CANDY_MACHINE_V2,
     deployments: LIVE_CLUSTERS,
   },
   DjVE6JNiYqPL2QXyCUUh8rNjHrbz9hXHNYt99MQ59qw1: {


### PR DESCRIPTION
Problem
Candy Machine V2 program ID not searchable on explorer

Summary of Changes
Add CMv2 program Id to all clusters
