### PR TITLE
sdk: Add --jobs parameter in build/test bpf

### DIFF
--- a/sdk/cargo-test-bpf/src/main.rs
+++ b/sdk/cargo-test-bpf/src/main.rs
@@ -24,6 +24,7 @@ struct Config {
     offline: bool,
     verbose: bool,
     workspace: bool,
+    jobs: Option<String>,
 }
 
 impl Default for Config {
@@ -42,6 +43,7 @@ impl Default for Config {
             offline: false,
             verbose: false,
             workspace: false,
+            jobs: None,
         }
     }
 }
@@ -115,6 +117,10 @@ fn test_bpf_package(config: &Config, target_directory: &Path, package: &cargo_me
     }
     if config.verbose {
         cargo_args.push("--verbose");
+    }
+    if let Some(jobs) = &config.jobs {
+        cargo_args.push("--jobs");
+        cargo_args.push(jobs);
     }
 
     let mut build_bpf_args = cargo_args.clone();
@@ -295,6 +301,15 @@ fn main() {
                 .help("Test all BPF packages in the workspace"),
         )
         .arg(
+            Arg::new("jobs")
+                .short('j')
+                .long("jobs")
+                .takes_value(true)
+                .value_name("N")
+                .validator(|val| val.parse::<usize>().map_err(|e| e.to_string()))
+                .help("Number of parallel jobs, defaults to # of CPUs"),
+        )
+        .arg(
             Arg::new("extra_cargo_test_args")
                 .value_name("extra args for cargo test and the test binary")
                 .index(1)
@@ -319,6 +334,7 @@ fn main() {
         offline: matches.is_present("offline"),
         verbose: matches.is_present("verbose"),
         workspace: matches.is_present("workspace"),
+        jobs: matches.value_of_t("jobs").ok(),
         ..Config::default()
     };
 


### PR DESCRIPTION
#### Problem

It's impossible to set the number of jobs to `build-bpf` and `test-bpf`, since `--jobs` figures as a pre-`--` parameter for `cargo build` and `cargo test`.  The extra parsing to pass the post `--` parameters also doesn't pass `--jobs` correctly, and we're having build failures on `cargo test-bpf` for the SPL governance program due to memory consumption.

#### Summary of Changes

Add a `--jobs` flag to both `build-bpf` and `test-bpf`.  The parsing looks a bit wonky since it validates it as a number, then stores it as a string.  This is done to make it easier to pass into `cargo`.