### PR TITLE
fix: adds grab mint metadata for ft's

### DIFF
--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -193,7 +193,7 @@ export function AccountHeader({
     } else {
       token = {
         logoURI: data.nftData!.json?.image,
-        name: data.nftData!.json?.name,
+        name: "Unverified: " + data.nftData!.json?.name,
       };
     }
 

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -185,14 +185,25 @@ export function AccountHeader({
     );
   }
 
-  if (tokenDetails && isToken) {
+  if (isToken) {
+    let token;
+
+    if (tokenDetails) {
+      token = tokenDetails;
+    } else {
+      token = {
+        logoURI: data.nftData!.json?.image,
+        name: data.nftData!.json?.name,
+      };
+    }
+
     return (
       <div className="row align-items-end">
         <div className="col-auto">
           <div className="avatar avatar-lg header-avatar-top">
-            {tokenDetails?.logoURI ? (
+            {token?.logoURI ? (
               <img
-                src={tokenDetails.logoURI}
+                src={token.logoURI}
                 alt="token logo"
                 className="avatar-img rounded-circle border border-4 border-body"
               />
@@ -208,9 +219,7 @@ export function AccountHeader({
 
         <div className="col mb-3 ms-n3 ms-md-n2">
           <h6 className="header-pretitle">Token</h6>
-          <h2 className="header-title">
-            {tokenDetails?.name || "Unknown Token"}
-          </h2>
+          <h2 className="header-title">{token?.name || "Unknown Token"}</h2>
         </div>
       </div>
     );

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -187,18 +187,26 @@ export function AccountHeader({
 
   if (isToken) {
     let token;
+    let unverified = false;
 
     if (tokenDetails) {
       token = tokenDetails;
     } else {
       token = {
-        logoURI: data.nftData!.json?.image,
-        name: "Unverified: " + data.nftData!.json?.name,
+        logoURI: data?.nftData?.json?.image,
+        name: data?.nftData?.json?.name,
       };
+      unverified = true;
     }
 
     return (
       <div className="row align-items-end">
+        {unverified && (
+          <div className="alert alert-danger alert-scam" role="alert">
+            Warning! This token uses custom metadata and may have spoofed its
+            name and logo to look like another token.
+          </div>
+        )}
         <div className="col-auto">
           <div className="avatar avatar-lg header-avatar-top">
             {token?.logoURI ? (


### PR DESCRIPTION
#### Problem
Explorer needs to also grab mint metadata from metaplex for fungible tokens

#### Summary of Changes
Use the existing `Metadata.load` function from `@metaplex-foundation/mpl-token-metadata` that we use to fill the [metadata card](https://github.com/solana-labs/solana/blob/d6927365ed427cb21b9191fb0a48c51d031a8ab9/explorer/src/components/account/MetaplexMetadataCard.tsx) and use the new [fungible token metadata standard](https://docs.metaplex.com/token-metadata/specification#token-standards) to show wallet metadata on a mint page

Fixes #
#23748
