### PR TITLE
validator: add setTpuAddress to admin RPC

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -664,6 +664,12 @@ impl ClusterInfo {
         self.my_contact_info.read().unwrap().shred_version
     }
 
+    /// Sets the node's own TPU address in gossip cluster info.
+    pub fn set_tpu_address(&self, tpu_address: SocketAddr) {
+        self.my_contact_info.write().unwrap().tpu = tpu_address;
+        self.push_self(&HashMap::new(), None);
+    }
+
     fn lookup_epoch_slots(&self, ix: EpochSlotsIndex) -> EpochSlots {
         let self_pubkey = self.id();
         let label = CrdsValueLabel::EpochSlots(ix, self_pubkey);

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -165,6 +165,9 @@ pub trait AdminRpc {
 
     #[rpc(meta, name = "contactInfo")]
     fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo>;
+
+    #[rpc(meta, name = "setTpuAddress")]
+    fn set_tpu_address(&self, meta: Self::Metadata, tpu_address: SocketAddr) -> Result<()>;
 }
 
 pub struct AdminRpcImpl;
@@ -279,6 +282,15 @@ impl AdminRpc for AdminRpcImpl {
 
     fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo> {
         meta.with_post_init(|post_init| Ok(post_init.cluster_info.my_contact_info().into()))
+    }
+
+    fn set_tpu_address(&self, meta: Self::Metadata, tpu_address: SocketAddr) -> Result<()> {
+        debug!("set_tpu_address({}) request received", tpu_address);
+
+        meta.with_post_init(|post_init| {
+            post_init.cluster_info.set_tpu_address(tpu_address);
+            Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
#### Problem

The validator is not able to update its TPU address on the fly.

The TPU network environment changes quickly so admins should be able to respond quickly too, without having to restart their validators.

#### Summary of Changes

Fixes #

---

Rebased version of #24870
