### PR TITLE
Support quic in bench-tps

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -49,6 +49,7 @@ pub struct Config {
     pub target_slots_per_epoch: u64,
     pub target_node: Option<Pubkey>,
     pub external_client_type: ExternalClientType,
+    pub use_quic: bool,
 }
 
 impl Default for Config {
@@ -74,6 +75,7 @@ impl Default for Config {
             target_slots_per_epoch: 0,
             target_node: None,
             external_client_type: ExternalClientType::default(),
+            use_quic: false,
         }
     }
 }
@@ -254,6 +256,13 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .takes_value(false)
                 .help("Submit transactions with a TpuClient")
         )
+        .arg(
+            Arg::with_name("tpu_use_quic")
+                .long("tpu-use-quic")
+                .takes_value(false)
+                .help("Submit transactions via QUIC; only affects ThinClient (default) \
+                    or TpuClient sends"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -291,6 +300,10 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
 
     if matches.is_present("tpu_client") {
         args.external_client_type = ExternalClientType::TpuClient;
+    }
+
+    if matches.is_present("tpu_use_quic") {
+        args.use_quic = true;
     }
 
     if let Some(addr) = matches.value_of("entrypoint") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -7,6 +7,7 @@ use {
         keypairs::get_keypairs,
     },
     solana_client::{
+        connection_cache,
         rpc_client::RpcClient,
         tpu_client::{TpuClient, TpuClientConfig},
     },
@@ -45,6 +46,7 @@ fn main() {
         num_lamports_per_account,
         target_node,
         external_client_type,
+        use_quic,
         ..
     } = &cli_config;
 
@@ -88,6 +90,9 @@ fn main() {
                     eprintln!("Failed to discover {} nodes: {:?}", num_nodes, err);
                     exit(1);
                 });
+            if *use_quic {
+                connection_cache::set_use_quic(true);
+            }
             let client = if *multi_client {
                 let (client, num_clients) = get_multi_client(&nodes, &SocketAddrSpace::Unspecified);
                 if nodes.len() < num_clients {
@@ -130,6 +135,9 @@ fn main() {
                 json_rpc_url.to_string(),
                 CommitmentConfig::confirmed(),
             ));
+            if *use_quic {
+                connection_cache::set_use_quic(true);
+            }
             let client = Arc::new(
                 TpuClient::new(rpc_client, websocket_url, TpuClientConfig::default())
                     .unwrap_or_else(|err| {

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         client_error::ClientError,
+        connection_cache::send_wire_transaction,
         pubsub_client::{PubsubClient, PubsubClientError, PubsubClientSubscription},
         rpc_client::RpcClient,
         rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
@@ -17,6 +18,7 @@ use {
         signature::SignerError,
         signers::Signers,
         transaction::{Transaction, TransactionError},
+        transport::{Result as TransportResult, TransportError},
     },
     std::{
         collections::{HashMap, HashSet, VecDeque},
@@ -73,7 +75,7 @@ impl Default for TpuClientConfig {
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
 pub struct TpuClient {
-    send_socket: UdpSocket,
+    _deprecated: UdpSocket, // TpuClient now uses the connection_cache to choose a send_socket
     fanout_slots: u64,
     leader_tpu_service: LeaderTpuService,
     exit: Arc<AtomicBool>,
@@ -96,28 +98,22 @@ impl TpuClient {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
-    pub fn try_send_transaction(
-        &self,
-        transaction: &Transaction,
-    ) -> std::result::Result<(), std::io::Error> {
+    pub fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
         let wire_transaction = serialize(transaction).expect("serialization should succeed");
         self.try_send_wire_transaction(&wire_transaction)
     }
 
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
-    fn try_send_wire_transaction(
-        &self,
-        wire_transaction: &[u8],
-    ) -> std::result::Result<(), std::io::Error> {
-        let mut last_error: Option<std::io::Error> = None;
+    fn try_send_wire_transaction(&self, wire_transaction: &[u8]) -> TransportResult<()> {
+        let mut last_error: Option<TransportError> = None;
         let mut some_success = false;
 
         for tpu_address in self
             .leader_tpu_service
             .leader_tpu_sockets(self.fanout_slots)
         {
-            let result = self.send_socket.send_to(wire_transaction, tpu_address);
+            let result = send_wire_transaction(wire_transaction, &tpu_address);
             if let Err(err) = result {
                 last_error = Some(err);
             } else {
@@ -128,7 +124,7 @@ impl TpuClient {
             Err(if let Some(err) = last_error {
                 err
             } else {
-                std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted")
+                std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted").into()
             })
         } else {
             Ok(())
@@ -146,7 +142,7 @@ impl TpuClient {
             LeaderTpuService::new(rpc_client.clone(), websocket_url, exit.clone())?;
 
         Ok(Self {
-            send_socket: UdpSocket::bind("0.0.0.0:0").unwrap(),
+            _deprecated: UdpSocket::bind("0.0.0.0:0").unwrap(),
             fanout_slots: config.fanout_slots.min(MAX_FANOUT_SLOTS).max(1),
             leader_tpu_service,
             exit,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1171,7 +1171,7 @@ pub fn main() {
             Arg::with_name("tpu_use_quic")
                 .long("tpu-use-quic")
                 .takes_value(false)
-                .help("When this is set to true, the system will use QUIC to send transactions."),
+                .help("Use QUIC to send transactions."),
         )
         .arg(
             Arg::with_name("rocksdb_max_compaction_jitter")


### PR DESCRIPTION
#### Problem
Need better ways to test the performance of quic tpu implementation

#### Summary of Changes
- Add support for quic to TpuClient; this enables targeting a live cluster, like testnet
- Plumb `--tpu-use-quic` cli arg into bench-tps, which will toggle quic for either ThinClient or TpuClient runs

Tested against `testnet-dev-tyera`, plus a small run against testnet this afternoon.
Example commands:

```
// TpuClient UDP
$ solana-bench-tps --read-client-keys keypairs.yaml \
    --duration 30 --tx_count 100 --thread-batch-sleep-ms 500 \
    --identity funder.json -u http://<RPC_IP>:8899 --use-tpu-client

// TpuClient Quic
$ solana-bench-tps --read-client-keys keypairs.yaml \
    --duration 30 --tx_count 100 --thread-batch-sleep-ms 500 \
    --identity funder.json -u http://<RPC_IP>:8899 --use-tpu-client --tpu-use-quic

// ThinClient UDP
$ solana-bench-tps --read-client-keys keypairs.yaml \
    --duration 30 --tx_count 100 --thread-batch-sleep-ms 500 \
    --identity funder.json -n <ENTRYPOINT_IP>:8001

// TpuClient Quic
$ solana-bench-tps --read-client-keys keypairs.yaml \
    --duration 30 --tx_count 100 --thread-batch-sleep-ms 500 \
    --identity funder.json --n <ENTRYPOINT_IP>:8001 --tpu-use-quic
```

cc @aeyakovenko 
