### PR TITLE
Allow for custom recentBlockhash to be supplied in web3.js

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3986,6 +3986,21 @@ export class Connection {
 
     if (transaction.nonceInfo && signers) {
       transaction.sign(...signers);
+    } else if (transaction.recentBlockhash) {
+      let disableCache = this._disableBlockhashCaching;
+      for (;;) {
+        transaction.sign(...signers);
+        if (!transaction.signature) {
+          throw new Error('!signature'); // should never happen
+        }
+
+        const signature = transaction.signature.toString('base64');
+        if (!this._blockhashInfo.transactionSignatures.includes(signature)) {
+          this._blockhashInfo.transactionSignatures.push(signature);
+          break;
+        } else {
+          disableCache = true;
+        }
     } else {
       let disableCache = this._disableBlockhashCaching;
       for (;;) {


### PR DESCRIPTION
#### Problem
This enables us to supply a custom recentBlockhash. The use-case is for a transaction to be able to be re-broadcasted with the same blockhash when it is dropped from the mempool.

#### Summary of Changes
Added a conditional case that checks if recentBlockhash is part of the transaction which is then used for the tx instead of a new one


#### Question
One question along this PR: Why do we use for(;;) = while(true) in this piece of code? In the end this only checks for one signature doesn't it?
