### PR TITLE
stake config's `warmup_cooldown_rate` should not be above 1.0

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -221,7 +221,7 @@ impl LocalCluster {
             create_stake_config_account(
                 1,
                 &stake_config::Config {
-                    warmup_cooldown_rate: 1_000_000_000.0f64,
+                    warmup_cooldown_rate: 1.0,
                     slash_penalty: std::u8::MAX,
                 },
             ),


### PR DESCRIPTION
The `warmup_cooldown_rate` should be in the range [0.0, 1.0], but it is much larger in local-cluster unnecessarily.

(This is coming up because as I raise the stake minimum delegation, tests need to be updated with higher stake amounts. This in turn causes test times to inflate greatly, depending on the existing stake + the warmup rate.)