### PR TITLE
Remove `KeyedAccount` in builtin program "stake"

### DIFF
--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -12,11 +12,12 @@ use {
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         genesis_config::GenesisConfig,
         stake::config::{self, Config},
+        transaction_context::BorrowedAccount,
     },
 };
 
-pub fn from<T: ReadableAccount>(account: &T) -> Option<Config> {
-    get_config_data(account.data())
+pub fn from(account: &BorrowedAccount) -> Option<Config> {
+    get_config_data(account.get_data())
         .ok()
         .and_then(|data| deserialize(data).ok())
 }
@@ -34,15 +35,4 @@ pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
     genesis_config.add_account(config::id(), account);
 
     lamports
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, std::cell::RefCell};
-
-    #[test]
-    fn test() {
-        let account = RefCell::new(create_account(0, &Config::default()));
-        assert_eq!(from(&account.borrow()), Some(Config::default()));
-    }
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -161,12 +161,11 @@ pub fn process_instruction(
             )?;
             instruction_context.check_number_of_instruction_accounts(5)?;
             let config_account =
-                keyed_account_at_index(keyed_accounts, first_instruction_account + 4)?;
-            if !config::check_id(config_account.unsigned_key()) {
+                instruction_context.try_borrow_instruction_account(transaction_context, 4)?;
+            if !config::check_id(config_account.get_key()) {
                 return Err(InstructionError::InvalidArgument);
             }
-            let config = config::from(&*config_account.try_account_ref()?)
-                .ok_or(InstructionError::InvalidArgument)?;
+            let config = config::from(&config_account).ok_or(InstructionError::InvalidArgument)?;
             delegate(
                 invoke_context,
                 first_instruction_account,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -12,13 +12,12 @@ use {
     solana_program_runtime::{ic_msg, invoke_context::InvokeContext},
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
-        account_utils::{State, StateMut},
+        account_utils::StateMut,
         clock::{Clock, Epoch},
         feature_set::{
             stake_merge_with_unmatched_credits_observed, stake_split_uses_rent_sysvar, FeatureSet,
         },
         instruction::{checked_add, InstructionError},
-        keyed_account::{keyed_account_at_index, KeyedAccount},
         pubkey::Pubkey,
         rent::{Rent, ACCOUNT_STORAGE_OVERHEAD},
         stake::{
@@ -27,7 +26,7 @@ use {
             program::id,
         },
         stake_history::{StakeHistory, StakeHistoryEntry},
-        transaction_context::{InstructionContext, TransactionContext},
+        transaction_context::{BorrowedAccount, InstructionContext, TransactionContext},
     },
     solana_vote_program::vote_state::{VoteState, VoteStateVersions},
     std::{collections::HashSet, convert::TryFrom},
@@ -367,21 +366,21 @@ fn calculate_stake_rewards(
 }
 
 pub fn initialize(
-    stake_account: &KeyedAccount,
+    stake_account: &mut BorrowedAccount,
     authorized: &Authorized,
     lockup: &Lockup,
     rent: &Rent,
     feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
-    if stake_account.data_len()? != std::mem::size_of::<StakeState>() {
+    if stake_account.get_data().len() != std::mem::size_of::<StakeState>() {
         return Err(InstructionError::InvalidAccountData);
     }
-    if let StakeState::Uninitialized = stake_account.state()? {
-        let rent_exempt_reserve = rent.minimum_balance(stake_account.data_len()?);
+    if let StakeState::Uninitialized = stake_account.get_state()? {
+        let rent_exempt_reserve = rent.minimum_balance(stake_account.get_data().len());
         let minimum_delegation = crate::get_minimum_delegation(feature_set);
         let minimum_balance = rent_exempt_reserve + minimum_delegation;
 
-        if stake_account.lamports()? >= minimum_balance {
+        if stake_account.get_lamports() >= minimum_balance {
             stake_account.set_state(&StakeState::Initialized(Meta {
                 rent_exempt_reserve,
                 authorized: *authorized,
@@ -399,7 +398,7 @@ pub fn initialize(
 /// multiple times, but will implicitly withdraw authorization from the previously authorized
 /// staker. The default staker is the owner of the stake account's pubkey.
 pub fn authorize(
-    stake_account: &KeyedAccount,
+    stake_account: &mut BorrowedAccount,
     signers: &HashSet<Pubkey>,
     new_authority: &Pubkey,
     stake_authorize: StakeAuthorize,
@@ -407,7 +406,7 @@ pub fn authorize(
     clock: &Clock,
     custodian: Option<&Pubkey>,
 ) -> Result<(), InstructionError> {
-    match stake_account.state()? {
+    match stake_account.get_state()? {
         StakeState::Stake(mut meta, stake) => {
             meta.authorized.authorize(
                 signers,
@@ -438,10 +437,11 @@ pub fn authorize(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn authorize_with_seed(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-    stake_account: &KeyedAccount,
+    stake_account: &mut BorrowedAccount,
     authority_base_index: usize,
     authority_seed: &str,
     authority_owner: &Pubkey,
@@ -474,7 +474,8 @@ pub fn authorize_with_seed(
 }
 
 pub fn delegate(
-    invoke_context: &InvokeContext,
+    transaction_context: &TransactionContext,
+    instruction_context: &InstructionContext,
     stake_account_index: usize,
     vote_account_index: usize,
     clock: &Clock,
@@ -482,24 +483,25 @@ pub fn delegate(
     config: &Config,
     signers: &HashSet<Pubkey>,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
-    let vote_account = keyed_account_at_index(keyed_accounts, vote_account_index)?;
-    if vote_account.owner()? != solana_vote_program::id() {
+    let vote_account =
+        instruction_context.try_borrow_account(transaction_context, vote_account_index)?;
+    if *vote_account.get_owner() != solana_vote_program::id() {
         return Err(InstructionError::IncorrectProgramId);
     }
-    let vote_pubkey = vote_account.unsigned_key();
-    let vote_state = State::<VoteStateVersions>::state(vote_account);
+    let vote_pubkey = *vote_account.get_key();
+    let vote_state = vote_account.get_state::<VoteStateVersions>();
     drop(vote_account);
 
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
-    match stake_account.state()? {
+    let mut stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
+    match stake_account.get_state()? {
         StakeState::Initialized(meta) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let ValidatedDelegatedInfo { stake_amount } =
-                validate_delegated_amount(stake_account, &meta)?;
+                validate_delegated_amount(&stake_account, &meta)?;
             let stake = new_stake(
                 stake_amount,
-                vote_pubkey,
+                &vote_pubkey,
                 &vote_state?.convert_to_current(),
                 clock.epoch,
                 config,
@@ -509,11 +511,11 @@ pub fn delegate(
         StakeState::Stake(meta, mut stake) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let ValidatedDelegatedInfo { stake_amount } =
-                validate_delegated_amount(stake_account, &meta)?;
+                validate_delegated_amount(&stake_account, &meta)?;
             redelegate(
                 &mut stake,
                 stake_amount,
-                vote_pubkey,
+                &vote_pubkey,
                 &vote_state?.convert_to_current(),
                 clock,
                 stake_history,
@@ -526,11 +528,11 @@ pub fn delegate(
 }
 
 pub fn deactivate(
-    stake_account: &KeyedAccount,
+    stake_account: &mut BorrowedAccount,
     clock: &Clock,
     signers: &HashSet<Pubkey>,
 ) -> Result<(), InstructionError> {
-    if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
+    if let StakeState::Stake(meta, mut stake) = stake_account.get_state()? {
         meta.authorized.check(signers, StakeAuthorize::Staker)?;
         stake.deactivate(clock.epoch)?;
 
@@ -541,12 +543,12 @@ pub fn deactivate(
 }
 
 pub fn set_lockup(
-    stake_account: &KeyedAccount,
+    stake_account: &mut BorrowedAccount,
     lockup: &LockupArgs,
     signers: &HashSet<Pubkey>,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    match stake_account.state()? {
+    match stake_account.get_state()? {
         StakeState::Initialized(mut meta) => {
             meta.set_lockup(lockup, signers, clock)?;
             stake_account.set_state(&StakeState::Initialized(meta))
@@ -568,24 +570,24 @@ pub fn split(
     split_index: usize,
     signers: &HashSet<Pubkey>,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
-    let split = keyed_account_at_index(keyed_accounts, split_index)?;
-    if split.owner()? != id() {
+    let split = instruction_context.try_borrow_account(transaction_context, split_index)?;
+    if *split.get_owner() != id() {
         return Err(InstructionError::IncorrectProgramId);
     }
-    if split.data_len()? != std::mem::size_of::<StakeState>() {
+    if split.get_data().len() != std::mem::size_of::<StakeState>() {
         return Err(InstructionError::InvalidAccountData);
     }
-    if !matches!(split.state()?, StakeState::Uninitialized) {
+    if !matches!(split.get_state()?, StakeState::Uninitialized) {
         return Err(InstructionError::InvalidAccountData);
     }
-    let split_lamport_balance = split.lamports()?;
+    let split_lamport_balance = split.get_lamports();
     drop(split);
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
-    if lamports > stake_account.lamports()? {
+    let stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
+    if lamports > stake_account.get_lamports() {
         return Err(InstructionError::InsufficientFunds);
     }
-    let stake_state = stake_account.state()?;
+    let stake_state = stake_account.get_state()?;
     drop(stake_account);
 
     match stake_state {
@@ -593,6 +595,8 @@ pub fn split(
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let validated_split_info = validate_split_amount(
                 invoke_context,
+                transaction_context,
+                instruction_context,
                 stake_account_index,
                 split_index,
                 lamports,
@@ -635,16 +639,20 @@ pub fn split(
             let mut split_meta = meta;
             split_meta.rent_exempt_reserve = validated_split_info.destination_rent_exempt_reserve;
 
-            let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
+            let mut stake_account =
+                instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
             stake_account.set_state(&StakeState::Stake(meta, stake))?;
             drop(stake_account);
-            let split = keyed_account_at_index(keyed_accounts, split_index)?;
+            let mut split =
+                instruction_context.try_borrow_account(transaction_context, split_index)?;
             split.set_state(&StakeState::Stake(split_meta, split_stake))?;
         }
         StakeState::Initialized(meta) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
             let validated_split_info = validate_split_amount(
                 invoke_context,
+                transaction_context,
+                instruction_context,
                 stake_account_index,
                 split_index,
                 lamports,
@@ -653,7 +661,8 @@ pub fn split(
             )?;
             let mut split_meta = meta;
             split_meta.rent_exempt_reserve = validated_split_info.destination_rent_exempt_reserve;
-            let split = keyed_account_at_index(keyed_accounts, split_index)?;
+            let mut split =
+                instruction_context.try_borrow_account(transaction_context, split_index)?;
             split.set_state(&StakeState::Initialized(split_meta))?;
         }
         StakeState::Uninitialized => {
@@ -668,27 +677,25 @@ pub fn split(
     }
 
     // Deinitialize state upon zero balance
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
-    if lamports == stake_account.lamports()? {
+    let mut stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
+    if lamports == stake_account.get_lamports() {
         stake_account.set_state(&StakeState::Uninitialized)?;
     }
     drop(stake_account);
 
-    let split = keyed_account_at_index(keyed_accounts, split_index)?;
-    split
-        .try_account_ref_mut()?
-        .checked_add_lamports(lamports)?;
+    let mut split = instruction_context.try_borrow_account(transaction_context, split_index)?;
+    split.checked_add_lamports(lamports)?;
     drop(split);
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
-    stake_account
-        .try_account_ref_mut()?
-        .checked_sub_lamports(lamports)?;
+    let mut stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
+    stake_account.checked_sub_lamports(lamports)?;
     Ok(())
 }
 
 pub fn merge(
     invoke_context: &InvokeContext,
-    _transaction_context: &TransactionContext,
+    transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stake_account_index: usize,
     source_account_index: usize,
@@ -696,10 +703,10 @@ pub fn merge(
     stake_history: &StakeHistory,
     signers: &HashSet<Pubkey>,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
-    let source_account = keyed_account_at_index(keyed_accounts, source_account_index)?;
+    let mut source_account =
+        instruction_context.try_borrow_account(transaction_context, source_account_index)?;
     // Ensure source isn't spoofed
-    if source_account.owner()? != id() {
+    if *source_account.get_owner() != id() {
         return Err(InstructionError::IncorrectProgramId);
     }
     // Close the stake_account-reference loophole
@@ -708,13 +715,14 @@ pub fn merge(
     {
         return Err(InstructionError::InvalidArgument);
     }
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
+    let mut stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
 
     ic_msg!(invoke_context, "Checking if destination stake is mergeable");
     let stake_merge_kind = MergeKind::get_if_mergeable(
         invoke_context,
-        &stake_account.state()?,
-        stake_account.lamports()?,
+        &stake_account.get_state()?,
+        stake_account.get_lamports(),
         clock,
         stake_history,
     )?;
@@ -728,8 +736,8 @@ pub fn merge(
     ic_msg!(invoke_context, "Checking if source stake is mergeable");
     let source_merge_kind = MergeKind::get_if_mergeable(
         invoke_context,
-        &source_account.state()?,
-        source_account.lamports()?,
+        &source_account.get_state()?,
+        source_account.get_lamports(),
         clock,
         stake_history,
     )?;
@@ -743,18 +751,14 @@ pub fn merge(
     source_account.set_state(&StakeState::Uninitialized)?;
 
     // Drain the source stake account
-    let lamports = source_account.lamports()?;
-    source_account
-        .try_account_ref_mut()?
-        .checked_sub_lamports(lamports)?;
-    stake_account
-        .try_account_ref_mut()?
-        .checked_add_lamports(lamports)?;
+    let lamports = source_account.get_lamports();
+    source_account.checked_sub_lamports(lamports)?;
+    stake_account.checked_add_lamports(lamports)?;
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn withdraw(
-    invoke_context: &InvokeContext,
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     stake_account_index: usize,
@@ -766,7 +770,6 @@ pub fn withdraw(
     custodian_index: Option<usize>,
     feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let withdraw_authority_pubkey = transaction_context.get_key_of_account_at_index(
         instruction_context.get_index_in_transaction(withdraw_authority_index)?,
     )?;
@@ -776,8 +779,9 @@ pub fn withdraw(
     let mut signers = HashSet::new();
     signers.insert(*withdraw_authority_pubkey);
 
-    let stake_account = keyed_account_at_index(keyed_accounts, stake_account_index)?;
-    let (lockup, reserve, is_staked) = match stake_account.state()? {
+    let mut stake_account =
+        instruction_context.try_borrow_account(transaction_context, stake_account_index)?;
+    let (lockup, reserve, is_staked) = match stake_account.get_state()? {
         StakeState::Stake(meta, stake) => {
             meta.authorized
                 .check(&signers, StakeAuthorize::Withdrawer)?;
@@ -806,7 +810,7 @@ pub fn withdraw(
             (meta.lockup, reserve, false)
         }
         StakeState::Uninitialized => {
-            if !signers.contains(stake_account.unsigned_key()) {
+            if !signers.contains(stake_account.get_key()) {
                 return Err(InstructionError::MissingRequiredSignature);
             }
             (Lockup::default(), 0, false) // no lockup, no restrictions
@@ -834,29 +838,27 @@ pub fn withdraw(
     let lamports_and_reserve = checked_add(lamports, reserve)?;
     // if the stake is active, we mustn't allow the account to go away
     if is_staked // line coverage for branch coverage
-            && lamports_and_reserve > stake_account.lamports()?
+            && lamports_and_reserve > stake_account.get_lamports()
     {
         return Err(InstructionError::InsufficientFunds);
     }
 
-    if lamports != stake_account.lamports()? // not a full withdrawal
-            && lamports_and_reserve > stake_account.lamports()?
+    if lamports != stake_account.get_lamports() // not a full withdrawal
+            && lamports_and_reserve > stake_account.get_lamports()
     {
         assert!(!is_staked);
         return Err(InstructionError::InsufficientFunds);
     }
 
     // Deinitialize state upon zero balance
-    if lamports == stake_account.lamports()? {
+    if lamports == stake_account.get_lamports() {
         stake_account.set_state(&StakeState::Uninitialized)?;
     }
 
-    stake_account
-        .try_account_ref_mut()?
-        .checked_sub_lamports(lamports)?;
+    stake_account.checked_sub_lamports(lamports)?;
     drop(stake_account);
-    let to = keyed_account_at_index(keyed_accounts, to_index)?;
-    to.try_account_ref_mut()?.checked_add_lamports(lamports)?;
+    let mut to = instruction_context.try_borrow_account(transaction_context, to_index)?;
+    to.checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -869,10 +871,12 @@ struct ValidatedDelegatedInfo {
 /// Ensure the stake delegation amount is valid.  This checks that the account meets the minimum
 /// balance requirements of delegated stake.  If not, return an error.
 fn validate_delegated_amount(
-    account: &KeyedAccount,
+    account: &BorrowedAccount,
     meta: &Meta,
 ) -> Result<ValidatedDelegatedInfo, InstructionError> {
-    let stake_amount = account.lamports()?.saturating_sub(meta.rent_exempt_reserve); // can't stake the rent
+    let stake_amount = account
+        .get_lamports()
+        .saturating_sub(meta.rent_exempt_reserve); // can't stake the rent
     Ok(ValidatedDelegatedInfo { stake_amount })
 }
 
@@ -890,20 +894,23 @@ struct ValidatedSplitInfo {
 /// not, return an error.
 fn validate_split_amount(
     invoke_context: &InvokeContext,
+    transaction_context: &TransactionContext,
+    instruction_context: &InstructionContext,
     source_account_index: usize,
     destination_account_index: usize,
     lamports: u64,
     source_meta: &Meta,
     source_stake: Option<&Stake>,
 ) -> Result<ValidatedSplitInfo, InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
-    let source_account = keyed_account_at_index(keyed_accounts, source_account_index)?;
-    let source_lamports = source_account.lamports()?;
-    let source_data_len = source_account.data_len()?;
+    let source_account =
+        instruction_context.try_borrow_account(transaction_context, source_account_index)?;
+    let source_lamports = source_account.get_lamports();
+    let source_data_len = source_account.get_data().len();
     drop(source_account);
-    let destination_account = keyed_account_at_index(keyed_accounts, destination_account_index)?;
-    let destination_lamports = destination_account.lamports()?;
-    let destination_data_len = destination_account.data_len()?;
+    let destination_account =
+        instruction_context.try_borrow_account(transaction_context, destination_account_index)?;
+    let destination_lamports = destination_account.get_lamports();
+    let destination_data_len = destination_account.get_data().len();
     drop(destination_account);
 
     // Split amount has to be something


### PR DESCRIPTION
#### Problem
Builtin programs still use `KeyedAccount`.

#### Summary of Changes
- Replaces `KeyedAccount` by `BorrowedAccount`.
- Replaces `keyed_account.signer_key()` by `instruction_context.is_signer()`.
- Uses `transaction_context.get_key_of_account_at_index()` when only the key is needed.
-  Refactors stake::config::from to use `BorrowedAccount` instead of `ReadableAccount`.