### PR TITLE
demotes WeightedShuffle failures to error metrics

### DIFF
--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -326,7 +326,7 @@ pub fn new_cluster_nodes<T: 'static>(
         .collect();
     let broadcast = TypeId::of::<T>() == TypeId::of::<BroadcastStage>();
     let stakes: Vec<u64> = nodes.iter().map(|node| node.stake).collect();
-    let mut weighted_shuffle = WeightedShuffle::new(&stakes).unwrap();
+    let mut weighted_shuffle = WeightedShuffle::new("cluster-nodes", &stakes);
     if broadcast {
         weighted_shuffle.remove_index(index[&self_pubkey]);
     }

--- a/gossip/benches/weighted_shuffle.rs
+++ b/gossip/benches/weighted_shuffle.rs
@@ -32,8 +32,7 @@ fn bench_weighted_shuffle_new(bencher: &mut Bencher) {
     let weights = make_weights(&mut rng);
     bencher.iter(|| {
         rng.fill(&mut seed[..]);
-        let shuffle = WeightedShuffle::new(&weights).unwrap();
-        shuffle
+        WeightedShuffle::new("", &weights)
             .shuffle(&mut ChaChaRng::from_seed(seed))
             .collect::<Vec<_>>()
     });

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2019,7 +2019,7 @@ impl ClusterInfo {
             return packet_batch;
         }
         let mut rng = rand::thread_rng();
-        let shuffle = WeightedShuffle::new(&scores).unwrap().shuffle(&mut rng);
+        let shuffle = WeightedShuffle::new("handle-pull-requests", &scores).shuffle(&mut rng);
         let mut total_bytes = 0;
         let mut sent = 0;
         for (addr, response) in shuffle.map(|i| &responses[i]) {

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -246,8 +246,7 @@ impl CrdsGossipPull {
             return Err(CrdsGossipError::NoPeers);
         }
         let mut rng = rand::thread_rng();
-        let mut peers = WeightedShuffle::new(&weights)
-            .unwrap()
+        let mut peers = WeightedShuffle::new("pull-options", &weights)
             .shuffle(&mut rng)
             .map(|i| peers[i]);
         let peer = {

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -169,8 +169,7 @@ impl CrdsGossipPush {
                 .filter(|(_, stake)| *stake > 0)
                 .collect();
             let weights: Vec<_> = peers.iter().map(|(_, stake)| *stake).collect();
-            WeightedShuffle::new(&weights)
-                .unwrap()
+            WeightedShuffle::new("prune-received-cache", &weights)
                 .shuffle(&mut rng)
                 .map(move |i| peers[i])
         };
@@ -370,7 +369,7 @@ impl CrdsGossipPush {
             return;
         }
         let num_bloom_items = MIN_NUM_BLOOM_ITEMS.max(network_size);
-        let shuffle = WeightedShuffle::new(&weights).unwrap().shuffle(&mut rng);
+        let shuffle = WeightedShuffle::new("push-options", &weights).shuffle(&mut rng);
         let mut active_set = self.active_set.write().unwrap();
         let need = Self::compute_need(self.num_active, active_set.len(), ratio);
         for peer in shuffle.map(|i| peers[i]) {


### PR DESCRIPTION

#### Problem
Since call-sites are calling unwrap anyways, panicking seems too punitive
for our use cases.


#### Summary of Changes
* Demoted failures to error metrics
