### PR TITLE
explorer: Support filtering block transactions by account

### DIFF
--- a/explorer/src/components/block/BlockAccountsCard.tsx
+++ b/explorer/src/components/block/BlockAccountsCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { BlockResponse, PublicKey } from "@solana/web3.js";
 import { Address } from "components/common/Address";
+import { Link } from "react-router-dom";
+import { clusterPath } from "utils/url";
 
 type AccountStats = {
   reads: number;
@@ -9,7 +11,13 @@ type AccountStats = {
 
 const PAGE_SIZE = 25;
 
-export function BlockAccountsCard({ block }: { block: BlockResponse }) {
+export function BlockAccountsCard({
+  block,
+  blockSlot,
+}: {
+  block: BlockResponse;
+  blockSlot: number;
+}) {
   const [numDisplayed, setNumDisplayed] = React.useState(10);
   const totalTransactions = block.transactions.length;
 
@@ -76,7 +84,16 @@ export function BlockAccountsCard({ block }: { block: BlockResponse }) {
                 return (
                   <tr key={address}>
                     <td>
-                      <Address pubkey={new PublicKey(address)} link />
+                      <Link
+                        to={clusterPath(
+                          `/block/${blockSlot}`,
+                          new URLSearchParams(
+                            `accountFilter=${address}&filter=all`
+                          )
+                        )}
+                      >
+                        <Address pubkey={new PublicKey(address)} />
+                      </Link>
                     </td>
                     <td>{writes}</td>
                     <td>{reads}</td>

--- a/explorer/src/components/block/BlockOverviewCard.tsx
+++ b/explorer/src/components/block/BlockOverviewCard.tsx
@@ -230,7 +230,9 @@ function MoreSection({
       </div>
       {tab === undefined && <BlockHistoryCard block={block} />}
       {tab === "rewards" && <BlockRewardsCard block={block} />}
-      {tab === "accounts" && <BlockAccountsCard block={block} />}
+      {tab === "accounts" && (
+        <BlockAccountsCard block={block} blockSlot={slot} />
+      )}
       {tab === "programs" && <BlockProgramsCard block={block} />}
     </>
   );


### PR DESCRIPTION
#### Summary of Changes
- Add support for "accountFilter" url param
- When accounts are clicked from a block's "Accounts" tab, it will open a filtered view of txs that load that account

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
