### PR TITLE
Optimize ClusterSlots update

### DIFF
--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -77,18 +77,14 @@ impl ClusterSlots {
                     .zip(std::iter::repeat((epoch_slots.from, stake)))
             })
             .into_group_map();
-        let slot_nodes_stakes: Vec<_> = {
+        {
             let mut cluster_slots = self.cluster_slots.write().unwrap();
             slot_nodes_stakes
                 .into_iter()
-                .map(|(slot, nodes_stakes)| {
+                .for_each(|(slot, nodes_stakes)| {
                     let slot_nodes = cluster_slots.entry(slot).or_default().clone();
-                    (slot_nodes, nodes_stakes)
-                })
-                .collect()
-        };
-        for (slot_nodes, nodes_stakes) in slot_nodes_stakes {
-            slot_nodes.write().unwrap().extend(nodes_stakes);
+                    slot_nodes.write().unwrap().extend(nodes_stakes);
+                });
         }
         {
             let mut cluster_slots = self.cluster_slots.write().unwrap();


### PR DESCRIPTION
#### Problem

ClusterSlots make 39% of the memory allocations in the validator run. The `update fn` can be optimized.

![image](https://user-images.githubusercontent.com/219428/166466966-cc911643-5265-4025-bf66-f81b6866f6b4.png)

https://github.com/solana-labs/solana/issues/24888


#### Summary of Changes
remove unnecessary usage of collect and loops


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
