### PR TITLE
Support token-2022 in RPC instruction parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,9 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e139feda2afd510dea2027584cc35a9ee9ebac0bfef1ab4d23647bf5c091a6"
+checksum = "7299c2ca50bd2d8a5b4a8043e4817892b5e700345234a31adc5b4c1208a32283"
 dependencies = [
  "bs58",
  "bv",
@@ -4755,7 +4755,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.10.9",
+ "solana-frozen-abi-macro 1.10.10",
  "thiserror",
 ]
 
@@ -4782,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798b851026ff2366b318f7818a64846dd1ebc7e613f7893fba07a61cd55e6a48"
+checksum = "d726d2fbe5b1b21cb8a81b8c3c1d1aca32bfcfd795f92536d8ff3e66e2e51df8"
 dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
@@ -5092,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d0e97c25935253d93bf9c4740a990264185d1cf59a638a87066278ed817f0"
+checksum = "cc6aeaa4145cc77bbfab151a233b14e611a82747fd2eee611a52e07f582544d6"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5263,9 +5263,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e41ae6eb080e3ab14e9eda4474b676861af63fb0871db8b9149b0c69aada4d"
+checksum = "6425f7248eb69806ae5e8c193a5b7dcfc764516d2f0d354cdf80bacaf422a188"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5296,9 +5296,9 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.9",
- "solana-frozen-abi-macro 1.10.9",
- "solana-sdk-macro 1.10.9",
+ "solana-frozen-abi 1.10.10",
+ "solana-frozen-abi-macro 1.10.10",
+ "solana-sdk-macro 1.10.10",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -5560,9 +5560,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef63e9db435bcc173d37073d769871379bb90c0fc60b20616f87edc0b06d890"
+checksum = "f5ad83e1a502a53512e0e077fbaa76bf73b19e8789dc014c940077506e8fb7ac"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5599,11 +5599,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.9",
- "solana-frozen-abi-macro 1.10.9",
- "solana-logger 1.10.9",
- "solana-program 1.10.9",
- "solana-sdk-macro 1.10.9",
+ "solana-frozen-abi 1.10.10",
+ "solana-frozen-abi-macro 1.10.10",
+ "solana-logger 1.10.10",
+ "solana-program 1.10.10",
+ "solana-sdk-macro 1.10.10",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4d6c73b2dea5705afd28266015a00e7a9c3496a98a45104733fa81e8dabbb5"
+checksum = "d0e117d4d001f4f3c1e568979da52d76a75d814344c1debf9febd10b5a571993"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.37",
@@ -6061,9 +6061,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "0.8.1"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b149253f9ed1afb68b3161b53b62b637d0dd7a3b328dffdc8bb5878d48358e"
+checksum = "1b48cc8372b23949286546f1b73c3859e06b1d42b8d2c13162484d6ca4b35cb2"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6071,7 +6071,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
- "cipher 0.3.0",
+ "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.16",
  "lazy_static",
@@ -6082,8 +6082,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.10.9",
- "solana-sdk 1.10.9",
+ "solana-program 1.10.10",
+ "solana-sdk 1.10.10",
  "subtle",
  "thiserror",
  "zeroize",
@@ -6164,7 +6164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
 dependencies = [
  "borsh",
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
  "spl-token",
 ]
 
@@ -6174,7 +6174,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
 ]
 
 [[package]]
@@ -6187,23 +6187,23 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-token-2022"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce48c69350134e8678de5c0956a531b7de586b28eebdddc03211ceec0660983"
+checksum = "83f001b3579e69a695a22e458fa1a4b76ab25a142544a094e3f65af63dc61c2f"
 dependencies = [
  "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.9",
- "solana-zk-token-sdk 0.8.1",
+ "solana-program 1.10.10",
+ "solana-zk-token-sdk 1.10.10",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -23,7 +23,7 @@ solana-config-program = { path = "../programs/config", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.2.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.3.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.11.1"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -48,7 +48,7 @@ solana-streamer = { path = "../streamer", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-spl-token-2022 = { version = "=0.2.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.3.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.8"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4368,9 +4368,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e139feda2afd510dea2027584cc35a9ee9ebac0bfef1ab4d23647bf5c091a6"
+checksum = "7299c2ca50bd2d8a5b4a8043e4817892b5e700345234a31adc5b4c1208a32283"
 dependencies = [
  "bs58",
  "bv",
@@ -4384,7 +4384,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.10.9",
+ "solana-frozen-abi-macro 1.10.10",
  "thiserror",
 ]
 
@@ -4410,9 +4410,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798b851026ff2366b318f7818a64846dd1ebc7e613f7893fba07a61cd55e6a48"
+checksum = "d726d2fbe5b1b21cb8a81b8c3c1d1aca32bfcfd795f92536d8ff3e66e2e51df8"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.6",
@@ -4566,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d0e97c25935253d93bf9c4740a990264185d1cf59a638a87066278ed817f0"
+checksum = "cc6aeaa4145cc77bbfab151a233b14e611a82747fd2eee611a52e07f582544d6"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4677,9 +4677,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e41ae6eb080e3ab14e9eda4474b676861af63fb0871db8b9149b0c69aada4d"
+checksum = "6425f7248eb69806ae5e8c193a5b7dcfc764516d2f0d354cdf80bacaf422a188"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -4710,9 +4710,9 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.9",
- "solana-frozen-abi-macro 1.10.9",
- "solana-sdk-macro 1.10.9",
+ "solana-frozen-abi 1.10.10",
+ "solana-frozen-abi-macro 1.10.10",
+ "solana-sdk-macro 1.10.10",
  "thiserror",
  "wasm-bindgen",
 ]
@@ -4934,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef63e9db435bcc173d37073d769871379bb90c0fc60b20616f87edc0b06d890"
+checksum = "f5ad83e1a502a53512e0e077fbaa76bf73b19e8789dc014c940077506e8fb7ac"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -4973,11 +4973,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.10.9",
- "solana-frozen-abi-macro 1.10.9",
- "solana-logger 1.10.9",
- "solana-program 1.10.9",
- "solana-sdk-macro 1.10.9",
+ "solana-frozen-abi 1.10.10",
+ "solana-frozen-abi-macro 1.10.10",
+ "solana-logger 1.10.10",
+ "solana-program 1.10.10",
+ "solana-sdk-macro 1.10.10",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5034,9 +5034,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.10.9"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4d6c73b2dea5705afd28266015a00e7a9c3496a98a45104733fa81e8dabbb5"
+checksum = "d0e117d4d001f4f3c1e568979da52d76a75d814344c1debf9febd10b5a571993"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.36",
@@ -5318,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "0.8.1"
+version = "1.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b149253f9ed1afb68b3161b53b62b637d0dd7a3b328dffdc8bb5878d48358e"
+checksum = "1b48cc8372b23949286546f1b73c3859e06b1d42b8d2c13162484d6ca4b35cb2"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5328,7 +5328,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder 1.4.3",
- "cipher 0.3.0",
+ "cipher 0.4.3",
  "curve25519-dalek",
  "getrandom 0.1.14",
  "lazy_static",
@@ -5339,8 +5339,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.10.9",
- "solana-sdk 1.10.9",
+ "solana-program 1.10.10",
+ "solana-sdk 1.10.10",
  "subtle",
  "thiserror",
  "zeroize",
@@ -5421,7 +5421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
 dependencies = [
  "borsh",
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
  "spl-token",
 ]
 
@@ -5431,7 +5431,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
 ]
 
 [[package]]
@@ -5444,23 +5444,23 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.9",
+ "solana-program 1.10.10",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-token-2022"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce48c69350134e8678de5c0956a531b7de586b28eebdddc03211ceec0660983"
+checksum = "83f001b3579e69a695a22e458fa1a4b76ab25a142544a094e3f65af63dc61c2f"
 dependencies = [
  "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.10.9",
- "solana-zk-token-sdk 0.8.1",
+ "solana-program 1.10.10",
+ "solana-zk-token-sdk 1.10.10",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -49,7 +49,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.11.0
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.2.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.3.0", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -18,6 +18,8 @@ update_solana_dependencies() {
   sed -i -e "s#\(solana-account-decoder = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-faucet = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
   sed -i -e "s#\(solana-faucet = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-zk-token-sdk = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-zk-token-sdk = { version = \"\)[^\"]*\(\"\)#\1=$solana_ver\2#g" "${tomls[@]}" || return $?
 }
 
 patch_crates_io_solana() {
@@ -32,5 +34,6 @@ solana-program = { path = "$solana_dir/sdk/program" }
 solana-program-test = { path = "$solana_dir/program-test" }
 solana-sdk = { path = "$solana_dir/sdk" }
 solana-faucet = { path = "$solana_dir/faucet" }
+solana-zk-token-sdk = { path = "$solana_dir/zk-token-sdk" }
 EOF
 }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,7 +29,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
 spl-associated-token-account = { version = "=1.0.5", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.2.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.3.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -651,15 +651,6 @@ mod test {
             .collect()
     }
 
-    // TODO: remove this hacky approach when update SPL token dependencies
-    fn make_coerced_message(
-        mut instruction: SplTokenInstruction,
-        program_id: &SplTokenPubkey,
-    ) -> Message {
-        instruction.program_id = *program_id;
-        Message::new(&[instruction], None)
-    }
-
     fn test_parse_token(program_id: &SplTokenPubkey) {
         let mint_pubkey = Pubkey::new_unique();
         let mint_authority = Pubkey::new_unique();
@@ -668,14 +659,14 @@ mod test {
 
         // Test InitializeMint variations
         let initialize_mint_ix = initialize_mint(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(mint_authority),
             Some(&convert_pubkey(freeze_authority)),
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_mint_ix, program_id);
+        let message = Message::new(&[initialize_mint_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -696,14 +687,14 @@ mod test {
         );
 
         let initialize_mint_ix = initialize_mint(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(mint_authority),
             None,
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_mint_ix, program_id);
+        let message = Message::new(&[initialize_mint_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -724,14 +715,14 @@ mod test {
 
         // Test InitializeMint2
         let initialize_mint_ix = initialize_mint2(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(mint_authority),
             Some(&convert_pubkey(freeze_authority)),
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_mint_ix, program_id);
+        let message = Message::new(&[initialize_mint_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -754,13 +745,13 @@ mod test {
         let account_pubkey = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
         let initialize_account_ix = initialize_account(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(owner),
         )
         .unwrap();
-        let message = make_coerced_message(initialize_account_ix, program_id);
+        let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -781,13 +772,13 @@ mod test {
 
         // Test InitializeAccount2
         let initialize_account_ix = initialize_account2(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(owner),
         )
         .unwrap();
-        let message = make_coerced_message(initialize_account_ix, program_id);
+        let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -808,13 +799,13 @@ mod test {
 
         // Test InitializeAccount3
         let initialize_account_ix = initialize_account3(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(owner),
         )
         .unwrap();
-        let message = make_coerced_message(initialize_account_ix, program_id);
+        let message = Message::new(&[initialize_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -838,7 +829,7 @@ mod test {
         let multisig_signer1 = Pubkey::new_unique();
         let multisig_signer2 = Pubkey::new_unique();
         let initialize_multisig_ix = initialize_multisig(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(multisig_pubkey),
             &[
                 &convert_pubkey(multisig_signer0),
@@ -848,7 +839,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_multisig_ix, program_id);
+        let message = Message::new(&[initialize_multisig_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -873,7 +864,7 @@ mod test {
 
         // Test InitializeMultisig2
         let initialize_multisig_ix = initialize_multisig2(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(multisig_pubkey),
             &[
                 &convert_pubkey(multisig_signer0),
@@ -883,7 +874,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_multisig_ix, program_id);
+        let message = Message::new(&[initialize_multisig_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -909,7 +900,7 @@ mod test {
         let recipient = Pubkey::new_unique();
         #[allow(deprecated)]
         let transfer_ix = transfer(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(recipient),
             &convert_pubkey(owner),
@@ -917,7 +908,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -938,7 +929,7 @@ mod test {
 
         #[allow(deprecated)]
         let transfer_ix = transfer(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(recipient),
             &convert_pubkey(multisig_pubkey),
@@ -974,7 +965,7 @@ mod test {
 
         // Test Approve, incl multisig
         let approve_ix = approve(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(recipient),
             &convert_pubkey(owner),
@@ -982,7 +973,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1002,7 +993,7 @@ mod test {
         );
 
         let approve_ix = approve(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(recipient),
             &convert_pubkey(multisig_pubkey),
@@ -1013,7 +1004,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1038,13 +1029,13 @@ mod test {
 
         // Test Revoke
         let revoke_ix = revoke(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(owner),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(revoke_ix, program_id);
+        let message = Message::new(&[revoke_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1064,7 +1055,7 @@ mod test {
         // Test SetOwner
         let new_freeze_authority = Pubkey::new_unique();
         let set_authority_ix = set_authority(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             Some(&convert_pubkey(new_freeze_authority)),
             AuthorityType::FreezeAccount,
@@ -1072,7 +1063,7 @@ mod test {
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(set_authority_ix, program_id);
+        let message = Message::new(&[set_authority_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1092,7 +1083,7 @@ mod test {
         );
 
         let set_authority_ix = set_authority(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             None,
             AuthorityType::CloseAccount,
@@ -1100,7 +1091,7 @@ mod test {
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(set_authority_ix, program_id);
+        let message = Message::new(&[set_authority_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         let new_authority: Option<String> = None;
         assert_eq!(
@@ -1122,7 +1113,7 @@ mod test {
 
         // Test MintTo
         let mint_to_ix = mint_to(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_authority),
@@ -1130,7 +1121,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(mint_to_ix, program_id);
+        let message = Message::new(&[mint_to_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1151,7 +1142,7 @@ mod test {
 
         // Test Burn
         let burn_ix = burn(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(owner),
@@ -1159,7 +1150,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(burn_ix, program_id);
+        let message = Message::new(&[burn_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1180,14 +1171,14 @@ mod test {
 
         // Test CloseAccount
         let close_account_ix = close_account(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(recipient),
             &convert_pubkey(owner),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(close_account_ix, program_id);
+        let message = Message::new(&[close_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1207,14 +1198,14 @@ mod test {
 
         // Test FreezeAccount
         let freeze_account_ix = freeze_account(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(freeze_authority),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(freeze_account_ix, program_id);
+        let message = Message::new(&[freeze_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1234,14 +1225,14 @@ mod test {
 
         // Test ThawAccount
         let thaw_account_ix = thaw_account(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(freeze_authority),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(thaw_account_ix, program_id);
+        let message = Message::new(&[thaw_account_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1261,7 +1252,7 @@ mod test {
 
         // Test TransferChecked, incl multisig
         let transfer_ix = transfer_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(recipient),
@@ -1271,7 +1262,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1297,7 +1288,7 @@ mod test {
         );
 
         let transfer_ix = transfer_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(recipient),
@@ -1310,7 +1301,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1341,7 +1332,7 @@ mod test {
 
         // Test ApproveChecked, incl multisig
         let approve_ix = approve_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(recipient),
@@ -1351,7 +1342,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1377,7 +1368,7 @@ mod test {
         );
 
         let approve_ix = approve_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(recipient),
@@ -1390,7 +1381,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1421,7 +1412,7 @@ mod test {
 
         // Test MintToChecked
         let mint_to_ix = mint_to_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_authority),
@@ -1430,7 +1421,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(mint_to_ix, program_id);
+        let message = Message::new(&[mint_to_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1456,7 +1447,7 @@ mod test {
 
         // Test BurnChecked
         let burn_ix = burn_checked(
-            &spl_token::id(), // TODO: replace with `program_id`
+            program_id,
             &convert_pubkey(account_pubkey),
             &convert_pubkey(mint_pubkey),
             &convert_pubkey(owner),
@@ -1465,7 +1456,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(burn_ix, program_id);
+        let message = Message::new(&[burn_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1490,12 +1481,8 @@ mod test {
         );
 
         // Test SyncNative
-        let sync_native_ix = sync_native(
-            &spl_token::id(), // TODO: replace with `program_id`,
-            &convert_pubkey(account_pubkey),
-        )
-        .unwrap();
-        let message = make_coerced_message(sync_native_ix, program_id);
+        let sync_native_ix = sync_native(program_id, &convert_pubkey(account_pubkey)).unwrap();
+        let message = Message::new(&[sync_native_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1512,12 +1499,9 @@ mod test {
         );
 
         // Test InitializeImmutableOwner
-        let init_immutable_owner_ix = initialize_immutable_owner(
-            &spl_token::id(), // TODO: replace with `program_id`,
-            &convert_pubkey(account_pubkey),
-        )
-        .unwrap();
-        let message = make_coerced_message(init_immutable_owner_ix, program_id);
+        let init_immutable_owner_ix =
+            initialize_immutable_owner(program_id, &convert_pubkey(account_pubkey)).unwrap();
+        let message = Message::new(&[init_immutable_owner_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1535,12 +1519,12 @@ mod test {
 
         // Test GetAccountDataSize
         let get_account_data_size_ix = get_account_data_size(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(mint_pubkey),
             &[], // This emulates the packed data of spl_token::instruction::get_account_data_size
         )
         .unwrap();
-        let message = make_coerced_message(get_account_data_size_ix, program_id);
+        let message = Message::new(&[get_account_data_size_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1557,12 +1541,12 @@ mod test {
         );
 
         let get_account_data_size_ix = get_account_data_size(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(mint_pubkey),
             &[ExtensionType::ImmutableOwner, ExtensionType::MemoTransfer],
         )
         .unwrap();
-        let message = make_coerced_message(get_account_data_size_ix, program_id);
+        let message = Message::new(&[get_account_data_size_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1583,13 +1567,9 @@ mod test {
         );
 
         // Test AmountToUiAmount
-        let amount_to_ui_amount_ix = amount_to_ui_amount(
-            &spl_token::id(), // TODO: replace with `program_id`,
-            &convert_pubkey(mint_pubkey),
-            4242,
-        )
-        .unwrap();
-        let message = make_coerced_message(amount_to_ui_amount_ix, program_id);
+        let amount_to_ui_amount_ix =
+            amount_to_ui_amount(program_id, &convert_pubkey(mint_pubkey), 4242).unwrap();
+        let message = Message::new(&[amount_to_ui_amount_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1607,13 +1587,9 @@ mod test {
         );
 
         // Test UiAmountToAmount
-        let ui_amount_to_amount_ix = ui_amount_to_amount(
-            &spl_token::id(), // TODO: replace with `program_id`,
-            &convert_pubkey(mint_pubkey),
-            "42.42",
-        )
-        .unwrap();
-        let message = make_coerced_message(ui_amount_to_amount_ix, program_id);
+        let ui_amount_to_amount_ix =
+            ui_amount_to_amount(program_id, &convert_pubkey(mint_pubkey), "42.42").unwrap();
+        let message = Message::new(&[ui_amount_to_amount_ix], None);
         let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_token(
@@ -1651,14 +1627,14 @@ mod test {
 
         // Test InitializeMint variations
         let initialize_mint_ix = initialize_mint(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             Some(&convert_pubkey(keys[2])),
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_mint_ix, program_id);
+        let message = Message::new(&[initialize_mint_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
@@ -1666,14 +1642,14 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let initialize_mint_ix = initialize_mint(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             None,
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_mint_ix, program_id);
+        let message = Message::new(&[initialize_mint_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
@@ -1682,7 +1658,7 @@ mod test {
 
         // Test InitializeMint2
         let initialize_mint_ix = initialize_mint2(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             Some(&convert_pubkey(keys[2])),
@@ -1698,13 +1674,13 @@ mod test {
 
         // Test InitializeAccount
         let initialize_account_ix = initialize_account(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
         )
         .unwrap();
-        let message = make_coerced_message(initialize_account_ix, program_id);
+        let message = Message::new(&[initialize_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
@@ -1713,7 +1689,7 @@ mod test {
 
         // Test InitializeAccount2
         let initialize_account_ix = initialize_account2(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[3]),
@@ -1728,7 +1704,7 @@ mod test {
 
         // Test InitializeAccount3
         let initialize_account_ix = initialize_account3(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
@@ -1743,7 +1719,7 @@ mod test {
 
         // Test InitializeMultisig
         let initialize_multisig_ix = initialize_multisig(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &[
                 &convert_pubkey(keys[1]),
@@ -1753,7 +1729,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(initialize_multisig_ix, program_id);
+        let message = Message::new(&[initialize_multisig_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
@@ -1762,7 +1738,7 @@ mod test {
 
         // Test InitializeMultisig2
         let initialize_multisig_ix = initialize_multisig2(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[0]),
             &[
                 &convert_pubkey(keys[1]),
@@ -1782,7 +1758,7 @@ mod test {
         // Test Transfer, incl multisig
         #[allow(deprecated)]
         let transfer_ix = transfer(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -1790,7 +1766,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1799,7 +1775,7 @@ mod test {
 
         #[allow(deprecated)]
         let transfer_ix = transfer(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
             &convert_pubkey(keys[4]),
@@ -1807,7 +1783,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
@@ -1816,7 +1792,7 @@ mod test {
 
         // Test Approve, incl multisig
         let approve_ix = approve(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -1824,7 +1800,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1832,7 +1808,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let approve_ix = approve(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
             &convert_pubkey(keys[4]),
@@ -1840,7 +1816,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..4], None)).is_err());
         compiled_instruction.accounts =
@@ -1849,13 +1825,13 @@ mod test {
 
         // Test Revoke
         let revoke_ix = revoke(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[0]),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(revoke_ix, program_id);
+        let message = Message::new(&[revoke_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
@@ -1864,7 +1840,7 @@ mod test {
 
         // Test SetAuthority
         let set_authority_ix = set_authority(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             Some(&convert_pubkey(keys[2])),
             AuthorityType::FreezeAccount,
@@ -1872,7 +1848,7 @@ mod test {
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(set_authority_ix, program_id);
+        let message = Message::new(&[set_authority_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..1], None)).is_err());
         compiled_instruction.accounts =
@@ -1881,7 +1857,7 @@ mod test {
 
         // Test MintTo
         let mint_to_ix = mint_to(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -1889,7 +1865,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(mint_to_ix, program_id);
+        let message = Message::new(&[mint_to_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1898,7 +1874,7 @@ mod test {
 
         // Test Burn
         let burn_ix = burn(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -1906,7 +1882,7 @@ mod test {
             42,
         )
         .unwrap();
-        let message = make_coerced_message(burn_ix, program_id);
+        let message = Message::new(&[burn_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1915,14 +1891,14 @@ mod test {
 
         // Test CloseAccount
         let close_account_ix = close_account(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(close_account_ix, program_id);
+        let message = Message::new(&[close_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1931,14 +1907,14 @@ mod test {
 
         // Test FreezeAccount
         let freeze_account_ix = freeze_account(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(freeze_account_ix, program_id);
+        let message = Message::new(&[freeze_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1947,14 +1923,14 @@ mod test {
 
         // Test ThawAccount
         let thaw_account_ix = thaw_account(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
             &[],
         )
         .unwrap();
-        let message = make_coerced_message(thaw_account_ix, program_id);
+        let message = Message::new(&[thaw_account_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -1963,7 +1939,7 @@ mod test {
 
         // Test TransferChecked, incl multisig
         let transfer_ix = transfer_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
@@ -1973,7 +1949,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
@@ -1981,7 +1957,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let transfer_ix = transfer_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
             &convert_pubkey(keys[4]),
@@ -1991,7 +1967,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(transfer_ix, program_id);
+        let message = Message::new(&[transfer_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
@@ -2000,7 +1976,7 @@ mod test {
 
         // Test ApproveChecked, incl multisig
         let approve_ix = approve_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
@@ -2010,7 +1986,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..3], None)).is_err());
         compiled_instruction.accounts =
@@ -2018,7 +1994,7 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         let approve_ix = approve_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[3]),
             &convert_pubkey(keys[4]),
@@ -2028,7 +2004,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(approve_ix, program_id);
+        let message = Message::new(&[approve_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..5], None)).is_err());
         compiled_instruction.accounts =
@@ -2037,7 +2013,7 @@ mod test {
 
         // Test MintToChecked
         let mint_to_ix = mint_to_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -2046,7 +2022,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(mint_to_ix, program_id);
+        let message = Message::new(&[mint_to_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -2055,7 +2031,7 @@ mod test {
 
         // Test BurnChecked
         let burn_ix = burn_checked(
-            &spl_token::id(),
+            program_id,
             &convert_pubkey(keys[1]),
             &convert_pubkey(keys[2]),
             &convert_pubkey(keys[0]),
@@ -2064,7 +2040,7 @@ mod test {
             2,
         )
         .unwrap();
-        let message = make_coerced_message(burn_ix, program_id);
+        let message = Message::new(&[burn_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys[0..2], None)).is_err());
         compiled_instruction.accounts =
@@ -2072,8 +2048,8 @@ mod test {
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&keys, None)).is_err());
 
         // Test SyncNative
-        let sync_native_ix = sync_native(&spl_token::id(), &convert_pubkey(keys[0])).unwrap();
-        let message = make_coerced_message(sync_native_ix, program_id);
+        let sync_native_ix = sync_native(program_id, &convert_pubkey(keys[0])).unwrap();
+        let message = Message::new(&[sync_native_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
@@ -2082,8 +2058,8 @@ mod test {
 
         // Test InitializeImmutableOwner
         let init_immutable_owner_ix =
-            initialize_immutable_owner(&spl_token::id(), &convert_pubkey(keys[0])).unwrap();
-        let message = make_coerced_message(init_immutable_owner_ix, program_id);
+            initialize_immutable_owner(program_id, &convert_pubkey(keys[0])).unwrap();
+        let message = Message::new(&[init_immutable_owner_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
@@ -2092,8 +2068,8 @@ mod test {
 
         // Test GetAccountDataSize
         let get_account_data_size_ix =
-            get_account_data_size(&spl_token::id(), &convert_pubkey(keys[0]), &[]).unwrap();
-        let message = make_coerced_message(get_account_data_size_ix, program_id);
+            get_account_data_size(program_id, &convert_pubkey(keys[0]), &[]).unwrap();
+        let message = Message::new(&[get_account_data_size_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
@@ -2102,8 +2078,8 @@ mod test {
 
         // Test AmountToUiAmount
         let amount_to_ui_amount_ix =
-            amount_to_ui_amount(&spl_token::id(), &convert_pubkey(keys[0]), 4242).unwrap();
-        let message = make_coerced_message(amount_to_ui_amount_ix, program_id);
+            amount_to_ui_amount(program_id, &convert_pubkey(keys[0]), 4242).unwrap();
+        let message = Message::new(&[amount_to_ui_amount_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =
@@ -2112,8 +2088,8 @@ mod test {
 
         // Test UiAmountToAmount
         let ui_amount_to_amount_ix =
-            ui_amount_to_amount(&spl_token::id(), &convert_pubkey(keys[0]), "42.42").unwrap();
-        let message = make_coerced_message(ui_amount_to_amount_ix, program_id);
+            ui_amount_to_amount(program_id, &convert_pubkey(keys[0]), "42.42").unwrap();
+        let message = Message::new(&[ui_amount_to_amount_ix], None);
         let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert!(parse_token(&compiled_instruction, &AccountKeys::new(&[], None)).is_err());
         compiled_instruction.accounts =

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -217,7 +217,8 @@ pub fn parse_token(
                 AuthorityType::MintTokens
                 | AuthorityType::FreezeAccount
                 | AuthorityType::TransferFeeConfig
-                | AuthorityType::WithheldWithdraw => "mint",
+                | AuthorityType::WithheldWithdraw
+                | AuthorityType::CloseMint => "mint",
                 AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
             };
             let mut value = json!({
@@ -521,6 +522,7 @@ pub enum UiAuthorityType {
     CloseAccount,
     TransferFeeConfig,
     WithheldWithdraw,
+    CloseMint,
 }
 
 impl From<AuthorityType> for UiAuthorityType {
@@ -532,6 +534,7 @@ impl From<AuthorityType> for UiAuthorityType {
             AuthorityType::CloseAccount => UiAuthorityType::CloseAccount,
             AuthorityType::TransferFeeConfig => UiAuthorityType::TransferFeeConfig,
             AuthorityType::WithheldWithdraw => UiAuthorityType::WithheldWithdraw,
+            AuthorityType::CloseMint => UiAuthorityType::CloseMint,
         }
     }
 }


### PR DESCRIPTION
#### Problem
RPC now recognizes the spl_token_2022 program id, but cannot parse all its instructions.

#### Summary of Changes
Following the changes in #23067, this change set uses the spl_token_2022 to parse Instructions for RPC.
Currently supports only the subset of instructions also supported by the upcoming spl_token library.

It is expected that spl_token_2022 be an exact superset of spl_token, so using `spl_token_2022::instruction::Instruction::unpack` should be correct for instructions for both token programs. However, we will add tests upstream in SPL to be certain (edit) done here: https://github.com/solana-labs/solana-program-library/pull/3106

Note: I considered parsing extensions in this PR, but discovered that I need the various instruction decoders made `pub` in a new spl-token-2022 release. So in the interest of moving faster, and smaller PRs, here's the basic functionality.
