### PR TITLE
Add datapoints to help debug the invalid blockhash issue with quic

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -426,14 +426,6 @@ fn poll_blockhash<T: BenchTpsClient>(
         let blockhash_updated = {
             let old_blockhash = *blockhash.read().unwrap();
             if let Some(new_blockhash) = get_new_latest_blockhash(client, &old_blockhash) {
-                datapoint_info!(
-                    "blockhash_stats",
-                    (
-                        "time_elapsed_since_blockhash_refreshed",
-                        blockhash_last_updated.elapsed().as_millis(),
-                        i64
-                    )
-                );
                 *blockhash.write().unwrap() = new_blockhash;
                 blockhash_last_updated = Instant::now();
                 true

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -117,13 +117,13 @@ fn generate_chunked_transfers(
     let mut last_blockhash_time = Instant::now();
     let mut old_blockhash = {
         let recent_blockhash_guard = recent_blockhash.read().unwrap();
-        recent_blockhash_guard.clone()
+        *recent_blockhash_guard
     };
 
     while start.elapsed() < duration {
         let new_blockhash = {
             let recent_blockhash_guard = recent_blockhash.read().unwrap();
-            recent_blockhash_guard.clone()
+            *recent_blockhash_guard
         };
         if old_blockhash != new_blockhash {
             old_blockhash = new_blockhash;

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -447,7 +447,7 @@ fn poll_blockhash<T: BenchTpsClient>(
             let balance = client.get_balance(id).unwrap_or(0);
             metrics_submit_lamport_balance(balance);
             datapoint_info!(
-                "poll_blockhash_stats",
+                "blockhash_stats",
                 (
                     "time_elapsed_since_last_blockhash_update",
                     blockhash_last_updated.elapsed().as_millis(),


### PR DESCRIPTION
#### Problem
We're seeing many invalid blockhash errors with bench-tps with quic

#### Summary of Changes
Adds some datapoints to help debug this

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
