### PR TITLE
Move duplicate-block proposal

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -179,6 +179,7 @@ module.exports = {
           "proposals/block-confirmation",
           "proposals/cluster-test-framework",
           "proposals/embedding-move",
+          "proposals/handle-duplicate-block",
           "proposals/interchain-transaction-verification",
           "proposals/ledger-replication-to-implement",
           "proposals/optimistic-confirmation-and-slashing",

--- a/docs/src/proposals/handle-duplicate-block.md
+++ b/docs/src/proposals/handle-duplicate-block.md
@@ -1,3 +1,7 @@
+---
+title: Handle Duplicate Block
+---
+
 # Leader Duplicate Block Slashing
 
 This design describes how the cluster slashes leaders that produce duplicate


### PR DESCRIPTION
#### Problem
Duplicate-block proposal is still in the `book` directory, probably because a docs reorg happened while that proposal was still in PR.

#### Summary of Changes
Move it
@carllin , should this be in the `implemented` section?
