### PR TITLE
Deprecate `KeyedAccount` and `StackFrame`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -173,6 +173,10 @@ impl fmt::Display for AllocErr {
     }
 }
 
+#[deprecated(
+    since = "1.11.0",
+    note = "Please use InstructionContext instead of StackFrame"
+)]
 #[allow(deprecated)]
 pub struct StackFrame<'a> {
     pub number_of_program_accounts: usize,
@@ -203,6 +207,7 @@ impl<'a> StackFrame<'a> {
 
 pub struct InvokeContext<'a> {
     pub transaction_context: &'a mut TransactionContext,
+    #[allow(deprecated)]
     invoke_stack: Vec<StackFrame<'a>>,
     rent: Rent,
     pre_accounts: Vec<PreAccount>,

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1,3 +1,5 @@
+#[allow(deprecated)]
+use solana_sdk::keyed_account::{create_keyed_accounts_unified, KeyedAccount};
 use {
     crate::{
         accounts_data_meter::AccountsDataMeter,
@@ -20,7 +22,6 @@ use {
         },
         hash::Hash,
         instruction::{AccountMeta, Instruction, InstructionError},
-        keyed_account::{create_keyed_accounts_unified, KeyedAccount},
         native_loader,
         pubkey::Pubkey,
         rent::Rent,
@@ -172,12 +173,14 @@ impl fmt::Display for AllocErr {
     }
 }
 
+#[allow(deprecated)]
 pub struct StackFrame<'a> {
     pub number_of_program_accounts: usize,
     pub keyed_accounts: Vec<KeyedAccount<'a>>,
     pub keyed_accounts_range: std::ops::Range<usize>,
 }
 
+#[allow(deprecated)]
 impl<'a> StackFrame<'a> {
     pub fn new(number_of_program_accounts: usize, keyed_accounts: Vec<KeyedAccount<'a>>) -> Self {
         let keyed_accounts_range = std::ops::Range {
@@ -411,6 +414,7 @@ impl<'a> InvokeContext<'a> {
         }
 
         // Create the KeyedAccounts that will be passed to the program
+        #[allow(deprecated)]
         let keyed_accounts = program_indices
             .iter()
             .map(|account_index| {
@@ -436,6 +440,7 @@ impl<'a> InvokeContext<'a> {
             .collect::<Result<Vec<_>, InstructionError>>()?;
 
         // Unsafe will be removed together with the keyed_accounts
+        #[allow(deprecated)]
         self.invoke_stack.push(StackFrame::new(
             program_indices.len(),
             create_keyed_accounts_unified(unsafe {
@@ -996,6 +1001,11 @@ impl<'a> InvokeContext<'a> {
         Err(InstructionError::UnsupportedProgramId)
     }
 
+    #[deprecated(
+        since = "1.11.0",
+        note = "Please use BorrowedAccount instead of KeyedAccount"
+    )]
+    #[allow(deprecated)]
     /// Get the list of keyed accounts including the chain of program accounts
     pub fn get_keyed_accounts(&self) -> Result<&[KeyedAccount], InstructionError> {
         self.invoke_stack

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -1,3 +1,8 @@
+#![deprecated(
+    since = "1.11.0",
+    note = "Please use BorrowedAccount instead of KeyedAccount"
+)]
+#![allow(deprecated)]
 use {
     crate::{
         account::{AccountSharedData, ReadableAccount},
@@ -249,48 +254,5 @@ where
     }
     fn set_state(&self, state: &T) -> Result<(), InstructionError> {
         self.try_account_ref_mut()?.set_state(state)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        crate::{
-            account::{create_account_for_test, from_account, to_account},
-            pubkey::Pubkey,
-            sysvar::Sysvar,
-        },
-    };
-
-    #[repr(C)]
-    #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
-    struct TestSysvar {
-        something: Pubkey,
-    }
-    crate::declare_id!("TestSysvar111111111111111111111111111111111");
-    impl solana_program::sysvar::SysvarId for TestSysvar {
-        fn id() -> crate::pubkey::Pubkey {
-            id()
-        }
-        fn check_id(pubkey: &crate::pubkey::Pubkey) -> bool {
-            check_id(pubkey)
-        }
-    }
-    impl Sysvar for TestSysvar {}
-
-    #[test]
-    fn test_sysvar_keyed_account_to_from() {
-        let test_sysvar = TestSysvar::default();
-        let key = crate::keyed_account::tests::id();
-
-        let account = create_account_for_test(&test_sysvar);
-        let test_sysvar = from_account::<TestSysvar, _>(&account).unwrap();
-        assert_eq!(test_sysvar, TestSysvar::default());
-
-        let mut account = AccountSharedData::new(42, TestSysvar::size_of(), &key);
-        to_account(&test_sysvar, &mut account).unwrap();
-        let test_sysvar = from_account::<TestSysvar, _>(&account).unwrap();
-        assert_eq!(test_sysvar, TestSysvar::default());
     }
 }


### PR DESCRIPTION
#### Problem
`InstructionContext` replaced `StackFrame` and `BorrowedAccount` replaced `KeyedAccount`.

#### Summary of Changes
Deprecates `KeyedAccount` and `StackFrame`.