### PR TITLE
Add pbkdf2:0.10.1 to Cargo.lock files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2568,6 +2568,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"


### PR DESCRIPTION
#### Problem

Build is broken. See https://buildkite.com/solana-labs/solana/builds/71345#910d850c-af0b-47cc-9df4-448a37a1ed31

#### Summary of Changes

Add `pbkdf2:0.10.1` to Cargo.lock files.