### PR TITLE
Make test less brittle

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9122,14 +9122,18 @@ pub(crate) mod tests {
         bank.collect_rent_in_partition((0, 0, 1), true);
         {
             let rewrites_skipped = bank.rewrites_skipped_this_slot.read().unwrap();
-            // this magic number is the number of non-rent paying accounts in the slot.
-            // These accounts will stop being written to the append vec when we start skipping rewrites.
-            // The number is unhappily brittle. 'collect_rent_in_partition' fills 'rewrites_skipped_this_slot' with
-            // rewrites that were skipped during rent collection but should still be considered in the slot's bank hash.
-            // If the slot is also written in the append vec, then the bank hash calc code ignores the contents of this list.
-            // This assert is confirming that the expected # of accounts were included in 'rewrites_skipped' by the call to
+            // `rewrites_skipped.len()` is the number of non-rent paying accounts in the slot. This
+            // is always at least the number of features in the Bank, due to
+            // `activate_all_features`. These accounts will stop being written to the append vec
+            // when we start skipping rewrites.
+            // 'collect_rent_in_partition' fills 'rewrites_skipped_this_slot' with rewrites that
+            // were skipped during rent collection but should still be considered in the slot's
+            // bank hash. If the slot is also written in the append vec, then the bank hash calc
+            // code ignores the contents of this list. This assert is confirming that the expected #
+            // of accounts were included in 'rewrites_skipped' by the call to
             // 'collect_rent_in_partition(..., true)' above.
-            assert_eq!(rewrites_skipped.len(), 91);
+            let num_features = bank.feature_set.inactive.len() + bank.feature_set.active.len();
+            assert!(rewrites_skipped.len() >= num_features);
             // should have skipped 'rent_exempt_pubkey'
             assert!(rewrites_skipped.contains_key(&rent_exempt_pubkey));
             // should NOT have skipped 'rent_exempt_pubkey'


### PR DESCRIPTION
#### Problem
`test_rent_eager_collect_rent_in_partition` currently needs to be updated every time a dev adds a feature. This is not obvious to devs, and shouldn't be necessary.

#### Summary of Changes
Update test assert based on number of features. This can be made more precise and helpful for rewrite-skip development later.

cc @joncinque 
