### PR TITLE
Use memory map to speed up snapshot untar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmarinus"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8098e6e7a3823fa237ef9569010d3af3894a1ae54c92f0c220b9e6357f9473"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5545,6 +5554,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
+ "mmarinus",
  "num-derive",
  "num-traits",
  "num_cpus",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2198,6 +2198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmarinus"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8098e6e7a3823fa237ef9569010d3af3894a1ae54c92f0c220b9e6357f9473"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +4930,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
+ "mmarinus",
  "num-derive",
  "num-traits",
  "num_cpus",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,6 +62,9 @@ zstd = "0.11.1"
 crate-type = ["lib"]
 name = "solana_runtime"
 
+[target.'cfg(unix)'.dependencies]
+mmarinus = "0.4.0"
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 ed25519-dalek = "=1.0.1"

--- a/runtime/src/shared_buffer_reader.rs
+++ b/runtime/src/shared_buffer_reader.rs
@@ -22,9 +22,9 @@ use {
 
 // tunable parameters:
 // # bytes allocated and populated by reading ahead
-const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 2_000_000_000;
+const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 4_000_000_000;
 // data is read-ahead and saved in chunks of this many bytes
-const CHUNK_SIZE_DEFAULT: usize = 100_000_000;
+const CHUNK_SIZE_DEFAULT: usize = 200_000_000;
 
 type OneSharedBuffer = Arc<Vec<u8>>;
 

--- a/runtime/src/shared_buffer_reader.rs
+++ b/runtime/src/shared_buffer_reader.rs
@@ -22,9 +22,9 @@ use {
 
 // tunable parameters:
 // # bytes allocated and populated by reading ahead
-const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 4_000_000_000;
+const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 2_000_000_000;
 // data is read-ahead and saved in chunks of this many bytes
-const CHUNK_SIZE_DEFAULT: usize = 200_000_000;
+const CHUNK_SIZE_DEFAULT: usize = 50_000_000;
 
 type OneSharedBuffer = Arc<Vec<u8>>;
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -778,7 +778,7 @@ pub struct BankFromArchiveTimings {
     pub verify_snapshot_bank_us: u64,
 }
 
-// From testing, 4 seems to be a sweet spot for ranges of 60M-360M accounts and 16-64 cores. This may need to be tuned later.
+// From testing, 8 seems to be a sweet spot for ranges of 60M-360M accounts and 16-64 cores. This may need to be tuned later.
 const PARALLEL_UNTAR_READERS_DEFAULT: usize = 8;
 
 /// Rebuild bank from snapshot archives.  Handles either just a full snapshot, or both a full


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24798

Use memory map to speed up snapshot untar.

#### Summary of Changes

1. use mmap to read snapshot archive files.
2. retune the parallel factor and chunksize

with mmap
```
reading entire decompressed file took: 44799890 us, bytes: 76654958592, read_us: 23072928, waiting_for_buffer_us: 21715846, largest fetch: 100000000, error: Ok(0)
```

master
```
reading entire decompressed file took: 44960804 us, bytes: 76654958592, read_us: 29821976, waiting_for_buffer_us: 15128175, largest fetch: 100000000, error: Ok(0)
```

The comparison does show that read_time is reduced from 29s to 23 seconds. But the the total untar time don't differ much. The reason is because, although we are reading the data faster, we spend more time on waiting for available buffer, 21s vs 15s. 

Next, we are going to tune the chunk ratio. 

```
// tunable parameters:
// # bytes allocated and populated by reading ahead
const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 2_000_000_000;
// data is read-ahead and saved in chunks of this many bytes
const CHUNK_SIZE_DEFAULT: usize = 100_000_000;
```

```
parallel_factor=8 buf_size=2G chunk=50M
reading entire decompressed file took: 32857423 us, bytes: 76654958592, read_us: 21869626, waiting_for_buffer_us: 10964636, largest fetch: 50000000, error: Ok(0)

parallel_factor=8 buf_size=2G chunk=25M
reading entire decompressed file took: 33978930 us, bytes: 76654958592, read_us: 26325740, waiting_for_buffer_us: 7609328, largest fetch: 25000000, error: Ok(0)
```

So far, best config is *parallel_factor=8 buf_size=2G chunk=50M*. 
untar time reduced from 44s to 32s. 





Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
