### PR TITLE
Use RwLock instead of Mutex in QUIC connection cache

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -459,21 +459,6 @@ mod tests {
                 let conn = map.map.get(a).expect("Address not found");
                 assert!(a.ip() == ip(conn.clone()));
             });
-
-            assert!(map.map.peek(&first_addr).is_none());
         }
-
-        // Test that get_connection updates which connection is next up for eviction
-        // when an existing connection is used. Initially, addrs[0] should be next up for eviction, since
-        // it was the earliest added. But we do get_connection(&addrs[0]), thereby using
-        // that connection, and bumping it back to the end of the queue. So addrs[1] should be
-        // the next up for eviction. So we add a new connection, and test that addrs[0] is not
-        // evicted but addrs[1] is.
-        get_connection(&addrs[0]);
-        get_connection(&get_addr(&mut rng));
-
-        let map = (*CONNECTION_MAP).read().unwrap();
-        assert!(map.map.get(&addrs[0]).is_some());
-        assert!(map.map.get(&addrs[1]).is_none());
     }
 }

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -472,8 +472,8 @@ mod tests {
         get_connection(&addrs[0]);
         get_connection(&get_addr(&mut rng));
 
-        let map = (*CONNECTION_MAP).lock().unwrap();
-        assert!(map.map.peek(&addrs[0]).is_some());
-        assert!(map.map.peek(&addrs[1]).is_none());
+        let map = (*CONNECTION_MAP).read().unwrap();
+        assert!(map.map.get(&addrs[0]).is_some());
+        assert!(map.map.get(&addrs[1]).is_none());
     }
 }


### PR DESCRIPTION
#### Problem
`get_connection` takes excessive amount of time in `lock()` and on a cache hit. The time is in terms of 2-3 seconds.

#### Summary of Changes
Replace `Mutex` with `RwLock` and perform `read` lock for looking up the cache. The `write` lock is acquired only on cache miss for adding the new value.

Also, replace `LruCache` with a `BTreeMap`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
