### PR TITLE
Add GetMinimumDelegation (backport of #24020, #24158, #24192, #24175)

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3903,6 +3903,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-get-minimum-delegation"
+version = "1.10.12"
+dependencies = [
+ "solana-program 1.10.12",
+]
+
+[[package]]
 name = "solana-bpf-rust-instruction-introspection"
 version = "1.10.12"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "rust/error_handling",
     "rust/log_data",
     "rust/external_spend",
+    "rust/get_minimum_delegation",
     "rust/finalize",
     "rust/instruction_introspection",
     "rust/invoke",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -70,6 +70,7 @@ fn main() {
             "log_data",
             "external_spend",
             "finalize",
+            "get_minimum_delegation",
             "instruction_introspection",
             "invoke",
             "invoke_and_error",

--- a/programs/bpf/rust/get_minimum_delegation/Cargo.toml
+++ b/programs/bpf/rust/get_minimum_delegation/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-bpf-rust-get-minimum-delegation"
+version = "1.10.12"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-get-minimum-delegation"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.10.12" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/get_minimum_delegation/src/lib.rs
+++ b/programs/bpf/rust/get_minimum_delegation/src/lib.rs
@@ -1,0 +1,23 @@
+//! Example/test program to get the minimum stake delegation via the helper function
+
+#![allow(unreachable_code)]
+
+extern crate solana_program;
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey, stake,
+};
+
+solana_program::entrypoint!(process_instruction);
+#[allow(clippy::unnecessary_wraps)]
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let minimum_delegation = stake::tools::get_minimum_delegation()?;
+    msg!(
+        "The minimum stake delegation is {} lamports",
+        minimum_delegation
+    );
+    Ok(())
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -56,6 +56,7 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         signature::{keypair_from_seed, Keypair, Signer},
+        stake,
         system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
         system_program,
         sysvar::{self, clock, rent},
@@ -3520,4 +3521,33 @@ fn test_program_fees() {
         .unwrap();
     let post_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     assert_eq!(pre_balance - post_balance, expected_min_fee);
+}
+
+#[test]
+#[cfg(feature = "bpf_rust")]
+fn test_get_minimum_delegation() {
+    let GenesisConfigInfo {
+        genesis_config,
+        mint_keypair,
+        ..
+    } = create_genesis_config(100_123_456_789);
+    let mut bank = Bank::new_for_tests(&genesis_config);
+    bank.feature_set = Arc::new(FeatureSet::all_enabled());
+
+    let (name, id, entrypoint) = solana_bpf_loader_program!();
+    bank.add_builtin(&name, &id, entrypoint);
+    let bank = Arc::new(bank);
+    let bank_client = BankClient::new_shared(&bank);
+
+    let program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_get_minimum_delegation",
+    );
+
+    let account_metas = vec![AccountMeta::new_readonly(stake::program::id(), false)];
+    let instruction = Instruction::new_with_bytes(program_id, &[], account_metas);
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    assert!(result.is_ok());
 }

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(min_specialization))]
 #![allow(clippy::integer_arithmetic)]
-use solana_sdk::genesis_config::GenesisConfig;
 #[deprecated(
     since = "1.8.0",
     note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` instead"
 )]
 pub use solana_sdk::stake::program::{check_id, id};
+use solana_sdk::{feature_set::FeatureSet, genesis_config::GenesisConfig};
 
 pub mod config;
 pub mod stake_instruction;
@@ -13,4 +13,16 @@ pub mod stake_state;
 
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
     config::add_genesis_account(genesis_config)
+}
+
+/// The minimum stake amount that can be delegated, in lamports.
+/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
+/// rent exempt reserve _plus_ the minimum stake delegation.
+#[inline(always)]
+pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
+    // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
+    // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
+    // removed, use it here as to not duplicate magic constants.
+    #[allow(deprecated)]
+    solana_sdk::stake::MINIMUM_STAKE_DELEGATION
 }

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -19,7 +19,7 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
 /// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
 /// rent exempt reserve _plus_ the minimum stake delegation.
 #[inline(always)]
-pub(crate) fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
+pub fn get_minimum_delegation(_feature_set: &FeatureSet) -> u64 {
     // If/when the minimum delegation amount is changed, the `feature_set` parameter will be used
     // to chose the correct value.  And since the MINIMUM_STAKE_DELEGATION constant cannot be
     // removed, use it here as to not duplicate magic constants.

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -365,7 +365,7 @@ mod tests {
             sysvar::{self, stake_history::StakeHistory},
         },
         solana_vote_program::vote_state::{self, VoteState, VoteStateVersions},
-        std::{collections::HashSet, str::FromStr},
+        std::{collections::HashSet, str::FromStr, sync::Arc},
     };
 
     fn create_default_account() -> AccountSharedData {
@@ -3489,5 +3489,137 @@ mod tests {
                 Ok(())
             },
         );
+    }
+
+    // Ensure that the correct errors are returned when processing instructions
+    //
+    // The GetMinimumDelegation instruction does not take any accounts; so when it was added,
+    // `process_instruction()` needed to be updated to *not* need a stake account passed in, which
+    // changes the error *ordering* conditions.  These changes shall only occur when the
+    // `add_get_minimum_delegation_instruction_to_stake_program` feature is enabled, and this test
+    // ensures it.
+    //
+    // For the following combinations of the feature enabled/disabled, if the instruction is
+    // valid/invalid, and if a stake account is passed in or not, assert the result:
+    //
+    //  feature | instruction | account || result
+    // ---------+-------------+---------++--------
+    //  enabled | good        | some    || Ok
+    //  enabled | bad         | some    || Err InvalidInstructionData
+    //  enabled | good        | none    || Err NotEnoughAccountKeys
+    //  enabled | bad         | none    || Err InvalidInstructionData
+    // disabled | good        | some    || Ok
+    // disabled | bad         | some    || Err InvalidInstructionData
+    // disabled | good        | none    || Err NotEnoughAccountKeys
+    // disabled | bad         | none    || Err NotEnoughAccountKeys
+    #[test]
+    fn test_stake_process_instruction_error_ordering() {
+        let rent = Rent::default();
+        let rent_address = sysvar::rent::id();
+        let rent_account = account::create_account_shared_data_for_test(&rent);
+
+        let good_stake_address = Pubkey::new_unique();
+        let good_stake_account = AccountSharedData::new(
+            u64::MAX,
+            std::mem::size_of::<crate::stake_state::StakeState>(),
+            &id(),
+        );
+        let good_instruction = instruction::initialize(
+            &good_stake_address,
+            &Authorized::auto(&good_stake_address),
+            &Lockup::default(),
+        );
+        let good_transaction_accounts = vec![
+            (good_stake_address, good_stake_account),
+            (rent_address, rent_account),
+        ];
+        let good_instruction_accounts = vec![
+            AccountMeta {
+                pubkey: good_stake_address,
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: rent_address,
+                is_signer: false,
+                is_writable: false,
+            },
+        ];
+        let good_accounts = (good_transaction_accounts, good_instruction_accounts);
+
+        // The instruction data needs to deserialize to a bogus StakeInstruction.  We likely never
+        // will have `usize::MAX`-number of instructions, so this should be a safe constant to
+        // always map to an invalid stake instruction.
+        let bad_instruction = Instruction::new_with_bincode(id(), &usize::MAX, Vec::default());
+        let bad_transaction_accounts = Vec::default();
+        let bad_instruction_accounts = Vec::default();
+        let bad_accounts = (bad_transaction_accounts, bad_instruction_accounts);
+
+        for (
+            is_feature_enabled,
+            instruction,
+            (transaction_accounts, instruction_accounts),
+            expected_result,
+        ) in [
+            (true, &good_instruction, &good_accounts, Ok(())),
+            (
+                true,
+                &bad_instruction,
+                &good_accounts,
+                Err(InstructionError::InvalidInstructionData),
+            ),
+            (
+                true,
+                &good_instruction,
+                &bad_accounts,
+                Err(InstructionError::NotEnoughAccountKeys),
+            ),
+            (
+                true,
+                &bad_instruction,
+                &bad_accounts,
+                Err(InstructionError::InvalidInstructionData),
+            ),
+            (false, &good_instruction, &good_accounts, Ok(())),
+            (
+                false,
+                &bad_instruction,
+                &good_accounts,
+                Err(InstructionError::InvalidInstructionData),
+            ),
+            (
+                false,
+                &good_instruction,
+                &bad_accounts,
+                Err(InstructionError::NotEnoughAccountKeys),
+            ),
+            (
+                false,
+                &bad_instruction,
+                &bad_accounts,
+                Err(InstructionError::NotEnoughAccountKeys),
+            ),
+        ] {
+            mock_process_instruction(
+                &id(),
+                Vec::new(),
+                &instruction.data,
+                transaction_accounts.clone(),
+                instruction_accounts.clone(),
+                expected_result,
+                if is_feature_enabled {
+                    |first_instruction_account, data, invoke_context| {
+                        super::process_instruction(first_instruction_account, data, invoke_context)
+                    }
+                } else {
+                    |first_instruction_account, data, invoke_context| {
+                        let mut feature_set = FeatureSet::all_enabled();
+                        feature_set.deactivate(&feature_set::add_get_minimum_delegation_instruction_to_stake_program::id());
+                        invoke_context.feature_set = Arc::new(feature_set);
+                        super::process_instruction(first_instruction_account, data, invoke_context)
+                    }
+                },
+            );
+        }
     }
 }

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -222,6 +222,15 @@ pub enum StakeInstruction {
     ///   1. `[SIGNER]` Lockup authority or withdraw authority
     ///   2. Optional: `[SIGNER]` New lockup authority
     SetLockupChecked(LockupCheckedArgs),
+
+    /// Get the minimum stake delegation, in lamports
+    ///
+    /// # Account references
+    ///   None
+    ///
+    /// The minimum delegation will be returned via the transaction context's returndata.
+    /// Use `get_return_data()` to retrieve the result.
+    GetMinimumDelegation,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -675,6 +684,14 @@ pub fn set_lockup_checked(
         id(),
         &StakeInstruction::SetLockupChecked(lockup_checked),
         account_metas,
+    )
+}
+
+pub fn get_minimum_delegation() -> Instruction {
+    Instruction::new_with_bincode(
+        id(),
+        &StakeInstruction::GetMinimumDelegation,
+        Vec::default(),
     )
 }
 

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -228,8 +228,11 @@ pub enum StakeInstruction {
     /// # Account references
     ///   None
     ///
-    /// The minimum delegation will be returned via the transaction context's returndata.
-    /// Use `get_return_data()` to retrieve the result.
+    /// Returns the minimum delegation as a little-endian encoded u64 value.
+    /// Programs can use the [`get_minimum_delegation()`] helper function to invoke and
+    /// retrieve the return value for this instruction.
+    ///
+    /// [`get_minimum_delegation()`]: super::tools::get_minimum_delegation
     GetMinimumDelegation,
 }
 

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod instruction;
 pub mod state;
+pub mod tools;
 
 pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");

--- a/sdk/program/src/stake/mod.rs
+++ b/sdk/program/src/stake/mod.rs
@@ -6,7 +6,8 @@ pub mod program {
     crate::declare_id!("Stake11111111111111111111111111111111111111");
 }
 
-/// The minimum stake amount that can be delegated, in lamports.
-/// NOTE: This is also used to calculate the minimum balance of a stake account, which is the
-/// rent exempt reserve _plus_ the minimum stake delegation.
+#[deprecated(
+    since = "1.10.12",
+    note = "This constant may be outdated, please use `solana_stake_program::get_minimum_delegation` instead"
+)]
 pub const MINIMUM_STAKE_DELEGATION: u64 = 1;

--- a/sdk/program/src/stake/tools.rs
+++ b/sdk/program/src/stake/tools.rs
@@ -1,0 +1,38 @@
+//! Utility functions
+use crate::program_error::ProgramError;
+
+/// Helper function for programs to call [`GetMinimumDelegation`] and then fetch the return data
+///
+/// This fn handles performing the CPI to call the [`GetMinimumDelegation`] function, and then
+/// calls [`get_return_data()`] to fetch the return data.
+///
+/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`get_return_data()`]: crate::program::get_return_data
+pub fn get_minimum_delegation() -> Result<u64, ProgramError> {
+    let instruction = super::instruction::get_minimum_delegation();
+    crate::program::invoke_unchecked(&instruction, &[])?;
+    get_minimum_delegation_return_data()
+}
+
+/// Helper function for programs to get the return data after calling [`GetMinimumDelegation`]
+///
+/// This fn handles calling [`get_return_data()`], ensures the result is from the correct
+/// program, and returns the correct type.
+///
+/// [`GetMinimumDelegation`]: super::instruction::StakeInstruction::GetMinimumDelegation
+/// [`get_return_data()`]: crate::program::get_return_data
+fn get_minimum_delegation_return_data() -> Result<u64, ProgramError> {
+    crate::program::get_return_data()
+        .ok_or(ProgramError::InvalidInstructionData)
+        .and_then(|(program_id, return_data)| {
+            (program_id == super::program::id())
+                .then(|| return_data)
+                .ok_or(ProgramError::IncorrectProgramId)
+        })
+        .and_then(|return_data| {
+            return_data
+                .try_into()
+                .or(Err(ProgramError::InvalidInstructionData))
+        })
+        .map(u64::from_le_bytes)
+}

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -335,6 +335,10 @@ pub mod spl_associated_token_account_v1_1_0 {
     solana_sdk::declare_id!("FaTa17gVKoqbh38HcfiQonPsAaQViyDCCSg71AubYZw8");
 }
 
+pub mod add_get_minimum_delegation_instruction_to_stake_program {
+    solana_sdk::declare_id!("St8k9dVXP97xT6faW24YmRSYConLbhsMJA4TJTBLmMT");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -413,6 +417,7 @@ lazy_static! {
         (drop_redundant_turbine_path::id(), "drop redundant turbine path"),
         (spl_token_v3_4_0::id(), "SPL Token Program version 3.4.0 release #24740"),
         (spl_associated_token_account_v1_1_0::id(), "SPL Associated Token Account Program version 1.1.0 release #24741"),
+        (add_get_minimum_delegation_instruction_to_stake_program::id(), "add GetMinimumDelegation instruction to stake program"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -3,7 +3,7 @@ use {
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
     bincode::deserialize,
-    serde_json::{json, Map},
+    serde_json::{json, Map, Value},
     solana_sdk::{
         instruction::CompiledInstruction, message::AccountKeys,
         stake::instruction::StakeInstruction,
@@ -269,6 +269,10 @@ pub fn parse_stake(
                 }),
             })
         }
+        StakeInstruction::GetMinimumDelegation => Ok(ParsedInstructionEnum {
+            instruction_type: "getMinimumDelegation".to_string(),
+            info: Value::default(),
+        }),
     }
 }
 


### PR DESCRIPTION
#### Problem

As part of #22559, the PR to actually raise the minimum delegation (#24357) fails CI during downstream-projects when building/testing stake-pool. The stake-pool program would like to have a v1.10 of the SDK that has the new `GetMinimumDelegation` instruction, which it can use internally to query the value, instead of using a hard-coded literal.

#### Summary of Changes

Backport `GetMinimumDelegation` to v1.10. Due to the changes in the program-runtime (how accounts are passed in), a mergify backport will not be trivial. Instead, I've manually backported #24020, #24158, #24192, #24175 due to how much the code has diverged. Note that v1.10 *will not* get the feature to actually raise the minimum delegation.

The number of changes in this PR is quite large. If it's preferred, I can break it up into smaller chunks as well. There should not be any functional changes when compared to `master`.

Feature Gate Issue: #24057