### PR TITLE
Fix bench-tps

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -296,7 +296,10 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         matches.value_of("identity").unwrap_or(""),
         &config.keypair_path,
     );
-    args.id = read_keypair_file(id_path).expect("could not parse identity path");
+
+    if matches.is_present("identity") {
+        args.id = read_keypair_file(id_path).expect("could not parse identity path");
+    }
 
     if matches.is_present("tpu_client") {
         args.external_client_type = ExternalClientType::TpuClient;


### PR DESCRIPTION
#### Problem

tps-bench is broken because the keypair_file is not found.

```
./multinode-demo/bench-tps.sh
thread 'main' panicked at 'could not parse identity path: Os { code: 2, kind: NotFound, message: "No such file or directory" }
', bench-tps/src/cli.rs:299:42
```

#### Summary of Changes
Only read keypair file when "identity" argument is specified. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
