### PR TITLE
Add more banking stage benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3563,7 +3563,7 @@ dependencies = [
 name = "rbpf-cli"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.6",
+ "clap 3.1.8",
  "serde",
  "serde_json",
  "solana-bpf-loader-program",
@@ -4373,7 +4373,7 @@ dependencies = [
 name = "solana-banking-bench"
 version = "1.11.0"
 dependencies = [
- "clap 2.33.3",
+ "clap 3.1.8",
  "crossbeam-channel",
  "log",
  "rand 0.7.3",
@@ -4438,7 +4438,7 @@ dependencies = [
 name = "solana-bench-streamer"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.6",
+ "clap 3.1.8",
  "crossbeam-channel",
  "solana-net-utils",
  "solana-streamer",
@@ -4530,7 +4530,7 @@ version = "1.11.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
- "clap 3.1.6",
+ "clap 3.1.8",
  "regex",
  "serial_test",
  "solana-download-utils",
@@ -4543,7 +4543,7 @@ name = "solana-cargo-test-bpf"
 version = "1.11.0"
 dependencies = [
  "cargo_metadata",
- "clap 3.1.6",
+ "clap 3.1.8",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ name = "solana-dos"
 version = "1.11.0"
 dependencies = [
  "bincode",
- "clap 3.1.6",
+ "clap 3.1.8",
  "log",
  "rand 0.7.3",
  "serde",
@@ -5242,7 +5242,7 @@ name = "solana-log-analyzer"
 version = "1.11.0"
 dependencies = [
  "byte-unit",
- "clap 3.1.6",
+ "clap 3.1.8",
  "serde",
  "serde_json",
  "solana-logger 1.11.0",
@@ -5319,7 +5319,7 @@ dependencies = [
 name = "solana-net-shaper"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.6",
+ "clap 3.1.8",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -5331,7 +5331,7 @@ name = "solana-net-utils"
 version = "1.11.0"
 dependencies = [
  "bincode",
- "clap 3.1.6",
+ "clap 3.1.8",
  "crossbeam-channel",
  "log",
  "nix",
@@ -5408,7 +5408,7 @@ dependencies = [
 name = "solana-poh-bench"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.6",
+ "clap 3.1.8",
  "log",
  "rand 0.7.3",
  "rayon",

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://solana.com/"
 publish = false
 
 [dependencies]
-clap = "3.1.8"
+clap = { version = "3.1.8", features = ["derive"] }
 crossbeam-channel = "0.5"
 log = "0.4.14"
 rand = "0.7.0"

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://solana.com/"
 publish = false
 
 [dependencies]
-clap = "2.33.1"
+clap = "3.1.8"
 crossbeam-channel = "0.5"
 log = "0.4.14"
 rand = "0.7.0"

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 use {
-    clap::{crate_description, crate_name, value_t, App, Arg},
+    clap::{crate_description, crate_name, Arg, Command},
     crossbeam_channel::{unbounded, Receiver},
     log::*,
     rand::{thread_rng, Rng},
@@ -109,55 +109,58 @@ fn bytes_as_usize(bytes: &[u8]) -> usize {
 fn main() {
     solana_logger::setup();
 
-    let matches = App::new(crate_name!())
+    let matches = Command::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
         .arg(
-            Arg::with_name("num_chunks")
+            Arg::new("num_chunks")
                 .long("num-chunks")
                 .takes_value(true)
                 .value_name("SIZE")
                 .help("Number of transaction chunks."),
         )
         .arg(
-            Arg::with_name("packets_per_chunk")
+            Arg::new("packets_per_chunk")
                 .long("packets-per-chunk")
                 .takes_value(true)
                 .value_name("SIZE")
                 .help("Packets per chunk"),
         )
         .arg(
-            Arg::with_name("skip_sanity")
+            Arg::new("skip_sanity")
                 .long("skip-sanity")
                 .takes_value(false)
                 .help("Skip transaction sanity execution"),
         )
         .arg(
-            Arg::with_name("same_payer")
+            Arg::new("same_payer")
                 .long("same-payer")
                 .takes_value(false)
                 .help("Use the same payer for transfers"),
         )
         .arg(
-            Arg::with_name("iterations")
+            Arg::new("iterations")
                 .long("iterations")
                 .takes_value(true)
                 .help("Number of iterations"),
         )
         .arg(
-            Arg::with_name("num_threads")
+            Arg::new("num_threads")
                 .long("num-threads")
                 .takes_value(true)
                 .help("Number of iterations"),
         )
         .get_matches();
 
-    let num_threads =
-        value_t!(matches, "num_threads", usize).unwrap_or(BankingStage::num_threads() as usize);
+    let num_threads = matches
+        .value_of_t::<usize>("num_threads")
+        .unwrap_or(BankingStage::num_threads() as usize);
     //   a multiple of packet chunk duplicates to avoid races
-    let num_chunks = value_t!(matches, "num_chunks", usize).unwrap_or(16);
-    let packets_per_chunk = value_t!(matches, "packets_per_chunk", usize).unwrap_or(192);
-    let iterations = value_t!(matches, "iterations", usize).unwrap_or(1000);
+    let num_chunks = matches.value_of_t::<usize>("num_chunks").unwrap_or(16);
+    let packets_per_chunk = matches
+        .value_of_t::<usize>("packets_per_chunk")
+        .unwrap_or(192);
+    let iterations = matches.value_of_t::<usize>("iterations").unwrap_or(1000);
 
     let total_num_transactions = num_chunks * num_threads * packets_per_chunk;
     let mint_total = 1_000_000_000_000;

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -402,7 +402,7 @@ impl BankingStage {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn new_num_threads(
+    pub fn new_num_threads(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         verified_receiver: CrossbeamReceiver<Vec<PacketBatch>>,


### PR DESCRIPTION
These cover different batch sizes and account lock contention scenarios.

Some initial measurements for a different number of non-vote banking stage threads:

```
                     batch sz    1 threads   2 threads   3 threads
all same account       192         136ms       269ms       216ms
independent batches    192         136ms       109ms       106ms
two contentions        192           8ms         6ms         6ms
no same accounts       192           7ms         6ms         5ms
all same account        12          45ms       436ms (??)  142ms
independent batches     12          45ms        37ms        26ms
two contentions         12          14ms        11ms         8ms
no same accounts        12          11ms         9ms         6ms
```

After review feedback the PR was adjusted to improve banking-bench instead:
- Add write-lock-contention option, replacing same_payer
- write-lock-contention also has a same-batch-only value, where
  contention happens only inside batches, not between them
- Rename num-threads to batches-per-iteration, which is closer to what
  it is actually doing.
- Add num-banking-threads as a new option
- Rename packets-per-chunk to packets-per-batch, because this is closer
  to what's happening; and it was previously confusing that num-chunks
  had little to do with packets-per-chunk.

Example output for a iterations=100 and a permutation of inputs:

```
contention,threads,batchsize,batchcount,tps
none,           3,192, 4,65290.30
none,           4,192, 4,77358.06
none,           5,192, 4,86436.65
none,           3, 12,64,43944.57
none,           4, 12,64,65852.15
none,           5, 12,64,70674.37
same-batch-only,3,192, 4,3928.21
same-batch-only,4,192, 4,6460.15
same-batch-only,5,192, 4,7242.85
same-batch-only,3, 12,64,11377.58
same-batch-only,4, 12,64,19582.79
same-batch-only,5, 12,64,24648.45
full,           3,192, 4,3914.26
full,           4,192, 4,2102.99
full,           5,192, 4,3041.87
full,           3, 12,64,11316.17
full,           4, 12,64,2224.99
full,           5, 12,64,5240.32
```

#### Problem
Banking stage benchmarks cover only cases without account lock contention and one batch size.

#### Summary of Changes
Add benchmarks.