### PR TITLE
make ledger-tool arg help consistent

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -880,7 +880,7 @@ fn main() {
 
     let starting_slot_arg = Arg::with_name("starting_slot")
         .long("starting-slot")
-        .value_name("NUM")
+        .value_name("SLOT")
         .takes_value(true)
         .default_value("0")
         .help("Start at this slot");
@@ -1119,7 +1119,7 @@ fn main() {
             .arg(
                 Arg::with_name("target_db")
                     .long("target-db")
-                    .value_name("PATH")
+                    .value_name("DIR")
                     .takes_value(true)
                     .help("Target db"),
             )


### PR DESCRIPTION
#### Problem

This is not ideal:
```
USAGE:
    solana-ledger-tool copy --ending-slot <SLOT> --ledger <DIR> --starting-slot <NUM> --target-db <PATH>

with this PR:
    solana-ledger-tool copy --ending-slot <SLOT> --ledger <DIR> --starting-slot <SLOT> --target-db <DIR>

```
SLOT vs NUM
DIR vs PATH
#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
