### PR TITLE
Increase default --maximum-local-snapshot-age to 2500

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -836,7 +836,7 @@ pub fn main() {
                 .long("maximum-local-snapshot-age")
                 .value_name("NUMBER_OF_SLOTS")
                 .takes_value(true)
-                .default_value("500")
+                .default_value("2500")
                 .help("Reuse a local snapshot if it's less than this many \
                        slots behind the highest snapshot available for \
                        download from other validators"),


### PR DESCRIPTION
The current default max local snapshot age of 500 slots is now much too small for mainnet's 23GB snapshots.  Adjust the default to be more tolerant of slightly-older local snapshots.

Fixes #24486

