### PR TITLE
zk-token-sdk: verify WithdrawWithheldTokens proof under the correct context

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -57,7 +57,7 @@ pub fn process_instruction(
         }
         ProofInstruction::VerifyWithdrawWithheldTokens => {
             ic_msg!(invoke_context, "VerifyWithdrawWithheldTokens");
-            verify::<WithdrawData>(invoke_context)
+            verify::<WithdrawWithheldTokensData>(invoke_context)
         }
         ProofInstruction::VerifyTransfer => {
             ic_msg!(invoke_context, "VerifyTransfer");


### PR DESCRIPTION
#### Problem
The ZK proof for `VerifyWithdrawWithheldTokens` instructions are verified as in a `VerifyWithdraw` instruction causing it to always fail.

#### Summary of Changes
Fixed the issue by interpretting the `VerifyWithdrawWithheldTokens` under the same context.