### PR TITLE
Make workflow not fail if no doc files changed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,17 +36,14 @@ jobs:
           files: |
             docs/**
 
-      - name: Exit if no file changes in docs/
-        if: steps.changed-files-specific.outputs.any_changed != 'true'
-        run: |
-          exit 1
-
       - name: Setup Node
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: 14
 
       - name: Build
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         working-directory: docs
         run: |
           npm install


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/25029 added a new action that exits with return code 1 in a scenario that is perfectly valid, thus making the whole job fail.
