### PR TITLE
Batch tpu calls in send-transaction-service

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -179,6 +179,7 @@ impl Banks for BanksServer {
             last_valid_block_height,
             None,
             None,
+            None,
         );
         self.transaction_sender.send(info).unwrap();
     }
@@ -308,6 +309,7 @@ impl Banks for BanksServer {
             signature,
             serialize(&transaction).unwrap(),
             last_valid_block_height,
+            None,
             None,
             None,
         );

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -30,7 +30,7 @@ use {
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Condvar, RwLock,
+            Arc, RwLock,
         },
         thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -30,7 +30,7 @@ use {
         net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, RwLock,
+            Arc, Condvar, RwLock,
         },
         thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -61,6 +61,12 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-use-quic ]]; then
+      args+=("$1")
+      shift
+    elif [[ $1 = --tpu-do-batch ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -64,9 +64,12 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --tpu-use-quic ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --tpu-do-batch ]]; then
-      args+=("$1")
-      shift
+    elif [[ $1 = --rpc-send-batch-ms ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --rpc-send-batch-size ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -150,9 +150,12 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --tpu-use-quic ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --tpu-do-batch ]]; then
-      args+=("$1")
-      shift
+    elif [[ $1 = --rpc-send-batch-ms ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --rpc-send-batch-size ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --log ]]; then
       args+=("$1" "$2")
       shift 2

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -147,6 +147,12 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-use-quic ]]; then
+      args+=("$1")
+      shift
+    elif [[ $1 = --tpu-do-batch ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --log ]]; then
       args+=("$1" "$2")
       shift 2

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -10,6 +10,7 @@ use {
     },
 };
 
+#[derive(Clone)]
 pub struct ClusterTpuInfo {
     cluster_info: Arc<ClusterInfo>,
     poh_recorder: Arc<Mutex<PohRecorder>>,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2392,6 +2392,7 @@ fn _send_transaction(
         last_valid_block_height,
         durable_nonce_info,
         max_retries,
+        None,
     );
     meta.transaction_sender
         .lock()

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -376,9 +376,9 @@ impl SendTransactionService {
             .collect::<Vec<&[u8]>>();
 
         for address in &addresses {
-            if let Err(err) =
-                connection_cache::send_wire_transaction_batch(&wire_transacions, address)
-            {
+            let send_result =
+                connection_cache::send_wire_transaction_batch(&wire_transacions, address);
+            if let Err(err) = send_result {
                 warn!(
                     "Failed to send transactions in batch to {}: {:?}",
                     tpu_address, err

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -34,12 +34,18 @@ const DEFAULT_SERVICE_MAX_RETRIES: usize = usize::MAX;
 /// When this size is reached, send out the transactions.
 const DEFAULT_TRANSACTION_BATCH_SIZE: usize = 1;
 
+// The maximum transaction batch size
+pub const MAX_TRANSACTION_BATCH_SIZE: usize = 10_000;
+
 /// Maximum transactions per second
 pub const MAX_TPS: u64 = 1_000;
 
 /// Default maximum batch waiting time in ms. If this time is reached,
 /// whatever transaction cached will be sent.
 const DEFAULT_BATCH_SEND_RATE_MS: u64 = 1;
+
+// The maximum transaction batch send rate in MS
+pub const MAX_BATCH_SEND_RATE_MS: usize = 100_000;
 
 pub struct SendTransactionService {
     thread: JoinHandle<()>,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -78,7 +78,7 @@ impl TransactionInfo {
             durable_nonce_info,
             max_retries,
             retries: 0,
-            last_sent_time
+            last_sent_time,
         }
     }
 }
@@ -635,7 +635,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 None,
-                Some(Instant::now().sub(Duration::from_millis(4000)))
+                Some(Instant::now().sub(Duration::from_millis(4000))),
             ),
         );
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -249,9 +249,10 @@ impl SendTransactionService {
                                 datapoint_warn!("send_transaction_service-queue-overflow");
                                 break;
                             }
-                        } else {
-                            transaction_info.last_sent_time = Some(last_sent_time);
-                            entry.or_insert(transaction_info);
+                            else {
+                                transaction_info.last_sent_time = Some(last_sent_time);
+                                entry.or_insert(transaction_info);
+                            }
                         }
                     }
                     drop(retry_transactions);

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -243,13 +243,13 @@ impl SendTransactionService {
                     let last_sent_time = Instant::now();
                     let mut retry_transactions = retry_transactions.lock().unwrap();
                     for (signature, mut transaction_info) in transactions.drain() {
+                        let retry_len = retry_transactions.len();
                         let entry = retry_transactions.entry(signature);
                         if let Entry::Vacant(_) = entry {
-                            if retry_transactions.len() >= MAX_TRANSACTION_QUEUE_SIZE {
+                            if retry_len >= MAX_TRANSACTION_QUEUE_SIZE {
                                 datapoint_warn!("send_transaction_service-queue-overflow");
                                 break;
-                            }
-                            else {
+                            } else {
                                 transaction_info.last_sent_time = Some(last_sent_time);
                                 entry.or_insert(transaction_info);
                             }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -344,7 +344,7 @@ impl SendTransactionService {
                                 .as_millis()
                                 > config.retry_rate_ms as u128
                         {
-                            batched_transactions.insert(signature.clone());
+                            batched_transactions.insert(*signature);
                             transaction_info.last_sent_time = Some(Instant::now());
                         }
                         return true;

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -290,8 +290,14 @@ impl SendTransactionService {
             }
             if let Some((nonce_pubkey, durable_nonce)) = transaction_info.durable_nonce_info {
                 let nonce_account = working_bank.get_account(&nonce_pubkey).unwrap_or_default();
+                let now = Instant::now();
+                let expired = transaction_info
+                    .last_sent_time
+                    .map(|last| now.duration_since(last) >= retry_rate)
+                    .unwrap_or(false);
                 if !nonce_account::verify_nonce_account(&nonce_account, &durable_nonce)
                     && working_bank.get_signature_status_slot(signature).is_none()
+                    && expired
                 {
                     info!("Dropping expired durable-nonce transaction: {}", signature);
                     result.expired += 1;

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -389,7 +389,7 @@ impl SendTransactionService {
         let addresses = leader_info
             .as_ref()
             .map(|leader_info| leader_info.get_leader_tpus(config.leader_forward_count));
-        let addresses = addresses
+        addresses
             .map(|address_list| {
                 if address_list.is_empty() {
                     vec![tpu_address]
@@ -397,8 +397,7 @@ impl SendTransactionService {
                     address_list
                 }
             })
-            .unwrap_or_else(|| vec![&tpu_address]);
-        addresses
+            .unwrap_or_else(|| vec![tpu_address])
     }
 
     fn send_single_transaction<T: TpuInfo + std::marker::Send + 'static>(

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -339,7 +339,7 @@ impl SendTransactionService {
                         }
 
                         batched_transactions.insert(*signature);
-                        transaction_info.last_sent_time = Some(Instant::now());
+                        transaction_info.last_sent_time = Some(now);
                     }
                     true
                 }
@@ -364,7 +364,7 @@ impl SendTransactionService {
             let wire_transacions = transactions
                 .iter()
                 .filter(|(signature, _)| batched_transactions.contains(signature))
-                .map(|(_, transaction_info)| &transaction_info.wire_transaction as &[u8])
+                .map(|(_, transaction_info)| transaction_info.wire_transaction.as_ref())
                 .collect::<Vec<&[u8]>>();
 
             for address in &addresses {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -497,8 +497,9 @@ impl SendTransactionService {
     fn send_transactions_with_metrics(tpu_address: &SocketAddr, wire_transactions: &[&[u8]]) {
         let mut measure = Measure::start("send_transaction_service-batch-us");
 
+        let wire_transactions = wire_transactions.iter().map(|t| t.to_vec()).collect();
         let send_result =
-            connection_cache::send_wire_transaction_batch(wire_transactions, tpu_address);
+            connection_cache::send_wire_transaction_batch_async(wire_transactions, tpu_address);
         if let Err(err) = send_result {
             warn!(
                 "Failed to send transaction batch to {}: {:?}",

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -69,6 +69,7 @@ impl TransactionInfo {
         last_valid_block_height: u64,
         durable_nonce_info: Option<(Pubkey, Hash)>,
         max_retries: Option<usize>,
+        last_sent_time: Option<Instant>,
     ) -> Self {
         Self {
             signature,
@@ -77,7 +78,7 @@ impl TransactionInfo {
             durable_nonce_info,
             max_retries,
             retries: 0,
-            last_sent_time: None,
+            last_sent_time
         }
     }
 }
@@ -445,6 +446,7 @@ mod test {
             account::AccountSharedData, genesis_config::create_genesis_config, nonce,
             pubkey::Pubkey, signature::Signer, system_program, system_transaction,
         },
+        std::ops::Sub,
     };
 
     #[test]
@@ -516,6 +518,7 @@ mod test {
                 root_bank.block_height() - 1,
                 None,
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -544,6 +547,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -572,6 +576,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -600,6 +605,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -629,8 +635,10 @@ mod test {
                 working_bank.block_height(),
                 None,
                 None,
+                Some(Instant::now().sub(Duration::from_millis(4000)))
             ),
         );
+
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
@@ -658,6 +666,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 Some(0),
+                Some(Instant::now()),
             ),
         );
         transactions.insert(
@@ -668,6 +677,7 @@ mod test {
                 working_bank.block_height(),
                 None,
                 Some(1),
+                Some(Instant::now().sub(Duration::from_millis(4000))),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -763,6 +773,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, durable_nonce)),
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -790,6 +801,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, Hash::new_unique())),
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -819,6 +831,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, Hash::new_unique())),
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -846,6 +859,7 @@ mod test {
                 root_bank.block_height() - 1,
                 Some((nonce_address, durable_nonce)),
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -874,6 +888,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, Hash::new_unique())), // runtime should advance nonce on failed transactions
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -902,6 +917,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, Hash::new_unique())), // runtime advances nonce when transaction lands
                 None,
+                Some(Instant::now()),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
@@ -931,6 +947,7 @@ mod test {
                 last_valid_block_height,
                 Some((nonce_address, durable_nonce)),
                 None,
+                Some(Instant::now().sub(Duration::from_millis(4000))),
             ),
         );
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -164,6 +164,10 @@ impl SendTransactionService {
         let mut last_leader_refresh = Instant::now();
         let mut transactions = HashMap::new();
 
+        info!(
+            "Starting send-transaction-service thread with config {:?}",
+            config
+        );
         if let Some(leader_info) = leader_info.as_mut() {
             leader_info.refresh_recent_peers();
         }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -325,14 +325,14 @@ impl SendTransactionService {
                         if transaction_info.last_sent_time.is_some() {
                             // Transaction sent before is unknown to the working bank, it might have been
                             // dropped or landed in another fork.  Re-send it
-    
+
                             info!("Retrying transaction: {}", signature);
                             result.retried += 1;
                             transaction_info.retries += 1;
-    
+
                             inc_new_counter_info!("send_transaction_service-retry", 1);
                         }
-    
+
                         batched_transactions.insert(*signature);
                         transaction_info.last_sent_time = Some(Instant::now());
                     }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -110,7 +110,7 @@ pub struct Config {
     pub use_quic: bool,
     /// The batch size for sending transactions in batches
     pub batch_size: usize,
-    /// Controls the how frequently send the batches
+    /// How frequently batches are sent
     pub batch_send_rate_ms: u64,
 }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -63,7 +63,7 @@ pub struct TransactionInfo {
     pub durable_nonce_info: Option<(Pubkey, Hash)>,
     pub max_retries: Option<usize>,
     retries: usize,
-    /// Last time when the transaction is sent
+    /// Last time the transaction was sent
     last_sent_time: Option<Instant>,
 }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -106,7 +106,7 @@ pub struct Config {
     pub leader_forward_count: u64,
     pub default_max_retries: Option<usize>,
     pub service_max_retries: usize,
-    /// Controls if to use Quic protocol to send transactions
+    /// Whether to use Quic protocol to send transactions
     pub use_quic: bool,
     /// The batch size for sending transaction in batch
     pub batch_size: usize,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -108,7 +108,7 @@ pub struct Config {
     pub service_max_retries: usize,
     /// Whether to use Quic protocol to send transactions
     pub use_quic: bool,
-    /// The batch size for sending transaction in batch
+    /// The batch size for sending transactions in batches
     pub batch_size: usize,
     /// Controls the how frequently send the batches
     pub batch_send_rate_ms: u64,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -518,7 +518,7 @@ impl SendTransactionService {
         measure.stop();
         inc_new_counter_info!(
             "send_transaction_service-batch-us",
-            measure.as_us() as usize,
+            measure.as_us() as usize
         );
     }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -44,7 +44,7 @@ pub const MAX_TRANSACTION_BATCH_SIZE: usize = 10_000;
 pub const MAX_TRANSACTION_SENDS_PER_SECOND: u64 = 1_000;
 
 /// Default maximum batch waiting time in ms. If this time is reached,
-/// whatever transaction cached will be sent.
+/// whatever transactions are cached will be sent.
 const DEFAULT_BATCH_SEND_RATE_MS: u64 = 1;
 
 // The maximum transaction batch send rate in MS

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -5,6 +5,7 @@ pub trait TpuInfo {
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr>;
 }
 
+#[derive(Clone)]
 pub struct NullTpuInfo;
 
 impl TpuInfo for NullTpuInfo {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2378,7 +2378,9 @@ pub fn main() {
         eprintln!(
             "Either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \
             'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
-            batch_size, batch_send_rate_ms, send_transaction_service::MAX_TPS
+            batch_size,
+            batch_send_rate_ms,
+            send_transaction_service::MAX_TPS
         );
         exit(1);
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1174,6 +1174,12 @@ pub fn main() {
                 .help("Use QUIC to send transactions."),
         )
         .arg(
+            Arg::with_name("tpu_do_batch")
+                .long("tpu-do-batch")
+                .takes_value(false)
+                .help("When this is set to true, the system will send transactions in batches."),
+        )
+        .arg(
             Arg::with_name("rocksdb_max_compaction_jitter")
                 .long("rocksdb-max-compaction-jitter-slots")
                 .value_name("ROCKSDB_MAX_COMPACTION_JITTER_SLOTS")
@@ -2144,6 +2150,7 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = matches.is_present("tpu_use_quic");
+    let tpu_do_batch = matches.is_present("tpu_do_batch");
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {
@@ -2425,6 +2432,7 @@ pub fn main() {
                 usize
             ),
             use_quic: tpu_use_quic,
+            do_batch: tpu_do_batch,
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2357,10 +2357,10 @@ pub fn main() {
     let batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
     let batch_send_rate_ms = value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64);
 
-    if batch_send_rate_ms < retry_rate_ms || batch_send_rate_ms < 1 {
+    if batch_send_rate_ms > retry_rate_ms || batch_send_rate_ms < 1 {
         eprintln!(
             "The specified rpc-send-batch-ms ({}) is invalid, it must be between 1 and the value of rpc-send-retry-ms ({})",
-            retry_rate_ms, batch_send_rate_ms
+            batch_send_rate_ms, retry_rate_ms, 
         );
         exit(1);
     }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -67,7 +67,9 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
-    solana_send_transaction_service::send_transaction_service,
+    solana_send_transaction_service::send_transaction_service::{
+        self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
+    },
     solana_streamer::socket::SocketAddrSpace,
     solana_validator::{
         admin_rpc_service, bootstrap, dashboard::Dashboard, ledger_lockfile, lock_ledger,
@@ -1358,7 +1360,7 @@ pub fn main() {
                 .hidden(true)
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
-                .validator(|s| is_within_range(s, 1, usize::MAX))
+                .validator(|s| is_within_range(s, 1, MAX_BATCH_SEND_RATE_MS))
                 .default_value(&default_rpc_send_transaction_batch_ms)
                 .help("The rate at which transactions sent via rpc service are sent in batch."),
         )
@@ -1395,7 +1397,7 @@ pub fn main() {
                 .hidden(true)
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
-                .validator(|s| is_within_range(s, 1, usize::MAX))
+                .validator(|s| is_within_range(s, 1, MAX_TRANSACTION_BATCH_SIZE))
                 .default_value(&default_rpc_send_transaction_batch_size)
                 .help("The size of transactions to be sent in batch."),
         )

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -434,6 +434,9 @@ pub fn main() {
     let default_rpc_send_transaction_retry_ms = default_send_transaction_service_config
         .retry_rate_ms
         .to_string();
+    let default_rpc_send_transaction_batch_ms = default_send_transaction_service_config
+        .batch_send_rate_ms
+        .to_string();
     let default_rpc_send_transaction_leader_forward_count = default_send_transaction_service_config
         .leader_forward_count
         .to_string();
@@ -1349,6 +1352,15 @@ pub fn main() {
                 .validator(is_parsable::<u64>)
                 .default_value(&default_rpc_send_transaction_retry_ms)
                 .help("The rate at which transactions sent via rpc service are retried."),
+        )
+        .arg(
+            Arg::with_name("rpc_send_transaction_batch_ms")
+                .long("rpc-send-batch-ms")
+                .value_name("MILLISECS")
+                .takes_value(true)
+                .validator(is_parsable::<u64>)
+                .default_value(&default_rpc_send_transaction_batch_ms)
+                .help("The rate at which transactions sent via rpc service are sent in batch."),
         )
         .arg(
             Arg::with_name("rpc_send_transaction_leader_forward_count")
@@ -2433,6 +2445,7 @@ pub fn main() {
             ),
             use_quic: tpu_use_quic,
             do_batch: tpu_do_batch,
+            batch_send_rate_ms: value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64),
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -443,6 +443,9 @@ pub fn main() {
     let default_rpc_send_transaction_service_max_retries = default_send_transaction_service_config
         .service_max_retries
         .to_string();
+    let default_rpc_send_transaction_batch_size = default_send_transaction_service_config
+        .batch_size
+        .to_string();
     let default_rpc_threads = num_cpus::get().to_string();
     let default_accountsdb_repl_threads = num_cpus::get().to_string();
     let default_maximum_full_snapshot_archives_to_retain =
@@ -1387,6 +1390,15 @@ pub fn main() {
                 .validator(is_parsable::<usize>)
                 .default_value(&default_rpc_send_transaction_service_max_retries)
                 .help("The maximum number of transaction broadcast retries, regardless of requested value."),
+        )
+        .arg(
+            Arg::with_name("rpc_send_transaction_batch_size")
+                .long("rpc-send-service-batch-size")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .validator(is_parsable::<usize>)
+                .default_value(&default_rpc_send_transaction_batch_size)
+                .help("The size of transactions to be sent in batch."),
         )
         .arg(
             Arg::with_name("rpc_scan_and_fix_roots")
@@ -2446,6 +2458,7 @@ pub fn main() {
             use_quic: tpu_use_quic,
             do_batch: tpu_do_batch,
             batch_send_rate_ms: value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64),
+            batch_size: value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize),
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2360,8 +2360,7 @@ pub fn main() {
     if batch_send_rate_ms > retry_rate_ms || batch_send_rate_ms < 1 {
         eprintln!(
             "The specified rpc-send-batch-ms ({}) is invalid, it must be between 1 and the value of rpc-send-retry-ms ({})",
-            batch_send_rate_ms, retry_rate_ms, 
-        );
+            batch_send_rate_ms, retry_rate_ms);
         exit(1);
     }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -104,6 +104,7 @@ const INCLUDE_KEY: &str = "account-index-include-key";
 const DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED: u64 = 10485760;
 // The maximum times of snapshot download abort and retry
 const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
+const MILLIS_PER_SECOND: u64 = 1000;
 
 fn monitor_validator(ledger_path: &Path) {
     let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
@@ -1359,7 +1360,6 @@ pub fn main() {
                 .value_name("MILLISECS")
                 .hidden(true)
                 .takes_value(true)
-                .validator(is_parsable::<u64>)
                 .validator(|s| is_within_range(s, 1, MAX_BATCH_SEND_RATE_MS))
                 .default_value(&default_rpc_send_transaction_batch_ms)
                 .help("The rate at which transactions sent via rpc service are sent in batch."),
@@ -1396,7 +1396,6 @@ pub fn main() {
                 .value_name("NUMBER")
                 .hidden(true)
                 .takes_value(true)
-                .validator(is_parsable::<usize>)
                 .validator(|s| is_within_range(s, 1, MAX_TRANSACTION_BATCH_SIZE))
                 .default_value(&default_rpc_send_transaction_batch_size)
                 .help("The size of transactions to be sent in batch."),
@@ -2370,7 +2369,7 @@ pub fn main() {
         exit(1);
     }
 
-    let tps = batch_size as u64 * 1000 / batch_send_rate_ms;
+    let tps = batch_size as u64 * MILLIS_PER_SECOND / batch_send_rate_ms;
     if tps > send_transaction_service::MAX_TPS {
         eprintln!(
             "Either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2370,13 +2370,13 @@ pub fn main() {
     }
 
     let tps = batch_size as u64 * MILLIS_PER_SECOND / batch_send_rate_ms;
-    if tps > send_transaction_service::MAX_TPS {
+    if tps > send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND {
         eprintln!(
             "Either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \
             'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
             batch_size,
             batch_send_rate_ms,
-            send_transaction_service::MAX_TPS
+            send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND
         );
         exit(1);
     }


### PR DESCRIPTION
#### Problem
Send transaction in batches to improve throughput

#### Summary of Changes
1. Introduced flag --tpu-do-batch2. 
2. Introduced flag to control the batch size-- by default 100 
3. The default batch timeout is 200ms -- configurable. If either it time out or the batch size is filled, a new batch is sent 
4. The batch honor the retry rate on the transaction already sent before.  
5. Introduced two threads in STS: one for receiving new transactions and doing batch send and one for retrying old transactions and doing batch.6.  
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
