### PR TITLE
adds hard-coded tests for backward compatibility of shreds serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,6 +4964,7 @@ dependencies = [
  "assert_matches",
  "bincode",
  "bitflags",
+ "bs58",
  "byteorder",
  "chrono",
  "chrono-humanize",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -64,6 +64,7 @@ features = ["lz4"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+bs58 = "0.4.0"
 matches = "0.1.9"
 solana-account-decoder = { path = "../account-decoder", version = "=1.11.0" }
 solana-logger = { path = "../logger", version = "=1.11.0" }


### PR DESCRIPTION

#### Problem
Working towards embedding versioning into shred binary.
Need to maintain backward compatibility while changing shred struct.

#### Summary of Changes
Added hard-coded tests to assert that shreds are backward
compatible when serialized and de-serialized.

