### PR TITLE
Add metrics to connection-cache to measure cache hits and misses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
  "solana-faucet",
  "solana-logger 1.11.0",
  "solana-measure",
+ "solana-metrics",
  "solana-net-utils",
  "solana-sdk",
  "solana-streamer",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -40,6 +40,7 @@ solana-account-decoder = { path = "../account-decoder", version = "=1.11.0" }
 solana-clap-utils = { path = "../clap-utils", version = "=1.11.0" }
 solana-faucet = { path = "../faucet", version = "=1.11.0" }
 solana-measure = { path = "../measure", version = "=1.11.0" }
+solana-metrics = { path = "../metrics", version = "=1.11.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-streamer = { path = "../streamer", version = "=1.11.0" }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,6 +2,9 @@
 #[macro_use]
 extern crate serde_derive;
 
+#[macro_use]
+extern crate solana_metrics;
+
 pub mod blockhash_query;
 pub mod client_error;
 pub mod connection_cache;

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-faucet",
  "solana-measure",
+ "solana-metrics",
  "solana-net-utils",
  "solana-sdk",
  "solana-streamer",


### PR DESCRIPTION
#### Problem
We currently don't have metrics to allow us to know how often connection-cache gets cache hits and misses. We need this info to tune the cache size and possibly how other modules use connection-cache

#### Summary of Changes
Adds such metrics to connection-cache

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
