### PR TITLE
enable quic and perf

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -807,6 +807,7 @@ $(
     install-libssl-compatability.sh \
     install-redis.sh \
     install-rsync.sh \
+    install-perf.sh \
     localtime.sh \
     network-config.sh \
     remove-docker-interface.sh \
@@ -846,6 +847,8 @@ gce_self_destruct_motd
 
 # Add self-destruct countdown to terminal prompt
 export PS1='\[\e]0;\u@\h: \w\a\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]$(/solana-scratch/gce-self-destruct-ps1.sh):\[\033[01;34m\]\w\[\033[00m\]\$ '
+export TERM=xterm
+
 EOS
 EOSD
     cat <<EOSD

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -272,6 +272,7 @@ EOF
       --gossip-host "$entrypointIp"
       --gossip-port 8001
       --init-complete-file "$initCompleteFile"
+      --tpu-use-quic
     )
 
     if [[ "$tmpfsAccounts" = "true" ]]; then

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -181,7 +181,7 @@ cloud_CreateInstances() {
     imageName="ubuntu-2004-focal-v20201211-with-cuda-10-2 --image-project principal-lane-200702"
   else
     # Upstream Ubuntu 20.04 LTS image
-    imageName="ubuntu-2004-focal-v20201201 --image-project ubuntu-os-cloud"
+    imageName="ubuntu-2004-focal-v20220419 --image-project ubuntu-os-cloud"
   fi
 
   declare -a nodes

--- a/net/scripts/install-perf.sh
+++ b/net/scripts/install-perf.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Rsync setup
+#
+set -ex
+
+[[ $(uname) = Linux ]] || exit 1
+[[ $USER = root ]] || exit 1
+
+apt-get --assume-yes install linux-tools-common linux-tools-generic linux-tools-`uname -r`
+apt-get --assume-yes install zsh


### PR DESCRIPTION
This PR is just to show how quic was enabled.

```
./gce.sh create -n 1 -c 1
./init-metrics.sh $(whoami)
./net.sh start -c bench-tps=1="--tpu-use-quic"
./ssh.sh <validator-ip>
perf record -F 99 -p  <PID>  --call-graph fp -- sleep 90
perf script > bench-quic.perf
```

It looks like quic is running fine:
![image](https://user-images.githubusercontent.com/687962/166805091-0e671fab-4757-4f45-adb4-93b1515178aa.png)
