### PR TITLE
Fix automerge automation for backport PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,6 +35,7 @@ pull_request_rules:
         - status-success=buildkite/solana
         - status-success=ci-gate
         - label=automerge
+        - label!=no-automerge
         - author≠@dont-squash-my-commits
         - or:
           # only require travis success if docs files changed
@@ -61,6 +62,7 @@ pull_request_rules:
         - status-success=Travis CI - Pull Request
         - status-success=ci-gate
         - label=automerge
+        - label!=no-automerge
         - author=@dont-squash-my-commits
         - or:
           # only require explorer checks if explorer files changed
@@ -89,6 +91,17 @@ pull_request_rules:
     actions:
       dismiss_reviews:
         changes_requested: true
+  - name: set automerge label on mergify backport PRs
+     conditions:
+       - author=mergify[bot]
+       - head~=^mergify/bp/
+       - "#status-failure=0"
+       - "-merged"
+       - label!=no-automerge
+     actions:
+       label:
+         add:
+           - automerge
   - name: v1.9 feature-gate backport
     conditions:
       - label=v1.9
@@ -97,7 +110,6 @@ pull_request_rules:
       backport:
         ignore_conflicts: true
         labels:
-          - automerge
           - feature-gate
         branches:
           - v1.9
@@ -108,8 +120,6 @@ pull_request_rules:
     actions:
       backport:
         ignore_conflicts: true
-        labels:
-          - automerge
         branches:
           - v1.9
   - name: v1.10 feature-gate backport
@@ -120,7 +130,6 @@ pull_request_rules:
       backport:
         ignore_conflicts: true
         labels:
-          - automerge
           - feature-gate
         branches:
           - v1.10
@@ -131,8 +140,6 @@ pull_request_rules:
     actions:
       backport:
         ignore_conflicts: true
-        labels:
-          - automerge
         branches:
           - v1.10
 


### PR DESCRIPTION
#### Problem
The `automerge` label is no longer applied automatically after retrying failed CI jobs for backport PR's

#### Summary of Changes
- Fix automerge automation
- Disable automerge automation when the `no-automerge` label is added

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
