### PR TITLE
Implement From<[u8; 32]> for Pubkey and Hash

### DIFF
--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -55,6 +55,12 @@ impl Hasher {
 
 impl Sanitize for Hash {}
 
+impl From<[u8; HASH_BYTES]> for Hash {
+    fn from(from: [u8; 32]) -> Self {
+        Self(from)
+    }
+}
+
 impl AsRef<[u8]> for Hash {
     fn as_ref(&self) -> &[u8] {
         &self.0[..]

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -110,6 +110,12 @@ impl FromStr for Pubkey {
     }
 }
 
+impl From<[u8; 32]> for Pubkey {
+    fn from(from: [u8; 32]) -> Self {
+        Self(from)
+    }
+}
+
 impl TryFrom<&str> for Pubkey {
     type Error = ParsePubkeyError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {


### PR DESCRIPTION
These are just conveniences to avoid having to import and then explicitly call the constructor.

```rust
use blah_blah_blah::Pubkey;

fn blah_blah_blah() {
  let _ = some_method_that_requires_pubkey(Pubkey::new_from_array([0; 32]));
}
```

```rust
fn blah_blah_blah() {
  let _ = some_method_that_requires_pubkey([0; 32].into());
}
```