### PR TITLE
checks the account owner when initializing a vote-account

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1404,6 +1404,7 @@ pub mod test {
                 let mut account = AccountSharedData::from(Account {
                     data: vec![0; VoteState::size_of()],
                     lamports: *lamports,
+                    owner: solana_vote_program::id(),
                     ..Account::default()
                 });
                 let mut vote_state = VoteState::default();
@@ -1417,7 +1418,7 @@ pub mod test {
                 .expect("serialize state");
                 (
                     solana_sdk::pubkey::new_rand(),
-                    (*lamports, VoteAccount::from(account)),
+                    (*lamports, VoteAccount::try_from(account).unwrap()),
                 )
             })
             .collect()

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -695,7 +695,15 @@ impl ProgressMap {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_runtime::vote_account::VoteAccount};
+    use {super::*, solana_runtime::vote_account::VoteAccount, solana_sdk::account::Account};
+
+    fn new_test_vote_account() -> VoteAccount {
+        let account = Account {
+            owner: solana_vote_program::id(),
+            ..Account::default()
+        };
+        VoteAccount::try_from(account).unwrap()
+    }
 
     #[test]
     fn test_add_vote_pubkey() {
@@ -730,7 +738,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, VoteAccount::default())))
+            .map(|pubkey| (*pubkey, (1, new_test_vote_account())))
             .collect();
 
         let mut stats = PropagatedStats::default();
@@ -772,7 +780,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, VoteAccount::default())))
+            .map(|pubkey| (*pubkey, (1, new_test_vote_account())))
             .collect();
         stats.add_node_pubkey_internal(&node_pubkey, &vote_account_pubkeys, &epoch_vote_accounts);
         assert!(stats.propagated_node_ids.contains(&node_pubkey));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3780,7 +3780,7 @@ pub mod tests {
                     VoteState::serialize(&versioned, vote_account.data_as_mut_slice()).unwrap();
                     (
                         solana_sdk::pubkey::new_rand(),
-                        (stake, VoteAccount::from(vote_account)),
+                        (stake, VoteAccount::try_from(vote_account).unwrap()),
                     )
                 })
                 .collect()

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -28,7 +28,7 @@ pub mod shred_stats;
 mod shredder;
 pub mod sigverify_shreds;
 pub mod slot_stats;
-pub mod staking_utils;
+mod staking_utils;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -113,11 +113,12 @@ pub(crate) mod tests {
             let account = AccountSharedData::new_data(
                 rng.gen(), // lamports
                 &VoteStateVersions::new_current(vote_state),
-                &Pubkey::new_unique(), // owner
+                &solana_vote_program::id(), // owner
             )
             .unwrap();
             let vote_pubkey = Pubkey::new_unique();
-            (vote_pubkey, (stake, VoteAccount::from(account)))
+            let vote_account = VoteAccount::try_from(account).unwrap();
+            (vote_pubkey, (stake, vote_account))
         });
         let result = vote_accounts.collect::<VoteAccounts>().staked_nodes();
         assert_eq!(result.len(), 2);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2910,7 +2910,7 @@ impl Bank {
             {
                 vote_accounts_cache_miss_count.fetch_add(1, Relaxed);
             }
-            Some(VoteAccount::from(account))
+            VoteAccount::try_from(account).ok()
         };
         let invalid_vote_keys = DashMap::<Pubkey, InvalidCacheEntryReason>::new();
         let make_vote_delegations_entry = |vote_pubkey| {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -190,10 +190,8 @@ pub(crate) mod tests {
             .iter()
             .flat_map(|(_, vote_accounts)| {
                 vote_accounts.iter().map(|v| {
-                    (
-                        v.vote_account,
-                        (stake_per_account, VoteAccount::from(v.account.clone())),
-                    )
+                    let vote_account = VoteAccount::try_from(v.account.clone()).unwrap();
+                    (v.vote_account, (stake_per_account, vote_account))
                 })
             })
             .collect();

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -30,8 +30,8 @@ pub enum Error {
     InstructionError(#[from] InstructionError),
     #[error("Invalid delegation: {0:?}")]
     InvalidDelegation(StakeState),
-    #[error("Invalid stake account owner: {owner:?}")]
-    InvalidOwner { owner: Pubkey },
+    #[error("Invalid stake account owner: {0}")]
+    InvalidOwner(/*owner:*/ Pubkey),
 }
 
 impl<T> StakeAccount<T> {
@@ -59,9 +59,7 @@ impl TryFrom<AccountSharedData> for StakeAccount<()> {
     type Error = Error;
     fn try_from(account: AccountSharedData) -> Result<Self, Self::Error> {
         if account.owner() != &solana_stake_program::id() {
-            return Err(Error::InvalidOwner {
-                owner: *account.owner(),
-            });
+            return Err(Error::InvalidOwner(*account.owner()));
         }
         let stake_state = account.state()?;
         Ok(Self {


### PR DESCRIPTION
#### Problem
A VoteAccount may only wrap an account if the account owner is
`solana_vote_program:id` or this check returns true:
`solana_vote_program::check_id(account.owner())`


#### Summary of Changes
Check the account owner when initializing a vote-account.