### PR TITLE
security: Set expectation on when to get a response

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 email to security@solana.com and provide your github username so we can add you
 to a new draft security advisory for further discussion.
 
-Expect a response as fast as possible, within one business day at the latest.
+Expect a response as fast as possible, within 72 hours at the latest.
 
 <a name="bounty"></a>
 ## Security Bug Bounties

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 email to security@solana.com and provide your github username so we can add you
 to a new draft security advisory for further discussion.
 
-Expect a response as fast as possible, within 72 hours at the latest.
+Expect a response as fast as possible, typically within 72 hours.
 
 <a name="bounty"></a>
 ## Security Bug Bounties


### PR DESCRIPTION
#### Problem

One business day is a little aggressive for a response in the security policy.

#### Summary of Changes

Change it to 72 hours.