### PR TITLE
mechanism for disabling hash calc caching

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -43,6 +43,14 @@ pub struct CalcAccountsHashConfig<'a> {
     pub rent_collector: &'a RentCollector,
 }
 
+impl<'a> CalcAccountsHashConfig<'a> {
+    /// return true if we should cache accounts hash intermediate data between calls
+    pub fn get_should_cache_hash_data() -> bool {
+        // when we are skipping rewrites, we cannot rely on the cached data from old append vecs, so we have to disable caching for now
+        false
+    }
+}
+
 // smallest, 3 quartiles, largest, average
 pub type StorageSizeQuartileStats = [usize; 6];
 


### PR DESCRIPTION
#### Problem

Caching of accounts hash intermediate state will not be correct when we eliminate rewrites. In the meantime, accounts hash calculation has been moved to accounts hash verifier threads from accounts background service. This takes some performance pressure off accounts hash calculation.

#### Summary of Changes

disable accounts hash calc

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
