### PR TITLE
feat: Support Fungible Asset token standard

### DIFF
--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -10,6 +10,7 @@ export default function isMetaplexNFT(
     data?.parsed.type === "mint" &&
     data?.nftData &&
     mintInfo?.decimals === 0 &&
-    parseInt(mintInfo.supply) === 1
+    (parseInt(mintInfo.supply) === 1 ||
+    data?.nftData?.metadata?.tokenStandard === 1)
   );
 }

--- a/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
+++ b/explorer/src/providers/accounts/utils/isMetaplexNFT.ts
@@ -11,6 +11,6 @@ export default function isMetaplexNFT(
     data?.nftData &&
     mintInfo?.decimals === 0 &&
     (parseInt(mintInfo.supply) === 1 ||
-    data?.nftData?.metadata?.tokenStandard === 1)
+      data?.nftData?.metadata?.tokenStandard === 1)
   );
 }


### PR DESCRIPTION
#### Problem
Explorer currently defines an NFT as any token with decimals = 0 and a supply of exactly one. However, the new [Fungible Asset](https://docs.metaplex.com/token-metadata/specification#token-standards) specification allows for NFT-style tokens with a supply of greater than one.

#### Summary of Changes
Change the `isMetaplexNFT` method to consider the token's `tokenStandard`, if defined.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
