### PR TITLE
defines shred flags using bitflags crate

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -10,8 +10,7 @@ use {
     },
     solana_entry::entry::Entry,
     solana_ledger::shred::{
-        ProcessShredsStats, Shred, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
-        SHRED_TICK_REFERENCE_MASK,
+        ProcessShredsStats, Shred, ShredFlags, Shredder, MAX_DATA_SHREDS_PER_FEC_BLOCK,
     },
     solana_sdk::{
         signature::Keypair,
@@ -63,6 +62,7 @@ impl StandardBroadcastRun {
         max_ticks_in_slot: u8,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
+        const SHRED_TICK_REFERENCE_MASK: u8 = ShredFlags::SHRED_TICK_REFERENCE_MASK.bits();
         let (current_slot, _) = self.current_slot_and_parent.unwrap();
         match self.unfinished_slot {
             None => Vec::default(),

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -351,8 +351,8 @@ mod tests {
     use {
         super::*,
         crate::shred::{
-            max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred, ShredType,
-            SHRED_TICK_REFERENCE_MASK,
+            max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred, ShredFlags,
+            ShredType,
         },
         bincode::serialized_size,
         matches::assert_matches,
@@ -549,10 +549,13 @@ mod tests {
             0,    // next_code_index
         );
         data_shreds.iter().for_each(|s| {
-            assert_eq!(s.reference_tick(), SHRED_TICK_REFERENCE_MASK);
+            assert_eq!(
+                s.reference_tick(),
+                ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
+            );
             assert_eq!(
                 Shred::reference_tick_from_data(s.payload()),
-                SHRED_TICK_REFERENCE_MASK
+                ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
             );
         });
 
@@ -561,7 +564,7 @@ mod tests {
                 .unwrap();
         assert_eq!(
             deserialized_shred.reference_tick(),
-            SHRED_TICK_REFERENCE_MASK
+            ShredFlags::SHRED_TICK_REFERENCE_MASK.bits(),
         );
     }
 


### PR DESCRIPTION
#### Problem
shred flags uses raw bitmasking ops which lacks type-safety:
https://github.com/solana-labs/solana/blob/a829ddc92/ledger/src/shred.rs#L112-L114

#### Summary of Changes
use `bitflags` crate instead.