### PR TITLE
Remove `KeyedAccount` in builtin program "BPF loader"

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -456,10 +456,6 @@ fn process_loader_upgradeable_instruction(
         UpgradeableLoaderInstruction::Write { offset, bytes } => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             let buffer = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
-            let authority = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account.saturating_add(1),
-            )?;
 
             if let UpgradeableLoaderState::Buffer { authority_address } = buffer.state()? {
                 if authority_address.is_none() {
@@ -476,7 +472,7 @@ fn process_loader_upgradeable_instruction(
                     ic_logger_msg!(log_collector, "Incorrect buffer authority provided");
                     return Err(InstructionError::IncorrectAuthority);
                 }
-                if authority.signer_key().is_none() {
+                if !instruction_context.is_signer(first_instruction_account.saturating_add(1))? {
                     ic_logger_msg!(log_collector, "Buffer authority did not sign");
                     return Err(InstructionError::MissingRequiredSignature);
                 }
@@ -513,17 +509,12 @@ fn process_loader_upgradeable_instruction(
             let clock =
                 get_sysvar_with_account_check::clock(invoke_context, instruction_context, 5)?;
             instruction_context.check_number_of_instruction_accounts(8)?;
-            let authority = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account.saturating_add(7),
-            )?;
             let authority_key = Some(
                 *transaction_context.get_key_of_account_at_index(
                     instruction_context
                         .get_index_in_transaction(first_instruction_account.saturating_add(7))?,
                 )?,
             );
-            let upgrade_authority_signer = authority.signer_key().is_none();
 
             // Verify Program account
 
@@ -549,7 +540,7 @@ fn process_loader_upgradeable_instruction(
                     ic_logger_msg!(log_collector, "Buffer and upgrade authority don't match");
                     return Err(InstructionError::IncorrectAuthority);
                 }
-                if upgrade_authority_signer {
+                if !instruction_context.is_signer(first_instruction_account.saturating_add(7))? {
                     ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                     return Err(InstructionError::MissingRequiredSignature);
                 }
@@ -709,10 +700,6 @@ fn process_loader_upgradeable_instruction(
                         .get_index_in_transaction(first_instruction_account.saturating_add(6))?,
                 )?,
             );
-            let authority = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account.saturating_add(6),
-            )?;
 
             // Verify Program account
 
@@ -750,7 +737,7 @@ fn process_loader_upgradeable_instruction(
                     ic_logger_msg!(log_collector, "Buffer and upgrade authority don't match");
                     return Err(InstructionError::IncorrectAuthority);
                 }
-                if authority.signer_key().is_none() {
+                if !instruction_context.is_signer(first_instruction_account.saturating_add(6))? {
                     ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                     return Err(InstructionError::MissingRequiredSignature);
                 }
@@ -799,7 +786,7 @@ fn process_loader_upgradeable_instruction(
                     ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
                     return Err(InstructionError::IncorrectAuthority);
                 }
-                if authority.signer_key().is_none() {
+                if !instruction_context.is_signer(first_instruction_account.saturating_add(6))? {
                     ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                     return Err(InstructionError::MissingRequiredSignature);
                 }
@@ -879,10 +866,6 @@ fn process_loader_upgradeable_instruction(
                 instruction_context
                     .get_index_in_transaction(first_instruction_account.saturating_add(1))?,
             )?;
-            let present_authority = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account.saturating_add(1),
-            )?;
             let new_authority = instruction_context
                 .get_index_in_transaction(first_instruction_account.saturating_add(2))
                 .and_then(|index_in_transaction| {
@@ -904,7 +887,9 @@ fn process_loader_upgradeable_instruction(
                         ic_logger_msg!(log_collector, "Incorrect buffer authority provided");
                         return Err(InstructionError::IncorrectAuthority);
                     }
-                    if present_authority.signer_key().is_none() {
+                    if !instruction_context
+                        .is_signer(first_instruction_account.saturating_add(1))?
+                    {
                         ic_logger_msg!(log_collector, "Buffer authority did not sign");
                         return Err(InstructionError::MissingRequiredSignature);
                     }
@@ -924,7 +909,9 @@ fn process_loader_upgradeable_instruction(
                         ic_logger_msg!(log_collector, "Incorrect upgrade authority provided");
                         return Err(InstructionError::IncorrectAuthority);
                     }
-                    if present_authority.signer_key().is_none() {
+                    if !instruction_context
+                        .is_signer(first_instruction_account.saturating_add(1))?
+                    {
                         ic_logger_msg!(log_collector, "Upgrade authority did not sign");
                         return Err(InstructionError::MissingRequiredSignature);
                     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -36,8 +36,6 @@ use {
         vm::{Config, EbpfVm, InstructionMeter},
     },
     solana_sdk::{
-        account::{ReadableAccount, WritableAccount},
-        account_utils::State,
         bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         entrypoint::{HEAP_LENGTH, SUCCESS},
@@ -48,7 +46,6 @@ use {
             reduce_required_deploy_balance, reject_callx_r10, requestable_heap_size,
         },
         instruction::{AccountMeta, InstructionError},
-        keyed_account::keyed_account_at_index,
         loader_instruction::LoaderInstruction,
         loader_upgradeable_instruction::UpgradeableLoaderInstruction,
         program_error::MAX_ACCOUNTS_DATA_SIZE_EXCEEDED,
@@ -430,7 +427,6 @@ fn process_loader_upgradeable_instruction(
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
     let program_id = instruction_context.get_program_key(transaction_context)?;
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     match limited_deserialize(instruction_data)? {
         UpgradeableLoaderInstruction::InitializeBuffer => {
@@ -626,7 +622,6 @@ fn process_loader_upgradeable_instruction(
             )?;
             invoke_context.update_executor(&new_program_id, executor);
 
-            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -806,7 +801,6 @@ fn process_loader_upgradeable_instruction(
             )?;
             invoke_context.update_executor(&new_program_id, executor);
 
-            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -1071,7 +1065,6 @@ fn process_loader_instruction(
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
     let program_id = instruction_context.get_program_key(transaction_context)?;
-    let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let program = instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
     if program.get_owner() != program_id {
         ic_msg!(
@@ -1102,7 +1095,6 @@ fn process_loader_instruction(
             }
             let executor =
                 create_executor(first_instruction_account, 0, invoke_context, use_jit, true)?;
-            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let transaction_context = &invoke_context.transaction_context;
             let instruction_context = transaction_context.get_current_instruction_context()?;
             let mut program =
@@ -1290,6 +1282,7 @@ mod tests {
         solana_sdk::{
             account::{
                 create_account_shared_data_for_test as create_account_for_test, AccountSharedData,
+                ReadableAccount, WritableAccount,
             },
             account_utils::StateMut,
             client::SyncClient,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -930,18 +930,21 @@ fn process_loader_upgradeable_instruction(
         }
         UpgradeableLoaderInstruction::Close => {
             instruction_context.check_number_of_instruction_accounts(2)?;
-            let close_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
-            let recipient_account = keyed_account_at_index(
-                keyed_accounts,
-                first_instruction_account.saturating_add(1),
-            )?;
-            if close_account.unsigned_key() == recipient_account.unsigned_key() {
+            if instruction_context.get_index_in_transaction(first_instruction_account)?
+                == instruction_context
+                    .get_index_in_transaction(first_instruction_account.saturating_add(1))?
+            {
                 ic_logger_msg!(
                     log_collector,
                     "Recipient is the same as the account being closed"
                 );
                 return Err(InstructionError::InvalidArgument);
             }
+            let close_account = keyed_account_at_index(keyed_accounts, first_instruction_account)?;
+            let recipient_account = keyed_account_at_index(
+                keyed_accounts,
+                first_instruction_account.saturating_add(1),
+            )?;
 
             match close_account.state()? {
                 UpgradeableLoaderState::Uninitialized => {


### PR DESCRIPTION
#### Problem
Builtin programs still use `KeyedAccount`.

#### Summary of Changes
- Replaces `KeyedAccount` by `BorrowedAccount`.
- Replaces `keyed_account.signer_key()` by `instruction_context.is_signer()`.
- Uses `transaction_context.get_key_of_account_at_index()` when only the key is needed.