### PR TITLE
chore(explorer): add .prettierrc.json

### DIFF
--- a/explorer/.prettierrc.json
+++ b/explorer/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
#### Problem
Currently when your run `npm run format:fix` it will do nothing or it will use your own local configuration.

My prettier configuration is different from the one used on the `solana/explorer` files, so it's updating all the files of the repository with my configuration and when I save a file it's formatting with my own configuration as well.

#### Summary of Changes
- Add a `.prettierrc.json` file matching the actual format rules of the repository

