### PR TITLE
Increase worker thread limits in quic streamer runtime

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -31,6 +31,7 @@ use {
 
 pub const MAX_STAKED_CONNECTIONS: usize = 2000;
 pub const MAX_UNSTAKED_CONNECTIONS: usize = 500;
+const NUM_QUIC_STREAMER_WORKER_THREADS: usize = 4;
 
 /// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
@@ -131,7 +132,7 @@ fn new_cert_params(identity_keypair: &Keypair, san: IpAddr) -> CertificateParams
 
 fn rt() -> Runtime {
     Builder::new_multi_thread()
-        .worker_threads(1)
+        .worker_threads(NUM_QUIC_STREAMER_WORKER_THREADS)
         .enable_all()
         .build()
         .unwrap()
@@ -700,8 +701,9 @@ mod test {
             let mut s1 = conn1.connection.open_uni().await.unwrap();
             let mut s2 = conn2.connection.open_uni().await.unwrap();
             s1.write_all(&[0u8]).await.unwrap();
+            s2.write_all(&[0u8]).await.unwrap();
             s1.finish().await.unwrap();
-            s2.write_all(&[0u8])
+            s2.finish()
                 .await
                 .expect_err("shouldn't be able to open 2 connections");
         });

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -597,6 +597,7 @@ mod test {
         quinn::{ClientConfig, NewConnection},
         solana_sdk::quic::QUIC_KEEP_ALIVE_MS,
         std::{net::SocketAddr, time::Instant},
+        tokio::time::sleep,
     };
 
     struct SkipServerVerification;
@@ -703,6 +704,9 @@ mod test {
             s1.write_all(&[0u8]).await.unwrap();
             s2.write_all(&[0u8]).await.unwrap();
             s1.finish().await.unwrap();
+            // Wait for a few milliseconds to allow connection close state to
+            // propagate from server to the client
+            sleep(Duration::from_millis(10)).await;
             s2.finish()
                 .await
                 .expect_err("shouldn't be able to open 2 connections");


### PR DESCRIPTION
#### Problem
The original PR (#24535) was merged but caused flakiness in the CI. `test_quic_server_block_multiple_connections` was failing sporadically. #24535 was reverted due to the CI failures.

#### Summary of Changes
This is a resubmit of the original PR along with a fix to the flaky test.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
