### PR TITLE
explorer: replace Block with Slot

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -274,7 +274,7 @@ function StatusCard({
         </tr>
 
         <tr>
-          <td>Block</td>
+          <td>Slot</td>
           <td className="text-lg-end">
             <Slot slot={info.slot} link />
           </td>


### PR DESCRIPTION
#### Problem

I got a question from community.

https://github.com/solana-labs/solana/blob/b48fd4eec273db5cd733532cdc73b7278954ab09/explorer/src/pages/TransactionDetailsPage.tsx#L276-L281

here we use Block instead of Slot

but actually it is a slot number not a block number.

#### Summary of Changes

replace Block with Slot