### PR TITLE
Add transaction update error to Geyser plugin interface

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -107,6 +107,10 @@ pub enum GeyserPluginError {
     /// Any custom error defined by the plugin.
     #[error("Plugin-defined custom error. Error message: ({0})")]
     Custom(Box<dyn error::Error + Send + Sync>),
+
+    /// Error when updating the transaction.
+    #[error("Error updating transaction. Error message: ({msg})")]
+    TransactionUpdateError { msg: String },
 }
 
 /// The current status of a slot


### PR DESCRIPTION
#### Problem

Geyser plugin interface only supports errors for slot status update and account update. This PR adds support for transaction update error.

#### Summary of Changes

Add one more enum variant `TransactionUpdateError` to Geyser plugin's error enum.
