### PR TITLE
chore: re-re-repair web3.js typegen

### DIFF
--- a/web3.js/scripts/typegen.sh
+++ b/web3.js/scripts/typegen.sh
@@ -7,13 +7,16 @@ npx tsc -p tsconfig.d.json -d
 npx rollup -c rollup.config.types.js
 
 # Replace export with closing brace for module declaration
-sed -i='' '$s/export {.*};/}/' lib/index.d.ts
+sed -i.bak '$s/export {.*};/}/' lib/index.d.ts
 
 # Replace declare's with export's
-sed -i='' 's/declare/export/g' lib/index.d.ts
+sed -i.bak 's/declare/export/g' lib/index.d.ts
 
 # Prepend declare module line
-sed -i='' '2s;^;declare module "@solana/web3.js" {\n;' lib/index.d.ts
+sed -i.bak '2s;^;declare module "@solana/web3.js" {\n;' lib/index.d.ts
+
+# Remove backup file from `sed` above
+rm lib/index.d.ts.bak
 
 # Run prettier
 npx prettier --write lib/index.d.ts


### PR DESCRIPTION
This reverts https://github.com/solana-labs/solana/pull/24567. That trick left a file name `lib/index.d.ts=` in the `lib/` directory on OS X.