### PR TITLE
expand block capacity calc

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -161,9 +161,10 @@ fn sum_additional_costs(batch: &TransactionBatch) -> u64 {
 
     for transaction in transactions {
         let transaction_cost = cost_model.calculate_cost(transaction);
-        additional_costs += transaction_cost.signature_cost;
-        additional_costs += transaction_cost.write_lock_cost;
-        additional_costs += transaction_cost.data_bytes_cost;
+        additiona_costs.saturating_add_in_place(transaction_cost.signature_cost);
+        additiona_costs.saturating_add_in_place(transaction_cost.write_lock_cost);
+        additiona_costs.saturating_add_in_place(transaction_cost.data_bytes_cost);
+        additiona_costs.saturating_add_in_place(transaction_cost.builtins_execution_cost);
     }
     additional_costs
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -160,7 +160,7 @@ fn sum_additional_costs(batch: &TransactionBatch) -> u64 {
     let cost_model = CostModel::new();
 
     for transaction in transactions {
-        let transaction_cost = cost_model.calculate_costs(transaction);     // computing a lot more than it needs to.. make sub-functions public and replace this
+        let transaction_cost = cost_model.calculate_cost(transaction);
         additional_costs += transaction_cost.signature_cost;
         additional_costs += transaction_cost.write_lock_cost;
         additional_costs += transaction_cost.data_bytes_cost;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -160,7 +160,11 @@ fn sum_additional_costs(batch: &TransactionBatch) -> u64 {
     let cost_model = CostModel::new();
 
     for transaction in transactions {
+<<<<<<< HEAD
         let transaction_cost = cost_model.calculate_cost(transaction);
+=======
+        let transaction_cost = cost_model.calculate_costs(transaction);     // computing a lot more than it needs to.. make sub-functions public and replace this
+>>>>>>> 156b608556 (Add additional cost values to capacity-gating of blocks during replay)
         additional_costs += transaction_cost.signature_cost;
         additional_costs += transaction_cost.write_lock_cost;
         additional_costs += transaction_cost.data_bytes_cost;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -161,10 +161,10 @@ fn sum_additional_costs(batch: &TransactionBatch) -> u64 {
 
     for transaction in transactions {
         let transaction_cost = cost_model.calculate_cost(transaction);
-        additiona_costs.saturating_add_in_place(transaction_cost.signature_cost);
-        additiona_costs.saturating_add_in_place(transaction_cost.write_lock_cost);
-        additiona_costs.saturating_add_in_place(transaction_cost.data_bytes_cost);
-        additiona_costs.saturating_add_in_place(transaction_cost.builtins_execution_cost);
+        additional_costs = additional_costs.saturating_add(transaction_cost.signature_cost);
+        additional_costs = additional_costs.saturating_add(transaction_cost.write_lock_cost);
+        additional_costs = additional_costs.saturating_add(transaction_cost.data_bytes_cost);
+        additional_costs = additional_costs.saturating_add(transaction_cost.builtins_execution_cost);
     }
     additional_costs
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -160,11 +160,7 @@ fn sum_additional_costs(batch: &TransactionBatch) -> u64 {
     let cost_model = CostModel::new();
 
     for transaction in transactions {
-<<<<<<< HEAD
         let transaction_cost = cost_model.calculate_cost(transaction);
-=======
-        let transaction_cost = cost_model.calculate_costs(transaction);     // computing a lot more than it needs to.. make sub-functions public and replace this
->>>>>>> 156b608556 (Add additional cost values to capacity-gating of blocks during replay)
         additional_costs += transaction_cost.signature_cost;
         additional_costs += transaction_cost.write_lock_cost;
         additional_costs += transaction_cost.data_bytes_cost;

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -134,16 +134,14 @@ impl CostModel {
         tx_cost: &mut TransactionCost,
         transaction: &SanitizedTransaction,
     ) -> u64 {
-        let write_lock_cost: u64 = 0;
+        let mut write_lock_cost: u64 = 0;
         let message = transaction.message();
         message
             .account_keys()
             .iter()
             .enumerate()
             .for_each(|(i, k)| {
-                let is_writable = message.is_writable(i);
-
-                if is_writable {
+                if message.is_writable(i) {
                     tx_cost.writable_accounts.push(*k);
                     write_lock_cost += WRITE_LOCK_UNITS;
                 }

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -143,7 +143,7 @@ impl CostModel {
             .for_each(|(i, k)| {
                 if message.is_writable(i) {
                     tx_cost.writable_accounts.push(*k);
-                    write_lock_cost += WRITE_LOCK_UNITS;
+                    write_lock_cost.saturating_add_in_place(WRITE_LOCK_UNITS);
                 }
             });
         write_lock_cost

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -95,7 +95,7 @@ impl CostModel {
         let mut tx_cost = TransactionCost::new_with_capacity(MAX_WRITABLE_ACCOUNTS);
 
         tx_cost.signature_cost = self.get_signature_cost(transaction);
-        self.get_write_lock_cost(&mut tx_cost, transaction);
+        tx_cost.write_lock_cost = self.get_write_lock_cost(&mut tx_cost, transaction);
         tx_cost.data_bytes_cost = self.get_data_bytes_cost(transaction);
         (tx_cost.builtins_execution_cost, tx_cost.bpf_execution_cost) =
             self.get_transaction_cost(transaction);
@@ -133,7 +133,8 @@ impl CostModel {
         &self,
         tx_cost: &mut TransactionCost,
         transaction: &SanitizedTransaction,
-    ) {
+    ) -> u64 {
+        let write_lock_cost: u64 = 0;
         let message = transaction.message();
         message
             .account_keys()
@@ -144,9 +145,10 @@ impl CostModel {
 
                 if is_writable {
                     tx_cost.writable_accounts.push(*k);
-                    tx_cost.write_lock_cost += WRITE_LOCK_UNITS;
+                    write_lock_cost += WRITE_LOCK_UNITS;
                 }
             });
+        write_lock_cost
     }
 
     fn get_data_bytes_cost(&self, transaction: &SanitizedTransaction) -> u64 {

--- a/runtime/src/cost_model.rs
+++ b/runtime/src/cost_model.rs
@@ -143,7 +143,7 @@ impl CostModel {
             .for_each(|(i, k)| {
                 if message.is_writable(i) {
                     tx_cost.writable_accounts.push(*k);
-                    write_lock_cost.saturating_add_in_place(WRITE_LOCK_UNITS);
+                    write_lock_cost = write_lock_cost.saturating_add(WRITE_LOCK_UNITS);
                 }
             });
         write_lock_cost


### PR DESCRIPTION
#### Problem
A leader could put more transactions into a block than can be completed during the slot. Could put validators behind on future blocks, an even bigger issue if that validator will soon be a leader.

#### Summary of Changes
If, during replay, we've already taken more time (in compute-unit terms) than fits in a slot, existing code stops work on this block and moves on (if this feature is turned on). This PR expands the capacity-gating of blocks during replay to not only include execution time used, but also three static values -- signature, write-lock, and data bytes costs. This will give a more accurate (and earlier) stopping point if needed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
