### PR TITLE
tvu and tpu timeout on joining its microservices

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -38,6 +38,9 @@ use {
 
 pub const DEFAULT_TPU_COALESCE_MS: u64 = 5;
 
+/// Timeout interval when joining threads during TPU close
+pub const TPU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
+
 // allow multiple connections for NAT and any open/close overlap
 pub const MAX_QUIC_CONNECTIONS_PER_IP: usize = 8;
 
@@ -217,7 +220,7 @@ impl Tpu {
         });
 
         // timeout of 10s for closing tpu
-        let timeout = Duration::from_secs(10);
+        let timeout = Duration::from_secs(TPU_THREADS_JOIN_TIMEOUT_SECONDS);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             error!("timeout for closing tvu");
         }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -219,7 +219,7 @@ impl Tpu {
             sender.send(()).unwrap();
         });
 
-        // timeout of 10s for closing tpu
+        // exit can deadlock. put an upper-bound on how long we wait for it
         let timeout = Duration::from_secs(TPU_THREADS_JOIN_TIMEOUT_SECONDS);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             error!("timeout for closing tvu");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -39,7 +39,7 @@ use {
 pub const DEFAULT_TPU_COALESCE_MS: u64 = 5;
 
 /// Timeout interval when joining threads during TPU close
-pub const TPU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
+const TPU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
 
 // allow multiple connections for NAT and any open/close overlap
 pub const MAX_QUIC_CONNECTIONS_PER_IP: usize = 8;

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -67,7 +67,7 @@ use {
 };
 
 /// Timeout interval when joining threads during TVU close
-pub const TVU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
+const TVU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
 
 pub struct Tvu {
     fetch_stage: ShredFetchStage,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -373,7 +373,7 @@ impl Tvu {
         });
 
         // timeout of 10s for closing tvu
-        let timeout = Duration::from_secs(TPU_THREADS_JOIN_TIMEOUT_SECONDS);
+        let timeout = Duration::from_secs(TVU_THREADS_JOIN_TIMEOUT_SECONDS);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             error!("timeout for closing tvu");
         }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -66,6 +66,9 @@ use {
     },
 };
 
+/// Timeout interval when joining threads during TVU close
+pub const TVU_THREADS_JOIN_TIMEOUT_SECONDS: u64 = 10;
+
 pub struct Tvu {
     fetch_stage: ShredFetchStage,
     sigverify_stage: SigVerifyStage,
@@ -370,7 +373,7 @@ impl Tvu {
         });
 
         // timeout of 10s for closing tvu
-        let timeout = Duration::from_secs(10);
+        let timeout = Duration::from_secs(TPU_THREADS_JOIN_TIMEOUT_SECONDS);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             error!("timeout for closing tvu");
         }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -365,7 +365,7 @@ impl Tvu {
         // spawn a new thread to wait for tvu close
         let (sender, receiver) = bounded(0);
         let _ = thread::spawn(move || {
-            self.do_join();
+            let _ = self.do_join();
             sender.send(()).unwrap();
         });
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -372,7 +372,7 @@ impl Tvu {
             sender.send(()).unwrap();
         });
 
-        // timeout of 10s for closing tvu
+        // exit can deadlock. put an upper-bound on how long we wait for it
         let timeout = Duration::from_secs(TVU_THREADS_JOIN_TIMEOUT_SECONDS);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             error!("timeout for closing tvu");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1047,21 +1047,26 @@ impl Validator {
         drop(self.bank_forks);
         drop(self.cluster_info);
 
+        error!("join poh_service");
         self.poh_service.join().expect("poh_service");
         drop(self.poh_recorder);
 
+        error!("join json_rpc_service");
         if let Some(json_rpc_service) = self.json_rpc_service {
             json_rpc_service.join().expect("rpc_service");
         }
 
+        error!("join pubsub_service");
         if let Some(pubsub_service) = self.pubsub_service {
             pubsub_service.join().expect("pubsub_service");
         }
 
+        error!("join rpc_completed_slot_service");
         self.rpc_completed_slots_service
             .join()
             .expect("rpc_completed_slots_service");
 
+        error!("join optimistically_confirmed_bank_tracker");
         if let Some(optimistically_confirmed_bank_tracker) =
             self.optimistically_confirmed_bank_tracker
         {
@@ -1070,66 +1075,88 @@ impl Validator {
                 .expect("optimistically_confirmed_bank_tracker");
         }
 
+        error!("join transaction_status_service");
         if let Some(transaction_status_service) = self.transaction_status_service {
             transaction_status_service
                 .join()
                 .expect("transaction_status_service");
         }
 
+        error!("join rewards_recorder_service");
         if let Some(rewards_recorder_service) = self.rewards_recorder_service {
             rewards_recorder_service
                 .join()
                 .expect("rewards_recorder_service");
         }
 
+        error!("join cache_block_meta_service");
         if let Some(cache_block_meta_service) = self.cache_block_meta_service {
             cache_block_meta_service
                 .join()
                 .expect("cache_block_meta_service");
         }
 
+        error!("join system_monitor_service");
         if let Some(system_monitor_service) = self.system_monitor_service {
             system_monitor_service
                 .join()
                 .expect("system_monitor_service");
         }
 
+        error!("join sample_performance_service");
         if let Some(sample_performance_service) = self.sample_performance_service {
             sample_performance_service
                 .join()
                 .expect("sample_performance_service");
         }
 
+        error!("join snapshot_package_service");
         if let Some(s) = self.snapshot_packager_service {
             s.join().expect("snapshot_packager_service");
         }
 
+        error!("join gossip_service");
         self.gossip_service.join().expect("gossip_service");
+
+        error!("join serve_repair_service");
         self.serve_repair_service
             .join()
             .expect("serve_repair_service");
+
+        error!("join stats_reporter_service");
         self.stats_reporter_service
             .join()
             .expect("stats_reporter_service");
+
+        error!("join tpu");
         self.tpu.join().expect("tpu");
+
+        error!("join tvu");
         self.tvu.join().expect("tvu");
+
+        error!("join completed_data_sets_service");
         self.completed_data_sets_service
             .join()
             .expect("completed_data_sets_service");
+
+        error!("join ip_echo_server");
         if let Some(ip_echo_server) = self.ip_echo_server {
             ip_echo_server.shutdown_background();
         }
 
+        error!("join accountsdb_repl_service");
         if let Some(accountsdb_repl_service) = self.accountsdb_repl_service {
             accountsdb_repl_service
                 .join()
                 .expect("accountsdb_repl_service");
         }
 
+        error!("join geyser_plugin_service");
         if let Some(geyser_plugin_service) = self.geyser_plugin_service {
             geyser_plugin_service.join().expect("geyser_plugin_service");
         }
 
+        error!("join poh_timing_report_service");
         self.poh_timing_report_service
             .join()
             .expect("poh_timing_report_service");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1876,7 +1876,7 @@ mod tests {
             sender.send(()).unwrap();
         });
 
-        // timeout of 30s for shutting down the validators
+        // exit can deadlock. put an upper-bound on how long we wait for it
         let timeout = Duration::from_secs(30);
         if let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(timeout) {
             panic!("timeout for closing validator");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1047,26 +1047,21 @@ impl Validator {
         drop(self.bank_forks);
         drop(self.cluster_info);
 
-        error!("join poh_service");
         self.poh_service.join().expect("poh_service");
         drop(self.poh_recorder);
 
-        error!("join json_rpc_service");
         if let Some(json_rpc_service) = self.json_rpc_service {
             json_rpc_service.join().expect("rpc_service");
         }
 
-        error!("join pubsub_service");
         if let Some(pubsub_service) = self.pubsub_service {
             pubsub_service.join().expect("pubsub_service");
         }
 
-        error!("join rpc_completed_slot_service");
         self.rpc_completed_slots_service
             .join()
             .expect("rpc_completed_slots_service");
 
-        error!("join optimistically_confirmed_bank_tracker");
         if let Some(optimistically_confirmed_bank_tracker) =
             self.optimistically_confirmed_bank_tracker
         {
@@ -1075,88 +1070,66 @@ impl Validator {
                 .expect("optimistically_confirmed_bank_tracker");
         }
 
-        error!("join transaction_status_service");
         if let Some(transaction_status_service) = self.transaction_status_service {
             transaction_status_service
                 .join()
                 .expect("transaction_status_service");
         }
 
-        error!("join rewards_recorder_service");
         if let Some(rewards_recorder_service) = self.rewards_recorder_service {
             rewards_recorder_service
                 .join()
                 .expect("rewards_recorder_service");
         }
 
-        error!("join cache_block_meta_service");
         if let Some(cache_block_meta_service) = self.cache_block_meta_service {
             cache_block_meta_service
                 .join()
                 .expect("cache_block_meta_service");
         }
 
-        error!("join system_monitor_service");
         if let Some(system_monitor_service) = self.system_monitor_service {
             system_monitor_service
                 .join()
                 .expect("system_monitor_service");
         }
 
-        error!("join sample_performance_service");
         if let Some(sample_performance_service) = self.sample_performance_service {
             sample_performance_service
                 .join()
                 .expect("sample_performance_service");
         }
 
-        error!("join snapshot_package_service");
         if let Some(s) = self.snapshot_packager_service {
             s.join().expect("snapshot_packager_service");
         }
 
-        error!("join gossip_service");
         self.gossip_service.join().expect("gossip_service");
-
-        error!("join serve_repair_service");
         self.serve_repair_service
             .join()
             .expect("serve_repair_service");
-
-        error!("join stats_reporter_service");
         self.stats_reporter_service
             .join()
             .expect("stats_reporter_service");
-
-        error!("join tpu");
         self.tpu.join().expect("tpu");
-
-        error!("join tvu");
         self.tvu.join().expect("tvu");
-
-        error!("join completed_data_sets_service");
         self.completed_data_sets_service
             .join()
             .expect("completed_data_sets_service");
-
-        error!("join ip_echo_server");
         if let Some(ip_echo_server) = self.ip_echo_server {
             ip_echo_server.shutdown_background();
         }
 
-        error!("join accountsdb_repl_service");
         if let Some(accountsdb_repl_service) = self.accountsdb_repl_service {
             accountsdb_repl_service
                 .join()
                 .expect("accountsdb_repl_service");
         }
 
-        error!("join geyser_plugin_service");
         if let Some(geyser_plugin_service) = self.geyser_plugin_service {
             geyser_plugin_service.join().expect("geyser_plugin_service");
         }
 
-        error!("join poh_timing_report_service");
         self.poh_timing_report_service
             .join()
             .expect("poh_timing_report_service");

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -55,7 +55,7 @@ pub struct SendDroppedBankCallback {
 
 impl DropCallback for SendDroppedBankCallback {
     fn callback(&self, bank: &Bank) {
-        if let Err(e) = self.sender.send((bank.slot(), bank.bank_id())) {
+        if let Err(e) = self.sender.try_send((bank.slot(), bank.bank_id())) {
             warn!("Error sending dropped banks: {:?}", e);
         }
     }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -55,7 +55,7 @@ pub struct SendDroppedBankCallback {
 
 impl DropCallback for SendDroppedBankCallback {
     fn callback(&self, bank: &Bank) {
-        if let Err(e) = self.sender.try_send((bank.slot(), bank.bank_id())) {
+        if let Err(e) = self.sender.send((bank.slot(), bank.bank_id())) {
             warn!("Error sending dropped banks: {:?}", e);
         }
     }


### PR DESCRIPTION
#### Problem

During validator shutdown, the validator could hang and deadlock on joining microservices inside TVU and TPU. During my test, this deadlock happens approximately about 1 out 10 runs.

This is because of the blocking recev calls on the signals receiver in those microservices, one example is here.
https://github.com/solana-labs/solana/blob/eb65ffb7798e26dc559e31f480ab20e297e951ac/core/src/shred_fetch_stage.rs#L87
There could be other places. I will try to address them in future.

Here, in this pull request, I added a timeout of 10s for joining TVU and TPU in case that they are in deadlock when shutting down. I have run the coverage test suite locally last night for `1173` times without hanging. 


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
