### PR TITLE
Use atomics instead of mutable statics in slot_hashes

### DIFF
--- a/sdk/program/src/slot_hashes.rs
+++ b/sdk/program/src/slot_hashes.rs
@@ -5,23 +5,25 @@
 pub use crate::clock::Slot;
 use {
     crate::hash::Hash,
-    std::{iter::FromIterator, ops::Deref},
+    std::{
+        iter::FromIterator,
+        ops::Deref,
+        sync::atomic::{AtomicUsize, Ordering},
+    },
 };
 
 pub const MAX_ENTRIES: usize = 512; // about 2.5 minutes to get your vote in
 
 // This is to allow tests with custom slot hash expiry to avoid having to generate
 // 512 blocks for such tests.
-static mut NUM_ENTRIES: usize = MAX_ENTRIES;
+static NUM_ENTRIES: AtomicUsize = AtomicUsize::new(MAX_ENTRIES);
 
 pub fn get_entries() -> usize {
-    unsafe { NUM_ENTRIES }
+    NUM_ENTRIES.load(Ordering::Relaxed)
 }
 
-pub fn set_entries_for_tests_only(_entries: usize) {
-    unsafe {
-        NUM_ENTRIES = _entries;
-    }
+pub fn set_entries_for_tests_only(entries: usize) {
+    NUM_ENTRIES.store(entries, Ordering::Relaxed);
 }
 
 pub type SlotHash = (Slot, Hash);


### PR DESCRIPTION
#### Problem

This module is accessing a mutable usize with a pattern that is prone to data races. Using an atomic makes it foolproof.

I don't think this will have any affect on BPF targets as this module is not useful to BPF programs, and BPF programs can't write to this value anyway.

#### Summary of Changes

Use an AtomicUsize instead.
