### PR TITLE
updates rewards at epoch boundary using cached accounts

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -65,7 +65,7 @@ mod tests {
             accounts_index::AccountSecondaryIndexes,
             bank::{Bank, BankSlotDelta},
             bank_forks::BankForks,
-            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
             snapshot_archive_info::FullSnapshotArchiveInfo,
             snapshot_config::SnapshotConfig,
             snapshot_package::{
@@ -124,7 +124,15 @@ mod tests {
             let accounts_dir = TempDir::new().unwrap();
             let bank_snapshots_dir = TempDir::new().unwrap();
             let snapshot_archives_dir = TempDir::new().unwrap();
-            let mut genesis_config_info = create_genesis_config(10_000);
+            // validator_stake_lamports should be non-zero otherwise stake
+            // account will not be stored in accounts-db but still cached in
+            // bank stakes which results in mismatch when banks are loaded from
+            // snapshots.
+            let mut genesis_config_info = create_genesis_config_with_leader(
+                10_000,                          // mint_lamports
+                &solana_sdk::pubkey::new_rand(), // validator_pubkey
+                1,                               // validator_stake_lamports
+            );
             genesis_config_info.genesis_config.cluster_type = cluster_type;
             let bank0 = Bank::new_with_paths_for_tests(
                 &genesis_config_info.genesis_config,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -61,7 +61,7 @@ use {
             calculate_stake_weighted_timestamp, MaxAllowableDrift, MAX_ALLOWABLE_DRIFT_PERCENTAGE,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW,
         },
-        stakes::{InvalidCacheEntryReason, Stakes, StakesCache},
+        stakes::{InvalidCacheEntryReason, Stakes, StakesCache, StakesEnum},
         status_cache::{SlotDelta, StatusCache},
         system_instruction_processor::{get_system_account_kind, SystemAccountKind},
         transaction_batch::TransactionBatch,
@@ -1499,8 +1499,7 @@ impl Bank {
         //  slot = 0 and genesis configuration
         {
             let stakes = bank.stakes_cache.stakes().clone();
-            let stakes = Stakes::<Delegation>::try_from(stakes).unwrap();
-            let stakes = Arc::new(stakes);
+            let stakes = Arc::new(StakesEnum::from(stakes));
             for epoch in 0..=bank.get_leader_schedule_epoch(bank.slot) {
                 bank.epoch_stakes
                     .insert(epoch, EpochStakes::new(stakes.clone(), epoch));
@@ -2404,8 +2403,8 @@ impl Bank {
                 epoch >= leader_schedule_epoch.saturating_sub(MAX_LEADER_SCHEDULE_STAKES)
             });
             let stakes = self.stakes_cache.stakes().clone();
-            let stakes = Stakes::<Delegation>::try_from(stakes).unwrap();
-            let new_epoch_stakes = EpochStakes::new(Arc::new(stakes), leader_schedule_epoch);
+            let stakes = Arc::new(StakesEnum::from(stakes));
+            let new_epoch_stakes = EpochStakes::new(stakes, leader_schedule_epoch);
             {
                 let vote_stakes: HashMap<_, _> = self
                     .stakes_cache

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1265,7 +1265,8 @@ pub struct Bank {
 struct VoteWithStakeDelegations {
     vote_state: Arc<VoteState>,
     vote_account: AccountSharedData,
-    delegations: Vec<(Pubkey, StakeAccount)>,
+    // TODO: use StakeAccount<Delegation> once the old code is deleted.
+    delegations: Vec<(Pubkey, StakeAccount<()>)>,
 }
 
 struct LoadVoteAndStakeAccountsResult {
@@ -2000,7 +2001,7 @@ impl Bank {
         // from Stakes<Delegation> by reading the full account state from
         // accounts-db. Note that it is crucial that these accounts are loaded
         // at the right slot and match precisely with serialized Delegations.
-        let stakes = Stakes::<StakeAccount>::new(&fields.stakes, |pubkey| {
+        let stakes = Stakes::new(&fields.stakes, |pubkey| {
             let (account, _slot) = bank_rc.accounts.load_with_fixed_root(&ancestors, pubkey)?;
             Some(account)
         })
@@ -2648,7 +2649,7 @@ impl Bank {
             stake_delegations
                 .into_par_iter()
                 .for_each(|(stake_pubkey, stake_account)| {
-                    let delegation = stake_account.delegation().unwrap();
+                    let delegation = stake_account.delegation();
                     let vote_pubkey = &delegation.voter_pubkey;
                     if invalid_vote_keys.contains_key(vote_pubkey) {
                         return;
@@ -2661,7 +2662,7 @@ impl Bank {
                             return;
                         }
                     };
-                    let stake_account = match StakeAccount::try_from(stake_account) {
+                    let stake_account = match StakeAccount::<()>::try_from(stake_account) {
                         Ok(stake_account) => stake_account,
                         Err(stake_account::Error::InvalidOwner { .. }) => {
                             invalid_stake_keys
@@ -2671,6 +2672,15 @@ impl Bank {
                         Err(stake_account::Error::InstructionError(_)) => {
                             invalid_stake_keys
                                 .insert(*stake_pubkey, InvalidCacheEntryReason::BadState);
+                            return;
+                        }
+                        Err(stake_account::Error::InvalidDelegation(_)) => {
+                            // This should not happen.
+                            error!(
+                                "Unexpected code path! StakeAccount<()> \
+                                should not check if stake-state is a \
+                                Delegation."
+                            );
                             return;
                         }
                     };
@@ -2761,7 +2771,7 @@ impl Bank {
                 .fold(
                     HashSet::default,
                     |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
-                        let delegation = stake_account.delegation().unwrap();
+                        let delegation = stake_account.delegation();
                         voter_pubkeys.insert(delegation.voter_pubkey);
                         voter_pubkeys
                     },
@@ -2823,8 +2833,8 @@ impl Bank {
                     .collect()
             });
         // Join stake accounts with vote-accounts.
-        let push_stake_delegation = |(stake_pubkey, stake_account): (&Pubkey, &StakeAccount)| {
-            let delegation = stake_account.delegation().unwrap();
+        let push_stake_delegation = |(stake_pubkey, stake_account): (&Pubkey, &StakeAccount<_>)| {
+            let delegation = stake_account.delegation();
             let mut vote_delegations =
                 match vote_with_stake_delegations_map.get_mut(&delegation.voter_pubkey) {
                     Some(vote_delegations) => vote_delegations,
@@ -2836,7 +2846,8 @@ impl Bank {
                 let event = RewardCalculationEvent::Staking(stake_pubkey, &delegation);
                 reward_calc_tracer(&event);
             }
-            let stake_delegation = (*stake_pubkey, stake_account.clone());
+            let stake_account = StakeAccount::from(stake_account.clone());
+            let stake_delegation = (*stake_pubkey, stake_account);
             vote_delegations.delegations.push(stake_delegation);
         };
         thread_pool.install(|| {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,7 @@
 use {
     crate::{stakes::Stakes, vote_account::VoteAccountsHashMap},
     serde::{Deserialize, Serialize},
-    solana_sdk::{clock::Epoch, pubkey::Pubkey},
+    solana_sdk::{clock::Epoch, pubkey::Pubkey, stake::state::Delegation},
     std::{collections::HashMap, sync::Arc},
 };
 
@@ -16,26 +16,26 @@ pub struct NodeVoteAccounts {
 
 #[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct EpochStakes {
-    stakes: Arc<Stakes>,
+    stakes: Arc<Stakes<Delegation>>,
     total_stake: u64,
     node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
     epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
 }
 
 impl EpochStakes {
-    pub fn new(stakes: &Stakes, leader_schedule_epoch: Epoch) -> Self {
+    pub(crate) fn new(stakes: Arc<Stakes<Delegation>>, leader_schedule_epoch: Epoch) -> Self {
         let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
             Self::parse_epoch_vote_accounts(epoch_vote_accounts.as_ref(), leader_schedule_epoch);
         Self {
-            stakes: Arc::new(stakes.clone()),
+            stakes,
             total_stake,
             node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
             epoch_authorized_voters: Arc::new(epoch_authorized_voters),
         }
     }
 
-    pub fn stakes(&self) -> &Stakes {
+    pub fn stakes(&self) -> &Stakes<Delegation> {
         &self.stakes
     }
 

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,7 @@
 use {
-    crate::{stakes::Stakes, vote_account::VoteAccountsHashMap},
+    crate::{stakes::StakesEnum, vote_account::VoteAccountsHashMap},
     serde::{Deserialize, Serialize},
-    solana_sdk::{clock::Epoch, pubkey::Pubkey, stake::state::Delegation},
+    solana_sdk::{clock::Epoch, pubkey::Pubkey},
     std::{collections::HashMap, sync::Arc},
 };
 
@@ -16,14 +16,15 @@ pub struct NodeVoteAccounts {
 
 #[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct EpochStakes {
-    stakes: Arc<Stakes<Delegation>>,
+    #[serde(with = "crate::stakes::serde_stakes_enum_compat")]
+    stakes: Arc<StakesEnum>,
     total_stake: u64,
     node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
     epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
 }
 
 impl EpochStakes {
-    pub(crate) fn new(stakes: Arc<Stakes<Delegation>>, leader_schedule_epoch: Epoch) -> Self {
+    pub(crate) fn new(stakes: Arc<StakesEnum>, leader_schedule_epoch: Epoch) -> Self {
         let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
             Self::parse_epoch_vote_accounts(epoch_vote_accounts.as_ref(), leader_schedule_epoch);
@@ -35,7 +36,7 @@ impl EpochStakes {
         }
     }
 
-    pub fn stakes(&self) -> &Stakes<Delegation> {
+    pub fn stakes(&self) -> &StakesEnum {
         &self.stakes
     }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -75,7 +75,15 @@ pub struct GenesisConfigInfo {
 }
 
 pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
-    create_genesis_config_with_leader(mint_lamports, &solana_sdk::pubkey::new_rand(), 0)
+    // Note that zero lamports for validator stake will result in stake account
+    // not being stored in accounts-db but still cached in bank stakes. This
+    // causes discrepancy between cached stakes accounts in bank and
+    // accounts-db which in particular will break snapshots test.
+    create_genesis_config_with_leader(
+        mint_lamports,
+        &solana_sdk::pubkey::new_rand(), // validator_pubkey
+        0,                               // validator_stake_lamports
+    )
 }
 
 pub fn create_genesis_config_with_vote_accounts(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,6 +59,7 @@ pub mod snapshot_hash;
 pub mod snapshot_package;
 pub mod snapshot_utils;
 pub mod sorted_storages;
+mod stake_account;
 pub mod stake_history;
 pub mod stake_weighted_timestamp;
 pub mod stakes;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -367,7 +367,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "DnT7iwf29YvGxLTt2iLYPmixwP13LXvusVVKpXGgizhc")]
+    #[frozen_abi(digest = "2RqbikYfG4rXV8gtqsKCNSn6g4g6nfkegXDRe1G6RGFQ")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -367,7 +367,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "2RqbikYfG4rXV8gtqsKCNSn6g4g6nfkegXDRe1G6RGFQ")]
+    #[frozen_abi(digest = "HT9yewU4zJ6ZAgJ7aDSbHPtzZGZqASpq6rkq6ET42Kki")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -16,7 +16,7 @@ use {
 /// Generic type T enforces type-saftey so that StakeAccount<Delegation> can
 /// only wrap a stake-state which is a Delegation; whereas StakeAccount<()>
 /// wraps any account with stake state.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 pub struct StakeAccount<T> {
     account: AccountSharedData,
     stake_state: StakeState,
@@ -102,6 +102,17 @@ impl<T> From<StakeAccount<T>> for (AccountSharedData, StakeState) {
     #[inline]
     fn from(stake_account: StakeAccount<T>) -> Self {
         (stake_account.account, stake_account.stake_state)
+    }
+}
+
+impl<S, T> PartialEq<StakeAccount<S>> for StakeAccount<T> {
+    fn eq(&self, other: &StakeAccount<S>) -> bool {
+        let StakeAccount {
+            account,
+            stake_state,
+            _phantom,
+        } = other;
+        account == &self.account && stake_state == &self.stake_state
     }
 }
 

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -13,10 +13,10 @@ use {
 
 /// An account and a stake state deserialized from the account.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub(crate) struct StakeAccount(AccountSharedData, StakeState);
+pub struct StakeAccount(AccountSharedData, StakeState);
 
 #[derive(Debug, Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error(transparent)]
     InstructionError(#[from] InstructionError),
     #[error("Invalid stake account owner: {owner:?}")]

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,0 +1,48 @@
+use {
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        account_utils::StateMut,
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        stake::state::StakeState,
+    },
+    thiserror::Error,
+};
+
+/// An account and a stake state deserialized from the account.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct StakeAccount(AccountSharedData, StakeState);
+
+#[derive(Debug, Error)]
+pub(crate) enum Error {
+    #[error(transparent)]
+    InstructionError(#[from] InstructionError),
+    #[error("Invalid stake account owner: {owner:?}")]
+    InvalidOwner { owner: Pubkey },
+}
+
+impl StakeAccount {
+    #[inline]
+    pub(crate) fn stake_state(&self) -> &StakeState {
+        &self.1
+    }
+}
+
+impl TryFrom<AccountSharedData> for StakeAccount {
+    type Error = Error;
+    fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
+        if account.owner() != &solana_stake_program::id() {
+            return Err(Error::InvalidOwner {
+                owner: *account.owner(),
+            });
+        }
+        let stake_state = account.state()?;
+        Ok(Self(account, stake_state))
+    }
+}
+
+impl From<StakeAccount> for (AccountSharedData, StakeState) {
+    fn from(stake_account: StakeAccount) -> Self {
+        (stake_account.0, stake_account.1)
+    }
+}

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -56,6 +56,10 @@ impl StakesCache {
     }
 
     pub fn check_and_store(&self, pubkey: &Pubkey, account: &AccountSharedData) {
+        // TODO: If the account is already cached as a vote or stake account
+        // but the owner changes, then this needs to evict the account from
+        // the cache. see:
+        // https://github.com/solana-labs/solana/pull/24200#discussion_r849935444
         if solana_vote_program::check_id(account.owner()) {
             let new_vote_account = if account.lamports() != 0
                 && VoteState::is_correct_size_and_initialized(account.data())

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -196,6 +196,12 @@ impl From<AccountSharedData> for VoteAccount {
     }
 }
 
+impl From<VoteAccount> for AccountSharedData {
+    fn from(account: VoteAccount) -> Self {
+        Self::from(account.0.account.clone())
+    }
+}
+
 impl From<Account> for VoteAccount {
     fn from(account: Account) -> Self {
         Self(Arc::new(VoteAccountInner::from(account)))

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -56,6 +56,10 @@ impl VoteAccount {
         self.0.account.lamports()
     }
 
+    pub(crate) fn owner(&self) -> &Pubkey {
+        self.0.account.owner()
+    }
+
     pub fn vote_state(&self) -> RwLockReadGuard<Result<VoteState, InstructionError>> {
         let inner = &self.0;
         inner.vote_state_once.call_once(|| {

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -80,6 +80,10 @@ impl VoteAccount {
 }
 
 impl VoteAccounts {
+    pub(crate) fn len(&self) -> usize {
+        self.vote_accounts.len()
+    }
+
     pub fn staked_nodes(&self) -> Arc<HashMap<Pubkey, u64>> {
         self.staked_nodes_once.call_once(|| {
             let staked_nodes = self
@@ -235,6 +239,23 @@ impl Default for VoteAccountInner {
 impl PartialEq<VoteAccountInner> for VoteAccountInner {
     fn eq(&self, other: &Self) -> bool {
         self.account == other.account
+    }
+}
+
+impl PartialEq<AccountSharedData> for VoteAccount {
+    fn eq(&self, other: &AccountSharedData) -> bool {
+        let Account {
+            lamports,
+            data,
+            owner,
+            executable,
+            rent_epoch,
+        } = &self.0.account;
+        other.lamports() == *lamports
+            && other.executable() == *executable
+            && other.rent_epoch() == *rent_epoch
+            && other.owner() == owner
+            && other.data() == data
     }
 }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -359,6 +359,10 @@ pub mod fix_recent_blockhashes {
     solana_sdk::declare_id!("6iyggb5MTcsvdcugX7bEKbHV8c6jdLbpHwkncrgLMhfo");
 }
 
+pub mod update_rewards_from_cached_accounts {
+    solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -443,6 +447,7 @@ lazy_static! {
         (drop_redundant_turbine_path::id(), "drop redundant turbine path"),
         (executables_incur_cpi_data_cost::id(), "Executables incure CPI data costs"),
         (fix_recent_blockhashes::id(), "stop adding hashes for skipped slots to recent blockhashes"),
+        (update_rewards_from_cached_accounts::id(), "update rewards from cached accounts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Updating rewards at epoch boundary is slow; and Loading vote and stake accounts from accounts-db takes a significant portion of that computation time.

#### Summary of Changes
* This change bypasses accounts-db on the read path and instead uses vote and stake accounts cached in bank stakes:
https://github.com/solana-labs/solana/blob/d2702201c/runtime/src/stakes.rs#L148-L152
* These cached accounts are synchronized with accounts-db after each transaction, and so there should not be any change in the resulting computation:
https://github.com/solana-labs/solana/blob/d2702201c/runtime/src/bank.rs#L4526
Nevertheless, to avoid any chances of introducing a consensus issue, the switch to cached account is feature gated.
* In order to maintain backward compatibility, values in `stake_delegations` map in `Stakes` struct are now generic. `Stakes<Delegation>` is equivalent to the old code and is used for backward compatibility in `BankFieldsTo{Serialize,Deserialize}`.
* But banks cache `Stakes<StakeAccount>` which includes the entire stake account and `StakeState` deserialized from the account. Doing so, will remove the need to load the stake account from accounts-db when working with stake-delegations.
* The change shows ~30% improvement in `update_rewards_with_thread_pool_us` metric.

Feature Gate Issue: https://github.com/solana-labs/solana/issues/24278