### PR TITLE
Add custom rpc/tpu address options for bench-tps ThinClient

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -123,6 +123,26 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .help("WebSocket URL for the solana cluster"),
         )
         .arg(
+            Arg::with_name("rpc_addr")
+                .long("rpc-addr")
+                .value_name("HOST:PORT")
+                .takes_value(true)
+                .conflicts_with("tpu_client")
+                .conflicts_with("rpc_client")
+                .requires("tpu_addr")
+                .help("Specify custom rpc_addr to create thin_client"),
+        )
+        .arg(
+            Arg::with_name("tpu_addr")
+                .long("tpu-addr")
+                .value_name("HOST:PORT")
+                .conflicts_with("tpu_client")
+                .conflicts_with("rpc_client")
+                .takes_value(true)
+                .requires("rpc_addr")
+                .help("Specify custom tpu_addr to create thin_client"),
+        )
+        .arg(
             Arg::with_name("entrypoint")
                 .short("n")
                 .long("entrypoint")


### PR DESCRIPTION
#### Problem

ThinClient with gossip mode for bench-tps is annoying to use because it doesn't know how long to wait for the target node to appear also it takes a while to find it.

#### Summary of Changes

Let me set my own custom ThinClient addresses.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
