### PR TITLE
patches bug in data-shred index sanitize

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -519,7 +519,7 @@ impl Shred {
         }
         match self.shred_type() {
             ShredType::Data => {
-                if self.index() as usize > MAX_DATA_SHREDS_PER_SLOT {
+                if self.index() as usize >= MAX_DATA_SHREDS_PER_SLOT {
                     return Err(Error::InvalidDataShredIndex {
                         index: self.index(),
                     });
@@ -2134,6 +2134,14 @@ mod tests {
                     size: 0,
                     payload: 1228,
                 })
+            );
+        }
+        {
+            let mut shred = shred.clone();
+            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32;
+            assert_matches!(
+                shred.sanitize(),
+                Err(Error::InvalidDataShredIndex { index: 32768 })
             );
         }
         {


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/24653
introduced an off-by-one error in data-shred index sanitize.



#### Summary of Changes
Patched the off-by-one error and added test coverage.