### PR TITLE
List cmake as a package to install in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, etc
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang make
+$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make
 ```
 
 ## **2. Download the source code.**


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/24147 bumped `prost` dependency version; the new version requires `cmake`. Without it, I got the following error building from source

```
  running: "cmake" "/home/.../.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.10.0/third-party/protobuf/cmake" 
"-DCMAKE_INSTALL_PREFIX=/home/steven_solana_com/solana/target/release/build/prost-build-6551c412a1f344fc/out" 
"-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" 
"-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" 
"-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc"
"-DCMAKE_BUILD_TYPE=Debug"

  --- stderr
  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?
```