### PR TITLE
Add log for progress map size

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -672,9 +672,12 @@ impl ProgressMap {
         self.progress_map
             .retain(|k, _| bank_forks.get(*k).is_some());
         let after = self.progress_map.len();
-        info!(
-            "progress map prune {}: before={}, after={}",
-            new_root, before, after
+        datapoint_info!(
+            "progress-map-prune",
+            ("slot", new_root as i64, i64),
+            ("before", before as i64, i64),
+            ("after", after as i64, i64),
+            ("diff", (before - after) as i64, i64),
         );
     }
 

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -667,9 +667,15 @@ impl ProgressMap {
             .unwrap_or(None)
     }
 
-    pub fn handle_new_root(&mut self, bank_forks: &BankForks) {
+    pub fn handle_new_root(&mut self, new_root: Slot, bank_forks: &BankForks) {
+        let before = self.progress_map.len();
         self.progress_map
             .retain(|k, _| bank_forks.get(*k).is_some());
+        let after = self.progress_map.len();
+        info!(
+            "progress map prune {}: before={}, after={}",
+            new_root, before, after
+        );
     }
 
     pub fn log_propagated_stats(&self, slot: Slot, bank_forks: &RwLock<BankForks>) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2965,7 +2965,7 @@ impl ReplayStage {
                 std::mem::take(voted_signatures);
             }
         }
-        progress.handle_new_root(&r_bank_forks);
+        progress.handle_new_root(new_root, &r_bank_forks);
         heaviest_subtree_fork_choice.set_root((new_root, r_bank_forks.root_bank().hash()));
         let mut slots_ge_root = duplicate_slots_tracker.split_off(&new_root);
         // duplicate_slots_tracker now only contains entries >= `new_root`
@@ -4848,7 +4848,7 @@ pub(crate) mod tests {
         bank_forks.insert(bank5);
 
         // Should purge only `previous_leader_slot` from the progress map
-        progress_map.handle_new_root(&bank_forks);
+        progress_map.handle_new_root(5, &bank_forks);
 
         // Should succeed
         assert!(ReplayStage::check_propagation_for_start_leader(


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/24880

When high fork happens, the *progress_map* might grow too big. We want to measure how big the *progress_map* can become.

#### Summary of Changes
Add log for progress map size.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
