### PR TITLE
Do not hold lock unnecessarily when hashing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6203,12 +6203,12 @@ impl Bank {
             self.last_blockhash().as_ref(),
         ]);
 
-        if let Some(buf) = self
+        let buf = self
             .hard_forks
             .read()
             .unwrap()
-            .get_hash_data(self.slot(), self.parent_slot())
-        {
+            .get_hash_data(self.slot(), self.parent_slot());
+        if let Some(buf) = buf {
             info!("hard fork at bank {}", self.slot());
             hash = extend_and_hash(&hash, &buf)
         }


### PR DESCRIPTION
#### Problem

In `Bank::hash_internal_state()`, the call to rehash unnecessarily holds the `HardForks` lock longer than necessary.

Note that the `hash::extend_and_hash()` function is likely very fast, but we were also holding the lock while performing I/O via the `info!()` call, which is relatively an eternity.

This investigation was prompted by @buffalu in Discord and their comment here: https://github.com/solana-labs/solana/pull/24799#issuecomment-1112382120

#### Summary of Changes

Get the hash data outside of the `if let` so as to not hold the lock unnecessarily.
