### PR TITLE
Add resolver = 2 to fix Windows build error on Travis CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,6 @@ members = [
 exclude = [
     "programs/bpf",
 ]
+
+# This prevents a Travis CI error when building for Windows.
+resolver = "2"


### PR DESCRIPTION
Fixes #24092 

#### Problem
Travis CI's Windows build is failing:
```
error: failed to run custom build command for `openssl-sys v0.9.70`
Caused by:
  process didn't exit successfully: `C:\Users\travis\build\solana-labs\solana\target\release\build\openssl-sys-804e10fa12494634\build-script-main` (exit code: 101)
  --- stdout
  cargo:rustc-cfg=const_fn
  cargo:rerun-if-env-changed=X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR
  X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
  OPENSSL_NO_VENDOR unset
  running "perl" "./Configure" "--prefix=C:\\Users\\travis\\build\\solana-labs\\solana\\target\\release\\build\\openssl-sys-ff[987]()6ab091654e7\\out\\openssl-build\\install" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-legacy" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-capieng" "no-asm" "VC-WIN64A"
  --- stderr
  Can't locate Locale/Maketext/Simple.pm in @INC (you may need to install the Locale::Maketext::Simple module) (@INC contains: /c/Users/travis/build/solana-labs/solana/target/release/build/openssl-sys-ff9876ab091654e7/out/openssl-build/build/src/util/perl /usr/lib/perl5/site_perl /usr/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl /usr/share/perl5/core_perl /c/Users/travis/build/solana-labs/solana/target/release/build/openssl-sys-ff9876ab091654e7/out/openssl-build/build/src/external/perl/Text-Template-1.56/lib) at /usr/share/perl5/core_perl/Params/Check.pm line 6.
  BEGIN failed--compilation aborted at /usr/share/perl5/core_perl/Params/Check.pm line 6.
  Compilation failed in require at /usr/share/perl5/core_perl/IPC/Cmd.pm line 59.
  BEGIN failed--compilation aborted at /usr/share/perl5/core_perl/IPC/Cmd.pm line 59.
  Compilation failed in require at /c/Users/travis/build/solana-labs/solana/target/release/build/openssl-sys-ff9876ab091654e7/out/openssl-build/build/src/util/perl/OpenSSL/config.pm line 18.
  BEGIN failed--compilation aborted at /c/Users/travis/build/solana-labs/solana/target/release/build/openssl-sys-ff9876ab091654e7/out/openssl-build/build/src/util/perl/OpenSSL/config.pm line 18.
  Compilation failed in require at ./Configure line 23.
  BEGIN failed--compilation aborted at ./Configure line 23.
  thread 'main' panicked at '
  Error configuring OpenSSL build:
      Command: "perl" "./Configure" "--prefix=C:\\Users\\travis\\build\\solana-labs\\solana\\target\\release\\build\\openssl-sys-ff9876ab091654e7\\out\\openssl-build\\install" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-legacy" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-capieng" "no-asm" "VC-WIN64A"
      Exit status: exit code: 2
      ', C:\Users\travis\.cargo\registry\src\github.com-1ecc6299db9ec823\openssl-src-300.0.5+3.0.2\src\lib.rs:544:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
The command "ci/publish-tarball.sh" exited with 101.
error: build failed
```

The problem started with [d896ff74](https://github.com/solana-labs/solana/commit/d896ff74ec33ff92f08b2fee61d55fbcdac55dff). I haven't been able to reproduce the build error locally (my laptop can build Windows binaries). I've tried a few other solutions and haven't gotten anything to work. As far as I can tell this change is innocuous

#### Summary of Changes
Add resolver = "2" to manifest. 