### PR TITLE
test: increase timeout for getEstimatedFee test

### DIFF
--- a/web3.js/test/transaction.test.ts
+++ b/web3.js/test/transaction.test.ts
@@ -134,7 +134,7 @@ describe('Transaction', () => {
 
     const fee = await transaction.getEstimatedFee(connection);
     expect(fee).to.eq(5000);
-  }).timeout(10 * 1000);
+  }).timeout(60 * 1000);
 
   it('partialSign', () => {
     const account1 = Keypair.generate();


### PR DESCRIPTION
#### Problem

See #24730.

#### Summary of Changes

Crank the timeout as a short-term mitigation.