### PR TITLE
Fix tests not building

### DIFF
--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -536,13 +536,13 @@ pub(crate) fn submit_gossip_stats(
         .pull
         .votes
         .into_iter()
-        .map(|(slot, num_votes)| (*slot, *num_votes))
+        .map(|(slot, num_votes)| (slot, num_votes))
         .chain(
             crds_stats
                 .push
                 .votes
                 .into_iter()
-                .map(|(slot, num_votes)| (*slot, *num_votes)),
+                .map(|(slot, num_votes)| (slot, num_votes)),
         )
         .into_grouping_map()
         .aggregate(|acc, _slot, num_votes| Some(acc.unwrap_or_default() + num_votes));


### PR DESCRIPTION
#### Problem

Tests don't build on `1.9`

#### Summary of Changes

`slot` and `num_votes` are `u64` and `usize` respectively (not `&u64`/`&usize`) and can't be dereferenced -- simply remove the dereference
