### PR TITLE
metric optimization: simply data structure used for metric datapoints and counter storage

### DIFF
--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -25,5 +25,8 @@ serial_test = "0.6.0"
 [lib]
 name = "solana_metrics"
 
+[[bench]]
+name = "metrics"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/metrics/benches/metrics.rs
+++ b/metrics/benches/metrics.rs
@@ -16,7 +16,7 @@ use {
 #[bench]
 fn bench_datapoint_submission(bencher: &mut Bencher) {
     let writer = Arc::new(MockMetricsWriter::new());
-    let agent = MetricsAgent::new(writer.clone(), Duration::from_secs(10), 1000);
+    let agent = MetricsAgent::new(writer, Duration::from_secs(10), 1000);
 
     bencher.iter(|| {
         for i in 0..1000 {
@@ -34,7 +34,7 @@ fn bench_datapoint_submission(bencher: &mut Bencher) {
 #[bench]
 fn bench_counter_submission(bencher: &mut Bencher) {
     let writer = Arc::new(MockMetricsWriter::new());
-    let agent = MetricsAgent::new(writer.clone(), Duration::from_secs(10), 1000);
+    let agent = MetricsAgent::new(writer, Duration::from_secs(10), 1000);
 
     bencher.iter(|| {
         for i in 0..1000 {

--- a/metrics/benches/metrics.rs
+++ b/metrics/benches/metrics.rs
@@ -1,0 +1,45 @@
+#![feature(test)]
+
+extern crate test;
+
+use {
+    log::*,
+    solana_metrics::{
+        counter::CounterPoint,
+        datapoint::DataPoint,
+        metrics::{test_mocks::MockMetricsWriter, MetricsAgent},
+    },
+    std::{sync::Arc, time::Duration},
+    test::Bencher,
+};
+
+#[bench]
+fn bench_datapoint_submission(bencher: &mut Bencher) {
+    let writer = Arc::new(MockMetricsWriter::new());
+    let agent = MetricsAgent::new(writer.clone(), Duration::from_secs(10), 1000);
+
+    bencher.iter(|| {
+        for i in 0..1000 {
+            agent.submit(
+                DataPoint::new("measurement")
+                    .add_field_i64("i", i)
+                    .to_owned(),
+                Level::Info,
+            );
+        }
+        agent.flush();
+    })
+}
+
+#[bench]
+fn bench_counter_submission(bencher: &mut Bencher) {
+    let writer = Arc::new(MockMetricsWriter::new());
+    let agent = MetricsAgent::new(writer.clone(), Duration::from_secs(10), 1000);
+
+    bencher.iter(|| {
+        for i in 0..1000 {
+            agent.submit_counter(CounterPoint::new("counter 1"), Level::Info, i);
+        }
+        agent.flush();
+    })
+}

--- a/metrics/benches/metrics.rs
+++ b/metrics/benches/metrics.rs
@@ -4,6 +4,7 @@ extern crate test;
 
 use {
     log::*,
+    rand::distributions::{Distribution, Uniform},
     solana_metrics::{
         counter::CounterPoint,
         datapoint::DataPoint,
@@ -39,6 +40,32 @@ fn bench_counter_submission(bencher: &mut Bencher) {
     bencher.iter(|| {
         for i in 0..1000 {
             agent.submit_counter(CounterPoint::new("counter 1"), Level::Info, i);
+        }
+        agent.flush();
+    })
+}
+
+#[bench]
+fn bench_random_submission(bencher: &mut Bencher) {
+    let writer = Arc::new(MockMetricsWriter::new());
+    let agent = MetricsAgent::new(writer, Duration::from_secs(10), 1000);
+    let mut rng = rand::thread_rng();
+    let die = Uniform::<i32>::from(1..7);
+
+    bencher.iter(|| {
+        for i in 0..1000 {
+            let dice = die.sample(&mut rng);
+
+            if dice == 6 {
+                agent.submit_counter(CounterPoint::new("counter 1"), Level::Info, i);
+            } else {
+                agent.submit(
+                    DataPoint::new("measurement")
+                        .add_field_i64("i", i as i64)
+                        .to_owned(),
+                    Level::Info,
+                );
+            }
         }
         agent.flush();
     })

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -32,7 +32,6 @@ pub struct CounterPoint {
 }
 
 impl CounterPoint {
-    #[cfg(test)]
     pub fn new(name: &'static str) -> Self {
         CounterPoint {
             name,

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -59,11 +59,7 @@ macro_rules! create_counter {
 #[macro_export]
 macro_rules! inc_counter {
     ($name:expr, $level:expr, $count:expr) => {
-        unsafe {
-            if log_enabled!($level) {
-                $name.inc($level, $count)
-            }
-        };
+        unsafe { $name.inc($level, $count) };
     };
 }
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::integer_arithmetic)]
 pub mod counter;
 pub mod datapoint;
-mod metrics;
+pub mod metrics;
 pub mod poh_timing_point;
 pub use crate::metrics::{flush, query, set_host_id, set_panic_hook, submit};
 use std::sync::{

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -36,11 +36,11 @@ enum MetricsCommand {
     SubmitCounter(CounterPoint, log::Level, u64),
 }
 
-struct MetricsAgent {
+pub struct MetricsAgent {
     sender: Sender<MetricsCommand>,
 }
 
-trait MetricsWriter {
+pub trait MetricsWriter {
     // Write the points and empty the vector.  Called on the internal
     // MetricsAgent worker thread.
     fn write(&self, points: Vec<DataPoint>);
@@ -148,7 +148,7 @@ impl Default for MetricsAgent {
 }
 
 impl MetricsAgent {
-    fn new(
+    pub fn new(
         writer: Arc<dyn MetricsWriter + Send + Sync>,
         write_frequency: Duration,
         max_points_per_sec: usize,
@@ -444,21 +444,21 @@ pub fn set_panic_hook(program: &'static str, version: Option<String>) {
     });
 }
 
-#[cfg(test)]
-mod test {
+pub mod test_mocks {
     use super::*;
 
-    struct MockMetricsWriter {
-        points_written: Arc<Mutex<Vec<DataPoint>>>,
+    pub struct MockMetricsWriter {
+        pub points_written: Arc<Mutex<Vec<DataPoint>>>,
     }
     impl MockMetricsWriter {
-        fn new() -> Self {
+        #[allow(dead_code)]
+        pub fn new() -> Self {
             MockMetricsWriter {
                 points_written: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
-        fn points_written(&self) -> usize {
+        pub fn points_written(&self) -> usize {
             self.points_written.lock().unwrap().len()
         }
     }
@@ -480,6 +480,11 @@ mod test {
             );
         }
     }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, test_mocks::MockMetricsWriter};
 
     #[test]
     fn test_submit() {

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -289,15 +289,19 @@ impl MetricsAgent {
     }
 
     pub fn submit(&self, point: DataPoint, level: log::Level) {
-        self.sender
-            .send(MetricsCommand::Submit(point, level))
-            .unwrap();
+        if log_enabled!($level) {
+            self.sender
+                .send(MetricsCommand::Submit(point, level))
+                .unwrap();
+        }
     }
 
     pub fn submit_counter(&self, counter: CounterPoint, level: log::Level, bucket: u64) {
-        self.sender
-            .send(MetricsCommand::SubmitCounter(counter, level, bucket))
-            .unwrap();
+        if log_enabled!($level) {
+            self.sender
+                .send(MetricsCommand::SubmitCounter(counter, level, bucket))
+                .unwrap();
+        }
     }
 
     pub fn flush(&self) {

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -463,6 +463,12 @@ pub mod test_mocks {
         }
     }
 
+    impl Default for MockMetricsWriter {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl MetricsWriter for MockMetricsWriter {
         fn write(&self, points: Vec<DataPoint>) {
             assert!(!points.is_empty());

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -160,7 +160,8 @@ impl MetricsAgent {
     }
 
     fn collect_points(points: &mut Vec<DataPoint>, counters: &mut CounterMap) -> Vec<DataPoint> {
-        let mut ret: Vec<DataPoint> = points.drain(..).collect();
+        let mut ret: Vec<DataPoint> = Vec::default();
+        std::mem::swap(&mut ret, points);
         for (_, v) in counters.drain() {
             ret.push(v.into());
         }


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24319

Metric agent use a HashMap of tuple of Vec and HashMap to store datapoint and counters. However, these data is flattened into a vector of datapoints before submission. 

This extra levels of nesting is not necessary, and can be removed.

The following shows the benchmarks comparison between the old and new implementation.
new 
```
test bench_counter_submission   ... bench:     890,414 ns/iter (+/- 634,869)
test bench_datapoint_submission ... bench:     487,493 ns/iter (+/- 106,276)

```
old
```
test bench_counter_submission   ... bench:     956,648 ns/iter (+/- 352,442)
test bench_datapoint_submission ... bench:     571,490 ns/iter (+/- 598,148)
```

For datapoints, the new implementation  is **17%** faster. For counters new implementation is **7%** faster with new implementation.
And datapoint submission is **1.8x** faster than counters.


#### Summary of Changes

use a vector to store datapoints and hashmap to store counters.




Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
