### PR TITLE
AccountsDb: Don't use threads for update_index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6143,37 +6143,25 @@ impl AccountsDb {
         previous_slot_entry_was_cached: bool,
     ) -> SlotList<AccountInfo> {
         let target_slot = accounts.target_slot();
-        // using a thread pool here results in deadlock panics from bank_hashes.write()
-        // so, instead we limit how many threads will be created to the same size as the bg thread pool
         let len = std::cmp::min(accounts.len(), infos.len());
-        let chunk_size = std::cmp::max(1, len / quarter_thread_count()); // # pubkeys/thread
-        let batches = 1 + len / chunk_size;
-        (0..batches)
-            .into_par_iter()
-            .map(|batch| {
-                let start = batch * chunk_size;
-                let end = std::cmp::min(start + chunk_size, len);
-                let mut reclaims = Vec::with_capacity((end - start) / 2);
-                (start..end).into_iter().for_each(|i| {
-                    let info = infos[i];
-                    let pubkey_account = (accounts.pubkey(i), accounts.account(i));
-                    let pubkey = pubkey_account.0;
-                    let old_slot = accounts.slot(i);
-                    self.accounts_index.upsert(
-                        target_slot,
-                        old_slot,
-                        pubkey,
-                        pubkey_account.1,
-                        &self.account_indexes,
-                        info,
-                        &mut reclaims,
-                        previous_slot_entry_was_cached,
-                    );
-                });
-                reclaims
-            })
-            .flatten()
-            .collect::<Vec<_>>()
+        let mut reclaims = Vec::with_capacity(len / 2);
+        (0..len).into_iter().for_each(|i| {
+            let info = infos[i];
+            let pubkey_account = (accounts.pubkey(i), accounts.account(i));
+            let pubkey = pubkey_account.0;
+            let old_slot = accounts.slot(i);
+            self.accounts_index.upsert(
+                target_slot,
+                old_slot,
+                pubkey,
+                pubkey_account.1,
+                &self.account_indexes,
+                info,
+                &mut reclaims,
+                previous_slot_entry_was_cached,
+            );
+        });
+        reclaims
     }
 
     fn should_not_shrink(aligned_bytes: u64, total_bytes: u64, num_stores: usize) -> bool {


### PR DESCRIPTION
#### Problem

I was profiling banking-bench runs with `some-batch-only` contention and noticed a lot of time was spent in `update_index()`. That makes sense, because `len` is 3 or something and splitting that up into multiple threads is primarily overhead.

But when I played with having a min_chunk_size I realized that dropping the parallelism also sped up the `none` contention case (where `len > 256`). Hence this patch just removes it completely.

banking-bench results:
```
           none      same-batch-only       full
before    96451          7967              3098
after    133738         15197             10504
```

(--packets-per-batch 128 --batches-per-iteration 6
 --iterations=1200 for none, 200 otherwise)

#### Summary of Changes

Drop parallelism from `update_index()` in accountsdb.