### PR TITLE
Add RpcClient support to bench-tps

### DIFF
--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -82,5 +82,6 @@ pub trait BenchTpsClient {
 }
 
 mod bank_client;
+mod rpc_client;
 mod thin_client;
 mod tpu_client;

--- a/bench-tps/src/bench_tps_client/rpc_client.rs
+++ b/bench-tps/src/bench_tps_client/rpc_client.rs
@@ -1,0 +1,83 @@
+use {
+    crate::bench_tps_client::{BenchTpsClient, Result},
+    solana_client::rpc_client::RpcClient,
+    solana_sdk::{
+        commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash, message::Message,
+        pubkey::Pubkey, signature::Signature, transaction::Transaction,
+    },
+};
+
+impl BenchTpsClient for RpcClient {
+    fn send_transaction(&self, transaction: Transaction) -> Result<Signature> {
+        RpcClient::send_transaction(self, &transaction).map_err(|err| err.into())
+    }
+    fn send_batch(&self, transactions: Vec<Transaction>) -> Result<()> {
+        for transaction in transactions {
+            BenchTpsClient::send_transaction(self, transaction)?;
+        }
+        Ok(())
+    }
+    fn get_latest_blockhash(&self) -> Result<Hash> {
+        RpcClient::get_latest_blockhash(self).map_err(|err| err.into())
+    }
+
+    fn get_latest_blockhash_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<(Hash, u64)> {
+        RpcClient::get_latest_blockhash_with_commitment(self, commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_transaction_count(&self) -> Result<u64> {
+        RpcClient::get_transaction_count(self).map_err(|err| err.into())
+    }
+
+    fn get_transaction_count_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
+        RpcClient::get_transaction_count_with_commitment(self, commitment_config)
+            .map_err(|err| err.into())
+    }
+
+    fn get_epoch_info(&self) -> Result<EpochInfo> {
+        RpcClient::get_epoch_info(self).map_err(|err| err.into())
+    }
+
+    fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {
+        RpcClient::get_balance(self, pubkey).map_err(|err| err.into())
+    }
+
+    fn get_balance_with_commitment(
+        &self,
+        pubkey: &Pubkey,
+        commitment_config: CommitmentConfig,
+    ) -> Result<u64> {
+        RpcClient::get_balance_with_commitment(self, pubkey, commitment_config)
+            .map(|res| res.value)
+            .map_err(|err| err.into())
+    }
+
+    fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
+        RpcClient::get_fee_for_message(self, message).map_err(|err| err.into())
+    }
+
+    fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64> {
+        RpcClient::get_minimum_balance_for_rent_exemption(self, data_len).map_err(|err| err.into())
+    }
+
+    fn addr(&self) -> String {
+        self.url()
+    }
+
+    fn request_airdrop_with_blockhash(
+        &self,
+        pubkey: &Pubkey,
+        lamports: u64,
+        recent_blockhash: &Hash,
+    ) -> Result<Signature> {
+        RpcClient::request_airdrop_with_blockhash(self, pubkey, lamports, recent_blockhash)
+            .map_err(|err| err.into())
+    }
+}

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -13,6 +13,8 @@ use {
 const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;
 
 pub enum ExternalClientType {
+    // Submits transactions to an Rpc node using an RpcClient
+    RpcClient,
     // Submits transactions directly to leaders using a ThinClient, broadcasting to multiple
     // leaders when num_nodes > 1
     ThinClient,
@@ -249,8 +251,16 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 ),
         )
         .arg(
+            Arg::with_name("rpc_client")
+                .long("use-rpc-client")
+                .conflicts_with("tpu_client")
+                .takes_value(false)
+                .help("Submit transactions with a RpcClient")
+        )
+        .arg(
             Arg::with_name("tpu_client")
                 .long("use-tpu-client")
+                .conflicts_with("rpc_client")
                 .takes_value(false)
                 .help("Submit transactions with a TpuClient")
         )
@@ -291,6 +301,8 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
 
     if matches.is_present("tpu_client") {
         args.external_client_type = ExternalClientType::TpuClient;
+    } else if matches.is_present("rpc_client") {
+        args.external_client_type = ExternalClientType::RpcClient;
     }
 
     if let Some(addr) = matches.value_of("entrypoint") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -82,6 +82,21 @@ fn main() {
     info!("Connecting to the cluster");
 
     match external_client_type {
+        ExternalClientType::RpcClient => {
+            let client = Arc::new(RpcClient::new_with_commitment(
+                json_rpc_url.to_string(),
+                CommitmentConfig::confirmed(),
+            ));
+            let keypairs = get_keypairs(
+                client.clone(),
+                id,
+                keypair_count,
+                *num_lamports_per_account,
+                client_ids_and_stake_file,
+                *read_from_client_file,
+            );
+            do_bench_tps(client, cli_config, keypairs);
+        }
         ExternalClientType::ThinClient => {
             let nodes = discover_cluster(entrypoint_addr, *num_nodes, SocketAddrSpace::Unspecified)
                 .unwrap_or_else(|err| {


### PR DESCRIPTION
#### Problem
We need a way to stress-test SendTransactionService performance on RPC nodes.

#### Summary of Changes
- Implement BenchTpsClient for RpcClient
- Plumb `--use-rpc-client` parameter into bench-tps, allowing the client to target an RPC node, and using the SendTransactionService to submit those transactions to a cluster

cc @lijunwangs 
