### PR TITLE
Leader info refresher

### DIFF
--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -662,6 +662,7 @@ mod test {
         let mut transactions = HashMap::new();
 
         info!("Expired transactions are dropped...");
+        let leader_info_provider = Arc::new(Mutex::new(LeaderInfoProvider::new(None)));
         transactions.insert(
             Signature::default(),
             TransactionInfo::new(
@@ -678,7 +679,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -707,7 +708,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -736,7 +737,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -765,7 +766,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -796,7 +797,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -837,7 +838,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -854,7 +855,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -928,12 +929,13 @@ mod test {
                 Some(Instant::now()),
             ),
         );
+        let leader_info_provider = Arc::new(Mutex::new(LeaderInfoProvider::new(None)));
         let result = SendTransactionService::process_transactions::<NullTpuInfo>(
             &working_bank,
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -961,7 +963,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -991,7 +993,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -1019,7 +1021,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -1048,7 +1050,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert!(transactions.is_empty());
@@ -1077,7 +1079,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -1108,7 +1110,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider.clone(),
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -1136,7 +1138,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            &None,
+            leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 0);

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -132,7 +132,10 @@ impl Default for Config {
 /// used for sending transactions.
 pub const LEADER_INFO_REFRESH_RATE_IN_MS: u64 = 1000;
 
-pub struct LeaderInfoProvider<T: TpuInfo + std::marker::Send + Clone + 'static> {
+pub struct LeaderInfoProvider<T>
+where
+    T: TpuInfo + std::marker::Send + Clone + 'static,
+{
     /// The last time the leader info is refreshed
     last_leader_refresh: Option<Instant>,
 
@@ -143,7 +146,10 @@ pub struct LeaderInfoProvider<T: TpuInfo + std::marker::Send + Clone + 'static> 
     refresh_rate: Duration,
 }
 
-impl<T: TpuInfo + std::marker::Send + Clone + 'static> LeaderInfoProvider<T> {
+impl<T> LeaderInfoProvider<T>
+where
+    T: TpuInfo + std::marker::Send + Clone + 'static,
+{
     /// Get the leader info, refresh if expired
     pub fn get_leader_info(&mut self) -> &Option<T> {
         if let Some(leader_info) = self.leader_info.as_mut() {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -128,26 +128,26 @@ impl Default for Config {
     }
 }
 
-/// The longest sleep the retry thread sleep before waking up
-/// to process the transactions need to be retried.
-pub const LONGEST_RETRY_SLEEP_IN_MS: u64 = 1000;
+/// The maximum duration the retry thread may be configured to sleep before
+/// processing the transactions that need to be retried.
+pub const MAX_RETRY_SLEEP_MS: u64 = 1000;
 
-/// The leader info refresh rate. It will be refresh every 1 second.
-pub const LEADER_INFO_REFRESH_RATE_IN_MS: u64 = 1000;
+/// The leader info refresh rate.
+pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
 
-/// A struct responsible for providing the up-to-date leader information
+/// A struct responsible for holding up-to-date leader information
 /// used for sending transactions.
 pub struct LeaderInfoProvider<T>
 where
     T: TpuInfo + std::marker::Send + 'static,
 {
-    /// The last time the leader info is refreshed
+    /// The last time the leader info was refreshed
     last_leader_refresh: Option<Instant>,
 
     /// The leader info
     leader_info: Option<T>,
 
-    /// Refresh the leader info every duration set by refresh_rate
+    /// How often to refresh the leader info
     refresh_rate: Duration,
 }
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -176,7 +176,7 @@ where
         Self {
             last_leader_refresh: None,
             leader_info,
-            refresh_rate: Duration::from_millis(LEADER_INFO_REFRESH_RATE_IN_MS),
+            refresh_rate: Duration::from_millis(LEADER_INFO_REFRESH_RATE_MS),
         }
     }
 }
@@ -342,7 +342,7 @@ impl SendTransactionService {
             .spawn(move || loop {
                 let retry_interval_ms = config.retry_rate_ms;
                 sleep(Duration::from_millis(
-                    LONGEST_RETRY_SLEEP_IN_MS.min(retry_interval_ms),
+                    MAX_RETRY_SLEEP_MS.min(retry_interval_ms),
                 ));
                 if exit.load(Ordering::Relaxed) {
                     break;

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -493,19 +493,19 @@ impl SendTransactionService {
 
         if !batched_transactions.is_empty() {
             // Processing the transactions in batch
-            let mut leader_info_provider = leader_info.lock().unwrap();
-            let leader_info = leader_info_provider.get_leader_info();
-            let addresses = Self::get_tpu_addresses(tpu_address, leader_info, config);
-
             let wire_transactions = transactions
                 .iter()
                 .filter(|(signature, _)| batched_transactions.contains(signature))
                 .map(|(_, transaction_info)| transaction_info.wire_transaction.as_ref())
                 .collect::<Vec<&[u8]>>();
 
-            for address in &addresses {
-                let iter = wire_transactions.chunks(config.batch_size);
-                for chunk in iter {
+            let iter = wire_transactions.chunks(config.batch_size);
+            for chunk in iter {
+                let mut leader_info_provider = leader_info.lock().unwrap();
+                let leader_info = leader_info_provider.get_leader_info();
+                let addresses = Self::get_tpu_addresses(tpu_address, leader_info, config);
+
+                for address in &addresses {
                     Self::send_transactions(address, chunk);
                 }
             }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -151,7 +151,7 @@ where
     T: TpuInfo + std::marker::Send + Clone + 'static,
 {
     /// Get the leader info, refresh if expired
-    pub fn get_leader_info(&mut self) -> &Option<T> {
+    pub fn get_leader_info(&mut self) -> Option<&T> {
         if let Some(leader_info) = self.leader_info.as_mut() {
             let now = Instant::now();
             let need_refresh = self
@@ -164,7 +164,7 @@ where
                 self.last_leader_refresh = Some(now);
             }
         }
-        &self.leader_info
+        self.leader_info.as_ref()
     }
 
     pub fn new(leader_info: Option<T>) -> Self {
@@ -359,7 +359,7 @@ impl SendTransactionService {
                         &root_bank,
                         &tpu_address,
                         &mut transactions,
-                        leader_info_provider.clone(),
+                        &leader_info_provider,
                         &config,
                     );
                 }
@@ -371,7 +371,7 @@ impl SendTransactionService {
     fn send_transactions_in_batch<T: TpuInfo>(
         tpu_address: &SocketAddr,
         transactions: &mut HashMap<Signature, TransactionInfo>,
-        leader_info: &Option<T>,
+        leader_info: Option<&T>,
         config: &Config,
     ) {
         let mut measure = Measure::start("send_transactions_in_batch-us");
@@ -402,7 +402,7 @@ impl SendTransactionService {
         root_bank: &Arc<Bank>,
         tpu_address: &SocketAddr,
         transactions: &mut HashMap<Signature, TransactionInfo>,
-        leader_info_provider: Arc<Mutex<LeaderInfoProvider<T>>>,
+        leader_info_provider: &Arc<Mutex<LeaderInfoProvider<T>>>,
         config: &Config,
     ) -> ProcessTransactionsResult {
         let mut result = ProcessTransactionsResult::default();
@@ -564,7 +564,7 @@ impl SendTransactionService {
 
     fn get_tpu_addresses<'a, T: TpuInfo>(
         tpu_address: &'a SocketAddr,
-        leader_info: &'a Option<T>,
+        leader_info: Option<&'a T>,
         config: &'a Config,
     ) -> Vec<&'a SocketAddr> {
         let addresses = leader_info
@@ -679,7 +679,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -708,7 +708,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -737,7 +737,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -766,7 +766,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -797,7 +797,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -838,7 +838,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -855,7 +855,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider,
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -935,7 +935,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -963,7 +963,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -993,7 +993,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -1021,7 +1021,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -1050,7 +1050,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert!(transactions.is_empty());
@@ -1079,7 +1079,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -1110,7 +1110,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider.clone(),
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 1);
@@ -1138,7 +1138,7 @@ mod test {
             &root_bank,
             &tpu_address,
             &mut transactions,
-            leader_info_provider,
+            &leader_info_provider,
             &config,
         );
         assert_eq!(transactions.len(), 0);

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -128,6 +128,48 @@ impl Default for Config {
     }
 }
 
+/// A struct responsible for providing the up-to-date leader information
+/// used for sending transactions.
+pub const LEADER_INFO_REFRESH_RATE_IN_MS: u64 = 1000;
+
+pub struct LeaderInfoProvider<T: TpuInfo + std::marker::Send + Clone + 'static> {
+    /// The last time the leader info is refreshed
+    last_leader_refresh: Option<Instant>,
+
+    /// The leader info
+    leader_info: Option<T>,
+
+    /// Refresh the leader info every duration set by refresh_rate
+    refresh_rate: Duration,
+}
+
+impl<T: TpuInfo + std::marker::Send + Clone + 'static> LeaderInfoProvider<T> {
+    /// Get the leader info, refresh if expired
+    pub fn get_leader_info(&mut self) -> &Option<T> {
+        if let Some(leader_info) = self.leader_info.as_mut() {
+            let now = Instant::now();
+            let expired = self
+                .last_leader_refresh
+                .map(|last| now.duration_since(last) >= self.refresh_rate)
+                .unwrap_or(false);
+
+            if expired {
+                leader_info.refresh_recent_peers();
+                self.last_leader_refresh = Some(now);
+            }
+        }
+        &self.leader_info
+    }
+
+    pub fn new(leader_info: Option<T>) -> Self {
+        Self {
+            last_leader_refresh: None,
+            leader_info,
+            refresh_rate: Duration::from_millis(LEADER_INFO_REFRESH_RATE_IN_MS),
+        }
+    }
+}
+
 impl SendTransactionService {
     pub fn new<T: TpuInfo + std::marker::Send + Clone + 'static>(
         tpu_address: SocketAddr,
@@ -155,11 +197,14 @@ impl SendTransactionService {
         config: Config,
     ) -> Self {
         let retry_transactions = Arc::new(Mutex::new(HashMap::new()));
+
+        let leader_info_provider = Arc::new(Mutex::new(LeaderInfoProvider::new(leader_info)));
+
         let exit = Arc::new(AtomicBool::new(false));
         let receive_txn_thread = Self::receive_txn_thread(
             tpu_address,
             receiver,
-            leader_info.clone(),
+            leader_info_provider.clone(),
             config.clone(),
             retry_transactions.clone(),
             exit.clone(),
@@ -168,7 +213,7 @@ impl SendTransactionService {
         let retry_thread = Self::retry_thread(
             tpu_address,
             bank_forks.clone(),
-            leader_info,
+            leader_info_provider,
             config,
             retry_transactions,
             exit.clone(),
@@ -181,25 +226,21 @@ impl SendTransactionService {
     }
 
     /// Thread responsible for receiving transactions from RPC clients.
-    fn receive_txn_thread<T: TpuInfo + std::marker::Send + 'static>(
+    fn receive_txn_thread<T: TpuInfo + std::marker::Send + Clone + 'static>(
         tpu_address: SocketAddr,
         receiver: Receiver<TransactionInfo>,
-        mut leader_info: Option<T>,
+        leader_info: Arc<Mutex<LeaderInfoProvider<T>>>,
         config: Config,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         let mut last_batch_sent = Instant::now();
-        let mut last_leader_refresh = Instant::now();
         let mut transactions = HashMap::new();
 
         info!(
             "Starting send-transaction-service::receive_txn_thread with config {:?}",
             config
         );
-        if let Some(leader_info) = leader_info.as_mut() {
-            leader_info.refresh_recent_peers();
-        }
         connection_cache::set_use_quic(config.use_quic);
         Builder::new()
             .name("send-tx-receive".to_string())
@@ -243,7 +284,7 @@ impl SendTransactionService {
                     let _result = Self::send_transactions_in_batch(
                         &tpu_address,
                         &mut transactions,
-                        &leader_info,
+                        leader_info.lock().unwrap().get_leader_info(),
                         &config,
                     );
                     let last_sent_time = Instant::now();
@@ -266,35 +307,24 @@ impl SendTransactionService {
                     }
 
                     last_batch_sent = Instant::now();
-                    if last_leader_refresh.elapsed().as_millis() > 1000 {
-                        if let Some(leader_info) = leader_info.as_mut() {
-                            leader_info.refresh_recent_peers();
-                        }
-                        last_leader_refresh = Instant::now();
-                    }
                 }
             })
             .unwrap()
     }
 
     /// Thread responsible for retrying transactions
-    fn retry_thread<T: TpuInfo + std::marker::Send + 'static>(
+    fn retry_thread<T: TpuInfo + std::marker::Send + Clone + 'static>(
         tpu_address: SocketAddr,
         bank_forks: Arc<RwLock<BankForks>>,
-        mut leader_info: Option<T>,
+        leader_info: Arc<Mutex<LeaderInfoProvider<T>>>,
         config: Config,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
-        let mut last_leader_refresh = Instant::now();
-
         info!(
             "Starting send-transaction-service::retry_thread with config {:?}",
             config
         );
-        if let Some(leader_info) = leader_info.as_mut() {
-            leader_info.refresh_recent_peers();
-        }
         connection_cache::set_use_quic(config.use_quic);
         Builder::new()
             .name("send-tx-retry".to_string())
@@ -323,15 +353,9 @@ impl SendTransactionService {
                         &root_bank,
                         &tpu_address,
                         &mut transactions,
-                        &leader_info,
+                        leader_info.clone(),
                         &config,
                     );
-                }
-                if last_leader_refresh.elapsed().as_millis() > 1000 {
-                    if let Some(leader_info) = leader_info.as_mut() {
-                        leader_info.refresh_recent_peers();
-                    }
-                    last_leader_refresh = Instant::now();
                 }
             })
             .unwrap()
@@ -367,12 +391,12 @@ impl SendTransactionService {
     }
 
     /// Retry transactions sent before.
-    fn process_transactions<T: TpuInfo>(
+    fn process_transactions<T: TpuInfo + std::marker::Send + Clone + 'static>(
         working_bank: &Arc<Bank>,
         root_bank: &Arc<Bank>,
         tpu_address: &SocketAddr,
         transactions: &mut HashMap<Signature, TransactionInfo>,
-        leader_info: &Option<T>,
+        leader_info: Arc<Mutex<LeaderInfoProvider<T>>>,
         config: &Config,
     ) -> ProcessTransactionsResult {
         let mut result = ProcessTransactionsResult::default();
@@ -469,6 +493,8 @@ impl SendTransactionService {
 
         if !batched_transactions.is_empty() {
             // Processing the transactions in batch
+            let mut leader_info_provider = leader_info.lock().unwrap();
+            let leader_info = leader_info_provider.get_leader_info();
             let addresses = Self::get_tpu_addresses(tpu_address, leader_info, config);
 
             let wire_transactions = transactions

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -148,12 +148,12 @@ impl<T: TpuInfo + std::marker::Send + Clone + 'static> LeaderInfoProvider<T> {
     pub fn get_leader_info(&mut self) -> &Option<T> {
         if let Some(leader_info) = self.leader_info.as_mut() {
             let now = Instant::now();
-            let expired = self
+            let need_refresh = self
                 .last_leader_refresh
                 .map(|last| now.duration_since(last) >= self.refresh_rate)
-                .unwrap_or(false);
+                .unwrap_or(true);
 
-            if expired {
+            if need_refresh {
                 leader_info.refresh_recent_peers();
                 self.last_leader_refresh = Some(now);
             }


### PR DESCRIPTION
Problem

In PR review https://github.com/solana-labs/solana/pull/24083/files#r852661162. We are concerned the leader info might be out dated if the retry queue is long causing large number transactions sent to outdated leaders and increasing the load in the network.

Proposed Solution

A leader info refresher can be used to ensure the leader info is up-to-date before being used in sending transactions. The refresher can update the new leader with updated endpoints.

# Fixes
#24525