### PR TITLE
Don't request reviews for community pr's that have been reviewed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,9 @@ pull_request_rules:
       # Only request reviews from the pr subscribers group if no one
       # has reviewed the community PR yet. These checks only match
       # reviewers with admin, write or maintain permission on the repository.
+      - "#approved-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - "#changes-requested-reviews-by=0"
       - "#review-requested=0"
     actions:
       request_reviews:


### PR DESCRIPTION
#### Problem
The change in https://github.com/solana-labs/solana/pull/24306 doesn't cover the case where a reviewer was not actively requested but has already reviewed a community PR

#### Summary of Changes
Cover all cases

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
