### PR TITLE
Fix Apple touch icon broken link 

### DIFF
--- a/explorer/public/index.html
+++ b/explorer/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Look up transactions and accounts on the various Solana clusters"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/rainbow192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
#### Problem
Apple touch icon had a broken link - it redirected to homepage and does not function as it should

#### Summary of Changes
Updated reference to current valid Apple touch icon (rainbow192.png, prior reference was logo192.png)

Fixes #