### PR TITLE
Add packets and batches sent to quic client stats

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -113,6 +113,21 @@ impl ConnectionCacheStats {
                 self.total_client_stats.tx_acks.load_and_reset(),
                 i64
             ),
+            (
+                "num_packets",
+                self.sent_packets.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "total_batches",
+                self.total_batches.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "batch_failure",
+                self.batch_failure.swap(0, Ordering::Relaxed),
+                i64
+            ),
         );
     }
 }


### PR DESCRIPTION
#### Problem

packets and batches stats left off

#### Summary of Changes

Add reporting for packets and batches stats

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
