### PR TITLE
Undo cost tracker changes for retryable tx

### DIFF
--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -170,6 +170,23 @@ impl QosService {
         (select_results, num_included)
     }
 
+    pub fn commit_transaction_cost(
+        &self,
+        bank: &Arc<Bank>,
+        transaction: &SanitizedTransaction,
+        actual_units: Option<u64>,
+    ) {
+        bank.write_cost_tracker()
+            .unwrap()
+            .commit_transaction(transaction, actual_units);
+    }
+
+    pub fn cancel_transaction_cost(&self, bank: &Arc<Bank>, transaction: &SanitizedTransaction) {
+        bank.write_cost_tracker()
+            .unwrap()
+            .cancel_transaction(transaction);
+    }
+
     // metrics are reported by bank slot
     pub fn report_metrics(&self, bank: Arc<Bank>) {
         self.report_sender

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -822,7 +822,7 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
                 num_programs += transaction.message().instructions().len();
 
                 let tx_cost = cost_model.calculate_cost(&transaction);
-                let result = cost_tracker.try_add(&transaction, &tx_cost);
+                let result = cost_tracker.try_add(&tx_cost);
                 if result.is_err() {
                     println!(
                         "Slot: {}, CostModel rejected transaction {:?}, reason {:?}",

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1069,14 +1069,14 @@ impl Accounts {
     pub fn lock_accounts_with_results<'a>(
         &self,
         txs: impl Iterator<Item = &'a SanitizedTransaction>,
-        results: impl Iterator<Item = Result<()>>,
+        results: impl Iterator<Item = &'a Result<()>>,
         feature_set: &FeatureSet,
     ) -> Vec<Result<()>> {
         let tx_account_locks_results: Vec<Result<_>> = txs
             .zip(results)
             .map(|(tx, result)| match result {
                 Ok(()) => tx.get_account_locks(feature_set),
-                Err(err) => Err(err),
+                Err(err) => Err(err.clone()),
             })
             .collect();
         self.lock_accounts_inner(tx_account_locks_results)
@@ -2831,7 +2831,7 @@ mod tests {
 
         let results = accounts.lock_accounts_with_results(
             txs.iter(),
-            qos_results.into_iter(),
+            qos_results.iter(),
             &FeatureSet::all_enabled(),
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3492,7 +3492,7 @@ impl Bank {
     pub fn prepare_sanitized_batch_with_results<'a, 'b>(
         &'a self,
         transactions: &'b [SanitizedTransaction],
-        transaction_results: impl Iterator<Item = Result<()>>,
+        transaction_results: impl Iterator<Item = &'b Result<()>>,
     ) -> TransactionBatch<'a, 'b> {
         // this lock_results could be: Ok, AccountInUse, WouldExceedBlockMaxLimit or WouldExceedAccountMaxLimit
         let lock_results = self.rc.accounts.lock_accounts_with_results(

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -16,7 +16,7 @@ use {
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
 
 // costs are stored in number of 'compute unit's
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TransactionCost {
     pub writable_accounts: Vec<Pubkey>,
     pub signature_cost: u64,

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -16,7 +16,7 @@ use {
 const MAX_WRITABLE_ACCOUNTS: usize = 256;
 
 // costs are stored in number of 'compute unit's
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransactionCost {
     pub writable_accounts: Vec<Pubkey>,
     pub signature_cost: u64,
@@ -24,6 +24,7 @@ pub struct TransactionCost {
     pub data_bytes_cost: u64,
     pub execution_cost: u64,
     pub account_data_size: u64,
+    pub is_simple_vote: bool,
 }
 
 impl Default for TransactionCost {
@@ -35,6 +36,7 @@ impl Default for TransactionCost {
             data_bytes_cost: 0u64,
             execution_cost: 0u64,
             account_data_size: 0u64,
+            is_simple_vote: false,
         }
     }
 }
@@ -53,6 +55,7 @@ impl TransactionCost {
         self.write_lock_cost = 0;
         self.data_bytes_cost = 0;
         self.execution_cost = 0;
+        self.is_simple_vote = false;
     }
 
     pub fn sum(&self) -> u64 {
@@ -90,6 +93,7 @@ impl CostModel {
         tx_cost.data_bytes_cost = self.get_data_bytes_cost(transaction);
         tx_cost.execution_cost = self.get_transaction_cost(transaction);
         tx_cost.account_data_size = self.calculate_account_data_size(transaction);
+        tx_cost.is_simple_vote = transaction.is_simple_vote_transaction();
 
         debug!("transaction {:?} has cost {:?}", transaction, tx_cost);
         tx_cost

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -111,6 +111,14 @@ impl CostTracker {
         self.remove_transaction_cost(tx_cost);
     }
 
+    pub fn block_cost(&self) -> u64 {
+        self.block_cost
+    }
+
+    pub fn transaction_count(&self) -> u64 {
+        self.transaction_count
+    }
+
     pub fn report_stats(&self, bank_slot: Slot) {
         // skip reporting if block is empty
         if self.transaction_count == 0 {

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -5,9 +5,7 @@
 //!
 use {
     crate::{block_cost_limits::*, cost_model::TransactionCost},
-    solana_sdk::{
-        clock::Slot, pubkey::Pubkey, signature::Signature, transaction::SanitizedTransaction,
-    },
+    solana_sdk::{clock::Slot, pubkey::Pubkey, transaction::SanitizedTransaction},
     std::collections::HashMap,
 };
 
@@ -45,12 +43,6 @@ pub struct CostTracker {
     /// The amount of total account data size remaining.  If `Some`, then do not add transactions
     /// that would cause `account_data_size` to exceed this limit.
     account_data_size_limit: Option<u64>,
-
-    // Transactions have passed would_fit check, is being executed.
-    // If the execution is successful, it's actual Units can be committed
-    // to cost_tracker; otherwise, it should be removed without impacting
-    // cost_tracker.
-    pending_transactions: HashMap<Signature, TransactionCost>,
 }
 
 impl Default for CostTracker {
@@ -71,7 +63,6 @@ impl Default for CostTracker {
             transaction_count: 0,
             account_data_size: 0,
             account_data_size_limit: None,
-            pending_transactions: HashMap::new(),
         }
     }
 }
@@ -100,31 +91,24 @@ impl CostTracker {
 
     pub fn try_add(
         &mut self,
-        transaction: &SanitizedTransaction,
+        _transaction: &SanitizedTransaction,
         tx_cost: &TransactionCost,
     ) -> Result<u64, CostTrackerError> {
         self.would_fit(tx_cost)?;
-        self.pending_transactions
-            .insert(*transaction.signature(), tx_cost.clone());
+        self.add_transaction_cost(tx_cost);
         Ok(self.block_cost)
     }
 
-    pub fn commit_transaction(
+    pub fn update_execution_cost(
         &mut self,
-        transaction: &SanitizedTransaction,
-        actual_units: Option<u64>,
+        _estimated_tx_cost: &TransactionCost,
+        _actual_execution_cost: u64,
     ) {
-        if let Some(mut tx_cost) = self.pending_transactions.remove(transaction.signature()) {
-            if let Some(actual_units) = actual_units {
-                // using actual units to update cost tracker if available
-                tx_cost.execution_cost = actual_units;
-            }
-            self.add_transaction(&tx_cost);
-        }
+        // adjust block_cost / vote_cost / account_cost by (actual_execution_cost - execution_cost)
     }
 
-    pub fn cancel_transaction(&mut self, transaction: &SanitizedTransaction) {
-        self.pending_transactions.remove(transaction.signature());
+    pub fn remove(&mut self, tx_cost: &TransactionCost) {
+        self.remove_transaction_cost(tx_cost);
     }
 
     pub fn report_stats(&self, bank_slot: Slot) {
@@ -166,34 +150,10 @@ impl CostTracker {
     }
 
     fn would_fit(&self, tx_cost: &TransactionCost) -> Result<(), CostTrackerError> {
-        let mut writable_account = vec![];
-        writable_account.extend(&tx_cost.writable_accounts);
-        let mut cost = tx_cost.sum();
-        let mut account_data_size = tx_cost.account_data_size;
-        let mut vote_cost = if tx_cost.is_simple_vote { cost } else { 0 };
+        let writable_accounts = &tx_cost.writable_accounts;
+        let cost = tx_cost.sum();
+        let vote_cost = if tx_cost.is_simple_vote { cost } else { 0 };
 
-        for tx_cost in self.pending_transactions.values() {
-            writable_account.extend(&tx_cost.writable_accounts);
-            cost = cost.saturating_add(tx_cost.sum());
-            account_data_size = account_data_size.saturating_add(tx_cost.account_data_size);
-            vote_cost = vote_cost.saturating_add(if tx_cost.is_simple_vote { cost } else { 0 });
-        }
-
-        self.would_aggregated_transactions_fit(
-            &writable_account,
-            cost,
-            account_data_size,
-            vote_cost,
-        )
-    }
-
-    fn would_aggregated_transactions_fit(
-        &self,
-        keys: &[Pubkey],
-        cost: u64,
-        account_data_len: u64,
-        vote_cost: u64,
-    ) -> Result<(), CostTrackerError> {
         // check against the total package cost
         if self.block_cost.saturating_add(cost) > self.block_cost_limit {
             return Err(CostTrackerError::WouldExceedBlockMaxLimit);
@@ -211,7 +171,9 @@ impl CostTracker {
 
         // NOTE: Check if the total accounts data size is exceeded *before* the block accounts data
         // size.  This way, transactions are not unnecessarily retried.
-        let account_data_size = self.account_data_size.saturating_add(account_data_len);
+        let account_data_size = self
+            .account_data_size
+            .saturating_add(tx_cost.account_data_size);
         if let Some(account_data_size_limit) = self.account_data_size_limit {
             if account_data_size > account_data_size_limit {
                 return Err(CostTrackerError::WouldExceedAccountDataTotalLimit);
@@ -223,7 +185,7 @@ impl CostTracker {
         }
 
         // check each account against account_cost_limit,
-        for account_key in keys.iter() {
+        for account_key in writable_accounts.iter() {
             match self.cost_by_writable_accounts.get(account_key) {
                 Some(chained_cost) => {
                     if chained_cost.saturating_add(cost) > self.account_cost_limit {
@@ -239,7 +201,7 @@ impl CostTracker {
         Ok(())
     }
 
-    fn add_transaction(&mut self, tx_cost: &TransactionCost) {
+    fn add_transaction_cost(&mut self, tx_cost: &TransactionCost) {
         let cost = tx_cost.sum();
         for account_key in tx_cost.writable_accounts.iter() {
             let account_cost = self
@@ -256,6 +218,25 @@ impl CostTracker {
             .account_data_size
             .saturating_add(tx_cost.account_data_size);
         self.transaction_count = self.transaction_count.saturating_add(1);
+    }
+
+    fn remove_transaction_cost(&mut self, tx_cost: &TransactionCost) {
+        let cost = tx_cost.sum();
+        for account_key in tx_cost.writable_accounts.iter() {
+            let account_cost = self
+                .cost_by_writable_accounts
+                .entry(*account_key)
+                .or_insert(0);
+            *account_cost = account_cost.saturating_sub(cost);
+        }
+        self.block_cost = self.block_cost.saturating_sub(cost);
+        if tx_cost.is_simple_vote {
+            self.vote_cost = self.vote_cost.saturating_sub(cost);
+        }
+        self.account_data_size = self
+            .account_data_size
+            .saturating_sub(tx_cost.account_data_size);
+        self.transaction_count = self.transaction_count.saturating_sub(1);
     }
 }
 


### PR DESCRIPTION
#### Problem

#23030. The cost tracker values get adjusted for transactions that don't get executed and may be retried.

#### Summary of Changes

Previously tx that need to be retried (like due to AccountInUse) affected the CostTracker. Meaning that their cost would be added again when the tx was retried.

Now, retryable accounts have their costs removed from the CostTracker again.

This is a draft because I still want to measure the performance impact and add a test.

I also tried to make the patch easy to backport. It may be worthwhile to adjust the way the locking and cost model interact entirely. Or even use the real-cu in the cost tracker instead of estimated-cu.

Fixes #23030
