### PR TITLE
Assign backports for automerged PR to pr-subscribers group

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -109,7 +109,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by }}"
+          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
         ignore_conflicts: true
         labels:
           - feature-gate
@@ -122,7 +122,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by }}"
+          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
         ignore_conflicts: true
         branches:
           - v1.9
@@ -133,7 +133,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by }}"
+          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
         ignore_conflicts: true
         labels:
           - feature-gate
@@ -146,7 +146,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by }}"
+          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
         ignore_conflicts: true
         branches:
           - v1.10

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -108,7 +108,7 @@ pull_request_rules:
       - label=feature-gate
     actions:
       backport:
-        assignees:
+        assignees: &BackportAssignee
           - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         ignore_conflicts: true
         labels:
@@ -121,8 +121,7 @@ pull_request_rules:
       - label!=feature-gate
     actions:
       backport:
-        assignees:
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
+        assignees: *BackportAssignee
         ignore_conflicts: true
         branches:
           - v1.9
@@ -132,8 +131,7 @@ pull_request_rules:
       - label=feature-gate
     actions:
       backport:
-        assignees:
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
+        assignees: *BackportAssignee
         ignore_conflicts: true
         labels:
           - feature-gate
@@ -145,8 +143,7 @@ pull_request_rules:
       - label!=feature-gate
     actions:
       backport:
-        assignees:
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
+        assignees: *BackportAssignee
         ignore_conflicts: true
         branches:
           - v1.10

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -109,7 +109,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         ignore_conflicts: true
         labels:
           - feature-gate
@@ -122,7 +122,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         ignore_conflicts: true
         branches:
           - v1.9
@@ -133,7 +133,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         ignore_conflicts: true
         labels:
           - feature-gate
@@ -146,7 +146,7 @@ pull_request_rules:
     actions:
       backport:
         assignees:
-          - "{{ merged_by|replace('mergify[bot]', '@solana-labs/community-pr-subscribers') }}"
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         ignore_conflicts: true
         branches:
           - v1.10


### PR DESCRIPTION
#### Problem
Backports for automerged PR's are assigned to the mergify bot account

#### Summary of Changes
Assign to author if community label isn't present, otherwise assign to community-pr-subscribers team

Jinja Filters ref: https://jinja.palletsprojects.com/en/3.0.x/templates/#list-of-builtin-filters
YAML anchor ref: https://docs.mergify.com/configuration/#yaml-anchors-and-aliases

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
