### PR TITLE
Double max transaction blockhash age

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -10,7 +10,7 @@ use {
     solana_measure::measure::Measure,
     solana_metrics::{self, datapoint_info},
     solana_sdk::{
-        clock::{DEFAULT_MS_PER_SLOT, DEFAULT_S_PER_SLOT, MAX_PROCESSING_AGE},
+        clock::{DEFAULT_MS_PER_SLOT, DEFAULT_S_PER_SLOT, MAX_TRANSACTION_BLOCKHASH_AGE},
         commitment_config::CommitmentConfig,
         hash::Hash,
         instruction::{AccountMeta, Instruction},
@@ -35,7 +35,7 @@ use {
 };
 
 // The point at which transactions become "too old", in seconds.
-const MAX_TX_QUEUE_AGE: u64 = (MAX_PROCESSING_AGE as f64 * DEFAULT_S_PER_SLOT) as u64;
+const MAX_TX_QUEUE_AGE: u64 = (MAX_TRANSACTION_BLOCKHASH_AGE as f64 * DEFAULT_S_PER_SLOT) as u64;
 
 pub const MAX_SPENDS_PER_TX: u64 = 4;
 

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -17,7 +17,7 @@ use {
     solana_sdk::{
         account::Account,
         client::{AsyncClient, Client, SyncClient},
-        clock::{Slot, MAX_PROCESSING_AGE},
+        clock::{Slot, MAX_TRANSACTION_BLOCKHASH_AGE},
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -206,7 +206,7 @@ impl ThinClient {
         for x in 0..tries {
             let now = Instant::now();
             let mut num_confirmed = 0;
-            let mut wait_time = MAX_PROCESSING_AGE;
+            let mut wait_time = MAX_TRANSACTION_BLOCKHASH_AGE;
             // resend the same transaction until the transaction has no chance of succeeding
             let wire_transaction =
                 bincode::serialize(&transaction).expect("transaction serialization failed");
@@ -228,7 +228,8 @@ impl ThinClient {
                     // all pending confirmations. Resending the transaction could result into
                     // extra transaction fees
                     wait_time = wait_time.max(
-                        MAX_PROCESSING_AGE * pending_confirmations.saturating_sub(num_confirmed),
+                        MAX_TRANSACTION_BLOCKHASH_AGE
+                            * pending_confirmations.saturating_sub(num_confirmed),
                     );
                 }
             }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -40,7 +40,7 @@ use {
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
-        clock::{Slot, MAX_PROCESSING_AGE},
+        clock::Slot,
         feature_set,
         genesis_config::GenesisConfig,
         hash::Hash,
@@ -179,7 +179,6 @@ fn execute_batch(
 
     let (tx_results, balances) = batch.bank().load_execute_and_commit_transactions(
         batch,
-        MAX_PROCESSING_AGE,
         transaction_status_sender.is_some(),
         transaction_status_sender.is_some(),
         transaction_status_sender.is_some(),
@@ -3570,7 +3569,6 @@ pub mod tests {
             _balances,
         ) = batch.bank().load_execute_and_commit_transactions(
             &batch,
-            MAX_PROCESSING_AGE,
             false,
             false,
             false,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -44,7 +44,7 @@ use {
     solana_sdk::{
         account::AccountSharedData,
         client::{AsyncClient, SyncClient},
-        clock::{self, Slot, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE},
+        clock::{self, Slot, DEFAULT_TICKS_PER_SLOT, MAX_TRANSACTION_BLOCKHASH_AGE},
         commitment_config::CommitmentConfig,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         genesis_config::ClusterType,
@@ -2620,7 +2620,7 @@ fn test_votes_land_in_fork_during_long_partition() {
     let on_partition_resolved = |cluster: &mut LocalCluster, context: &mut PartitionContext| {
         let lighter_validator_ledger_path = cluster.ledger_path(&context.lighter_validator_key);
         let start = Instant::now();
-        let max_wait = ms_for_n_slots(MAX_PROCESSING_AGE as u64, DEFAULT_TICKS_PER_SLOT);
+        let max_wait = ms_for_n_slots(MAX_TRANSACTION_BLOCKHASH_AGE as u64, DEFAULT_TICKS_PER_SLOT);
         // Wait for the lighter node to switch over and root the `context.heavier_fork_slot`
         loop {
             assert!(

--- a/local-cluster/tests/local_cluster_slow.rs
+++ b/local-cluster/tests/local_cluster_slow.rs
@@ -31,7 +31,7 @@ use {
     },
     solana_runtime::vote_parser,
     solana_sdk::{
-        clock::{Slot, MAX_PROCESSING_AGE},
+        clock::{Slot, MAX_TRANSACTION_BLOCKHASH_AGE},
         hash::Hash,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -130,8 +130,9 @@ fn test_fork_choice_refresh_old_votes() {
     let ticks_per_slot = 8;
     let on_before_partition_resolved =
         |cluster: &mut LocalCluster, context: &mut PartitionContext| {
-            // Equal to ms_per_slot * MAX_PROCESSING_AGE, rounded up
-            let sleep_time_ms = ms_for_n_slots(MAX_PROCESSING_AGE as u64, ticks_per_slot);
+            // Equal to ms_per_slot * MAX_TRANSACTION_BLOCKHASH_AGE, rounded up
+            let sleep_time_ms =
+                ms_for_n_slots(MAX_TRANSACTION_BLOCKHASH_AGE as u64, ticks_per_slot);
             info!("Wait for blockhashes to expire, {} ms", sleep_time_ms);
 
             // Wait for blockhashes to expire

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -44,7 +44,6 @@ use {
         account_utils::StateMut,
         bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         client::SyncClient,
-        clock::MAX_PROCESSING_AGE,
         compute_budget::ComputeBudgetInstruction,
         entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
         feature_set::FeatureSet,
@@ -318,7 +317,6 @@ fn process_transaction_and_record_inner(
     let mut results = bank
         .load_execute_and_commit_transactions(
             &tx_batch,
-            MAX_PROCESSING_AGE,
             false,
             true,
             false,
@@ -358,15 +356,7 @@ fn execute_transactions(
             post_balances,
             ..
         },
-    ) = bank.load_execute_and_commit_transactions(
-        &batch,
-        std::usize::MAX,
-        true,
-        true,
-        true,
-        true,
-        &mut timings,
-    );
+    ) = bank.load_execute_and_commit_transactions(&batch, true, true, true, true, &mut timings);
     let tx_post_token_balances = collect_token_balances(&bank, &batch, &mut mint_decimals);
 
     izip!(

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -142,10 +142,6 @@ impl BlockhashQueue {
             recent_blockhashes::IterItem(v.hash_height, k, v.fee_calculator.lamports_per_signature)
         })
     }
-
-    pub(crate) fn get_max_age(&self) -> usize {
-        self.max_age
-    }
 }
 #[cfg(test)]
 mod tests {

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -61,9 +61,17 @@ static_assertions::const_assert_eq!(MAX_RECENT_BLOCKHASHES, 300);
 pub const MAX_RECENT_BLOCKHASHES: usize =
     MAX_HASH_AGE_IN_SECONDS * DEFAULT_TICKS_PER_SECOND as usize / DEFAULT_TICKS_PER_SLOT as usize;
 
+/// The maximum age of a transaction's blockhash
+pub const MAX_TRANSACTION_BLOCKHASH_AGE: usize = MAX_RECENT_BLOCKHASHES;
+
 #[cfg(test)]
-static_assertions::const_assert_eq!(MAX_PROCESSING_AGE, 150);
+mod max_processing_age {
+    #![allow(deprecated)]
+    static_assertions::const_assert_eq!(super::MAX_PROCESSING_AGE, 150);
+}
+
 // The maximum age of a blockhash that will be accepted by the leader
+#[deprecated]
 pub const MAX_PROCESSING_AGE: usize = MAX_RECENT_BLOCKHASHES / 2;
 
 /// This is maximum time consumed in forwarding a transaction from one node to next, before

--- a/sdk/program/src/sysvar/recent_blockhashes.rs
+++ b/sdk/program/src/sysvar/recent_blockhashes.rs
@@ -163,13 +163,12 @@ pub fn create_test_recent_blockhashes(start: usize) -> RecentBlockhashes {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::clock::MAX_PROCESSING_AGE};
+    use {super::*, crate::clock::MAX_RECENT_BLOCKHASHES};
 
     #[test]
     #[allow(clippy::assertions_on_constants)]
-    fn test_sysvar_can_hold_all_active_blockhashes() {
-        // Ensure we can still hold all of the active entries in `BlockhashQueue`
-        assert!(MAX_PROCESSING_AGE <= MAX_ENTRIES);
+    fn test_sysvar_size_doesnt_exceed_blockhash_queue_size() {
+        assert!(MAX_ENTRIES <= MAX_RECENT_BLOCKHASHES);
     }
 
     #[test]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -343,6 +343,10 @@ pub mod reject_callx_r10 {
     solana_sdk::declare_id!("3NKRSwpySNwD3TvP5pHnRmkAQRsdkXWRr1WaQh8p4PWX");
 }
 
+pub mod double_max_transaction_blockhash_age {
+    solana_sdk::declare_id!("AzwYx8kfjfi3wC4yw2txXWijQ4TN15xweXXD4yBqhxZ");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -423,6 +427,7 @@ lazy_static! {
         (add_get_minimum_delegation_instruction_to_stake_program::id(), "add GetMinimumDelegation instruction to stake program"),
         (error_on_syscall_bpf_function_hash_collisions::id(), "error on bpf function hash collisions"),
         (reject_callx_r10::id(), "Reject bpf callx r10 instructions"),
+        (double_max_transaction_blockhash_age::id(), "increase max allowed age of transaction recent blockhashes"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
`Bank::get_blockhash_last_valid_block_height` uses the max age of the blockhash queue to return whether a transaction blockhash is valid but that max age is double the max age for transaction processing. 

#### Summary of Changes
- Double the max age for transaction blockhashes to match the max age of the blockhash queue
- Update bank methods to use the max transaction blockhash age value instead of the blockhash queue max age

Feature Gate Issue: https://github.com/solana-labs/solana/issues/24424
<!-- Don't forget to add the "feature-gate" label -->
