### PR TITLE
Backport Batch tpu calls in send-transaction-service (#24083)

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -179,6 +179,7 @@ impl Banks for BanksServer {
             last_valid_block_height,
             None,
             None,
+            None,
         );
         self.transaction_sender.send(info).unwrap();
     }
@@ -306,6 +307,7 @@ impl Banks for BanksServer {
             signature,
             serialize(&transaction).unwrap(),
             last_valid_block_height,
+            None,
             None,
             None,
         );

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -58,6 +58,15 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-use-quic ]]; then
+      args+=("$1")
+      shift
+    elif [[ $1 = --rpc-send-batch-ms ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --rpc-send-batch-size ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -144,6 +144,15 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --tpu-use-quic ]]; then
+      args+=("$1")
+      shift
+    elif [[ $1 = --rpc-send-batch-ms ]]; then
+      args+=("$1" "$2")
+      shift 2
+    elif [[ $1 = --rpc-send-batch-size ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --log ]]; then
       args+=("$1" "$2")
       shift 2

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -10,6 +10,7 @@ use {
     },
 };
 
+#[derive(Clone)]
 pub struct ClusterTpuInfo {
     cluster_info: Arc<ClusterInfo>,
     poh_recorder: Arc<Mutex<PohRecorder>>,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2392,6 +2392,7 @@ fn _send_transaction(
         last_valid_block_height,
         durable_nonce_info,
         max_retries,
+        None,
     );
     meta.transaction_sender
         .lock()

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -5,6 +5,7 @@ pub trait TpuInfo {
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr>;
 }
 
+#[derive(Clone)]
 pub struct NullTpuInfo;
 
 impl TpuInfo for NullTpuInfo {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -14,6 +14,7 @@ use {
         input_validators::{
             is_keypair, is_keypair_or_ask_keyword, is_niceness_adjustment_valid, is_parsable,
             is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
+            is_within_range,
         },
         keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
@@ -66,7 +67,9 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
-    solana_send_transaction_service::send_transaction_service,
+    solana_send_transaction_service::send_transaction_service::{
+        self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
+    },
     solana_streamer::socket::SocketAddrSpace,
     solana_validator::{
         admin_rpc_service, bootstrap, dashboard::Dashboard, ledger_lockfile, lock_ledger,
@@ -101,6 +104,7 @@ const INCLUDE_KEY: &str = "account-index-include-key";
 const DEFAULT_MIN_SNAPSHOT_DOWNLOAD_SPEED: u64 = 10485760;
 // The maximum times of snapshot download abort and retry
 const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
+const MILLIS_PER_SECOND: u64 = 1000;
 
 fn monitor_validator(ledger_path: &Path) {
     let dashboard = Dashboard::new(ledger_path, None, None).unwrap_or_else(|err| {
@@ -434,11 +438,17 @@ pub fn main() {
     let default_rpc_send_transaction_retry_ms = default_send_transaction_service_config
         .retry_rate_ms
         .to_string();
+    let default_rpc_send_transaction_batch_ms = default_send_transaction_service_config
+        .batch_send_rate_ms
+        .to_string();
     let default_rpc_send_transaction_leader_forward_count = default_send_transaction_service_config
         .leader_forward_count
         .to_string();
     let default_rpc_send_transaction_service_max_retries = default_send_transaction_service_config
         .service_max_retries
+        .to_string();
+    let default_rpc_send_transaction_batch_size = default_send_transaction_service_config
+        .batch_size
         .to_string();
     let default_rpc_threads = num_cpus::get().to_string();
     let default_accountsdb_repl_threads = num_cpus::get().to_string();
@@ -1323,6 +1333,16 @@ pub fn main() {
                 .help("The rate at which transactions sent via rpc service are retried."),
         )
         .arg(
+            Arg::with_name("rpc_send_transaction_batch_ms")
+                .long("rpc-send-batch-ms")
+                .value_name("MILLISECS")
+                .hidden(true)
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 1, MAX_BATCH_SEND_RATE_MS))
+                .default_value(&default_rpc_send_transaction_batch_ms)
+                .help("The rate at which transactions sent via rpc service are sent in batch."),
+        )
+        .arg(
             Arg::with_name("rpc_send_transaction_leader_forward_count")
                 .long("rpc-send-leader-count")
                 .value_name("NUMBER")
@@ -1347,6 +1367,16 @@ pub fn main() {
                 .validator(is_parsable::<usize>)
                 .default_value(&default_rpc_send_transaction_service_max_retries)
                 .help("The maximum number of transaction broadcast retries, regardless of requested value."),
+        )
+        .arg(
+            Arg::with_name("rpc_send_transaction_batch_size")
+                .long("rpc-send-batch-size")
+                .value_name("NUMBER")
+                .hidden(true)
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 1, MAX_TRANSACTION_BATCH_SIZE))
+                .default_value(&default_rpc_send_transaction_batch_size)
+                .help("The size of transactions to be sent in batch."),
         )
         .arg(
             Arg::with_name("rpc_scan_and_fix_roots")
@@ -2293,6 +2323,31 @@ pub fn main() {
         None
     };
 
+    let rpc_send_retry_rate_ms = value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64);
+    let rpc_send_batch_size = value_t_or_exit!(matches, "rpc_send_transaction_batch_size", usize);
+    let rpc_send_batch_send_rate_ms =
+        value_t_or_exit!(matches, "rpc_send_transaction_batch_ms", u64);
+
+    if rpc_send_batch_send_rate_ms > rpc_send_retry_rate_ms {
+        eprintln!(
+            "The specified rpc-send-batch-ms ({}) is invalid, it must be <= rpc-send-retry-ms ({})",
+            rpc_send_batch_send_rate_ms, rpc_send_retry_rate_ms
+        );
+        exit(1);
+    }
+
+    let tps = rpc_send_batch_size as u64 * MILLIS_PER_SECOND / rpc_send_batch_send_rate_ms;
+    if tps > send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND {
+        eprintln!(
+            "Either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \
+            'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
+            rpc_send_batch_size,
+            rpc_send_batch_send_rate_ms,
+            send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND
+        );
+        exit(1);
+    }
+
     let mut validator_config = ValidatorConfig {
         require_tower: matches.is_present("require_tower"),
         tower_storage,
@@ -2375,7 +2430,7 @@ pub fn main() {
         contact_debug_interval,
         bpf_jit: !matches.is_present("no_bpf_jit"),
         send_transaction_service_config: send_transaction_service::Config {
-            retry_rate_ms: value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64),
+            retry_rate_ms: rpc_send_retry_rate_ms,
             leader_forward_count: value_t_or_exit!(
                 matches,
                 "rpc_send_transaction_leader_forward_count",
@@ -2393,6 +2448,8 @@ pub fn main() {
                 usize
             ),
             use_quic: tpu_use_quic,
+            batch_send_rate_ms: rpc_send_batch_send_rate_ms,
+            batch_size: rpc_send_batch_size,
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),


### PR DESCRIPTION
Introduced flag --tpu-do-batch2.
Introduced flag to control the batch size-- by default 100
The default batch timeout is 200ms -- configurable. If either it time out or the batch size is filled, a new batch is sent
The batch honor the retry rate on the transaction already sent before.
Introduced two threads in STS: one for receiving new transactions and doing batch send and one for retrying old transactions and doing batch.6.
Fixes #

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
