### PR TITLE
explorer: Don't show successful count if meta missing

### DIFF
--- a/explorer/src/components/block/BlockOverviewCard.tsx
+++ b/explorer/src/components/block/BlockOverviewCard.tsx
@@ -46,7 +46,12 @@ export function BlockOverviewCard({
 
   const { block, blockLeader, childSlot, childLeader, parentLeader } =
     confirmedBlock.data;
-  const committedTxs = block.transactions.filter((tx) => tx.meta?.err === null);
+  const showSuccessfulCount = block.transactions.every(
+    (tx) => tx.meta !== null
+  );
+  const successfulTxs = block.transactions.filter(
+    (tx) => tx.meta?.err === null
+  );
   const epoch = clusterInfo?.epochSchedule.getEpoch(slot);
 
   return (
@@ -153,12 +158,14 @@ export function BlockOverviewCard({
               <span>{block.transactions.length}</span>
             </td>
           </tr>
-          <tr>
-            <td className="w-100">Successful Transactions</td>
-            <td className="text-lg-end font-monospace">
-              <span>{committedTxs.length}</span>
-            </td>
-          </tr>
+          {showSuccessfulCount && (
+            <tr>
+              <td className="w-100">Successful Transactions</td>
+              <td className="text-lg-end font-monospace">
+                <span>{successfulTxs.length}</span>
+              </td>
+            </tr>
+          )}
         </TableCardBody>
       </div>
 

--- a/explorer/src/components/block/BlockProgramsCard.tsx
+++ b/explorer/src/components/block/BlockProgramsCard.tsx
@@ -53,6 +53,7 @@ export function BlockProgramsCard({ block }: { block: BlockResponse }) {
     return 0;
   });
 
+  const showSuccessRate = block.transactions.every((tx) => tx.meta !== null);
   return (
     <>
       <div className="card">
@@ -86,7 +87,9 @@ export function BlockProgramsCard({ block }: { block: BlockResponse }) {
                 <th className="text-muted">% of Total</th>
                 <th className="text-muted">Instruction Count</th>
                 <th className="text-muted">% of Total</th>
-                <th className="text-muted">Success Rate</th>
+                {showSuccessRate && (
+                  <th className="text-muted">Success Rate</th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -102,7 +105,9 @@ export function BlockProgramsCard({ block }: { block: BlockResponse }) {
                     <td>{((100 * txFreq) / totalTransactions).toFixed(2)}%</td>
                     <td>{ixFreq}</td>
                     <td>{((100 * ixFreq) / totalInstructions).toFixed(2)}%</td>
-                    <td>{((100 * successes) / txFreq).toFixed(0)}%</td>
+                    {showSuccessRate && (
+                      <td>{((100 * successes) / txFreq).toFixed(0)}%</td>
+                    )}
                   </tr>
                 );
               })}


### PR DESCRIPTION
#### Problem
Old blocks don't have transaction metadata so the explorer shows that the transactions failed.

#### Summary of Changes
Don't show success details if metadata is missing for any tx in a block

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
