### PR TITLE
ci: Fixup downstream build for token-cli

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -58,11 +58,15 @@ spl() {
 
     ./patch.crates-io.sh "$solana_dir"
 
-    $cargo build
-    $cargo test
     for program in "${PROGRAMS[@]}"; do
       $cargo_test_bpf --manifest-path "$program"/Cargo.toml
     done
+
+    # TODO better: `build.rs` for spl-token-cli doesn't seem to properly build
+    # the required programs to run the tests, so instead we run the tests
+    # after we know programs have been built
+    $cargo build
+    $cargo test
   )
 }
 


### PR DESCRIPTION
#### Problem

The new spl-token-cli tests have messed up buildkite, because the required programs aren't being built.

#### Summary of Changes

As a quick fix, run the tests after the programs have been built for utmost safety. I'll take a longer look at this next week, but this should at least unblock CI.