### PR TITLE
remove bank epoch_scheduler. use rent_collector's

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1617,8 +1617,12 @@ impl Bank {
         )
     }
 
-    fn get_rent_collector_from(rent_collector: &RentCollector, epoch: Epoch) -> RentCollector {
-        rent_collector.clone_with_epoch(epoch)
+    fn get_rent_collector_from(
+        rent_collector: &RentCollector,
+        epoch_schedule: EpochSchedule,
+        epoch: Epoch,
+    ) -> RentCollector {
+        rent_collector.clone_with_schedule_and_epoch(epoch_schedule, epoch)
     }
 
     fn _new_from_parent(
@@ -1749,7 +1753,11 @@ impl Bank {
             genesis_creation_time: parent.genesis_creation_time,
             slots_per_year: parent.slots_per_year,
             collected_rent: AtomicU64::new(0),
-            rent_collector: Self::get_rent_collector_from(&parent.rent_collector, epoch),
+            rent_collector: Self::get_rent_collector_from(
+                &parent.rent_collector,
+                *parent.epoch_schedule(),
+                epoch,
+            ),
             max_tick_height: (slot + 1) * parent.ticks_per_slot,
             block_height: parent.block_height + 1,
             fee_calculator,
@@ -2121,7 +2129,11 @@ impl Bank {
             fee_rate_governor: fields.fee_rate_governor,
             collected_rent: AtomicU64::new(fields.collected_rent),
             // clone()-ing is needed to consider a gated behavior in rent_collector
-            rent_collector: Self::get_rent_collector_from(&fields.rent_collector, fields.epoch),
+            rent_collector: Self::get_rent_collector_from(
+                &fields.rent_collector,
+                genesis_config.epoch_schedule,
+                fields.epoch,
+            ),
             inflation: Arc::new(RwLock::new(fields.inflation)),
             stakes_cache: StakesCache::new(stakes),
             epoch_stakes: fields.epoch_stakes,

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -77,7 +77,7 @@ impl RentCollector {
         }
     }
 
-    pub fn clone_with_schedule_and_epoch(
+    pub(crate) fn clone_with_schedule_and_epoch(
         &self,
         epoch_schedule: EpochSchedule,
         epoch: Epoch,

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -77,6 +77,18 @@ impl RentCollector {
         }
     }
 
+    pub fn clone_with_schedule_and_epoch(
+        &self,
+        epoch_schedule: EpochSchedule,
+        epoch: Epoch,
+    ) -> Self {
+        Self {
+            epoch_schedule,
+            epoch,
+            ..self.clone()
+        }
+    }
+
     /// true if it is easy to determine this account should consider having rent collected from it
     pub fn should_collect_rent(&self, address: &Pubkey, account: &impl ReadableAccount) -> bool {
         !(account.executable() // executable accounts must be rent-exempt balance


### PR DESCRIPTION
#### Problem
https://discord.com/channels/428295358100013066/439194979856809985/967620591974772756

bank.epoch_schedule and bank.rent_collector.epoch_schedule did not match when loading from a devnet snapshot

#### Summary of Changes
Remove bank.epoch_schedule and use bank.rent_collector.epoch_schdule as the epoch_schedule internally in bank

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
