### PR TITLE
(LedgerStore) Improve RocksDB perf metric samples

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2743,6 +2743,7 @@ pub fn main() {
             "rocksdb_perf_sample_interval",
             usize
         ),
+        ..LedgerColumnOptions::default()
     };
 
     if matches.is_present("halt_on_known_validators_accounts_hash_mismatch") {


### PR DESCRIPTION
#### Summary of Changes
This PR replaces the use of thread_rng in RocksDB perf metric samples by
AtomicU32 with Ordering::Relaxed to improve the performance of determining
whether to sample the current RocksDB's read/write perf metric.

This PR depends on #24761, and #24682.