### PR TITLE
look up domain owner on .sol search (explorer)

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -25,16 +25,10 @@ interface SearchOptions {
   }[];
 }
 
-interface TempSearchOptions {
-  searchOptions: SearchOptions[];
-  searchTerm: string;
-}
-
 export function SearchBar() {
   const [search, setSearch] = React.useState("");
+  const searchRef = React.useRef("");
   const [searchOptions, setSearchOptions] = React.useState<SearchOptions[]>([]);
-  const [tempSearchOptions, setTempSearchOptions] =
-    React.useState<TempSearchOptions>({ searchOptions: [], searchTerm: "" });
   const [loadingSearch, setLoadingSearch] = React.useState<boolean>(false);
   const [loadingSearchMessage, setLoadingSearchMessage] =
     React.useState<string>("loading...");
@@ -61,6 +55,7 @@ export function SearchBar() {
   };
 
   React.useEffect(() => {
+    searchRef.current = search;
     setLoadingSearchMessage("Loading...");
     setLoadingSearch(true);
 
@@ -72,10 +67,7 @@ export function SearchBar() {
       clusterInfo?.epochInfo.epoch
     );
 
-    setTempSearchOptions({
-      searchOptions: options,
-      searchTerm: search,
-    });
+    setSearchOptions(options);
 
     // checking for non local search output
     if (hasDomainSyntax(search)) {
@@ -99,22 +91,13 @@ export function SearchBar() {
       search,
       options
     );
-
-    setTempSearchOptions({
-      searchOptions: updatedOptions,
-      searchTerm: searchTerm,
-    });
-    // after attempting to fetch the domain name we can conclude the loading state
-    setLoadingSearch(false);
-    setLoadingSearchMessage("Loading...");
-  };
-
-  React.useEffect(() => {
-    if (tempSearchOptions.searchTerm === search) {
-      setSearchOptions(tempSearchOptions.searchOptions);
+    if (searchRef.current === searchTerm) {
+      setSearchOptions(updatedOptions);
+      // after attempting to fetch the domain name we can conclude the loading state
+      setLoadingSearch(false);
+      setLoadingSearchMessage("Loading...");
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tempSearchOptions, tempSearchOptions.searchOptions]);
+  };
 
   const resetValue = "" as any;
   return (

--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -14,7 +14,7 @@ import { Cluster, useCluster } from "providers/cluster";
 import { useTokenRegistry } from "providers/mints/token-registry";
 import { TokenInfoMap } from "@solana/spl-token-registry";
 import { Connection } from "@solana/web3.js";
-import { getDomainOwner, hasDomainSyntax } from "utils/name-service";
+import { getDomainInfo, hasDomainSyntax } from "utils/name-service";
 
 interface SearchOptions {
   label: string;
@@ -69,7 +69,6 @@ export function SearchBar() {
       search,
       cluster,
       tokenRegistry,
-      url,
       clusterInfo?.epochInfo.epoch
     );
 
@@ -279,7 +278,7 @@ async function buildDomainOptions(
   search: string,
   options: SearchOptions[]
 ) {
-  const domainInfo = await getDomainOwner(search, connection);
+  const domainInfo = await getDomainInfo(search, connection);
   const updatedOptions: SearchOptions[] = [...options];
   if (domainInfo && domainInfo.owner && domainInfo.address) {
     updatedOptions.push({
@@ -311,7 +310,6 @@ function buildOptions(
   rawSearch: string,
   cluster: Cluster,
   tokenRegistry: TokenInfoMap,
-  url: string,
   currentEpoch?: number
 ) {
   const search = rawSearch.trim();

--- a/explorer/src/utils/name-service.tsx
+++ b/explorer/src/utils/name-service.tsx
@@ -1,6 +1,9 @@
 import { PublicKey, Connection } from "@solana/web3.js";
 import {
   getFilteredProgramAccounts,
+  getHashedName,
+  getNameAccountKey,
+  NameRegistryState,
   NAME_PROGRAM_ID,
   performReverseLookup,
 } from "@bonfida/spl-name-service";
@@ -11,10 +14,17 @@ import { Cluster, useCluster } from "providers/cluster";
 const SOL_TLD_AUTHORITY = new PublicKey(
   "58PwtjSDuFHuUkYjH9BYnnQKHfwo9reZhC2zMJv9JPkx"
 );
+
 export interface DomainInfo {
   name: string;
   address: PublicKey;
 }
+export const hasDomainSyntax = (value: string) => {
+  if (value.length >= 4 && value.substring(value.length - 4) === ".sol")
+    return true;
+  return false;
+};
+
 
 async function getUserDomainAddresses(
   connection: Connection,

--- a/explorer/src/utils/name-service.tsx
+++ b/explorer/src/utils/name-service.tsx
@@ -38,7 +38,7 @@ async function getDomainKey(
 }
 
 // returns non empty wallet string if a given .sol domain is owned by a wallet
-export async function getDomainOwner(domain: string, connection: Connection) {
+export async function getDomainInfo(domain: string, connection: Connection) {
   const domainKey = await getDomainKey(
     domain.slice(0, -4), // remove .sol
     undefined,


### PR DESCRIPTION
#### Problem
It's currently not possible to search the owner of a .sol domain in the explorer.

#### Summary of Changes
If the search input ends in .sol, the name service lookup gets called to check if a wallet owns that domain. If so, the search input gets replaced with that wallet address to help the user look up the account.

https://user-images.githubusercontent.com/23406704/163066564-2569add1-9d48-4fa6-b190-d4fdb3da3ebc.mp4

**_Note:_** one could alternatively update it to only replace the .sol domain with the actual domain owning address on keypress (e.g. enter). 

**_Possible additions going forward:_** 
Ideally I think it would be great to allow for customized explorer url paths based on which wallet owns a domain. 
e.g. `explorer.solana.com/address/hello` could show the Account details of the wallet that owns hello.sol.

Fixes #
