### PR TITLE
cli: sort option for validators by version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "pretty-hex",
+ "semver 1.0.6",
  "serde",
  "serde_json",
  "solana-account-decoder",

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -18,6 +18,7 @@ console = "0.15.0"
 humantime = "2.0.1"
 indicatif = "0.16.2"
 pretty-hex = "0.2.1"
+semver = "1.0.6"
 serde = "1.0.136"
 serde_json = "1.0.79"
 solana-account-decoder = { path = "../account-decoder", version = "=1.11.0" }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -356,6 +356,7 @@ pub enum CliValidatorsSortOrder {
     SkipRate,
     Stake,
     VoteAccount,
+    Version,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -493,6 +494,22 @@ impl fmt::Display for CliValidators {
             }
             CliValidatorsSortOrder::Stake => {
                 sorted_validators.sort_by_key(|a| a.activated_stake);
+            }
+            CliValidatorsSortOrder::Version => {
+                sorted_validators.sort_by(|a, b| {
+                    use std::cmp::Ordering;
+                    let a_version = semver::Version::parse(a.version.as_str()).ok();
+                    let b_version = semver::Version::parse(b.version.as_str()).ok();
+                    match (a_version, b_version) {
+                        (None, None) => a.version.cmp(&b.version),
+                        (None, Some(_)) => Ordering::Less,
+                        (Some(_), None) => Ordering::Greater,
+                        (Some(va), Some(vb)) => match va.cmp(&vb) {
+                            Ordering::Equal => a.activated_stake.cmp(&b.activated_stake),
+                            ordering => ordering,
+                        },
+                    }
+                });
             }
         }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -379,6 +379,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                             "root",
                             "skip-rate",
                             "stake",
+                            "version",
                             "vote-account",
                         ])
                         .default_value("stake")
@@ -650,6 +651,7 @@ pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
         "skip-rate" => CliValidatorsSortOrder::SkipRate,
         "stake" => CliValidatorsSortOrder::Stake,
         "vote-account" => CliValidatorsSortOrder::VoteAccount,
+        "version" => CliValidatorsSortOrder::Version,
         _ => unreachable!(),
     };
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3347,6 +3347,7 @@ dependencies = [
  "humantime",
  "indicatif",
  "pretty-hex",
+ "semver 1.0.6",
  "serde",
  "serde_json",
  "solana-account-decoder",


### PR DESCRIPTION
#### Problem

`solana validators --help` offers no option to sort by version. which makes monitoring upgrades annoying

#### Summary of Changes

add `--sort version`