### PR TITLE
Parse token-2022 account extensions (mostly)

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -11,6 +11,7 @@ pub mod parse_nonce;
 pub mod parse_stake;
 pub mod parse_sysvar;
 pub mod parse_token;
+pub mod parse_token_extension;
 pub mod parse_vote;
 pub mod validator_info;
 

--- a/account-decoder/src/parse_token_extension.rs
+++ b/account-decoder/src/parse_token_extension.rs
@@ -13,8 +13,8 @@ pub enum UiExtension {
     TransferFeeConfig(UiTransferFeeConfig),
     TransferFeeAmount(UiTransferFeeAmount),
     MintCloseAuthority(UiMintCloseAuthority),
-    ConfidentialTransferMint,
-    ConfidentialTransferAccount,
+    ConfidentialTransferMint,    // Implementation of extension state to come
+    ConfidentialTransferAccount, // Implementation of extension state to come
     DefaultAccountState(UiDefaultAccountState),
     ImmutableOwner,
     MemoTransfer(UiMemoTransfer),

--- a/account-decoder/src/parse_token_extension.rs
+++ b/account-decoder/src/parse_token_extension.rs
@@ -1,0 +1,161 @@
+use {
+    crate::parse_token::UiAccountState,
+    spl_token_2022::{
+        extension::{self, BaseState, ExtensionType, StateWithExtensions},
+        solana_program::pubkey::Pubkey,
+    },
+};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "extension", content = "state")]
+pub enum UiExtension {
+    Uninitialized,
+    TransferFeeConfig(UiTransferFeeConfig),
+    TransferFeeAmount(UiTransferFeeAmount),
+    MintCloseAuthority(UiMintCloseAuthority),
+    ConfidentialTransferMint,
+    ConfidentialTransferAccount,
+    DefaultAccountState(UiDefaultAccountState),
+    ImmutableOwner,
+    MemoTransfer(UiMemoTransfer),
+    UnparseableExtension,
+}
+
+pub fn parse_extension<S: BaseState>(
+    extension_type: &ExtensionType,
+    account: &StateWithExtensions<S>,
+) -> UiExtension {
+    match &extension_type {
+        ExtensionType::Uninitialized => UiExtension::Uninitialized,
+        ExtensionType::TransferFeeConfig => account
+            .get_extension::<extension::transfer_fee::TransferFeeConfig>()
+            .map(|&extension| UiExtension::TransferFeeConfig(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+        ExtensionType::TransferFeeAmount => account
+            .get_extension::<extension::transfer_fee::TransferFeeAmount>()
+            .map(|&extension| UiExtension::TransferFeeAmount(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+        ExtensionType::MintCloseAuthority => account
+            .get_extension::<extension::mint_close_authority::MintCloseAuthority>()
+            .map(|&extension| UiExtension::MintCloseAuthority(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+        ExtensionType::ConfidentialTransferMint => UiExtension::ConfidentialTransferMint,
+        ExtensionType::ConfidentialTransferAccount => UiExtension::ConfidentialTransferAccount,
+        ExtensionType::DefaultAccountState => account
+            .get_extension::<extension::default_account_state::DefaultAccountState>()
+            .map(|&extension| UiExtension::DefaultAccountState(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+        ExtensionType::ImmutableOwner => UiExtension::ImmutableOwner,
+        ExtensionType::MemoTransfer => account
+            .get_extension::<extension::memo_transfer::MemoTransfer>()
+            .map(|&extension| UiExtension::MemoTransfer(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiTransferFee {
+    pub epoch: u64,
+    pub maximum_fee: u64,
+    pub transfer_fee_basis_points: u16,
+}
+
+impl From<extension::transfer_fee::TransferFee> for UiTransferFee {
+    fn from(transfer_fee: extension::transfer_fee::TransferFee) -> Self {
+        Self {
+            epoch: u64::from(transfer_fee.epoch),
+            maximum_fee: u64::from(transfer_fee.maximum_fee),
+            transfer_fee_basis_points: u16::from(transfer_fee.transfer_fee_basis_points),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiTransferFeeConfig {
+    pub transfer_fee_config_authority: Option<String>,
+    pub withdraw_withheld_authority: Option<String>,
+    pub withheld_amount: u64,
+    pub older_transfer_fee: UiTransferFee,
+    pub newer_transfer_fee: UiTransferFee,
+}
+
+impl From<extension::transfer_fee::TransferFeeConfig> for UiTransferFeeConfig {
+    fn from(transfer_fee_config: extension::transfer_fee::TransferFeeConfig) -> Self {
+        let transfer_fee_config_authority: Option<Pubkey> =
+            transfer_fee_config.transfer_fee_config_authority.into();
+        let withdraw_withheld_authority: Option<Pubkey> =
+            transfer_fee_config.withdraw_withheld_authority.into();
+
+        Self {
+            transfer_fee_config_authority: transfer_fee_config_authority
+                .map(|pubkey| pubkey.to_string()),
+            withdraw_withheld_authority: withdraw_withheld_authority
+                .map(|pubkey| pubkey.to_string()),
+            withheld_amount: u64::from(transfer_fee_config.withheld_amount),
+            older_transfer_fee: transfer_fee_config.older_transfer_fee.into(),
+            newer_transfer_fee: transfer_fee_config.newer_transfer_fee.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiTransferFeeAmount {
+    pub withheld_amount: u64,
+}
+
+impl From<extension::transfer_fee::TransferFeeAmount> for UiTransferFeeAmount {
+    fn from(transfer_fee_amount: extension::transfer_fee::TransferFeeAmount) -> Self {
+        Self {
+            withheld_amount: u64::from(transfer_fee_amount.withheld_amount),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiMintCloseAuthority {
+    pub close_authority: Option<String>,
+}
+
+impl From<extension::mint_close_authority::MintCloseAuthority> for UiMintCloseAuthority {
+    fn from(mint_close_authority: extension::mint_close_authority::MintCloseAuthority) -> Self {
+        let authority: Option<Pubkey> = mint_close_authority.close_authority.into();
+        Self {
+            close_authority: authority.map(|pubkey| pubkey.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiDefaultAccountState {
+    pub account_state: UiAccountState,
+}
+
+impl From<extension::default_account_state::DefaultAccountState> for UiDefaultAccountState {
+    fn from(default_account_state: extension::default_account_state::DefaultAccountState) -> Self {
+        let account_state =
+            spl_token_2022::state::AccountState::try_from(default_account_state.state)
+                .unwrap_or_default();
+        Self {
+            account_state: account_state.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiMemoTransfer {
+    pub require_incoming_transfer_memos: bool,
+}
+
+impl From<extension::memo_transfer::MemoTransfer> for UiMemoTransfer {
+    fn from(memo_transfer: extension::memo_transfer::MemoTransfer) -> Self {
+        Self {
+            require_incoming_transfer_memos: memo_transfer.require_incoming_transfer_memos.into(),
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
After #24619, Rpc can parse token-2022 accounts, but not the extensions

#### Summary of Changes
Parse all token-2022 Account and Mint extensions, except `ConfidentialTransferMint` and `ConfidentialTransferAccount`. I left these out largely due to PR size, but maybe it makes sense to hold off until closer to confidential-transfer launch anyway. Each of those extensions will appear in the extension list, but without any `state` (much like the `immutableOwner` in the example below).

- If any extension fails to parse, this api will currently return `unparseableExtension` in the list. I thought this was better than failing either the extension-parsing, or the account-parsing altogether. Thoughts?
- Thoughts on the response structure? Examples:
```
// An extended Mint
...
"parsed": {
            "info": {
              "decimals": 2,
              "extensions": [
                {
                  "extension": "defaultAccountState",
                  "state": {
                    "accountState": "frozen"
                  }
                },
                {
                  "extension": "mintCloseAuthority",
                  "state": {
                    "closeAuthority": "G8NmZvi3t1x77AyYGBxve1XGnZ5FNYVm33FGiR8dH1MY"
                  }
                }
              ],
              "freezeAuthority": "G8NmZvi3t1x77AyYGBxve1XGnZ5FNYVm33FGiR8dH1MY",
              "isInitialized": true,
              "mintAuthority": "G8NmZvi3t1x77AyYGBxve1XGnZ5FNYVm33FGiR8dH1MY",
              "supply": "0"
            },
            "type": "mint"
          }

// An extended Account
...
"parsed": {
            "info": {
              "extensions": [
                {
                  "extension": "immutableOwner"
                },
                {
                  "extension": "memoTransfer",
                  "state": {
                    "requireIncomingTransferMemos": true
                  }
                }
              ],
              "isNative": false,
              "mint": "3va5pj3hA1gWHpc2ymiQxZB3tZ6Syqk9pKsdtg9XbttU",
              "owner": "G8NmZvi3t1x77AyYGBxve1XGnZ5FNYVm33FGiR8dH1MY",
              "state": "frozen",
              "tokenAmount": {
                "amount": "0",
                "decimals": 2,
                "uiAmount": 0,
                "uiAmountString": "0"
              }
            },
            "type": "account"
          }
```

✅ ~~Needs rebase on #24619 , only last commit should be reviewed~~
✅ ~~Still needs tests~~
