### PR TITLE
Limit batches size to avoid sigverify starving the banking stage during tx spam

### DIFF
--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -267,13 +267,17 @@ pub fn recv_vec_packet_batches(
         .iter()
         .map(|packets| packets.packets.len())
         .sum::<usize>();
-    while let Ok(packet_batch) = recvr.try_recv() {
-        trace!("got more packets");
-        num_packets += packet_batch
-            .iter()
-            .map(|packets| packets.packets.len())
-            .sum::<usize>();
-        packet_batches.extend(packet_batch);
+    while num_packets < 100_000 {
+        if let Ok(packet_batch) = recvr.try_recv() {
+            trace!("got more packets");
+            num_packets += packet_batch
+                .iter()
+                .map(|packets| packets.packets.len())
+                .sum::<usize>();
+            packet_batches.extend(packet_batch);
+        } else {
+            break;
+        }
     }
     let recv_duration = recv_start.elapsed();
     trace!(
@@ -293,10 +297,14 @@ pub fn recv_packet_batches(
     trace!("got packets");
     let mut num_packets = packet_batch.packets.len();
     let mut packet_batches = vec![packet_batch];
-    while let Ok(packet_batch) = recvr.try_recv() {
-        trace!("got more packets");
-        num_packets += packet_batch.packets.len();
-        packet_batches.push(packet_batch);
+    while num_packets < 100_000 {
+        if let Ok(packet_batch) = recvr.try_recv() {
+            trace!("got more packets");
+            num_packets += packet_batch.packets.len();
+            packet_batches.push(packet_batch);
+        } else {
+            break;
+        }
     }
     let recv_duration = recv_start.elapsed();
     trace!(


### PR DESCRIPTION
#### Problem

In times of transaction spam, the sigverify stage takes too long to process a `Vec<PacketBatch>` and thereby stalls the banking stage.

Look at
![image](https://user-images.githubusercontent.com/833306/165556730-a15d4410-90a5-45bd-9e88-333bac909c0c.png)
This graph shows that the banking stage spent >400ms in `receive_and_buffer_packets` during a recent tx spam incident (don't mind the `_us` postfix, that's wrong).

Upon investigation, I belive this happens because the banking stage has processed all its batches and is not receiving more from sigverify. Check out what happens to `total_shrink_time` during the incident:
![image](https://user-images.githubusercontent.com/833306/165557176-d3dece7c-77a1-4e96-bbd8-fc96666300be.png)

The metric is in microseconds. Sigverify aims to report metrics every 2s, yet reports 7s+ in `shrink` alone. This suggests that a single call of `SigVerifyStage::verifier` is taking more than 7s to complete. (Note that there are no good total-time-taken metrics for dedup/discard/verify, they might take even more time)

More evidence for this interpretation is that the `packets_90pct` metric will be equal to `total_packets` during spam events.

Since messages are sent to the banking stage queue only at the end of the call, this means that no further packet batches are available to the banking stage for a long while, effectively causing a denial of service and small blocks.

#### Summary of Changes

Limit the number of packets in a list of batches to 100k. This is an arbitrary number and the patch is just to illustrate the point and start discussion.

@taozhu-chicago 