### PR TITLE
fix: enable React 18 in Explorer

### DIFF
--- a/explorer/src/index.tsx
+++ b/explorer/src/index.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router } from "react-router-dom";
 import * as Sentry from "@sentry/react";
 import "./scss/theme-dark.scss";
@@ -20,7 +19,8 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
-ReactDOM.render(
+const root = createRoot(document.getElementById("root")!);
+root.render(
   <Router>
     <ClusterProvider>
       <StatsProvider>
@@ -41,6 +41,5 @@ ReactDOM.render(
         </SupplyProvider>
       </StatsProvider>
     </ClusterProvider>
-  </Router>,
-  document.getElementById("root")
+  </Router>
 );


### PR DESCRIPTION
#### Problem

Until we mount the app using the `createRoot()` API, the Explorer will run in React 17 compatibility mode.

#### Summary of Changes

* Enable React 18 through use of `createRoot` API.

#### Test plan

Clicked through https://solana-explorer-clvt2er0x-steveluscher.vercel.app/