### PR TITLE
Fix missing solana_sdk module docs

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -572,8 +572,6 @@ pub mod ed25519_program;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_schedule;
-#[cfg(not(target_arch = "bpf"))]
-pub mod example_mocks;
 pub mod feature;
 pub mod fee_calculator;
 pub mod hash;
@@ -779,6 +777,15 @@ macro_rules! unchecked_div_by_const {
         quotient
     }};
 }
+
+// This module is purposefully listed after all other exports: because of an
+// interaction within rustdoc between the reexports inside this module of
+// `solana_program`'s top-level modules, and `solana_sdk`'s glob re-export of
+// `solana_program`'s top-level modules, if this module is not lexically last
+// rustdoc fails to generate documentation for the re-exports within
+// `solana_sdk`.
+#[cfg(not(target_arch = "bpf"))]
+pub mod example_mocks;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Problem

The API docs for solana_sdk are missing several modules.

#### Summary of Changes

As described in https://github.com/solana-labs/solana/issues/23326#issuecomment-1104469118, this is happening because of an interaction that I don't fully understand between reexports in `solana_program::example_mocks::solana_sdk` and similar reexports in `solana_sdk`. Essentially, in this case rustdoc appears to choose the first reexport it finds to document, and leaves subsequent reexports undocumented.

Reordering the declaration of `solana_program::example_mocks` causes rustdoc to choose to document the reexports in `solana_sdk`.

This is a hack, and this patch documents it as such. It may be possible to fix within rustdoc itself, but that is not clear.

Fixes #23326


<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
