### PR TITLE
Limit token options appended to search options object in /explorer

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -187,7 +187,7 @@ function buildTokenOptions(
   if (matchedTokens.length > 0) {
     return {
       label: "Tokens",
-      options: matchedTokens.map(([id, details]) => ({
+      options: matchedTokens.slice(0, 10).map(([id, details]) => ({
         label: details.name,
         value: [details.name, details.symbol, id],
         pathname: "/address/" + id,


### PR DESCRIPTION
#### Problem 
The search currently maps hundreds of tokens when a user types in a few letters which makes the search experience feel a bit slow / delayed.

#### Summary of Changes
As discussed [here](https://github.com/solana-labs/solana/pull/24300#discussion_r851587677), this will cap the token search results that get mapped to the search options object. Given that the search options revealed to the user are a few at most, I think a limit of appending ~10 tokens at most should be enough.

Tagging @jstarry for visibility

Fixes #
