### PR TITLE
Remove travis success condition for automerging doc changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -38,8 +38,8 @@ pull_request_rules:
         - label!=no-automerge
         - author≠@dont-squash-my-commits
         - or:
-          # only require travis success if docs files changed
-          - status-success=Travis CI - Pull Request
+          # only require docs checks if docs files changed
+          # - status-success=<REPLACE WITH GITHUB ACTION>
           - -files~=^docs/
         - or:
           # only require explorer checks if explorer files changed
@@ -59,11 +59,14 @@ pull_request_rules:
     conditions:
       - and:
         - status-success=buildkite/solana
-        - status-success=Travis CI - Pull Request
         - status-success=ci-gate
         - label=automerge
         - label!=no-automerge
         - author=@dont-squash-my-commits
+        - or:
+          # only require docs checks if docs files changed
+          # - status-success=<REPLACE WITH GITHUB ACTION>
+          - -files~=^docs/
         - or:
           # only require explorer checks if explorer files changed
           - status-success=check-explorer


### PR DESCRIPTION
#### Problem
Automerge doesn't work if docs files were updated because the travis job doesn't exist anymore but is still required for automerge
 
#### Summary of Changes
- Leave placeholder for docs GitHub action check
