### PR TITLE
Typo in validator-failover.md

### DIFF
--- a/docs/src/running-validator/validator-failover.md
+++ b/docs/src/running-validator/validator-failover.md
@@ -17,7 +17,7 @@ which is used to store the tower voting record for your validator.
 
 ### etcd cluster setup
 
-There is ample documentation regarding etcd setup and configuration at
+There is sample documentation regarding etcd setup and configuration at
 https://etcd.io/, please generally familiarize yourself with etcd before
 continuing.
 


### PR DESCRIPTION
#### Problem
Typo in the word "sample" that was witten as "ample"

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
