### PR TITLE
Split out rust doctests in CI

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -148,6 +148,18 @@ all_test_steps() {
 
   # Full test suite
   command_step stable ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-stable.sh" 70
+
+  # Docs tests
+  if affects \
+             .rs$ \
+             ^ci/rust-version.sh \
+             ^ci/test-docs.sh \
+      ; then
+    command_step doctest "ci/test-docs.sh" 15
+  else
+    annotate --style info --context test-docs \
+      "Docs skipped as no .rs files were modified"
+  fi
   wait_step
 
   # BPF test suite

--- a/ci/test-docs.sh
+++ b/ci/test-docs.sh
@@ -1,0 +1,1 @@
+test-stable.sh

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -30,7 +30,7 @@ JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 echo "Executing $testName"
 case $testName in
 test-stable)
-  _ "$cargo" stable test --jobs "$JOBS" --all --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
+  _ "$cargo" stable test --jobs "$JOBS" --all --tests --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   ;;
 test-stable-bpf)
   # Clear the C dependency files, if dependency moves these files are not regenerated
@@ -128,6 +128,10 @@ test-wasm)
       popd
     fi
   done
+  exit 0
+  ;;
+test-docs)
+  _ "$cargo" stable test --jobs "$JOBS" --all --doc --exclude solana-local-cluster ${V:+--verbose} -- --nocapture
   exit 0
   ;;
 *)


### PR DESCRIPTION
#### Problem
The CI stable job takes a long time. Now that we have some legitimate rust docs, doctests are taking up a noticeable chunk of this time.


#### Summary of Changes
Only run `--tests` in the stable job; run doctests in parallel
