### PR TITLE
Move dedup into a separate fast stage before sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,6 +5208,7 @@ dependencies = [
  "dlopen",
  "dlopen_derive",
  "fnv",
+ "itertools",
  "lazy_static",
  "libc",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -94,6 +94,9 @@ name = "gen_keys"
 name = "sigverify_stage"
 
 [[bench]]
+name = "dedup_stage"
+
+[[bench]]
 name = "retransmit_stage"
 
 [package.metadata.docs.rs]

--- a/core/benches/dedup_stage.rs
+++ b/core/benches/dedup_stage.rs
@@ -1,0 +1,113 @@
+#![feature(test)]
+#![allow(clippy::integer_arithmetic)]
+
+extern crate solana_core;
+extern crate test;
+
+use {
+    crossbeam_channel::unbounded,
+    log::*,
+    rand::{thread_rng, Rng},
+    solana_core::{find_packet_sender_stake_stage::FindPacketSenderStakeStage},
+    solana_perf::{
+        packet::{to_packet_batches, PacketBatch},
+        test_tx::test_tx,
+    },
+    solana_gossip::{
+        cluster_info::{ClusterInfo, Node},
+    },
+    solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    solana_streamer::socket::SocketAddrSpace,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, Signer},
+        system_transaction,
+        timing::duration_as_ms,
+        pubkey,
+    },
+    std::{
+        time::{Duration, Instant},
+        sync::{Arc, RwLock},
+        },
+    test::Bencher,
+};
+
+fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch> {
+    let len = 4096;
+    let chunk_size = 1024;
+    if use_same_tx {
+        let tx = test_tx();
+        to_packet_batches(&vec![tx; len], chunk_size)
+    } else {
+        let from_keypair = Keypair::new();
+        let to_keypair = Keypair::new();
+        let txs: Vec<_> = (0..len)
+            .map(|_| {
+                let amount = thread_rng().gen();
+                system_transaction::transfer(
+                    &from_keypair,
+                    &to_keypair.pubkey(),
+                    amount,
+                    Hash::default(),
+                )
+            })
+            .collect();
+        to_packet_batches(&txs, chunk_size)
+    }
+}
+
+#[bench]
+fn bench_dedup_stage(bencher: &mut Bencher) {
+    solana_logger::setup();
+    trace!("start");
+    let leader_pubkey = pubkey::new_rand();
+    let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
+    let cluster_info = Arc::new(ClusterInfo::new(
+        leader_info.info,
+        Arc::new(Keypair::new()),
+        SocketAddrSpace::Unspecified,
+    ));
+
+    let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+    let bank = Bank::new_for_benches(&genesis_config);
+    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+
+    let (packet_s, packet_r) = unbounded();
+    let (verified_s, verified_r) = unbounded();
+    let stage = FindPacketSenderStakeStage::new(packet_r, verified_s, bank_forks, cluster_info);
+
+    let use_same_tx = true;
+    bencher.iter(move || {
+        let now = Instant::now();
+        let mut batches = gen_batches(use_same_tx);
+        trace!(
+            "starting... generation took: {} ms batches: {}",
+            duration_as_ms(&now.elapsed()),
+            batches.len()
+        );
+
+        let mut sent_len = 0;
+        for _ in 0..batches.len() {
+            if let Some(batch) = batches.pop() {
+                sent_len += batch.packets.len();
+                packet_s.send(batch).unwrap();
+            }
+        }
+        let mut received = 0;
+        trace!("sent: {}", sent_len);
+        loop {
+            if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
+                while let Some(v) = verifieds.pop() {
+                    received += v.packets.len();
+                    batches.push(v);
+                }
+                if received >= sent_len {
+                    break;
+                }
+            }
+        }
+        trace!("received: {}", received);
+    });
+    stage.join().unwrap();
+}

--- a/core/benches/dedup_stage.rs
+++ b/core/benches/dedup_stage.rs
@@ -8,28 +8,26 @@ use {
     crossbeam_channel::unbounded,
     log::*,
     rand::{thread_rng, Rng},
-    solana_core::{find_packet_sender_stake_stage::FindPacketSenderStakeStage},
+    solana_core::find_packet_sender_stake_stage::FindPacketSenderStakeStage,
+    solana_gossip::cluster_info::{ClusterInfo, Node},
+    solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
     solana_perf::{
         packet::{to_packet_batches, PacketBatch},
         test_tx::test_tx,
     },
-    solana_gossip::{
-        cluster_info::{ClusterInfo, Node},
-    },
-    solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo},
-    solana_streamer::socket::SocketAddrSpace,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
         hash::Hash,
+        pubkey,
         signature::{Keypair, Signer},
         system_transaction,
         timing::duration_as_ms,
-        pubkey,
     },
+    solana_streamer::socket::SocketAddrSpace,
     std::{
-        time::{Duration, Instant},
         sync::{Arc, RwLock},
-        },
+        time::{Duration, Instant},
+    },
     test::Bencher,
 };
 

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -11,8 +11,8 @@ use {
     solana_core::{sigverify::TransactionSigVerifier, sigverify_stage::SigVerifyStage},
     solana_perf::{
         packet::{to_packet_batches, PacketBatch},
-        test_tx::test_tx,
         sigverify::discard_excess_packets,
+        test_tx::test_tx,
     },
     solana_sdk::{
         hash::Hash,

--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -12,6 +12,7 @@ use {
     solana_perf::{
         packet::{to_packet_batches, PacketBatch},
         test_tx::test_tx,
+        sigverify::discard_excess_packets,
     },
     solana_sdk::{
         hash::Hash,
@@ -51,7 +52,7 @@ fn run_bench_packet_discard(num_ips: usize, bencher: &mut Bencher) {
     info!("total packets: {}", total);
 
     bencher.iter(move || {
-        SigVerifyStage::discard_excess_packets(&mut batches, 10_000);
+        discard_excess_packets(&mut batches, 10_000);
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for p in batch.packets.iter_mut() {
@@ -98,7 +99,7 @@ fn bench_packet_discard_mixed_senders(bencher: &mut Bencher) {
         }
     }
     bencher.iter(move || {
-        SigVerifyStage::discard_excess_packets(&mut batches, 10_000);
+        discard_excess_packets(&mut batches, 10_000);
         let mut num_packets = 0;
         for batch in batches.iter_mut() {
             for packet in batch.packets.iter_mut() {

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -1,13 +1,9 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    itertools::Itertools,
     rayon::{prelude::*, ThreadPool},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
-    solana_perf::{
-        packet::PacketBatch,
-        sigverify::{shrink_batches, Deduper},
-    },
+    solana_perf::{packet::PacketBatch, sigverify::Deduper},
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::timing::timestamp,
@@ -25,8 +21,6 @@ use {
 const IP_TO_STAKE_REFRESH_DURATION: Duration = Duration::from_secs(5);
 const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
 const MAX_DEDUPER_ITEMS: u32 = 1_000_000;
-const MAX_EMPTY_BATCH_RATIO: usize = 4;
-const DISCARD_TARGET_PACKET_COUNT: usize = 10_000;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -45,14 +39,9 @@ struct FindPacketSenderStakeStats {
     send_batches_time: u64,
     receive_batches_time: u64,
     dedup_time: u64,
-    discard_time: u64,
-    shrink_time: u64,
     total_batches: u64,
     total_packets: u64,
     total_packets_dedup: u64,
-    total_packets_excess: u64,
-    total_packets_sent: u64,
-    total_shrinks: u64,
 }
 
 impl FindPacketSenderStakeStats {
@@ -79,14 +68,9 @@ impl FindPacketSenderStakeStats {
                     i64
                 ),
                 ("dedup_time_us", self.dedup_time, i64),
-                ("discard_time_us", self.discard_time, i64),
-                ("shrink_time_us", self.shrink_time, i64),
                 ("total_batches", self.total_batches as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
                 ("total_packets_dedup", self.total_packets_dedup, i64),
-                ("total_packets_excess", self.total_packets_excess, i64),
-                ("total_packets_sent", self.total_packets_sent, i64),
-                ("total_shrinks", self.total_shrinks, i64),
             );
             *self = FindPacketSenderStakeStats::default();
             self.last_print = now;
@@ -123,34 +107,11 @@ impl FindPacketSenderStake {
         let mut dedup_time = Measure::start("dedup_time");
         let dedup_fail = self.deduper.dedup_packets(&mut batches) as usize;
         dedup_time.stop();
-        let num_unique = num_packets.saturating_sub(dedup_fail);
 
         // Fill packet.meta.sender_stake.
         let mut apply_sender_stakes_time = Measure::start("apply_sender_stakes_time");
         Self::apply_sender_stakes(&mut batches, &self.ip_to_stake);
         apply_sender_stakes_time.stop();
-
-        // Discard packets early if more than the target amount remain.
-        let mut discard_time = Measure::start("discard_time");
-        let mut num_sent_packets = num_unique;
-        if num_unique > DISCARD_TARGET_PACKET_COUNT {
-            Self::discard_excess_packets(&mut batches, DISCARD_TARGET_PACKET_COUNT);
-            num_sent_packets = DISCARD_TARGET_PACKET_COUNT;
-        }
-        let excess_fail = num_unique.saturating_sub(DISCARD_TARGET_PACKET_COUNT);
-        discard_time.stop();
-
-        // Shrink, if the previous stages significantly reduced the packet count.
-        // This produces full batches at the cost of copying packet data. It also
-        // releases memory.
-        let mut shrink_time = Measure::start("shrink_time");
-        let start_len = batches.len();
-        if num_packets > num_sent_packets.saturating_mul(MAX_EMPTY_BATCH_RATIO) {
-            let valid = shrink_batches(&mut batches);
-            batches.truncate(valid);
-        }
-        let total_shrinks = start_len.saturating_sub(batches.len());
-        shrink_time.stop();
 
         let mut send_batches_time = Measure::start("send_batches_time");
         if let Err(e) = sender.send(batches) {
@@ -172,49 +133,11 @@ impl FindPacketSenderStake {
             .receive_batches_time
             .saturating_add(recv_duration.as_nanos() as u64);
         stats.dedup_time = stats.dedup_time.saturating_add(dedup_time.as_us() as u64);
-        stats.discard_time = stats
-            .discard_time
-            .saturating_add(discard_time.as_us() as u64);
-        stats.shrink_time = stats.shrink_time.saturating_add(shrink_time.as_us() as u64);
         stats.total_batches = stats.total_batches.saturating_add(num_batches as u64);
         stats.total_packets = stats.total_packets.saturating_add(num_packets as u64);
         stats.total_packets_dedup = stats.total_packets_dedup.saturating_add(dedup_fail as u64);
-        stats.total_packets_excess = stats
-            .total_packets_excess
-            .saturating_add(excess_fail as u64);
-        stats.total_packets_sent = stats
-            .total_packets_sent
-            .saturating_add(num_sent_packets as u64);
-        stats.total_shrinks = stats.total_shrinks.saturating_add(total_shrinks as u64);
 
         Ok(())
-    }
-
-    fn discard_excess_packets(batches: &mut [PacketBatch], mut max_packets: usize) {
-        // TODO: let sender_stake influence the discard decision
-
-        // Group packets by their incoming IP address.
-        let mut addrs = batches
-            .iter_mut()
-            .rev()
-            .flat_map(|batch| batch.packets.iter_mut().rev())
-            .filter(|packet| !packet.meta.discard())
-            .map(|packet| (packet.meta.addr, packet))
-            .into_group_map();
-        // Allocate max_packets evenly across addresses.
-        while max_packets > 0 && !addrs.is_empty() {
-            let num_addrs = addrs.len();
-            addrs.retain(|_, packets| {
-                let cap = (max_packets + num_addrs - 1) / num_addrs;
-                max_packets -= packets.len().min(cap);
-                packets.truncate(packets.len().saturating_sub(cap));
-                !packets.is_empty()
-            });
-        }
-        // Discard excess packets from each address.
-        for packet in addrs.into_values().flatten() {
-            packet.meta.set_discard(true);
-        }
     }
 
     fn try_refresh_ip_to_stake(&mut self) {
@@ -291,40 +214,5 @@ impl FindPacketSenderStakeStage {
 
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use {super::*, solana_perf::packet::Packet};
-
-    fn count_non_discard(packet_batches: &[PacketBatch]) -> usize {
-        packet_batches
-            .iter()
-            .map(|batch| {
-                batch
-                    .packets
-                    .iter()
-                    .map(|p| if p.meta.discard() { 0 } else { 1 })
-                    .sum::<usize>()
-            })
-            .sum::<usize>()
-    }
-
-    #[test]
-    fn test_packet_discard() {
-        solana_logger::setup();
-        let mut batch = PacketBatch::default();
-        batch.packets.resize(10, Packet::default());
-        batch.packets[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
-        batch.packets[3].meta.set_discard(true);
-        batch.packets[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
-        let mut batches = vec![batch];
-        let max = 3;
-        FindPacketSenderStake::discard_excess_packets(&mut batches, max);
-        assert_eq!(count_non_discard(&batches), max);
-        assert!(!batches[0].packets[0].meta.discard());
-        assert!(batches[0].packets[3].meta.discard());
-        assert!(!batches[0].packets[4].meta.discard());
     }
 }

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -1,9 +1,13 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    itertools::Itertools,
     rayon::{prelude::*, ThreadPool},
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
-    solana_perf::packet::PacketBatch,
+    solana_perf::{
+        packet::PacketBatch,
+        sigverify::{shrink_batches, Deduper},
+    },
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::timing::timestamp,
@@ -19,6 +23,10 @@ use {
 };
 
 const IP_TO_STAKE_REFRESH_DURATION: Duration = Duration::from_secs(5);
+const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
+const MAX_DEDUPER_ITEMS: u32 = 1_000_000;
+const MAX_EMPTY_BATCH_RATIO: usize = 4;
+const DISCARD_TARGET_PACKET_COUNT: usize = 10_000;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -36,8 +44,15 @@ struct FindPacketSenderStakeStats {
     apply_sender_stakes_time: u64,
     send_batches_time: u64,
     receive_batches_time: u64,
+    dedup_time: u64,
+    discard_time: u64,
+    shrink_time: u64,
     total_batches: u64,
     total_packets: u64,
+    total_packets_dedup: u64,
+    total_packets_excess: u64,
+    total_packets_sent: u64,
+    total_shrinks: u64,
 }
 
 impl FindPacketSenderStakeStats {
@@ -48,27 +63,191 @@ impl FindPacketSenderStakeStats {
             datapoint_info!(
                 "find_packet_sender_stake-services_stats",
                 (
-                    "refresh_ip_to_stake_time",
+                    "refresh_ip_to_stake_time_us",
                     self.refresh_ip_to_stake_time as i64,
                     i64
                 ),
                 (
-                    "apply_sender_stakes_time",
+                    "apply_sender_stakes_time_us",
                     self.apply_sender_stakes_time as i64,
                     i64
                 ),
-                ("send_batches_time", self.send_batches_time as i64, i64),
+                ("send_batches_time_us", self.send_batches_time as i64, i64),
                 (
-                    "receive_batches_time",
+                    "receive_batches_time_ns",
                     self.receive_batches_time as i64,
                     i64
                 ),
+                ("dedup_time_us", self.dedup_time, i64),
+                ("discard_time_us", self.discard_time, i64),
+                ("shrink_time_us", self.shrink_time, i64),
                 ("total_batches", self.total_batches as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
+                ("total_packets_dedup", self.total_packets_dedup, i64),
+                ("total_packets_excess", self.total_packets_excess, i64),
+                ("total_packets_sent", self.total_packets_sent, i64),
+                ("total_shrinks", self.total_shrinks, i64),
             );
             *self = FindPacketSenderStakeStats::default();
             self.last_print = now;
         }
+    }
+}
+
+struct FindPacketSenderStake {
+    last_stakes: Instant,
+    ip_to_stake: HashMap<IpAddr, u64>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    cluster_info: Arc<ClusterInfo>,
+    deduper: Deduper,
+    stats: FindPacketSenderStakeStats,
+}
+
+impl FindPacketSenderStake {
+    fn exec(
+        &mut self,
+        packet_receiver: &streamer::PacketBatchReceiver,
+        sender: &FindPacketSenderStakeSender,
+    ) -> Result<(), streamer::StreamerError> {
+        self.deduper.reset();
+
+        let mut refresh_ip_to_stake_time = Measure::start("refresh_ip_to_stake_time");
+        self.try_refresh_ip_to_stake();
+        refresh_ip_to_stake_time.stop();
+
+        let (mut batches, num_packets, recv_duration) =
+            streamer::recv_packet_batches(packet_receiver)?;
+        let num_batches = batches.len();
+
+        // Mark duplicate packets as discarded.
+        let mut dedup_time = Measure::start("dedup_time");
+        let dedup_fail = self.deduper.dedup_packets(&mut batches) as usize;
+        dedup_time.stop();
+        let num_unique = num_packets.saturating_sub(dedup_fail);
+
+        // Fill packet.meta.sender_stake.
+        let mut apply_sender_stakes_time = Measure::start("apply_sender_stakes_time");
+        Self::apply_sender_stakes(&mut batches, &self.ip_to_stake);
+        apply_sender_stakes_time.stop();
+
+        // Discard packets early if more than the target amount remain.
+        let mut discard_time = Measure::start("discard_time");
+        let mut num_sent_packets = num_unique;
+        if num_unique > DISCARD_TARGET_PACKET_COUNT {
+            Self::discard_excess_packets(&mut batches, DISCARD_TARGET_PACKET_COUNT);
+            num_sent_packets = DISCARD_TARGET_PACKET_COUNT;
+        }
+        let excess_fail = num_unique.saturating_sub(DISCARD_TARGET_PACKET_COUNT);
+        discard_time.stop();
+
+        // Shrink, if the previous stages significantly reduced the packet count.
+        // This produces full batches at the cost of copying packet data. It also
+        // releases memory.
+        let mut shrink_time = Measure::start("shrink_time");
+        let start_len = batches.len();
+        if num_packets > num_sent_packets.saturating_mul(MAX_EMPTY_BATCH_RATIO) {
+            let valid = shrink_batches(&mut batches);
+            batches.truncate(valid);
+        }
+        let total_shrinks = start_len.saturating_sub(batches.len());
+        shrink_time.stop();
+
+        let mut send_batches_time = Measure::start("send_batches_time");
+        if let Err(e) = sender.send(batches) {
+            info!("Sender error: {:?}", e);
+        }
+        send_batches_time.stop();
+
+        let mut stats = &mut self.stats;
+        stats.refresh_ip_to_stake_time = stats
+            .refresh_ip_to_stake_time
+            .saturating_add(refresh_ip_to_stake_time.as_us());
+        stats.apply_sender_stakes_time = stats
+            .apply_sender_stakes_time
+            .saturating_add(apply_sender_stakes_time.as_us());
+        stats.send_batches_time = stats
+            .send_batches_time
+            .saturating_add(send_batches_time.as_us());
+        stats.receive_batches_time = stats
+            .receive_batches_time
+            .saturating_add(recv_duration.as_nanos() as u64);
+        stats.dedup_time = stats.dedup_time.saturating_add(dedup_time.as_us() as u64);
+        stats.discard_time = stats
+            .discard_time
+            .saturating_add(discard_time.as_us() as u64);
+        stats.shrink_time = stats.shrink_time.saturating_add(shrink_time.as_us() as u64);
+        stats.total_batches = stats.total_batches.saturating_add(num_batches as u64);
+        stats.total_packets = stats.total_packets.saturating_add(num_packets as u64);
+        stats.total_packets_dedup = stats.total_packets_dedup.saturating_add(dedup_fail as u64);
+        stats.total_packets_excess = stats
+            .total_packets_excess
+            .saturating_add(excess_fail as u64);
+        stats.total_packets_sent = stats
+            .total_packets_sent
+            .saturating_add(num_sent_packets as u64);
+        stats.total_shrinks = stats.total_shrinks.saturating_add(total_shrinks as u64);
+
+        Ok(())
+    }
+
+    fn discard_excess_packets(batches: &mut [PacketBatch], mut max_packets: usize) {
+        // TODO: let sender_stake influence the discard decision
+
+        // Group packets by their incoming IP address.
+        let mut addrs = batches
+            .iter_mut()
+            .rev()
+            .flat_map(|batch| batch.packets.iter_mut().rev())
+            .filter(|packet| !packet.meta.discard())
+            .map(|packet| (packet.meta.addr, packet))
+            .into_group_map();
+        // Allocate max_packets evenly across addresses.
+        while max_packets > 0 && !addrs.is_empty() {
+            let num_addrs = addrs.len();
+            addrs.retain(|_, packets| {
+                let cap = (max_packets + num_addrs - 1) / num_addrs;
+                max_packets -= packets.len().min(cap);
+                packets.truncate(packets.len().saturating_sub(cap));
+                !packets.is_empty()
+            });
+        }
+        // Discard excess packets from each address.
+        for packet in addrs.into_values().flatten() {
+            packet.meta.set_discard(true);
+        }
+    }
+
+    fn try_refresh_ip_to_stake(&mut self) {
+        if self.last_stakes.elapsed() > IP_TO_STAKE_REFRESH_DURATION {
+            let root_bank = self.bank_forks.read().unwrap().root_bank();
+            let staked_nodes = root_bank.staked_nodes();
+            self.ip_to_stake = self
+                .cluster_info
+                .tvu_peers()
+                .into_iter()
+                .filter_map(|node| {
+                    let stake = staked_nodes.get(&node.id)?;
+                    Some((node.tvu.ip(), *stake))
+                })
+                .collect();
+            self.last_stakes = Instant::now();
+        }
+    }
+
+    fn apply_sender_stakes(batches: &mut [PacketBatch], ip_to_stake: &HashMap<IpAddr, u64>) {
+        PAR_THREAD_POOL.with(|thread_pool| {
+            thread_pool.borrow().install(|| {
+                batches
+                    .into_par_iter()
+                    .flat_map(|batch| batch.packets.par_iter_mut())
+                    .for_each(|packet| {
+                        if !packet.meta.discard() {
+                            packet.meta.sender_stake =
+                                *ip_to_stake.get(&packet.meta.addr().ip()).unwrap_or(&0);
+                        }
+                    });
+            })
+        });
     }
 }
 
@@ -83,103 +262,69 @@ impl FindPacketSenderStakeStage {
         bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: Arc<ClusterInfo>,
     ) -> Self {
-        let mut stats = FindPacketSenderStakeStats::default();
         let thread_hdl = Builder::new()
             .name("find-packet-sender-stake".to_string())
             .spawn(move || {
-                let mut last_stakes = Instant::now();
-                let mut ip_to_stake: HashMap<IpAddr, u64> = HashMap::new();
+                let mut job = FindPacketSenderStake {
+                    last_stakes: Instant::now(),
+                    ip_to_stake: HashMap::new(),
+                    bank_forks,
+                    cluster_info,
+                    deduper: Deduper::new(MAX_DEDUPER_ITEMS, MAX_DEDUPER_AGE),
+                    stats: FindPacketSenderStakeStats::default(),
+                };
                 loop {
-                    let mut refresh_ip_to_stake_time = Measure::start("refresh_ip_to_stake_time");
-                    Self::try_refresh_ip_to_stake(
-                        &mut last_stakes,
-                        &mut ip_to_stake,
-                        bank_forks.clone(),
-                        cluster_info.clone(),
-                    );
-                    refresh_ip_to_stake_time.stop();
-                    stats.refresh_ip_to_stake_time = stats
-                        .refresh_ip_to_stake_time
-                        .saturating_add(refresh_ip_to_stake_time.as_us());
-
-                    match streamer::recv_packet_batches(&packet_receiver) {
-                        Ok((mut batches, num_packets, recv_duration)) => {
-                            let num_batches = batches.len();
-                            let mut apply_sender_stakes_time =
-                                Measure::start("apply_sender_stakes_time");
-                            Self::apply_sender_stakes(&mut batches, &ip_to_stake);
-                            apply_sender_stakes_time.stop();
-
-                            let mut send_batches_time = Measure::start("send_batches_time");
-                            if let Err(e) = sender.send(batches) {
-                                info!("Sender error: {:?}", e);
-                            }
-                            send_batches_time.stop();
-
-                            stats.apply_sender_stakes_time = stats
-                                .apply_sender_stakes_time
-                                .saturating_add(apply_sender_stakes_time.as_us());
-                            stats.send_batches_time = stats
-                                .send_batches_time
-                                .saturating_add(send_batches_time.as_us());
-                            stats.receive_batches_time = stats
-                                .receive_batches_time
-                                .saturating_add(recv_duration.as_nanos() as u64);
-                            stats.total_batches =
-                                stats.total_batches.saturating_add(num_batches as u64);
-                            stats.total_packets =
-                                stats.total_packets.saturating_add(num_packets as u64);
-                        }
-                        Err(e) => match e {
+                    if let Err(e) = job.exec(&packet_receiver, &sender) {
+                        match e {
                             StreamerError::RecvTimeout(RecvTimeoutError::Disconnected) => break,
                             StreamerError::RecvTimeout(RecvTimeoutError::Timeout) => (),
                             _ => error!("error: {:?}", e),
-                        },
+                        };
                     }
 
-                    stats.report();
+                    job.stats.report();
                 }
             })
             .unwrap();
         Self { thread_hdl }
     }
 
-    fn try_refresh_ip_to_stake(
-        last_stakes: &mut Instant,
-        ip_to_stake: &mut HashMap<IpAddr, u64>,
-        bank_forks: Arc<RwLock<BankForks>>,
-        cluster_info: Arc<ClusterInfo>,
-    ) {
-        if last_stakes.elapsed() > IP_TO_STAKE_REFRESH_DURATION {
-            let root_bank = bank_forks.read().unwrap().root_bank();
-            let staked_nodes = root_bank.staked_nodes();
-            *ip_to_stake = cluster_info
-                .tvu_peers()
-                .into_iter()
-                .filter_map(|node| {
-                    let stake = staked_nodes.get(&node.id)?;
-                    Some((node.tvu.ip(), *stake))
-                })
-                .collect();
-            *last_stakes = Instant::now();
-        }
-    }
-
-    fn apply_sender_stakes(batches: &mut [PacketBatch], ip_to_stake: &HashMap<IpAddr, u64>) {
-        PAR_THREAD_POOL.with(|thread_pool| {
-            thread_pool.borrow().install(|| {
-                batches
-                    .into_par_iter()
-                    .flat_map(|batch| batch.packets.par_iter_mut())
-                    .for_each(|packet| {
-                        packet.meta.sender_stake =
-                            *ip_to_stake.get(&packet.meta.addr().ip()).unwrap_or(&0);
-                    });
-            })
-        });
-    }
-
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_perf::packet::Packet};
+
+    fn count_non_discard(packet_batches: &[PacketBatch]) -> usize {
+        packet_batches
+            .iter()
+            .map(|batch| {
+                batch
+                    .packets
+                    .iter()
+                    .map(|p| if p.meta.discard() { 0 } else { 1 })
+                    .sum::<usize>()
+            })
+            .sum::<usize>()
+    }
+
+    #[test]
+    fn test_packet_discard() {
+        solana_logger::setup();
+        let mut batch = PacketBatch::default();
+        batch.packets.resize(10, Packet::default());
+        batch.packets[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
+        batch.packets[3].meta.set_discard(true);
+        batch.packets[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
+        let mut batches = vec![batch];
+        let max = 3;
+        FindPacketSenderStake::discard_excess_packets(&mut batches, max);
+        assert_eq!(count_non_discard(&batches), max);
+        assert!(!batches[0].packets[0].meta.discard());
+        assert!(batches[0].packets[3].meta.discard());
+        assert!(!batches[0].packets[4].meta.discard());
     }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -163,7 +163,8 @@ impl SigVerifyStage {
         verifier: &T,
         stats: &mut SigVerifierStats,
     ) -> Result<()> {
-        let (mut batches, num_packets, recv_duration) = streamer::recv_vec_packet_batches(recvr)?;
+        let (mut batches, _, recv_duration) = streamer::recv_vec_packet_batches(recvr)?;
+        let num_packets = count_valid_packets(&batches);
 
         let batches_len = batches.len();
         debug!(

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -7,13 +7,11 @@
 
 use {
     crate::{find_packet_sender_stake_stage, sigverify},
-    core::time::Duration,
     crossbeam_channel::{RecvTimeoutError, SendError, Sender},
-    itertools::Itertools,
     solana_measure::measure::Measure,
     solana_perf::{
         packet::PacketBatch,
-        sigverify::{count_valid_packets, shrink_batches, Deduper},
+        sigverify::{count_valid_packets, shrink_batches},
     },
     solana_sdk::timing,
     solana_streamer::streamer::{self, StreamerError},
@@ -23,8 +21,6 @@ use {
     },
     thiserror::Error,
 };
-
-const MAX_SIGVERIFY_BATCH: usize = 10_000;
 
 #[derive(Error, Debug)]
 pub enum SigVerifyServiceError {
@@ -52,17 +48,14 @@ pub struct DisabledSigVerifier {}
 struct SigVerifierStats {
     recv_batches_us_hist: histogram::Histogram, // time to call recv_batch
     verify_batches_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
-    discard_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
-    dedup_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     batches_hist: histogram::Histogram,         // number of packet batches per verify call
     packets_hist: histogram::Histogram,         // number of packets per verify call
     total_batches: usize,
     total_packets: usize,
-    total_dedup: usize,
-    total_excess_fail: usize,
+    total_valid_packets: usize,
+    total_verify_time: usize,
     total_shrink_time: usize,
     total_shrinks: usize,
-    total_valid_packets: usize,
 }
 
 impl SigVerifierStats {
@@ -110,48 +103,6 @@ impl SigVerifierStats {
                 i64
             ),
             (
-                "discard_packets_pp_us_90pct",
-                self.discard_packets_pp_us_hist
-                    .percentile(90.0)
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_min",
-                self.discard_packets_pp_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_max",
-                self.discard_packets_pp_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "discard_packets_pp_us_mean",
-                self.discard_packets_pp_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_90pct",
-                self.dedup_packets_pp_us_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_min",
-                self.dedup_packets_pp_us_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_max",
-                self.dedup_packets_pp_us_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "dedup_packets_pp_us_mean",
-                self.dedup_packets_pp_us_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
                 "batches_90pct",
                 self.batches_hist.percentile(90.0).unwrap_or(0),
                 i64
@@ -169,11 +120,10 @@ impl SigVerifierStats {
             ("packets_mean", self.packets_hist.mean().unwrap_or(0), i64),
             ("total_batches", self.total_batches, i64),
             ("total_packets", self.total_packets, i64),
-            ("total_dedup", self.total_dedup, i64),
-            ("total_excess_fail", self.total_excess_fail, i64),
-            ("total_shrink_time", self.total_shrink_time, i64),
-            ("total_shrinks", self.total_shrinks, i64),
             ("total_valid_packets", self.total_valid_packets, i64),
+            ("total_verify_time_us", self.total_verify_time, i64),
+            ("total_shrink_time_us", self.total_shrink_time, i64),
+            ("total_shrinks", self.total_shrinks, i64),
         );
     }
 }
@@ -201,39 +151,13 @@ impl SigVerifyStage {
         Self { thread_hdl }
     }
 
-    pub fn discard_excess_packets(batches: &mut [PacketBatch], mut max_packets: usize) {
-        // Group packets by their incoming IP address.
-        let mut addrs = batches
-            .iter_mut()
-            .rev()
-            .flat_map(|batch| batch.packets.iter_mut().rev())
-            .filter(|packet| !packet.meta.discard())
-            .map(|packet| (packet.meta.addr, packet))
-            .into_group_map();
-        // Allocate max_packets evenly across addresses.
-        while max_packets > 0 && !addrs.is_empty() {
-            let num_addrs = addrs.len();
-            addrs.retain(|_, packets| {
-                let cap = (max_packets + num_addrs - 1) / num_addrs;
-                max_packets -= packets.len().min(cap);
-                packets.truncate(packets.len().saturating_sub(cap));
-                !packets.is_empty()
-            });
-        }
-        // Discard excess packets from each address.
-        for packet in addrs.into_values().flatten() {
-            packet.meta.set_discard(true);
-        }
-    }
-
     fn verifier<T: SigVerifier>(
-        deduper: &Deduper,
         recvr: &find_packet_sender_stake_stage::FindPacketSenderStakeReceiver,
         sendr: &Sender<Vec<PacketBatch>>,
         verifier: &T,
         stats: &mut SigVerifierStats,
     ) -> Result<()> {
-        let (mut batches, num_packets, recv_duration) = streamer::recv_vec_packet_batches(recvr)?;
+        let (batches, num_packets, recv_duration) = streamer::recv_vec_packet_batches(recvr)?;
 
         let batches_len = batches.len();
         debug!(
@@ -242,22 +166,8 @@ impl SigVerifyStage {
             num_packets,
         );
 
-        let mut dedup_time = Measure::start("sigverify_dedup_time");
-        let dedup_fail = deduper.dedup_packets(&mut batches) as usize;
-        dedup_time.stop();
-        let num_unique = num_packets.saturating_sub(dedup_fail);
-
-        let mut discard_time = Measure::start("sigverify_discard_time");
-        let mut num_valid_packets = num_unique;
-        if num_unique > MAX_SIGVERIFY_BATCH {
-            Self::discard_excess_packets(&mut batches, MAX_SIGVERIFY_BATCH);
-            num_valid_packets = MAX_SIGVERIFY_BATCH;
-        }
-        let excess_fail = num_unique.saturating_sub(MAX_SIGVERIFY_BATCH);
-        discard_time.stop();
-
         let mut verify_batch_time = Measure::start("sigverify_batch_time");
-        let mut batches = verifier.verify_batches(batches, num_valid_packets);
+        let mut batches = verifier.verify_batches(batches, num_packets);
         verify_batch_time.stop();
 
         let mut shrink_time = Measure::start("sigverify_shrink_time");
@@ -291,22 +201,13 @@ impl SigVerifyStage {
             .verify_batches_pp_us_hist
             .increment(verify_batch_time.as_us() / (num_packets as u64))
             .unwrap();
-        stats
-            .discard_packets_pp_us_hist
-            .increment(discard_time.as_us() / (num_packets as u64))
-            .unwrap();
-        stats
-            .dedup_packets_pp_us_hist
-            .increment(dedup_time.as_us() / (num_packets as u64))
-            .unwrap();
         stats.batches_hist.increment(batches_len as u64).unwrap();
         stats.packets_hist.increment(num_packets as u64).unwrap();
         stats.total_batches += batches_len;
         stats.total_packets += num_packets;
-        stats.total_dedup += dedup_fail;
         stats.total_valid_packets += num_valid_packets;
-        stats.total_excess_fail += excess_fail;
         stats.total_shrink_time += shrink_time.as_us() as usize;
+        stats.total_verify_time += verify_batch_time.as_us() as usize;
         stats.total_shrinks += total_shrinks;
 
         Ok(())
@@ -321,39 +222,29 @@ impl SigVerifyStage {
         let verifier = verifier.clone();
         let mut stats = SigVerifierStats::default();
         let mut last_print = Instant::now();
-        const MAX_DEDUPER_AGE: Duration = Duration::from_secs(2);
-        const MAX_DEDUPER_ITEMS: u32 = 1_000_000;
         Builder::new()
             .name("solana-verifier".to_string())
-            .spawn(move || {
-                let mut deduper = Deduper::new(MAX_DEDUPER_ITEMS, MAX_DEDUPER_AGE);
-                loop {
-                    deduper.reset();
-                    if let Err(e) = Self::verifier(
-                        &deduper,
-                        &packet_receiver,
-                        &verified_sender,
-                        &verifier,
-                        &mut stats,
-                    ) {
-                        match e {
-                            SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
-                                RecvTimeoutError::Disconnected,
-                            )) => break,
-                            SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
-                                RecvTimeoutError::Timeout,
-                            )) => (),
-                            SigVerifyServiceError::Send(_) => {
-                                break;
-                            }
-                            _ => error!("{:?}", e),
+            .spawn(move || loop {
+                if let Err(e) =
+                    Self::verifier(&packet_receiver, &verified_sender, &verifier, &mut stats)
+                {
+                    match e {
+                        SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
+                            RecvTimeoutError::Disconnected,
+                        )) => break,
+                        SigVerifyServiceError::Streamer(StreamerError::RecvTimeout(
+                            RecvTimeoutError::Timeout,
+                        )) => (),
+                        SigVerifyServiceError::Send(_) => {
+                            break;
                         }
+                        _ => error!("{:?}", e),
                     }
-                    if last_print.elapsed().as_secs() > 2 {
-                        stats.report(name);
-                        stats = SigVerifierStats::default();
-                        last_print = Instant::now();
-                    }
+                }
+                if last_print.elapsed().as_secs() > 2 {
+                    stats.report(name);
+                    stats = SigVerifierStats::default();
+                    last_print = Instant::now();
                 }
             })
             .unwrap()
@@ -378,42 +269,11 @@ mod tests {
     use {
         super::*,
         crate::{sigverify::TransactionSigVerifier, sigverify_stage::timing::duration_as_ms},
+        core::time::Duration,
         crossbeam_channel::unbounded,
-        solana_perf::{
-            packet::{to_packet_batches, Packet},
-            test_tx::test_tx,
-        },
+        solana_perf::{packet::to_packet_batches, test_tx::test_tx},
     };
 
-    fn count_non_discard(packet_batches: &[PacketBatch]) -> usize {
-        packet_batches
-            .iter()
-            .map(|batch| {
-                batch
-                    .packets
-                    .iter()
-                    .map(|p| if p.meta.discard() { 0 } else { 1 })
-                    .sum::<usize>()
-            })
-            .sum::<usize>()
-    }
-
-    #[test]
-    fn test_packet_discard() {
-        solana_logger::setup();
-        let mut batch = PacketBatch::default();
-        batch.packets.resize(10, Packet::default());
-        batch.packets[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
-        batch.packets[3].meta.set_discard(true);
-        batch.packets[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
-        let mut batches = vec![batch];
-        let max = 3;
-        SigVerifyStage::discard_excess_packets(&mut batches, max);
-        assert_eq!(count_non_discard(&batches), max);
-        assert!(!batches[0].packets[0].meta.discard());
-        assert!(batches[0].packets[3].meta.discard());
-        assert!(!batches[0].packets[4].meta.discard());
-    }
     fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch> {
         let len = 4096;
         let chunk_size = 1024;

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -17,6 +17,7 @@ curve25519-dalek = { version = "3" }
 dlopen = "0.1.8"
 dlopen_derive = "0.1.4"
 fnv = "1.0.7"
+itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 rand = "0.7.0"


### PR DESCRIPTION
#### Problem

Dedup is fast, but sigverify is around 25x slower on CPUs.

Dedup and sigverify together were unable to keep up with incoming data during a packet flood. This lead to the inbound queue for SigVerifyStage growing out of control, increasing memory use and the size of the next sigverify work-unit. Eventually sigverify-stage needed to process 70M packets and finished only 60+ seconds later. This stalled the banking stage.

See #24747 for details.

With dedup moved to an earlier stage we should be able to keep up with incoming packets if they are mostly duplicates.

~~If there are too many valid non-duplicate packets, we still run into the same problem...~~

#### Summary of Changes

Moved dedup/~~discard/shrink~~ to the FindPacketSenderStakeStage.

TODO:
- Rename FindPacketSenderStakeStage
- Add benchmarks
- General cleanup and testing
- ~~Actually discard should be moved back into SigVerify. Right now FindPacketSenderStakeStage could produce 10k-packet chunks at a pace that SigVerify can't deal with.~~

@sakridge 
