### PR TITLE
Define const fn `StakeState::size_of` for stake account size

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2113,7 +2113,7 @@ impl RentLengthValue {
     pub fn length(&self) -> usize {
         match self {
             Self::Nonce => NonceState::size(),
-            Self::Stake => std::mem::size_of::<StakeState>(),
+            Self::Stake => StakeState::size_of(),
             Self::System => 0,
             Self::Vote => VoteState::size_of(),
             Self::Bytes(l) => *l,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1310,7 +1310,7 @@ pub fn process_create_stake_account(
         }
 
         let minimum_balance =
-            rpc_client.get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>())?;
+            rpc_client.get_minimum_balance_for_rent_exemption(StakeState::size_of())?;
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
@@ -1784,7 +1784,7 @@ pub fn process_split_stake(
         }
 
         let minimum_balance =
-            rpc_client.get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>())?;
+            rpc_client.get_minimum_balance_for_rent_exemption(StakeState::size_of())?;
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1078,7 +1078,7 @@ fn test_stake_split() {
 
     // Create stake account, identity is authority
     let minimum_stake_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>())
+        .get_minimum_balance_for_rent_exemption(StakeState::size_of())
         .unwrap();
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let stake_account_pubkey = stake_keypair.pubkey();
@@ -1227,7 +1227,7 @@ fn test_stake_set_lockup() {
 
     // Create stake account, identity is authority
     let minimum_stake_balance = rpc_client
-        .get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>())
+        .get_minimum_balance_for_rent_exemption(StakeState::size_of())
         .unwrap();
 
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -836,7 +836,7 @@ mod tests {
             account::create_account_shared_data_for_test(&sysvar::clock::Clock::default());
         let config_address = stake_config::id();
         let config_account = config::create_account(0, &stake_config::Config::default());
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let withdrawal_amount = rent_exempt_reserve + minimum_delegation;
 
@@ -1087,7 +1087,7 @@ mod tests {
         let rent = Rent::default();
         let rent_address = sysvar::rent::id();
         let rent_account = account::create_account_shared_data_for_test(&rent);
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
 
         // Test InitializeChecked with non-signing withdrawer
@@ -1169,7 +1169,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             42,
             &StakeState::Initialized(Meta::auto(&authorized_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1281,7 +1281,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             42,
             &StakeState::Initialized(Meta::auto(&address_with_seed)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1385,7 +1385,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             42,
             &StakeState::Initialized(Meta::auto(&withdrawer)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1422,12 +1422,11 @@ mod tests {
     #[test]
     fn test_stake_initialize() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
-        let stake_account =
-            AccountSharedData::new(stake_lamports, std::mem::size_of::<StakeState>(), &id());
+        let stake_account = AccountSharedData::new(stake_lamports, StakeState::size_of(), &id());
         let custodian_address = solana_sdk::pubkey::new_rand();
         let lockup = Lockup {
             epoch: 1,
@@ -1503,7 +1502,7 @@ mod tests {
 
         // incorrect account sizes
         let stake_account =
-            AccountSharedData::new(stake_lamports, std::mem::size_of::<StakeState>() + 1, &id());
+            AccountSharedData::new(stake_lamports, StakeState::size_of() + 1, &id());
         transaction_accounts[0] = (stake_address, stake_account);
         process_instruction(
             &instruction_data,
@@ -1513,7 +1512,7 @@ mod tests {
         );
 
         let stake_account =
-            AccountSharedData::new(stake_lamports, std::mem::size_of::<StakeState>() - 1, &id());
+            AccountSharedData::new(stake_lamports, StakeState::size_of() - 1, &id());
         transaction_accounts[0] = (stake_address, stake_account);
         process_instruction(
             &instruction_data,
@@ -1532,7 +1531,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::default(),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1585,7 +1584,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1705,7 +1704,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1819,7 +1818,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -1929,7 +1928,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2135,7 +2134,7 @@ mod tests {
                 },
                 ..Meta::default()
             }),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2347,7 +2346,7 @@ mod tests {
     fn test_redelegate_consider_balance_changes() {
         let mut clock = Clock::default();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let initial_lamports = 4242424242;
         let stake_lamports = rent_exempt_reserve + initial_lamports;
         let recipient_address = solana_sdk::pubkey::new_rand();
@@ -2362,7 +2361,7 @@ mod tests {
                 rent_exempt_reserve,
                 ..Meta::auto(&authority_address)
             }),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2563,7 +2562,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2599,7 +2598,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -2645,7 +2644,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &solana_sdk::pubkey::new_rand(),
         )
         .unwrap();
@@ -2669,7 +2668,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2894,7 +2893,7 @@ mod tests {
 
         // overflow
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_account = AccountSharedData::new_data_with_space(
             1_000_000_000,
             &StakeState::Initialized(Meta {
@@ -2905,7 +2904,7 @@ mod tests {
                 },
                 lockup: Lockup::default(),
             }),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2923,7 +2922,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::RewardsPool,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -2946,7 +2945,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             total_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3083,7 +3082,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             total_lamports,
             &StakeState::Initialized(meta),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3157,7 +3156,7 @@ mod tests {
         let stake_account_self_as_custodian = AccountSharedData::new_data_with_space(
             total_lamports,
             &StakeState::Initialized(meta),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3193,7 +3192,7 @@ mod tests {
         let custodian_address = solana_sdk::pubkey::new_rand();
         let stake_address = solana_sdk::pubkey::new_rand();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = 7 * minimum_delegation;
         let stake_account = AccountSharedData::new_data_with_space(
@@ -3202,7 +3201,7 @@ mod tests {
                 rent_exempt_reserve,
                 ..Meta::auto(&stake_address)
             }),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3297,7 +3296,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_address)),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3417,7 +3416,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3684,7 +3683,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let instruction_data = serialize(&StakeInstruction::Initialize(
             Authorized::auto(&stake_address),
@@ -3712,7 +3711,7 @@ mod tests {
         ] {
             let stake_account = AccountSharedData::new(
                 stake_delegation + rent_exempt_reserve,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             );
             process_instruction(
@@ -3746,7 +3745,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
@@ -3793,7 +3792,7 @@ mod tests {
                 let stake_account = AccountSharedData::new_data_with_space(
                     stake_delegation + rent_exempt_reserve,
                     stake_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -3837,7 +3836,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -3847,7 +3846,7 @@ mod tests {
         let dest_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3892,7 +3891,7 @@ mod tests {
                 let source_account = AccountSharedData::new_data_with_space(
                     source_starting_balance,
                     source_stake_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -3928,7 +3927,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -3938,7 +3937,7 @@ mod tests {
         let dest_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -3968,7 +3967,7 @@ mod tests {
                 let source_account = AccountSharedData::new_data_with_space(
                     stake_delegation + rent_exempt_reserve,
                     source_stake_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -3996,7 +3995,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let source_address = Pubkey::new_unique();
         let source_meta = Meta {
             rent_exempt_reserve,
@@ -4080,14 +4079,14 @@ mod tests {
                 let source_account = AccountSharedData::new_data_with_space(
                     source_balance,
                     &source_stake_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
                 let dest_account = AccountSharedData::new_data_with_space(
                     destination_starting_balance,
                     &StakeState::Uninitialized,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4141,7 +4140,7 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
             rent_exempt_reserve,
@@ -4191,7 +4190,7 @@ mod tests {
                 let stake_account = AccountSharedData::new_data_with_space(
                     starting_stake_delegation + rent_exempt_reserve + rewards_balance,
                     stake_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -4244,11 +4243,11 @@ mod tests {
         let feature_set = FeatureSet::all_enabled();
         let minimum_delegation = crate::get_minimum_delegation(&feature_set);
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_address = solana_sdk::pubkey::new_rand();
         let stake_account = AccountSharedData::new(
             rent_exempt_reserve + minimum_delegation,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         );
         let vote_address = solana_sdk::pubkey::new_rand();
@@ -4416,14 +4415,14 @@ mod tests {
     #[test]
     fn test_split_source_uninitialized() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4431,7 +4430,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4513,7 +4512,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&stake_address), stake_lamports),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4539,7 +4538,7 @@ mod tests {
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
                 split_to_state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4558,7 +4557,7 @@ mod tests {
     #[test]
     fn test_split_more_than_staked() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -4571,7 +4570,7 @@ mod tests {
                 },
                 stake_lamports / 2 - 1,
             ),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4579,7 +4578,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4615,7 +4614,7 @@ mod tests {
     #[test]
     fn test_split_with_rent() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let minimum_balance = rent_exempt_reserve + minimum_delegation;
         let stake_lamports = minimum_balance * 2;
@@ -4624,7 +4623,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4654,7 +4653,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4719,7 +4718,7 @@ mod tests {
     #[test]
     fn test_split_to_account_with_rent_exempt_reserve() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = (rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -4732,7 +4731,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -4764,7 +4763,7 @@ mod tests {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4841,9 +4840,8 @@ mod tests {
     #[test]
     fn test_split_from_larger_sized_account() {
         let rent = Rent::default();
-        let source_larger_rent_exempt_reserve =
-            rent.minimum_balance(std::mem::size_of::<StakeState>() + 100);
-        let split_rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let source_larger_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of() + 100);
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = (source_larger_rent_exempt_reserve + minimum_delegation) * 2;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -4856,7 +4854,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            std::mem::size_of::<StakeState>() + 100,
+            StakeState::size_of() + 100,
             &id(),
         )
         .unwrap();
@@ -4888,7 +4886,7 @@ mod tests {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -4970,10 +4968,8 @@ mod tests {
     #[test]
     fn test_split_from_smaller_sized_account() {
         let rent = Rent::default();
-        let source_smaller_rent_exempt_reserve =
-            rent.minimum_balance(std::mem::size_of::<StakeState>());
-        let split_rent_exempt_reserve =
-            rent.minimum_balance(std::mem::size_of::<StakeState>() + 100);
+        let source_smaller_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of() + 100);
         let stake_lamports = split_rent_exempt_reserve + 1;
         let stake_address = solana_sdk::pubkey::new_rand();
         let meta = Meta {
@@ -4985,7 +4981,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -5014,7 +5010,7 @@ mod tests {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>() + 100,
+                StakeState::size_of() + 100,
                 &id(),
             )
             .unwrap();
@@ -5048,7 +5044,7 @@ mod tests {
     #[test]
     fn test_split_100_percent_of_source() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5061,7 +5057,7 @@ mod tests {
         let split_to_account = AccountSharedData::new_data_with_space(
             0,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -5086,7 +5082,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5142,7 +5138,7 @@ mod tests {
     #[test]
     fn test_split_100_percent_of_source_to_account_with_lamports() {
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5155,7 +5151,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &state,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -5187,7 +5183,7 @@ mod tests {
             let split_to_account = AccountSharedData::new_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5236,9 +5232,8 @@ mod tests {
     #[test]
     fn test_split_rent_exemptness() {
         let rent = Rent::default();
-        let source_rent_exempt_reserve =
-            rent.minimum_balance(std::mem::size_of::<StakeState>() + 100);
-        let split_rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let source_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of() + 100);
+        let split_rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let minimum_delegation = crate::get_minimum_delegation(&FeatureSet::all_enabled());
         let stake_lamports = source_rent_exempt_reserve + minimum_delegation;
         let stake_address = solana_sdk::pubkey::new_rand();
@@ -5269,14 +5264,14 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>() + 10000,
+                StakeState::size_of() + 10000,
                 &id(),
             )
             .unwrap();
@@ -5300,14 +5295,14 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 &state,
-                std::mem::size_of::<StakeState>() + 100,
+                StakeState::size_of() + 100,
                 &id(),
             )
             .unwrap();
             let split_to_account = AccountSharedData::new_data_with_space(
                 0,
                 &StakeState::Uninitialized,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5411,7 +5406,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5422,7 +5417,7 @@ mod tests {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -5501,7 +5496,7 @@ mod tests {
         let stake_address = solana_sdk::pubkey::new_rand();
         let authorized_address = solana_sdk::pubkey::new_rand();
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_amount = 4242424242;
         let stake_lamports = rent_exempt_reserve + stake_amount;
         let meta = Meta {
@@ -5519,7 +5514,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Stake(meta, stake),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -5613,7 +5608,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5624,7 +5619,7 @@ mod tests {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -5705,7 +5700,7 @@ mod tests {
             let stake_account = AccountSharedData::new_data_with_space(
                 stake_lamports,
                 state,
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &id(),
             )
             .unwrap();
@@ -5713,7 +5708,7 @@ mod tests {
                 let merge_from_account = AccountSharedData::new_data_with_space(
                     stake_lamports,
                     merge_from_state,
-                    std::mem::size_of::<StakeState>(),
+                    StakeState::size_of(),
                     &id(),
                 )
                 .unwrap();
@@ -5750,14 +5745,14 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&authorized_address), stake_lamports),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
         let merge_from_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &just_stake(Meta::auto(&authorized_address), stake_lamports),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &solana_sdk::pubkey::new_rand(),
         )
         .unwrap();
@@ -5817,7 +5812,7 @@ mod tests {
         let authorized_address = solana_sdk::pubkey::new_rand();
         let base_lamports = 4242424242;
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_amount = base_lamports;
         let stake_lamports = rent_exempt_reserve + stake_amount;
         let merge_from_amount = base_lamports;
@@ -5837,7 +5832,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Stake(meta, stake),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -5853,7 +5848,7 @@ mod tests {
         let merge_from_account = AccountSharedData::new_data_with_space(
             merge_from_lamports,
             &StakeState::Stake(meta, merge_from_stake),
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();
@@ -6244,7 +6239,7 @@ mod tests {
         let stake_account = AccountSharedData::new_data_with_space(
             1, /* lamports */
             &initial_stake_state,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .unwrap();

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -373,7 +373,7 @@ pub fn initialize(
     rent: &Rent,
     feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
-    if stake_account.get_data().len() != std::mem::size_of::<StakeState>() {
+    if stake_account.get_data().len() != StakeState::size_of() {
         return Err(InstructionError::InvalidAccountData);
     }
     if let StakeState::Uninitialized = stake_account.get_state()? {
@@ -575,7 +575,7 @@ pub fn split(
     if *split.get_owner() != id() {
         return Err(InstructionError::IncorrectProgramId);
     }
-    if split.get_data().len() != std::mem::size_of::<StakeState>() {
+    if split.get_data().len() != StakeState::size_of() {
         return Err(InstructionError::InvalidAccountData);
     }
     if !matches!(split.get_state()?, StakeState::Uninitialized) {
@@ -1425,8 +1425,7 @@ pub fn create_lockup_stake_account(
     rent: &Rent,
     lamports: u64,
 ) -> AccountSharedData {
-    let mut stake_account =
-        AccountSharedData::new(lamports, std::mem::size_of::<StakeState>(), &id());
+    let mut stake_account = AccountSharedData::new(lamports, StakeState::size_of(), &id());
 
     let rent_exempt_reserve = rent.minimum_balance(stake_account.data().len());
     assert!(
@@ -1492,8 +1491,7 @@ fn do_create_account(
     lamports: u64,
     activation_epoch: Epoch,
 ) -> AccountSharedData {
-    let mut stake_account =
-        AccountSharedData::new(lamports, std::mem::size_of::<StakeState>(), &id());
+    let mut stake_account = AccountSharedData::new(lamports, StakeState::size_of(), &id());
 
     let vote_state = VoteState::from(vote_account).expect("vote_state");
 
@@ -1674,7 +1672,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_stake_from_fail() {
-        let mut stake_account = AccountSharedData::new(0, std::mem::size_of::<StakeState>(), &id());
+        let mut stake_account = AccountSharedData::new(0, StakeState::size_of(), &id());
 
         stake_account
             .set_state(&StakeState::default())
@@ -2669,7 +2667,7 @@ mod tests {
     #[ignore]
     #[should_panic]
     fn test_dbg_stake_minimum_balance() {
-        let minimum_balance = Rent::default().minimum_balance(std::mem::size_of::<StakeState>());
+        let minimum_balance = Rent::default().minimum_balance(StakeState::size_of());
         panic!(
             "stake minimum_balance: {} lamports, {} SOL",
             minimum_balance,
@@ -2967,7 +2965,7 @@ mod tests {
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
         let rent = Rent::default();
-        let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
+        let rent_exempt_reserve = rent.minimum_balance(StakeState::size_of());
         let stake_lamports = rent_exempt_reserve + initial_lamports;
 
         let meta = Meta {
@@ -2977,7 +2975,7 @@ mod tests {
         let mut stake_account = AccountSharedData::new_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
-            std::mem::size_of::<StakeState>(),
+            StakeState::size_of(),
             &id(),
         )
         .expect("stake_account");

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -264,7 +264,7 @@ mod tests {
             let stake_account = Account::new_data_with_space(
                 balance,
                 &StakeState::Initialized(meta),
-                std::mem::size_of::<StakeState>(),
+                StakeState::size_of(),
                 &stake::program::id(),
             )
             .unwrap();

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -50,7 +50,7 @@ impl StakesCache {
     pub fn is_stake(account: &AccountSharedData) -> bool {
         solana_vote_program::check_id(account.owner())
             || stake::program::check_id(account.owner())
-                && account.data().len() >= std::mem::size_of::<StakeState>()
+                && account.data().len() >= StakeState::size_of()
     }
 
     pub fn check_and_store(&self, pubkey: &Pubkey, account: &AccountSharedData) {

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -328,7 +328,7 @@ pub fn create_account_with_seed(
             base,
             seed,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -347,7 +347,7 @@ pub fn create_account(
             from_pubkey,
             stake_pubkey,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize(stake_pubkey, authorized, lockup),
@@ -369,7 +369,7 @@ pub fn create_account_with_seed_checked(
             base,
             seed,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -387,7 +387,7 @@ pub fn create_account_checked(
             from_pubkey,
             stake_pubkey,
             lamports,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         initialize_checked(stake_pubkey, authorized),
@@ -416,7 +416,7 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, std::mem::size_of::<StakeState>() as u64),
+        system_instruction::allocate(split_stake_pubkey, StakeState::size_of() as u64),
         system_instruction::assign(split_stake_pubkey, &id()),
         _split(
             stake_pubkey,
@@ -440,7 +440,7 @@ pub fn split_with_seed(
             split_stake_pubkey,
             base,
             seed,
-            std::mem::size_of::<StakeState>() as u64,
+            StakeState::size_of() as u64,
             &id(),
         ),
         _split(

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -74,8 +74,13 @@ impl Default for StakeState {
 }
 
 impl StakeState {
+    /// The fixed number of bytes used to serialize each stake account
+    pub const fn size_of() -> usize {
+        200 // see test_size_of
+    }
+
     pub fn get_rent_exempt_reserve(rent: &Rent) -> u64 {
-        rent.minimum_balance(std::mem::size_of::<StakeState>())
+        rent.minimum_balance(Self::size_of())
     }
 
     pub fn stake(&self) -> Option<Stake> {
@@ -593,6 +598,11 @@ mod test {
         let bincode_serialized = serialize(&stake).unwrap();
         let borsh_serialized = StakeState::try_to_vec(&stake).unwrap();
         assert_eq!(bincode_serialized, borsh_serialized);
+    }
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(StakeState::size_of(), std::mem::size_of::<StakeState>());
     }
 
     #[test]

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -297,7 +297,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair, u64) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let bank = Bank::new_for_tests(&genesis_config);
-        let rent = bank.get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>());
+        let rent = bank.get_minimum_balance_for_rent_exemption(StakeState::size_of());
         (bank, mint_keypair, rent)
     }
 

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -601,8 +601,8 @@ export class StakeProgram {
    * Max space of a Stake account
    *
    * This is generated from the solana-stake-program StakeState struct as
-   * `std::mem::size_of::<StakeState>()`:
-   * https://docs.rs/solana-stake-program/1.4.4/solana_stake_program/stake_state/enum.StakeState.html
+   * `StakeState::size_of()`:
+   * https://docs.rs/solana-stake-program/latest/solana_stake_program/stake_state/enum.StakeState.html
    */
   static space: number = 200;
 


### PR DESCRIPTION
#### Problem
It's not obvious what the enforced size of a stake account is

#### Summary of Changes
- Added a new const fn `StakeState::serialized_size()` to use in place of `size_of::<StakeState>()`
- Added a test assertion to make it obvious that 200 is the current size

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
