### PR TITLE
Simplify syscall register and bind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6197,9 +6197,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd266a6c58aa37380b52e6ee627762d794840116d796879867e7419445e6fe5"
+checksum = "bec5c1525c69ec74323d6a2d145a29b51844c4153a2cd5e4ac0d08b3fe81c806"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.26"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3972,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd266a6c58aa37380b52e6ee627762d794840116d796879867e7419445e6fe5"
+checksum = "bec5c1525c69ec74323d6a2d145a29b51844c4153a2cd5e4ac0d08b3fe81c806"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.11.0" }
 solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-measure = { path = "../../measure", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.26"
 solana-runtime = { path = "../../runtime", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.26"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -146,6 +146,9 @@ pub fn create_executor(
         reject_callx_r10: invoke_context
             .feature_set
             .is_active(&reject_callx_r10::id()),
+        dynamic_stack_frames: false,
+        enable_sdiv: false,
+        optimize_rodata: false,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
     let mut create_executor_metrics = executor_metrics::CreateMetrics::default();

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -115,145 +115,247 @@ impl SyscallConsume for Rc<RefCell<ComputeMeter>> {
     }
 }
 
+macro_rules! register_feature_gated_syscall {
+    ($syscall_registry:expr, $is_feature_active:expr, $name:expr, $init:expr, $call:expr $(,)?) => {
+        if $is_feature_active {
+            $syscall_registry.register_syscall_by_name($name, $init, $call)
+        } else {
+            Ok(())
+        }
+    };
+}
+
 pub fn register_syscalls(
     invoke_context: &mut InvokeContext,
 ) -> Result<SyscallRegistry, EbpfError<BpfError>> {
+    let secp256k1_recover_syscall_enabled = invoke_context
+        .feature_set
+        .is_active(&secp256k1_recover_syscall_enabled::id());
+    let blake3_syscall_enabled = invoke_context
+        .feature_set
+        .is_active(&blake3_syscall_enabled::id());
+    let zk_token_sdk_enabled = invoke_context
+        .feature_set
+        .is_active(&zk_token_sdk_enabled::id());
+    let disable_fees_sysvar = invoke_context
+        .feature_set
+        .is_active(&disable_fees_sysvar::id());
+    let return_data_syscall_enabled = invoke_context
+        .feature_set
+        .is_active(&return_data_syscall_enabled::id());
+    let sol_log_data_syscall_enabled = invoke_context
+        .feature_set
+        .is_active(&sol_log_data_syscall_enabled::id());
+    let add_get_processed_sibling_instruction_syscall = invoke_context
+        .feature_set
+        .is_active(&add_get_processed_sibling_instruction_syscall::id());
+
     let mut syscall_registry = SyscallRegistry::default();
 
-    syscall_registry.register_syscall_by_name(b"abort", SyscallAbort::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_panic_", SyscallPanic::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_log_", SyscallLog::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_log_64_", SyscallLogU64::call)?;
+    // Abort
+    syscall_registry.register_syscall_by_name(b"abort", SyscallAbort::init, SyscallAbort::call)?;
 
-    syscall_registry
-        .register_syscall_by_name(b"sol_log_compute_units_", SyscallLogBpfComputeUnits::call)?;
+    // Panic
+    syscall_registry.register_syscall_by_name(
+        b"sol_panic_",
+        SyscallPanic::init,
+        SyscallPanic::call,
+    )?;
 
-    syscall_registry.register_syscall_by_name(b"sol_log_pubkey", SyscallLogPubkey::call)?;
+    // Logging
+    syscall_registry.register_syscall_by_name(b"sol_log_", SyscallLog::init, SyscallLog::call)?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_log_64_",
+        SyscallLogU64::init,
+        SyscallLogU64::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_log_compute_units_",
+        SyscallLogBpfComputeUnits::init,
+        SyscallLogBpfComputeUnits::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_log_pubkey",
+        SyscallLogPubkey::init,
+        SyscallLogPubkey::call,
+    )?;
 
+    // Program defined addresses (PDA)
     syscall_registry.register_syscall_by_name(
         b"sol_create_program_address",
+        SyscallCreateProgramAddress::init,
         SyscallCreateProgramAddress::call,
     )?;
     syscall_registry.register_syscall_by_name(
         b"sol_try_find_program_address",
+        SyscallTryFindProgramAddress::init,
         SyscallTryFindProgramAddress::call,
     )?;
 
-    syscall_registry.register_syscall_by_name(b"sol_sha256", SyscallSha256::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_keccak256", SyscallKeccak256::call)?;
+    // Sha256
+    syscall_registry.register_syscall_by_name(
+        b"sol_sha256",
+        SyscallSha256::init,
+        SyscallSha256::call,
+    )?;
 
-    if invoke_context
-        .feature_set
-        .is_active(&secp256k1_recover_syscall_enabled::id())
-    {
-        syscall_registry
-            .register_syscall_by_name(b"sol_secp256k1_recover", SyscallSecp256k1Recover::call)?;
-    }
+    // Keccak256
+    syscall_registry.register_syscall_by_name(
+        b"sol_keccak256",
+        SyscallKeccak256::init,
+        SyscallKeccak256::call,
+    )?;
 
-    if invoke_context
-        .feature_set
-        .is_active(&blake3_syscall_enabled::id())
-    {
-        syscall_registry.register_syscall_by_name(b"sol_blake3", SyscallBlake3::call)?;
-    }
+    // Secp256k1 Recover
+    register_feature_gated_syscall!(
+        syscall_registry,
+        secp256k1_recover_syscall_enabled,
+        b"sol_secp256k1_recover",
+        SyscallSecp256k1Recover::init,
+        SyscallSecp256k1Recover::call,
+    )?;
 
-    if invoke_context
-        .feature_set
-        .is_active(&zk_token_sdk_enabled::id())
-    {
-        syscall_registry
-            .register_syscall_by_name(b"sol_zk_token_elgamal_op", SyscallZkTokenElgamalOp::call)?;
-        syscall_registry.register_syscall_by_name(
-            b"sol_zk_token_elgamal_op_with_lo_hi",
-            SyscallZkTokenElgamalOpWithLoHi::call,
-        )?;
-        syscall_registry.register_syscall_by_name(
-            b"sol_zk_token_elgamal_op_with_scalar",
-            SyscallZkTokenElgamalOpWithScalar::call,
-        )?;
-    }
+    // Blake3
+    register_feature_gated_syscall!(
+        syscall_registry,
+        blake3_syscall_enabled,
+        b"sol_blake3",
+        SyscallBlake3::init,
+        SyscallBlake3::call,
+    )?;
 
-    syscall_registry
-        .register_syscall_by_name(b"sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
+    // ZK Token
+    register_feature_gated_syscall!(
+        syscall_registry,
+        zk_token_sdk_enabled,
+        b"sol_zk_token_elgamal_op",
+        SyscallZkTokenElgamalOp::init,
+        SyscallZkTokenElgamalOp::call,
+    )?;
+    register_feature_gated_syscall!(
+        syscall_registry,
+        zk_token_sdk_enabled,
+        b"sol_zk_token_elgamal_op_with_lo_hi",
+        SyscallZkTokenElgamalOpWithLoHi::init,
+        SyscallZkTokenElgamalOpWithLoHi::call,
+    )?;
+    register_feature_gated_syscall!(
+        syscall_registry,
+        zk_token_sdk_enabled,
+        b"sol_zk_token_elgamal_op_with_scalar",
+        SyscallZkTokenElgamalOpWithScalar::init,
+        SyscallZkTokenElgamalOpWithScalar::call,
+    )?;
+
+    // Sysvars
+    syscall_registry.register_syscall_by_name(
+        b"sol_get_clock_sysvar",
+        SyscallGetClockSysvar::init,
+        SyscallGetClockSysvar::call,
+    )?;
     syscall_registry.register_syscall_by_name(
         b"sol_get_epoch_schedule_sysvar",
+        SyscallGetEpochScheduleSysvar::init,
         SyscallGetEpochScheduleSysvar::call,
     )?;
-    if !invoke_context
-        .feature_set
-        .is_active(&disable_fees_sysvar::id())
-    {
-        syscall_registry
-            .register_syscall_by_name(b"sol_get_fees_sysvar", SyscallGetFeesSysvar::call)?;
-    }
-    syscall_registry
-        .register_syscall_by_name(b"sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
+    register_feature_gated_syscall!(
+        syscall_registry,
+        disable_fees_sysvar,
+        b"sol_get_fees_sysvar",
+        SyscallGetFeesSysvar::init,
+        SyscallGetFeesSysvar::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_get_rent_sysvar",
+        SyscallGetRentSysvar::init,
+        SyscallGetRentSysvar::call,
+    )?;
 
-    syscall_registry.register_syscall_by_name(b"sol_memcpy_", SyscallMemcpy::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memmove_", SyscallMemmove::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memcmp_", SyscallMemcmp::call)?;
-    syscall_registry.register_syscall_by_name(b"sol_memset_", SyscallMemset::call)?;
+    // Memory ops
+    syscall_registry.register_syscall_by_name(
+        b"sol_memcpy_",
+        SyscallMemcpy::init,
+        SyscallMemcpy::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_memmove_",
+        SyscallMemmove::init,
+        SyscallMemmove::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_memcmp_",
+        SyscallMemcmp::init,
+        SyscallMemcmp::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_memset_",
+        SyscallMemset::init,
+        SyscallMemset::call,
+    )?;
 
-    // Cross-program invocation syscalls
-    syscall_registry
-        .register_syscall_by_name(b"sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
-    syscall_registry
-        .register_syscall_by_name(b"sol_invoke_signed_rust", SyscallInvokeSignedRust::call)?;
+    // Cross-program invocation
+    syscall_registry.register_syscall_by_name(
+        b"sol_invoke_signed_c",
+        SyscallInvokeSignedC::init,
+        SyscallInvokeSignedC::call,
+    )?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_invoke_signed_rust",
+        SyscallInvokeSignedRust::init,
+        SyscallInvokeSignedRust::call,
+    )?;
 
     // Memory allocator
-    syscall_registry.register_syscall_by_name(b"sol_alloc_free_", SyscallAllocFree::call)?;
+    syscall_registry.register_syscall_by_name(
+        b"sol_alloc_free_",
+        SyscallAllocFree::init,
+        SyscallAllocFree::call,
+    )?;
 
     // Return data
-    if invoke_context
-        .feature_set
-        .is_active(&return_data_syscall_enabled::id())
-    {
-        syscall_registry
-            .register_syscall_by_name(b"sol_set_return_data", SyscallSetReturnData::call)?;
-        syscall_registry
-            .register_syscall_by_name(b"sol_get_return_data", SyscallGetReturnData::call)?;
-    }
+    register_feature_gated_syscall!(
+        syscall_registry,
+        return_data_syscall_enabled,
+        b"sol_set_return_data",
+        SyscallSetReturnData::init,
+        SyscallSetReturnData::call,
+    )?;
+    register_feature_gated_syscall!(
+        syscall_registry,
+        return_data_syscall_enabled,
+        b"sol_get_return_data",
+        SyscallGetReturnData::init,
+        SyscallGetReturnData::call,
+    )?;
 
     // Log data
-    if invoke_context
-        .feature_set
-        .is_active(&sol_log_data_syscall_enabled::id())
-    {
-        syscall_registry.register_syscall_by_name(b"sol_log_data", SyscallLogData::call)?;
-    }
+    register_feature_gated_syscall!(
+        syscall_registry,
+        sol_log_data_syscall_enabled,
+        b"sol_log_data",
+        SyscallLogData::init,
+        SyscallLogData::call,
+    )?;
 
-    if invoke_context
-        .feature_set
-        .is_active(&add_get_processed_sibling_instruction_syscall::id())
-    {
-        syscall_registry.register_syscall_by_name(
-            b"sol_get_processed_sibling_instruction",
-            SyscallGetProcessedSiblingInstruction::call,
-        )?;
-    }
+    // Processed sibling instructions
+    register_feature_gated_syscall!(
+        syscall_registry,
+        add_get_processed_sibling_instruction_syscall,
+        b"sol_get_processed_sibling_instruction",
+        SyscallGetProcessedSiblingInstruction::init,
+        SyscallGetProcessedSiblingInstruction::call,
+    )?;
 
-    if invoke_context
-        .feature_set
-        .is_active(&add_get_processed_sibling_instruction_syscall::id())
-    {
-        syscall_registry
-            .register_syscall_by_name(b"sol_get_stack_height", SyscallGetStackHeight::call)?;
-    }
+    // Stack height
+    register_feature_gated_syscall!(
+        syscall_registry,
+        add_get_processed_sibling_instruction_syscall,
+        b"sol_get_stack_height",
+        SyscallGetStackHeight::init,
+        SyscallGetStackHeight::call,
+    )?;
 
     Ok(syscall_registry)
-}
-
-macro_rules! bind_feature_gated_syscall_context_object {
-    ($vm:expr, $is_feature_active:expr, $syscall_context_object:expr $(,)?) => {
-        if $is_feature_active {
-            match $vm.bind_syscall_context_object($syscall_context_object, None) {
-                Err(EbpfError::SyscallNotRegistered(_)) | Ok(()) => {}
-                Err(err) => {
-                    return Err(err);
-                }
-            }
-        }
-    };
 }
 
 pub fn bind_syscall_context_objects<'a, 'b>(
@@ -261,28 +363,6 @@ pub fn bind_syscall_context_objects<'a, 'b>(
     invoke_context: &'a mut InvokeContext<'b>,
     heap: AlignedMemory,
 ) -> Result<(), EbpfError<BpfError>> {
-    let is_blake3_syscall_active = invoke_context
-        .feature_set
-        .is_active(&blake3_syscall_enabled::id());
-    let is_secp256k1_recover_syscall_active = invoke_context
-        .feature_set
-        .is_active(&secp256k1_recover_syscall_enabled::id());
-    let is_fee_sysvar_via_syscall_active = !invoke_context
-        .feature_set
-        .is_active(&disable_fees_sysvar::id());
-    let is_return_data_syscall_active = invoke_context
-        .feature_set
-        .is_active(&return_data_syscall_enabled::id());
-    let is_sol_log_data_syscall_active = invoke_context
-        .feature_set
-        .is_active(&sol_log_data_syscall_enabled::id());
-    let is_zk_token_sdk_enabled = invoke_context
-        .feature_set
-        .is_active(&zk_token_sdk_enabled::id());
-    let add_get_processed_sibling_instruction_syscall = invoke_context
-        .feature_set
-        .is_active(&add_get_processed_sibling_instruction_syscall::id());
-
     invoke_context.set_check_aligned(
         bpf_loader_deprecated::id()
             != invoke_context
@@ -310,225 +390,7 @@ pub fn bind_syscall_context_objects<'a, 'b>(
 
     let invoke_context = Rc::new(RefCell::new(invoke_context));
 
-    // Syscall functions common across languages
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallAbort {
-            _invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallPanic {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallLog {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallLogU64 {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallLogBpfComputeUnits {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallLogPubkey {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallCreateProgramAddress {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallTryFindProgramAddress {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallSha256 {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallKeccak256 {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallMemcpy {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallMemmove {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallMemcmp {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallMemset {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_secp256k1_recover_syscall_active,
-        Box::new(SyscallSecp256k1Recover {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_blake3_syscall_active,
-        Box::new(SyscallBlake3 {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_zk_token_sdk_enabled,
-        Box::new(SyscallZkTokenElgamalOp {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_zk_token_sdk_enabled,
-        Box::new(SyscallZkTokenElgamalOpWithLoHi {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_zk_token_sdk_enabled,
-        Box::new(SyscallZkTokenElgamalOpWithScalar {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    vm.bind_syscall_context_object(
-        Box::new(SyscallGetClockSysvar {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallGetEpochScheduleSysvar {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_fee_sysvar_via_syscall_active,
-        Box::new(SyscallGetFeesSysvar {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-    vm.bind_syscall_context_object(
-        Box::new(SyscallGetRentSysvar {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    // Return data
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_return_data_syscall_active,
-        Box::new(SyscallSetReturnData {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_return_data_syscall_active,
-        Box::new(SyscallGetReturnData {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    // sol_log_data
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        is_sol_log_data_syscall_active,
-        Box::new(SyscallLogData {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    // processed inner instructions
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        add_get_processed_sibling_instruction_syscall,
-        Box::new(SyscallGetProcessedSiblingInstruction {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    // Get stack height
-    bind_feature_gated_syscall_context_object!(
-        vm,
-        add_get_processed_sibling_instruction_syscall,
-        Box::new(SyscallGetStackHeight {
-            invoke_context: invoke_context.clone(),
-        }),
-    );
-
-    // Cross-program invocation syscalls
-    vm.bind_syscall_context_object(
-        Box::new(SyscallInvokeSignedC {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-    vm.bind_syscall_context_object(
-        Box::new(SyscallInvokeSignedRust {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
-
-    // Memory allocator
-    vm.bind_syscall_context_object(
-        Box::new(SyscallAllocFree {
-            invoke_context: invoke_context.clone(),
-        }),
-        None,
-    )?;
+    vm.bind_syscall_context_objects(invoke_context, None)?;
 
     Ok(())
 }
@@ -651,12 +513,19 @@ fn translate_string_and_do(
     }
 }
 
+type SyscallContext<'a, 'b> = Rc<RefCell<&'a mut InvokeContext<'b>>>;
+
 /// Abort syscall functions, called when the BPF program calls `abort()`
 /// LLVM will insert calls to `abort()` if it detects an untenable situation,
 /// `abort()` is not intended to be called explicitly by the program.
 /// Causes the BPF program to be halted immediately
 pub struct SyscallAbort<'a, 'b> {
-    _invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallAbort<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallAbort<'a, 'b> {
     fn call(
@@ -669,6 +538,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallAbort<'a, 'b> {
         _memory_mapping: &MemoryMapping,
         result: &mut Result<u64, EbpfError<BpfError>>,
     ) {
+        let _ = question_mark!(
+            self.invoke_context
+                .try_borrow()
+                .map_err(|_| SyscallError::InvokeContextBorrowFailed),
+            result
+        );
         *result = Err(SyscallError::Abort.into());
     }
 }
@@ -677,7 +552,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallAbort<'a, 'b> {
 /// Causes the BPF program to be halted immediately
 /// Log a user's info message
 pub struct SyscallPanic<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallPanic<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallPanic<'a, 'b> {
     fn call(
@@ -716,7 +596,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallPanic<'a, 'b> {
 
 /// Log a user's info message
 pub struct SyscallLog<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallLog<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallLog<'a, 'b> {
     fn call(
@@ -768,7 +653,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLog<'a, 'b> {
 
 /// Log 5 64-bit values
 pub struct SyscallLogU64<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallLogU64<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallLogU64<'a, 'b> {
     fn call(
@@ -803,7 +693,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogU64<'a, 'b> {
 
 /// Log current compute consumption
 pub struct SyscallLogBpfComputeUnits<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallLogBpfComputeUnits<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a, 'b> {
     fn call(
@@ -843,7 +738,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogBpfComputeUnits<'a, 'b> {
 
 /// Log 5 64-bit values
 pub struct SyscallLogPubkey<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallLogPubkey<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallLogPubkey<'a, 'b> {
     fn call(
@@ -885,7 +785,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogPubkey<'a, 'b> {
 /// information about that memory (start address and size) is passed
 /// to the VM to use for enforcement.
 pub struct SyscallAllocFree<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallAllocFree<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallAllocFree<'a, 'b> {
     fn call(
@@ -980,7 +885,12 @@ fn translate_and_check_program_address_inputs<'a>(
 
 /// Create a program address
 struct SyscallCreateProgramAddress<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallCreateProgramAddress<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a, 'b> {
     fn call(
@@ -1040,7 +950,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallCreateProgramAddress<'a, 'b> {
 
 /// Create a program address
 struct SyscallTryFindProgramAddress<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallTryFindProgramAddress<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a, 'b> {
     fn call(
@@ -1118,7 +1033,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallTryFindProgramAddress<'a, 'b> {
 
 /// SHA256
 pub struct SyscallSha256<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallSha256<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallSha256<'a, 'b> {
     fn call(
@@ -1238,7 +1158,12 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
 
 /// Get a Clock sysvar
 struct SyscallGetClockSysvar<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetClockSysvar<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetClockSysvar<'a, 'b> {
     fn call(
@@ -1268,7 +1193,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetClockSysvar<'a, 'b> {
 }
 /// Get a EpochSchedule sysvar
 struct SyscallGetEpochScheduleSysvar<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetEpochScheduleSysvar<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a, 'b> {
     fn call(
@@ -1298,7 +1228,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a, 'b> {
 }
 /// Get a Fees sysvar
 struct SyscallGetFeesSysvar<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetFeesSysvar<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 #[allow(deprecated)]
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a, 'b> {
@@ -1329,7 +1264,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a, 'b> {
 }
 /// Get a Rent sysvar
 struct SyscallGetRentSysvar<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetRentSysvar<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetRentSysvar<'a, 'b> {
     fn call(
@@ -1360,7 +1300,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetRentSysvar<'a, 'b> {
 
 // Keccak256
 pub struct SyscallKeccak256<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallKeccak256<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallKeccak256<'a, 'b> {
     fn call(
@@ -1485,7 +1430,12 @@ fn mem_op_consume<'a, 'b>(
 
 /// memcpy
 pub struct SyscallMemcpy<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallMemcpy<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
     fn call(
@@ -1579,7 +1529,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcpy<'a, 'b> {
 }
 /// memmove
 pub struct SyscallMemmove<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallMemmove<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallMemmove<'a, 'b> {
     fn call(
@@ -1628,7 +1583,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemmove<'a, 'b> {
 }
 /// memcmp
 pub struct SyscallMemcmp<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallMemcmp<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcmp<'a, 'b> {
     fn call(
@@ -1704,7 +1664,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemcmp<'a, 'b> {
 }
 /// memset
 pub struct SyscallMemset<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallMemset<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallMemset<'a, 'b> {
     fn call(
@@ -1744,7 +1709,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallMemset<'a, 'b> {
 
 /// secp256k1_recover
 pub struct SyscallSecp256k1Recover<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallSecp256k1Recover<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a, 'b> {
     fn call(
@@ -1856,7 +1826,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSecp256k1Recover<'a, 'b> {
 }
 
 pub struct SyscallZkTokenElgamalOp<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallZkTokenElgamalOp<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOp<'a, 'b> {
     fn call(
@@ -1918,7 +1893,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOp<'a, 'b> {
 }
 
 pub struct SyscallZkTokenElgamalOpWithLoHi<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallZkTokenElgamalOpWithLoHi<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithLoHi<'a, 'b> {
     fn call(
@@ -1988,7 +1968,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithLoHi<'a, 'b>
 }
 
 pub struct SyscallZkTokenElgamalOpWithScalar<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallZkTokenElgamalOpWithScalar<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithScalar<'a, 'b> {
     fn call(
@@ -2043,7 +2028,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallZkTokenElgamalOpWithScalar<'a, '
 
 // Blake3
 pub struct SyscallBlake3<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallBlake3<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallBlake3<'a, 'b> {
     fn call(
@@ -2193,7 +2183,12 @@ trait SyscallInvokeSigned<'a, 'b> {
 
 /// Cross-SyscallInvokeSignedRust invocation called from Rust
 pub struct SyscallInvokeSignedRust<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallInvokeSignedRust<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedRust<'a, 'b> {
     fn call(
@@ -2486,7 +2481,12 @@ struct SolSignerSeedsC {
 
 /// Cross-program invocation called from C
 pub struct SyscallInvokeSignedC<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallInvokeSignedC<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallInvokeSignedC<'a, 'b> {
     fn call(
@@ -3081,7 +3081,12 @@ fn call<'a, 'b: 'a>(
 
 // Return data handling
 pub struct SyscallSetReturnData<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallSetReturnData<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
     fn call(
@@ -3158,7 +3163,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallSetReturnData<'a, 'b> {
 }
 
 pub struct SyscallGetReturnData<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetReturnData<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetReturnData<'a, 'b> {
     fn call(
@@ -3247,7 +3257,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetReturnData<'a, 'b> {
 
 // Log data handling
 pub struct SyscallLogData<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallLogData<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallLogData<'a, 'b> {
     fn call(
@@ -3327,7 +3342,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallLogData<'a, 'b> {
 }
 
 pub struct SyscallGetProcessedSiblingInstruction<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetProcessedSiblingInstruction<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'a, 'b> {
     fn call(
@@ -3456,7 +3476,12 @@ impl<'a, 'b> SyscallObject<BpfError> for SyscallGetProcessedSiblingInstruction<'
 }
 
 pub struct SyscallGetStackHeight<'a, 'b> {
-    invoke_context: Rc<RefCell<&'a mut InvokeContext<'b>>>,
+    invoke_context: SyscallContext<'a, 'b>,
+}
+impl<'a, 'b> SyscallGetStackHeight<'a, 'b> {
+    pub fn init(invoke_context: SyscallContext<'a, 'b>) -> Box<(dyn SyscallObject<BpfError> + 'a)> {
+        Box::new(Self { invoke_context })
+    }
 }
 impl<'a, 'b> SyscallObject<BpfError> for SyscallGetStackHeight<'a, 'b> {
     fn call(
@@ -3812,7 +3837,7 @@ mod tests {
         let mut result: Result<u64, EbpfError<BpfError>> = Ok(0);
         SyscallAbort::call(
             &mut SyscallAbort {
-                _invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
+                invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             },
             0,
             0,

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.26"


### PR DESCRIPTION
#### Problem

Syscall registration and binding are currently disjoint operations requiring the callers to explicitly do both for each syscall.

This can lead to mismatch or missing registration/binds and complicates the code. Another side effect is that it is difficult/impossible given the current API for callers to filter syscalls at the registration stage but allow them at the binding stage. One example is the effort to deprecate/disallow syscalls by preventing new deployments of programs that rely on a disallowed syscall while continuing to support existing programs that already rely on them.

#### Summary of Changes

These changes depend and build off the changes here: https://github.com/solana-labs/rbpf/pull/293

Syscalls are registered once, and later the bind operation uses a common context to bind all the previously registered syscalls. Thus, no longer requires an explicit bind for each syscall and without the complications of keeping two identical lists of syscalls for registration and bind.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->