### PR TITLE
 add maybe_update_rent_epoch_on_load

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -178,6 +178,8 @@ pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
 
 pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 
+pub type Rewrites = DashMap<Pubkey, Hash>;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RentDebit {
     rent_collected: u64,


### PR DESCRIPTION
#### Problem

Infrastructure for determining on load that we need to modify an account's rent_epoch because we skipped a rewrite.
This will be used by a later pr.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
