### PR TITLE
Bumps solana_rbpf to v0.2.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6141,9 +6141,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd266a6c58aa37380b52e6ee627762d794840116d796879867e7419445e6fe5"
+checksum = "3dec11db92171a996e44d36fb1d223233f2cefacf9ba6884b33e5baa92a81d37"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.27"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5376,9 +5376,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd266a6c58aa37380b52e6ee627762d794840116d796879867e7419445e6fe5"
+checksum = "3dec11db92171a996e44d36fb1d223233f2cefacf9ba6884b33e5baa92a81d37"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.11.0" }
 solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-measure = { path = "../../measure", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.27"
 solana-runtime = { path = "../../runtime", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -264,7 +264,7 @@ fn run_program(name: &str) -> u64 {
                 if config.enable_instruction_tracing {
                     if i == 1 {
                         if !Tracer::compare(tracer.as_ref().unwrap(), vm.get_tracer()) {
-                            let analysis = Analysis::from_executable(&executable);
+                            let analysis = Analysis::from_executable(&executable).unwrap();
                             let stdout = std::io::stdout();
                             println!("TRACE (interpreted):");
                             tracer
@@ -278,7 +278,7 @@ fn run_program(name: &str) -> u64 {
                                 .unwrap();
                             assert!(false);
                         } else if log_enabled!(Trace) {
-                            let analysis = Analysis::from_executable(&executable);
+                            let analysis = Analysis::from_executable(&executable).unwrap();
                             let mut trace_buffer = Vec::<u8>::new();
                             tracer
                                 .as_ref()

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.27"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3559,7 +3559,7 @@ mod tests {
         let memory_mapping = MemoryMapping::new::<UserError>(
             vec![
                 MemoryRegion::default(),
-                MemoryRegion::new_from_slice(&data, START, 0, false),
+                MemoryRegion::new_readonly(&data, START),
             ],
             &config,
         )
@@ -4126,14 +4126,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4166,14 +4166,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4206,14 +4206,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4246,15 +4246,15 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let config = Config::default();
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.25"
+solana_rbpf = "=0.2.27"

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -382,6 +382,6 @@ impl<'a> LazyAnalysis<'a> {
             return analysis;
         }
         self.analysis
-            .insert(Analysis::from_executable(self.executable))
+            .insert(Analysis::from_executable(self.executable).unwrap())
     }
 }


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.27](https://github.com/solana-labs/rbpf/releases/tag/v0.2.27) was released.

#### Summary of Changes
v0.2.25 => v0.2.27

v0.2.26 was skipped as it had changes that were reverted, see: https://github.com/solana-labs/solana/pull/24647