### PR TITLE
Un-deprecate `MINIMUM_STAKE_DELEGATION`

### DIFF
--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -23,6 +23,5 @@ pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
     // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
     // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
     // removed, use it here as to not duplicate magic constants.
-    #[allow(deprecated)]
     solana_sdk::stake::MINIMUM_STAKE_DELEGATION
 }

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -6,8 +6,6 @@ pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
-#[deprecated(
-    since = "1.10.6",
-    note = "This constant may be outdated, please use `solana_stake_program::get_minimum_delegation` instead"
-)]
+// NOTE: This constant will be deprecated soon; if possible, use
+// `solana_stake_program::get_minimum_delegation()` instead.
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;


### PR DESCRIPTION
#### Problem

`MINIMUM_STAKE_DELEGATION` should not have been marked as `deprecated` in PR #24020.

See https://github.com/solana-labs/solana/pull/24020#discussion_r841000035 for context.

#### Summary of Changes

Un-deprecate `MINIMUM_STAKE_DELEGATION`.
