### PR TITLE
ci: Remove redundant `build-bpf` from downstream

### DIFF
--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -12,7 +12,6 @@ source scripts/read-cargo-variable.sh
 solana_ver=$(readCargoVariable version sdk/Cargo.toml)
 solana_dir=$PWD
 cargo="$solana_dir"/cargo
-cargo_build_bpf="$solana_dir"/cargo-build-bpf
 cargo_test_bpf="$solana_dir"/cargo-test-bpf
 
 mkdir -p target/downstream-projects-anchor
@@ -72,7 +71,6 @@ mango() {
 
     $cargo build
     $cargo test
-    $cargo_build_bpf
     $cargo_test_bpf
   )
 }
@@ -91,7 +89,6 @@ metaplex() {
 
     $cargo build
     $cargo test
-    $cargo_build_bpf
     $cargo_test_bpf
   )
 }

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -47,7 +47,6 @@ spl() {
 
     $cargo build
     $cargo test
-    $cargo_build_bpf
     $cargo_test_bpf
   )
 }


### PR DESCRIPTION
#### Problem

The downstream projects build often times out, but it's doing `cargo build-bpf` followed by `cargo test-bpf`, which again triggers `build-bpf`.  Even the SPL CI only does `build`, `test`, and `test-bpf`, so we can remove the `build-bpf` step, in the hope that it'll speed things up.

#### Summary of Changes

Remove `cargo build-bpf` step in the SPL portion.