### PR TITLE
demote gossip request counters logging to debug

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -132,7 +132,7 @@ impl ReceiveWindowStats {
             ("elapsed_micros", self.elapsed.as_micros(), i64),
         );
         for (slot, num_shreds) in &self.slots {
-            datapoint_info!(
+            datapoint_debug!(
                 "receive_window_num_slot_shreds",
                 ("slot", *slot, i64),
                 ("num_shreds", *num_shreds, i64)

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -286,7 +286,7 @@ impl Protocol {
                 if caller.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_debug!("cluster_info-gossip_pull_request_verify_fail", 1);
+                    inc_new_counter_info!("cluster_info-gossip_pull_request_verify_fail", 1);
                     None
                 }
             }
@@ -294,7 +294,7 @@ impl Protocol {
                 let size = data.len();
                 let data: Vec<_> = data.into_par_iter().filter(Signable::verify).collect();
                 if size != data.len() {
-                    inc_new_counter_debug!(
+                    inc_new_counter_info!(
                         "cluster_info-gossip_pull_response_verify_fail",
                         size - data.len()
                     );
@@ -309,7 +309,7 @@ impl Protocol {
                 let size = data.len();
                 let data: Vec<_> = data.into_par_iter().filter(Signable::verify).collect();
                 if size != data.len() {
-                    inc_new_counter_debug!(
+                    inc_new_counter_info!(
                         "cluster_info-gossip_push_msg_verify_fail",
                         size - data.len()
                     );
@@ -324,7 +324,7 @@ impl Protocol {
                 if data.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_debug!("cluster_info-gossip_prune_msg_verify_fail", 1);
+                    inc_new_counter_info!("cluster_info-gossip_prune_msg_verify_fail", 1);
                     None
                 }
             }
@@ -332,7 +332,7 @@ impl Protocol {
                 if ping.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_debug!("cluster_info-gossip_ping_msg_verify_fail", 1);
+                    inc_new_counter_info!("cluster_info-gossip_ping_msg_verify_fail", 1);
                     None
                 }
             }
@@ -340,7 +340,7 @@ impl Protocol {
                 if pong.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_debug!("cluster_info-gossip_pong_msg_verify_fail", 1);
+                    inc_new_counter_info!("cluster_info-gossip_pong_msg_verify_fail", 1);
                     None
                 }
             }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -286,7 +286,7 @@ impl Protocol {
                 if caller.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_info!("cluster_info-gossip_pull_request_verify_fail", 1);
+                    inc_new_counter_debug!("cluster_info-gossip_pull_request_verify_fail", 1);
                     None
                 }
             }
@@ -294,7 +294,7 @@ impl Protocol {
                 let size = data.len();
                 let data: Vec<_> = data.into_par_iter().filter(Signable::verify).collect();
                 if size != data.len() {
-                    inc_new_counter_info!(
+                    inc_new_counter_debug!(
                         "cluster_info-gossip_pull_response_verify_fail",
                         size - data.len()
                     );
@@ -309,7 +309,7 @@ impl Protocol {
                 let size = data.len();
                 let data: Vec<_> = data.into_par_iter().filter(Signable::verify).collect();
                 if size != data.len() {
-                    inc_new_counter_info!(
+                    inc_new_counter_debug!(
                         "cluster_info-gossip_push_msg_verify_fail",
                         size - data.len()
                     );
@@ -332,7 +332,7 @@ impl Protocol {
                 if ping.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_info!("cluster_info-gossip_ping_msg_verify_fail", 1);
+                    inc_new_counter_debug!("cluster_info-gossip_ping_msg_verify_fail", 1);
                     None
                 }
             }
@@ -340,7 +340,7 @@ impl Protocol {
                 if pong.verify() {
                     Some(self)
                 } else {
-                    inc_new_counter_info!("cluster_info-gossip_pong_msg_verify_fail", 1);
+                    inc_new_counter_debug!("cluster_info-gossip_pong_msg_verify_fail", 1);
                     None
                 }
             }
@@ -2033,7 +2033,7 @@ impl ClusterInfo {
                         packet_batch.packets.push(packet);
                         sent += 1;
                     } else {
-                        inc_new_counter_info!("gossip_pull_request-no_budget", 1);
+                        inc_new_counter_debug!("gossip_pull_request-no_budget", 1);
                         break;
                     }
                 }
@@ -2041,8 +2041,8 @@ impl ClusterInfo {
         }
         time.stop();
         let dropped_responses = responses.len() - sent;
-        inc_new_counter_info!("gossip_pull_request-sent_requests", sent);
-        inc_new_counter_info!("gossip_pull_request-dropped_requests", dropped_responses);
+        inc_new_counter_debug!("gossip_pull_request-sent_requests", sent);
+        inc_new_counter_debug!("gossip_pull_request-dropped_requests", dropped_responses);
         debug!(
             "handle_pull_requests: {} sent: {} total: {} total_bytes: {}",
             time,

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -559,11 +559,11 @@ impl CrdsGossipPull {
                 .map(|(caller, filter)| apply_filter(caller, filter))
                 .collect()
         });
-        inc_new_counter_info!(
+        inc_new_counter_debug!(
             "gossip_filter_crds_values-dropped_requests",
             dropped_requests.into_inner()
         );
-        inc_new_counter_info!(
+        inc_new_counter_debug!(
             "gossip_filter_crds_values-dropped_values",
             total_skipped.into_inner()
         );


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24319
For rpc node, the metric agent is unable to catching up with logging at info level. gossip request counters are among the heaviest loggers.

#### Summary of Changes
demote gossip request counters logging to debug

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
