### PR TITLE
Refactor web3 notification tests

### DIFF
--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -32,6 +32,7 @@ import {
   EpochInfo,
   InflationGovernor,
   Logs,
+  SignatureResult,
   SlotInfo,
 } from '../src/connection';
 import {sleep} from '../src/util/sleep';
@@ -3683,6 +3684,20 @@ describe('Connection', function () {
             await connection.removeRootChangeListener(subscriptionId);
           }
         }
+      });
+
+      it('signature notification', async () => {
+        const owner = Keypair.generate();
+        const signature = await connection.requestAirdrop(
+          owner.publicKey,
+          LAMPORTS_PER_SOL,
+        );
+        const signatureResult = await new Promise<SignatureResult>(resolve => {
+          // NOTE: Signature subscriptions auto-remove themselves, so there's no
+          // need to track the subscription id and remove it when the test ends.
+          connection.onSignature(signature, resolve, 'processed');
+        });
+        expect(signatureResult.err).to.be.null;
       });
 
       it('logs notification', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3720,10 +3720,6 @@ describe('Connection', function () {
       await connection.removeRootChangeListener(subscriptionId);
     });
 
-    /*
-
-    TODO: debug why this test is flaky. Websocket connection issues?
-
     it('logs notification', async () => {
       let listener: number | undefined;
       const owner = Keypair.generate();
@@ -3744,7 +3740,10 @@ describe('Connection', function () {
         (async () => {
           while (!received) {
             // Execute a transaction so that we can pickup its logs.
-            await connection.requestAirdrop(owner.publicKey, 1  * LAMPORTS_PER_SOL);
+            await connection.requestAirdrop(
+              owner.publicKey,
+              1 * LAMPORTS_PER_SOL,
+            );
             await sleep(1000);
           }
         })();
@@ -3759,7 +3758,6 @@ describe('Connection', function () {
       );
       await connection.removeOnLogsListener(listener!);
     }).timeout(60 * 1000);
-    */
 
     it('https request', async () => {
       const connection = new Connection('https://api.mainnet-beta.solana.com');


### PR DESCRIPTION
* Re-enabled the log subscription test now that we've gotten to the bottom of the flakiness (#24215)
* Rewrote the account change subscription test
* Refactored all of the tests to be promise-based rather than to rely on spamming the validator until a notification is received.
* Added a missing test for signature notifications