### PR TITLE
Remove StakeState::get_rent_exempt_reserve()

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -135,7 +135,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .to_string();
     // stake account
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
-        .max(StakeState::get_rent_exempt_reserve(&rent))
+        .max(rent.minimum_balance(StakeState::size_of()))
         .to_string();
 
     let default_target_tick_duration =
@@ -430,7 +430,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let bootstrap_validator_stake_lamports = rent_exempt_check(
         &matches,
         "bootstrap_validator_stake_lamports",
-        StakeState::get_rent_exempt_reserve(&rent),
+        rent.minimum_balance(StakeState::size_of()),
     )?;
 
     let bootstrap_stake_authorized_pubkey =

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -107,7 +107,7 @@ pub fn create_and_add_stakes(
 
     let mut address_generator = AddressGenerator::new(&authorized.staker, &stake::program::id());
 
-    let stake_rent_reserve = StakeState::get_rent_exempt_reserve(&genesis_config.rent);
+    let stake_rent_reserve = genesis_config.rent.minimum_balance(StakeState::size_of());
 
     for unlock in unlocks {
         let lamports = unlock.amount(stakes_lamports);
@@ -193,7 +193,7 @@ mod tests {
             .iter()
             .all(|(_pubkey, account)| account.lamports <= granularity
                 || account.lamports - granularity
-                    <= StakeState::get_rent_exempt_reserve(&genesis_config.rent)));
+                    <= genesis_config.rent.minimum_balance(StakeState::size_of())));
     }
 
     //    #[ignore]
@@ -238,7 +238,7 @@ mod tests {
             ..Rent::default()
         };
 
-        let reserve = StakeState::get_rent_exempt_reserve(&rent);
+        let reserve = rent.minimum_balance(StakeState::size_of());
         let staker_reserve = rent.minimum_balance(0);
 
         // verify that a small remainder ends up in the last stake

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1043,7 +1043,7 @@ fn main() {
         .max(VoteState::get_rent_exempt_reserve(&rent))
         .to_string();
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
-        .max(StakeState::get_rent_exempt_reserve(&rent))
+        .max(rent.minimum_balance(StakeState::size_of()))
         .to_string();
 
     let matches = App::new(crate_name!())
@@ -2227,7 +2227,7 @@ fn main() {
                     value_t_or_exit!(arg_matches, "bootstrap_validator_lamports", u64);
                 let bootstrap_validator_stake_lamports =
                     value_t_or_exit!(arg_matches, "bootstrap_validator_stake_lamports", u64);
-                let minimum_stake_lamports = StakeState::get_rent_exempt_reserve(&rent);
+                let minimum_stake_lamports = rent.minimum_balance(StakeState::size_of());
                 if bootstrap_validator_stake_lamports < minimum_stake_lamports {
                     eprintln!(
                         "Error: insufficient --bootstrap-validator-stake-lamports. \

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -21,7 +21,7 @@ const VALIDATOR_LAMPORTS: u64 = 42;
 
 // fun fact: rustc is very close to make this const fn.
 pub fn bootstrap_validator_stake_lamports() -> u64 {
-    StakeState::get_rent_exempt_reserve(&Rent::default())
+    Rent::default().minimum_balance(StakeState::size_of())
 }
 
 // Number of lamports automatically used for genesis accounts

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -4,7 +4,6 @@ use {
         clock::{Clock, Epoch, UnixTimestamp},
         instruction::InstructionError,
         pubkey::Pubkey,
-        rent::Rent,
         stake::{
             config::Config,
             instruction::{LockupArgs, StakeError},
@@ -77,10 +76,6 @@ impl StakeState {
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
         200 // see test_size_of
-    }
-
-    pub fn get_rent_exempt_reserve(rent: &Rent) -> u64 {
-        rent.minimum_balance(Self::size_of())
     }
 
     pub fn stake(&self) -> Option<Stake> {


### PR DESCRIPTION
1. `StakeState::get_rent_exempt_reserve()` implicitly makes an assumption about the size of StakeStake, which may not be true in the future. 
2. Additionally, RPC clients tend to not use this method and go directly to `StakeStake::size_of()` anyway since an RPC client doesn't have a `Rent` struct to work with
3. With @brooksprumo's work at #24603, `StakeState::get_rent_exempt_reserve()` becomes even more useless since Stake accounts will require more than rent exempt reserve.
4. Scrubbing this function also points out a couple additional locations in the code base (ledger-tool/ and genesis/)  that will require updating as a part of #24603