### PR TITLE
Refactor to use EpochSchedule from within RentCollector struct

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -16,7 +16,7 @@ use {
         rent_collector::RentCollector,
     },
     solana_sdk::{
-        genesis_config::ClusterType, pubkey::Pubkey, sysvar::epoch_schedule::EpochSchedule,
+        genesis_config::ClusterType, pubkey::Pubkey,
     },
     std::{env, fs, path::PathBuf},
 };

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -15,9 +15,7 @@ use {
         ancestors::Ancestors,
         rent_collector::RentCollector,
     },
-    solana_sdk::{
-        genesis_config::ClusterType, pubkey::Pubkey,
-    },
+    solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey},
     std::{env, fs, path::PathBuf},
 };
 
@@ -120,11 +118,10 @@ fn main() {
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
-            let results = accounts.accounts_db.update_accounts_hash(
-                0,
-                &ancestors,
-                &RentCollector::default(),
-            );
+            let results =
+                accounts
+                    .accounts_db
+                    .update_accounts_hash(0, &ancestors, &RentCollector::default());
             time.stop();
             let mut time_store = Measure::start("hash using store");
             let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -123,7 +123,6 @@ fn main() {
             let results = accounts.accounts_db.update_accounts_hash(
                 0,
                 &ancestors,
-                &EpochSchedule::default(),
                 &RentCollector::default(),
             );
             time.stop();
@@ -135,7 +134,6 @@ fn main() {
                 &ancestors,
                 None,
                 false,
-                &EpochSchedule::default(),
                 &RentCollector::default(),
                 false,
             );

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -306,7 +306,6 @@ mod tests {
             genesis_config::ClusterType,
             hash::hash,
             signature::{Keypair, Signer},
-            sysvar::epoch_schedule::EpochSchedule,
         },
         solana_streamer::socket::SocketAddrSpace,
         std::str::FromStr,
@@ -389,7 +388,6 @@ mod tests {
                 cluster_type: ClusterType::MainnetBeta,
                 snapshot_type: None,
                 accounts: Arc::clone(&accounts),
-                epoch_schedule: EpochSchedule::default(),
                 rent_collector: RentCollector::default(),
             };
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -139,7 +139,6 @@ impl AccountsHashVerifier {
                     check_hash: false,
                     ancestors: None,
                     use_write_cache: false,
-                    epoch_schedule: &accounts_package.epoch_schedule,
                     rent_collector: &accounts_package.rent_collector,
                 },
                 &sorted_storages,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -21,7 +21,6 @@ use {
         hash::Hash,
         lamports::LamportsError,
         pubkey::Pubkey,
-        sysvar::epoch_schedule::EpochSchedule,
     },
     std::{
         collections::{HashMap, HashSet},

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -112,7 +112,6 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(
         0,
         &ancestors,
-        &EpochSchedule::default(),
         &RentCollector::default(),
     );
     let test_hash_calculation = false;
@@ -122,7 +121,6 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
             &ancestors,
             total_lamports,
             test_hash_calculation,
-            &EpochSchedule::default(),
             &RentCollector::default()
         ))
     });
@@ -145,7 +143,6 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
         accounts.accounts_db.update_accounts_hash(
             0,
             &ancestors,
-            &EpochSchedule::default(),
             &RentCollector::default(),
         );
     });

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -108,11 +108,10 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let slot = 0;
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
     let ancestors = Ancestors::from(vec![0]);
-    let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(
-        0,
-        &ancestors,
-        &RentCollector::default(),
-    );
+    let (_, total_lamports) =
+        accounts
+            .accounts_db
+            .update_accounts_hash(0, &ancestors, &RentCollector::default());
     let test_hash_calculation = false;
     bencher.iter(|| {
         assert!(accounts.verify_bank_hash_and_lamports(
@@ -139,11 +138,9 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
     let ancestors = Ancestors::from(vec![0]);
     bencher.iter(|| {
-        accounts.accounts_db.update_accounts_hash(
-            0,
-            &ancestors,
-            &RentCollector::default(),
-        );
+        accounts
+            .accounts_db
+            .update_accounts_hash(0, &ancestors, &RentCollector::default());
     });
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -747,7 +747,6 @@ impl Accounts {
         slot: Slot,
         can_cached_slot_be_unflushed: bool,
         debug_verify: bool,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> u64 {
         let use_index = false;
@@ -760,7 +759,6 @@ impl Accounts {
                 ancestors,
                 None,
                 can_cached_slot_be_unflushed,
-                epoch_schedule,
                 rent_collector,
                 is_startup,
             )
@@ -775,7 +773,6 @@ impl Accounts {
         ancestors: &Ancestors,
         total_lamports: u64,
         test_hash_calculation: bool,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports_new(
@@ -783,7 +780,6 @@ impl Accounts {
             ancestors,
             total_lamports,
             test_hash_calculation,
-            epoch_schedule,
             rent_collector,
         ) {
             warn!("verify_bank_hash failed: {:?}", err);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -42,7 +42,7 @@ use {
         pubkey::Pubkey,
         slot_hashes::SlotHashes,
         system_program,
-        sysvar::{self, epoch_schedule::EpochSchedule, instructions::construct_instructions_data},
+        sysvar::{self, instructions::construct_instructions_data},
         transaction::{Result, SanitizedTransaction, TransactionAccountLocks, TransactionError},
         transaction_context::TransactionAccount,
     },

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -157,7 +157,6 @@ impl SnapshotRequestHandler {
                             check_hash,
                             ancestors: None,
                             use_write_cache: false,
-                            epoch_schedule: snapshot_root_bank.epoch_schedule(),
                             rent_collector: snapshot_root_bank.rent_collector(),
                         },
                     ).unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -10242,7 +10242,7 @@ pub mod tests {
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default()),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &RentCollector::default()),
             Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5274,7 +5274,6 @@ impl AccountsDb {
         &self,
         slot: Slot,
         ancestors: &Ancestors,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> (Hash, u64) {
         self.update_accounts_hash_with_index_option(
@@ -5284,7 +5283,6 @@ impl AccountsDb {
             ancestors,
             None,
             false,
-            epoch_schedule,
             rent_collector,
             false,
         )
@@ -5298,7 +5296,6 @@ impl AccountsDb {
             ancestors,
             None,
             false,
-            &EpochSchedule::default(),
             &RentCollector::default(),
             false,
         )
@@ -5554,7 +5551,7 @@ impl AccountsDb {
                 Some(slot),
             );
 
-            self.mark_old_slots_as_dirty(&storages, Some(config.epoch_schedule.slots_per_epoch));
+            self.mark_old_slots_as_dirty(&storages, Some(config.rent_collector.epoch_schedule.slots_per_epoch));
             sort_time.stop();
 
             let mut timings = HashStats {
@@ -5608,7 +5605,6 @@ impl AccountsDb {
         ancestors: &Ancestors,
         expected_capitalization: Option<u64>,
         can_cached_slot_be_unflushed: bool,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
         is_startup: bool,
     ) -> (Hash, u64) {
@@ -5623,7 +5619,6 @@ impl AccountsDb {
                     check_hash,
                     ancestors: Some(ancestors),
                     use_write_cache: can_cached_slot_be_unflushed,
-                    epoch_schedule,
                     rent_collector,
                 },
                 expected_capitalization,
@@ -5831,7 +5826,6 @@ impl AccountsDb {
         ancestors: &Ancestors,
         total_lamports: u64,
         test_hash_calculation: bool,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> Result<(), BankHashVerificationError> {
         self.verify_bank_hash_and_lamports_new(
@@ -5839,7 +5833,6 @@ impl AccountsDb {
             ancestors,
             total_lamports,
             test_hash_calculation,
-            epoch_schedule,
             rent_collector,
         )
     }
@@ -5851,7 +5844,6 @@ impl AccountsDb {
         ancestors: &Ancestors,
         total_lamports: u64,
         test_hash_calculation: bool,
-        epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
@@ -5870,7 +5862,6 @@ impl AccountsDb {
                     check_hash,
                     ancestors: Some(ancestors),
                     use_write_cache: can_cached_slot_be_unflushed,
-                    epoch_schedule,
                     rent_collector,
                 },
                 None,
@@ -7630,7 +7621,6 @@ pub mod tests {
                     check_hash,
                     ancestors: None,
                     use_write_cache: false,
-                    epoch_schedule: &EpochSchedule::default(),
                     rent_collector: &RentCollector::default(),
                 },
                 None,
@@ -8019,7 +8009,6 @@ pub mod tests {
                     check_hash: false,
                     ancestors: None,
                     use_write_cache: false,
-                    epoch_schedule: &EpochSchedule::default(),
                     rent_collector: &RentCollector::default(),
                 },
                 &get_storage_refs(&storages),
@@ -8048,7 +8037,6 @@ pub mod tests {
                     check_hash: false,
                     ancestors: None,
                     use_write_cache: false,
-                    epoch_schedule: &EpochSchedule::default(),
                     rent_collector: &RentCollector::default(),
                 },
                 &get_storage_refs(&storages),
@@ -8110,7 +8098,6 @@ pub mod tests {
                 check_hash: false,
                 ancestors: None,
                 use_write_cache: false,
-                epoch_schedule: &EpochSchedule::default(),
                 rent_collector: &RentCollector::default(),
             },
             &get_storage_refs(&storages),
@@ -9481,13 +9468,11 @@ pub mod tests {
             daccounts.update_accounts_hash(
                 latest_slot,
                 &ancestors,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             accounts.update_accounts_hash(
                 latest_slot,
                 &ancestors,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             )
         );
@@ -9771,7 +9756,6 @@ pub mod tests {
         accounts.update_accounts_hash(
             4,
             &Ancestors::default(),
-            &EpochSchedule::default(),
             &RentCollector::default(),
         );
 
@@ -9790,7 +9774,6 @@ pub mod tests {
                 &Ancestors::default(),
                 1222,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default(),
             )
             .unwrap();
@@ -10102,7 +10085,6 @@ pub mod tests {
                         check_hash,
                         ancestors: Some(&ancestors),
                         use_write_cache: false,
-                        epoch_schedule: &EpochSchedule::default(),
                         rent_collector: &RentCollector::default(),
                     },
                 )
@@ -10134,7 +10116,6 @@ pub mod tests {
                     check_hash,
                     ancestors: Some(&ancestors),
                     use_write_cache: false,
-                    epoch_schedule: &EpochSchedule::default(),
                     rent_collector: &RentCollector::default(),
                 },
             )
@@ -10147,7 +10128,6 @@ pub mod tests {
                     check_hash,
                     ancestors: Some(&ancestors),
                     use_write_cache: false,
-                    epoch_schedule: &EpochSchedule::default(),
                     rent_collector: &RentCollector::default(),
                 },
             )
@@ -10176,7 +10156,6 @@ pub mod tests {
                 &ancestors,
                 1,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Ok(_)
@@ -10189,7 +10168,6 @@ pub mod tests {
                 &ancestors,
                 1,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Err(MissingBankHash)
@@ -10211,7 +10189,6 @@ pub mod tests {
                 &ancestors,
                 1,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Err(MismatchedBankHash)
@@ -10239,7 +10216,6 @@ pub mod tests {
                 &ancestors,
                 1,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Ok(_)
@@ -10260,7 +10236,6 @@ pub mod tests {
                 &ancestors,
                 2,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Ok(_)
@@ -10292,7 +10267,6 @@ pub mod tests {
                 &ancestors,
                 0,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Ok(_)
@@ -10329,7 +10303,6 @@ pub mod tests {
                 &ancestors,
                 1,
                 true,
-                &EpochSchedule::default(),
                 &RentCollector::default()
             ),
             Err(MismatchedBankHash)
@@ -10938,7 +10911,6 @@ pub mod tests {
             accounts.update_accounts_hash(
                 current_slot,
                 &no_ancestors,
-                &EpochSchedule::default(),
                 &RentCollector::default(),
             );
             accounts
@@ -10947,7 +10919,6 @@ pub mod tests {
                     &no_ancestors,
                     22300,
                     true,
-                    &EpochSchedule::default(),
                     &RentCollector::default(),
                 )
                 .unwrap();
@@ -10959,7 +10930,6 @@ pub mod tests {
                     &no_ancestors,
                     22300,
                     true,
-                    &EpochSchedule::default(),
                     &RentCollector::default(),
                 )
                 .unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5551,7 +5551,10 @@ impl AccountsDb {
                 Some(slot),
             );
 
-            self.mark_old_slots_as_dirty(&storages, Some(config.rent_collector.epoch_schedule.slots_per_epoch));
+            self.mark_old_slots_as_dirty(
+                &storages,
+                Some(config.rent_collector.epoch_schedule.slots_per_epoch),
+            );
             sort_time.stop();
 
             let mut timings = HashStats {
@@ -9465,16 +9468,8 @@ pub mod tests {
 
         let ancestors = linear_ancestors(latest_slot);
         assert_eq!(
-            daccounts.update_accounts_hash(
-                latest_slot,
-                &ancestors,
-                &RentCollector::default()
-            ),
-            accounts.update_accounts_hash(
-                latest_slot,
-                &ancestors,
-                &RentCollector::default()
-            )
+            daccounts.update_accounts_hash(latest_slot, &ancestors, &RentCollector::default()),
+            accounts.update_accounts_hash(latest_slot, &ancestors, &RentCollector::default())
         );
     }
 
@@ -9753,11 +9748,7 @@ pub mod tests {
         accounts.add_root(current_slot);
 
         accounts.print_accounts_stats("pre_f");
-        accounts.update_accounts_hash(
-            4,
-            &Ancestors::default(),
-            &RentCollector::default(),
-        );
+        accounts.update_accounts_hash(4, &Ancestors::default(), &RentCollector::default());
 
         let accounts = f(accounts, current_slot);
 
@@ -10908,11 +10899,7 @@ pub mod tests {
             );
 
             let no_ancestors = Ancestors::default();
-            accounts.update_accounts_hash(
-                current_slot,
-                &no_ancestors,
-                &RentCollector::default(),
-            );
+            accounts.update_accounts_hash(current_slot, &no_ancestors, &RentCollector::default());
             accounts
                 .verify_bank_hash_and_lamports(
                     current_slot,

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -41,7 +41,6 @@ pub struct CalcAccountsHashConfig<'a> {
     /// does hash calc need to consider account data that exists in the write cache?
     /// if so, 'ancestors' will be used for this purpose as well as storages.
     pub use_write_cache: bool,
-    pub epoch_schedule: &'a EpochSchedule,
     pub rent_collector: &'a RentCollector,
 }
 

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -6,7 +6,6 @@ use {
     solana_sdk::{
         hash::{Hash, Hasher},
         pubkey::Pubkey,
-        sysvar::epoch_schedule::EpochSchedule,
     },
     std::{
         borrow::Borrow,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5907,7 +5907,6 @@ impl Bank {
             &self.ancestors,
             self.capitalization(),
             test_hash_calculation,
-            self.epoch_schedule(),
             &self.rent_collector,
         )
     }
@@ -5976,7 +5975,6 @@ impl Bank {
             self.slot(),
             can_cached_slot_be_unflushed,
             debug_verify,
-            self.epoch_schedule(),
             &self.rent_collector,
         )
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6030,7 +6030,6 @@ impl Bank {
                 &self.ancestors,
                 Some(self.capitalization()),
                 false,
-                self.epoch_schedule(),
                 &self.rent_collector,
                 is_startup,
             );
@@ -6056,7 +6055,6 @@ impl Bank {
                         &self.ancestors,
                         Some(self.capitalization()),
                         false,
-                        self.epoch_schedule(),
                         &self.rent_collector,
                         is_startup,
                     );

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -12,7 +12,7 @@ use {
     },
     log::*,
     solana_sdk::{
-        clock::Slot, genesis_config::ClusterType, hash::Hash, sysvar::epoch_schedule::EpochSchedule,
+        clock::Slot, genesis_config::ClusterType, hash::Hash,
     },
     std::{
         fs,
@@ -45,7 +45,6 @@ pub struct AccountsPackage {
     pub cluster_type: ClusterType,
     pub snapshot_type: Option<SnapshotType>,
     pub accounts: Arc<Accounts>,
-    pub epoch_schedule: EpochSchedule,
     pub rent_collector: RentCollector,
 }
 
@@ -111,7 +110,6 @@ impl AccountsPackage {
             cluster_type: bank.cluster_type(),
             snapshot_type,
             accounts: bank.accounts(),
-            epoch_schedule: *bank.epoch_schedule(),
             rent_collector: bank.rent_collector().clone(),
         })
     }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -11,9 +11,7 @@ use {
         },
     },
     log::*,
-    solana_sdk::{
-        clock::Slot, genesis_config::ClusterType, hash::Hash,
-    },
+    solana_sdk::{clock::Slot, genesis_config::ClusterType, hash::Hash},
     std::{
         fs,
         path::{Path, PathBuf},

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3451,7 +3451,6 @@ mod tests {
                 cluster_type: solana_sdk::genesis_config::ClusterType::Development,
                 snapshot_type,
                 accounts: Arc::new(crate::accounts::Accounts::default_for_tests()),
-                epoch_schedule: solana_sdk::epoch_schedule::EpochSchedule::default(),
                 rent_collector: crate::rent_collector::RentCollector::default(),
             }
         }


### PR DESCRIPTION
#### Problem
A number of functions were recently changed to add a pair of params, EpochSchedule and RentCollector. However, RentCollector already contains an EpochSchedule, so this was redundant. 

#### Summary of Changes
Removed the EpochSchedule param and used the value within RentCollector instead. Also removed epoch_schedule from the AccountsPackage struct, as it was no longer being used anywhere and was just defaulted.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
