### PR TITLE
validator: add setTpuAddress to admin RPC

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -663,6 +663,12 @@ impl ClusterInfo {
         self.my_contact_info.read().unwrap().shred_version
     }
 
+    /// Sets the node's own TPU address in gossip cluster info.
+    pub fn set_tpu_address(&self, tpu_address: SocketAddr) {
+        self.my_contact_info.write().unwrap().tpu = tpu_address;
+        self.push_self(&HashMap::new(), None);
+    }
+
     fn lookup_epoch_slots(&self, ix: EpochSlotsIndex) -> EpochSlots {
         let self_pubkey = self.id();
         let label = CrdsValueLabel::EpochSlots(ix, self_pubkey);

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -90,6 +90,9 @@ pub trait AdminRpc {
         keypair_file: String,
         require_tower: bool,
     ) -> Result<()>;
+
+    #[rpc(meta, name = "setTpuAddress")]
+    fn set_tpu_address(&self, meta: Self::Metadata, tpu_address: SocketAddr) -> Result<()>;
 }
 
 pub struct AdminRpcImpl;
@@ -198,6 +201,15 @@ impl AdminRpc for AdminRpcImpl {
                 .cluster_info
                 .set_keypair(Arc::new(identity_keypair));
             warn!("Identity set to {}", post_init.cluster_info.id());
+            Ok(())
+        })
+    }
+
+    fn set_tpu_address(&self, meta: Self::Metadata, tpu_address: SocketAddr) -> Result<()> {
+        debug!("set_tpu_address({}) request received", tpu_address);
+
+        meta.with_post_init(|post_init| {
+            post_init.cluster_info.set_tpu_address(tpu_address);
             Ok(())
         })
     }


### PR DESCRIPTION
#### Problem

The validator is not able to update its TPU address on the fly.

The TPU network environment changes quickly so admins should be able to respond quickly too, without having to restart their validators.

#### Summary of Changes

Fixes #