### PR TITLE
Throttling on metric queue

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -292,7 +292,7 @@ impl MetricsAgent {
     fn send(&self, command: MetricsCommand) {
         match self.sender.try_send(command) {
             Err(TrySendError::Full(cmd)) => {
-                warn!("metric queue full, point dropped: {?}.", cmd);
+                warn!("metric queue full, point dropped: {:?}.", cmd);
             }
             Err(TrySendError::Disconnected(_)) => {
                 warn!("metric queue disconnected.");

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -290,7 +290,6 @@ impl MetricsAgent {
     }
 
     fn send(&self, command: MetricsCommand) {
-        error!("haha command queue size: {}", self.sender.len());
         match self.sender.try_send(command) {
             Err(TrySendError::Full(_)) => {
                 warn!("metric queue full, point dropped.");

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -291,8 +291,8 @@ impl MetricsAgent {
 
     fn send(&self, command: MetricsCommand) {
         match self.sender.try_send(command) {
-            Err(TrySendError::Full(_)) => {
-                warn!("metric queue full, point dropped.");
+            Err(TrySendError::Full(cmd)) => {
+                warn!("metric queue full, point dropped: {?}.", cmd);
             }
             Err(TrySendError::Disconnected(_)) => {
                 warn!("metric queue disconnected.");


### PR DESCRIPTION
#### Problem

We are seeing more memory usage for validator when logging at info level. 
https://github.com/solana-labs/solana/issues/24319

#### Summary of Changes
Metric signal queue is unbounded. When the receiver fails to catch up with the sender, the queue will grow and eat up the memory. 

The change is to make the queue bounded, throttle at 2000 pending commands and drop any commands when the queue is full.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
