### PR TITLE
Eliminate circular dependencies in web3 js

### DIFF
--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -37,8 +37,12 @@ function generateConfig(configType, format) {
       }),
     ],
     onwarn: function (warning, rollupWarn) {
-      if (warning.code !== 'CIRCULAR_DEPENDENCY') {
-        rollupWarn(warning);
+      rollupWarn(warning);
+      if (warning.code === 'CIRCULAR_DEPENDENCY') {
+        throw new Error(
+          'Please eliminate the circular dependencies listed ' +
+            'above and retry the build',
+        );
       }
     },
     treeshake: {

--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'buffer';
 import * as BufferLayout from '@solana/buffer-layout';
 
 import {PublicKey} from './publickey';
-import {Transaction, PACKET_DATA_SIZE} from './transaction';
+import {Transaction} from './transaction';
 import {SYSVAR_RENT_PUBKEY} from './sysvar';
 import {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 import {sleep} from './util/sleep';
@@ -10,6 +10,7 @@ import type {Connection} from './connection';
 import type {Signer} from './keypair';
 import {SystemProgram} from './system-program';
 import {IInstructionInputData} from './instruction';
+import {PACKET_DATA_SIZE} from './transaction-constants';
 
 // Keep program chunks under PACKET_DATA_SIZE, leaving enough room for the
 // rest of the Transaction fields

--- a/web3.js/src/message.ts
+++ b/web3.js/src/message.ts
@@ -5,7 +5,7 @@ import * as BufferLayout from '@solana/buffer-layout';
 import {PublicKey} from './publickey';
 import type {Blockhash} from './blockhash';
 import * as Layout from './layout';
-import {PACKET_DATA_SIZE} from './transaction';
+import {PACKET_DATA_SIZE} from './transaction-constants';
 import * as shortvec from './util/shortvec-encoding';
 import {toBuffer} from './util/to-buffer';
 

--- a/web3.js/src/transaction-constants.ts
+++ b/web3.js/src/transaction-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Maximum over-the-wire size of a Transaction
+ *
+ * 1280 is IPv6 minimum MTU
+ * 40 bytes is the size of the IPv6 header
+ * 8 bytes is the size of the fragment header
+ */
+export const PACKET_DATA_SIZE = 1280 - 40 - 8;
+
+export const SIGNATURE_LENGTH_IN_BYTES = 64;

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -2,6 +2,10 @@ import nacl from 'tweetnacl';
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
 
+import {
+  PACKET_DATA_SIZE,
+  SIGNATURE_LENGTH_IN_BYTES,
+} from './transaction-constants';
 import {Connection} from './connection';
 import {Message} from './message';
 import {PublicKey} from './publickey';
@@ -19,21 +23,8 @@ export type TransactionSignature = string;
 
 /**
  * Default (empty) signature
- *
- * Signatures are 64 bytes in length
  */
-const DEFAULT_SIGNATURE = Buffer.alloc(64).fill(0);
-
-/**
- * Maximum over-the-wire size of a Transaction
- *
- * 1280 is IPv6 minimum MTU
- * 40 bytes is the size of the IPv6 header
- * 8 bytes is the size of the fragment header
- */
-export const PACKET_DATA_SIZE = 1280 - 40 - 8;
-
-const SIGNATURE_LENGTH = 64;
+const DEFAULT_SIGNATURE = Buffer.alloc(SIGNATURE_LENGTH_IN_BYTES).fill(0);
 
 /**
  * Account metadata used to define instructions
@@ -747,8 +738,8 @@ export class Transaction {
     const signatureCount = shortvec.decodeLength(byteArray);
     let signatures = [];
     for (let i = 0; i < signatureCount; i++) {
-      const signature = byteArray.slice(0, SIGNATURE_LENGTH);
-      byteArray = byteArray.slice(SIGNATURE_LENGTH);
+      const signature = byteArray.slice(0, SIGNATURE_LENGTH_IN_BYTES);
+      byteArray = byteArray.slice(SIGNATURE_LENGTH_IN_BYTES);
       signatures.push(bs58.encode(Buffer.from(signature)));
     }
 


### PR DESCRIPTION
#### Problem

Circular dependencies are actually really really bad. Let's eliminate them and keep them out.

_Musing: I haven't checked yet, but I wonder if this might have something to do with why some folks are having so much trouble doing tree-shaking._

#### Summary of Changes

* Turn circular dependencies into a build error.
* Actually fix the existing circular deps.