### PR TITLE
allow ledger-tool halt at slot to calc hash using write cache

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1309,7 +1309,8 @@ fn load_frozen_forks(
 
             if slot >= halt_at_slot {
                 bank.force_flush_accounts_cache();
-                let _ = bank.verify_bank_hash(false);
+                let can_cached_slot_be_unflushed = true;
+                let _ = bank.verify_bank_hash(false, can_cached_slot_be_unflushed);
                 break;
             }
         }

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -123,7 +123,8 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
             total_lamports,
             test_hash_calculation,
             &EpochSchedule::default(),
-            &RentCollector::default()
+            &RentCollector::default(),
+            false
         ))
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -790,6 +790,7 @@ impl Accounts {
         test_hash_calculation: bool,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        can_cached_slot_be_unflushed: bool,
     ) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports_new(
             slot,
@@ -798,6 +799,7 @@ impl Accounts {
             test_hash_calculation,
             epoch_schedule,
             rent_collector,
+            can_cached_slot_be_unflushed,
         ) {
             warn!("verify_bank_hash failed: {:?}", err);
             false

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5948,6 +5948,7 @@ impl AccountsDb {
         test_hash_calculation: bool,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        can_cached_slot_be_unflushed: bool,
     ) -> Result<(), BankHashVerificationError> {
         self.verify_bank_hash_and_lamports_new(
             slot,
@@ -5956,6 +5957,7 @@ impl AccountsDb {
             test_hash_calculation,
             epoch_schedule,
             rent_collector,
+            can_cached_slot_be_unflushed,
         )
     }
 
@@ -5968,13 +5970,13 @@ impl AccountsDb {
         test_hash_calculation: bool,
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
+        can_cached_slot_be_unflushed: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
         let use_index = false;
         let check_hash = false; // this will not be supported anymore
         let is_startup = true;
-        let can_cached_slot_be_unflushed = false;
         let (calculated_hash, calculated_lamports) = self
             .calculate_accounts_hash_helper_with_verify(
                 use_index,
@@ -9938,6 +9940,7 @@ pub mod tests {
                 true,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
+                false,
             )
             .unwrap();
     }
@@ -10323,7 +10326,8 @@ pub mod tests {
                 1,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false,
             ),
             Ok(_)
         );
@@ -10336,7 +10340,8 @@ pub mod tests {
                 1,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false,
             ),
             Err(MissingBankHash)
         );
@@ -10358,7 +10363,8 @@ pub mod tests {
                 1,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false,
             ),
             Err(MismatchedBankHash)
         );
@@ -10386,7 +10392,8 @@ pub mod tests {
                 1,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false
             ),
             Ok(_)
         );
@@ -10407,13 +10414,14 @@ pub mod tests {
                 2,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false
             ),
             Ok(_)
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default()),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true, &EpochSchedule::default(), &RentCollector::default(), false),
             Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }
@@ -10439,7 +10447,8 @@ pub mod tests {
                 0,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false
             ),
             Ok(_)
         );
@@ -10476,7 +10485,8 @@ pub mod tests {
                 1,
                 true,
                 &EpochSchedule::default(),
-                &RentCollector::default()
+                &RentCollector::default(),
+                false
             ),
             Err(MismatchedBankHash)
         );
@@ -11095,6 +11105,7 @@ pub mod tests {
                     true,
                     &EpochSchedule::default(),
                     &RentCollector::default(),
+                    false,
                 )
                 .unwrap();
 
@@ -11107,6 +11118,7 @@ pub mod tests {
                     true,
                     &EpochSchedule::default(),
                     &RentCollector::default(),
+                    false,
                 )
                 .unwrap();
 


### PR DESCRIPTION
#### Problem

When running ledger tool, we run a final hash calc check when we halt. based on which slots get flushed from the cache, we sometimes end up with cap mismatches between bank and accounts hash calc. This is misleading and incorrect. This startup/ledger-tool only code path needs to allow us to use the write cache for this case.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
