### PR TITLE
fix: latest go version requires using 'go install' instead of 'go get'.

### DIFF
--- a/docs/src/running-validator/validator-failover.md
+++ b/docs/src/running-validator/validator-failover.md
@@ -30,8 +30,7 @@ First install `etcd` as desired for your machine. Then TLS certificates must be
 created for authentication between the etcd cluster and your validator.  Here is
 one way to do this:
 
-With [Golang](https://golang.org/) installed, run `go get
-github.com/cloudflare/cfssl/cmd/cfssl`.  The `cfssl` program should now be
+With [Golang](https://golang.org/) installed, run `go install github.com/cloudflare/cfssl/cmd/cfssl@latest`.  The `cfssl` program should now be
 available at `~/go/bin/cfssl`.  Ensure `~/go/bin` is in your PATH by running
 `PATH=$PATH:~/go/bin/`.
 


### PR DESCRIPTION
#### Problem
per https://github.com/golang/go/issues/40276, we need to use `go install` instead of `go get`


#### Summary of Changes
doc update

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
