### PR TITLE
Zk instructions check length

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -56,7 +56,7 @@ pub fn process_instruction(
             verify::<WithdrawData>(invoke_context)
         }
         ProofInstruction::VerifyWithdrawWithheldTokens => {
-            ic_msg!(invoke_context, "VerifyWithdraw");
+            ic_msg!(invoke_context, "VerifyWithdrawWithheldTokens");
             verify::<WithdrawData>(invoke_context)
         }
         ProofInstruction::VerifyTransfer => {

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -73,11 +73,7 @@ impl ProofInstruction {
     }
 
     pub fn decode_type(input: &[u8]) -> Option<Self> {
-        if input.is_empty() {
-            None
-        } else {
-            FromPrimitive::from_u8(input[0])
-        }
+        input.get(0).map(FromPrimitive::from_u8)
     }
 
     pub fn decode_data<T: Pod>(input: &[u8]) -> Option<&T> {

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -73,7 +73,11 @@ impl ProofInstruction {
     }
 
     pub fn decode_type(input: &[u8]) -> Option<Self> {
-        FromPrimitive::from_u8(input[0])
+        if input.is_empty() {
+            None
+        } else {
+            FromPrimitive::from_u8(input[0])
+        }
     }
 
     pub fn decode_data<T: Pod>(input: &[u8]) -> Option<&T> {

--- a/zk-token-sdk/src/zk_token_proof_instruction.rs
+++ b/zk-token-sdk/src/zk_token_proof_instruction.rs
@@ -73,7 +73,7 @@ impl ProofInstruction {
     }
 
     pub fn decode_type(input: &[u8]) -> Option<Self> {
-        input.get(0).map(FromPrimitive::from_u8)
+        input.get(0).and_then(|x| FromPrimitive::from_u8(*x))
     }
 
     pub fn decode_data<T: Pod>(input: &[u8]) -> Option<&T> {


### PR DESCRIPTION
#### Problem
The current zk proof program immediately accesses the instruction bytes without checking the length. This can cause the decoding process to panic on malformed instructions.

#### Summary of Changes
The program now checks if the byte array is empty prior to accessing the first byte. Also fixed a minor spelling.