### PR TITLE
fix: don't fatal Explorer when there's a 'failed' type message at the top level

### DIFF
--- a/explorer/src/utils/program-logs.ts
+++ b/explorer/src/utils/program-logs.ts
@@ -24,10 +24,22 @@ export function parseProgramLogs(
 ): InstructionLogs[] {
   let depth = 0;
   let prettyLogs: InstructionLogs[] = [];
-  const prefixBuilder = (depth: number) => {
-    const prefix = new Array(depth - 1).fill("\u00A0\u00A0").join("");
+  function prefixBuilder(
+    // Indent level starts at 1.
+    indentLevel: number
+  ) {
+    let prefix;
+    if (indentLevel <= 0) {
+      console.warn(
+        `Tried to build a prefix for a program log at indent level \`${indentLevel}\`. ` +
+          "Logs should only ever be built at indent level 1 or higher."
+      );
+      prefix = "";
+    } else {
+      prefix = new Array(indentLevel - 1).fill("\u00A0\u00A0").join("");
+    }
     return prefix + "> ";
-  };
+  }
 
   let prettyError;
   if (error) {


### PR DESCRIPTION
#### Problem

@austbot ran into a problem where this transaction fataled the Explorer:

http://explorer.solana.com/tx/4zvAQJKkeY3RvgxLN4fDYBYRNKKEy77ptFAjDmPoEqpjnjQyxUhQVZ1t7RThsjNoNXeQbTbEqmeMK4sFGhHmi3r1?cluster=devnet

The reason was because this tx had _both_:

1. A log that starts with the word ‘failed’, and
2. A first-class `TransactionError`.

The ‘failed’ transaction tried to decrement the indent level, but it was _already_ at the top level.

#### Summary of Changes

* Make sure never to try to produce an indent marker when the depth is less than 2.

This doesn't fix the problem of this particular transaction having weird depth-tracking behavior, but at least it favors ‘bad rendering’ over ‘fataling the entire page.’

#### Test plan

1. Visit http://localhost:3000/tx/4zvAQJKkeY3RvgxLN4fDYBYRNKKEy77ptFAjDmPoEqpjnjQyxUhQVZ1t7RThsjNoNXeQbTbEqmeMK4sFGhHmi3r1?cluster=devnet

Logs render.

<img width="923" alt="image" src="https://user-images.githubusercontent.com/13243/166127212-13b89e51-98b8-495d-940b-f81d049355fd.png">