### PR TITLE
Add "profiling" cargo build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,8 @@ exclude = [
 
 # This prevents a Travis CI error when building for Windows.
 resolver = "2"
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false


### PR DESCRIPTION
#### Problem

Building binaries designed for profiling (optimizations ON, debug symbols ON) could be easier.

#### Summary of Changes

Add a new cargo build profile, "profiling", which inherits from "release" and enables debug symbols.

To use:

```
$ cargo build --profile profiling --bin solana-validator
```

Also open to other names. Specifically, should the profile be the _intent_ (i.e. "test", "bench", "release", "debug"), or the _details_ (i.e. "release-with-debug-symbols")? As you can see, I've gone with the _intent_-side. But I acknowledge that `--profile profiling` isn't the best.