### PR TITLE
Add `solana-client` header to client requests

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -47,11 +47,12 @@ impl HttpSender {
     /// The URL is an HTTP URL, usually for port 8899.
     pub fn new_with_timeout<U: ToString>(url: U, timeout: Duration) -> Self {
         let mut default_headers = header::HeaderMap::new();
-        let user_agent_string =
-            format!("rust-solana-client/{}", solana_version::Version::default());
         default_headers.append(
-            header::USER_AGENT,
-            header::HeaderValue::from_str(user_agent_string.as_str()).unwrap(),
+            header::HeaderName::from_static("solana-client"),
+            header::HeaderValue::from_str(
+                format!("rust/{}", solana_version::Version::default()).as_str(),
+            )
+            .unwrap(),
         );
 
         let client = Arc::new(

--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -71,6 +71,9 @@ function generateConfig(configType, format) {
         values: {
           'process.env.NODE_ENV': JSON.stringify(env),
           'process.env.BROWSER': JSON.stringify(browser),
+          'process.env.npm_package_version': JSON.stringify(
+            process.env.npm_package_version,
+          ),
         },
       }),
     ],

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -995,6 +995,7 @@ function createRpcClient(
           'Content-Type': 'application/json',
         },
         httpHeaders || {},
+        COMMON_HTTP_HEADERS,
       ),
     };
 
@@ -2158,7 +2159,12 @@ export type ConfirmedSignatureInfo = {
 /**
  * An object defining headers to be passed to the RPC server
  */
-export type HttpHeaders = {[header: string]: string};
+export type HttpHeaders = {
+  [header: string]: string;
+} & {
+  // Prohibited headers; for internal use only.
+  'solana-client'?: never;
+};
 
 /**
  * The type of the JavaScript `fetch()` API
@@ -2192,6 +2198,11 @@ export type ConnectionConfig = {
   disableRetryOnRateLimit?: boolean;
   /** time to allow for the server to initially process a transaction (in milliseconds) */
   confirmTransactionInitialTimeout?: number;
+};
+
+/** @internal */
+const COMMON_HTTP_HEADERS = {
+  'solana-client': `js/${process.env.npm_package_version ?? 'UNKNOWN'}`,
 };
 
 /**


### PR DESCRIPTION
#### Problem

RPC providers collect metrics today, but have no way of filtering those metrics by a particular version of the Solana client. This would be useful in identifying regressions (eg. a version of web3.js that's particularly badly behaved) or improvements (eg. a version of the Rust client that reduces load on RPCs).

#### Summary of Changes

Added a `solana-client` HTTP header to each request.

Read and followed this guidance: https://www.rfc-editor.org/rfc/rfc6648#page-4

#### Test plan

##### Rust

The Rust client changes are a follow-on to #26262 that turned out to be a regrettable decision. In #26262 we added a `user-agent` header. This is fine for Rust/Node, but you _can't_ mess with the `user-agent` header in the browser. You _can_ add your own custom header though, which is what should have been done from the start.

```
cd cli && cargo run block 125791054 
```

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/13243/176356690-0a561c59-eba1-4af9-b296-f6866eb84e3a.png">

##### JavaScript
```
(cd web3.js && yarn && yarn build && yarn link)
(cd explorer && npm link @solana/web3.js && npm i && npm start)
```

1. Load up localhost:3000
2. Open the Chrome network panel

Observe that the RPC requests now have headers attached to them.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/13243/176360574-75b6c320-ce3e-4842-a595-98dd6afa1cf7.png">

**NOTE**: This works for RPC requests, but it doesn't work for the WebSocket (ie. RPC subscriptions) because you can't set HTTP headers on WebSocket requests. One idea of something we could do there is to add a version query param (eg. `wss://foo.com:8900/?solweb3_version=1.41.3`).