### PR TITLE
ledger-tool: Clear accounts directory

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -767,6 +767,18 @@ fn load_bank_forks(
             "Default accounts path is switched aligning with Blockstore's secondary access: {:?}",
             non_primary_accounts_path
         );
+
+        if non_primary_accounts_path.exists() {
+            info!("Clearing {:?}", non_primary_accounts_path);
+            if let Err(err) = std::fs::remove_dir_all(&non_primary_accounts_path) {
+                eprintln!(
+                    "error deleting accounts path {:?}: {}",
+                    non_primary_accounts_path, err
+                );
+                exit(1);
+            }
+        }
+
         vec![non_primary_accounts_path]
     };
 


### PR DESCRIPTION
#### Problem
ledger-tool's non-primary access accounts directory can grow in size since it is never cleared.

#### Summary of Changes
Clear the directory (if it exists) when ledger-tool will use the directory to load accounts into.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
