### PR TITLE
Move error counters to be reported by leader only at end of slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -29,13 +29,13 @@ use {
     solana_poh::poh_recorder::{BankStart, PohRecorder, PohRecorderError, TransactionRecorder},
     solana_program_runtime::timings::ExecuteTimings,
     solana_runtime::{
-        accounts_db::ErrorCounters,
         bank::{
             Bank, LoadAndExecuteTransactionsOutput, TransactionBalancesSet, TransactionCheckResult,
         },
         bank_utils,
         cost_model::{CostModel, TransactionCost},
         transaction_batch::TransactionBatch,
+        transaction_error_metrics::TransactionErrorMetrics,
         vote_sender_types::ReplayVoteSender,
     },
     solana_sdk::{
@@ -121,6 +121,7 @@ pub struct ExecuteAndCommitTransactionsOutput {
     // committed into the Poh stream.
     commit_transactions_result: Result<Vec<CommitTransactionDetails>, PohRecorderError>,
     execute_and_commit_timings: LeaderExecuteAndCommitTimings,
+    error_counters: TransactionErrorMetrics,
 }
 
 #[derive(Debug, Default)]
@@ -1172,6 +1173,7 @@ impl BankingStage {
             executed_transactions_count,
             executed_with_successful_result_count,
             signature_count,
+            error_counters,
             ..
         } = load_and_execute_transactions_output;
 
@@ -1232,6 +1234,7 @@ impl BankingStage {
                 retryable_transaction_indexes,
                 commit_transactions_result: Err(recorder_err),
                 execute_and_commit_timings,
+                error_counters,
             };
         }
 
@@ -1338,6 +1341,7 @@ impl BankingStage {
             retryable_transaction_indexes,
             commit_transactions_result: Ok(commit_transaction_statuses),
             execute_and_commit_timings,
+            error_counters,
         }
     }
 
@@ -1556,6 +1560,7 @@ impl BankingStage {
         let mut total_cost_model_throttled_transactions_count: usize = 0;
         let mut total_cost_model_us: u64 = 0;
         let mut total_execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
+        let mut total_error_counters = TransactionErrorMetrics::default();
         let mut reached_max_poh_height = false;
         while chunk_start != transactions.len() {
             let chunk_end = std::cmp::min(
@@ -1589,10 +1594,12 @@ impl BankingStage {
                 retryable_transaction_indexes: new_retryable_transaction_indexes,
                 commit_transactions_result: new_commit_transactions_result,
                 execute_and_commit_timings: new_execute_and_commit_timings,
+                error_counters: new_error_counters,
                 ..
             } = execute_and_commit_transactions_output;
 
             total_execute_and_commit_timings.accumulate(&new_execute_and_commit_timings);
+            total_error_counters.accumulate(&new_error_counters);
             total_transactions_attempted_execution_count =
                 total_transactions_attempted_execution_count
                     .saturating_add(new_transactions_attempted_execution_count);
@@ -1655,6 +1662,7 @@ impl BankingStage {
             cost_model_throttled_transactions_count: total_cost_model_throttled_transactions_count,
             cost_model_us: total_cost_model_us,
             execute_and_commit_timings: total_execute_and_commit_timings,
+            error_counters: total_error_counters,
         }
     }
 
@@ -1727,7 +1735,7 @@ impl BankingStage {
         let filter =
             Self::prepare_filter_for_pending_transactions(transactions.len(), pending_indexes);
 
-        let mut error_counters = ErrorCounters::default();
+        let mut error_counters = TransactionErrorMetrics::default();
         // The following code also checks if the blockhash for a transaction is too old
         // The check accounts for
         //  1. Transaction forwarding delay
@@ -1808,10 +1816,12 @@ impl BankingStage {
 
         let ProcessTransactionsSummary {
             ref retryable_transaction_indexes,
+            ref error_counters,
             ..
         } = process_transactions_summary;
 
         slot_metrics_tracker.accumulate_process_transactions_summary(&process_transactions_summary);
+        slot_metrics_tracker.accumulate_transaction_errors(error_counters);
 
         let retryable_tx_count = retryable_transaction_indexes.len();
         inc_new_counter_info!("banking_stage-unprocessed_transactions", retryable_tx_count);

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2568,6 +2568,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -224,26 +224,6 @@ pub enum ScanStorageResult<R, B> {
     Stored(B),
 }
 
-#[derive(Debug, Default)]
-pub struct ErrorCounters {
-    pub total: usize,
-    pub account_in_use: usize,
-    pub account_loaded_twice: usize,
-    pub account_not_found: usize,
-    pub blockhash_not_found: usize,
-    pub blockhash_too_old: usize,
-    pub call_chain_too_deep: usize,
-    pub already_processed: usize,
-    pub instruction_error: usize,
-    pub insufficient_funds: usize,
-    pub invalid_account_for_fee: usize,
-    pub invalid_account_index: usize,
-    pub invalid_program_for_execution: usize,
-    pub not_allowed_during_cluster_maintenance: usize,
-    pub invalid_writable_account: usize,
-    pub invalid_rent_paying_account: usize,
-}
-
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IndexGenerationInfo {
     pub accounts_data_len: u64,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -43,7 +43,7 @@ use {
             TransactionLoadResult,
         },
         accounts_db::{
-            AccountShrinkThreshold, AccountsDbConfig, ErrorCounters, SnapshotStorages,
+            AccountShrinkThreshold, AccountsDbConfig, SnapshotStorages,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{AccountSecondaryIndexes, IndexKey, ScanConfig, ScanResult},
@@ -66,6 +66,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         system_instruction_processor::{get_system_account_kind, SystemAccountKind},
         transaction_batch::TransactionBatch,
+        transaction_error_metrics::TransactionErrorMetrics,
         vote_account::{VoteAccount, VoteAccountsHashMap},
         vote_parser,
     },
@@ -664,6 +665,7 @@ pub struct LoadAndExecuteTransactionsOutput {
     // an error.
     pub executed_with_successful_result_count: usize,
     pub signature_count: u64,
+    pub error_counters: TransactionErrorMetrics,
 }
 
 #[derive(Debug, Clone)]
@@ -3914,7 +3916,7 @@ impl Bank {
         txs: impl Iterator<Item = &'a SanitizedTransaction>,
         lock_results: &[Result<()>],
         max_age: usize,
-        error_counters: &mut ErrorCounters,
+        error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let hash_queue = self.blockhash_queue.read().unwrap();
         txs.zip(lock_results)
@@ -3951,7 +3953,7 @@ impl Bank {
         &self,
         sanitized_txs: &[SanitizedTransaction],
         lock_results: Vec<TransactionCheckResult>,
-        error_counters: &mut ErrorCounters,
+        error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let rcache = self.src.status_cache.read().unwrap();
         sanitized_txs
@@ -4005,7 +4007,7 @@ impl Bank {
         sanitized_txs: &[SanitizedTransaction],
         lock_results: &[Result<()>],
         max_age: usize,
-        error_counters: &mut ErrorCounters,
+        error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let age_results =
             self.check_age(sanitized_txs.iter(), lock_results, max_age, error_counters);
@@ -4022,88 +4024,6 @@ impl Bank {
             balances.push(transaction_balances);
         }
         balances
-    }
-
-    #[allow(clippy::cognitive_complexity)]
-    fn update_error_counters(error_counters: &ErrorCounters) {
-        if 0 != error_counters.total {
-            inc_new_counter_info!(
-                "bank-process_transactions-error_count",
-                error_counters.total
-            );
-        }
-        if 0 != error_counters.account_not_found {
-            inc_new_counter_info!(
-                "bank-process_transactions-account_not_found",
-                error_counters.account_not_found
-            );
-        }
-        if 0 != error_counters.account_in_use {
-            inc_new_counter_info!(
-                "bank-process_transactions-account_in_use",
-                error_counters.account_in_use
-            );
-        }
-        if 0 != error_counters.account_loaded_twice {
-            inc_new_counter_info!(
-                "bank-process_transactions-account_loaded_twice",
-                error_counters.account_loaded_twice
-            );
-        }
-        if 0 != error_counters.blockhash_not_found {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-blockhash_not_found",
-                error_counters.blockhash_not_found
-            );
-        }
-        if 0 != error_counters.blockhash_too_old {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-blockhash_too_old",
-                error_counters.blockhash_too_old
-            );
-        }
-        if 0 != error_counters.invalid_account_index {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-invalid_account_index",
-                error_counters.invalid_account_index
-            );
-        }
-        if 0 != error_counters.invalid_account_for_fee {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-invalid_account_for_fee",
-                error_counters.invalid_account_for_fee
-            );
-        }
-        if 0 != error_counters.insufficient_funds {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-insufficient_funds",
-                error_counters.insufficient_funds
-            );
-        }
-        if 0 != error_counters.instruction_error {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-instruction_error",
-                error_counters.instruction_error
-            );
-        }
-        if 0 != error_counters.already_processed {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-already_processed",
-                error_counters.already_processed
-            );
-        }
-        if 0 != error_counters.not_allowed_during_cluster_maintenance {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-cluster-maintenance",
-                error_counters.not_allowed_during_cluster_maintenance
-            );
-        }
-        if 0 != error_counters.invalid_writable_account {
-            inc_new_counter_info!(
-                "bank-process_transactions-error-invalid_writable_account",
-                error_counters.invalid_writable_account
-            );
-        }
     }
 
     /// Get any cached executors needed by the transaction
@@ -4176,7 +4096,7 @@ impl Bank {
         enable_log_recording: bool,
         enable_return_data_recording: bool,
         timings: &mut ExecuteTimings,
-        error_counters: &mut ErrorCounters,
+        error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionExecutionResult {
         let mut get_executors_time = Measure::start("get_executors_time");
         let executors = self.get_executors(&loaded_transaction.accounts);
@@ -4325,7 +4245,7 @@ impl Bank {
         let sanitized_txs = batch.sanitized_transactions();
         debug!("processing transactions: {}", sanitized_txs.len());
         inc_new_counter_info!("bank-process_transactions", sanitized_txs.len());
-        let mut error_counters = ErrorCounters::default();
+        let mut error_counters = TransactionErrorMetrics::default();
 
         let retryable_transaction_indexes: Vec<_> = batch
             .lock_results()
@@ -4544,7 +4464,6 @@ impl Bank {
                 *err_count + executed_with_successful_result_count
             );
         }
-        Self::update_error_counters(&error_counters);
         LoadAndExecuteTransactionsOutput {
             loaded_transactions,
             execution_results,
@@ -4552,6 +4471,7 @@ impl Bank {
             executed_transactions_count,
             executed_with_successful_result_count,
             signature_count,
+            error_counters,
         }
     }
 
@@ -17535,7 +17455,7 @@ pub(crate) mod tests {
         let number_of_instructions_at_transaction_level = tx.message().instructions.len();
         let num_accounts = tx.message().account_keys.len();
         let sanitized_tx = SanitizedTransaction::try_from_legacy_transaction(tx).unwrap();
-        let mut error_counters = ErrorCounters::default();
+        let mut error_counters = TransactionErrorMetrics::default();
         let loaded_txs = bank.rc.accounts.load_accounts(
             &bank.ancestors,
             &[sanitized_tx.clone()],

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -69,6 +69,7 @@ mod storable_accounts;
 mod system_instruction_processor;
 pub mod transaction_batch;
 pub mod transaction_cost_metrics_sender;
+pub mod transaction_error_metrics;
 pub mod vote_account;
 pub mod vote_parser;
 pub mod vote_sender_types;

--- a/runtime/src/transaction_error_metrics.rs
+++ b/runtime/src/transaction_error_metrics.rs
@@ -1,0 +1,110 @@
+use solana_sdk::{clock::Slot, saturating_add_assign};
+
+#[derive(Debug, Default)]
+pub struct TransactionErrorMetrics {
+    pub total: usize,
+    pub account_in_use: usize,
+    pub account_loaded_twice: usize,
+    pub account_not_found: usize,
+    pub blockhash_not_found: usize,
+    pub blockhash_too_old: usize,
+    pub call_chain_too_deep: usize,
+    pub already_processed: usize,
+    pub instruction_error: usize,
+    pub insufficient_funds: usize,
+    pub invalid_account_for_fee: usize,
+    pub invalid_account_index: usize,
+    pub invalid_program_for_execution: usize,
+    pub not_allowed_during_cluster_maintenance: usize,
+    pub invalid_writable_account: usize,
+    pub invalid_rent_paying_account: usize,
+}
+
+impl TransactionErrorMetrics {
+    pub fn new() -> Self {
+        Self { ..Self::default() }
+    }
+
+    pub fn accumulate(&mut self, other: &TransactionErrorMetrics) {
+        saturating_add_assign!(self.total, other.total);
+        saturating_add_assign!(self.account_in_use, other.account_in_use);
+        saturating_add_assign!(self.account_loaded_twice, other.account_loaded_twice);
+        saturating_add_assign!(self.account_not_found, other.account_not_found);
+        saturating_add_assign!(self.blockhash_not_found, other.blockhash_not_found);
+        saturating_add_assign!(self.blockhash_too_old, other.blockhash_too_old);
+        saturating_add_assign!(self.call_chain_too_deep, other.call_chain_too_deep);
+        saturating_add_assign!(self.already_processed, other.already_processed);
+        saturating_add_assign!(self.instruction_error, other.instruction_error);
+        saturating_add_assign!(self.insufficient_funds, other.insufficient_funds);
+        saturating_add_assign!(self.invalid_account_for_fee, other.invalid_account_for_fee);
+        saturating_add_assign!(self.invalid_account_index, other.invalid_account_index);
+        saturating_add_assign!(
+            self.invalid_program_for_execution,
+            other.invalid_program_for_execution
+        );
+        saturating_add_assign!(
+            self.not_allowed_during_cluster_maintenance,
+            other.not_allowed_during_cluster_maintenance
+        );
+        saturating_add_assign!(
+            self.invalid_writable_account,
+            other.invalid_writable_account
+        );
+        saturating_add_assign!(
+            self.invalid_rent_paying_account,
+            other.invalid_rent_paying_account
+        );
+    }
+
+    pub fn report(&self, id: u32, slot: Slot) {
+        datapoint_info!(
+            "banking_stage-leader_slot_transaction_errors",
+            ("id", id as i64, i64),
+            ("slot", slot as i64, i64),
+            ("total", self.total as i64, i64),
+            ("account_in_use", self.account_in_use as i64, i64),
+            (
+                "account_loaded_twice",
+                self.account_loaded_twice as i64,
+                i64
+            ),
+            ("account_not_found", self.account_not_found as i64, i64),
+            ("blockhash_not_found", self.blockhash_not_found as i64, i64),
+            ("blockhash_too_old", self.blockhash_too_old as i64, i64),
+            ("call_chain_too_deep", self.call_chain_too_deep as i64, i64),
+            ("already_processed", self.already_processed as i64, i64),
+            ("instruction_error", self.instruction_error as i64, i64),
+            ("insufficient_funds", self.insufficient_funds as i64, i64),
+            (
+                "invalid_account_for_fee",
+                self.invalid_account_for_fee as i64,
+                i64
+            ),
+            (
+                "invalid_account_index",
+                self.invalid_account_index as i64,
+                i64
+            ),
+            (
+                "invalid_program_for_execution",
+                self.invalid_program_for_execution as i64,
+                i64
+            ),
+            (
+                "not_allowed_during_cluster_maintenance",
+                self.not_allowed_during_cluster_maintenance as i64,
+                i64
+            ),
+            (
+                "invalid_writable_account",
+                self.invalid_writable_account as i64,
+                i64
+            ),
+            (
+                "invalid_rent_paying_account",
+                self.invalid_rent_paying_account as i64,
+                i64
+            ),
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/24456

#### Summary of Changes
Move error counters inside `LeaderSlotMetrics` so that they're reported solely by the leader at the end of the block it's generating

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
