### PR TITLE
keygen: fix debug build after migration to clap-v3-utils

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -104,7 +104,6 @@ fn no_passphrase_arg<'a>() -> Arg<'a> {
 fn no_outfile_arg<'a>() -> Arg<'a> {
     Arg::new(NO_OUTFILE_ARG.name)
         .long(NO_OUTFILE_ARG.long)
-        .conflicts_with_all(&["outfile", "silent"])
         .help(NO_OUTFILE_ARG.help)
 }
 
@@ -391,7 +390,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 )
                 .key_generation_common_args()
-                .arg(no_outfile_arg())
+                .arg(no_outfile_arg()
+                    .conflicts_with_all(&["outfile", "silent"])
+                )
         )
         .subcommand(
             Command::new("grind")


### PR DESCRIPTION
#### Problem

```
$ target/debug/solana-keygen grind --starts-with a:1

thread 'main' panicked at 'Command grind: Argument or group 'outfile' specified in 'conflicts_with*' for 'no_outfile' does not exist', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.1.8/src/build/debug_asserts.rs:171:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
