### PR TITLE
Make program_memory functions unsafe

### DIFF
--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -133,15 +133,15 @@ impl<'a> AccountInfo<'a> {
             // Then set the new length in the local slice
             let ptr = &mut *(((self.data.as_ptr() as *const u64).offset(1) as u64) as *mut u64);
             *ptr = new_len as u64;
-        }
 
-        // zero-init if requested
-        if zero_init && new_len > orig_len {
-            sol_memset(
-                &mut self.try_borrow_mut_data()?[orig_len..],
-                0,
-                new_len.saturating_sub(orig_len),
-            );
+            // zero-init if requested
+            if zero_init && new_len > orig_len {
+                sol_memset(
+                    &mut self.try_borrow_mut_data()?[orig_len..],
+                    0,
+                    new_len.saturating_sub(orig_len),
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
#### Problem

3 functions in solana_program::program_memory do unsafe things but are not unsafe.

#### Summary of Changes

Per https://github.com/solana-labs/solana/pull/24128#discussion_r847659937 this patch makes the functions unsafe, and documents them.

This is a breaking API change. I don't know the process for it in Solana.

This breaks code in solana-program-library. I don't know the process for updating that repo when APIs change.

Fixes #24035
