### PR TITLE
defines const fn for serialized size of VoteState, Feature and Nonce

### DIFF
--- a/sdk/program/src/feature.rs
+++ b/sdk/program/src/feature.rs
@@ -24,11 +24,8 @@ pub struct Feature {
 }
 
 impl Feature {
-    pub fn size_of() -> usize {
-        bincode::serialized_size(&Feature {
-            activated_at: Some(0),
-        })
-        .unwrap() as usize
+    pub const fn size_of() -> usize {
+        9 // see test_feature_size_of.
     }
 
     pub fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
@@ -65,7 +62,13 @@ mod test {
     use {super::*, solana_program::clock::Slot};
 
     #[test]
-    fn feature_sizeof() {
+    fn test_feature_size_of() {
+        assert_eq!(Feature::size_of() as u64, {
+            let feature = Feature {
+                activated_at: Some(0),
+            };
+            bincode::serialized_size(&feature).unwrap()
+        });
         assert!(
             Feature::size_of() >= bincode::serialized_size(&Feature::default()).unwrap() as usize
         );

--- a/sdk/program/src/nonce/state/current.rs
+++ b/sdk/program/src/nonce/state/current.rs
@@ -1,5 +1,4 @@
 use {
-    super::Versions,
     crate::{fee_calculator::FeeCalculator, hash::Hash, pubkey::Pubkey},
     serde_derive::{Deserialize, Serialize},
 };
@@ -60,18 +59,24 @@ impl State {
     }
 
     /// Get the serialized size of the nonce state.
-    pub fn size() -> usize {
-        let data = Versions::new_current(State::Initialized(Data::default()));
-        bincode::serialized_size(&data).unwrap() as usize
+    pub const fn size() -> usize {
+        80 // see test_nonce_state_size.
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {super::*, crate::nonce::state::Versions};
 
     #[test]
     fn default_is_uninitialized() {
         assert_eq!(State::default(), State::Uninitialized)
+    }
+
+    #[test]
+    fn test_nonce_state_size() {
+        let data = Versions::new_current(State::Initialized(Data::default()));
+        let size = bincode::serialized_size(&data).unwrap();
+        assert_eq!(State::size() as u64, size);
     }
 }


### PR DESCRIPTION
#### Problem
`bincode::serialized_sized` requires constructing a temporary object and
it is slow. Silently changing serialized size of these structs can also
be a backward incompatible change.



#### Summary of Changes
This commit instead hard-codes serialized size of `VoteState`, `Feature` and
`Nonce`, and defines the functions as `const`. Added tests verify hard-coded
values.