### PR TITLE
zk-token-sdk: add support for scalar - ciphertext/commitment mult

### DIFF
--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -460,10 +460,10 @@ impl ElGamalCiphertext {
 impl<'a, 'b> Add<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
-    fn add(self, other: &'b ElGamalCiphertext) -> ElGamalCiphertext {
+    fn add(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
         ElGamalCiphertext {
-            commitment: &self.commitment + &other.commitment,
-            handle: &self.handle + &other.handle,
+            commitment: &self.commitment + &ciphertext.commitment,
+            handle: &self.handle + &ciphertext.handle,
         }
     }
 }
@@ -477,10 +477,10 @@ define_add_variants!(
 impl<'a, 'b> Sub<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
-    fn sub(self, other: &'b ElGamalCiphertext) -> ElGamalCiphertext {
+    fn sub(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
         ElGamalCiphertext {
-            commitment: &self.commitment - &other.commitment,
-            handle: &self.handle - &other.handle,
+            commitment: &self.commitment - &ciphertext.commitment,
+            handle: &self.handle - &ciphertext.handle,
         }
     }
 }
@@ -494,10 +494,10 @@ define_sub_variants!(
 impl<'a, 'b> Mul<&'b Scalar> for &'a ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 
-    fn mul(self, other: &'b Scalar) -> ElGamalCiphertext {
+    fn mul(self, scalar: &'b Scalar) -> ElGamalCiphertext {
         ElGamalCiphertext {
-            commitment: &self.commitment * other,
-            handle: &self.handle * other,
+            commitment: &self.commitment * scalar,
+            handle: &self.handle * scalar,
         }
     }
 }
@@ -505,6 +505,23 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a ElGamalCiphertext {
 define_mul_variants!(
     LHS = ElGamalCiphertext,
     RHS = Scalar,
+    Output = ElGamalCiphertext
+);
+
+impl<'a, 'b> Mul<&'b ElGamalCiphertext> for &'a Scalar {
+    type Output = ElGamalCiphertext;
+
+    fn mul(self, ciphertext: &'b ElGamalCiphertext) -> ElGamalCiphertext {
+        ElGamalCiphertext {
+            commitment: self * &ciphertext.commitment,
+            handle: self * &ciphertext.handle,
+        }
+    }
+}
+
+define_mul_variants!(
+    LHS = Scalar,
+    RHS = ElGamalCiphertext,
     Output = ElGamalCiphertext
 );
 
@@ -535,8 +552,8 @@ impl DecryptHandle {
 impl<'a, 'b> Add<&'b DecryptHandle> for &'a DecryptHandle {
     type Output = DecryptHandle;
 
-    fn add(self, other: &'b DecryptHandle) -> DecryptHandle {
-        DecryptHandle(&self.0 + &other.0)
+    fn add(self, handle: &'b DecryptHandle) -> DecryptHandle {
+        DecryptHandle(&self.0 + &handle.0)
     }
 }
 
@@ -549,8 +566,8 @@ define_add_variants!(
 impl<'a, 'b> Sub<&'b DecryptHandle> for &'a DecryptHandle {
     type Output = DecryptHandle;
 
-    fn sub(self, other: &'b DecryptHandle) -> DecryptHandle {
-        DecryptHandle(&self.0 - &other.0)
+    fn sub(self, handle: &'b DecryptHandle) -> DecryptHandle {
+        DecryptHandle(&self.0 - &handle.0)
     }
 }
 
@@ -563,12 +580,22 @@ define_sub_variants!(
 impl<'a, 'b> Mul<&'b Scalar> for &'a DecryptHandle {
     type Output = DecryptHandle;
 
-    fn mul(self, other: &'b Scalar) -> DecryptHandle {
-        DecryptHandle(&self.0 * other)
+    fn mul(self, scalar: &'b Scalar) -> DecryptHandle {
+        DecryptHandle(&self.0 * scalar)
     }
 }
 
 define_mul_variants!(LHS = DecryptHandle, RHS = Scalar, Output = DecryptHandle);
+
+impl<'a, 'b> Mul<&'b DecryptHandle> for &'a Scalar {
+    type Output = DecryptHandle;
+
+    fn mul(self, handle: &'b DecryptHandle) -> DecryptHandle {
+        DecryptHandle(self * &handle.0)
+    }
+}
+
+define_mul_variants!(LHS = Scalar, RHS = DecryptHandle, Output = DecryptHandle);
 
 #[cfg(test)]
 mod tests {
@@ -700,6 +727,7 @@ mod tests {
             ElGamal::encrypt_with(amount_0 * amount_1, &public, &(&opening * scalar));
 
         assert_eq!(ciphertext_prod, ciphertext * scalar);
+        assert_eq!(ciphertext_prod, scalar * ciphertext);
     }
 
     #[test]

--- a/zk-token-sdk/src/encryption/pedersen.rs
+++ b/zk-token-sdk/src/encryption/pedersen.rs
@@ -109,8 +109,8 @@ impl ConstantTimeEq for PedersenOpening {
 impl<'a, 'b> Add<&'b PedersenOpening> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
-    fn add(self, other: &'b PedersenOpening) -> PedersenOpening {
-        PedersenOpening(&self.0 + &other.0)
+    fn add(self, opening: &'b PedersenOpening) -> PedersenOpening {
+        PedersenOpening(&self.0 + &opening.0)
     }
 }
 
@@ -123,8 +123,8 @@ define_add_variants!(
 impl<'a, 'b> Sub<&'b PedersenOpening> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
-    fn sub(self, other: &'b PedersenOpening) -> PedersenOpening {
-        PedersenOpening(&self.0 - &other.0)
+    fn sub(self, opening: &'b PedersenOpening) -> PedersenOpening {
+        PedersenOpening(&self.0 - &opening.0)
     }
 }
 
@@ -137,14 +137,28 @@ define_sub_variants!(
 impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenOpening {
     type Output = PedersenOpening;
 
-    fn mul(self, other: &'b Scalar) -> PedersenOpening {
-        PedersenOpening(&self.0 * other)
+    fn mul(self, scalar: &'b Scalar) -> PedersenOpening {
+        PedersenOpening(&self.0 * scalar)
     }
 }
 
 define_mul_variants!(
     LHS = PedersenOpening,
     RHS = Scalar,
+    Output = PedersenOpening
+);
+
+impl<'a, 'b> Mul<&'b PedersenOpening> for &'a Scalar {
+    type Output = PedersenOpening;
+
+    fn mul(self, opening: &'b PedersenOpening) -> PedersenOpening {
+        PedersenOpening(self * &opening.0)
+    }
+}
+
+define_mul_variants!(
+    LHS = Scalar,
+    RHS = PedersenOpening,
     Output = PedersenOpening
 );
 
@@ -171,8 +185,8 @@ impl PedersenCommitment {
 impl<'a, 'b> Add<&'b PedersenCommitment> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
-    fn add(self, other: &'b PedersenCommitment) -> PedersenCommitment {
-        PedersenCommitment(&self.0 + &other.0)
+    fn add(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
+        PedersenCommitment(&self.0 + &commitment.0)
     }
 }
 
@@ -185,8 +199,8 @@ define_add_variants!(
 impl<'a, 'b> Sub<&'b PedersenCommitment> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
-    fn sub(self, other: &'b PedersenCommitment) -> PedersenCommitment {
-        PedersenCommitment(&self.0 - &other.0)
+    fn sub(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
+        PedersenCommitment(&self.0 - &commitment.0)
     }
 }
 
@@ -199,14 +213,28 @@ define_sub_variants!(
 impl<'a, 'b> Mul<&'b Scalar> for &'a PedersenCommitment {
     type Output = PedersenCommitment;
 
-    fn mul(self, other: &'b Scalar) -> PedersenCommitment {
-        PedersenCommitment(&self.0 * other)
+    fn mul(self, scalar: &'b Scalar) -> PedersenCommitment {
+        PedersenCommitment(scalar * &self.0)
     }
 }
 
 define_mul_variants!(
     LHS = PedersenCommitment,
     RHS = Scalar,
+    Output = PedersenCommitment
+);
+
+impl<'a, 'b> Mul<&'b PedersenCommitment> for &'a Scalar {
+    type Output = PedersenCommitment;
+
+    fn mul(self, commitment: &'b PedersenCommitment) -> PedersenCommitment {
+        PedersenCommitment(self * &commitment.0)
+    }
+}
+
+define_mul_variants!(
+    LHS = Scalar,
+    RHS = PedersenCommitment,
     Output = PedersenCommitment
 );
 
@@ -256,6 +284,7 @@ mod tests {
         let comm_addition = Pedersen::with(amt_0 * amt_1, &(open * scalar));
 
         assert_eq!(comm_addition, comm * scalar);
+        assert_eq!(comm_addition, scalar * comm);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Whem multiplying scalars with ElGamal ciphertext or Pedersen commitments, the scalar always needed to be on the right side. This is inconsistent with how protocol specifications are generally written as well as syscall scalar/point multiplication.

#### Summary of Changes
Added support for scalar multiplication so that scalar can be multiplied into ciphertexts or commitments in either sides.