### PR TITLE
Add skip account flag to solana-test-validator

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -260,17 +260,26 @@ impl TestValidatorGenesis {
         self
     }
 
-    pub fn clone_accounts<T>(&mut self, addresses: T, rpc_client: &RpcClient) -> &mut Self
+    pub fn clone_accounts<T>(
+        &mut self,
+        addresses: T,
+        rpc_client: &RpcClient,
+        skip_missing: bool,
+    ) -> &mut Self
     where
         T: IntoIterator<Item = Pubkey>,
     {
         for address in addresses {
             info!("Fetching {} over RPC...", address);
-            let account = rpc_client.get_account(&address).unwrap_or_else(|err| {
-                error!("Failed to fetch {}: {}", address, err);
+            let res = rpc_client.get_account(&address);
+            if let Ok(account) = res {
+                self.add_account(address, AccountSharedData::from(account));
+            } else if skip_missing {
+                warn!("Could not find {}, skipping.", address);
+            } else {
+                error!("Failed to fetch {}: {}", address, res.unwrap_err());
                 solana_core::validator::abort();
-            });
-            self.add_account(address, AccountSharedData::from(account));
+            }
         }
         self
     }


### PR DESCRIPTION
#### Problem
currently, `solana-test-validator -u m -c [ADDRESS]` will die if the account doesnt exist

#### Summary of Changes
i added a flag `--skip-missing-accounts` which ignores accounts that dont exist instead and continues fetching down the list. existing behavior without the flag is unchanged

my usecase is i want to take a transaction and generate a `solana-test-validator` command that fetches every account in its account list so i can easily replay the transaction in a test environment. without this flag i would need to fetch every account in my own code to see which ones dont exist, doubling my use of rpc resources