### PR TITLE
(LedgerStore) Move trait ColumnMetrics and metric-macros to blockstore_metrics.rs

### DIFF
--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -1,4 +1,8 @@
 use {
+    crate::blockstore_db::{
+        columns, BlockstoreCompressionType, BlockstoreRocksDbColumnFamilyMetrics,
+        LedgerColumnOptions, ShredStorageType,
+    },
     rocksdb::{
         perf::{set_perf_stats, PerfMetric, PerfStatsLevel},
         PerfContext,
@@ -11,6 +15,55 @@ use {
         },
     },
 };
+
+#[macro_export]
+macro_rules! rocksdb_metric_header {
+    ($metric_name:literal, $cf_name:literal, $column_options:expr) => {
+        match $column_options.shred_storage_type {
+            ShredStorageType::RocksLevel =>
+                rocksdb_metric_header!(@compression_type $metric_name, $cf_name, $column_options, "rocks_level"),
+            ShredStorageType::RocksFifo(_) =>
+                rocksdb_metric_header!(@compression_type $metric_name, $cf_name, $column_options, "rocks_fifo"),
+        }
+    };
+
+    (@compression_type $metric_name:literal, $cf_name:literal, $column_options:expr, $storage_type:literal) => {
+        match $column_options.compression_type {
+            BlockstoreCompressionType::None => rocksdb_metric_header!(@all_fields
+                $metric_name,
+                $cf_name,
+                $storage_type,
+                "None"
+            ),
+            BlockstoreCompressionType::Snappy => rocksdb_metric_header!(@all_fields
+                $metric_name,
+                $cf_name,
+                $storage_type,
+                "Snappy"
+            ),
+            BlockstoreCompressionType::Lz4 => rocksdb_metric_header!(@all_fields
+                $metric_name,
+                $cf_name,
+                $storage_type,
+                "Lz4"
+            ),
+            BlockstoreCompressionType::Zlib => rocksdb_metric_header!(@all_fields
+                $metric_name,
+                $cf_name,
+                $storage_type,
+                "Zlib"
+            ),
+        }
+    };
+
+    (@all_fields $metric_name:literal, $cf_name:literal, $storage_type:literal, $compression_type:literal) => {
+        concat!($metric_name,
+            ",cf_name=", $cf_name,
+            ",storage=", $storage_type,
+            ",compression=", $compression_type,
+        )
+    };
+}
 
 // Thread local instance of RocksDB's PerfContext.
 thread_local! {static PER_THREAD_ROCKS_PERF_CONTEXT: RefCell<PerfContext> = RefCell::new(PerfContext::default());}
@@ -289,4 +342,699 @@ pub(crate) fn report_rocksdb_write_perf(metric_header: &'static str) {
             ),
         );
     });
+}
+
+pub trait ColumnMetrics {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    );
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str;
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str;
+    fn rocksdb_delete_perf_metric_header(column_options: &Arc<LedgerColumnOptions>)
+        -> &'static str;
+}
+
+impl ColumnMetrics for columns::TransactionStatus {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "transaction_status",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "transaction_status",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "transaction_status",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "transaction_status",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::AddressSignatures {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "address_signatures",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "address_signatures",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "address_signatures",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "address_signatures",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::TransactionMemos {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "transaction_memos",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "transaction_memos",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "transaction_memos",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "transaction_memos",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::TransactionStatusIndex {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "transaction_status_index",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "transaction_status_index",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "transaction_status_index",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "transaction_status_index",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::Rewards {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "rewards",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "rewards",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "rewards",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "rewards",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::Blocktime {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "blocktime",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "blocktime",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "blocktime",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "blocktime",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::PerfSamples {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "perf_samples",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "perf_samples",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "perf_samples",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "perf_samples",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::BlockHeight {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "block_height",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "block_height",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "block_height",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "block_height",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::ProgramCosts {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "program_costs",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "program_costs",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "program_costs",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "program_costs",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::ShredCode {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "shred_code",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "shred_code",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "shred_code",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "shred_code",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::ShredData {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "shred_data",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "shred_data",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "shred_data",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "shred_data",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::Index {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "index",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "index",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "index",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "index",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::DeadSlots {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "dead_slots",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "dead_slots",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "dead_slots",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "dead_slots",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::DuplicateSlots {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "duplicate_slots",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "duplicate_slots",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "duplicate_slots",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "duplicate_slots",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::Orphans {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "orphans",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "orphans",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "orphans",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "orphans",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::BankHash {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "bank_hash",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "bank_hash",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "bank_hash",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "bank_hash",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::Root {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "root",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "root",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "root",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "root",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::SlotMeta {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "slot_meta",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "slot_meta",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "slot_meta",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "slot_meta",
+            column_options
+        )
+    }
+}
+
+impl ColumnMetrics for columns::ErasureMeta {
+    fn report_cf_metrics(
+        cf_metrics: BlockstoreRocksDbColumnFamilyMetrics,
+        column_options: &Arc<LedgerColumnOptions>,
+    ) {
+        cf_metrics.report_metrics(rocksdb_metric_header!(
+            "blockstore_rocksdb_cfs",
+            "erasure_meta",
+            column_options
+        ));
+    }
+    fn rocksdb_get_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_read_perf,op=get",
+            "erasure_meta",
+            column_options
+        )
+    }
+    fn rocksdb_put_perf_metric_header(column_options: &Arc<LedgerColumnOptions>) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=put",
+            "erasure_meta",
+            column_options
+        )
+    }
+    fn rocksdb_delete_perf_metric_header(
+        column_options: &Arc<LedgerColumnOptions>,
+    ) -> &'static str {
+        rocksdb_metric_header!(
+            "blockstore_rocksdb_write_perf,op=delete",
+            "erasure_meta",
+            column_options
+        )
+    }
 }

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -13,6 +13,7 @@ pub mod blockstore;
 pub mod ancestor_iterator;
 pub mod blockstore_db;
 pub mod blockstore_meta;
+#[macro_use]
 pub mod blockstore_metrics;
 pub mod blockstore_processor;
 pub mod builtins;


### PR DESCRIPTION
#### Problem
blockstore_db.rs becomes bigger.

#### Summary of Changes
Move trait ColumnMetrics and metric-macros to blockstore_metric.rs out from blockstore_db.rs.