### PR TITLE
cli: Feature status improvements

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -108,7 +108,9 @@ impl Ord for CliFeature {
 #[serde(rename_all = "camelCase")]
 pub struct CliFeatures {
     pub features: Vec<CliFeature>,
+    #[serde(skip)]
     pub epoch_schedule: EpochSchedule,
+    #[serde(skip)]
     pub current_slot: Slot,
     pub feature_activation_allowed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -447,7 +447,8 @@ pub fn parse_feature_subcommand(
             } else {
                 FEATURE_NAMES.keys().cloned().collect()
             };
-            let display_all = matches.is_present("display_all");
+            let display_all =
+                matches.is_present("display_all") || features.len() < FEATURE_NAMES.len();
             features.sort();
             CliCommandInfo {
                 command: CliCommand::Feature(FeatureCliCommand::Status {

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -126,8 +126,8 @@ impl fmt::Display for CliFeatures {
                 f,
                 "{}",
                 style(format!(
-                    "{:<44} | {:<23} | {}",
-                    "Feature", "Status", "Description"
+                    "{:<44} | {:<23} | {} | {}",
+                    "Feature", "Status", "Activation Slot", "Description"
                 ))
                 .bold()
             )?;
@@ -135,7 +135,7 @@ impl fmt::Display for CliFeatures {
         for feature in &self.features {
             writeln!(
                 f,
-                "{:<44} | {:<23} | {}",
+                "{:<44} | {:<23} | {:<15} | {}",
                 feature.id,
                 match feature.status {
                     CliFeatureStatus::Inactive => style("inactive".to_string()).red(),
@@ -147,6 +147,10 @@ impl fmt::Display for CliFeatures {
                         let activation_epoch = self.epoch_schedule.get_epoch(activation_slot);
                         style(format!("active since epoch {}", activation_epoch)).green()
                     }
+                },
+                match feature.status {
+                    CliFeatureStatus::Active(activation_slot) => activation_slot.to_string(),
+                    _ => "NA".to_string(),
                 },
                 feature.description,
             )?;

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -119,13 +119,13 @@ pub struct CliFeatures {
 
 impl fmt::Display for CliFeatures {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.features.len() > 0 {
+        if !self.features.is_empty() {
             writeln!(
                 f,
                 "{}",
                 style(format!(
-                    "{:<44} | {:<9} | {} | {}",
-                    "Feature", "Status", "Epoch", "Description"
+                    "{:<44} | {:<23} | {}",
+                    "Feature", "Status", "Description"
                 ))
                 .bold()
             )?;
@@ -133,22 +133,17 @@ impl fmt::Display for CliFeatures {
         for feature in &self.features {
             writeln!(
                 f,
-                "{:<44} | {:<9} | {:<5} | {}",
+                "{:<44} | {:<23} | {}",
                 feature.id,
                 match feature.status {
-                    CliFeatureStatus::Inactive => style("inactive").red(),
-                    CliFeatureStatus::Pending => style("pending").yellow(),
-                    CliFeatureStatus::Active(_) => style("activated").green(),
-                },
-                match feature.status {
-                    CliFeatureStatus::Inactive => style("NA".to_string()).red(),
+                    CliFeatureStatus::Inactive => style("inactive".to_string()).red(),
                     CliFeatureStatus::Pending => {
                         let current_epoch = self.epoch_schedule.get_epoch(self.current_slot);
-                        style((current_epoch + 1).to_string()).yellow()
+                        style(format!("pending until epoch {}", current_epoch + 1)).yellow()
                     }
                     CliFeatureStatus::Active(activation_slot) => {
                         let activation_epoch = self.epoch_schedule.get_epoch(activation_slot);
-                        style(activation_epoch.to_string()).green()
+                        style(format!("active since epoch {}", activation_epoch)).green()
                     }
                 },
                 feature.description,


### PR DESCRIPTION
#### Problems
- Features are always activated at epoch boundaries so it's not very useful to display the activation slot.
- The status of old features is not displayed even when querying specifically for them

#### Summary of Changes
- Use the epoch schedule to display the activation epoch of features instead of the activation slot
- Always display the status for old features if they are being specifically queried for
- Display the epoch for a pending feature

<img width="1194" alt="截圖 2022-04-27 下午11 19 08" src="https://user-images.githubusercontent.com/1076145/165552813-acdc7713-eb6c-4d88-8e25-2047f1152c2e.png">



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
