### PR TITLE
(LedgerStore) Move metric sample counters out from LedgerColumnOptions

### DIFF
--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -9,6 +9,7 @@ use {
     solana_metrics::datapoint_info,
     std::{
         cell::RefCell,
+        fmt::Debug,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
@@ -509,6 +510,13 @@ pub(crate) fn report_rocksdb_write_perf(metric_header: &'static str) {
             ),
         );
     });
+}
+
+#[derive(Debug, Default, Clone)]
+/// A struct that holds the current status of RocksDB perf sampling.
+pub struct BlockstoreRocksDbPerfSamplingStatus {
+    // The number of RocksDB operations since the last perf sample.
+    pub(crate) op_count: Arc<AtomicUsize>,
 }
 
 pub trait ColumnMetrics {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2743,7 +2743,6 @@ pub fn main() {
             "rocksdb_perf_sample_interval",
             usize
         ),
-        ..LedgerColumnOptions::default()
     };
 
     if matches.is_present("halt_on_known_validators_accounts_hash_mismatch") {


### PR DESCRIPTION
#### Problem
LedgerColumnOptions contain two fields, perf_read_counter and perf_write_counter,
that are not really options but internal counters.

#### Summary of Changes
This PR introduces BlockstoreRocksDbPerfSamplingStatus, a struct that holds internal
status for RocksDB perf sampling and moves perf_read_counter and perf_write_counter
out from LedgerColumnOptions.
