### PR TITLE
Speed up metrics counter point submission

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -20,8 +20,8 @@ use {
 
 type CounterMap = HashMap<(&'static str, u64), CounterPoint>;
 
-impl From<CounterPoint> for DataPoint {
-    fn from(counter_point: CounterPoint) -> Self {
+impl From<&CounterPoint> for DataPoint {
+    fn from(counter_point: &CounterPoint) -> Self {
         let mut point = Self::new(counter_point.name);
         point.timestamp = counter_point.timestamp;
         point.add_field_i64("count", counter_point.count);
@@ -162,9 +162,8 @@ impl MetricsAgent {
     fn collect_points(points: &mut Vec<DataPoint>, counters: &mut CounterMap) -> Vec<DataPoint> {
         let mut ret: Vec<DataPoint> = Vec::default();
         std::mem::swap(&mut ret, points);
-        for (_, v) in counters.drain() {
-            ret.push(v.into());
-        }
+        ret.extend(counters.values().map(|v| v.into()));
+        counters.clear();
         ret
     }
 


### PR DESCRIPTION
#### Problem

When we take the counter points from hashmap and convert them to datapoints for submission, the counter points are by reference. But the *From* trait for conversion expects counter point by value. Unnecessary copy incurred.  

https://github.com/solana-labs/solana/issues/24319


#### Summary of Changes

Avoid copy when converting counters to datapoints

before:

```
test bench_counter_submission   ... bench:     958,245 ns/iter (+/- 587,452)
test bench_datapoint_submission ... bench:     457,622 ns/iter (+/- 58,431)
test bench_random_submission    ... bench:     660,389 ns/iter (+/- 94,540)

```
after:
```
test bench_counter_submission   ... bench:     496,585 ns/iter (+/- 97,219)
test bench_datapoint_submission ... bench:     484,038 ns/iter (+/- 61,726)
test bench_random_submission    ... bench:     488,835 ns/iter (+/- 64,879)

```



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
