### PR TITLE
Cost model tracks builtins and bpf programs separately 

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -334,7 +334,8 @@ pub struct BatchedTransactionCostDetails {
     pub batched_signature_cost: u64,
     pub batched_write_lock_cost: u64,
     pub batched_data_bytes_cost: u64,
-    pub batched_execute_cost: u64,
+    pub batched_builtins_execute_cost: u64,
+    pub batched_bpf_execute_cost: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1461,8 +1462,14 @@ impl BankingStage {
                         cost.data_bytes_cost
                     );
                     saturating_add_assign!(
-                        batched_transaction_details.costs.batched_execute_cost,
-                        cost.execution_cost
+                        batched_transaction_details
+                            .costs
+                            .batched_builtins_execute_cost,
+                        cost.builtins_execution_cost
+                    );
+                    saturating_add_assign!(
+                        batched_transaction_details.costs.batched_bpf_execute_cost,
+                        cost.bpf_execution_cost
                     );
                 }
                 Err(transaction_error) => match transaction_error {
@@ -4367,21 +4374,21 @@ mod tests {
                 signature_cost: 1,
                 write_lock_cost: 2,
                 data_bytes_cost: 3,
-                execution_cost: 10,
+                bpf_execution_cost: 10,
                 ..TransactionCost::default()
             },
             TransactionCost {
                 signature_cost: 4,
                 write_lock_cost: 5,
                 data_bytes_cost: 6,
-                execution_cost: 20,
+                bpf_execution_cost: 20,
                 ..TransactionCost::default()
             },
             TransactionCost {
                 signature_cost: 7,
                 write_lock_cost: 8,
                 data_bytes_cost: 9,
-                execution_cost: 40,
+                bpf_execution_cost: 40,
                 ..TransactionCost::default()
             },
         ];
@@ -4411,7 +4418,7 @@ mod tests {
         );
         assert_eq!(
             expected_executions,
-            batched_transaction_details.costs.batched_execute_cost
+            batched_transaction_details.costs.batched_bpf_execute_cost
         );
     }
 

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -253,7 +253,7 @@ impl QosService {
             Ordering::Relaxed,
         );
         self.metrics.stats.estimated_execute_cu.fetch_add(
-            batched_transaction_details.costs.batched_execute_cost,
+            batched_transaction_details.costs.batched_bpf_execute_cost,
             Ordering::Relaxed,
         );
 

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -252,7 +252,13 @@ impl QosService {
             batched_transaction_details.costs.batched_data_bytes_cost,
             Ordering::Relaxed,
         );
-        self.metrics.stats.estimated_execute_cu.fetch_add(
+        self.metrics.stats.estimated_builtins_execute_cu.fetch_add(
+            batched_transaction_details
+                .costs
+                .batched_builtins_execute_cost,
+            Ordering::Relaxed,
+        );
+        self.metrics.stats.estimated_bpf_execute_cu.fetch_add(
             batched_transaction_details.costs.batched_bpf_execute_cost,
             Ordering::Relaxed,
         );
@@ -307,7 +313,7 @@ impl QosService {
     pub fn accumulate_actual_execute_cu(&self, units: u64) {
         self.metrics
             .stats
-            .actual_execute_cu
+            .actual_bpf_execute_cu
             .fetch_add(units, Ordering::Relaxed);
     }
 
@@ -376,11 +382,14 @@ struct QosServiceMetricsStats {
     /// accumulated estimated instructino data Compute Units to be packed into block
     estimated_data_bytes_cu: AtomicU64,
 
-    /// accumulated estimated program Compute Units to be packed into block
-    estimated_execute_cu: AtomicU64,
+    /// accumulated estimated builtin programs Compute Units to be packed into block
+    estimated_builtins_execute_cu: AtomicU64,
+
+    /// accumulated estimated BPF program Compute Units to be packed into block
+    estimated_bpf_execute_cu: AtomicU64,
 
     /// accumulated actual program Compute Units that have been packed into block
-    actual_execute_cu: AtomicU64,
+    actual_bpf_execute_cu: AtomicU64,
 
     /// accumulated actual program execute micro-sec that have been packed into block
     actual_execute_time_us: AtomicU64,
@@ -461,13 +470,22 @@ impl QosServiceMetrics {
                     i64
                 ),
                 (
-                    "estimated_execute_cu",
-                    self.stats.estimated_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                    "estimated_builtins_execute_cu",
+                    self.stats
+                        .estimated_builtins_execute_cu
+                        .swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
                 (
-                    "actual_execute_cu",
-                    self.stats.actual_execute_cu.swap(0, Ordering::Relaxed) as i64,
+                    "estimated_bpf_execute_cu",
+                    self.stats
+                        .estimated_bpf_execute_cu
+                        .swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "actual_bpf_execute_cu",
+                    self.stats.actual_bpf_execute_cu.swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
                 (

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -394,6 +394,7 @@ fn execute_transactions(
                         inner_instructions,
                         durable_nonce_fee,
                         return_data,
+                        ..
                     } = details;
 
                     let lamports_per_signature = match durable_nonce_fee {

--- a/runtime/src/cost_tracker.rs
+++ b/runtime/src/cost_tracker.rs
@@ -296,7 +296,7 @@ mod tests {
             system_transaction::transfer(mint_keypair, &keypair.pubkey(), 2, *start_hash),
         );
         let mut tx_cost = TransactionCost::new_with_capacity(1);
-        tx_cost.execution_cost = 5;
+        tx_cost.bpf_execution_cost = 5;
         tx_cost.writable_accounts.push(mint_keypair.pubkey());
 
         (simple_transaction, tx_cost)
@@ -324,7 +324,7 @@ mod tests {
         )
         .unwrap();
         let mut tx_cost = TransactionCost::new_with_capacity(1);
-        tx_cost.execution_cost = 10;
+        tx_cost.bpf_execution_cost = 10;
         tx_cost.writable_accounts.push(mint_keypair.pubkey());
         tx_cost.is_simple_vote = true;
 
@@ -627,7 +627,7 @@ mod tests {
         {
             let tx_cost = TransactionCost {
                 writable_accounts: vec![acct1, acct2, acct3],
-                execution_cost: cost,
+                bpf_execution_cost: cost,
                 ..TransactionCost::default()
             };
             assert!(testee.try_add(&tx_cost).is_ok());
@@ -645,7 +645,7 @@ mod tests {
         {
             let tx_cost = TransactionCost {
                 writable_accounts: vec![acct2],
-                execution_cost: cost,
+                bpf_execution_cost: cost,
                 ..TransactionCost::default()
             };
             assert!(testee.try_add(&tx_cost).is_ok());
@@ -665,7 +665,7 @@ mod tests {
         {
             let tx_cost = TransactionCost {
                 writable_accounts: vec![acct1, acct2],
-                execution_cost: cost,
+                bpf_execution_cost: cost,
                 ..TransactionCost::default()
             };
             assert!(testee.try_add(&tx_cost).is_err());

--- a/runtime/src/transaction_cost_metrics_sender.rs
+++ b/runtime/src/transaction_cost_metrics_sender.rs
@@ -16,7 +16,8 @@ pub enum TransactionCostMetrics {
         signature_cost: u64,
         write_lock_cost: u64,
         data_bytes_cost: u64,
-        execution_cost: u64,
+        builtins_execution_cost: u64,
+        bpf_execution_cost: u64,
     },
 }
 
@@ -51,7 +52,8 @@ impl TransactionCostMetricsSender {
                     signature_cost: cost.signature_cost,
                     write_lock_cost: cost.write_lock_cost,
                     data_bytes_cost: cost.data_bytes_cost,
-                    execution_cost: cost.execution_cost,
+                    builtins_execution_cost: cost.builtins_execution_cost,
+                    bpf_execution_cost: cost.bpf_execution_cost,
                 })
                 .unwrap_or_else(|err| {
                     warn!(
@@ -92,7 +94,8 @@ impl TransactionCostMetricsService {
                     signature_cost,
                     write_lock_cost,
                     data_bytes_cost,
-                    execution_cost,
+                    builtins_execution_cost,
+                    bpf_execution_cost,
                 } => {
                     // report transaction cost details per slot|signature
                     datapoint_trace!(
@@ -102,7 +105,12 @@ impl TransactionCostMetricsService {
                         ("signature_cost", signature_cost as i64, i64),
                         ("write_lock_cost", write_lock_cost as i64, i64),
                         ("data_bytes_cost", data_bytes_cost as i64, i64),
-                        ("execution_cost", execution_cost as i64, i64),
+                        (
+                            "builtins_execution_cost",
+                            builtins_execution_cost as i64,
+                            i64
+                        ),
+                        ("bpf_execution_cost", bpf_execution_cost as i64, i64),
                     );
                 }
             }


### PR DESCRIPTION
#### Problem

Builtin programs are added to cost_table, being updated with `0` compute units from program-timing, lowers the builtin program costs. 

#### Summary of Changes

- removed builtin program from cost_table
- builtin program cost are queried directly from static `BUILT_IN_INSTRUCTION_COSTS`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
