### PR TITLE
Explorer: Added a big red warning on devnet and testnet

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -60,7 +60,6 @@ export function TransactionDetailsPage({ signature: raw }: SignatureProps) {
       signature = raw;
     }
   } catch (err) {}
-
   const status = useTransactionStatus(signature);
   const [zeroConfirmationRetries, setZeroConfirmationRetries] =
     React.useState(0);
@@ -119,7 +118,11 @@ function StatusCard({
   const fetchStatus = useFetchTransactionStatus();
   const status = useTransactionStatus(signature);
   const details = useTransactionDetails(signature);
-  const { clusterInfo, status: clusterStatus } = useCluster();
+  const {
+    clusterInfo,
+    status: clusterStatus,
+    name: clusterName,
+  } = useCluster();
 
   // Fetch transaction on load
   React.useEffect(() => {
@@ -226,6 +229,15 @@ function StatusCard({
       </div>
 
       <TableCardBody>
+        {clusterName != "Mainnet Beta" && (
+          <tr>
+            <td>WARNING:</td>
+            <td className="text-lg-end alert-danger alert-scam">
+              You are on the {clusterName} cluster. Transactions and SOL
+              transfered here are NOT REAL.
+            </td>
+          </tr>
+        )}
         <tr>
           <td>Signature</td>
           <td className="text-lg-end">

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -229,7 +229,7 @@ function StatusCard({
       </div>
 
       <TableCardBody>
-        {clusterName != "Mainnet Beta" && (
+        {clusterName !== "Mainnet Beta" && (
           <tr>
             <td>WARNING:</td>
             <td className="text-lg-end alert-danger alert-scam">

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -11,7 +11,8 @@ pre {
   color: $black;
 }
 
-.badge.bg-primary, .btn-primary {
+.badge.bg-primary,
+.btn-primary {
   color: $gray-900;
 }
 
@@ -218,7 +219,9 @@ h4.slot-pill {
   width: 24px;
   height: 24px;
 }
-
+.alert-text {
+  color: RED;
+}
 .forced-truncate {
   .address-truncate {
     max-width: 180px;
@@ -448,28 +451,29 @@ p.updated-time {
 
 // security-txt css hacks
 .security-txt ul {
-    list-style: none;
-    text-align: right;
-    margin: 0;
-    padding-inline-start: 0;
+  list-style: none;
+  text-align: right;
+  margin: 0;
+  padding-inline-start: 0;
 }
 
-.security-txt p, pre {
-    text-align: left !important;
-    margin: 0;
+.security-txt p,
+pre {
+  text-align: left !important;
+  margin: 0;
 }
 
 .security-txt a {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 .security-txt td {
-    white-space: unset;
+  white-space: unset;
 }
 
 .security-txt code {
-    white-space: pre-wrap;
-    display: block;
+  white-space: pre-wrap;
+  display: block;
 }
 
 .security-txt-link-color-hack-reee {


### PR DESCRIPTION
#### Problem

Ive seen an uptick in scams where perpetrators are using Solana explorers connected to devnet/testnet clusters to scam unknowing people. For a new Solana user the cluster that the explorer is connected to does not pop out, and they usually also do not know what it means if they do see it and the link is way too long to notice before clicking. 

I know we can probably do better on how it looks, but its supposed to be an annoying eye sore to catch peoples attention. I'll probably bring this up with SolScan also, as a lot of these types of scams are on that explorer as well. 

#### Summary of Changes

Ive added a big noticeable warning that the SOL transferred on devnet and testnet is not real. Hopefully this will save some people from being scammed. 

![Screen Shot 2022-04-04 at 3 53 50 AM](https://user-images.githubusercontent.com/31865497/161529500-a7569730-e38f-44b8-aa64-fb07aa2d1278.png)

also fixed some prettier problems with an old commit. 