### PR TITLE
(LedgerStore) Skip sampling check if SOLANA_METRICS_ROCKSDB_PERF_SAMPLES_IN_1K == 0

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -2295,6 +2295,9 @@ mod rocks_metrics_utils {
     ///
     /// Returns true if the PerfContext is enabled.
     pub fn maybe_collect_perf_context() -> bool {
+        if *ROCKSDB_PERF_CONTEXT_SAMPLES_IN_1K <= 0 {
+            return false;
+        }
         if thread_rng().gen_range(0, METRIC_SAMPLES_1K) > *ROCKSDB_PERF_CONTEXT_SAMPLES_IN_1K {
             return false;
         }


### PR DESCRIPTION
#### Problem
Currently, even if SOLANA_METRICS_ROCKSDB_PERF_SAMPLES_IN_1K == 0, we are still doing
the sampling check for every RocksDB read.

```
thread_rng().gen_range(0, METRIC_SAMPLES_1K) > *ROCKSDB_PERF_CONTEXT_SAMPLES_IN_1K
```

#### Summary of Changes
This PR skips the sampling check when SOLANA_METRICS_ROCKSDB_PERF_SAMPLES_IN_1K
is set to 0.

