### PR TITLE
Report metric command queue size

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -186,7 +186,7 @@ impl MetricsAgent {
         max_points: usize,
         max_points_per_sec: usize,
         last_write_time: Instant,
-        cmd_queue_size: usize,
+        points_buffered: usize,
     ) {
         if points.is_empty() {
             return;
@@ -209,7 +209,7 @@ impl MetricsAgent {
                 .add_field_i64("points_written", points_written as i64)
                 .add_field_i64("num_points", num_points as i64)
                 .add_field_i64("points_lost", (num_points - points_written) as i64)
-                .add_field_i64("pending_command_queue_size", cmd_queue_size as i64)
+                .add_field_i64("points_buffered", points_buffered as i64)
                 .add_field_i64(
                     "secs_since_last_write",
                     now.duration_since(last_write_time).as_secs() as i64,

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -186,6 +186,7 @@ impl MetricsAgent {
         max_points: usize,
         max_points_per_sec: usize,
         last_write_time: Instant,
+        cmd_queue_size: usize,
     ) {
         if points.is_empty() {
             return;
@@ -208,6 +209,7 @@ impl MetricsAgent {
                 .add_field_i64("points_written", points_written as i64)
                 .add_field_i64("num_points", num_points as i64)
                 .add_field_i64("points_lost", (num_points - points_written) as i64)
+                .add_field_i64("pending_command_queue_size", cmd_queue_size as i64)
                 .add_field_i64(
                     "secs_since_last_write",
                     now.duration_since(last_write_time).as_secs() as i64,
@@ -239,6 +241,7 @@ impl MetricsAgent {
                             max_points,
                             max_points_per_sec,
                             last_write_time,
+                            receiver.len(),
                         );
                         last_write_time = Instant::now();
                         barrier.wait();
@@ -281,6 +284,7 @@ impl MetricsAgent {
                     max_points,
                     max_points_per_sec,
                     last_write_time,
+                    receiver.len(),
                 );
                 last_write_time = now;
             }


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24319

When logger is spammed, system will use more memory. However, there is no clear indicator of how many pending metrics are in the queue.


#### Summary of Changes

Add a report of metric command queue size.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
