### PR TITLE
fix: don't override a transaction's recentBlockhash when calling simulate if it's already set

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3888,7 +3888,9 @@ export class Connection {
     } else {
       let disableCache = this._disableBlockhashCaching;
       for (;;) {
-        transaction.recentBlockhash = await this._recentBlockhash(disableCache);
+        if (!transaction.recentBlockhash) {
+          transaction.recentBlockhash = await this._recentBlockhash(disableCache);
+        }
 
         if (!signers) break;
 

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3889,7 +3889,9 @@ export class Connection {
       let disableCache = this._disableBlockhashCaching;
       for (;;) {
         if (!transaction.recentBlockhash) {
-          transaction.recentBlockhash = await this._recentBlockhash(disableCache);
+          transaction.recentBlockhash = await this._recentBlockhash(
+            disableCache,
+          );
         }
 
         if (!signers) break;


### PR DESCRIPTION
Simulate has been overriding the recentBlockhash of the passed
Transaction which can be considered destructive and with side effects.

Since the purpose of this function is to purely simulate, it should not
override recentBlockhash if it has already been set

Refs https://github.com/solana-labs/solana/issues/24279
