### PR TITLE
Don't request reviews from community-pr-subscribers if reviewer assigned

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,9 +21,7 @@ pull_request_rules:
       # Only request reviews from the pr subscribers group if no one
       # has reviewed the community PR yet. These checks only match
       # reviewers with admin, write or maintain permission on the repository.
-      - "#approved-reviews-by=0"
-      - "#commented-reviews-by=0"
-      - "#changes-requested-reviews-by=0"
+      - "review-requested~=^@solana-labs/community-pr-subscribers"
     actions:
       request_reviews:
         teams:


### PR DESCRIPTION
#### Problem
@solana-labs/community-pr-subscribers get spammed even if someone has already become a reviewer for a community PR

#### Summary of Changes
Down with the spam

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
