### PR TITLE
Use Release/Acquire instead of SeqCst for is_bank_drop_callback_enabled

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4014,7 +4014,7 @@ impl AccountsDb {
         pruned_banks_sender: DroppedSlotsSender,
     ) -> SendDroppedBankCallback {
         self.is_bank_drop_callback_enabled
-            .store(true, Ordering::SeqCst);
+            .store(true, Ordering::Release);
         SendDroppedBankCallback::new(pruned_banks_sender)
     }
 
@@ -4022,7 +4022,7 @@ impl AccountsDb {
     /// comment below for more explanation.
     /// `is_from_abs` is true if the caller is the AccountsBackgroundService
     pub fn purge_slot(&self, slot: Slot, bank_id: BankId, is_from_abs: bool) {
-        if self.is_bank_drop_callback_enabled.load(Ordering::SeqCst) && !is_from_abs {
+        if self.is_bank_drop_callback_enabled.load(Ordering::Acquire) && !is_from_abs {
             panic!("bad drop callpath detected; Bank::drop() must run serially with other logic in ABS like clean_accounts()")
         }
         // BANK_DROP_SAFETY: Because this function only runs once the bank is dropped,


### PR DESCRIPTION
#### Problem

Storing and loading `AccountsDb::is_bank_drop_callback_enabled` uses `Ordering::SeqCst`, but there are no interactions with other atomics that require sequential ordering (that I could find). Since `AccountsDb::is_bank_drop_callback_enabled` is loaded every time `AccountsDb::purge_slot()` is called, this introduces unnecessary memory barriers/fences.

#### Summary of Changes

Store `AccountsDb::is_bank_drop_callback_enabled` with `Ordering::Release` and load with `Ordering::Acquire`.