### PR TITLE
Enable the explorer to render content from data URIs

### DIFF
--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -317,6 +317,8 @@ async function fetchAccountInfo(
   });
 }
 
+const IMAGE_MIME_TYPE_REGEX = /data:image\/(svg\+xml|png|jpeg|gif)/g;
+
 const getMetaDataJSON = async (
   id: string,
   metadata: programs.metadata.MetadataData
@@ -331,9 +333,11 @@ const getMetaDataJSON = async (
       }
 
       if (extended?.image) {
-        extended.image = (extended.image.startsWith("http") || extended.image.startsWith("data:"))
-          ? extended.image
-          : `${metadata.data.uri}/${extended.image}`;
+        extended.image =
+          extended.image.startsWith("http") ||
+          IMAGE_MIME_TYPE_REGEX.test(extended.image)
+            ? extended.image
+            : `${metadata.data.uri}/${extended.image}`;
       }
 
       return extended;

--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -331,7 +331,7 @@ const getMetaDataJSON = async (
       }
 
       if (extended?.image) {
-        extended.image = extended.image.startsWith("http")
+        extended.image = (extended.image.startsWith("http") || extended.image.startsWith("data:"))
           ? extended.image
           : `${metadata.data.uri}/${extended.image}`;
       }


### PR DESCRIPTION
### Problem
The explorer is unable to render NFT content that is encoded via a [data URI](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). The logic to extract the image URI assumes the value can only start with `http`, whereas the [metadata](https://docs.metaplex.com/token-metadata/specification) specification does not make this assumption.

We can see this issue in the explorer today. The explorer renders the Solana logo for this NFT mint on devnet: [BkGcm8poHh5SnhvLBCXbqnemLL4qwtCGmC9BTX1X9uwV](https://explorer.solana.com/address/BkGcm8poHh5SnhvLBCXbqnemLL4qwtCGmC9BTX1X9uwV?cluster=devnet). We would expect to see the actual SVG like shown on [Solscan](https://solscan.io/address/BkGcm8poHh5SnhvLBCXbqnemLL4qwtCGmC9BTX1X9uwV?cluster=devnet). Please allow some time for the image to render, backed by a low end Heroku dyno for demo purposes.

### Summary of Changes
Allow image URIs that begin with either `http` or `data:`. Previously, the code would try to append the entire data URI to the JSON's URI such that given 
* URI pointing to JSON metadata: `https://endpoint.com/api/metadata/BkGcm8poHh5SnhvLBCXbqnemLL4qwtCGmC9BTX1X9uwV` and
* image URI `data:image/svg+xml;base64,PHN2ZyB4bW...`,

we would end up with the following image URI:

```
https://endpoint.com/api/metadata/BkGcm8poHh5SnhvLBCXbqnemLL4qwtCGmC9BTX1X9uwV/data:image/svg+xml;base64,PHN2ZyB4bW...
```

when we would expect to directly render the data URI:

```
data:image/svg+xml;base64,PHN2ZyB4bW...
```

**Behavior before change**
![explorer-current-behavior](https://user-images.githubusercontent.com/102701023/162672820-3881f989-f1aa-424b-bdda-deb57c7b177c.png)

**Behavior after change**
![explorer-expected-behavior](https://user-images.githubusercontent.com/102701023/162672857-ddfd8d77-fd18-492d-a4e7-4a52ec565a47.png)