### PR TITLE
Async send for send transaction service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,6 +4637,7 @@ dependencies = [
  "solana-faucet",
  "solana-logger 1.11.0",
  "solana-measure",
+ "solana-metrics",
  "solana-net-utils",
  "solana-sdk",
  "solana-streamer",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -39,6 +39,7 @@ solana-account-decoder = { path = "../account-decoder", version = "=1.11.0" }
 solana-clap-utils = { path = "../clap-utils", version = "=1.11.0" }
 solana-faucet = { path = "../faucet", version = "=1.11.0" }
 solana-measure = { path = "../measure", version = "=1.11.0" }
+solana-metrics = { path = "../metrics", version = "=1.11.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-streamer = { path = "../streamer", version = "=1.11.0" }

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -136,8 +136,8 @@ pub fn send_wire_transaction_async(
 ) -> Result<(), TransportError> {
     let conn = get_connection(addr);
     match conn {
-        Connection::Udp(conn) => conn.send_wire_transaction_async::<Vec<u8>>(packets),
-        Connection::Quic(conn) => conn.send_wire_transaction_async::<Vec<u8>>(packets),
+        Connection::Udp(conn) => conn.send_wire_transaction_async(packets),
+        Connection::Quic(conn) => conn.send_wire_transaction_async(packets),
     }
 }
 

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -130,6 +130,17 @@ pub fn send_wire_transaction_batch(
     }
 }
 
+pub fn send_wire_transaction_async(
+    packets: Vec<u8>,
+    addr: &SocketAddr,
+) -> Result<(), TransportError> {
+    let conn = get_connection(addr);
+    match conn {
+        Connection::Udp(conn) => conn.send_wire_transaction_async::<Vec<u8>>(packets),
+        Connection::Quic(conn) => conn.send_wire_transaction_async::<Vec<u8>>(packets),
+    }
+}
+
 pub fn send_wire_transaction(
     wire_transaction: &[u8],
     addr: &SocketAddr,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -28,6 +28,9 @@ pub mod tpu_connection;
 pub mod transaction_executor;
 pub mod udp_client;
 
+#[macro_use]
+extern crate solana_metrics;
+
 pub mod mock_sender_for_cli {
     /// Magic `SIGNATURE` value used by `solana-cli` unit tests.
     /// Please don't use this constant.

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -6,6 +6,7 @@ use {
     async_mutex::Mutex,
     futures::future::join_all,
     itertools::Itertools,
+    log::*,
     quinn::{ClientConfig, Endpoint, EndpointConfig, NewConnection, WriteError},
     solana_sdk::{
         quic::{QUIC_MAX_CONCURRENT_STREAMS, QUIC_PORT_OFFSET},
@@ -91,7 +92,9 @@ impl TpuConnection for QuicTpuConnection {
         //drop and detach the task
         let _ = self.client.runtime.spawn(async move {
             let send_buffer = self.client.send_buffer(wire_transaction);
-            let _ = self.client.runtime.block_on(send_buffer);
+            if let Err(e) = self.client.runtime.block_on(send_buffer) {
+                warn!("Failed to send transaction async to {:?}", e);
+            }
             ()
         });
         Ok(())

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -6,6 +6,7 @@ use {
     async_mutex::Mutex,
     futures::future::join_all,
     itertools::Itertools,
+    lazy_static::lazy_static,
     log::*,
     quinn::{ClientConfig, Endpoint, EndpointConfig, NewConnection, WriteError},
     solana_sdk::{
@@ -17,8 +18,6 @@ use {
         sync::Arc,
     },
     tokio::runtime::Runtime,
-    lazy_static::lazy_static,
-
 };
 
 struct SkipServerVerification;
@@ -43,10 +42,10 @@ impl rustls::client::ServerCertVerifier for SkipServerVerification {
     }
 }
 lazy_static! {
-static ref RUNTIME: Runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .unwrap();
+    static ref RUNTIME: Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
 }
 
 struct QuicClient {
@@ -91,8 +90,7 @@ impl TpuConnection for QuicTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_async<T>(&self, wire_transaction: Vec<u8>) -> TransportResult<()>
-    {
+    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
         let _guard = RUNTIME.enter();
         //drop and detach the task
         let client = self.client.clone();

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -103,7 +103,6 @@ impl TpuConnection for QuicTpuConnection {
             } else {
                 inc_new_counter_info!("send_wire_transaction_async_pass", 1);
             }
-            ()
         });
         Ok(())
     }

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -94,10 +94,14 @@ impl TpuConnection for QuicTpuConnection {
         let _guard = RUNTIME.enter();
         //drop and detach the task
         let client = self.client.clone();
+        inc_new_counter_info!("send_wire_transaction_async", 1);
         let _ = RUNTIME.spawn(async move {
             let send_buffer = client.send_buffer(wire_transaction);
             if let Err(e) = send_buffer.await {
+                inc_new_counter_warn!("send_wire_transaction_async_fail", 1);
                 warn!("Failed to send transaction async to {:?}", e);
+            } else {
+                inc_new_counter_info!("send_wire_transaction_async_pass", 1);
             }
             ()
         });

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -96,7 +96,7 @@ impl TpuConnection for QuicTpuConnection {
         let client = self.client.clone();
         let _ = RUNTIME.spawn(async move {
             let send_buffer = client.send_buffer(wire_transaction);
-            if let Err(e) = RUNTIME.block_on(send_buffer) {
+            if let Err(e) = send_buffer.await {
                 warn!("Failed to send transaction async to {:?}", e);
             }
             ()

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -22,6 +22,11 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]>;
 
+    fn send_wire_transaction_async<T>(&'static self, wire_transaction: T) -> TransportResult<()>
+    where
+        T: AsRef<[u8]> + Send + 'static;
+
+
     fn par_serialize_and_send_transaction_batch(
         &self,
         transactions: &[VersionedTransaction],

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -26,7 +26,6 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]> + Send + 'static;
 
-
     fn par_serialize_and_send_transaction_batch(
         &self,
         transactions: &[VersionedTransaction],

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -22,9 +22,7 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]>;
 
-    fn send_wire_transaction_async<T>(&'static self, wire_transaction: T) -> TransportResult<()>
-    where
-        T: AsRef<[u8]> + Send + 'static;
+    fn send_wire_transaction_async<T>(&self, wire_transaction: Vec<u8>) -> TransportResult<()>;
 
     fn par_serialize_and_send_transaction_batch(
         &self,

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -22,7 +22,7 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]>;
 
-    fn send_wire_transaction_async<T>(&self, wire_transaction: Vec<u8>) -> TransportResult<()>;
+    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()>;
 
     fn par_serialize_and_send_transaction_batch(
         &self,

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -42,7 +42,6 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
-
     fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
     where
         T: AsRef<[u8]>,

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -34,9 +34,7 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_async<T>(&'static self, wire_transaction: T) -> TransportResult<()>
-    where
-        T: AsRef<[u8]> + Send + 'static,
+    fn send_wire_transaction_async<T>(&self, wire_transaction: Vec<u8>) -> TransportResult<()>
     {
         self.socket.send_to(wire_transaction.as_ref(), self.addr)?;
         Ok(())

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -34,8 +34,7 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_async<T>(&self, wire_transaction: Vec<u8>) -> TransportResult<()>
-    {
+    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
         self.socket.send_to(wire_transaction.as_ref(), self.addr)?;
         Ok(())
     }

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -34,6 +34,15 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
+    fn send_wire_transaction_async<T>(&'static self, wire_transaction: T) -> TransportResult<()>
+    where
+        T: AsRef<[u8]> + Send + 'static,
+    {
+        self.socket.send_to(wire_transaction.as_ref(), self.addr)?;
+        Ok(())
+    }
+
+
     fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
     where
         T: AsRef<[u8]>,

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3382,6 +3382,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-faucet",
  "solana-measure",
+ "solana-metrics",
  "solana-net-utils",
  "solana-sdk",
  "solana-streamer",

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -311,7 +311,9 @@ impl SendTransactionService {
     fn send_transaction(tpu_address: &SocketAddr, wire_transaction: &[u8]) {
         let mut measure = Measure::start("send_transaction_service-us");
 
-        if let Err(err) = connection_cache::send_wire_transaction_async(wire_transaction, tpu_address) {
+        if let Err(err) =
+            connection_cache::send_wire_transaction_async(wire_transaction, tpu_address)
+        {
             warn!("Failed to send transaction to {}: {:?}", tpu_address, err);
         }
         measure.stop();

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -311,7 +311,7 @@ impl SendTransactionService {
     fn send_transaction(tpu_address: &SocketAddr, wire_transaction: &[u8]) {
         let mut measure = Measure::start("send_transaction_service-us");
 
-        if let Err(err) = connection_cache::send_wire_transaction(wire_transaction, tpu_address) {
+        if let Err(err) = connection_cache::send_wire_transaction_async(wire_transaction, tpu_address) {
             warn!("Failed to send transaction to {}: {:?}", tpu_address, err);
         }
         measure.stop();

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -312,7 +312,7 @@ impl SendTransactionService {
         let mut measure = Measure::start("send_transaction_service-us");
 
         if let Err(err) =
-            connection_cache::send_wire_transaction_async(wire_transaction, tpu_address)
+            connection_cache::send_wire_transaction_async(wire_transaction.to_vec(), tpu_address)
         {
             warn!("Failed to send transaction to {}: {:?}", tpu_address, err);
         }


### PR DESCRIPTION
#### Problem

Send transaction service blocks on each sent request causing a head of queue blocking issue

#### Summary of Changes

Make the Tokio client runtime static.  This is necessary so other threads can hand of ownership of items to async Tokio tasks. 

Hand of the send to the Tokio runtime and let it handle it out of order

<img width="1163" alt="Screen Shot 2022-04-11 at 9 20 31 PM" src="https://user-images.githubusercontent.com/1029046/162884763-881a5098-f475-40d1-84b3-872dffdef730.png">

