### PR TITLE
Log subscription for `All` no longer clobbers `Some` subscription for pubkey

### DIFF
--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -13,10 +13,7 @@ use {
     },
     solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
     std::{
-        collections::{
-            hash_map::{Entry, HashMap},
-            HashSet,
-        },
+        collections::hash_map::{Entry, HashMap},
         fmt,
         sync::{
             atomic::{AtomicU64, Ordering},
@@ -373,20 +370,21 @@ impl LogsSubscriptionsIndex {
     }
 
     fn update_config(&self) {
+        let mentioned_addresses = self.single_count.keys().copied().collect();
         let config = if self.all_with_votes_count > 0 {
             TransactionLogCollectorConfig {
                 filter: TransactionLogCollectorFilter::AllWithVotes,
-                mentioned_addresses: HashSet::new(),
+                mentioned_addresses,
             }
         } else if self.all_count > 0 {
             TransactionLogCollectorConfig {
                 filter: TransactionLogCollectorFilter::All,
-                mentioned_addresses: HashSet::new(),
+                mentioned_addresses,
             }
         } else {
             TransactionLogCollectorConfig {
                 filter: TransactionLogCollectorFilter::OnlyMentionedAddresses,
-                mentioned_addresses: self.single_count.keys().copied().collect(),
+                mentioned_addresses,
             }
         };
 

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -288,6 +288,21 @@ impl SubscriptionControl {
     }
 
     #[cfg(test)]
+    pub fn logs_subscribed(&self, pubkey: Option<&Pubkey>) -> bool {
+        self.0.subscriptions.iter().any(|item| {
+            if let SubscriptionParams::Logs(params) = item.key() {
+                let subscribed_pubkey = match &params.kind {
+                    LogsSubscriptionKind::All | LogsSubscriptionKind::AllWithVotes => None,
+                    LogsSubscriptionKind::Single(pubkey) => Some(pubkey),
+                };
+                subscribed_pubkey == pubkey
+            } else {
+                false
+            }
+        })
+    }
+
+    #[cfg(test)]
     pub fn signature_subscribed(&self, signature: &Signature) -> bool {
         self.0.subscriptions.iter().any(|item| {
             if let SubscriptionParams::Signature(params) = item.key() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5666,6 +5666,25 @@ impl Bank {
             .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
     }
 
+    /// Process a Transaction and store program log data. This is used for unit tests, and simply
+    /// replicates the vector Bank::process_transactions method with `enable_cpi_recording: true`
+    pub fn process_transaction_with_logs(&self, tx: &Transaction) -> Result<()> {
+        let txs = vec![VersionedTransaction::from(tx.clone())];
+        let batch = self.prepare_entry_batch(txs)?;
+        let _results = self.load_execute_and_commit_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            false,
+            false,
+            true,
+            false,
+            &mut ExecuteTimings::default(),
+        );
+        tx.signatures
+            .get(0)
+            .map_or(Ok(()), |sig| self.get_signature_status(sig).unwrap())
+    }
+
     /// Process multiple transaction in a single batch. This is used for benches and unit tests.
     ///
     /// # Panics


### PR DESCRIPTION
#### Problem

1. Make a subscription for `LogsSubscriptionKind::All` or `LogsSubscriptionKind::AllWithVotes`.
2. Also make a subscription for a specific pubkey using `LogsSubscriptionKind::Single(pubkey)`.

The presence of the `All` subscription starves the pubkey-specific ones. The `Single` subscribers will not be notified of any logs until the last `All` subscriber disappears.

cc/ @Riateche.

#### Repro

1. Uncomment [this test](https://github.com/solana-labs/solana/blob/c08cfafd6c599abbf440fbac1974ac8d754e265f/web3.js/test/connection.test.ts#L3723-L3762).
2. `solana-test-validator`
3. `solana logs`
4. `(cd web3.js && yarn && yarn test)`

The presence of the connected `solana logs` process will make that test fail. Quitting the `solana logs` process makes the test pass.

#### Summary of Changes

Always fill in the map of mentioned accounts.

#### Test plan

```
cargo test test_logs_subscribe
```