### PR TITLE
Typo fix in javascript-api docs

### DIFF
--- a/docs/src/developing/clients/javascript-api.md
+++ b/docs/src/developing/clients/javascript-api.md
@@ -207,7 +207,7 @@ let allocateStruct = {
 };
 ```
 
-The above is created using using u32 and ns64 from `@solana/buffer-layout` to facilitate the payload creation. The `allocate` function takes in the parameter `space`. To interact with the function we must provide the data as a Buffer format. The `buffer-layout` library helps with allocating the buffer and encoding it correctly for Rust programs on Solana to interpret.
+The above is created using `u32` and `ns64` from `@solana/buffer-layout` to facilitate the payload creation. The `allocate` function takes in the parameter `space`. To interact with the function we must provide the data as a Buffer format. The `buffer-layout` library helps with allocating the buffer and encoding it correctly for Rust programs on Solana to interpret.
 
 Let's break down this struct.
 


### PR DESCRIPTION
#### Problem
There's a small typo in the javascript-api docs.

#### Summary of Changes
This PR fixes the typo by removing a duplicated word and adds code styling to specific text for better clarity.

