### PR TITLE
Allow user to override the default CLI config

### DIFF
--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -62,7 +62,7 @@ use std::{
     path::Path,
 };
 pub use {
-    config::{Config, CONFIG_FILE},
+    config::{Config, CONFIG_FILE, CONFIG_FILE_OVERRIDE},
     config_input::{ConfigInput, SettingType},
 };
 

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -167,6 +167,22 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                         ),
                 )
                 .subcommand(
+                    SubCommand::with_name("default")
+                        .about("Set the default config file")
+                        .arg(
+                            Arg::with_name("filepath")
+                                .value_name("FILEPATH")
+                                .required_unless("reset")
+                                .help("Path to the new default config file"),
+                        ).arg(
+                            Arg::with_name("reset")
+                                .value_name("RESET")
+                                .short("r")
+                                .takes_value(false)
+                                .help("Reset to default"),
+                        ),
+                )
+                .subcommand(
                     SubCommand::with_name("import-address-labels")
                         .about("Import a list of address labels")
                         .arg(


### PR DESCRIPTION
#### Problem
During development, there are often cases when the Solana CLI is used to interact with multiple setups/profiles. E.g. wallet A on devnet, wallet A on localnet, wallet B on mainnet.
Afaik the way to handle this currently is to explicitly pass the config file to use as argument (`-C`), but it can become a drag when using the CLI a lot.

#### Summary of Changes
This PR proposes to add the ability for the user to set a different default config file. There are several ways to go about this, but this PR makes use of a new, intermediary, and optional config file located in `~/.config/solana/cli/config_override`, used (when it exists) by the lazy loaded `CONFIG_FILE` to point all consumer functions to this user-defined config file instead of `~/.config/solana/cli/config.yml`.

An example interaction would then be:

```sh
$ solana config get
Config File: /home/ubuntu/.config/solana/cli/config.yml
RPC URL: http://127.0.0.1:8899 
WebSocket URL: ws://127.0.0.1:8900/ (computed)
Keypair Path: /home/ubuntu/.config/solana/id.json 
Commitment: confirmed

$ solana config default /home/ubuntu/tmp/test_override.yml
Default config changed to: /home/ubuntu/tmp/test_override.yml

$ solana config get
Config File: /home/ubuntu/tmp/test_override.yml
RPC URL: http://127.0.0.1:8899 
WebSocket URL: ws://127.0.0.1:8900/ (computed)
Keypair Path: /home/ubuntu/.config/solana/blah.json 
Commitment: confirmed

$ solana config default -r
Default config reset

$ solana config default -r
Already default

$ solana config get
Config File: /home/ubuntu/.config/solana/cli/config.yml
RPC URL: http://127.0.0.1:8899 
WebSocket URL: ws://127.0.0.1:8900/ (computed)
Keypair Path: /home/ubuntu/.config/solana/id.json 
Commitment: confirmed
```

If this proposal is deemed useful, please let me know if there are UX aspects and refactors you'd like. For instance atm nothing prevents a user from providing a non-existent config path, in which case the config currently seems to fallback on each field's default. It does not overly shock me as I would quickly be able to figure out that the path is wrong through e.g.:
```
$ solana config get
Config File: /path/with/a/typo/maybe.yml
RPC URL: https://api.mainnet-beta.solana.com 
WebSocket URL: wss://api.mainnet-beta.solana.com/ (computed)
Keypair Path: /home/ubuntu/.config/solana/id.json 
Commitment: confirmed
```
but maybe it's just me.