### PR TITLE
Reset onLogs subscriptions when websocket disconnects

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4154,6 +4154,9 @@ export class Connection {
     Object.values(this._accountChangeSubscriptions).forEach(
       s => (s.subscriptionId = null),
     );
+    Object.values(this._logsSubscriptions).forEach(
+      s => (s.subscriptionId = null),
+    );
     Object.values(this._programAccountChangeSubscriptions).forEach(
       s => (s.subscriptionId = null),
     );


### PR DESCRIPTION
Leaving these `subscriptionIds` intact makes the code _think_ that there are live subscriptions upon reconnect, when in fact there are not.

Clearing out these ids means that the subscriptions will be set up anew when the socket reconnects.

Fixes #24100.