### PR TITLE
foreground_requests_resources allows bg threads to sleep

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -4,6 +4,7 @@ use {
         ancestors::Ancestors,
         bucket_map_holder::{Age, BucketMapHolder},
         contains::Contains,
+        foreground_requests_resources::ForegroundRequestsResources,
         in_mem_accounts_index::{InMemAccountsIndex, InsertNewEntryResults},
         inline_spl_token::{self, GenericTokenAccount},
         inline_spl_token_2022,
@@ -695,6 +696,10 @@ impl<T: IndexValue> AccountsIndex<T> {
         }
     }
 
+    pub fn foreground_requests_resources(&self) -> &Arc<ForegroundRequestsResources> {
+        &self.storage.storage.foreground_requests_resources
+    }
+
     fn allocate_accounts_index(
         config: Option<AccountsIndexConfig>,
     ) -> (
@@ -708,7 +713,8 @@ impl<T: IndexValue> AccountsIndex<T> {
             .unwrap_or(BINS_DEFAULT);
         // create bin_calculator early to verify # bins is reasonable
         let bin_calculator = PubkeyBinCalculator24::new(bins);
-        let storage = AccountsIndexStorage::new(bins, &config);
+        let foreground_requests_resources = Arc::default();
+        let storage = AccountsIndexStorage::new(bins, &config, foreground_requests_resources);
         let account_maps = (0..bins)
             .into_iter()
             .map(|bin| RwLock::new(Arc::clone(&storage.in_mem[bin])))

--- a/runtime/src/accounts_index_storage.rs
+++ b/runtime/src/accounts_index_storage.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         accounts_index::{AccountsIndexConfig, IndexValue},
         bucket_map_holder::BucketMapHolder,
+        foreground_requests_resources::ForegroundRequestsResources,
         in_mem_accounts_index::InMemAccountsIndex,
         waitable_condvar::WaitableCondvar,
     },
@@ -143,13 +144,22 @@ impl<T: IndexValue> AccountsIndexStorage<T> {
     }
 
     /// allocate BucketMapHolder and InMemAccountsIndex[]
-    pub fn new(bins: usize, config: &Option<AccountsIndexConfig>) -> Self {
+    pub fn new(
+        bins: usize,
+        config: &Option<AccountsIndexConfig>,
+        foreground_requests_resources: Arc<ForegroundRequestsResources>,
+    ) -> Self {
         let threads = config
             .as_ref()
             .and_then(|config| config.flush_threads)
             .unwrap_or_else(Self::num_threads);
 
-        let storage = Arc::new(BucketMapHolder::new(bins, config, threads));
+        let storage = Arc::new(BucketMapHolder::new(
+            bins,
+            config,
+            threads,
+            foreground_requests_resources,
+        ));
 
         let in_mem = (0..bins)
             .into_iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1748,6 +1748,12 @@ impl Bank {
         let (_, update_epoch_time) = Measure::this(
             |_| {
                 if parent_epoch < new.epoch() {
+                    let _fg_requests_resources = parent
+                        .rc
+                        .accounts
+                        .accounts_db
+                        .foreground_requests_resources
+                        .activate();
                     let (thread_pool, thread_pool_time) = Measure::this(
                         |_| ThreadPoolBuilder::new().build().unwrap(),
                         (),

--- a/runtime/src/foreground_requests_resources.rs
+++ b/runtime/src/foreground_requests_resources.rs
@@ -1,0 +1,64 @@
+//! keep track of areas of the validator that are currently active
+use {
+    crate::waitable_condvar::WaitableCondvar,
+    std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct ForegroundRequestsResources {
+    /// # of calls to set_busy(true) - # of calls to set_busy(false)
+    busy_count: AtomicUsize,
+    /// mechanism for waiting and waking up
+    wait: Arc<WaitableCondvar>,
+}
+
+/// sole purpose is to handle 'drop' so that count is decremented when self is dropped
+pub struct ForegroundRequestsResourcesGuard<'a> {
+    requests: &'a ForegroundRequestsResources,
+}
+
+impl<'a> Drop for ForegroundRequestsResourcesGuard<'a> {
+    fn drop(&mut self) {
+        self.requests.set_busy(false);
+    }
+}
+
+impl ForegroundRequestsResources {
+    #[must_use]
+    /// inc the count and create a stack object to dec the count on drop
+    pub fn activate(&self) -> ForegroundRequestsResourcesGuard<'_> {
+        self.set_busy(true);
+        ForegroundRequestsResourcesGuard { requests: self }
+    }
+
+    /// true if busy_count > 0, indicating bg processes should sleep
+    pub fn get_busy(&self) -> bool {
+        self.busy_count.load(Ordering::Acquire) > 0
+    }
+
+    /// if fg requested resources, sleep a bit
+    /// could also sleep until request is satisfied
+    pub fn possibly_sleep(&self) {
+        if self.get_busy() {
+            self.wait.wait_timeout(Duration::from_millis(1));
+        }
+    }
+
+    /// specify that foreground is busy or not
+    fn set_busy(&self, busy: bool) {
+        if busy {
+            self.busy_count.fetch_add(1, Ordering::Release);
+        } else {
+            let result = self.busy_count.fetch_sub(1, Ordering::Release);
+            if result == 1 {
+                self.wait.notify_all();
+            }
+        }
+    }
+}

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1272,6 +1272,7 @@ mod tests {
             BINS_FOR_TESTING,
             &Some(AccountsIndexConfig::default()),
             1,
+            Arc::default(),
         ));
         let bin = 0;
         InMemAccountsIndex::new(&holder, bin)
@@ -1285,6 +1286,7 @@ mod tests {
                 ..AccountsIndexConfig::default()
             }),
             1,
+            Arc::default(),
         ));
         let bin = 0;
         let bucket = InMemAccountsIndex::new(&holder, bin);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,6 +31,7 @@ pub mod cost_tracker;
 pub mod epoch_stakes;
 pub mod execute_cost_table;
 mod expected_rent_collection;
+pub mod foreground_requests_resources;
 pub mod genesis_utils;
 pub mod hardened_unpack;
 pub mod in_mem_accounts_index;


### PR DESCRIPTION
#### Problem

There are times when the fg processes expect heavy use of resources. End of an epoch is an example. During those times, non-critical bg processes can easily sleep to cede resources (ram, i/o, cpu) to the demanding fg processes.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
