### PR TITLE
Limit number of received packets per verifier loop in SigVerifyStage

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -24,7 +24,9 @@ use {
     thiserror::Error,
 };
 
-const MAX_SIGVERIFY_BATCH: usize = 10_000;
+/// Maximum number of valid, filtered packets that can be sent along for
+/// signature verification.
+const MAX_SIGVERIFY_VALID_PACKETS: usize = 10_000;
 
 #[derive(Error, Debug)]
 pub enum SigVerifyServiceError {
@@ -255,11 +257,11 @@ impl SigVerifyStage {
 
         let mut discard_time = Measure::start("sigverify_discard_time");
         let mut num_valid_packets = num_unique;
-        if num_unique > MAX_SIGVERIFY_BATCH {
-            Self::discard_excess_packets(&mut batches, MAX_SIGVERIFY_BATCH);
-            num_valid_packets = MAX_SIGVERIFY_BATCH;
+        if num_unique > MAX_SIGVERIFY_VALID_PACKETS {
+            Self::discard_excess_packets(&mut batches, MAX_SIGVERIFY_VALID_PACKETS);
+            num_valid_packets = MAX_SIGVERIFY_VALID_PACKETS;
         }
-        let excess_fail = num_unique.saturating_sub(MAX_SIGVERIFY_BATCH);
+        let excess_fail = num_unique.saturating_sub(MAX_SIGVERIFY_VALID_PACKETS);
         discard_time.stop();
 
         let mut verify_time = Measure::start("sigverify_batch_time");

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -260,21 +260,13 @@ pub fn recv_vec_packet_batches(
     recvr: &Receiver<Vec<PacketBatch>>,
 ) -> Result<(Vec<PacketBatch>, usize, Duration)> {
     let timer = Duration::new(1, 0);
-    let mut packet_batches = recvr.recv_timeout(timer)?;
+    let packet_batches = recvr.recv_timeout(timer)?;
     let recv_start = Instant::now();
     trace!("got packets");
-    let mut num_packets = packet_batches
+    let num_packets = packet_batches
         .iter()
         .map(|packets| packets.packets.len())
         .sum::<usize>();
-    while let Ok(packet_batch) = recvr.try_recv() {
-        trace!("got more packets");
-        num_packets += packet_batch
-            .iter()
-            .map(|packets| packets.packets.len())
-            .sum::<usize>();
-        packet_batches.extend(packet_batch);
-    }
     let recv_duration = recv_start.elapsed();
     trace!(
         "packet batches len: {}, num packets: {}",
@@ -286,6 +278,7 @@ pub fn recv_vec_packet_batches(
 
 pub fn recv_packet_batches(
     recvr: &PacketBatchReceiver,
+    max_num_packets: usize,
 ) -> Result<(Vec<PacketBatch>, usize, Duration)> {
     let timer = Duration::new(1, 0);
     let packet_batch = recvr.recv_timeout(timer)?;
@@ -293,10 +286,17 @@ pub fn recv_packet_batches(
     trace!("got packets");
     let mut num_packets = packet_batch.packets.len();
     let mut packet_batches = vec![packet_batch];
-    while let Ok(packet_batch) = recvr.try_recv() {
-        trace!("got more packets");
-        num_packets += packet_batch.packets.len();
-        packet_batches.push(packet_batch);
+    loop {
+        if num_packets >= max_num_packets {
+            break;
+        }
+        if let Ok(packet_batch) = recvr.try_recv() {
+            trace!("got more packets");
+            num_packets += packet_batch.packets.len();
+            packet_batches.push(packet_batch);
+        } else {
+            break;
+        }
     }
     let recv_duration = recv_start.elapsed();
     trace!(


### PR DESCRIPTION
#### Problem
Under load spikes, a single loop of the `SigVerifyStage` verifier can ingest tens of millions of packets which means we have to filter out millions of packets before any are sent along through the pipeline.

#### Summary of Changes
- Limit number of received packets in each `FindPacketSenderStakeStage` loop
- Limit number of received packets in each `SigVerifyStage` loop

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
