### PR TITLE
Support token-2022 in RPC account parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
+ "spl-token-2022",
  "stream-cancel",
  "symlink",
  "thiserror",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4871,6 +4871,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "spl-token",
+ "spl-token-2022",
  "stream-cancel",
  "thiserror",
  "tokio",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -49,6 +49,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.11.0
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.2.0", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/rpc/src/parsed_token_accounts.rs
+++ b/rpc/src/parsed_token_accounts.rs
@@ -13,7 +13,7 @@ use {
         account::{AccountSharedData, ReadableAccount},
         pubkey::Pubkey,
     },
-    spl_token::{solana_program::program_pack::Pack, state::Mint},
+    spl_token_2022::{extension::StateWithExtensions, state::Mint},
     std::{collections::HashMap, sync::Arc},
 };
 
@@ -91,9 +91,9 @@ pub fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(P
 }
 
 fn get_mint_decimals(data: &[u8]) -> Result<u8> {
-    Mint::unpack(data)
+    StateWithExtensions::<Mint>::unpack(data)
         .map_err(|_| {
             Error::invalid_params("Invalid param: Token mint could not be unpacked".to_string())
         })
-        .map(|mint| mint.decimals)
+        .map(|mint| mint.base.decimals)
 }


### PR DESCRIPTION
#### Problem
RPC now recognizes the spl-token-2022 program id, but cannot parse its accounts

#### Summary of Changes
All spl-token accounts are now parsed via spl-token-2022 (there are copious tests in SPL that demonstrate that base spl-token-2022 accounts parse the same as spl-token accounts).
Extensions are not yet parsed and represented, although extended accounts are otherwise parsed.
