### PR TITLE
Add Solanart program name

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -93,6 +93,7 @@ export enum PROGRAM_NAMES {
   SWITCHBOARD = "Switchboard Oracle Program",
   WORMHOLE = "Wormhole",
   SOLANART = "Solanart",
+  SOLANART_GO = "Solanart - Global offers",
 }
 
 const ALL_CLUSTERS = [
@@ -371,6 +372,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
   },
   CJsLwbP1iu5DuUikHEJnLfANgKy6stB2uFgvBBHoyxwz: {
     name: PROGRAM_NAMES.SOLANART,
+    deployments: [Cluster.MainnetBeta],
+  },
+  "5ZfZAwP2m93waazg8DkrrVmsupeiPEvaEHowiUP7UAbJ": {
+    name: PROGRAM_NAMES.SOLANART_GO,
     deployments: [Cluster.MainnetBeta],
   },
 };

--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -92,6 +92,7 @@ export enum PROGRAM_NAMES {
   SWIM_SWAP = "Swim Swap Program",
   SWITCHBOARD = "Switchboard Oracle Program",
   WORMHOLE = "Wormhole",
+  SOLANART = "Solanart",
 }
 
 const ALL_CLUSTERS = [
@@ -366,6 +367,10 @@ export const PROGRAM_INFO_BY_ID: { [address: string]: ProgramInfo } = {
   },
   WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC: {
     name: PROGRAM_NAMES.WORMHOLE,
+    deployments: [Cluster.MainnetBeta],
+  },
+  CJsLwbP1iu5DuUikHEJnLfANgKy6stB2uFgvBBHoyxwz: {
+    name: PROGRAM_NAMES.SOLANART,
     deployments: [Cluster.MainnetBeta],
   },
 };


### PR DESCRIPTION
#### Problem

We would like to get our contract identified clearly on official Solana Explorer to facilitate user understanding and limit scams when they're inspecting transactions.

Contract: `CJsLwbP1iu5DuUikHEJnLfANgKy6stB2uFgvBBHoyxwz`

#### Summary of Changes

- Update the `utils/tx.ts` file to implement name and address of the Solanart contract
