### PR TITLE
Use unsigned_abs() instead of casting abs()

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2317,7 +2317,7 @@ impl fmt::Display for CliBlock {
                     format!(
                         "{}◎{:<14.9}",
                         sign,
-                        lamports_to_sol(reward.lamports.abs() as u64)
+                        lamports_to_sol(reward.lamports.unsigned_abs())
                     ),
                     if reward.post_balance == 0 {
                         "          -                 -".to_string()
@@ -2342,7 +2342,7 @@ impl fmt::Display for CliBlock {
                 f,
                 "Total Rewards: {}◎{:<12.9}",
                 sign,
-                lamports_to_sol(total_rewards.abs() as u64)
+                lamports_to_sol(total_rewards.unsigned_abs())
             )?;
         }
         for (index, transaction_with_meta) in

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -528,7 +528,7 @@ fn write_rewards<W: io::Write>(
                         "-".to_string()
                     },
                     sign,
-                    lamports_to_sol(reward.lamports.abs() as u64),
+                    lamports_to_sol(reward.lamports.unsigned_abs()),
                     lamports_to_sol(reward.post_balance)
                 )?;
             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -116,7 +116,7 @@ fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &LedgerOutpu
                             "-".to_string()
                         },
                         sign,
-                        lamports_to_sol(reward.lamports.abs() as u64),
+                        lamports_to_sol(reward.lamports.unsigned_abs()),
                         lamports_to_sol(reward.post_balance),
                         reward
                             .commission

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -529,7 +529,7 @@ impl JsonRpcRequestProcessor {
                     return Some(RpcInflationReward {
                         epoch,
                         effective_slot: first_confirmed_block_in_epoch,
-                        amount: reward.lamports.abs() as u64,
+                        amount: reward.lamports.unsigned_abs(),
                         post_balance: reward.post_balance,
                         commission: reward.commission,
                     });


### PR DESCRIPTION
clippy started complaining about this:

```
warning: casting the result of `i64::abs()` to u64
   --> ledger-tool/src/main.rs:119:41
    |
119 |                         lamports_to_sol(reward.lamports.abs() as u64),
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `reward.lamports.unsigned_abs()`
    |
    = note: `#[warn(clippy::cast_abs_to_unsigned)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_abs_to_unsigned
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
