### PR TITLE
Explorer: Fix domain table and bump @bonfida/spl-name-service to 0.1.30

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,7 @@ pull_request_rules:
       # Only request reviews from the pr subscribers group if no one
       # has reviewed the community PR yet. These checks only match
       # reviewers with admin, write or maintain permission on the repository.
-      - "review-requested~=^@solana-labs/community-pr-subscribers"
+      - "#review-requested=0"
     actions:
       request_reviews:
         teams:

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@blockworks-foundation/mango-client": "^3.2.16",
         "@bonfida/bot": "^0.5.3",
-        "@bonfida/spl-name-service": "^0.1.22",
+        "@bonfida/spl-name-service": "^0.1.30",
         "@cloudflare/stream-react": "^1.2.0",
         "@metamask/jazzicon": "^2.0.0",
         "@metaplex/js": "4.12.0",
@@ -1933,481 +1933,18 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@bonfida/spl-name-service": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.22.tgz",
-      "integrity": "sha512-XhHe+po8MvDhOExV84MjimWyfYEsxJfinENYD3zSVp/DYUpX55QPhHK1btpZWbiEf3WrDr86EX6THolviZN0Mw==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.30.tgz",
+      "integrity": "sha512-0aSpymeNDq7rDSDEJgB6/qKyy3yUkHLQk7Jxwtmibfva3s1johEfFdl2kUDDPWi/ubgbxYjPxJRGrlGQNEmmQw==",
       "dependencies": {
-        "@project-serum/sol-wallet-adapter": "^0.1.5",
-        "@solana/spl-token": "0.1.3",
-        "@solana/web3.js": "^1.29.2",
-        "bip32": "^2.0.6",
-        "bn.js": "^5.1.3",
-        "borsh": "^0.6.0",
-        "bs58": "4.0.1",
-        "buffer-layout": "^1.2.0",
-        "core-util-is": "^1.0.2",
-        "csv-parser": "^3.0.0",
-        "fs": "^0.0.1-security",
-        "tweetnacl": "^1.0.3",
-        "webpack-dev-server": "^3.11.2"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/@solana/spl-token": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.3.tgz",
-      "integrity": "sha512-M251on5RDz8VQXoKoQPeLANEyI4qhThKLZBeUiLbFZ93KRgouGfmV5D/bUZXkLF75PlLcARIzU9ptoHOlZ6SbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "@solana/web3.js": "^1.2.2",
-        "bn.js": "^5.1.0",
-        "buffer": "6.0.3",
-        "buffer-layout": "^1.2.0",
-        "dotenv": "8.2.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dependencies": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/anymatch/node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/borsh": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.6.0.tgz",
-      "integrity": "sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/braces": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-      "dependencies": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/braces/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-      "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
-      "dependencies": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "optionalDependencies": {
-        "fsevents": "^1.2.7"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/fill-range/node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/glob-parent/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/import-local": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-      "dependencies": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/is-absolute-url": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dependencies": {
-        "binary-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/is-number": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "dependencies": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "dependencies": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/webpack-dev-server": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
-      "dependencies": {
-        "ansi-html-community": "0.0.8",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.1.8",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "debug": "^4.1.1",
-        "del": "^4.1.1",
-        "express": "^4.17.1",
-        "html-entities": "^1.3.1",
-        "http-proxy-middleware": "0.19.1",
-        "import-local": "^2.0.0",
-        "internal-ip": "^4.3.0",
-        "ip": "^1.1.5",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
-        "loglevel": "^1.6.8",
-        "opn": "^5.5.0",
-        "p-retry": "^3.0.1",
-        "portfinder": "^1.0.26",
-        "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.8",
-        "semver": "^6.3.0",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.21",
-        "sockjs-client": "^1.5.0",
-        "spdy": "^4.0.2",
-        "strip-ansi": "^3.0.1",
-        "supports-color": "^6.1.0",
-        "url": "^0.11.0",
-        "webpack-dev-middleware": "^3.7.2",
-        "webpack-log": "^2.0.0",
-        "ws": "^6.2.1",
-        "yargs": "^13.3.2"
-      },
-      "bin": {
-        "webpack-dev-server": "bin/webpack-dev-server.js"
-      },
-      "engines": {
-        "node": ">= 6.11.5"
+        "ethers": "^5.6.2"
       },
       "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@bonfida/spl-name-service/node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/spl-token": "0.2.0",
+        "@solana/web3.js": "^1.37.1",
+        "bn.js": "^5.1.3",
+        "borsh": "^0.7.0"
       }
     },
     "node_modules/@cloudflare/stream-react": {
@@ -2645,10 +2182,10 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/@ethersproject/bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
-      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+    "node_modules/@ethersproject/abi": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.1.tgz",
+      "integrity": "sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==",
       "funding": [
         {
           "type": "individual",
@@ -2660,13 +2197,317 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
+      "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/networks": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/web": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
+      "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
+      "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
+      "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
+      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
+      "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "bn.js": "^4.11.9"
+      }
+    },
+    "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
+      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.0.tgz",
+      "integrity": "sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.6.0",
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
+      "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.0.tgz",
+      "integrity": "sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
+      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
+      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
       "funding": [
         {
           "type": "individual",
@@ -2678,10 +2519,10 @@
         }
       ]
     },
-    "node_modules/@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+    "node_modules/@ethersproject/networks": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.2.tgz",
+      "integrity": "sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==",
       "funding": [
         {
           "type": "individual",
@@ -2693,9 +2534,331 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
+      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
+      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.3.tgz",
+      "integrity": "sha512-PKTEZXjdAhGK/+hUwRLQqlGrwTRrK4D0FHEP2V9klUF8C6+AWfHkA3AoLI+a8oq5CUZoRAH0nMecYGkKxUjeSw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/networks": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/web": "^5.6.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
+      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
+      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.0.tgz",
+      "integrity": "sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
         "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
+      "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
+      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
+      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
+      "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
+      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.0.tgz",
+      "integrity": "sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/json-wallets": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
+      "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
+      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
       }
     },
     "node_modules/@hapi/address": {
@@ -6628,6 +6791,11 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -6713,17 +6881,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "bin": {
-        "ansi-html": "bin/ansi-html"
-      }
-    },
-    "node_modules/ansi-html-community": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "engines": [
         "node >= 0.8.0"
       ],
@@ -7826,6 +7983,11 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -9617,20 +9779,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
       "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-    },
-    "node_modules/csv-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
-      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "csv-parser": "bin/csv-parser"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -11564,6 +11712,53 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ethers": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.3.tgz",
+      "integrity": "sha512-TkZAYGtbnzsGzEzqonLEMpOkmD5JIKCoWlAlj9ShAJlJszEkgKh3jVSeX1edLkYmqnpvJvGlBDK2y/HVe84LNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.6.1",
+        "@ethersproject/abstract-provider": "5.6.0",
+        "@ethersproject/abstract-signer": "5.6.0",
+        "@ethersproject/address": "5.6.0",
+        "@ethersproject/base64": "5.6.0",
+        "@ethersproject/basex": "5.6.0",
+        "@ethersproject/bignumber": "5.6.0",
+        "@ethersproject/bytes": "5.6.1",
+        "@ethersproject/constants": "5.6.0",
+        "@ethersproject/contracts": "5.6.0",
+        "@ethersproject/hash": "5.6.0",
+        "@ethersproject/hdnode": "5.6.0",
+        "@ethersproject/json-wallets": "5.6.0",
+        "@ethersproject/keccak256": "5.6.0",
+        "@ethersproject/logger": "5.6.0",
+        "@ethersproject/networks": "5.6.2",
+        "@ethersproject/pbkdf2": "5.6.0",
+        "@ethersproject/properties": "5.6.0",
+        "@ethersproject/providers": "5.6.3",
+        "@ethersproject/random": "5.6.0",
+        "@ethersproject/rlp": "5.6.0",
+        "@ethersproject/sha2": "5.6.0",
+        "@ethersproject/signing-key": "5.6.0",
+        "@ethersproject/solidity": "5.6.0",
+        "@ethersproject/strings": "5.6.0",
+        "@ethersproject/transactions": "5.6.0",
+        "@ethersproject/units": "5.6.0",
+        "@ethersproject/wallet": "5.6.0",
+        "@ethersproject/web": "5.6.0",
+        "@ethersproject/wordlists": "5.6.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -12489,11 +12684,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "node_modules/fs-extra": {
       "version": "1.0.0",
@@ -23068,6 +23258,11 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+    },
     "node_modules/secp256k1": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
@@ -28827,380 +29022,11 @@
       }
     },
     "@bonfida/spl-name-service": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.22.tgz",
-      "integrity": "sha512-XhHe+po8MvDhOExV84MjimWyfYEsxJfinENYD3zSVp/DYUpX55QPhHK1btpZWbiEf3WrDr86EX6THolviZN0Mw==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.30.tgz",
+      "integrity": "sha512-0aSpymeNDq7rDSDEJgB6/qKyy3yUkHLQk7Jxwtmibfva3s1johEfFdl2kUDDPWi/ubgbxYjPxJRGrlGQNEmmQw==",
       "requires": {
-        "@project-serum/sol-wallet-adapter": "^0.1.5",
-        "@solana/spl-token": "0.1.3",
-        "@solana/web3.js": "^1.29.2",
-        "bip32": "^2.0.6",
-        "bn.js": "^5.1.3",
-        "borsh": "^0.6.0",
-        "bs58": "4.0.1",
-        "buffer-layout": "^1.2.0",
-        "core-util-is": "^1.0.2",
-        "csv-parser": "^3.0.0",
-        "fs": "^0.0.1-security",
-        "tweetnacl": "^1.0.3",
-        "webpack-dev-server": "^3.11.2"
-      },
-      "dependencies": {
-        "@solana/spl-token": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.3.tgz",
-          "integrity": "sha512-M251on5RDz8VQXoKoQPeLANEyI4qhThKLZBeUiLbFZ93KRgouGfmV5D/bUZXkLF75PlLcARIzU9ptoHOlZ6SbQ==",
-          "requires": {
-            "@babel/runtime": "^7.10.5",
-            "@solana/web3.js": "^1.2.2",
-            "bn.js": "^5.1.0",
-            "buffer": "6.0.3",
-            "buffer-layout": "^1.2.0",
-            "dotenv": "8.2.0"
-          }
-        },
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-              "requires": {
-                "remove-trailing-separator": "^1.0.1"
-              }
-            }
-          }
-        },
-        "binary-extensions": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-        },
-        "borsh": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.6.0.tgz",
-          "integrity": "sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==",
-          "requires": {
-            "bn.js": "^5.2.0",
-            "bs58": "^4.0.0",
-            "text-encoding-utf-8": "^1.0.2"
-          }
-        },
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fsevents": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "import-local": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-          "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-          "requires": {
-            "pkg-dir": "^3.0.0",
-            "resolve-cwd": "^2.0.0"
-          }
-        },
-        "is-absolute-url": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-          "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-          "requires": {
-            "binary-extensions": "^1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "resolve-cwd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-          "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-          "requires": {
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
-        "webpack-dev-server": {
-          "version": "3.11.3",
-          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-          "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
-          "requires": {
-            "ansi-html-community": "0.0.8",
-            "bonjour": "^3.5.0",
-            "chokidar": "^2.1.8",
-            "compression": "^1.7.4",
-            "connect-history-api-fallback": "^1.6.0",
-            "debug": "^4.1.1",
-            "del": "^4.1.1",
-            "express": "^4.17.1",
-            "html-entities": "^1.3.1",
-            "http-proxy-middleware": "0.19.1",
-            "import-local": "^2.0.0",
-            "internal-ip": "^4.3.0",
-            "ip": "^1.1.5",
-            "is-absolute-url": "^3.0.3",
-            "killable": "^1.0.1",
-            "loglevel": "^1.6.8",
-            "opn": "^5.5.0",
-            "p-retry": "^3.0.1",
-            "portfinder": "^1.0.26",
-            "schema-utils": "^1.0.0",
-            "selfsigned": "^1.10.8",
-            "semver": "^6.3.0",
-            "serve-index": "^1.9.1",
-            "sockjs": "^0.3.21",
-            "sockjs-client": "^1.5.0",
-            "spdy": "^4.0.2",
-            "strip-ansi": "^3.0.1",
-            "supports-color": "^6.1.0",
-            "url": "^0.11.0",
-            "webpack-dev-middleware": "^3.7.2",
-            "webpack-log": "^2.0.0",
-            "ws": "^6.2.1",
-            "yargs": "^13.3.2"
-          }
-        },
-        "ws": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
+        "ethers": "^5.6.2"
       }
     },
     "@cloudflare/stream-react": {
@@ -29394,27 +29220,387 @@
         }
       }
     },
-    "@ethersproject/bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
-      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+    "@ethersproject/abi": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.1.tgz",
+      "integrity": "sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==",
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
+      "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/networks": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/web": "^5.6.0"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz",
+      "integrity": "sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
+      "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
+      "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0"
+      }
+    },
+    "@ethersproject/basex": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
+      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
+      "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "bn.js": "^4.11.9"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "requires": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
+      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0"
+      }
+    },
+    "@ethersproject/contracts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.0.tgz",
+      "integrity": "sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==",
+      "requires": {
+        "@ethersproject/abi": "^5.6.0",
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0"
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
+      "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.0.tgz",
+      "integrity": "sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
+      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/pbkdf2": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
+      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+    },
+    "@ethersproject/networks": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.2.tgz",
+      "integrity": "sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==",
+      "requires": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
+      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0"
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
+      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "requires": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.3.tgz",
+      "integrity": "sha512-PKTEZXjdAhGK/+hUwRLQqlGrwTRrK4D0FHEP2V9klUF8C6+AWfHkA3AoLI+a8oq5CUZoRAH0nMecYGkKxUjeSw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/basex": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/networks": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/web": "^5.6.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
+      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
+      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
     },
     "@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.0.tgz",
+      "integrity": "sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
         "hash.js": "1.1.7"
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.0.tgz",
+      "integrity": "sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
+      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/sha2": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
+      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.0.tgz",
+      "integrity": "sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==",
+      "requires": {
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
+      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.0.tgz",
+      "integrity": "sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.6.0",
+        "@ethersproject/abstract-signer": "^5.6.0",
+        "@ethersproject/address": "^5.6.0",
+        "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/hdnode": "^5.6.0",
+        "@ethersproject/json-wallets": "^5.6.0",
+        "@ethersproject/keccak256": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/random": "^5.6.0",
+        "@ethersproject/signing-key": "^5.6.0",
+        "@ethersproject/transactions": "^5.6.0",
+        "@ethersproject/wordlists": "^5.6.0"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
+      "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
+      "requires": {
+        "@ethersproject/base64": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
+      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/hash": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/strings": "^5.6.0"
       }
     },
     "@hapi/address": {
@@ -32370,6 +32556,11 @@
         "regex-parser": "^2.2.11"
       }
     },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -32431,11 +32622,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
-    },
-    "ansi-html-community": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -33311,6 +33497,11 @@
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         }
       }
+    },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bfj": {
       "version": "7.0.2",
@@ -34769,14 +34960,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
       "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
-    },
-    "csv-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
-      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
-      "requires": {
-        "minimist": "^1.2.0"
-      }
     },
     "cyclist": {
       "version": "1.0.1",
@@ -36248,6 +36431,43 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "ethers": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.3.tgz",
+      "integrity": "sha512-TkZAYGtbnzsGzEzqonLEMpOkmD5JIKCoWlAlj9ShAJlJszEkgKh3jVSeX1edLkYmqnpvJvGlBDK2y/HVe84LNg==",
+      "requires": {
+        "@ethersproject/abi": "5.6.1",
+        "@ethersproject/abstract-provider": "5.6.0",
+        "@ethersproject/abstract-signer": "5.6.0",
+        "@ethersproject/address": "5.6.0",
+        "@ethersproject/base64": "5.6.0",
+        "@ethersproject/basex": "5.6.0",
+        "@ethersproject/bignumber": "5.6.0",
+        "@ethersproject/bytes": "5.6.1",
+        "@ethersproject/constants": "5.6.0",
+        "@ethersproject/contracts": "5.6.0",
+        "@ethersproject/hash": "5.6.0",
+        "@ethersproject/hdnode": "5.6.0",
+        "@ethersproject/json-wallets": "5.6.0",
+        "@ethersproject/keccak256": "5.6.0",
+        "@ethersproject/logger": "5.6.0",
+        "@ethersproject/networks": "5.6.2",
+        "@ethersproject/pbkdf2": "5.6.0",
+        "@ethersproject/properties": "5.6.0",
+        "@ethersproject/providers": "5.6.3",
+        "@ethersproject/random": "5.6.0",
+        "@ethersproject/rlp": "5.6.0",
+        "@ethersproject/sha2": "5.6.0",
+        "@ethersproject/signing-key": "5.6.0",
+        "@ethersproject/solidity": "5.6.0",
+        "@ethersproject/strings": "5.6.0",
+        "@ethersproject/transactions": "5.6.0",
+        "@ethersproject/units": "5.6.0",
+        "@ethersproject/wallet": "5.6.0",
+        "@ethersproject/web": "5.6.0",
+        "@ethersproject/wordlists": "5.6.0"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -37008,11 +37228,6 @@
           }
         }
       }
-    },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "fs-extra": {
       "version": "1.0.0",
@@ -45176,6 +45391,11 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "secp256k1": {
       "version": "4.0.2",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@blockworks-foundation/mango-client": "^3.2.16",
     "@bonfida/bot": "^0.5.3",
-    "@bonfida/spl-name-service": "^0.1.22",
+    "@bonfida/spl-name-service": "^0.1.30",
     "@cloudflare/stream-react": "^1.2.0",
     "@metamask/jazzicon": "^2.0.0",
     "@metaplex/js": "4.12.0",


### PR DESCRIPTION
#### Problem
#24271 build failed due to breaking changes in the package's new versions.

#### Summary of Changes
The `NameRegistryState` class does not have an `address` field in versions `0.1.23` & above and `retrieveBatch()` does not return the address either so I rewrote `performReverseLookup()` to account for that. The change doesn't break the domain display and load time seems similar, though I haven't tested it with accounts with a large amount of domains.

What do you think @jstarry ?

_**Note:**_ for some reason I could only get it to run by installing bootstrap's peer dependency `@popperjs/core`. Not sure if it's a needed change.

Fixes #
