### PR TITLE
Reduce bank, cluster-info, account-db metrics logging

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1114,7 +1114,7 @@ impl ClusterInfo {
                 transaction
             })
             .collect();
-        inc_new_counter_info!("cluster_info-get_votes-count", txs.len());
+        inc_new_counter_debug!("cluster_info-get_votes-count", txs.len());
         txs
     }
 
@@ -1134,7 +1134,7 @@ impl ClusterInfo {
                 (vote.value.label(), transaction)
             })
             .unzip();
-        inc_new_counter_info!("cluster_info-get_votes-count", txs.len());
+        inc_new_counter_debug!("cluster_info-get_votes-count", txs.len());
         (labels, txs)
     }
 
@@ -1668,7 +1668,7 @@ impl ClusterInfo {
             self.gossip
                 .purge(&self_pubkey, thread_pool, timestamp(), &timeouts)
         };
-        inc_new_counter_info!("cluster_info-purge-count", num_purged);
+        inc_new_counter_debug!("cluster_info-purge-count", num_purged);
     }
 
     // Trims the CRDS table by dropping all values associated with the pubkeys

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3057,15 +3057,15 @@ impl AccountsDb {
             }
         }
         measure.stop();
-        inc_new_counter_info!(
+        inc_new_counter_debug!(
             "shrink_select_top_sparse_storage_entries-ms",
             measure.as_ms() as usize
         );
-        inc_new_counter_info!(
+        inc_new_counter_debug!(
             "shrink_select_top_sparse_storage_entries-seeds",
             candidates_count
         );
-        inc_new_counter_info!(
+        inc_new_counter_debug!(
             "shrink_total_preliminary_candidate_stores",
             total_candidate_stores
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3783,79 +3783,79 @@ impl Bank {
     #[allow(clippy::cognitive_complexity)]
     fn update_error_counters(error_counters: &ErrorCounters) {
         if 0 != error_counters.total {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error_count",
                 error_counters.total
             );
         }
         if 0 != error_counters.account_not_found {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-account_not_found",
                 error_counters.account_not_found
             );
         }
         if 0 != error_counters.account_in_use {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-account_in_use",
                 error_counters.account_in_use
             );
         }
         if 0 != error_counters.account_loaded_twice {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-account_loaded_twice",
                 error_counters.account_loaded_twice
             );
         }
         if 0 != error_counters.blockhash_not_found {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-blockhash_not_found",
                 error_counters.blockhash_not_found
             );
         }
         if 0 != error_counters.blockhash_too_old {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-blockhash_too_old",
                 error_counters.blockhash_too_old
             );
         }
         if 0 != error_counters.invalid_account_index {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-invalid_account_index",
                 error_counters.invalid_account_index
             );
         }
         if 0 != error_counters.invalid_account_for_fee {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-invalid_account_for_fee",
                 error_counters.invalid_account_for_fee
             );
         }
         if 0 != error_counters.insufficient_funds {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-insufficient_funds",
                 error_counters.insufficient_funds
             );
         }
         if 0 != error_counters.instruction_error {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-instruction_error",
                 error_counters.instruction_error
             );
         }
         if 0 != error_counters.already_processed {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-already_processed",
                 error_counters.already_processed
             );
         }
         if 0 != error_counters.not_allowed_during_cluster_maintenance {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-cluster-maintenance",
                 error_counters.not_allowed_during_cluster_maintenance
             );
         }
         if 0 != error_counters.invalid_writable_account {
-            inc_new_counter_info!(
+            inc_new_counter_debug!(
                 "bank-process_transactions-error-invalid_writable_account",
                 error_counters.invalid_writable_account
             );
@@ -4073,8 +4073,7 @@ impl Bank {
         timings: &mut ExecuteTimings,
     ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
-        debug!("processing transactions: {}", sanitized_txs.len());
-        inc_new_counter_info!("bank-process_transactions", sanitized_txs.len());
+        inc_new_counter_debug!("bank-process_transactions", sanitized_txs.len());
         let mut error_counters = ErrorCounters::default();
 
         let retryable_transaction_indexes: Vec<_> = batch
@@ -4496,7 +4495,7 @@ impl Bank {
             "bank-process_transactions-txs",
             committed_transactions_count as usize
         );
-        inc_new_counter_info!("bank-process_transactions-sigs", signature_count as usize);
+        inc_new_counter_debug!("bank-process_transactions-sigs", signature_count as usize);
 
         if committed_with_failure_result_count > 0 {
             self.transaction_error_count


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24319
For rpc node, the metric agent is unable to catching up with logging at info level. bank transaction processing counter and transaction error counters are among the heaviest loggers.

```
 ("bank-process_transactions-sigs", 1182664), ("bank-process_transactions-txs", 1181666), ("bank-process_transactions", 1177898), ("bank-process_transactions-error-instruction_error", 253095), ("bank-process_transactions-error_count", 253078), ("shrink_total_preliminary_candidate_stores", 18067), ("shrink_select_top_sparse_storage_entries-ms", 18067), ("shrink_select_top_sparse_storage_entries-seeds", 18067), ("cluster_info-purge-count", 17213), ("cluster_info-get_votes-count", 17163)
```

#### Summary of Changes
Reduce their log level to debug.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
