### PR TITLE
Extend RpcBatchRequest take optional id params.

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -71,6 +71,7 @@ type RpcBatchRequest = (requests: RpcParams[]) => any;
  * @internal
  */
 export type RpcParams = {
+  id?: string;
   methodName: string;
   args: Array<any>;
 };
@@ -922,7 +923,7 @@ function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
       if (requests.length === 0) resolve([]);
 
       const batch = requests.map((params: RpcParams) => {
-        return client.request(params.methodName, params.args);
+        return client.request(params.methodName, params.args, params?.id);
       });
 
       client.request(batch, (err: any, response: any) => {

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2668,7 +2668,7 @@ export class Connection {
     configOrCommitment?: GetProgramAccountsConfig | Commitment,
   ) => {
     const extra: Pick<GetProgramAccountsConfig, 'dataSlice' | 'filters'> = {};
-  
+
     let commitment;
     let encoding;
     if (configOrCommitment) {
@@ -2677,7 +2677,7 @@ export class Connection {
       } else {
         commitment = configOrCommitment.commitment;
         encoding = configOrCommitment.encoding;
-  
+
         if (configOrCommitment.dataSlice) {
           extra.dataSlice = configOrCommitment.dataSlice;
         }
@@ -2686,7 +2686,7 @@ export class Connection {
         }
       }
     }
-  
+
     return this._buildArgs(
       [programId.toBase58()],
       commitment,


### PR DESCRIPTION
#### Problem
Existing RpcBatch Request does auto-generate id for requests. there are scenarios user might want to track their request for post-processing.

#### Summary of Changes
* Extended RpcParams with optional id field.
* Passed id param in batch request function.
* Separate the logic of building getProgramAccounts arg builder for reusability. 


Ref: https://github.com/TheBuilderDAO/kafe/pull/105
Ref: https://github.com/project-serum/anchor/pull/1735