### PR TITLE
deprecate rent_collector epoch_schedule. Pass into necessary function(s)

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -15,7 +15,7 @@ use {
         ancestors::Ancestors,
         rent_collector::RentCollector,
     },
-    solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey},
+    solana_sdk::{epoch_schedule::EpochSchedule, genesis_config::ClusterType, pubkey::Pubkey},
     std::{env, fs, path::PathBuf},
 };
 
@@ -118,10 +118,13 @@ fn main() {
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
-            let results =
-                accounts
-                    .accounts_db
-                    .update_accounts_hash(0, &ancestors, &RentCollector::default());
+            let epoch_schedule = EpochSchedule::default();
+            let results = accounts.accounts_db.update_accounts_hash(
+                0,
+                &ancestors,
+                &RentCollector::default(),
+                &epoch_schedule,
+            );
             time.stop();
             let mut time_store = Measure::start("hash using store");
             let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
@@ -132,6 +135,7 @@ fn main() {
                 None,
                 false,
                 &RentCollector::default(),
+                &epoch_schedule,
                 false,
             );
             time_store.stop();

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -140,6 +140,7 @@ impl AccountsHashVerifier {
                     ancestors: None,
                     use_write_cache: false,
                     rent_collector: &accounts_package.rent_collector,
+                    epoch_schedule: &accounts_package.epoch_schedule,
                 },
                 &sorted_storages,
                 timings,
@@ -303,6 +304,7 @@ mod tests {
             snapshot_utils::{ArchiveFormat, SnapshotVersion},
         },
         solana_sdk::{
+            epoch_schedule::EpochSchedule,
             genesis_config::ClusterType,
             hash::hash,
             signature::{Keypair, Signer},
@@ -389,6 +391,7 @@ mod tests {
                 snapshot_type: None,
                 accounts: Arc::clone(&accounts),
                 rent_collector: RentCollector::default(),
+                epoch_schedule: EpochSchedule::default(),
             };
 
             AccountsHashVerifier::process_accounts_package(

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -17,6 +17,7 @@ use {
     },
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount},
+        epoch_schedule::EpochSchedule,
         genesis_config::{create_genesis_config, ClusterType},
         hash::Hash,
         lamports::LamportsError,
@@ -108,10 +109,12 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let slot = 0;
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
     let ancestors = Ancestors::from(vec![0]);
-    let (_, total_lamports) =
-        accounts
-            .accounts_db
-            .update_accounts_hash(0, &ancestors, &RentCollector::default());
+    let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(
+        0,
+        &ancestors,
+        &RentCollector::default(),
+        &EpochSchedule::default(),
+    );
     let test_hash_calculation = false;
     bencher.iter(|| {
         assert!(accounts.verify_bank_hash_and_lamports(
@@ -119,7 +122,8 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
             &ancestors,
             total_lamports,
             test_hash_calculation,
-            &RentCollector::default()
+            &RentCollector::default(),
+            &EpochSchedule::default(),
         ))
     });
 }
@@ -138,9 +142,12 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
     let ancestors = Ancestors::from(vec![0]);
     bencher.iter(|| {
-        accounts
-            .accounts_db
-            .update_accounts_hash(0, &ancestors, &RentCollector::default());
+        accounts.accounts_db.update_accounts_hash(
+            0,
+            &ancestors,
+            &RentCollector::default(),
+            &EpochSchedule::default(),
+        );
     });
 }
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -234,6 +234,7 @@ impl SnapshotRequestHandler {
                             ancestors: None,
                             use_write_cache: false,
                             rent_collector: snapshot_root_bank.rent_collector(),
+                            epoch_schedule: snapshot_root_bank.epoch_schedule(),
                         },
                     ).unwrap();
                     assert_eq!(previous_hash, this_hash);

--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -4,6 +4,7 @@ use {
     rayon::prelude::*,
     solana_measure::measure::Measure,
     solana_sdk::{
+        epoch_schedule::EpochSchedule,
         hash::{Hash, Hasher},
         pubkey::Pubkey,
     },
@@ -41,6 +42,7 @@ pub struct CalcAccountsHashConfig<'a> {
     /// if so, 'ancestors' will be used for this purpose as well as storages.
     pub use_write_cache: bool,
     pub rent_collector: &'a RentCollector,
+    pub epoch_schedule: &'a EpochSchedule,
 }
 
 impl<'a> CalcAccountsHashConfig<'a> {

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -11,7 +11,9 @@ use {
         },
     },
     log::*,
-    solana_sdk::{clock::Slot, genesis_config::ClusterType, hash::Hash},
+    solana_sdk::{
+        clock::Slot, epoch_schedule::EpochSchedule, genesis_config::ClusterType, hash::Hash,
+    },
     std::{
         fs,
         path::{Path, PathBuf},
@@ -44,6 +46,7 @@ pub struct AccountsPackage {
     pub snapshot_type: Option<SnapshotType>,
     pub accounts: Arc<Accounts>,
     pub rent_collector: RentCollector,
+    pub epoch_schedule: EpochSchedule,
 }
 
 impl AccountsPackage {
@@ -109,6 +112,7 @@ impl AccountsPackage {
             snapshot_type,
             accounts: bank.accounts(),
             rent_collector: bank.rent_collector().clone(),
+            epoch_schedule: *bank.epoch_schedule(),
         })
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3454,6 +3454,7 @@ mod tests {
                 snapshot_type,
                 accounts: Arc::new(crate::accounts::Accounts::default_for_tests()),
                 rent_collector: crate::rent_collector::RentCollector::default(),
+                epoch_schedule: solana_sdk::epoch_schedule::EpochSchedule::default(),
             }
         }
 


### PR DESCRIPTION
#### Problem
Same problem as #24709 

#### Summary of Changes
Different approach compared to #24709, instead leaving the epoch_schedule on the Bank (a more inituitive place for it to be owned). Did not remove the epoch_schedule from the RentCollector so it doesn't break ABI, but we skip it on deserialization and do not use it. Can be removed in the future.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
