### PR TITLE
Add cloned to bank in block_subscribe

### DIFF
--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -942,7 +942,8 @@ impl RpcSubscriptions {
                 SubscriptionParams::Block(params) => {
                     num_blocks_found.fetch_add(1, Ordering::Relaxed);
                     if let Some(slot) = slot {
-                        if let Some(bank) = bank_forks.read().unwrap().get(slot) {
+                        let bank = bank_forks.read().unwrap().get(slot).cloned();
+                        if let Some(bank) = bank {
                             // We're calling it unnotified in this context
                             // because, logically, it gets set to `last_notified_slot + 1`
                             // on the final iteration of the loop down below.


### PR DESCRIPTION
#### Problem
On my M1 Max, was running into some type of bank_forks deadlock issue. I'm not able to reproduce it yet on my Linux machine, but changing to this makes the issue go away.

#### Summary of Changes
Add .cloned() to bank and drop lock immediately after grabbing Arc<Bank>
