### PR TITLE
Reorder a boolean computation to speed up processing

### DIFF
--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -521,8 +521,6 @@ impl Message {
     }
 
     pub fn is_writable(&self, i: usize) -> bool {
-        let demote_program_id =
-            self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present();
         (i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize
             || (i >= self.header.num_required_signatures as usize
@@ -532,7 +530,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && !demote_program_id
+            && !(self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present())
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -530,10 +530,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && !{
-                let demote_program_id = self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present();
-                demote_program_id
-            }
+            && (!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present()) // !demote_program_id
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -530,7 +530,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && (!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present()) // !demote_program_id
+            && (/* !demote_program_id */ !self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -520,6 +520,10 @@ impl Message {
         self.program_position(i).is_some()
     }
 
+    pub fn demote_program_id(&self, i: usize) -> bool {
+        self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present()
+    }
+
     pub fn is_writable(&self, i: usize) -> bool {
         (i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize
@@ -530,7 +534,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && (/* !demote_program_id */!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
+            && !self.demote_program_id(i)
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -530,7 +530,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && !(self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present())
+            && (!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -530,7 +530,10 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && (!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
+            && !{
+                let demote_program_id = self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present();
+                demote_program_id
+            }
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -530,7 +530,7 @@ impl Message {
                 let key = self.account_keys[i];
                 sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key)
             }
-            && (/* !demote_program_id */ !self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
+            && (/* !demote_program_id */!self.is_key_called_as_program(i) || self.is_upgradeable_loader_present())
     }
 
     pub fn is_signer(&self, i: usize) -> bool {

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -109,11 +109,10 @@ impl<'a> LoadedMessage<'a> {
     pub fn is_writable(&self, key_index: usize) -> bool {
         if self.is_writable_index(key_index) {
             if let Some(key) = self.account_keys().get(key_index) {
-                let demote_program_id = self.is_key_called_as_program(key_index)
-                    && !self.is_upgradeable_loader_present();
                 return !(sysvar::is_sysvar_id(key)
                     || BUILTIN_PROGRAMS_KEYS.contains(key)
-                    || demote_program_id);
+                    || (self.is_key_called_as_program(key_index)
+                        && !self.is_upgradeable_loader_present()));
             }
         }
         false

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -111,8 +111,7 @@ impl<'a> LoadedMessage<'a> {
             if let Some(key) = self.account_keys().get(key_index) {
                 return !(sysvar::is_sysvar_id(key)
                     || BUILTIN_PROGRAMS_KEYS.contains(key)
-                    || (self.is_key_called_as_program(key_index)
-                        && !self.is_upgradeable_loader_present()));
+                    || self.demote_program_id(key_index));
             }
         }
         false
@@ -120,6 +119,10 @@ impl<'a> LoadedMessage<'a> {
 
     pub fn is_signer(&self, i: usize) -> bool {
         i < self.message.header.num_required_signatures as usize
+    }
+
+    pub fn demote_program_id(&self, i: usize) -> bool {
+        self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present()
     }
 
     /// Returns true if the account at the specified index is called as a program by an instruction


### PR DESCRIPTION
#### Problem
A bool variable is computed before it's actually used, resulting in a needless computation a reasonable percentage of the time.

#### Summary of Changes
Moved the two function calls involved to be made only when needed. Since these two calls are deceptively slow (and any slowness is exacerbated by code that's called once per referenced account per transaction), this results in a measurable speedup. This code is used in several places, including by the leader for every transaction in the block.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
