### PR TITLE
explorer: fix pretty printed logs for native programs without logging

### DIFF
--- a/explorer/src/components/ProgramLogsCardBody.tsx
+++ b/explorer/src/components/ProgramLogsCardBody.tsx
@@ -44,7 +44,11 @@ export function ProgramLogsCardBody({
         let programLogs: InstructionLogs | undefined = logs[logIndex];
         if (programLogs?.invokedProgram === programAddress) {
           logIndex++;
-        } else if (programLogs?.invokedProgram === null && programLogs.logs.length > 0 && NATIVE_PROGRAMS_MISSING_INVOKE_LOG.includes(programAddress)) {
+        } else if (
+          programLogs?.invokedProgram === null &&
+          programLogs.logs.length > 0 &&
+          NATIVE_PROGRAMS_MISSING_INVOKE_LOG.includes(programAddress)
+        ) {
           logIndex++;
         } else {
           programLogs = undefined;

--- a/explorer/src/components/ProgramLogsCardBody.tsx
+++ b/explorer/src/components/ProgramLogsCardBody.tsx
@@ -5,6 +5,14 @@ import { InstructionLogs } from "utils/program-logs";
 import { ProgramName } from "utils/anchor";
 import React from "react";
 
+const NATIVE_PROGRAMS_MISSING_INVOKE_LOG: string[] = [
+  "AddressLookupTab1e1111111111111111111111111",
+  "ZkTokenProof1111111111111111111111111111111",
+  "BPFLoader1111111111111111111111111111111111",
+  "BPFLoader2111111111111111111111111111111111",
+  "BPFLoaderUpgradeab1e11111111111111111111111",
+];
+
 export function ProgramLogsCardBody({
   message,
   logs,
@@ -16,6 +24,7 @@ export function ProgramLogsCardBody({
   cluster: Cluster;
   url: string;
 }) {
+  let logIndex = 0;
   return (
     <TableCardBody>
       {message.instructions.map((ix, index) => {
@@ -30,7 +39,16 @@ export function ProgramLogsCardBody({
         } else {
           programId = ix.programId;
         }
-        const programLogs: InstructionLogs | undefined = logs[index];
+
+        const programAddress = programId.toBase58();
+        let programLogs: InstructionLogs | undefined = logs[logIndex];
+        if (programLogs?.invokedProgram === programAddress) {
+          logIndex++;
+        } else if (programLogs?.invokedProgram === null && programLogs.logs.length > 0 && NATIVE_PROGRAMS_MISSING_INVOKE_LOG.includes(programAddress)) {
+          logIndex++;
+        } else {
+          programLogs = undefined;
+        }
 
         let badgeColor = "white";
         if (programLogs) {

--- a/explorer/src/utils/program-logs.ts
+++ b/explorer/src/utils/program-logs.ts
@@ -10,6 +10,7 @@ export type LogMessage = {
 };
 
 export type InstructionLogs = {
+  invokedProgram: string | null;
   logs: LogMessage[];
   failed: boolean;
 };
@@ -50,6 +51,7 @@ export function prettyProgramLogs(
 
         if (depth === 0) {
           prettyLogs.push({
+            invokedProgram: programAddress,
             logs: [],
             failed: false,
           });
@@ -83,12 +85,13 @@ export function prettyProgramLogs(
       } else {
         if (depth === 0) {
           prettyLogs.push({
+            invokedProgram: null,
             logs: [],
             failed: false,
           });
           depth++;
         }
-        // system transactions don't start with "Program log:"
+        // native program logs don't start with "Program log:"
         prettyLogs[prettyLogs.length - 1].logs.push({
           prefix: prefixBuilder(depth),
           text: log,
@@ -102,6 +105,7 @@ export function prettyProgramLogs(
   // For example BpfUpgradableLoader fails without returning any logs for Upgrade instruction with buffer that doesn't exist
   if (prettyError && prettyLogs.length === 0) {
     prettyLogs.push({
+      invokedProgram: null,
       logs: [],
       failed: true,
     });


### PR DESCRIPTION
#### Problem
Some native programs don't emit logs and so the log pretty printer doesn't properly match up tx instructions and logs

#### Summary of Changes
Only match tx instructions to logs if the program id matches

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
