### PR TITLE
compare contents of serialized banks instead of exact file format

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -349,7 +349,7 @@ mod tests {
             snapshots_dir,
             accounts_dir,
             archive_format,
-            None,
+            snapshot_utils::VerifyBank::Deterministic,
         );
     }
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -349,6 +349,7 @@ mod tests {
             snapshots_dir,
             accounts_dir,
             archive_format,
+            None,
         );
     }
 }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -553,7 +553,7 @@ mod tests {
             saved_snapshots_dir.path(),
             saved_accounts_dir.path(),
             ArchiveFormat::TarBzip2,
-            Some(saved_slot),
+            snapshot_utils::VerifyBank::NonDeterministic(saved_slot),
         );
     }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -553,6 +553,7 @@ mod tests {
             saved_snapshots_dir.path(),
             saved_accounts_dir.path(),
             ArchiveFormat::TarBzip2,
+            Some(saved_slot),
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -894,7 +894,7 @@ impl NonceInfo for NonceFull {
 // Bank's common fields shared by all supported snapshot versions for deserialization.
 // Sync fields with BankFieldsToSerialize! This is paired with it.
 // All members are made public to remain Bank's members private and to make versioned deserializer workable on this
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct BankFieldsToDeserialize {
     pub(crate) blockhash_queue: BlockhashQueue,
     pub(crate) ancestors: AncestorsForSerialization,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -191,26 +191,18 @@ where
 /// used by tests to compare contents of serialized bank fields
 /// serialized format is not deterministic - likely due to randomness in structs like hashmaps
 pub(crate) fn compare_two_serialized_banks(
-    serde_style: SerdeStyle,
     path1: impl AsRef<Path>,
     path2: impl AsRef<Path>,
 ) -> std::result::Result<bool, Error> {
-    macro_rules! COMPARE {
-        ($style:ident) => {{
-            use std::fs::File;
-            let file1 = File::open(path1)?;
-            let mut stream1 = BufReader::new(file1);
-            let file2 = File::open(path2)?;
-            let mut stream2 = BufReader::new(file2);
+    use std::fs::File;
+    let file1 = File::open(path1)?;
+    let mut stream1 = BufReader::new(file1);
+    let file2 = File::open(path2)?;
+    let mut stream2 = BufReader::new(file2);
 
-            let fields1 = $style::Context::deserialize_bank_fields(&mut stream1)?;
-            let fields2 = $style::Context::deserialize_bank_fields(&mut stream2)?;
-            Ok(fields1 == fields2)
-        }};
-    }
-    match serde_style {
-        SerdeStyle::Newer => COMPARE!(newer),
-    }
+    let fields1 = newer::Context::deserialize_bank_fields(&mut stream1)?;
+    let fields2 = newer::Context::deserialize_bank_fields(&mut stream2)?;
+    Ok(fields1 == fields2)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -176,6 +176,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl<'a> solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableVersionedBank<'a> {}
 
+#[derive(PartialEq)]
 pub(super) struct Context {}
 
 impl<'a> TypeContext<'a> for Context {

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1609,8 +1609,8 @@ pub fn verify_snapshot_archive<P, Q, R>(
 
         assert!(crate::serde_snapshot::compare_two_serialized_banks(
             SerdeStyle::Newer,
-            p1.clone(),
-            p2.clone()
+            &p1,
+            &p2
         )
         .unwrap());
         std::fs::remove_file(p1).unwrap();

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1582,9 +1582,8 @@ pub fn verify_snapshot_archive<P, Q, R>(
     slot: Option<Slot>,
 ) where
     P: AsRef<Path>,
-    Q: AsRef<Path> + Clone,
+    Q: AsRef<Path>,
     R: AsRef<Path>,
-    PathBuf: From<Q>,
 {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let unpack_dir = temp_dir.path();
@@ -1602,9 +1601,7 @@ pub fn verify_snapshot_archive<P, Q, R>(
     if let Some(slot) = slot {
         // file contents may be different, but deserialized structs should be equal
         let slot = slot.to_string();
-        let p1 = PathBuf::from(snapshots_to_verify.clone())
-            .join(&slot)
-            .join(&slot);
+        let p1 = snapshots_to_verify.as_ref().join(&slot).join(&slot);
         let p2 = unpacked_snapshots.join(&slot).join(&slot);
 
         assert!(crate::serde_snapshot::compare_two_serialized_banks(&p1, &p2).unwrap());

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1582,9 +1582,8 @@ pub fn verify_snapshot_archive<P, Q, R>(
     slot: Option<Slot>,
 ) where
     P: AsRef<Path>,
-    Q: AsRef<Path> + Clone + std::fmt::Debug,
+    Q: AsRef<Path>,
     R: AsRef<Path>,
-    PathBuf: From<Q>,
 {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let unpack_dir = temp_dir.path();


### PR DESCRIPTION
#### Problem

reserializing a bank produces non-deterministic file contents. Likely due to randomness in HashMaps at runtime, affecting order of contents on serialize. So, have this test compare the deserialized contents instead of the exact file bits.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
