### PR TITLE
Explorer: Fix NFT verified collection row rendering

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -343,7 +343,7 @@ function NonFungibleTokenMintAccountCard({
             </td>
           </tr>
         )}
-        {nftData?.metadata.collection?.verified && (
+        {!!nftData?.metadata.collection?.verified && (
           <tr>
             <td>Verified Collection Address</td>
             <td className="text-lg-end">


### PR DESCRIPTION
#### Problem
Rendering is broken for NFTs that use an integer for the `metadata.collection.verified` field
<img width="232" alt="截圖 2022-04-12 下午4 17 03" src="https://user-images.githubusercontent.com/1076145/162914486-fdb74a87-325c-4090-8ed9-f24d5a55694d.png">
<img width="354" alt="截圖 2022-04-12 下午4 17 14" src="https://user-images.githubusercontent.com/1076145/162914495-5002481e-2d79-4886-b003-58b9e328c4d5.png">



#### Summary of Changes
Evaluate the field into a boolean to fix rendering

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
