### PR TITLE
Block packets in vote-only mode

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -113,6 +113,7 @@ fn main() -> Result<()> {
             stats.clone(),
             1,
             true,
+            None,
         ));
     }
 

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -157,6 +157,7 @@ impl AncestorHashesService {
             )),
             1,
             false,
+            None,
         );
 
         let ancestor_hashes_request_statuses: Arc<DashMap<Slot, DeadSlotAncestorRequestStatus>> =
@@ -920,6 +921,7 @@ mod test {
                 )),
                 1,
                 false,
+                None,
             );
             let t_listen = ServeRepair::listen(
                 responder_serve_repair,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -53,6 +53,7 @@ impl FetchStage {
                 &vote_sender,
                 poh_recorder,
                 coalesce_ms,
+                None,
             ),
             receiver,
             vote_receiver,
@@ -68,6 +69,7 @@ impl FetchStage {
         vote_sender: &PacketBatchSender,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
+        in_vote_only_mode: Option<Arc<AtomicBool>>,
     ) -> Self {
         let tx_sockets = sockets.into_iter().map(Arc::new).collect();
         let tpu_forwards_sockets = tpu_forwards_sockets.into_iter().map(Arc::new).collect();
@@ -81,6 +83,7 @@ impl FetchStage {
             vote_sender,
             poh_recorder,
             coalesce_ms,
+            in_vote_only_mode,
         )
     }
 
@@ -135,6 +138,7 @@ impl FetchStage {
         vote_sender: &PacketBatchSender,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
+        in_vote_only_mode: Option<Arc<AtomicBool>>,
     ) -> Self {
         let recycler: PacketBatchRecycler = Recycler::warmed(1000, 1024);
 
@@ -150,6 +154,7 @@ impl FetchStage {
                     tpu_stats.clone(),
                     coalesce_ms,
                     true,
+                    in_vote_only_mode.clone(),
                 )
             })
             .collect();
@@ -167,6 +172,7 @@ impl FetchStage {
                     tpu_forward_stats.clone(),
                     coalesce_ms,
                     true,
+                    in_vote_only_mode.clone(),
                 )
             })
             .collect();
@@ -183,6 +189,7 @@ impl FetchStage {
                     tpu_vote_stats.clone(),
                     coalesce_ms,
                     true,
+                    None,
                 )
             })
             .collect();

--- a/core/src/serve_repair_service.rs
+++ b/core/src/serve_repair_service.rs
@@ -42,6 +42,7 @@ impl ServeRepairService {
             Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
             1,
             false,
+            None,
         );
         let (response_sender, response_receiver) = unbounded();
         let t_responder = streamer::responder(

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -142,6 +142,7 @@ impl ShredFetchStage {
                     Arc::new(StreamerReceiveStats::new("packet_modifier")),
                     1,
                     true,
+                    None,
                 )
             })
             .collect();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -113,6 +113,7 @@ impl Tpu {
             &vote_packet_sender,
             poh_recorder,
             tpu_coalesce_ms,
+            Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
         );
 
         let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) = unbounded();

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -57,6 +57,7 @@ impl GossipService {
             Arc::new(StreamerReceiveStats::new("gossip_receiver")),
             1,
             false,
+            None,
         );
         let (consume_sender, listen_receiver) = unbounded();
         let t_socket_consume = cluster_info.clone().start_socket_consume_thread(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -12,10 +12,12 @@ use {
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
-        sync::Arc,
+        sync::{atomic::AtomicBool, Arc},
         time::Instant,
     },
 };
+
+pub const MAX_ROOT_DISTANCE_FOR_VOTE_ONLY: Slot = 400;
 
 #[derive(Debug, Default, Copy, Clone)]
 struct SetRootMetrics {
@@ -48,6 +50,7 @@ pub struct BankForks {
 
     pub accounts_hash_interval_slots: Slot,
     last_accounts_hash_slot: Slot,
+    in_vote_only_mode: Arc<AtomicBool>,
 }
 
 impl Index<u64> for BankForks {
@@ -65,6 +68,18 @@ impl BankForks {
 
     pub fn banks(&self) -> HashMap<Slot, Arc<Bank>> {
         self.banks.clone()
+    }
+
+    pub fn get_vote_only_mode_signal(&self) -> Arc<AtomicBool> {
+        self.in_vote_only_mode.clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.banks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.banks.is_empty()
     }
 
     /// Create a map of bank slot id to the set of ancestors for the bank slot.
@@ -151,6 +166,7 @@ impl BankForks {
             snapshot_config: None,
             accounts_hash_interval_slots: std::u64::MAX,
             last_accounts_hash_slot: root,
+            in_vote_only_mode: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -18,7 +18,7 @@ use {
             atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc,
         },
-        thread::{Builder, JoinHandle},
+        thread::{sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -98,6 +98,7 @@ fn recv_loop(
     stats: &StreamerReceiveStats,
     coalesce_ms: u64,
     use_pinned_memory: bool,
+    in_vote_only_mode: Option<Arc<AtomicBool>>,
 ) -> Result<()> {
     loop {
         let mut packet_batch = if use_pinned_memory {
@@ -111,6 +112,14 @@ fn recv_loop(
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
+
+            if let Some(ref in_vote_only_mode) = in_vote_only_mode {
+                if in_vote_only_mode.load(Ordering::Relaxed) {
+                    sleep(Duration::from_millis(1));
+                    continue;
+                }
+            }
+
             if let Ok(len) = packet::recv_from(&mut packet_batch, socket, coalesce_ms) {
                 if len > 0 {
                     let StreamerReceiveStats {
@@ -144,6 +153,7 @@ pub fn receiver(
     stats: Arc<StreamerReceiveStats>,
     coalesce_ms: u64,
     use_pinned_memory: bool,
+    in_vote_only_mode: Option<Arc<AtomicBool>>,
 ) -> JoinHandle<()> {
     let res = socket.set_read_timeout(Some(Duration::new(1, 0)));
     assert!(res.is_ok(), "streamer::receiver set_read_timeout error");
@@ -158,6 +168,7 @@ pub fn receiver(
                 &stats,
                 coalesce_ms,
                 use_pinned_memory,
+                in_vote_only_mode,
             );
         })
         .unwrap()
@@ -451,6 +462,7 @@ mod test {
             stats.clone(),
             1,
             true,
+            None,
         );
         const NUM_PACKETS: usize = 5;
         let t_responder = {


### PR DESCRIPTION
#### Problem

If we are in vote-only-mode, incoming TPU packets can still produce load on the validator causing it to take a long time processing other threads.

#### Summary of Changes

Start ignoring the TPU port when tip - root > 400 banks.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
