### PR TITLE
Purge coding shreds earlier than other columns

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -36,9 +36,7 @@ use {
     },
     solana_ledger::{
         bank_forks_utils,
-        blockstore::{
-            Blockstore, BlockstoreError, BlockstoreSignals, CompletedSlotsReceiver, PurgeType,
-        },
+        blockstore::{Blockstore, BlockstoreError, BlockstoreSignals, CompletedSlotsReceiver},
         blockstore_db::{BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions},
         blockstore_processor::{self, TransactionStatusSender},
         leader_schedule::FixedSchedule,
@@ -1526,16 +1524,12 @@ fn backup_and_clear_blockstore(ledger_path: &Path, start_slot: Slot, shred_versi
         }
 
         let end_slot = last_slot.unwrap();
-        info!("Purging slots {} to {}", start_slot, end_slot);
+        info!(
+            "Purging and compacting slots {} to {}",
+            start_slot, end_slot
+        );
         blockstore.purge_from_next_slots(start_slot, end_slot);
-        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
-        info!("Purging done, compacting db..");
-        if let Err(e) = blockstore.compact_storage(start_slot, end_slot) {
-            warn!(
-                "Error from compacting storage from {} to {}: {:?}",
-                start_slot, end_slot, e
-            );
-        }
+        blockstore.purge_and_compact_slots(start_slot, end_slot);
         info!("done");
     }
     drop(blockstore);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -22,7 +22,7 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         bank_forks_utils,
-        blockstore::{create_new_ledger, Blockstore, PurgeType},
+        blockstore::{create_new_ledger, Blockstore, PurgeRanges, PurgeType},
         blockstore_db::{
             self, AccessType, BlockstoreOptions, BlockstoreRecoveryMode, Database,
             LedgerColumnOptions,
@@ -3167,7 +3167,10 @@ fn main() {
                 let purge_from_blockstore = |start_slot, end_slot| {
                     blockstore.purge_from_next_slots(start_slot, end_slot);
                     if no_compaction {
-                        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
+                        blockstore.purge_slots(
+                            PurgeRanges::all_columns(start_slot, end_slot),
+                            PurgeType::Exact,
+                        );
                     } else {
                         blockstore.purge_and_compact_slots(start_slot, end_slot);
                     }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -154,6 +154,7 @@ impl Index {
     pub(crate) fn data_mut(&mut self) -> &mut ShredIndex {
         &mut self.data
     }
+
     pub(crate) fn coding_mut(&mut self) -> &mut ShredIndex {
         &mut self.coding
     }
@@ -177,6 +178,10 @@ impl ShredIndex {
 
     pub(crate) fn insert(&mut self, index: u64) {
         self.index.insert(index);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.index.clear();
     }
 }
 

--- a/local-cluster/tests/common.rs
+++ b/local-cluster/tests/common.rs
@@ -11,7 +11,7 @@ use {
     solana_gossip::gossip_service::discover_cluster,
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
-        blockstore::{Blockstore, PurgeType},
+        blockstore::{Blockstore, PurgeRanges, PurgeType},
         blockstore_db::{AccessType, BlockstoreOptions},
         leader_schedule::{FixedSchedule, LeaderSchedule},
     },
@@ -86,7 +86,10 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
 
 pub fn purge_slots(blockstore: &Blockstore, start_slot: Slot, slot_count: Slot) {
     blockstore.purge_from_next_slots(start_slot, start_slot + slot_count);
-    blockstore.purge_slots(start_slot, start_slot + slot_count, PurgeType::Exact);
+    blockstore.purge_slots(
+        PurgeRanges::all_columns(start_slot, start_slot + slot_count),
+        PurgeType::Exact,
+    );
 }
 
 // Fetches the last vote in the tower, blocking until it has also appeared in blockstore.


### PR DESCRIPTION
#### Problem
Coding shreds are not needed after a slot has been rooted, so clean them
up more aggressively than the other columns in LedgerCleanupService.

I'll post some metric graphs after more runtime, but by purging coding shreds earlier, we reclaim that disk space prior to the 24 hour background compaction window. We may actually reclaim the space MUCH sooner, as the SST file moves down levels in the LSM tree

Fixes #23248 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
