### PR TITLE
Add configurable limit to number of blocks to check before Bigtable upload

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -14,7 +14,10 @@ use {
         display::println_transaction, CliBlock, CliTransaction, CliTransactionConfirmation,
         OutputFormat,
     },
-    solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType},
+    solana_ledger::{
+        bigtable_upload::ConfirmedBlockUploadConfig, blockstore::Blockstore,
+        blockstore_db::AccessType,
+    },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
     solana_storage_bigtable::CredentialType,
     solana_transaction_status::{
@@ -41,12 +44,17 @@ async fn upload(
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
+    let config = ConfirmedBlockUploadConfig {
+        force_reupload,
+        ..ConfirmedBlockUploadConfig::default()
+    };
+
     solana_ledger::bigtable_upload::upload_confirmed_blocks(
         Arc::new(blockstore),
         bigtable,
         starting_slot,
         ending_slot,
-        force_reupload,
+        config,
         Arc::new(AtomicBool::new(false)),
     )
     .await

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -58,6 +58,9 @@ async fn upload(
         Arc::new(AtomicBool::new(false)),
     )
     .await
+    .map(|last_slot_uploaded| {
+        info!("last slot uploaded: {}", last_slot_uploaded);
+    })
 }
 
 async fn delete_slots(

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -55,7 +55,7 @@ pub async fn upload_confirmed_blocks(
                 starting_slot, err
             )
         })?
-        .filter_map(|(slot, _slot_meta)| {
+        .map_while(|(slot, _slot_meta)| {
             if let Some(ending_slot) = &ending_slot {
                 if slot > *ending_slot {
                     return None;

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -48,14 +48,14 @@ pub async fn upload_confirmed_blocks(
 
     info!("Loading ledger slots starting at {}...", starting_slot);
     let blockstore_slots: Vec<_> = blockstore
-        .slot_meta_iterator(starting_slot)
+        .rooted_slot_iterator(starting_slot)
         .map_err(|err| {
             format!(
                 "Failed to load entries starting from slot {}: {:?}",
                 starting_slot, err
             )
         })?
-        .map_while(|(slot, _slot_meta)| {
+        .map_while(|slot| {
             if let Some(ending_slot) = &ending_slot {
                 if slot > *ending_slot {
                     return None;

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -5,6 +5,7 @@ use {
     solana_measure::measure::Measure,
     solana_sdk::clock::Slot,
     std::{
+        cmp::min,
         collections::HashSet,
         result::Result,
         sync::{
@@ -92,7 +93,11 @@ pub async fn upload_confirmed_blocks(
         let mut start_slot = *first_blockstore_slot;
         while start_slot <= *last_blockstore_slot {
             let mut next_bigtable_slots = loop {
-                match bigtable.get_confirmed_blocks(start_slot, 1000).await {
+                let num_bigtable_blocks = min(1000, config.max_num_slots_to_check * 2);
+                match bigtable
+                    .get_confirmed_blocks(start_slot, num_bigtable_blocks)
+                    .await
+                {
                     Ok(slots) => break slots,
                     Err(err) => {
                         error!("get_confirmed_blocks for {} failed: {:?}", start_slot, err);

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -76,7 +76,7 @@ impl BigTableUploadService {
         config: ConfirmedBlockUploadConfig,
         exit: Arc<AtomicBool>,
     ) {
-        let mut start_slot: u64 = 0;
+        let mut start_slot = blockstore.get_first_available_block().unwrap_or_default();
         loop {
             if exit.load(Ordering::Relaxed) {
                 break;

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -76,7 +76,7 @@ impl BigTableUploadService {
         config: ConfirmedBlockUploadConfig,
         exit: Arc<AtomicBool>,
     ) {
-        let mut start_slot = 0;
+        let mut start_slot: u64 = 0;
         loop {
             if exit.load(Ordering::Relaxed) {
                 break;
@@ -104,7 +104,7 @@ impl BigTableUploadService {
             ));
 
             match result {
-                Ok(()) => start_slot = end_slot,
+                Ok(last_slot_uploaded) => start_slot = last_slot_uploaded,
                 Err(err) => {
                     warn!("bigtable: upload_confirmed_blocks: {}", err);
                     std::thread::sleep(std::time::Duration::from_secs(2));

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -84,9 +84,13 @@ impl BigTableUploadService {
 
             // The highest slot eligible for upload is the highest root that has complete
             // transaction-status metadata
-            let end_slot = min(
+            let highest_complete_root = min(
                 max_complete_transaction_status_slot.load(Ordering::SeqCst),
                 block_commitment_cache.read().unwrap().root(),
+            );
+            let end_slot = min(
+                highest_complete_root,
+                start_slot.saturating_add(config.max_num_slots_to_check as u64 * 2),
             );
 
             if end_slot <= start_slot {

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -82,6 +82,8 @@ impl BigTableUploadService {
                 break;
             }
 
+            // The highest slot eligible for upload is the highest root that has complete
+            // transaction-status metadata
             let end_slot = min(
                 max_complete_transaction_status_slot.load(Ordering::SeqCst),
                 block_commitment_cache.read().unwrap().root(),

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -21,6 +21,7 @@ use {
     solana_client::rpc_cache::LargestAccountsCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
+        bigtable_upload::ConfirmedBlockUploadConfig,
         bigtable_upload_service::BigTableUploadService, blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
     },
@@ -395,12 +396,13 @@ impl JsonRpcService {
                         info!("BigTable ledger storage initialized");
 
                         let bigtable_ledger_upload_service = if enable_bigtable_ledger_upload {
-                            Some(Arc::new(BigTableUploadService::new(
+                            Some(Arc::new(BigTableUploadService::new_with_config(
                                 runtime.clone(),
                                 bigtable_ledger_storage.clone(),
                                 blockstore.clone(),
                                 block_commitment_cache.clone(),
                                 current_transaction_status_slot.clone(),
+                                ConfirmedBlockUploadConfig::default(),
                                 exit_bigtable_ledger_upload_service.clone(),
                             )))
                         } else {


### PR DESCRIPTION
#### Problem
Currently, the Foundation runs several warehouse nodes on mainnet-beta, which upload blocks to BigTable long-term storage. When the warehouse nodes have long queues of blocks to upload to BigTable, they all end up wasting time attempting to serialize and upload the same set of blocks. This is because the check for whether BigTable already has a block is done only once at the beginning of processing that long queue, here: https://github.com/solana-labs/solana/blob/7de339cb5c14d8d8f498b14fc3a3afd390bfb5fc/ledger/src/bigtable_upload.rs#L69

For instance:
```
[2022-04-26T19:00:13.295284511Z INFO  solana_ledger::bigtable_upload] Loading ledger slots starting at 130129788...
[2022-04-26T19:00:13.477310935Z INFO  solana_ledger::bigtable_upload] Found 5714 slots in the range (130129788, 130135957)
[2022-04-26T19:00:13.477340020Z INFO  solana_ledger::bigtable_upload] Loading list of bigtable blocks between slots 130129788 and 130135957...
[2022-04-26T19:00:13.616402326Z INFO  solana_ledger::bigtable_upload] 5713 blocks to be uploaded to the bucket in the range (130129789, 130135957)
```
This node will attempt to upload all 5713 blocks to BigTable regardless of whether another node has uploaded any of them in the meantime.

#### Summary of Changes
Add a configurable limit to the number of blocks to check before starting to serialize and upload blocks. If this limit is set, each node will work on a smaller batch of blocks (default 4 * parallel-block-upload-limit), making it more likely to identify blocks already existing in BigTable.

It turns out this doesn't make a whole lot of difference because uploading is still so slow, but should work better when https://github.com/solana-labs/solana/pull/24534 is added.

Also, found a few other smaller improvements:
- Exit Blockstore iterator early with `map_while` instead of `filter_map`, since once a slot is greater than ending_slot, all the rest will be
- Use `rooted_slot_iterator()` to avoid spending processes checking unrooted slots (if ending_slot is_none, for example)
