### PR TITLE
moves sign_shred and new_coding_shred_header out of Shredder

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -83,7 +83,7 @@ impl StandardBroadcastRun {
                     self.shred_version,
                     fec_set_index.unwrap(),
                 );
-                Shredder::sign_shred(keypair, &mut shred);
+                shred.sign(keypair);
                 state.data_shreds_buffer.push(shred.clone());
                 let mut shreds = make_coding_shreds(
                     keypair,

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -52,10 +52,7 @@ pub fn nonce(buf: &[u8]) -> Option<Nonce> {
 mod test {
     use {
         super::*,
-        solana_ledger::{
-            shred::{Shred, Shredder},
-            sigverify_shreds::verify_shred_cpu,
-        },
+        solana_ledger::{shred::Shred, sigverify_shreds::verify_shred_cpu},
         solana_sdk::{
             packet::PacketFlags,
             signature::{Keypair, Signer},
@@ -81,7 +78,7 @@ mod test {
         );
         assert_eq!(shred.slot(), slot);
         let keypair = Keypair::new();
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         trace!("signature {}", shred.common_header.signature);
         let nonce = 9;
         let mut packet = repair_response_packet_from_bytes(

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -69,10 +69,7 @@ impl SigVerifier for ShredSigVerifier {
 pub mod tests {
     use {
         super::*,
-        solana_ledger::{
-            genesis_utils::create_genesis_config_with_leader,
-            shred::{Shred, Shredder},
-        },
+        solana_ledger::{genesis_utils::create_genesis_config_with_leader, shred::Shred},
         solana_perf::packet::Packet,
         solana_runtime::bank::Bank,
         solana_sdk::signature::{Keypair, Signer},
@@ -95,7 +92,7 @@ pub mod tests {
         let mut batches = [PacketBatch::default(), PacketBatch::default()];
 
         let keypair = Keypair::new();
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         batches[0].packets.resize(1, Packet::default());
         batches[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[0].packets[0].meta.size = shred.payload.len();
@@ -111,7 +108,7 @@ pub mod tests {
             0,
             0xc0de,
         );
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         batches[1].packets.resize(1, Packet::default());
         batches[1].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[1].packets[0].meta.size = shred.payload.len();
@@ -145,7 +142,7 @@ pub mod tests {
             0,
             0xc0de,
         );
-        Shredder::sign_shred(&leader_keypair, &mut shred);
+        shred.sign(&leader_keypair);
         batches[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[0].packets[0].meta.size = shred.payload.len();
 
@@ -161,7 +158,7 @@ pub mod tests {
             0xc0de,
         );
         let wrong_keypair = Keypair::new();
-        Shredder::sign_shred(&wrong_keypair, &mut shred);
+        shred.sign(&wrong_keypair);
         batches[0].packets[1].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[0].packets[1].meta.size = shred.payload.len();
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -875,7 +875,7 @@ mod test {
         ));
 
         // coding shreds don't contain parent slot information, test that slot >= root
-        let (common, coding) = Shredder::new_coding_shred_header(
+        let (common, coding) = Shred::new_coding_shred_header(
             5, // slot
             5, // index
             5, // fec_set_index
@@ -886,7 +886,7 @@ mod test {
         );
         let mut coding_shred =
             Shred::new_empty_from_header(common, DataShredHeader::default(), coding);
-        Shredder::sign_shred(&leader_keypair, &mut coding_shred);
+        coding_shred.sign(&leader_keypair);
         // shred.slot() > root, shred continues
         assert!(should_retransmit_and_persist(
             &coding_shred,
@@ -959,7 +959,7 @@ mod test {
             std::net::{IpAddr, Ipv4Addr},
         };
         solana_logger::setup();
-        let (common, coding) = Shredder::new_coding_shred_header(
+        let (common, coding) = Shred::new_coding_shred_header(
             5, // slot
             5, // index
             5, // fec_set_index

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5977,7 +5977,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let slot = 1;
-        let (shred, coding) = Shredder::new_coding_shred_header(
+        let (shred, coding) = Shred::new_coding_shred_header(
             slot, 11, // index
             11, // fec_set_index
             11, // num_data_shreds
@@ -6034,7 +6034,7 @@ pub mod tests {
         let last_root = RwLock::new(0);
 
         let slot = 1;
-        let (mut shred, coding) = Shredder::new_coding_shred_header(
+        let (mut shred, coding) = Shred::new_coding_shred_header(
             slot, 11, // index
             11, // fec_set_index
             11, // num_data_shreds

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -394,6 +394,33 @@ impl Shred {
             .ok_or(ShredError::InvalidPayload)
     }
 
+    pub fn new_coding_shred_header(
+        slot: Slot,
+        index: u32,
+        fec_set_index: u32,
+        num_data_shreds: u16,
+        num_coding_shreds: u16,
+        position: u16,
+        version: u16,
+    ) -> (ShredCommonHeader, CodingShredHeader) {
+        let header = ShredCommonHeader {
+            shred_type: ShredType::Code,
+            index,
+            slot,
+            version,
+            fec_set_index,
+            ..ShredCommonHeader::default()
+        };
+        (
+            header,
+            CodingShredHeader {
+                num_data_shreds,
+                num_coding_shreds,
+                position,
+            },
+        )
+    }
+
     pub fn new_empty_coding(
         slot: Slot,
         index: u32,
@@ -403,7 +430,7 @@ impl Shred {
         position: u16,
         version: u16,
     ) -> Self {
-        let (header, coding_header) = Shredder::new_coding_shred_header(
+        let (header, coding_header) = Self::new_coding_shred_header(
             slot,
             index,
             fec_set_index,
@@ -607,6 +634,13 @@ impl Shred {
         self.common_header.signature
     }
 
+    pub fn sign(&mut self, keypair: &Keypair) {
+        let signature = keypair.sign_message(&self.payload[SIZE_OF_SIGNATURE..]);
+        bincode::serialize_into(&mut self.payload[..SIZE_OF_SIGNATURE], &signature)
+            .expect("Failed to generate serialized signature");
+        self.common_header.signature = signature;
+    }
+
     pub fn seed(&self, leader_pubkey: Pubkey) -> [u8; 32] {
         hashv(&[
             &self.slot().to_le_bytes(),
@@ -803,7 +837,7 @@ impl Shredder {
                 self.version,
                 fec_set_index.unwrap(),
             );
-            Shredder::sign_shred(keypair, &mut shred);
+            shred.sign(keypair);
             shred
         };
         let data_shreds: Vec<Shred> = PAR_THREAD_POOL.with(|thread_pool| {
@@ -873,7 +907,7 @@ impl Shredder {
         PAR_THREAD_POOL.with(|thread_pool| {
             thread_pool.borrow().install(|| {
                 coding_shreds.par_iter_mut().for_each(|coding_shred| {
-                    Shredder::sign_shred(keypair, coding_shred);
+                    coding_shred.sign(keypair);
                 })
             })
         });
@@ -882,40 +916,6 @@ impl Shredder {
         process_stats.gen_coding_elapsed += gen_coding_time.as_us();
         process_stats.sign_coding_elapsed += sign_coding_time.as_us();
         Ok(coding_shreds)
-    }
-
-    pub fn sign_shred(signer: &Keypair, shred: &mut Shred) {
-        let signature = signer.sign_message(&shred.payload[SIZE_OF_SIGNATURE..]);
-        bincode::serialize_into(&mut shred.payload[..SIZE_OF_SIGNATURE], &signature)
-            .expect("Failed to generate serialized signature");
-        shred.common_header.signature = signature;
-    }
-
-    pub fn new_coding_shred_header(
-        slot: Slot,
-        index: u32,
-        fec_set_index: u32,
-        num_data_shreds: u16,
-        num_coding_shreds: u16,
-        position: u16,
-        version: u16,
-    ) -> (ShredCommonHeader, CodingShredHeader) {
-        let header = ShredCommonHeader {
-            shred_type: ShredType::Code,
-            index,
-            slot,
-            version,
-            fec_set_index,
-            ..ShredCommonHeader::default()
-        };
-        (
-            header,
-            CodingShredHeader {
-                num_data_shreds,
-                num_coding_shreds,
-                position,
-            },
-        )
     }
 
     /// Generates coding shreds for the data shreds in the current FEC set
@@ -2031,7 +2031,7 @@ pub mod tests {
         assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
         assert_eq!(1, stats.index_out_of_bounds);
 
-        let (header, coding_header) = Shredder::new_coding_shred_header(
+        let (header, coding_header) = Shred::new_coding_shred_header(
             8,   // slot
             2,   // index
             10,  // fec_set_index

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -459,7 +459,7 @@ pub fn sign_shreds_gpu(
 pub mod tests {
     use {
         super::*,
-        crate::shred::{Shred, Shredder, SIZE_OF_DATA_SHRED_PAYLOAD},
+        crate::shred::{Shred, SIZE_OF_DATA_SHRED_PAYLOAD},
         solana_sdk::signature::{Keypair, Signer},
     };
 
@@ -479,7 +479,7 @@ pub mod tests {
         );
         assert_eq!(shred.slot(), slot);
         let keypair = Keypair::new();
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         trace!("signature {}", shred.common_header.signature);
         packet.data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         packet.meta.size = shred.payload.len();
@@ -524,7 +524,7 @@ pub mod tests {
             0xc0de,
         );
         let keypair = Keypair::new();
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         batches[0].packets.resize(1, Packet::default());
         batches[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[0].packets[0].meta.size = shred.payload.len();
@@ -579,7 +579,7 @@ pub mod tests {
             0xc0de,
         );
         let keypair = Keypair::new();
-        Shredder::sign_shred(&keypair, &mut shred);
+        shred.sign(&keypair);
         batches[0].packets.resize(1, Packet::default());
         batches[0].packets[0].data[0..shred.payload.len()].copy_from_slice(&shred.payload);
         batches[0].packets[0].meta.size = shred.payload.len();


### PR DESCRIPTION
#### Problem
Both methods belong to `Shred` and not `Shredder`.

#### Summary of Changes
Moved the methods to `Shred`.
Re-organizing this code for upcoming changes to `Shred` struct