### PR TITLE
(LedgerStore) Report perf metrics for RocksDB deletes

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -781,6 +781,8 @@ pub trait ColumnMetrics {
     );
     fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str;
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str;
+    fn rocksdb_delete_perf_metric_header(column_options: &Arc<LedgerColumnOptions>)
+        -> &'static str;
 }
 
 pub trait ColumnName {
@@ -892,6 +894,15 @@ impl ColumnMetrics for columns::TransactionStatus {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "transaction_status",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::TransactionStatus {
     const NAME: &'static str = TRANSACTION_STATUS_CF;
@@ -958,6 +969,15 @@ impl ColumnMetrics for columns::AddressSignatures {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "address_signatures",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::AddressSignatures {
     const NAME: &'static str = ADDRESS_SIGNATURES_CF;
@@ -1010,6 +1030,15 @@ impl ColumnMetrics for columns::TransactionMemos {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "transaction_memos",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "transaction_memos",
             column_options
         )
@@ -1070,6 +1099,15 @@ impl ColumnMetrics for columns::TransactionStatusIndex {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "transaction_status_index",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::TransactionStatusIndex {
     const NAME: &'static str = TRANSACTION_STATUS_INDEX_CF;
@@ -1097,6 +1135,15 @@ impl ColumnMetrics for columns::Rewards {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "rewards",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "rewards",
             column_options
         )
@@ -1135,6 +1182,15 @@ impl ColumnMetrics for columns::Blocktime {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "blocktime",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::Blocktime {
     const NAME: &'static str = BLOCKTIME_CF;
@@ -1165,6 +1221,15 @@ impl ColumnMetrics for columns::PerfSamples {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "perf_samples",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "perf_samples",
             column_options
         )
@@ -1203,6 +1268,15 @@ impl ColumnMetrics for columns::BlockHeight {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "block_height",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::BlockHeight {
     const NAME: &'static str = BLOCK_HEIGHT_CF;
@@ -1232,6 +1306,15 @@ impl ColumnMetrics for columns::ProgramCosts {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "program_costs",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "program_costs",
             column_options
         )
@@ -1316,6 +1399,15 @@ impl ColumnMetrics for columns::ShredCode {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "shred_code",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::ShredCode {
     const NAME: &'static str = CODE_SHRED_CF;
@@ -1371,6 +1463,15 @@ impl ColumnMetrics for columns::ShredData {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "shred_data",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::ShredData {
     const NAME: &'static str = DATA_SHRED_CF;
@@ -1398,6 +1499,15 @@ impl ColumnMetrics for columns::Index {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "index",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "index",
             column_options
         )
@@ -1436,6 +1546,15 @@ impl ColumnMetrics for columns::DeadSlots {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "dead_slots",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::DeadSlots {
     const NAME: &'static str = DEAD_SLOTS_CF;
@@ -1466,6 +1585,15 @@ impl ColumnMetrics for columns::DuplicateSlots {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "duplicate_slots",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "duplicate_slots",
             column_options
         )
@@ -1504,6 +1632,15 @@ impl ColumnMetrics for columns::Orphans {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "orphans",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::Orphans {
     const NAME: &'static str = ORPHANS_CF;
@@ -1534,6 +1671,15 @@ impl ColumnMetrics for columns::BankHash {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "bank_hash",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "bank_hash",
             column_options
         )
@@ -1572,6 +1718,15 @@ impl ColumnMetrics for columns::Root {
             column_options
         )
     }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "root",
+            column_options
+        )
+    }
 }
 impl ColumnName for columns::Root {
     const NAME: &'static str = ROOT_CF;
@@ -1602,6 +1757,15 @@ impl ColumnMetrics for columns::SlotMeta {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "slot_meta",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "slot_meta",
             column_options
         )
@@ -1661,6 +1825,15 @@ impl ColumnMetrics for columns::ErasureMeta {
     fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
         rocksdb_metric_header!(
             "blockstore_rocksdb_write_perf,op=put",
+            "erasure_meta",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
             "erasure_meta",
             column_options
         )
@@ -2387,7 +2560,12 @@ where
     }
 
     pub fn delete(&self, key: C::Index) -> Result<()> {
-        self.backend.delete_cf(self.handle(), &C::key(key))
+        let is_perf_context_enabled = maybe_collect_perf_context();
+        let result = self.backend.delete_cf(self.handle(), &C::key(key));
+        if is_perf_context_enabled {
+            report_write_perf_context(C::rocksdb_delete_perf_metric_header(&self.column_options));
+        }
+        result
     }
 }
 


### PR DESCRIPTION
#### Summary of Changes
This PR enables perf metrics reporting for RocksDB deletes.
Samples are reported under "blockstore_rocksdb_write_perf" with op=delete
The sampling rate is still controlled by env arg SOLANA_METRICS_ROCKSDB_PERF_SAMPLES_IN_1K
and its default to 10 (meaning we report 10 in 1000 perf samples).

This PR is based on top of #23951.