### PR TITLE
fix: allow signing a populated transaction

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -167,7 +167,7 @@ export interface TransactionJSON {
     nonceInstruction: TransactionInstructionJSON;
   } | null;
   instructions: TransactionInstructionJSON[];
-  signatures: {publicKey: string; signature: number[] | null}[];
+  signers: string[];
 }
 
 /**
@@ -242,10 +242,9 @@ export class Transaction {
           }
         : null,
       instructions: this.instructions.map(instruction => instruction.toJSON()),
-      signatures: this.signatures.map(({publicKey, signature}) => ({
-        publicKey: publicKey.toJSON(),
-        signature: signature ? [...signature] : null,
-      })),
+      signers: this.signatures.map(({publicKey}) => {
+        return publicKey.toJSON();
+      }),
     };
   }
 
@@ -280,7 +279,7 @@ export class Transaction {
     if (this._message) {
       if (JSON.stringify(this.toJSON()) !== JSON.stringify(this._json)) {
         throw new Error(
-          'Transaction mutated after being populated from Message',
+          'Transaction message mutated after being populated from Message',
         );
       }
       return this._message;

--- a/web3.js/test/transaction.test.ts
+++ b/web3.js/test/transaction.test.ts
@@ -134,7 +134,7 @@ describe('Transaction', () => {
 
     const fee = await transaction.getEstimatedFee(connection);
     expect(fee).to.eq(5000);
-  });
+  }).timeout(10 * 1000);
 
   it('partialSign', () => {
     const account1 = Keypair.generate();
@@ -412,7 +412,7 @@ describe('Transaction', () => {
 
     transaction.feePayer = new PublicKey(6);
     expect(() => transaction.compileMessage()).to.throw(
-      'Transaction mutated after being populated from Message',
+      'Transaction message mutated after being populated from Message',
     );
   });
 
@@ -612,8 +612,8 @@ describe('Transaction', () => {
         programId: Keypair.generate().publicKey,
       }),
     );
-    t0.partialSign(signer);
-    const t1 = Transaction.from(t0.serialize());
+    const t1 = Transaction.from(t0.serialize({requireAllSignatures: false}));
+    t1.partialSign(signer);
     t1.serialize();
   });
 });


### PR DESCRIPTION
#### Problem
Deserialized transactions can no longer be partially signed after Transaction mutation checks were added in https://github.com/solana-labs/solana/pull/23720

#### Summary of Changes
Only check for mutations in message fields, not for signatures

Fixes https://github.com/solana-labs/solana/issues/24462
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
