### PR TITLE
simplify can vote check in `select_vote_and_reset_forks`

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2695,11 +2695,7 @@ impl ReplayStage {
                 failure_reasons.push(HeaviestForkFailures::NoPropagatedConfirmation(bank.slot()));
             }
 
-            if !is_locked_out
-                && vote_threshold
-                && propagation_confirmed
-                && switch_fork_decision.can_vote()
-            {
+            if failure_reasons.is_empty() && switch_fork_decision.can_vote() {
                 info!("voting: {} {}", bank.slot(), fork_weight);
                 SelectVoteAndResetForkResult {
                     vote_bank: Some((bank.clone(), switch_fork_decision)),


### PR DESCRIPTION
#### Problem

A small refactor to simplify can vote check for `select_vote_and_reset_forks` 


#### Summary of Changes

Use `failure_reason.emtpy()` instead of individual flags to check can vote. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
