### PR TITLE
feat: allow PublicKey.isOnCurve to accept PublicKeyInitData

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -222,8 +222,9 @@ export class PublicKey extends Struct {
   /**
    * Check that a pubkey is on the ed25519 curve.
    */
-  static isOnCurve(pubkey: Uint8Array): boolean {
-    return is_on_curve(pubkey) == 1;
+  static isOnCurve(pubkeyData: PublicKeyInitData): boolean {
+    const pubkey = new PublicKey(pubkeyData);
+    return is_on_curve(pubkey.toBytes()) == 1;
   }
 }
 

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -232,6 +232,8 @@ describe('PublicKey', function () {
   it('isOnCurve', () => {
     let onCurve = Keypair.generate().publicKey;
     expect(PublicKey.isOnCurve(onCurve.toBuffer())).to.be.true;
+    expect(PublicKey.isOnCurve(onCurve.toBase58())).to.be.true;
+    expect(PublicKey.isOnCurve(onCurve)).to.be.true;
     // A program address, yanked from one of the above tests. This is a pretty
     // poor test vector since it was created by the same code it is testing.
     // Unfortunately, I've been unable to find a golden negative example input
@@ -240,6 +242,8 @@ describe('PublicKey', function () {
       '12rqwuEgBYiGhBrDJStCiqEtzQpTTiZbh7teNVLuYcFA',
     );
     expect(PublicKey.isOnCurve(offCurve.toBuffer())).to.be.false;
+    expect(PublicKey.isOnCurve(offCurve.toBase58())).to.be.false;
+    expect(PublicKey.isOnCurve(offCurve)).to.be.false;
   });
 
   it('canBeSerializedWithBorsh', () => {


### PR DESCRIPTION
#### Problem
`PublicKey.isOnCurve` accepts a byte array, so passing a `PublicKey` object would silently return true every time, which is unexpected.

#### Summary of Changes
Allow `isOnCurve` to accept `PublicKeyInitData` for convenience.

Re-opens #22653