### PR TITLE
Add `SanitizedVersionedMessage` wrapper type for usage in compute budget

### DIFF
--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -180,7 +180,11 @@ mod tests {
                 Hash::default(),
             ));
             let mut compute_budget = ComputeBudget::default();
-            let result = compute_budget.process_message(&tx.message(), true, true);
+            let result = compute_budget.process_instructions(
+                tx.message().program_instructions_iter(),
+                true,
+                true,
+            );
             assert_eq!($expected_error, result);
             assert_eq!(compute_budget, $expected_budget);
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4384,8 +4384,8 @@ impl Bank {
                     if tx_wide_compute_cap {
                         let mut compute_budget_process_transaction_time =
                             Measure::start("compute_budget_process_transaction_time");
-                        let process_transaction_result = compute_budget.process_message(
-                            tx.message(),
+                        let process_transaction_result = compute_budget.process_instructions(
+                            tx.message().program_instructions_iter(),
                             feature_set.is_active(&requestable_heap_size::id()),
                             feature_set.is_active(&default_units_per_instruction::id()),
                         );
@@ -4614,7 +4614,7 @@ impl Bank {
 
             let mut compute_budget = ComputeBudget::default();
             let additional_fee = compute_budget
-                .process_message(message, false, false)
+                .process_instructions(message.program_instructions_iter(), false, false)
                 .unwrap_or_default();
             let signature_fee = Self::get_num_signatures_in_message(message)
                 .saturating_mul(fee_structure.lamports_per_signature);

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -15,7 +15,10 @@ use {
     std::fmt,
 };
 
+mod sanitized;
 pub mod v0;
+
+pub use sanitized::*;
 
 /// Bit mask that indicates whether a serialized message is versioned.
 pub const MESSAGE_VERSION_PREFIX: u8 = 0x80;

--- a/sdk/program/src/message/versions/sanitized.rs
+++ b/sdk/program/src/message/versions/sanitized.rs
@@ -1,0 +1,41 @@
+use {
+    super::VersionedMessage,
+    crate::{instruction::CompiledInstruction, pubkey::Pubkey, sanitize::SanitizeError},
+};
+
+/// Wraps a sanitized `VersionedMessage` to provide a safe API
+pub struct SanitizedVersionedMessage<'a> {
+    message: &'a VersionedMessage,
+}
+
+impl<'a> TryFrom<&'a VersionedMessage> for SanitizedVersionedMessage<'a> {
+    type Error = SanitizeError;
+    fn try_from(message: &'a VersionedMessage) -> Result<Self, Self::Error> {
+        message.sanitize(true /* require_static_program_ids */)?;
+        Ok(Self { message })
+    }
+}
+
+impl SanitizedVersionedMessage<'_> {
+    /// Program instructions that will be executed in sequence and committed in
+    /// one atomic transaction if all succeed.
+    pub fn instructions(&self) -> &[CompiledInstruction] {
+        self.message.instructions()
+    }
+
+    /// Program instructions iterator which includes each instruction's program
+    /// id.
+    pub fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, &CompiledInstruction)> {
+        self.message.instructions().iter().map(move |ix| {
+            (
+                self.message
+                    .static_account_keys()
+                    .get(usize::from(ix.program_id_index))
+                    .expect("program id index is sanitized"),
+                ix,
+            )
+        })
+    }
+}


### PR DESCRIPTION
#### Problem
It's not possible to extract the compute fee for sanitized transactions in banking stage until they have had all addresses loaded from on-chain lookup tables

#### Summary of Changes
Adds a new `SanitizedVersionedMessage` type which doesn't require address lookup table processing

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
