### PR TITLE
Update install-solana-cli docs with Homebrew instructions

### DIFF
--- a/docs/src/cli/install-solana-cli-tools.md
+++ b/docs/src/cli/install-solana-cli-tools.md
@@ -8,6 +8,7 @@ depending on your preferred workflow:
 - [Use Solana's Install Tool (Simplest option)](#use-solanas-install-tool)
 - [Download Prebuilt Binaries](#download-prebuilt-binaries)
 - [Build from Source](#build-from-source)
+- [Use Homebrew](#use-homebrew)
 
 ## Use Solana's Install Tool
 
@@ -161,4 +162,22 @@ prebuilt binaries:
 
 ```bash
 solana-install init
+```
+
+## Use Homebrew
+
+This option requires you to have [Homebrew](https://brew.sh/) package manager on your MacOS or Linux machine.
+
+### MacOS & Linux
+
+- Follow instructions at: https://formulae.brew.sh/formula/solana
+
+[Homebrew formulae](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/solana.rb)
+is updated after each `solana` release, however it is possible that
+the Homebrew version is outdated.
+
+- Confirm you have the desired version of `solana` installed by entering:
+
+```bash
+solana --version
 ```


### PR DESCRIPTION
#### Problem

The simplest way of installing Solana CLI tool requires you to modify your $PATH variable manually. Given that developers are likely to have Homebrew installed on their machines, it would be easier to run the Homebrew install script. This will ensure solana tools are installed to the correct directory, are up to date and automatically added to $PATH.

#### Summary of Changes

Added Homebrew installation guide for solana tools.
