### PR TITLE
Send async quic batch of txs

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -256,6 +256,17 @@ pub fn send_wire_transaction_async(
     r
 }
 
+pub fn send_wire_transaction_batch_async(
+    packets: Vec<Vec<u8>>,
+    addr: &SocketAddr,
+) -> Result<(), TransportError> {
+    let conn = get_connection(addr);
+    match conn {
+        Connection::Udp(conn) => conn.send_wire_transaction_batch_async(packets),
+        Connection::Quic(conn) => conn.send_wire_transaction_batch_async(packets),
+    }
+}
+
 pub fn send_wire_transaction(
     wire_transaction: &[u8],
     addr: &SocketAddr,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,6 +2,9 @@
 #[macro_use]
 extern crate serde_derive;
 
+#[macro_use]
+extern crate solana_metrics;
+
 pub mod blockhash_query;
 pub mod client_error;
 pub mod connection_cache;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -27,9 +27,6 @@ pub mod tpu_connection;
 pub mod transaction_executor;
 pub mod udp_client;
 
-#[macro_use]
-extern crate solana_metrics;
-
 pub mod mock_sender_for_cli {
     /// Magic `SIGNATURE` value used by `solana-cli` unit tests.
     /// Please don't use this constant.

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -13,7 +13,6 @@ use {
     log::*,
     quinn::{ClientConfig, Endpoint, EndpointConfig, NewConnection, WriteError},
     quinn_proto::ConnectionStats,
-    solana_metrics::datapoint_debug,
     solana_sdk::{
         quic::{QUIC_MAX_CONCURRENT_STREAMS, QUIC_PORT_OFFSET},
         transport::Result as TransportResult,
@@ -126,7 +125,7 @@ impl TpuConnection for QuicTpuConnection {
             let send_buffer = client.send_buffer(wire_transaction, &stats);
             if let Err(e) = send_buffer.await {
                 warn!("Failed to send transaction async to {:?}", e);
-                datapoint_debug!("send-wire-async", ("failure", 1, i64),);
+                datapoint_warn!("send-wire-async", ("failure", 1, i64),);
             }
         });
         Ok(())
@@ -144,7 +143,7 @@ impl TpuConnection for QuicTpuConnection {
             let send_batch = client.send_batch(&buffers, &stats);
             if let Err(e) = send_batch.await {
                 warn!("Failed to send transaction batch async to {:?}", e);
-                datapoint_debug!("send-wire-batch-async", ("failure", 1, i64),);
+                datapoint_warn!("send-wire-batch-async", ("failure", 1, i64),);
             }
         });
         Ok(())

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -13,6 +13,7 @@ use {
     log::*,
     quinn::{ClientConfig, Endpoint, EndpointConfig, NewConnection, WriteError},
     quinn_proto::ConnectionStats,
+    solana_metrics::datapoint_debug,
     solana_sdk::{
         quic::{QUIC_MAX_CONCURRENT_STREAMS, QUIC_PORT_OFFSET},
         transport::Result as TransportResult,
@@ -119,16 +120,27 @@ impl TpuConnection for QuicTpuConnection {
         stats: Arc<ClientStats>,
     ) -> TransportResult<()> {
         let _guard = RUNTIME.enter();
-        //drop and detach the task
         let client = self.client.clone();
-        inc_new_counter_info!("send_wire_transaction_async", 1);
+        //drop and detach the task
         let _ = RUNTIME.spawn(async move {
             let send_buffer = client.send_buffer(wire_transaction, &stats);
             if let Err(e) = send_buffer.await {
-                inc_new_counter_warn!("send_wire_transaction_async_fail", 1);
                 warn!("Failed to send transaction async to {:?}", e);
-            } else {
-                inc_new_counter_info!("send_wire_transaction_async_pass", 1);
+                datapoint_debug!("send-wire-async", ("failure", 1, i64),);
+            }
+        });
+        Ok(())
+    }
+
+    fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
+        let _guard = RUNTIME.enter();
+        let client = self.client.clone();
+        //drop and detach the task
+        let _ = RUNTIME.spawn(async move {
+            let send_vecs = client.send_batch(&buffers);
+            if let Err(e) = send_vecs.await {
+                warn!("Failed to send transaction batch async to {:?}", e);
+                datapoint_debug!("send-wire-batch-async", ("failure", 1, i64),);
             }
         });
         Ok(())
@@ -269,13 +281,16 @@ impl QuicClient {
             .iter()
             .chunks(QUIC_MAX_CONCURRENT_STREAMS);
 
-        let futures = chunks.into_iter().map(|buffs| {
-            join_all(
-                buffs
-                    .into_iter()
-                    .map(|buf| Self::_send_buffer_using_conn(buf.as_ref(), connection_ref)),
-            )
-        });
+        let futures: Vec<_> = chunks
+            .into_iter()
+            .map(|buffs| {
+                join_all(
+                    buffs
+                        .into_iter()
+                        .map(|buf| Self::_send_buffer_using_conn(buf.as_ref(), connection_ref)),
+                )
+            })
+            .collect();
 
         for f in futures {
             f.await.into_iter().try_for_each(|res| res)?;

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -70,4 +70,6 @@ pub trait TpuConnection {
     ) -> TransportResult<()>
     where
         T: AsRef<[u8]>;
+
+    fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()>;
 }

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -71,5 +71,9 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]>;
 
-    fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()>;
+    fn send_wire_transaction_batch_async(
+        &self,
+        buffers: Vec<Vec<u8>>,
+        stats: Arc<ClientStats>,
+    ) -> TransportResult<()>;
 }

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -62,7 +62,11 @@ impl TpuConnection for UdpTpuConnection {
         batch_send(&self.socket, &pkts)?;
         Ok(())
     }
-    fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
+    fn send_wire_transaction_batch_async(
+        &self,
+        buffers: Vec<Vec<u8>>,
+        _stats: Arc<ClientStats>,
+    ) -> TransportResult<()> {
         let pkts: Vec<_> = buffers.into_iter().zip(repeat(self.tpu_addr())).collect();
         batch_send(&self.socket, &pkts)?;
         Ok(())

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -62,4 +62,9 @@ impl TpuConnection for UdpTpuConnection {
         batch_send(&self.socket, &pkts)?;
         Ok(())
     }
+    fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
+        let pkts: Vec<_> = buffers.into_iter().zip(repeat(self.tpu_addr())).collect();
+        batch_send(&self.socket, &pkts)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
#### Problem
Need api for async quic batch send of txs for bench-tps and forwarders

#### Summary of Changes
Add an async method to send the txs in a batch

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
