### PR TITLE
Do not require default keypair to exist for bench-tps

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -306,7 +306,11 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         matches.value_of("identity").unwrap_or(""),
         &config.keypair_path,
     );
-    args.id = read_keypair_file(id_path).expect("could not parse identity path");
+    if let Ok(id) = read_keypair_file(id_path) {
+        args.id = id;
+    } else if matches.is_present("identity") {
+        panic!("could not parse identity path");
+    }
 
     if matches.is_present("tpu_client") {
         args.external_client_type = ExternalClientType::TpuClient;


### PR DESCRIPTION
#### Problem
Some changes I made to use the default cli config in bench-tps when present broke the case where no default signer exists.

#### Summary of Changes
Only panic when trying to read_keypair_file of missing file if path explicitly set with `--identity`. Otherwise, use new keypair when file missing or unparseable

Closes #24353
