### PR TITLE
ci: remove spl downstream build tests

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -102,5 +102,4 @@ EOF
 
 
 _ example_helloworld
-_ spl
 _ serum_dex


### PR DESCRIPTION
#### Problem

SPL now targets v1.10 and has become incompatible with v1.9

#### Summary of Changes

relieve v1.9 of SPL downstream build responsibilities