### PR TITLE
Bump solana_rbpf to v0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6119,9 +6119,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.26"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec5c1525c69ec74323d6a2d145a29b51844c4153a2cd5e4ac0d08b3fe81c806"
+checksum = "036b2de45fa94424288070fe8f4cb5fa266c203af6e5ec56a33ccf0909d9448d"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-solana_rbpf = "=0.2.26"
+solana_rbpf = "=0.2.28"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.30"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5377,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.26"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec5c1525c69ec74323d6a2d145a29b51844c4153a2cd5e4ac0d08b3fe81c806"
+checksum = "036b2de45fa94424288070fe8f4cb5fa266c203af6e5ec56a33ccf0909d9448d"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.11.0" }
 solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-measure = { path = "../../measure", version = "=1.11.0" }
-solana_rbpf = "=0.2.26"
+solana_rbpf = "=0.2.28"
 solana-runtime = { path = "../../runtime", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -264,7 +264,7 @@ fn run_program(name: &str) -> u64 {
                 if config.enable_instruction_tracing {
                     if i == 1 {
                         if !Tracer::compare(tracer.as_ref().unwrap(), vm.get_tracer()) {
-                            let analysis = Analysis::from_executable(&executable);
+                            let analysis = Analysis::from_executable(&executable).unwrap();
                             let stdout = std::io::stdout();
                             println!("TRACE (interpreted):");
                             tracer
@@ -278,7 +278,7 @@ fn run_program(name: &str) -> u64 {
                                 .unwrap();
                             assert!(false);
                         } else if log_enabled!(Trace) {
-                            let analysis = Analysis::from_executable(&executable);
+                            let analysis = Analysis::from_executable(&executable).unwrap();
                             let mut trace_buffer = Vec::<u8>::new();
                             tracer
                                 .as_ref()

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.26"
+solana_rbpf = "=0.2.28"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -28,9 +28,10 @@ use {
     },
     solana_rbpf::{
         aligned_memory::AlignedMemory,
-        ebpf::HOST_ALIGN,
+        ebpf::{HOST_ALIGN, MM_INPUT_START},
         elf::Executable,
         error::{EbpfError, UserDefinedError},
+        memory_region::MemoryRegion,
         static_analysis::Analysis,
         verifier::{self, VerifierError},
         vm::{Config, EbpfVm, InstructionMeter},
@@ -149,6 +150,8 @@ pub fn create_executor(
         dynamic_stack_frames: false,
         enable_sdiv: false,
         optimize_rodata: false,
+        static_syscalls: false,
+        enable_elf_vaddr: false,
         // Warning, do not use `Config::default()` so that configuration here is explicit.
     };
     let mut create_executor_metrics = executor_metrics::CreateMetrics::default();
@@ -262,7 +265,8 @@ pub fn create_vm<'a, 'b>(
     }
     let mut heap =
         AlignedMemory::new_with_size(compute_budget.heap_size.unwrap_or(HEAP_LENGTH), HOST_ALIGN);
-    let mut vm = EbpfVm::new(program, heap.as_slice_mut(), parameter_bytes)?;
+    let parameter_region = MemoryRegion::new_writable(parameter_bytes, MM_INPUT_START);
+    let mut vm = EbpfVm::new(program, heap.as_slice_mut(), vec![parameter_region])?;
     syscalls::bind_syscall_context_objects(&mut vm, invoke_context, heap)?;
     Ok(vm)
 }
@@ -1197,7 +1201,7 @@ impl Executor for BpfExecutor {
             );
             if log_enabled!(Trace) {
                 let mut trace_buffer = Vec::<u8>::new();
-                let analysis = Analysis::from_executable(&self.executable);
+                let analysis = Analysis::from_executable(&self.executable).unwrap();
                 vm.get_tracer().write(&mut trace_buffer, &analysis).unwrap();
                 let trace_string = String::from_utf8(trace_buffer).unwrap();
                 trace!("BPF Program Instruction Trace:\n{}", trace_string);
@@ -1358,7 +1362,7 @@ mod tests {
             0x05, 0x00, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x00, // goto -2
             0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
         ];
-        let input = &mut [0x00];
+        let mut input_mem = [0x00];
         let config = Config::default();
         let syscall_registry = SyscallRegistry::default();
         let mut bpf_functions = std::collections::BTreeMap::<u32, (usize, String)>::new();
@@ -1378,8 +1382,10 @@ mod tests {
             bpf_functions,
         )
         .unwrap();
+        let input_region = MemoryRegion::new_writable(&mut input_mem, MM_INPUT_START);
         let mut vm =
-            EbpfVm::<BpfError, TestInstructionMeter>::new(&program, &mut [], input).unwrap();
+            EbpfVm::<BpfError, TestInstructionMeter>::new(&program, &mut [], vec![input_region])
+                .unwrap();
         let mut instruction_meter = TestInstructionMeter { remaining: 10 };
         vm.execute_program_interpreted(&mut instruction_meter)
             .unwrap();

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -389,8 +389,7 @@ pub fn bind_syscall_context_objects<'a, 'b>(
         .map_err(SyscallError::InstructionError)?;
 
     let invoke_context = Rc::new(RefCell::new(invoke_context));
-
-    vm.bind_syscall_context_objects(invoke_context, None)?;
+    vm.bind_syscall_context_objects(invoke_context)?;
 
     Ok(())
 }
@@ -3396,7 +3395,7 @@ mod tests {
         let memory_mapping = MemoryMapping::new::<UserError>(
             vec![
                 MemoryRegion::default(),
-                MemoryRegion::new_from_slice(&data, START, 0, false),
+                MemoryRegion::new_readonly(&data, START),
             ],
             &config,
         )
@@ -3963,14 +3962,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4003,14 +4002,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4043,14 +4042,14 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )
@@ -4083,15 +4082,15 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
             let config = Config::default();
             let memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_PROGRAM_START, 0, false),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_STACK_START, 4096, true),
-                    MemoryRegion::new_from_slice(heap.as_slice(), ebpf::MM_HEAP_START, 0, true),
-                    MemoryRegion::new_from_slice(&[], ebpf::MM_INPUT_START, 0, true),
+                    MemoryRegion::new_readonly(&[], ebpf::MM_PROGRAM_START),
+                    MemoryRegion::new_writable_gapped(&mut [], ebpf::MM_STACK_START, 4096),
+                    MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+                    MemoryRegion::new_writable(&mut [], ebpf::MM_INPUT_START),
                 ],
                 &config,
             )

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -22,4 +22,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.26"
+solana_rbpf = "=0.2.28"

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -427,6 +427,6 @@ impl<'a> LazyAnalysis<'a> {
             return analysis;
         }
         self.analysis
-            .insert(Analysis::from_executable(self.executable))
+            .insert(Analysis::from_executable(self.executable).unwrap())
     }
 }


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.28](https://github.com/solana-labs/rbpf/releases/tag/v0.2.28) was released.

#### Summary of Changes
v0.2.26 => v0.2.28

The bump to v0.2.27 was reverted, see: https://github.com/solana-labs/solana/pull/24724