### PR TITLE
Update all BankForks methods to return owned values

### DIFF
--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -125,7 +125,7 @@ fn test_account_subscription() {
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-    let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+    let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
@@ -331,7 +331,7 @@ fn test_program_subscription() {
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-    let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+    let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let bob = Keypair::new();
@@ -418,7 +418,7 @@ fn test_root_subscription() {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-    let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+    let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -70,12 +70,7 @@ fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
     bench.iter(move || {
         for _ in 0..num_banks {
             let _ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-            let _descendants = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .descendants()
-                .clone();
+            let _descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         }
     });
 }

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -1442,7 +1442,7 @@ mod test {
         ReplayStage::dump_then_repair_correct_slots(
             &mut duplicate_slots_to_repair,
             &mut bank_forks.read().unwrap().ancestors(),
-            &mut bank_forks.read().unwrap().descendants().clone(),
+            &mut bank_forks.read().unwrap().descendants(),
             &mut progress,
             &bank_forks,
             &requester_blockstore,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1362,7 +1362,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let vote_tracker = VoteTracker::default();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1473,7 +1473,7 @@ mod tests {
         let vote_tracker = VoteTracker::default();
         let exit = Arc::new(AtomicBool::new(false));
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank = bank_forks.read().unwrap().get(0).unwrap();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());

--- a/core/src/cluster_slot_state_verifier.rs
+++ b/core/src/cluster_slot_state_verifier.rs
@@ -1336,14 +1336,7 @@ mod test {
         // Create simple fork 0 -> 1 -> 2 -> 3
         let forks = tr(0) / (tr(1) / (tr(2) / tr(3)));
         let (vote_simulator, blockstore) = setup_forks_from_tree(forks, 1, None);
-
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
-
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         InitialState {
             heaviest_subtree_fork_choice: vote_simulator.heaviest_subtree_fork_choice,
             progress: vote_simulator.progress,

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -516,7 +516,7 @@ mod tests {
         // Create enough banks such that vote account will root slots 0 and 1
         for x in 0..33 {
             let previous_bank = bank_forks.get(x).unwrap();
-            let bank = Bank::new_from_parent(previous_bank, &Pubkey::default(), x + 1);
+            let bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), x + 1);
             let vote = vote_transaction::new_vote_transaction(
                 vec![x],
                 previous_bank.hash(),
@@ -541,7 +541,7 @@ mod tests {
 
         // Add an additional bank/vote that will root slot 2
         let bank33 = bank_forks.get(33).unwrap();
-        let bank34 = Bank::new_from_parent(bank33, &Pubkey::default(), 34);
+        let bank34 = Bank::new_from_parent(&bank33, &Pubkey::default(), 34);
         let vote33 = vote_transaction::new_vote_transaction(
             vec![33],
             bank33.hash(),
@@ -584,7 +584,7 @@ mod tests {
         // Add a forked bank. Because the vote for bank 33 landed in the non-ancestor, the vote
         // account's root (and thus the highest_confirmed_root) rolls back to slot 1
         let bank33 = bank_forks.get(33).unwrap();
-        let bank35 = Bank::new_from_parent(bank33, &Pubkey::default(), 35);
+        let bank35 = Bank::new_from_parent(&bank33, &Pubkey::default(), 35);
         bank_forks.insert(bank35);
 
         let working_bank = bank_forks.working_bank();
@@ -609,7 +609,7 @@ mod tests {
         // continues normally
         for x in 35..=37 {
             let previous_bank = bank_forks.get(x).unwrap();
-            let bank = Bank::new_from_parent(previous_bank, &Pubkey::default(), x + 1);
+            let bank = Bank::new_from_parent(&previous_bank, &Pubkey::default(), x + 1);
             let vote = vote_transaction::new_vote_transaction(
                 vec![x],
                 previous_bank.hash(),

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -244,8 +244,7 @@ impl Tower {
             .get_with_checked_hash((best_slot, best_hash))
             .expect(
                 "The best overall slot must be one of `frozen_banks` which all exist in bank_forks",
-            )
-            .clone();
+            );
 
         Self::new(node_pubkey, vote_account, root, &heaviest_bank)
     }
@@ -1522,13 +1521,7 @@ pub mod test {
         // Init state
         assert!(num_accounts > 1);
         let mut vote_simulator = VoteSimulator::new(num_accounts);
-        let bank0 = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .get(0)
-            .unwrap()
-            .clone();
+        let bank0 = vote_simulator.bank_forks.read().unwrap().get(0).unwrap();
         let total_stake = bank0.total_epoch_stake();
         assert_eq!(
             total_stake,
@@ -1560,12 +1553,7 @@ pub mod test {
     fn run_test_switch_threshold_duplicate_rollback(should_panic: bool) {
         let (bank0, mut vote_simulator, total_stake) = setup_switch_test(2);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         let mut tower = Tower::default();
 
         // Last vote is 47
@@ -1666,12 +1654,7 @@ pub mod test {
     fn test_switch_threshold() {
         let (bank0, mut vote_simulator, total_stake) = setup_switch_test(2);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let mut descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let mut descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         let mut tower = Tower::default();
         let other_vote_account = vote_simulator.vote_pubkeys[1];
 
@@ -1819,12 +1802,7 @@ pub mod test {
         tower.vote_state.root_slot = Some(43);
         // Refresh ancestors and descendants for new root.
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
 
         assert_eq!(
             tower.check_switch_threshold(
@@ -1846,12 +1824,7 @@ pub mod test {
         let num_validators = 2;
         let (bank0, mut vote_simulator, total_stake) = setup_switch_test(2);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         let mut tower = Tower::default();
         let other_vote_account = vote_simulator.vote_pubkeys[1];
 
@@ -1927,12 +1900,7 @@ pub mod test {
         // included in the switching proof
         vote_simulator.set_root(44);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         assert_eq!(
             tower.check_switch_threshold(
                 110,
@@ -2574,13 +2542,7 @@ pub mod test {
         // Init state
         let mut vote_simulator = VoteSimulator::new(2);
         let other_vote_account = vote_simulator.vote_pubkeys[1];
-        let bank0 = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .get(0)
-            .unwrap()
-            .clone();
+        let bank0 = vote_simulator.bank_forks.read().unwrap().get(0).unwrap();
         let total_stake = bank0.total_epoch_stake();
         assert_eq!(
             total_stake,
@@ -2605,12 +2567,7 @@ pub mod test {
         }
 
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         let mut tower = Tower::default();
 
         tower.record_vote(43, Hash::default());
@@ -2679,13 +2636,7 @@ pub mod test {
         // Prepare simulated validator restart!
         let mut vote_simulator = VoteSimulator::new(2);
         let other_vote_account = vote_simulator.vote_pubkeys[1];
-        let bank0 = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .get(0)
-            .unwrap()
-            .clone();
+        let bank0 = vote_simulator.bank_forks.read().unwrap().get(0).unwrap();
         let total_stake = bank0.total_epoch_stake();
         let forks = tr(0)
             / (tr(1)
@@ -2708,12 +2659,7 @@ pub mod test {
         let mut slot_history = SlotHistory::default();
         vote_simulator.set_root(replayed_root_slot);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-        let descendants = vote_simulator
-            .bank_forks
-            .read()
-            .unwrap()
-            .descendants()
-            .clone();
+        let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         for slot in &[0, 1, 2, 43, replayed_root_slot] {
             slot_history.add(*slot);
         }

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -969,15 +969,11 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
         (
             r_bank_forks
                 .get_with_checked_hash(self.best_overall_slot())
-                .unwrap()
-                .clone(),
+                .unwrap(),
             self.heaviest_slot_on_same_voted_fork(tower)
                 .map(|slot_hash| {
                     // BankForks should only contain one valid version of this slot
-                    r_bank_forks
-                        .get_with_checked_hash(slot_hash)
-                        .unwrap()
-                        .clone()
+                    r_bank_forks.get_with_checked_hash(slot_hash).unwrap()
                 }),
         )
     }

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -177,13 +177,7 @@ mod test {
             let optimistic_slots = vec![(1, bad_bank_hash), (3, Hash::default())];
             optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(optimistic_slots);
             let vote_simulator = setup_forks();
-            let bank1 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(1)
-                .cloned()
-                .unwrap();
+            let bank1 = vote_simulator.bank_forks.read().unwrap().get(1).unwrap();
             assert_eq!(
                 optimistic_confirmation_verifier
                     .verify_for_unrooted_optimistic_slots(&bank1, &blockstore),
@@ -225,13 +219,7 @@ mod test {
             // If root is on same fork, nothing should be returned
             optimistic_confirmation_verifier
                 .add_new_optimistic_confirmed_slots(optimistic_slots.clone());
-            let bank5 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(5)
-                .cloned()
-                .unwrap();
+            let bank5 = vote_simulator.bank_forks.read().unwrap().get(5).unwrap();
             assert!(optimistic_confirmation_verifier
                 .verify_for_unrooted_optimistic_slots(&bank5, &blockstore)
                 .is_empty());
@@ -241,13 +229,7 @@ mod test {
             // If root is on same fork, nothing should be returned
             optimistic_confirmation_verifier
                 .add_new_optimistic_confirmed_slots(optimistic_slots.clone());
-            let bank3 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(3)
-                .cloned()
-                .unwrap();
+            let bank3 = vote_simulator.bank_forks.read().unwrap().get(3).unwrap();
             assert!(optimistic_confirmation_verifier
                 .verify_for_unrooted_optimistic_slots(&bank3, &blockstore)
                 .is_empty());
@@ -261,13 +243,7 @@ mod test {
             // be returned
             optimistic_confirmation_verifier
                 .add_new_optimistic_confirmed_slots(optimistic_slots.clone());
-            let bank4 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(4)
-                .cloned()
-                .unwrap();
+            let bank4 = vote_simulator.bank_forks.read().unwrap().get(4).unwrap();
             assert_eq!(
                 optimistic_confirmation_verifier
                     .verify_for_unrooted_optimistic_slots(&bank4, &blockstore),
@@ -283,25 +259,13 @@ mod test {
             vote_simulator.set_root(5);
 
             // Add a new bank 7 that descends from 6
-            let bank6 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(6)
-                .cloned()
-                .unwrap();
+            let bank6 = vote_simulator.bank_forks.read().unwrap().get(6).unwrap();
             vote_simulator
                 .bank_forks
                 .write()
                 .unwrap()
                 .insert(Bank::new_from_parent(&bank6, &Pubkey::default(), 7));
-            let bank7 = vote_simulator
-                .bank_forks
-                .read()
-                .unwrap()
-                .get(7)
-                .unwrap()
-                .clone();
+            let bank7 = vote_simulator.bank_forks.read().unwrap().get(7).unwrap();
             assert!(!bank7.ancestors.contains_key(&3));
 
             // Should return slots 1, 3 as part of the rooted fork because there's no

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -79,7 +79,7 @@ impl VoteSimulator {
                 continue;
             }
             let parent = *walk.get_parent().unwrap().data();
-            let parent_bank = self.bank_forks.read().unwrap().get(parent).unwrap().clone();
+            let parent_bank = self.bank_forks.read().unwrap().get(parent).unwrap();
             let new_bank = Bank::new_from_parent(&parent_bank, &Pubkey::default(), slot);
             self.progress
                 .entry(slot)
@@ -171,11 +171,10 @@ impl VoteSimulator {
             .read()
             .unwrap()
             .get(vote_slot)
-            .expect("Bank must have been created before vote simulation")
-            .clone();
+            .expect("Bank must have been created before vote simulation");
 
         // Try to vote on the given slot
-        let descendants = self.bank_forks.read().unwrap().descendants().clone();
+        let descendants = self.bank_forks.read().unwrap().descendants();
         let SelectVoteAndResetForkResult {
             heaviest_fork_failures,
             ..

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -216,11 +216,8 @@ mod tests {
         )
         .unwrap();
 
-        let bank = old_bank_forks
-            .get(deserialized_bank.slot())
-            .unwrap()
-            .clone();
-        assert_eq!(*bank, deserialized_bank);
+        let bank = old_bank_forks.get(deserialized_bank.slot()).unwrap();
+        assert_eq!(bank.as_ref(), &deserialized_bank);
     }
 
     // creates banks up to "last_slot" and runs the input function `f` on each bank created
@@ -279,7 +276,7 @@ mod tests {
             snapshot_utils::get_highest_bank_snapshot_pre(bank_snapshots_dir)
                 .expect("no bank snapshots found in path");
         let accounts_package = AccountsPackage::new(
-            last_bank,
+            &last_bank,
             &last_bank_snapshot_info,
             bank_snapshots_dir,
             last_bank.src.slot_deltas(&last_bank.src.roots()),
@@ -370,7 +367,7 @@ mod tests {
         // Take snapshot of zeroth bank
         let bank0 = bank_forks.get(0).unwrap();
         let storages = bank0.get_snapshot_storages(None);
-        snapshot_utils::add_bank_snapshot(bank_snapshots_dir, bank0, &storages, snapshot_version)
+        snapshot_utils::add_bank_snapshot(bank_snapshots_dir, &bank0, &storages, snapshot_version)
             .unwrap();
 
         // Set up snapshotting channels
@@ -972,7 +969,7 @@ mod tests {
             // Make a new bank and perform some transactions
             let bank = {
                 let bank = Bank::new_from_parent(
-                    bank_forks.read().unwrap().get(slot - 1).unwrap(),
+                    &bank_forks.read().unwrap().get(slot - 1).unwrap(),
                     &Pubkey::default(),
                     slot,
                 );
@@ -1035,14 +1032,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(deserialized_bank.slot(), LAST_SLOT,);
+        assert_eq!(deserialized_bank.slot(), LAST_SLOT);
         assert_eq!(
-            deserialized_bank,
-            **bank_forks
+            &deserialized_bank,
+            bank_forks
                 .read()
                 .unwrap()
                 .get(deserialized_bank.slot())
                 .unwrap()
+                .as_ref()
         );
 
         // Stop the background services

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2315,8 +2315,7 @@ fn main() {
                             .unwrap_or_else(|| {
                                 eprintln!("Error: Slot {} is not available", snapshot_slot);
                                 exit(1);
-                            })
-                            .clone();
+                            });
 
                         let child_bank_required = rent_burn_percentage.is_ok()
                             || hashes_per_tick.is_some()
@@ -2913,7 +2912,7 @@ fn main() {
                                 }
                             };
                             let warped_bank = Bank::new_from_parent_with_tracer(
-                                base_bank,
+                                &base_bank,
                                 base_bank.collector_id(),
                                 next_epoch,
                                 tracer,
@@ -2930,7 +2929,7 @@ fn main() {
 
                             println!("Slot: {} => {}", base_bank.slot(), warped_bank.slot());
                             println!("Epoch: {} => {}", base_bank.epoch(), warped_bank.epoch());
-                            assert_capitalization(base_bank);
+                            assert_capitalization(&base_bank);
                             assert_capitalization(&warped_bank);
                             let interest_per_epoch = ((warped_bank.capitalization() as f64)
                                 / (base_bank.capitalization() as f64)
@@ -3177,7 +3176,7 @@ fn main() {
                                 );
                             }
 
-                            assert_capitalization(bank);
+                            assert_capitalization(&bank);
                             println!("Inflation: {:?}", bank.inflation());
                             println!("RentCollector: {:?}", bank.rent_collector());
                             println!("Capitalization: {}", Sol(bank.capitalization()));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -733,7 +733,7 @@ pub fn process_blockstore_from_root(
     info!("ledger processing timing: {:?}", timing);
     {
         let bank_forks = bank_forks.read().unwrap();
-        let mut bank_slots = bank_forks.banks().keys().collect::<Vec<_>>();
+        let mut bank_slots = bank_forks.banks().keys().copied().collect::<Vec<_>>();
         bank_slots.sort_unstable();
 
         info!(
@@ -1165,7 +1165,7 @@ fn load_frozen_forks(
     );
 
     process_next_slots(
-        bank_forks.read().unwrap().get(start_slot).unwrap(),
+        &bank_forks.read().unwrap().get(start_slot).unwrap(),
         start_slot_meta,
         blockstore,
         leader_schedule_cache,
@@ -3118,7 +3118,7 @@ pub mod tests {
 
         // Set up bank1
         let mut bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
-        let bank0 = bank_forks.get(0).unwrap().clone();
+        let bank0 = bank_forks.get(0).unwrap();
         let opts = ProcessOptions {
             poh_verify: true,
             accounts_db_test_hash_calculation: true,

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -217,7 +217,7 @@ impl OptimisticallyConfirmedBankTracker {
                         Self::notify_or_defer_confirmed_banks(
                             subscriptions,
                             bank_forks,
-                            bank,
+                            &bank,
                             *highest_confirmed_slot,
                             last_notified_confirmed_slot,
                             pending_optimistically_confirmed_banks,
@@ -330,13 +330,13 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap();
         let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
         bank_forks.write().unwrap().insert(bank2);
-        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
         let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
 
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(highest_confirmed_slot, 3);
 
         // Test bank will only be cached when frozen
-        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap();
         bank3.freeze();
 
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -420,7 +420,7 @@ mod tests {
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
 
         // Test higher root will be cached and clear pending_optimistically_confirmed_banks
-        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap();
         let bank4 = Bank::new_from_parent(&bank3, &Pubkey::default(), 4);
         bank_forks.write().unwrap().insert(bank4);
         OptimisticallyConfirmedBankTracker::process_notification(
@@ -438,10 +438,10 @@ mod tests {
         assert!(pending_optimistically_confirmed_banks.contains(&4));
         assert_eq!(highest_confirmed_slot, 4);
 
-        let bank4 = bank_forks.read().unwrap().get(4).unwrap().clone();
+        let bank4 = bank_forks.read().unwrap().get(4).unwrap();
         let bank5 = Bank::new_from_parent(&bank4, &Pubkey::default(), 5);
         bank_forks.write().unwrap().insert(bank5);
-        let bank5 = bank_forks.read().unwrap().get(5).unwrap().clone();
+        let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::Root(bank5),
             &bank_forks,
@@ -458,10 +458,10 @@ mod tests {
         assert_eq!(highest_confirmed_slot, 4);
 
         // Banks <= root do not get added to pending list, even if not frozen
-        let bank5 = bank_forks.read().unwrap().get(5).unwrap().clone();
+        let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         let bank6 = Bank::new_from_parent(&bank5, &Pubkey::default(), 6);
         bank_forks.write().unwrap().insert(bank6);
-        let bank5 = bank_forks.read().unwrap().get(5).unwrap().clone();
+        let bank5 = bank_forks.read().unwrap().get(5).unwrap();
         let bank7 = Bank::new_from_parent(&bank5, &Pubkey::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
         bank_forks

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -838,7 +838,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -964,7 +964,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -1152,7 +1152,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bob = Keypair::new();

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -145,7 +145,7 @@ where
     X: Clone + Default,
 {
     let mut notified = false;
-    if let Some(bank) = bank_forks.read().unwrap().get(slot).cloned() {
+    if let Some(bank) = bank_forks.read().unwrap().get(slot) {
         let results = bank_method(&bank, params);
         let mut w_last_notified_slot = subscription.last_notified_slot.write().unwrap();
         let (filter_results, result_slot) =
@@ -1262,7 +1262,7 @@ pub(crate) mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let alice = Keypair::new();
@@ -1839,10 +1839,10 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
         // add account for alice and process the transaction at bank1
         let alice = Keypair::new();
@@ -1870,7 +1870,7 @@ pub(crate) mod tests {
             16,
             &stake::program::id(),
         );
-        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
         bank2.process_transaction(&tx).unwrap();
 
@@ -1887,7 +1887,7 @@ pub(crate) mod tests {
             16,
             &stake::program::id(),
         );
-        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap();
 
         bank3.process_transaction(&tx).unwrap();
 
@@ -2026,10 +2026,10 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
         // add account for alice and process the transaction at bank1
         let alice = Keypair::new();
@@ -2057,7 +2057,7 @@ pub(crate) mod tests {
             16,
             &stake::program::id(),
         );
-        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
         bank2.process_transaction(&tx).unwrap();
 
@@ -2137,10 +2137,10 @@ pub(crate) mod tests {
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap();
 
         // add account for alice and process the transaction at bank1
         let alice = Keypair::new();
@@ -2168,7 +2168,7 @@ pub(crate) mod tests {
             16,
             &stake::program::id(),
         );
-        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
 
         bank2.process_transaction(&tx).unwrap();
 
@@ -2265,7 +2265,7 @@ pub(crate) mod tests {
             16,
             &stake::program::id(),
         );
-        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap();
 
         bank3.process_transaction(&tx).unwrap();
         bank3.freeze();
@@ -2330,7 +2330,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let next_bank = Bank::new_from_parent(
-            &bank_forks.get(0).unwrap().clone(),
+            &bank_forks.get(0).unwrap(),
             &solana_sdk::pubkey::new_rand(),
             1,
         );
@@ -2630,7 +2630,7 @@ pub(crate) mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
         let bank2 = Bank::new_from_parent(&bank0, &Pubkey::default(), 2);
@@ -2677,7 +2677,7 @@ pub(crate) mod tests {
         );
 
         // Add the transaction to the 1st bank and then freeze the bank
-        let bank1 = bank_forks.write().unwrap().get(1).cloned().unwrap();
+        let bank1 = bank_forks.write().unwrap().get(1).unwrap();
         bank1.process_transaction(&tx).unwrap();
         bank1.freeze();
 
@@ -2752,7 +2752,7 @@ pub(crate) mod tests {
             )
             .unwrap();
 
-        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
         bank2.freeze();
         highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -63,8 +63,8 @@ impl BankForks {
         Self::new_from_banks(&[Arc::new(bank)], root)
     }
 
-    pub fn banks(&self) -> &HashMap<Slot, Arc<Bank>> {
-        &self.banks
+    pub fn banks(&self) -> HashMap<Slot, Arc<Bank>> {
+        self.banks.clone()
     }
 
     /// Create a map of bank slot id to the set of ancestors for the bank slot.
@@ -80,8 +80,8 @@ impl BankForks {
     }
 
     /// Create a map of bank slot id to the set of all of its descendants
-    pub fn descendants(&self) -> &HashMap<Slot, HashSet<Slot>> {
-        &self.descendants
+    pub fn descendants(&self) -> HashMap<Slot, HashSet<Slot>> {
+        self.descendants.clone()
     }
 
     pub fn frozen_banks(&self) -> HashMap<Slot, Arc<Bank>> {
@@ -100,16 +100,16 @@ impl BankForks {
             .collect()
     }
 
-    pub fn get(&self, bank_slot: Slot) -> Option<&Arc<Bank>> {
-        self.banks.get(&bank_slot)
+    pub fn get(&self, bank_slot: Slot) -> Option<Arc<Bank>> {
+        self.banks.get(&bank_slot).cloned()
     }
 
     pub fn get_with_checked_hash(
         &self,
         (bank_slot, expected_hash): (Slot, Hash),
-    ) -> Option<&Arc<Bank>> {
-        let maybe_bank = self.banks.get(&bank_slot);
-        if let Some(bank) = maybe_bank {
+    ) -> Option<Arc<Bank>> {
+        let maybe_bank = self.get(bank_slot);
+        if let Some(bank) = &maybe_bank {
             assert_eq!(bank.hash(), expected_hash);
         }
         maybe_bank
@@ -506,10 +506,6 @@ impl BankForks {
         self.snapshot_config = snapshot_config;
     }
 
-    pub fn snapshot_config(&self) -> &Option<SnapshotConfig> {
-        &self.snapshot_config
-    }
-
     pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: u64) {
         self.accounts_hash_interval_slots = accounts_interval_slots;
     }
@@ -707,7 +703,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![
                 (0, vec![1, 2, 3, 4]),
                 (1, vec![2]),
@@ -724,7 +720,7 @@ mod tests {
         banks[2].squash();
         assert_eq!(bank_forks.ancestors(), make_hash_map(vec![(2, vec![]),]));
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![(0, vec![2]), (1, vec![2]), (2, vec![]),])
         );
         banks.push(bank_forks.insert(Bank::new_from_parent(&banks[2], &Pubkey::default(), 5)));
@@ -734,7 +730,7 @@ mod tests {
             make_hash_map(vec![(2, vec![]), (5, vec![2]), (6, vec![2, 5])])
         );
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![
                 (0, vec![2]),
                 (1, vec![2]),
@@ -766,7 +762,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![
                 (0, vec![1, 2, 3, 4]),
                 (1, vec![2]),
@@ -786,7 +782,7 @@ mod tests {
             make_hash_map(vec![(1, vec![]), (2, vec![]),])
         );
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![(0, vec![1, 2]), (1, vec![2]), (2, vec![]),])
         );
         banks.push(bank_forks.insert(Bank::new_from_parent(&banks[2], &Pubkey::default(), 5)));
@@ -801,7 +797,7 @@ mod tests {
             ])
         );
         assert_eq!(
-            *bank_forks.descendants(),
+            bank_forks.descendants(),
             make_hash_map(vec![
                 (0, vec![1, 2]),
                 (1, vec![2]),


### PR DESCRIPTION
#### Problem
It's too easy to hold onto a borrowed value returned from `BankForks` and forget that it keeps a read lock.

Case in point: https://github.com/solana-labs/solana/pull/24799

#### Summary of Changes
- Removed unused `BankForks::snapshot_config` method
- `BankForks::banks` now returns an owned `HashMap` because it's cheap to clone
- `BankForks::descendants` now returns a cloned value because we clone immediately everywhere we call this method
- `BankForks:get_with_checked_hash` and `BankForks::get` both return an owned `Arc<Bank>`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
