### PR TITLE
ci: Limit downstream spl projects

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -45,6 +45,7 @@ spl() {
       token/program-2022-test
       associated-token-account/program
       feature-proposal/program
+      governance/addin-mock/program
       governance/program
       memo/program
       name-service/program

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -38,6 +38,18 @@ example_helloworld() {
 
 spl() {
   (
+    # Mind the order!
+    PROGRAMS=(
+      token/program
+      token/program-2022
+      token/program-2022-test
+      associated-token-account/program
+      feature-proposal/program
+      governance/program
+      memo/program
+      name-service/program
+      stake-pool/program
+      )
     set -x
     rm -rf spl
     git clone https://github.com/solana-labs/solana-program-library.git spl
@@ -47,8 +59,9 @@ spl() {
 
     $cargo build
     $cargo test
-    $cargo_build_bpf
-    $cargo_test_bpf
+    for program in "${PROGRAMS[@]}"; do
+      $cargo_test_bpf --manifest-path "$program"/Cargo.toml
+    done
   )
 }
 


### PR DESCRIPTION
#### Problem

Downstream builds take too long because of SPL.

#### Summary of Changes

Reduce the number of projects to just those shipped to mainnet.
