### PR TITLE
Lower max sigverify batch size

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -24,7 +24,7 @@ use {
     thiserror::Error,
 };
 
-const MAX_SIGVERIFY_BATCH: usize = 10_000;
+const MAX_SIGVERIFY_BATCH: usize = 2_000;
 
 #[derive(Error, Debug)]
 pub enum SigVerifyServiceError {


### PR DESCRIPTION
#### Problem

10k batch size still sees nodes with CPU verify backup with packets in heavy flow

#### Summary of Changes

Lower the batch size to 2000 which should result in more packet discard and less packets to accumulate while sigverify is processing packets.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
