### PR TITLE
Add Ident case to `respan` procedural macro

### DIFF
--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -198,6 +198,10 @@ impl Parse for RespanInput {
                     respan_using: ident.span(),
                 })
             }
+            TokenTree::Ident(i) => Ok(RespanInput {
+                to_respan,
+                respan_using: i.span(),
+            }),
             val => Err(syn::Error::new_spanned(
                 val,
                 "expected None-delimited group",


### PR DESCRIPTION
#### Problem
solana-ledger doesn't compile on Rust 1.61.0-nightly (76d770ac2 2022-04-02) and later. This is because of the `respan` procedural macro and this change: https://github.com/rust-lang/rust/pull/95571
`respan` expects the module `$name` to parse as a None-delimited Group, but it is now parsing as an Ident.

Docs for solana-ledger and all crates that depend on it are hence broken, since docs.rs uses recent nightly for builds.

#### Summary of Changes
Add Ident case to match statement

@Aaron1011 , I wonder if you could take a look at this? Looks like you wrote our [respan macro](https://github.com/solana-labs/solana/pull/10905) (thank you!), and also approved the https://github.com/rust-lang/rust/pull/95571 change


Fixes #24361
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
