### PR TITLE
remove 'startup' from verify_snapshot_bank

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -43,7 +43,6 @@ use {
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult},
-        accounts_index_storage::Startup,
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         ancestors::{Ancestors, AncestorsForSerialization},
         blockhash_queue::BlockhashQueue,
@@ -6091,11 +6090,6 @@ impl Bank {
         }
         clean_time.stop();
 
-        self.rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .set_startup(Startup::Startup);
         let mut shrink_all_slots_time = Measure::start("shrink_all_slots");
         if !accounts_db_skip_shrink && self.slot() > 0 {
             info!("shrinking..");
@@ -6107,11 +6101,6 @@ impl Bank {
         let mut verify_time = Measure::start("verify_bank_hash");
         let mut verify = self.verify_bank_hash(test_hash_calculation);
         verify_time.stop();
-        self.rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .set_startup(Startup::Normal);
 
         info!("verify_hash..");
         let mut verify2_time = Measure::start("verify_hash");


### PR DESCRIPTION
#### Problem

This was added early on in disk index usage. It appears to be unnecessary now. So, simplify things by not having this state change. My original concern was acct idx getting too far behind and being a bottleneck for startup clean and shrink (and hash calc!?). This concern was misplaced. So, we can move the acct idx to behave 'normally'. This simplifies the state situations and future debugging.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
