### PR TITLE
Add a stringified credential option for LedgerStorage

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -16,6 +16,7 @@ use {
     },
     solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType},
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
+    solana_storage_bigtable::CredentialOption,
     solana_transaction_status::{
         BlockEncodingOptions, ConfirmedBlock, EncodeError, TransactionDetails,
         UiTransactionEncoding,
@@ -642,16 +643,19 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 instance_name,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
-            let credential_path = Some(value_t_or_exit!(
-                arg_matches,
-                "reference_credential",
-                String
-            ));
+
+            let credential_path = value_t_or_exit!(arg_matches, "reference_credential", String);
+
+            let reference_credential = CredentialOption {
+                stringified: false,
+                value: credential_path,
+            };
+
             let ref_instance_name =
                 value_t_or_exit!(arg_matches, "reference_instance_name", String);
             let ref_config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
-                credential_path,
+                credential_option: Some(reference_credential),
                 instance_name: ref_instance_name,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -16,7 +16,7 @@ use {
     },
     solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType},
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
-    solana_storage_bigtable::CredentialOption,
+    solana_storage_bigtable::CredentialType,
     solana_transaction_status::{
         BlockEncodingOptions, ConfirmedBlock, EncodeError, TransactionDetails,
         UiTransactionEncoding,
@@ -644,18 +644,17 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 
-            let credential_path = value_t_or_exit!(arg_matches, "reference_credential", String);
-
-            let reference_credential = CredentialOption {
-                stringified: false,
-                value: credential_path,
-            };
+            let credential_path = Some(value_t_or_exit!(
+                arg_matches,
+                "reference_credential",
+                String
+            ));
 
             let ref_instance_name =
                 value_t_or_exit!(arg_matches, "reference_instance_name", String);
             let ref_config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
-                credential_option: Some(reference_credential),
+                credential_type: CredentialType::Filepath(credential_path),
                 instance_name: ref_instance_name,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -36,8 +36,8 @@ use {
         exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
         native_token::lamports_to_sol, pubkey::Pubkey,
     },
-    solana_storage_bigtable::CredentialType,
     solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
+    solana_storage_bigtable::CredentialType,
     std::{
         collections::HashSet,
         net::SocketAddr,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -385,7 +385,7 @@ impl JsonRpcService {
                 let bigtable_config = solana_storage_bigtable::LedgerStorageConfig {
                     read_only: !enable_bigtable_ledger_upload,
                     timeout,
-                    credential_path: None,
+                    credential_option: None,
                     instance_name: bigtable_instance_name.clone(),
                 };
                 runtime

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -36,6 +36,7 @@ use {
         exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
         native_token::lamports_to_sol, pubkey::Pubkey,
     },
+    solana_storage_bigtable::CredentialType,
     solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
     std::{
         collections::HashSet,
@@ -385,7 +386,7 @@ impl JsonRpcService {
                 let bigtable_config = solana_storage_bigtable::LedgerStorageConfig {
                     read_only: !enable_bigtable_ledger_upload,
                     timeout,
-                    credential_option: None,
+                    credential_type: CredentialType::Filepath(None),
                     instance_name: bigtable_instance_name.clone(),
                 };
                 runtime

--- a/storage-bigtable/src/access_token.rs
+++ b/storage-bigtable/src/access_token.rs
@@ -31,10 +31,6 @@ fn load_credentials(filepath: Option<String>) -> Result<Credentials, String> {
 
 fn load_stringified_credentials(credential: String) -> Result<Credentials, String> {
     Credentials::from_str(&credential).map_err(|err| format!("{}", err))
-    // match credential {
-    //     Some(s) => Credentials::from_str(&s).map_err(|err| format!("{}", err)),
-    //     None => Err("stringified credential is not provided".to_string()),
-    // }
 }
 
 #[derive(Clone)]
@@ -48,7 +44,7 @@ pub struct AccessToken {
 impl AccessToken {
     pub async fn new(scope: Scope, credential_type: CredentialType) -> Result<Self, String> {
         let credentials = match credential_type {
-            CredentialType::Filepath(fp)=> load_credentials(fp)?,
+            CredentialType::Filepath(fp) => load_credentials(fp)?,
             CredentialType::Stringified(s) => load_stringified_credentials(s)?,
         };
 

--- a/storage-bigtable/src/access_token.rs
+++ b/storage-bigtable/src/access_token.rs
@@ -32,7 +32,7 @@ fn load_credentials(filepath: Option<String>) -> Result<Credentials, String> {
 fn load_stringified_credentials(credential: Option<String>) -> Result<Credentials, String> {
     match credential {
         Some(s) => Credentials::from_str(&s).map_err(|err| format!("{}", err)),
-        None => Err(format!("stringified credential is not provided")),
+        None => Err("stringified credential is not provided".to_string()),
     }
 }
 

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         access_token::{AccessToken, Scope},
         compression::{compress_best, decompress},
-        root_ca_certificate,
+        root_ca_certificate, CredentialOption,
     },
     backoff::{future::retry, ExponentialBackoff},
     log::*,
@@ -125,7 +125,7 @@ impl BigTableConnection {
         instance_name: &str,
         read_only: bool,
         timeout: Option<Duration>,
-        credential_path: Option<String>,
+        credential_option: Option<CredentialOption>,
     ) -> Result<Self> {
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {
@@ -148,7 +148,7 @@ impl BigTableConnection {
                     } else {
                         Scope::BigTableData
                     },
-                    credential_path,
+                    credential_option,
                 )
                 .await
                 .map_err(Error::AccessToken)?;

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -125,7 +125,7 @@ impl BigTableConnection {
         instance_name: &str,
         read_only: bool,
         timeout: Option<Duration>,
-        credential_option: CredentialType,
+        credential_type: CredentialType,
     ) -> Result<Self> {
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {
@@ -148,7 +148,7 @@ impl BigTableConnection {
                     } else {
                         Scope::BigTableData
                     },
-                    credential_option,
+                    credential_type,
                 )
                 .await
                 .map_err(Error::AccessToken)?;

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         access_token::{AccessToken, Scope},
         compression::{compress_best, decompress},
-        root_ca_certificate, CredentialOption,
+        root_ca_certificate, CredentialType,
     },
     backoff::{future::retry, ExponentialBackoff},
     log::*,
@@ -125,7 +125,7 @@ impl BigTableConnection {
         instance_name: &str,
         read_only: bool,
         timeout: Option<Duration>,
-        credential_option: Option<CredentialOption>,
+        credential_option: CredentialType,
     ) -> Result<Self> {
         match std::env::var("BIGTABLE_EMULATOR_HOST") {
             Ok(endpoint) => {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -395,10 +395,11 @@ pub struct LedgerStorage {
 }
 
 impl LedgerStorage {
-    pub async fn new(read_only: bool, timeout: Option<std::time::Duration>) -> Result<Self> {
+    pub async fn new(read_only: bool, timeout: Option<std::time::Duration>, credential_path: Option<String>) -> Result<Self> {
         Self::new_with_config(LedgerStorageConfig {
             read_only,
             timeout,
+            credential_type: CredentialType::Filepath(credential_path),
             ..LedgerStorageConfig::default()
         })
         .await

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -395,7 +395,11 @@ pub struct LedgerStorage {
 }
 
 impl LedgerStorage {
-    pub async fn new(read_only: bool, timeout: Option<std::time::Duration>, credential_path: Option<String>) -> Result<Self> {
+    pub async fn new(
+        read_only: bool,
+        timeout: Option<std::time::Duration>,
+        credential_path: Option<String>,
+    ) -> Result<Self> {
         Self::new_with_config(LedgerStorageConfig {
             read_only,
             timeout,

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -364,11 +364,19 @@ impl From<LegacyTransactionByAddrInfo> for TransactionByAddrInfo {
 
 pub const DEFAULT_INSTANCE_NAME: &str = "solana-ledger";
 
+// stringified = truev, alue is a stringified credential
+// stringified = false, value is a filepath (default)
+#[derive(Debug)]
+pub struct CredentialOption {
+    pub stringified: bool,
+    pub value: String,
+}
+
 #[derive(Debug)]
 pub struct LedgerStorageConfig {
     pub read_only: bool,
     pub timeout: Option<std::time::Duration>,
-    pub credential_path: Option<String>,
+    pub credential_option: Option<CredentialOption>,
     pub instance_name: String,
 }
 
@@ -377,7 +385,7 @@ impl Default for LedgerStorageConfig {
         Self {
             read_only: true,
             timeout: None,
-            credential_path: None,
+            credential_option: None,
             instance_name: DEFAULT_INSTANCE_NAME.to_string(),
         }
     }
@@ -392,12 +400,12 @@ impl LedgerStorage {
     pub async fn new(
         read_only: bool,
         timeout: Option<std::time::Duration>,
-        credential_path: Option<String>,
+        credential_option: Option<CredentialOption>,
     ) -> Result<Self> {
         Self::new_with_config(LedgerStorageConfig {
             read_only,
             timeout,
-            credential_path,
+            credential_option,
             ..LedgerStorageConfig::default()
         })
         .await
@@ -407,14 +415,14 @@ impl LedgerStorage {
         let LedgerStorageConfig {
             read_only,
             timeout,
-            credential_path,
+            credential_option,
             instance_name,
         } = config;
         let connection = bigtable::BigTableConnection::new(
             instance_name.as_str(),
             read_only,
             timeout,
-            credential_path,
+            credential_option,
         )
         .await?;
         Ok(Self { connection })

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -395,10 +395,7 @@ pub struct LedgerStorage {
 }
 
 impl LedgerStorage {
-    pub async fn new(
-        read_only: bool,
-        timeout: Option<std::time::Duration>,
-    ) -> Result<Self> {
+    pub async fn new(read_only: bool, timeout: Option<std::time::Duration>) -> Result<Self> {
         Self::new_with_config(LedgerStorageConfig {
             read_only,
             timeout,
@@ -406,7 +403,7 @@ impl LedgerStorage {
         })
         .await
     }
-    
+
     pub async fn new_with_config(config: LedgerStorageConfig) -> Result<Self> {
         let LedgerStorageConfig {
             read_only,
@@ -426,12 +423,11 @@ impl LedgerStorage {
 
     pub async fn new_with_stringified_credential(credential: String) -> Result<Self> {
         Self::new_with_config(LedgerStorageConfig {
-                credential_type: CredentialType::Stringified(credential),
-                ..LedgerStorageConfig::default()
-            })
-            .await
+            credential_type: CredentialType::Stringified(credential),
+            ..LedgerStorageConfig::default()
+        })
+        .await
     }
-    
 
     /// Return the available slot that contains a block
     pub async fn get_first_available_block(&self) -> Result<Option<Slot>> {


### PR DESCRIPTION
#### Problem
solana-ledger-tool provides input of google-credential only via file-path; however, a user needs to specify their credential via a stringified credential and ask for adding a stringified credential parameter for LedgerStorage.
#### Summary of Changes
+ Add a CredentialOption struct which can specify a credential if it is a stringified credential.
+ Pass the CredentialOption parameter through  LedgerStorage , BigTableConnection and AccessToken.
+ Create an access token from stringified credential.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
