### PR TITLE
Deprecate `MINIMUM_STAKE_DELEGATION`

### DIFF
--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -23,5 +23,6 @@ pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
     // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
     // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
     // removed, use it here as to not duplicate magic constants.
+    #[allow(deprecated)]
     solana_sdk::stake::MINIMUM_STAKE_DELEGATION
 }

--- a/sdk/program/src/stake/deprecated.rs
+++ b/sdk/program/src/stake/deprecated.rs
@@ -1,0 +1,5 @@
+#[deprecated(
+    since = "1.11.0",
+    note = "please use `solana_program::stake::tools::get_minimum_delegation()` instead"
+)]
+pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -3,13 +3,12 @@ pub mod instruction;
 pub mod state;
 pub mod tools;
 
+mod deprecated;
+pub use deprecated::*;
+
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
-
-// NOTE: This constant will be deprecated soon; if possible, use
-// `solana_stake_program::get_minimum_delegation()` instead.
-pub const MINIMUM_STAKE_DELEGATION: u64 = 1;
 
 /// The minimum number of epochs before stake account that is delegated to a delinquent vote
 /// account may be unstaked with `StakeInstruction::DeactivateDelinquent`


### PR DESCRIPTION
#### Problem

Now that `solana_program::stake::tools::get_minimum_delegation()` has been added, the `MINIMUM_STAKE_DELEGATION` constant should not be used.

#### Summary of Changes

Deprecate the `MINIMUM_STAKE_DELEGATION` constant.