### PR TITLE
IndexLimitMb option adds 'Unspecified' state

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -33,7 +33,7 @@ use {
     solana_measure::measure::Measure,
     solana_runtime::{
         accounts_db::{AccountsDbConfig, FillerAccountsConfig},
-        accounts_index::{AccountsIndexConfig, ScanConfig},
+        accounts_index::{AccountsIndexConfig, IndexLimitMb, ScanConfig},
         bank::{Bank, RewardCalculationEvent},
         bank_forks::BankForks,
         cost_model::CostModel,
@@ -2052,13 +2052,15 @@ fn main() {
                 let system_monitor_service =
                     SystemMonitorService::new(Arc::clone(&exit_signal), true, false);
 
-                if let Some(limit) =
+                accounts_index_config.index_limit_mb = if let Some(limit) =
                     value_t!(arg_matches, "accounts_index_memory_limit_mb", usize).ok()
                 {
-                    accounts_index_config.index_limit_mb = Some(limit);
+                    IndexLimitMb::Limit(limit)
                 } else if arg_matches.is_present("disable_accounts_disk_index") {
-                    accounts_index_config.index_limit_mb = None;
-                }
+                    IndexLimitMb::InMemOnly
+                } else {
+                    IndexLimitMb::Unspecified
+                };
 
                 {
                     let mut accounts_index_paths: Vec<PathBuf> =

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -50,7 +50,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndex
     bins: Some(BINS_FOR_TESTING),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: None,
+    index_limit_mb: IndexLimitMb::Unspecified,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     started_from_validator: false,
@@ -59,7 +59,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
     bins: Some(BINS_FOR_BENCHMARKS),
     flush_threads: Some(FLUSH_THREADS_TESTING),
     drives: None,
-    index_limit_mb: None,
+    index_limit_mb: IndexLimitMb::Unspecified,
     ages_to_stay_in_cache: None,
     scan_results_limit_bytes: None,
     started_from_validator: false,
@@ -157,12 +157,29 @@ pub struct AccountSecondaryIndexesIncludeExclude {
     pub keys: HashSet<Pubkey>,
 }
 
+/// specification of how much memory in-mem portion of account index can use
+#[derive(Debug, Clone)]
+pub enum IndexLimitMb {
+    /// nothing explicit specified, so default
+    Unspecified,
+    /// limit was specified, use disk index for rest
+    Limit(usize),
+    /// in-mem-only was specified, no disk index
+    InMemOnly,
+}
+
+impl Default for IndexLimitMb {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct AccountsIndexConfig {
     pub bins: Option<usize>,
     pub flush_threads: Option<usize>,
     pub drives: Option<Vec<PathBuf>>,
-    pub index_limit_mb: Option<usize>,
+    pub index_limit_mb: IndexLimitMb,
     pub ages_to_stay_in_cache: Option<Age>,
     pub scan_results_limit_bytes: Option<usize>,
     /// true if the accounts index is being created as a result of being started as a validator (as opposed to test, etc.)

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1263,7 +1263,7 @@ impl Drop for FlushGuard<'_> {
 mod tests {
     use {
         super::*,
-        crate::accounts_index::{AccountsIndexConfig, BINS_FOR_TESTING},
+        crate::accounts_index::{AccountsIndexConfig, IndexLimitMb, BINS_FOR_TESTING},
         itertools::Itertools,
     };
 
@@ -1281,7 +1281,7 @@ mod tests {
         let holder = Arc::new(BucketMapHolder::new(
             BINS_FOR_TESTING,
             &Some(AccountsIndexConfig {
-                index_limit_mb: Some(1),
+                index_limit_mb: IndexLimitMb::Limit(1),
                 ..AccountsIndexConfig::default()
             }),
             1,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -47,7 +47,7 @@ use {
         },
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude,
-            AccountsIndexConfig,
+            AccountsIndexConfig, IndexLimitMb,
         },
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
         snapshot_config::SnapshotConfig,
@@ -2233,11 +2233,14 @@ pub fn main() {
         accounts_index_config.bins = Some(bins);
     }
 
-    if let Some(limit) = value_t!(matches, "accounts_index_memory_limit_mb", usize).ok() {
-        accounts_index_config.index_limit_mb = Some(limit);
-    } else if matches.is_present("disable_accounts_disk_index") {
-        accounts_index_config.index_limit_mb = None;
-    }
+    accounts_index_config.index_limit_mb =
+        if let Some(limit) = value_t!(matches, "accounts_index_memory_limit_mb", usize).ok() {
+            IndexLimitMb::Limit(limit)
+        } else if matches.is_present("disable_accounts_disk_index") {
+            IndexLimitMb::InMemOnly
+        } else {
+            IndexLimitMb::Unspecified
+        };
 
     {
         let mut accounts_index_paths: Vec<PathBuf> = if matches.is_present("accounts_index_path") {


### PR DESCRIPTION
#### Problem

validator and ledger tool can specify specific disk index configurations. Not specifying a configuration should result in default behavior. I'd like to handle that in 1 place and cleanly. A tri state here lets me specify what caller intends.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
