### PR TITLE
Check insert optimization for bank_forks

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -131,7 +131,7 @@ impl BankForks {
             banks.insert(bank.slot(), bank.clone());
             let parents = bank.parents();
             for parent in parents {
-                if let Some(_) = banks.insert(parent.slot(), parent.clone()) {
+                if banks.insert(parent.slot(), parent.clone()).is_some() {
                     // All ancestors have already been inserted by another fork
                     break;
                 }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -131,11 +131,10 @@ impl BankForks {
             banks.insert(bank.slot(), bank.clone());
             let parents = bank.parents();
             for parent in parents {
-                if banks.contains_key(&parent.slot()) {
+                if let Some(_) = banks.insert(parent.slot(), parent.clone()) {
                     // All ancestors have already been inserted by another fork
                     break;
                 }
-                banks.insert(parent.slot(), parent.clone());
             }
         }
         let mut descendants = HashMap::<_, HashSet<_>>::new();


### PR DESCRIPTION
#### Problem
When inserting parent into bank_forks, we perform a check for existence then do the actual insert. This can be optimized by do the insert first, then check that if return is None. Thus, it saves one lookup of the parents.  


#### Summary of Changes
Do the insert first, then check the return value.



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
