### PR TITLE
Reverts the feature removal of `remove_native_loader`

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -203,6 +203,10 @@ pub mod optimize_epoch_boundary_updates {
     solana_sdk::declare_id!("265hPS8k8xJ37ot82KEgjRunsUp5w4n4Q4VwwiN9i9ps");
 }
 
+pub mod remove_native_loader {
+    solana_sdk::declare_id!("HTTgmruMYRZEntyL3EdCDdnS6e4D5wRq1FA7kQsb66qq");
+}
+
 pub mod send_to_tpu_vote_port {
     solana_sdk::declare_id!("C5fh68nJ7uyKAuYZg2x9sEQ5YrVf3dkW6oojNBSc3Jvo");
 }
@@ -392,6 +396,7 @@ lazy_static! {
         (do_support_realloc::id(), "support account data reallocation"),
         (prevent_calling_precompiles_as_programs::id(), "prevent calling precompiles as programs"),
         (optimize_epoch_boundary_updates::id(), "optimize epoch boundary updates"),
+        (remove_native_loader::id(), "remove support for the native loader"),
         (send_to_tpu_vote_port::id(), "send votes to the tpu vote port"),
         (requestable_heap_size::id(), "Requestable heap frame size"),
         (disable_fee_calculator::id(), "deprecate fee calculator"),


### PR DESCRIPTION
#### Problem
See: https://github.com/solana-labs/solana/pull/24296#discussion_r852810447

#### Summary of Changes
Adds `remove_native_loader` back in.