### PR TITLE
feat: add support for compute budget instructions

### DIFF
--- a/web3.js/src/compute-budget.ts
+++ b/web3.js/src/compute-budget.ts
@@ -1,0 +1,183 @@
+import * as BufferLayout from '@solana/buffer-layout';
+import {
+  encodeData,
+  decodeData,
+  InstructionType,
+  IInstructionInputData,
+} from './instruction';
+import {PublicKey} from './publickey';
+import {TransactionInstruction} from './transaction';
+
+/**
+ * Compute Budget Instruction class
+ */
+export class ComputeBudgetInstruction {
+  /**
+   * @internal
+   */
+  constructor() {}
+
+  /**
+   * Decode a compute budget instruction and retrieve the instruction type.
+   */
+  static decodeInstructionType(
+    instruction: TransactionInstruction,
+  ): ComputeBudgetInstructionType {
+    this.checkProgramId(instruction.programId);
+
+    const instructionTypeLayout = BufferLayout.u8('instruction');
+    const typeIndex = instructionTypeLayout.decode(instruction.data);
+
+    let type: ComputeBudgetInstructionType | undefined;
+    for (const [ixType, layout] of Object.entries(COMPUTE_BUDGET_INSTRUCTION_LAYOUTS)) {
+      if (layout.index == typeIndex) {
+        type = ixType as ComputeBudgetInstructionType;
+        break;
+      }
+    }
+
+    if (!type) {
+      throw new Error('Instruction type incorrect; not a ComputeBudgetInstruction');
+    }
+
+    return type;
+  }
+
+  /**
+   * Decode request units compute budget instruction and retrieve the instruction params.
+   */
+  static decodeRequestUnits(
+    instruction: TransactionInstruction,
+  ): RequestUnitsParams {
+    this.checkProgramId(instruction.programId);
+    const { units, additionalFee } = decodeData(
+      COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestUnits,
+      instruction.data,
+    ); 
+    return { units, additionalFee };
+  }
+
+  /**
+   * Decode request heap frame compute budget instruction and retrieve the instruction params.
+   */
+  static decodeRequestHeapFrame(
+    instruction: TransactionInstruction,
+  ): RequestHeapFrameParams {
+    this.checkProgramId(instruction.programId);
+    const { bytes } = decodeData(
+      COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestHeapFrame,
+      instruction.data,
+    );
+    return { bytes };
+  }
+
+  /**
+   * @internal
+   */
+  static checkProgramId(programId: PublicKey) {
+    if (!programId.equals(ComputeBudget.programId)) {
+      throw new Error('invalid instruction; programId is not ComputeBudgetProgram');
+    }
+  }
+}
+
+/**
+ * An enumeration of valid ComputeBudgetInstructionType's
+ */
+export type ComputeBudgetInstructionType =
+  // FIXME
+  // It would be preferable for this type to be `keyof ComputeBudgetInstructionInputData`
+  // but Typedoc does not transpile `keyof` expressions.
+  // See https://github.com/TypeStrong/typedoc/issues/1894
+  | 'RequestUnits'
+  | 'RequestHeapFrame';
+
+type ComputeBudgetInstructionInputData = {
+  RequestUnits: IInstructionInputData & 
+    Readonly<RequestUnitsParams>;
+  RequestHeapFrame: IInstructionInputData &
+    Readonly<RequestHeapFrameParams>;
+};
+
+/**
+ * Request units instruction params
+ */
+export interface RequestUnitsParams {
+  /** Units to request for transaction-wide compute */
+  units: number;
+
+  /** Additional fee to pay */
+  additionalFee: number; 
+}
+
+/**
+ * Request heap frame instruction params
+ */
+export type RequestHeapFrameParams = {
+  /** Requested transaction-wide program heap size in bytes. Must be multiple of 1024. Applies to each program, including CPIs. */
+  bytes: number;
+}
+
+/**
+ * An enumeration of valid ComputeBudget InstructionType's
+ * @internal
+ */
+export const COMPUTE_BUDGET_INSTRUCTION_LAYOUTS = Object.freeze<{
+  [Instruction in ComputeBudgetInstructionType]: InstructionType<
+    ComputeBudgetInstructionInputData[Instruction]
+  >;
+}>({
+  RequestUnits: {
+    index: 0,
+    layout: BufferLayout.struct<ComputeBudgetInstructionInputData['RequestUnits']>([
+      BufferLayout.u8('instruction'),
+      BufferLayout.u32('units'),
+      BufferLayout.u32('additionalFee'),
+    ]),
+  },
+  RequestHeapFrame: {
+    index: 1,
+    layout: BufferLayout.struct<ComputeBudgetInstructionInputData['RequestHeapFrame']>([
+      BufferLayout.u8('instruction'),
+      BufferLayout.u32('bytes'),
+    ]),
+  },
+});
+
+
+/**
+ * Factory class for transaction instructions to interact with the Compute Budget program
+ */
+export class ComputeBudget {
+  /**
+   * @internal
+   */
+  constructor() {}
+
+  /**
+   * Public key that identifies the Compute Budget program
+   */
+  static programId: PublicKey = new PublicKey(
+    'ComputeBudget111111111111111111111111111111',
+  );
+
+  static requestUnits(params: RequestUnitsParams): TransactionInstruction {
+    const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestUnits;
+    const data = encodeData(type, params);
+    return new TransactionInstruction({
+      keys: [],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  static requestHeapFrame(params: RequestHeapFrameParams): TransactionInstruction {
+    const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestHeapFrame;
+    const data = encodeData(type, params);
+    return new TransactionInstruction({
+      keys: [],
+      programId: this.programId,
+      data,
+    });
+  }
+}

--- a/web3.js/src/compute-budget.ts
+++ b/web3.js/src/compute-budget.ts
@@ -29,7 +29,9 @@ export class ComputeBudgetInstruction {
     const typeIndex = instructionTypeLayout.decode(instruction.data);
 
     let type: ComputeBudgetInstructionType | undefined;
-    for (const [ixType, layout] of Object.entries(COMPUTE_BUDGET_INSTRUCTION_LAYOUTS)) {
+    for (const [ixType, layout] of Object.entries(
+      COMPUTE_BUDGET_INSTRUCTION_LAYOUTS,
+    )) {
       if (layout.index == typeIndex) {
         type = ixType as ComputeBudgetInstructionType;
         break;
@@ -37,7 +39,9 @@ export class ComputeBudgetInstruction {
     }
 
     if (!type) {
-      throw new Error('Instruction type incorrect; not a ComputeBudgetInstruction');
+      throw new Error(
+        'Instruction type incorrect; not a ComputeBudgetInstruction',
+      );
     }
 
     return type;
@@ -50,11 +54,11 @@ export class ComputeBudgetInstruction {
     instruction: TransactionInstruction,
   ): RequestUnitsParams {
     this.checkProgramId(instruction.programId);
-    const { units, additionalFee } = decodeData(
+    const {units, additionalFee} = decodeData(
       COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestUnits,
       instruction.data,
-    ); 
-    return { units, additionalFee };
+    );
+    return {units, additionalFee};
   }
 
   /**
@@ -64,11 +68,11 @@ export class ComputeBudgetInstruction {
     instruction: TransactionInstruction,
   ): RequestHeapFrameParams {
     this.checkProgramId(instruction.programId);
-    const { bytes } = decodeData(
+    const {bytes} = decodeData(
       COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestHeapFrame,
       instruction.data,
     );
-    return { bytes };
+    return {bytes};
   }
 
   /**
@@ -76,7 +80,9 @@ export class ComputeBudgetInstruction {
    */
   static checkProgramId(programId: PublicKey) {
     if (!programId.equals(ComputeBudget.programId)) {
-      throw new Error('invalid instruction; programId is not ComputeBudgetProgram');
+      throw new Error(
+        'invalid instruction; programId is not ComputeBudgetProgram',
+      );
     }
   }
 }
@@ -89,14 +95,11 @@ export type ComputeBudgetInstructionType =
   // It would be preferable for this type to be `keyof ComputeBudgetInstructionInputData`
   // but Typedoc does not transpile `keyof` expressions.
   // See https://github.com/TypeStrong/typedoc/issues/1894
-  | 'RequestUnits'
-  | 'RequestHeapFrame';
+  'RequestUnits' | 'RequestHeapFrame';
 
 type ComputeBudgetInstructionInputData = {
-  RequestUnits: IInstructionInputData & 
-    Readonly<RequestUnitsParams>;
-  RequestHeapFrame: IInstructionInputData &
-    Readonly<RequestHeapFrameParams>;
+  RequestUnits: IInstructionInputData & Readonly<RequestUnitsParams>;
+  RequestHeapFrame: IInstructionInputData & Readonly<RequestHeapFrameParams>;
 };
 
 /**
@@ -107,7 +110,7 @@ export interface RequestUnitsParams {
   units: number;
 
   /** Additional fee to pay */
-  additionalFee: number; 
+  additionalFee: number;
 }
 
 /**
@@ -116,7 +119,7 @@ export interface RequestUnitsParams {
 export type RequestHeapFrameParams = {
   /** Requested transaction-wide program heap size in bytes. Must be multiple of 1024. Applies to each program, including CPIs. */
   bytes: number;
-}
+};
 
 /**
  * An enumeration of valid ComputeBudget InstructionType's
@@ -129,7 +132,9 @@ export const COMPUTE_BUDGET_INSTRUCTION_LAYOUTS = Object.freeze<{
 }>({
   RequestUnits: {
     index: 0,
-    layout: BufferLayout.struct<ComputeBudgetInstructionInputData['RequestUnits']>([
+    layout: BufferLayout.struct<
+      ComputeBudgetInstructionInputData['RequestUnits']
+    >([
       BufferLayout.u8('instruction'),
       BufferLayout.u32('units'),
       BufferLayout.u32('additionalFee'),
@@ -137,13 +142,11 @@ export const COMPUTE_BUDGET_INSTRUCTION_LAYOUTS = Object.freeze<{
   },
   RequestHeapFrame: {
     index: 1,
-    layout: BufferLayout.struct<ComputeBudgetInstructionInputData['RequestHeapFrame']>([
-      BufferLayout.u8('instruction'),
-      BufferLayout.u32('bytes'),
-    ]),
+    layout: BufferLayout.struct<
+      ComputeBudgetInstructionInputData['RequestHeapFrame']
+    >([BufferLayout.u8('instruction'), BufferLayout.u32('bytes')]),
   },
 });
-
 
 /**
  * Factory class for transaction instructions to interact with the Compute Budget program
@@ -171,7 +174,9 @@ export class ComputeBudget {
     });
   }
 
-  static requestHeapFrame(params: RequestHeapFrameParams): TransactionInstruction {
+  static requestHeapFrame(
+    params: RequestHeapFrameParams,
+  ): TransactionInstruction {
     const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestHeapFrame;
     const data = encodeData(type, params);
     return new TransactionInstruction({

--- a/web3.js/src/compute-budget.ts
+++ b/web3.js/src/compute-budget.ts
@@ -1,4 +1,5 @@
 import * as BufferLayout from '@solana/buffer-layout';
+
 import {
   encodeData,
   decodeData,
@@ -79,7 +80,7 @@ export class ComputeBudgetInstruction {
    * @internal
    */
   static checkProgramId(programId: PublicKey) {
-    if (!programId.equals(ComputeBudget.programId)) {
+    if (!programId.equals(ComputeBudgetProgram.programId)) {
       throw new Error(
         'invalid instruction; programId is not ComputeBudgetProgram',
       );
@@ -151,7 +152,7 @@ export const COMPUTE_BUDGET_INSTRUCTION_LAYOUTS = Object.freeze<{
 /**
  * Factory class for transaction instructions to interact with the Compute Budget program
  */
-export class ComputeBudget {
+export class ComputeBudgetProgram {
   /**
    * @internal
    */

--- a/web3.js/src/index.ts
+++ b/web3.js/src/index.ts
@@ -2,6 +2,7 @@ export * from './account';
 export * from './blockhash';
 export * from './bpf-loader-deprecated';
 export * from './bpf-loader';
+export * from './compute-budget';
 export * from './connection';
 export * from './epoch-schedule';
 export * from './ed25519-program';

--- a/web3.js/test/compute-budget.test.ts
+++ b/web3.js/test/compute-budget.test.ts
@@ -48,17 +48,26 @@ describe.skip('ComputeBudget', () => {
   });
 
   it('ComputeBudgetInstruction', async () => {
-    const requestUnits = ComputeBudget.requestUnits({ units: 150000, additionalFee: 0 });
-    const requestHeapFrame = ComputeBudget.requestHeapFrame({ bytes: 33 * 1024 });
+    const requestUnits = ComputeBudget.requestUnits({
+      units: 150000,
+      additionalFee: 0,
+    });
+    const requestHeapFrame = ComputeBudget.requestHeapFrame({bytes: 33 * 1024});
 
     const requestUnitsTransaction = new Transaction().add(requestUnits);
     expect(requestUnitsTransaction.instructions).to.have.length(1);
-    const requestUnitsTransactionType = ComputeBudgetInstruction.decodeInstructionType(requestUnitsTransaction.instructions[0]);
+    const requestUnitsTransactionType =
+      ComputeBudgetInstruction.decodeInstructionType(
+        requestUnitsTransaction.instructions[0],
+      );
     expect(requestUnitsTransactionType).to.eq('RequestUnits');
 
     const requestHeapFrameTransaction = new Transaction().add(requestHeapFrame);
     expect(requestHeapFrameTransaction.instructions).to.have.length(1);
-    const requestHeapFrameTransactionType = ComputeBudgetInstruction.decodeInstructionType(requestHeapFrameTransaction.instructions[0]);
+    const requestHeapFrameTransactionType =
+      ComputeBudgetInstruction.decodeInstructionType(
+        requestHeapFrameTransaction.instructions[0],
+      );
     expect(requestHeapFrameTransactionType).to.eq('RequestHeapFrame');
   });
 
@@ -76,7 +85,9 @@ describe.skip('ComputeBudget', () => {
         amount: STARTING_AMOUNT,
       });
 
-      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(STARTING_AMOUNT);
+      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(
+        STARTING_AMOUNT,
+      );
 
       const seed = 'hi there';
       const programId = Keypair.generate().publicKey;
@@ -100,22 +111,26 @@ describe.skip('ComputeBudget', () => {
         space,
         programId,
       };
-      
+
       const createAccountFeeTooHighTransaction = new Transaction().add(
-        ComputeBudget.requestUnits({ units: 2, additionalFee: 2 * FEE_AMOUNT }),
+        ComputeBudget.requestUnits({units: 2, additionalFee: 2 * FEE_AMOUNT}),
         SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
       );
-      await expect(sendAndConfirmTransaction(
-        connection,
-        createAccountFeeTooHighTransaction,
-        [baseAccount],
-        {preflightCommitment: 'confirmed'},
-      )).to.be.rejected;
+      await expect(
+        sendAndConfirmTransaction(
+          connection,
+          createAccountFeeTooHighTransaction,
+          [baseAccount],
+          {preflightCommitment: 'confirmed'},
+        ),
+      ).to.be.rejected;
 
-      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(STARTING_AMOUNT);
+      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(
+        STARTING_AMOUNT,
+      );
 
       const createAccountFeeTransaction = new Transaction().add(
-        ComputeBudget.requestUnits({ units: 2, additionalFee: FEE_AMOUNT }),
+        ComputeBudget.requestUnits({units: 2, additionalFee: FEE_AMOUNT}),
         SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
       );
       await sendAndConfirmTransaction(
@@ -124,18 +139,22 @@ describe.skip('ComputeBudget', () => {
         [baseAccount],
         {preflightCommitment: 'confirmed'},
       );
-      expect(await connection.getBalance(baseAccount.publicKey)).to.be.at.most(STARTING_AMOUNT - FEE_AMOUNT - minimumAmount);
+      expect(await connection.getBalance(baseAccount.publicKey)).to.be.at.most(
+        STARTING_AMOUNT - FEE_AMOUNT - minimumAmount,
+      );
 
       async function expectRequestHeapFailure(bytes: number) {
         const requestHeapFrameTransaction = new Transaction().add(
-          ComputeBudget.requestHeapFrame({ bytes }),
+          ComputeBudget.requestHeapFrame({bytes}),
         );
-        await expect(sendAndConfirmTransaction(
-          connection,
-          requestHeapFrameTransaction,
-          [baseAccount],
-          {preflightCommitment: 'confirmed'},
-        )).to.be.rejected;  
+        await expect(
+          sendAndConfirmTransaction(
+            connection,
+            requestHeapFrameTransaction,
+            [baseAccount],
+            {preflightCommitment: 'confirmed'},
+          ),
+        ).to.be.rejected;
       }
       const NOT_MULTIPLE_OF_1024 = 33 * 1024 + 1;
       const BELOW_MIN = 1024;
@@ -146,7 +165,7 @@ describe.skip('ComputeBudget', () => {
 
       const VALID_BYTES = 33 * 1024;
       const requestHeapFrameTransaction = new Transaction().add(
-        ComputeBudget.requestHeapFrame({ bytes: VALID_BYTES}),
+        ComputeBudget.requestHeapFrame({bytes: VALID_BYTES}),
       );
       await sendAndConfirmTransaction(
         connection,
@@ -155,6 +174,5 @@ describe.skip('ComputeBudget', () => {
         {preflightCommitment: 'confirmed'},
       );
     }).timeout(10 * 1000);
-
   }
 });

--- a/web3.js/test/compute-budget.test.ts
+++ b/web3.js/test/compute-budget.test.ts
@@ -6,7 +6,7 @@ import {
   Connection,
   LAMPORTS_PER_SOL,
   Transaction,
-  ComputeBudget,
+  ComputeBudgetProgram,
   ComputeBudgetInstruction,
   PublicKey,
   SystemProgram,
@@ -17,14 +17,14 @@ import {url} from './url';
 
 use(chaiAsPromised);
 
-describe.skip('ComputeBudget', () => {
+describe('ComputeBudgetProgram', () => {
   it('requestUnits', () => {
     const params = {
       units: 150000,
       additionalFee: 0,
     };
     const transaction = new Transaction().add(
-      ComputeBudget.requestUnits(params),
+      ComputeBudgetProgram.requestUnits(params),
     );
     expect(transaction.instructions).to.have.length(1);
     const [computeBudgetInstruction] = transaction.instructions;
@@ -38,7 +38,7 @@ describe.skip('ComputeBudget', () => {
       bytes: 33 * 1024,
     };
     const transaction = new Transaction().add(
-      ComputeBudget.requestHeapFrame(params),
+      ComputeBudgetProgram.requestHeapFrame(params),
     );
     expect(transaction.instructions).to.have.length(1);
     const [computeBudgetInstruction] = transaction.instructions;
@@ -47,12 +47,14 @@ describe.skip('ComputeBudget', () => {
     );
   });
 
-  it('ComputeBudgetInstruction', async () => {
-    const requestUnits = ComputeBudget.requestUnits({
+  it('ComputeBudgetInstruction', () => {
+    const requestUnits = ComputeBudgetProgram.requestUnits({
       units: 150000,
       additionalFee: 0,
     });
-    const requestHeapFrame = ComputeBudget.requestHeapFrame({bytes: 33 * 1024});
+    const requestHeapFrame = ComputeBudgetProgram.requestHeapFrame({
+      bytes: 33 * 1024,
+    });
 
     const requestUnitsTransaction = new Transaction().add(requestUnits);
     expect(requestUnitsTransaction.instructions).to.have.length(1);
@@ -113,7 +115,10 @@ describe.skip('ComputeBudget', () => {
       };
 
       const createAccountFeeTooHighTransaction = new Transaction().add(
-        ComputeBudget.requestUnits({units: 2, additionalFee: 2 * FEE_AMOUNT}),
+        ComputeBudgetProgram.requestUnits({
+          units: 2,
+          additionalFee: 2 * FEE_AMOUNT,
+        }),
         SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
       );
       await expect(
@@ -130,7 +135,10 @@ describe.skip('ComputeBudget', () => {
       );
 
       const createAccountFeeTransaction = new Transaction().add(
-        ComputeBudget.requestUnits({units: 2, additionalFee: FEE_AMOUNT}),
+        ComputeBudgetProgram.requestUnits({
+          units: 2,
+          additionalFee: FEE_AMOUNT,
+        }),
         SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
       );
       await sendAndConfirmTransaction(
@@ -145,7 +153,7 @@ describe.skip('ComputeBudget', () => {
 
       async function expectRequestHeapFailure(bytes: number) {
         const requestHeapFrameTransaction = new Transaction().add(
-          ComputeBudget.requestHeapFrame({bytes}),
+          ComputeBudgetProgram.requestHeapFrame({bytes}),
         );
         await expect(
           sendAndConfirmTransaction(
@@ -165,7 +173,7 @@ describe.skip('ComputeBudget', () => {
 
       const VALID_BYTES = 33 * 1024;
       const requestHeapFrameTransaction = new Transaction().add(
-        ComputeBudget.requestHeapFrame({bytes: VALID_BYTES}),
+        ComputeBudgetProgram.requestHeapFrame({bytes: VALID_BYTES}),
       );
       await sendAndConfirmTransaction(
         connection,

--- a/web3.js/test/compute-budget.test.ts
+++ b/web3.js/test/compute-budget.test.ts
@@ -1,0 +1,160 @@
+import {expect, use} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import {
+  Keypair,
+  Connection,
+  LAMPORTS_PER_SOL,
+  Transaction,
+  ComputeBudget,
+  ComputeBudgetInstruction,
+  PublicKey,
+  SystemProgram,
+  sendAndConfirmTransaction,
+} from '../src';
+import {helpers} from './mocks/rpc-http';
+import {url} from './url';
+
+use(chaiAsPromised);
+
+describe.skip('ComputeBudget', () => {
+  it('requestUnits', () => {
+    const params = {
+      units: 150000,
+      additionalFee: 0,
+    };
+    const transaction = new Transaction().add(
+      ComputeBudget.requestUnits(params),
+    );
+    expect(transaction.instructions).to.have.length(1);
+    const [computeBudgetInstruction] = transaction.instructions;
+    expect(params).to.eql(
+      ComputeBudgetInstruction.decodeRequestUnits(computeBudgetInstruction),
+    );
+  });
+
+  it('requestHeapFrame', () => {
+    const params = {
+      bytes: 33 * 1024,
+    };
+    const transaction = new Transaction().add(
+      ComputeBudget.requestHeapFrame(params),
+    );
+    expect(transaction.instructions).to.have.length(1);
+    const [computeBudgetInstruction] = transaction.instructions;
+    expect(params).to.eql(
+      ComputeBudgetInstruction.decodeRequestHeapFrame(computeBudgetInstruction),
+    );
+  });
+
+  it('ComputeBudgetInstruction', async () => {
+    const requestUnits = ComputeBudget.requestUnits({ units: 150000, additionalFee: 0 });
+    const requestHeapFrame = ComputeBudget.requestHeapFrame({ bytes: 33 * 1024 });
+
+    const requestUnitsTransaction = new Transaction().add(requestUnits);
+    expect(requestUnitsTransaction.instructions).to.have.length(1);
+    const requestUnitsTransactionType = ComputeBudgetInstruction.decodeInstructionType(requestUnitsTransaction.instructions[0]);
+    expect(requestUnitsTransactionType).to.eq('RequestUnits');
+
+    const requestHeapFrameTransaction = new Transaction().add(requestHeapFrame);
+    expect(requestHeapFrameTransaction.instructions).to.have.length(1);
+    const requestHeapFrameTransactionType = ComputeBudgetInstruction.decodeInstructionType(requestHeapFrameTransaction.instructions[0]);
+    expect(requestHeapFrameTransactionType).to.eq('RequestHeapFrame');
+  });
+
+  if (process.env.TEST_LIVE) {
+    const STARTING_AMOUNT = 2 * LAMPORTS_PER_SOL;
+    const FEE_AMOUNT = LAMPORTS_PER_SOL;
+    it('live compute budget actions', async () => {
+      const connection = new Connection(url, 'confirmed');
+
+      const baseAccount = Keypair.generate();
+      const basePubkey = baseAccount.publicKey;
+      await helpers.airdrop({
+        connection,
+        address: basePubkey,
+        amount: STARTING_AMOUNT,
+      });
+
+      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(STARTING_AMOUNT);
+
+      const seed = 'hi there';
+      const programId = Keypair.generate().publicKey;
+      const createAccountWithSeedAddress = await PublicKey.createWithSeed(
+        basePubkey,
+        seed,
+        programId,
+      );
+      const space = 0;
+
+      let minimumAmount = await connection.getMinimumBalanceForRentExemption(
+        space,
+      );
+
+      const createAccountWithSeedParams = {
+        fromPubkey: basePubkey,
+        newAccountPubkey: createAccountWithSeedAddress,
+        basePubkey,
+        seed,
+        lamports: minimumAmount,
+        space,
+        programId,
+      };
+      
+      const createAccountFeeTooHighTransaction = new Transaction().add(
+        ComputeBudget.requestUnits({ units: 2, additionalFee: 2 * FEE_AMOUNT }),
+        SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
+      );
+      await expect(sendAndConfirmTransaction(
+        connection,
+        createAccountFeeTooHighTransaction,
+        [baseAccount],
+        {preflightCommitment: 'confirmed'},
+      )).to.be.rejected;
+
+      expect(await connection.getBalance(baseAccount.publicKey)).to.eq(STARTING_AMOUNT);
+
+      const createAccountFeeTransaction = new Transaction().add(
+        ComputeBudget.requestUnits({ units: 2, additionalFee: FEE_AMOUNT }),
+        SystemProgram.createAccountWithSeed(createAccountWithSeedParams),
+      );
+      await sendAndConfirmTransaction(
+        connection,
+        createAccountFeeTransaction,
+        [baseAccount],
+        {preflightCommitment: 'confirmed'},
+      );
+      expect(await connection.getBalance(baseAccount.publicKey)).to.be.at.most(STARTING_AMOUNT - FEE_AMOUNT - minimumAmount);
+
+      async function expectRequestHeapFailure(bytes: number) {
+        const requestHeapFrameTransaction = new Transaction().add(
+          ComputeBudget.requestHeapFrame({ bytes }),
+        );
+        await expect(sendAndConfirmTransaction(
+          connection,
+          requestHeapFrameTransaction,
+          [baseAccount],
+          {preflightCommitment: 'confirmed'},
+        )).to.be.rejected;  
+      }
+      const NOT_MULTIPLE_OF_1024 = 33 * 1024 + 1;
+      const BELOW_MIN = 1024;
+      const ABOVE_MAX = 257 * 1024;
+      await expectRequestHeapFailure(NOT_MULTIPLE_OF_1024);
+      await expectRequestHeapFailure(BELOW_MIN);
+      await expectRequestHeapFailure(ABOVE_MAX);
+
+      const VALID_BYTES = 33 * 1024;
+      const requestHeapFrameTransaction = new Transaction().add(
+        ComputeBudget.requestHeapFrame({ bytes: VALID_BYTES}),
+      );
+      await sendAndConfirmTransaction(
+        connection,
+        requestHeapFrameTransaction,
+        [baseAccount],
+        {preflightCommitment: 'confirmed'},
+      );
+    }).timeout(10 * 1000);
+
+  }
+});


### PR DESCRIPTION
#### Problem
Missing ComputeBudgetInstruction in web3 sdk

#### Summary of Changes
Adds ComputeBudgetInstruction to web3 sdk

