### PR TITLE
connection_cache: make async interface the same as sync

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -83,24 +83,24 @@ fn get_connection(addr: &SocketAddr) -> Connection {
 // This will be done in a followup to
 // https://github.com/solana-labs/solana/pull/23817
 pub fn send_wire_transaction_batch(
-    packets: &[&[u8]],
+    wire_transactions: &[&[u8]],
     addr: &SocketAddr,
 ) -> Result<(), TransportError> {
     let conn = get_connection(addr);
     match conn {
-        Connection::Udp(conn) => conn.send_wire_transaction_batch(packets),
-        Connection::Quic(conn) => conn.send_wire_transaction_batch(packets),
+        Connection::Udp(conn) => conn.send_wire_transaction_batch(wire_transactions),
+        Connection::Quic(conn) => conn.send_wire_transaction_batch(wire_transactions),
     }
 }
 
 pub fn send_wire_transaction_async(
-    packets: Vec<u8>,
+    wire_transaction: Vec<u8>,
     addr: &SocketAddr,
 ) -> Result<(), TransportError> {
     let conn = get_connection(addr);
     match conn {
-        Connection::Udp(conn) => conn.send_wire_transaction_async(packets),
-        Connection::Quic(conn) => conn.send_wire_transaction_async(packets),
+        Connection::Udp(conn) => conn.send_wire_transaction_async(wire_transaction),
+        Connection::Quic(conn) => conn.send_wire_transaction_async(wire_transaction),
     }
 }
 

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -94,7 +94,7 @@ pub fn send_wire_transaction_batch(
 }
 
 pub fn send_wire_transaction_async(
-    wire_transaction: Vec<u8>,
+    wire_transaction: &[u8],
     addr: &SocketAddr,
 ) -> Result<(), TransportError> {
     let conn = get_connection(addr);

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -90,10 +90,11 @@ impl TpuConnection for QuicTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
+    fn send_wire_transaction_async(&self, wire_transaction: &[u8]) -> TransportResult<()> {
         let _guard = RUNTIME.enter();
         //drop and detach the task
         let client = self.client.clone();
+        let wire_transaction = wire_transaction.to_vec();
         inc_new_counter_info!("send_wire_transaction_async", 1);
         let _ = RUNTIME.spawn(async move {
             let send_buffer = client.send_buffer(wire_transaction);

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -22,7 +22,7 @@ pub trait TpuConnection {
     where
         T: AsRef<[u8]>;
 
-    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()>;
+    fn send_wire_transaction_async(&self, wire_transaction: &[u8]) -> TransportResult<()>;
 
     fn par_serialize_and_send_transaction_batch(
         &self,

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -34,7 +34,7 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
+    fn send_wire_transaction_async(&self, wire_transaction: &[u8]) -> TransportResult<()> {
         self.socket.send_to(wire_transaction.as_ref(), self.addr)?;
         Ok(())
     }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -312,7 +312,7 @@ impl SendTransactionService {
         let mut measure = Measure::start("send_transaction_service-us");
 
         if let Err(err) =
-            connection_cache::send_wire_transaction_async(wire_transaction.to_vec(), tpu_address)
+            connection_cache::send_wire_transaction_async(wire_transaction, tpu_address)
         {
             warn!("Failed to send transaction to {}: {:?}", tpu_address, err);
         }


### PR DESCRIPTION
#### Problem
`connection_cache::send_wire_transaction_async` takes a Vec, while all the other methods take a slice. This forces callers to have to change handling to switch between sync/async. It also makes it hard to explore other multithreaded approaches, since any changes have to be bubbled up to callers.

#### Summary of Changes
Move `to_vec()` allocation into `send_wire_transaction_async()`; that way if we choose to rework this with a different thread-safe approach, it won't break callers
Also, rename some variables that were unclear, or bad copy-pasta