### PR TITLE
hookup 'just_rewrites'

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5013,10 +5013,6 @@ impl Bank {
     /// if 'just_rewrites', function will only update bank's rewrites set and not actually store any accounts
     /// return # accounts loaded
     fn collect_rent_in_partition(&self, partition: Partition, just_rewrites: bool) -> usize {
-        if just_rewrites {
-            // this is not implemented yet. In the meantime, this call can have no side effects.
-            return 0;
-        }
         let subrange = Self::pubkey_range_from_partition(partition);
 
         let thread_pool = &self.rc.accounts.accounts_db.thread_pool;
@@ -5035,7 +5031,7 @@ impl Bank {
         let mut total_collected = CollectedInfo::default();
         let bank_slot = self.slot();
         let mut rewrites_skipped = Vec::with_capacity(accounts.len());
-        let can_skip_rewrites = self.rc.accounts.accounts_db.skip_rewrites;
+        let can_skip_rewrites = self.rc.accounts.accounts_db.skip_rewrites || just_rewrites;
         for (pubkey, mut account, loaded_slot) in accounts {
             let old_rent_epoch = account.rent_epoch();
             let collected = self.rent_collector.collect_from_existing_account(
@@ -5043,7 +5039,6 @@ impl Bank {
                 &mut account,
                 self.rc.accounts.accounts_db.filler_account_suffix.as_ref(),
             );
-            total_collected += collected;
             // only store accounts where we collected rent
             // but get the hash for all these accounts even if collected rent is 0 (= not updated).
             // Also, there's another subtle side-effect from this: this
@@ -5065,6 +5060,7 @@ impl Bank {
                     crate::accounts_db::AccountsDb::hash_account(self.slot(), &account, &pubkey);
                 rewrites_skipped.push((pubkey, hash));
             } else if !just_rewrites {
+                total_collected += collected;
                 self.store_account(&pubkey, &account);
             }
             rent_debits.insert(&pubkey, collected.rent_amount, account.lamports());
@@ -9084,6 +9080,18 @@ pub(crate) mod tests {
             vec![genesis_slot]
         );
 
+        assert_eq!(bank.collected_rent.load(Relaxed), 0);
+        // this should be a no-op because of just_rewrites=true
+        assert!(bank.rewrites_skipped_this_slot.read().unwrap().is_empty());
+        bank.collect_rent_in_partition((0, 0, 1), true);
+        {
+            let rewrites_skipped = bank.rewrites_skipped_this_slot.read().unwrap();
+            assert_eq!(rewrites_skipped.len(), 90);
+            assert!(rewrites_skipped.contains_key(&rent_exempt_pubkey));
+            assert!(!rewrites_skipped.contains_key(&rent_due_pubkey));
+        }
+
+        assert_eq!(bank.collected_rent.load(Relaxed), 0);
         bank.collect_rent_in_partition((0, 0, 1), false); // all range
 
         assert_eq!(bank.collected_rent.load(Relaxed), rent_collected);


### PR DESCRIPTION
#### Problem

rent collection has a mode when loading from snapshot where we need to build the list of skipped rewrites and not actually collect rent from any accounts or store any updates into the bank's append vec. When the validator was running, the population of the skipped rewrites list would have occurred when rent was collected for this bank. That occurred, but the only artifacts remaining are the accounts written to the bank's append vec. The accounts written to the append vec are not sufficient to calculate the bank's hash. We also need skipped rewrites. Skipped rewrites can be recalculated on snapshot load.

#### Summary of Changes

hook that mode up and correctly skip rewrites

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
