### PR TITLE
Add feature_set_override parameter to mock_process_instruction()

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1199,6 +1199,7 @@ pub fn mock_process_instruction(
     transaction_accounts: Vec<TransactionAccount>,
     instruction_accounts: Vec<AccountMeta>,
     sysvar_cache_override: Option<&SysvarCache>,
+    feature_set_override: Option<Arc<FeatureSet>>,
     expected_result: Result<(), InstructionError>,
     process_instruction: ProcessInstructionWithContext,
 ) -> Vec<AccountSharedData> {
@@ -1217,6 +1218,9 @@ pub fn mock_process_instruction(
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     if let Some(sysvar_cache) = sysvar_cache_override {
         invoke_context.sysvar_cache = Cow::Borrowed(sysvar_cache);
+    }
+    if let Some(feature_set) = feature_set_override {
+        invoke_context.feature_set = feature_set;
     }
     let result = invoke_context
         .push(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1326,6 +1326,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            None,
             expected_result,
             super::process_instruction,
         )
@@ -1586,6 +1587,7 @@ mod tests {
             &[],
             vec![(program_id, program_account.clone())],
             Vec::new(),
+            None,
             None,
             Err(InstructionError::ProgramFailedToComplete),
             |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
@@ -2851,6 +2853,7 @@ mod tests {
                 &instruction_data,
                 transaction_accounts,
                 instruction_accounts,
+                None,
                 None,
                 expected_result,
                 super::process_instruction,

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -169,6 +169,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            None,
             expected_result,
             super::process_instruction,
         )

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -538,6 +538,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             sysvar_cache_override,
+            None,
             expected_result,
             super::process_instruction,
         )
@@ -6073,6 +6074,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            None,
             Ok(()),
             |first_instruction_account, invoke_context| {
                 super::process_instruction(first_instruction_account, invoke_context)?;
@@ -6195,6 +6197,13 @@ mod tests {
                 Err(InstructionError::NotEnoughAccountKeys),
             ),
         ] {
+            let mut feature_set = FeatureSet::all_enabled();
+            if !is_feature_enabled {
+                feature_set.deactivate(
+                    &feature_set::add_get_minimum_delegation_instruction_to_stake_program::id(),
+                );
+            }
+
             mock_process_instruction(
                 &id(),
                 Vec::new(),
@@ -6202,19 +6211,9 @@ mod tests {
                 transaction_accounts.clone(),
                 instruction_accounts.clone(),
                 None,
+                Some(Arc::new(feature_set)),
                 expected_result,
-                if is_feature_enabled {
-                    |first_instruction_account, invoke_context| {
-                        super::process_instruction(first_instruction_account, invoke_context)
-                    }
-                } else {
-                    |first_instruction_account, invoke_context| {
-                        let mut feature_set = FeatureSet::all_enabled();
-                        feature_set.deactivate(&feature_set::add_get_minimum_delegation_instruction_to_stake_program::id());
-                        invoke_context.feature_set = Arc::new(feature_set);
-                        super::process_instruction(first_instruction_account, invoke_context)
-                    }
-                },
+                super::process_instruction,
             );
         }
     }

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -203,6 +203,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            None,
             expected_result,
             super::process_instruction,
         )
@@ -221,11 +222,9 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            Some(std::sync::Arc::new(FeatureSet::default())),
             expected_result,
-            |first_instruction_account: usize, invoke_context: &mut InvokeContext| {
-                invoke_context.feature_set = std::sync::Arc::new(FeatureSet::default());
-                super::process_instruction(first_instruction_account, invoke_context)
-            },
+            super::process_instruction,
         )
     }
 

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -531,6 +531,7 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             None,
+            None,
             expected_result,
             process_instruction,
         )


### PR DESCRIPTION
#### Problem

It's clunky to override the FeatureSet when using `mock_process_instruction()`.

I'm currently doing work on the stake program behind a feature-gate, and I want to run all the tests with (1) the new feature on, and (2) the new feature off. This PR is a stepping stone to make my testing goal simple/straight forward.

#### Summary of Changes

Add a `feature_set_override` parameter to `mock_instruction_process()`.