### PR TITLE
changed the name get_average_units() to get_global_average_units

### DIFF
--- a/runtime/src/execute_cost_table.rs
+++ b/runtime/src/execute_cost_table.rs
@@ -50,7 +50,7 @@ impl ExecuteCostTable {
     }
 
     /// average cost of all recorded programs
-    pub fn get_average_units(&self) -> u64 {
+    pub fn get_global_average_units(&self) -> u64 {
         if self.table.is_empty() {
             self.get_default_units()
         } else {
@@ -75,7 +75,7 @@ impl ExecuteCostTable {
     }
 
     /// returns None if program doesn't exist in table. In this case,
-    /// `get_default_units()`, `get_average_units()` or `get_statistical_mode_units()`
+    /// `get_default_units()`, `get_global_average_units()` or `get_statistical_mode_units()`
     /// can be used to assign a value to new program.
     pub fn get_cost(&self, key: &Pubkey) -> Option<&u64> {
         self.table.get(key)
@@ -225,14 +225,14 @@ mod tests {
         // insert one record
         testee.upsert(&key1, cost1);
         assert_eq!(1, testee.get_count());
-        assert_eq!(cost1, testee.get_average_units());
+        assert_eq!(cost1, testee.get_global_average_units());
         assert_eq!(cost1, testee.get_statistical_mode_units());
         assert_eq!(&cost1, testee.get_cost(&key1).unwrap());
 
         // insert 2nd record
         testee.upsert(&key2, cost2);
         assert_eq!(2, testee.get_count());
-        assert_eq!((cost1 + cost2) / 2_u64, testee.get_average_units());
+        assert_eq!((cost1 + cost2) / 2_u64, testee.get_global_average_units());
         assert_eq!(cost2, testee.get_statistical_mode_units());
         assert_eq!(&cost1, testee.get_cost(&key1).unwrap());
         assert_eq!(&cost2, testee.get_cost(&key2).unwrap());
@@ -242,7 +242,7 @@ mod tests {
         assert_eq!(2, testee.get_count());
         assert_eq!(
             ((cost1 + cost2) / 2 + cost2) / 2_u64,
-            testee.get_average_units()
+            testee.get_global_average_units()
         );
         assert_eq!((cost1 + cost2) / 2, testee.get_statistical_mode_units());
         assert_eq!(&((cost1 + cost2) / 2), testee.get_cost(&key1).unwrap());
@@ -278,7 +278,7 @@ mod tests {
         // insert 3rd record, pushes out the oldest (eg 1st) record
         testee.upsert(&key3, cost3);
         assert_eq!(2, testee.get_count());
-        assert_eq!((cost2 + cost3) / 2_u64, testee.get_average_units());
+        assert_eq!((cost2 + cost3) / 2_u64, testee.get_global_average_units());
         assert_eq!(cost3, testee.get_statistical_mode_units());
         assert!(testee.get_cost(&key1).is_none());
         assert_eq!(&cost2, testee.get_cost(&key2).unwrap());
@@ -290,7 +290,7 @@ mod tests {
         testee.upsert(&key4, cost4);
         assert_eq!(
             ((cost1 + cost2) / 2 + cost4) / 2_u64,
-            testee.get_average_units()
+            testee.get_global_average_units()
         );
         assert_eq!((cost1 + cost2) / 2, testee.get_statistical_mode_units());
         assert_eq!(2, testee.get_count());


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/24015#issue-1187074897
Solved the issue first PR here

#### Summary of Changes
function get_average_units() defined [here](https://github.com/solana-labs/solana/blob/master/runtime/src/execute_cost_table.rs#L52) is to get average of all recorded programs. I Renamed to get_global_average_units().

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
