### PR TITLE
Pin tokio to LTS release v1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,9 +6840,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -17,7 +17,7 @@ solana-program = { path = "../sdk/program", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
 tarpc = { version = "0.27.2", features = ["full"] }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 
 [dev-dependencies]

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -17,7 +17,7 @@ solana-runtime = { path = "../runtime", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.9.21" }
 tarpc = { version = "0.27.2", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
 tokio-stream = "0.1"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -33,7 +33,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.9.21
 solana-version = { path = "../version", version = "=1.9.21" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.21" }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 tungstenite = { version = "0.16.0", features = ["rustls-tls-webpki-roots"] }
 url = "2.2.2"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,7 +61,7 @@ tempfile = "3.2.0"
 thiserror = "1.0"
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.9.21" }
 sys-info = "0.9.1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 trees = "0.4.2"
 
 [dev-dependencies]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -24,7 +24,7 @@ solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-version = { path = "../version", version = "=1.9.21" }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -36,7 +36,7 @@ solana-storage-bigtable = { path = "../storage-bigtable", version = "=1.9.21" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.9.21" }
 solana-version = { path = "../version", version = "=1.9.21" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.21" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.14.1", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = {package = "tikv-jemallocator", version = "0.4.1", features = ["unprefixed_malloc_on_supported_platforms"]}

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -49,7 +49,7 @@ solana-storage-proto = { path = "../storage-proto", version = "=1.9.21" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.21" }
 tempfile = "3.2.0"
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 tokio-stream = "0.1"
 trees = "0.4.2"
 reed-solomon-erasure = { version = "5.0.1", features = ["simd-accel"] }

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -21,7 +21,7 @@ socket2 = "0.4.2"
 solana-logger = { path = "../logger", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-version = { path = "../version", version = "=1.9.21" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.14.1", features = ["full"] }
 url = "2.2.2"
 
 [lib]

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -23,7 +23,7 @@ solana-runtime = { path = "../runtime", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-vote-program = { path = "../programs/vote", version = "=1.9.21" }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.8.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585de5039d1ecce74773db49ba4e8107e42be7c2cd0b1a9e7fce27181db7b118"
+checksum = "c3bfae4cb9cd8c3c2a552d45e155cafd079f385a3b9421b9a010878f44531f1e"
 dependencies = [
  "http",
  "prost 0.9.0",
@@ -1224,7 +1224,7 @@ checksum = "46e245f4c8ec30c6415c56cb132c07e69e74f1942f6b4a4061da748b49f486ca"
 dependencies = [
  "cfg-if 1.0.0",
  "rustix",
- "windows-sys 0.30.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2334,20 +2334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
-dependencies = [
- "libc",
- "log 0.4.14",
- "miow 0.3.7",
- "ntapi",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "mio-extras"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,16 +2677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = [
- "lock_api 0.4.7",
- "parking_lot_core 0.9.2",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,19 +2703,6 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec 1.8.0",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall 0.2.10",
- "smallvec 1.8.0",
- "windows-sys 0.34.0",
 ]
 
 [[package]]
@@ -6043,20 +6006,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
 dependencies = [
+ "autocfg 1.1.0",
  "bytes 1.1.0",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio 0.7.14",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "winapi 0.3.9",
 ]
@@ -6720,12 +6683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6931,24 +6888,11 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "windows_aarch64_msvc 0.30.0",
- "windows_i686_gnu 0.30.0",
- "windows_i686_msvc 0.30.0",
- "windows_x86_64_gnu 0.30.0",
- "windows_x86_64_msvc 0.30.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
-dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -6958,22 +6902,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6982,34 +6914,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/replica-lib/Cargo.toml
+++ b/replica-lib/Cargo.toml
@@ -17,7 +17,7 @@ prost = "0.10.0"
 solana-rpc = { path = "../rpc", version = "=1.9.21" }
 solana-runtime = { path = "../runtime", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.14.1", features = ["full"] }
 tonic = { version = "0.7.1", features = ["tls", "transport"] }
 
 [package.metadata.docs.rs]

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -26,7 +26,7 @@ solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-streamer = { path = "../streamer", version = "=1.9.21" }
 solana-test-validator = { path = "../test-validator", version = "=1.9.21" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.9.21" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.14.1", features = ["full"] }
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.9.21" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -52,7 +52,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.9.21" }
 spl-token = { version = "=3.2.0", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec", "compat"] }
 
 [dev-dependencies]

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -28,7 +28,7 @@ solana-metrics = { path = "../metrics", version = "=1.9.21" }
 solana-sdk = { path = "../sdk", version = "=1.9.21" }
 solana-perf = { path = "../perf", version = "=1.9.21" }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "~1.14.1", features = ["full"] }
 
 [dev-dependencies]
 


### PR DESCRIPTION
#### Problem
The RPC stall problem we are debugging appears when upgrading tokio from v1.15 to v1.16. Currently, our branches do not restrict the tokio minor or patch versions


#### Summary of Changes
Pin tokio to the the long-term support release v1.14

Inspired by #24644
