### PR TITLE
Make test_next_leader_slot_next_epoch() aware of stake minimum delegation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5103,6 +5103,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-sdk 1.11.0",
+ "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-transaction-status",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -45,6 +45,7 @@ solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.0" }
 solana-runtime = { path = "../runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
+solana-stake-program = { path = "../programs/stake", version = "=1.11.0" }
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.11.0" }
 solana-storage-proto = { path = "../storage-proto", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -518,7 +518,8 @@ mod tests {
             &mint_keypair,
             &vote_account,
             &validator_identity,
-            bootstrap_validator_stake_lamports(),
+            bootstrap_validator_stake_lamports()
+                + solana_stake_program::get_minimum_delegation(&bank.feature_set),
         );
         let node_pubkey = validator_identity.pubkey();
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-sdk 1.11.0",
+ "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-transaction-status",

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -19,7 +19,7 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
 /// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
 /// rent exempt reserve _plus_ the minimum stake delegation.
 #[inline(always)]
-pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
+pub fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
     // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
     // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
     // removed, use it here as to not duplicate magic constants.


### PR DESCRIPTION
#### Problem

The ledger test `test_next_leader_slot_next_epoch()` fails once the stake minimum delegation is raised. See #24603 for more context.

#### Summary of Changes

- Update ledger test_next_leader_slot_next_epoch() to be aware of stake minimum delegation
- ~~Make `get_minimum_delegation` public~~