### PR TITLE
Avoid holding lock guards in match expressions

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2094,11 +2094,11 @@ fn next_leader_x<F>(
 where
     F: FnOnce(&ContactInfo) -> SocketAddr,
 {
-    if let Some(leader_pubkey) = poh_recorder
+    let leader_pubkey = poh_recorder
         .lock()
         .unwrap()
-        .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET)
-    {
+        .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET);
+    if let Some(leader_pubkey) = leader_pubkey {
         cluster_info.lookup_contact_info(&leader_pubkey, port_selector)
     } else {
         None

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -366,7 +366,8 @@ impl ClusterInfoVoteListener {
                 // Always set this to avoid taking the poh lock too often
                 time_since_lock = Instant::now();
                 // We will take this lock at most once every `BANK_SEND_VOTES_LOOP_SLEEP_MS`
-                if let Some(current_working_bank) = poh_recorder.lock().unwrap().bank() {
+                let current_working_bank = poh_recorder.lock().unwrap().bank();
+                if let Some(current_working_bank) = current_working_bank {
                     Self::check_for_leader_bank_and_send_votes(
                         &mut bank_vote_sender_state_option,
                         current_working_bank,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -101,11 +101,11 @@ impl FetchStage {
             }
         }
 
-        if poh_recorder
+        let would_be_leader = poh_recorder
             .lock()
             .unwrap()
-            .would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET.saturating_mul(DEFAULT_TICKS_PER_SLOT))
-        {
+            .would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET.saturating_mul(DEFAULT_TICKS_PER_SLOT));
+        if would_be_leader {
             inc_new_counter_debug!("fetch_stage-honor_forwards", num_packets);
             for packet_batch in packet_batches {
                 #[allow(clippy::question_mark)]

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -101,11 +101,11 @@ impl FetchStage {
             }
         }
 
-        let would_be_leader = poh_recorder
+        if poh_recorder
             .lock()
             .unwrap()
-            .would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET.saturating_mul(DEFAULT_TICKS_PER_SLOT));
-        if would_be_leader {
+            .would_be_leader(HOLD_TRANSACTIONS_SLOT_OFFSET.saturating_mul(DEFAULT_TICKS_PER_SLOT))
+        {
             inc_new_counter_debug!("fetch_stage-honor_forwards", num_packets);
             for packet_batch in packet_batches {
                 #[allow(clippy::question_mark)]

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -36,11 +36,11 @@ impl WarmQuicCacheService {
                 let slot_jitter = thread_rng().gen_range(-CACHE_JITTER_SLOT, CACHE_JITTER_SLOT);
                 let mut maybe_last_leader = None;
                 while !exit.load(Ordering::Relaxed) {
-                    if let Some(leader_pubkey) = poh_recorder
+                    let leader_pubkey =  poh_recorder
                         .lock()
                         .unwrap()
-                        .leader_after_n_slots((CACHE_OFFSET_SLOT + slot_jitter) as u64)
-                    {
+                        .leader_after_n_slots((CACHE_OFFSET_SLOT + slot_jitter) as u64);
+                    if let Some(leader_pubkey) = leader_pubkey {
                         if maybe_last_leader
                             .map_or(true, |last_leader| last_leader != leader_pubkey)
                         {

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -204,7 +204,8 @@ impl OptimisticallyConfirmedBankTracker {
         debug!("received bank notification: {:?}", notification);
         match notification {
             BankNotification::OptimisticallyConfirmed(slot) => {
-                if let Some(bank) = bank_forks.read().unwrap().get(slot) {
+                let bank = bank_forks.read().unwrap().get(slot);
+                if let Some(bank) = bank {
                     let mut w_optimistically_confirmed_bank =
                         optimistically_confirmed_bank.write().unwrap();
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -209,10 +209,8 @@ impl JsonRpcRequestProcessor {
     #[allow(deprecated)]
     fn bank(&self, commitment: Option<CommitmentConfig>) -> Arc<Bank> {
         debug!("RPC commitment_config: {:?}", commitment);
-        let r_bank_forks = self.bank_forks.read().unwrap();
 
         let commitment = commitment.unwrap_or_default();
-
         if commitment.is_confirmed() {
             let bank = self
                 .optimistically_confirmed_bank
@@ -250,6 +248,7 @@ impl JsonRpcRequestProcessor {
             CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
         };
 
+        let r_bank_forks = self.bank_forks.read().unwrap();
         r_bank_forks.get(slot).unwrap_or_else(|| {
             // We log a warning instead of returning an error, because all known error cases
             // are due to known bugs that should be fixed instead.

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -296,8 +296,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
 fn process_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<String> {
     match path {
         "/v0/circulating-supply" => {
-            let r_bank_forks = bank_forks.read().unwrap();
-            let bank = r_bank_forks.root_bank();
+            let bank = bank_forks.read().unwrap().root_bank();
             let total_supply = bank.capitalization();
             let non_circulating_supply =
                 solana_runtime::non_circulating_supply::calculate_non_circulating_supply(&bank)
@@ -309,8 +308,7 @@ fn process_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<Strin
             ))
         }
         "/v0/total-supply" => {
-            let r_bank_forks = bank_forks.read().unwrap();
-            let bank = r_bank_forks.root_bank();
+            let bank = bank_forks.read().unwrap().root_bank();
             let total_supply = bank.capitalization();
             Some(format!("{}", lamports_to_sol(total_supply)))
         }


### PR DESCRIPTION
#### Problem
- Getting the bank for an RPC request grabs the bank forks read lock for confirmed commitments even when it doesn't need it
- REST endpoints hold bank forks read lock for no reason
- Lock guards are used in temporary variables for match-like expressions
- Deadlock for macos reintroduced in https://github.com/solana-labs/solana/pull/24801

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
