### PR TITLE
cli: Fix `withdraw-stake` error display

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1714,7 +1714,7 @@ pub fn process_withdraw_stake(
             config.commitment,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
-        log_instruction_custom_error::<SystemError>(result, config)
+        log_instruction_custom_error::<StakeError>(result, config)
     }
 }
 


### PR DESCRIPTION
#### Problem

The CLI returns the incorrect error during `withdraw-stake`.  Unearthed while looking at stake-related issues and projects :smile: 

#### Summary of Changes

Format the error as a `StakeError` instead of a `SystemError`. So with a lockup, instead of returning `Error: account does not have enough SOL to perform the operation`, you'll see `Error: lockup has not yet expired`.

Fixes #9744
