### PR TITLE
(LedgerStore) Change perf_samples_counter from Arc<AtomicUsize> to AtomicUsize

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -4,8 +4,7 @@ use {
         blockstore_meta,
         blockstore_metrics::{
             maybe_enable_rocksdb_perf, report_rocksdb_read_perf, report_rocksdb_write_perf,
-            BlockstoreRocksDbColumnFamilyMetrics, BlockstoreRocksDbPerfSamplingStatus,
-            ColumnMetrics,
+            BlockstoreRocksDbColumnFamilyMetrics, ColumnMetrics, PerfSamplingStatus,
         },
         rocksdb_metric_header,
     },
@@ -308,7 +307,7 @@ struct Rocks {
     access_type: AccessType,
     oldest_slot: OldestSlot,
     column_options: LedgerColumnOptions,
-    write_batch_perf_status: BlockstoreRocksDbPerfSamplingStatus,
+    write_batch_perf_status: PerfSamplingStatus,
 }
 
 impl Rocks {
@@ -340,7 +339,7 @@ impl Rocks {
                 access_type: access_type.clone(),
                 oldest_slot,
                 column_options,
-                write_batch_perf_status: BlockstoreRocksDbPerfSamplingStatus::default(),
+                write_batch_perf_status: PerfSamplingStatus::default(),
             },
             AccessType::Secondary => {
                 let secondary_path = path.join("solana-secondary");
@@ -361,7 +360,7 @@ impl Rocks {
                     access_type: access_type.clone(),
                     oldest_slot,
                     column_options,
-                    write_batch_perf_status: BlockstoreRocksDbPerfSamplingStatus::default(),
+                    write_batch_perf_status: PerfSamplingStatus::default(),
                 }
             }
         };
@@ -985,14 +984,14 @@ impl TypedColumn for columns::ErasureMeta {
     type Type = blockstore_meta::ErasureMeta;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Database {
     backend: Arc<Rocks>,
     path: Arc<Path>,
     column_options: Arc<LedgerColumnOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LedgerColumn<C>
 where
     C: Column + ColumnName + ColumnMetrics,
@@ -1000,8 +999,8 @@ where
     backend: Arc<Rocks>,
     column: PhantomData<C>,
     pub column_options: Arc<LedgerColumnOptions>,
-    read_perf_status: BlockstoreRocksDbPerfSamplingStatus,
-    write_perf_status: BlockstoreRocksDbPerfSamplingStatus,
+    read_perf_status: PerfSamplingStatus,
+    write_perf_status: PerfSamplingStatus,
 }
 
 impl<C: Column + ColumnName + ColumnMetrics> LedgerColumn<C> {
@@ -1248,8 +1247,8 @@ impl Database {
             backend: Arc::clone(&self.backend),
             column: PhantomData,
             column_options: Arc::clone(&self.column_options),
-            read_perf_status: BlockstoreRocksDbPerfSamplingStatus::default(),
-            write_perf_status: BlockstoreRocksDbPerfSamplingStatus::default(),
+            read_perf_status: PerfSamplingStatus::default(),
+            write_perf_status: PerfSamplingStatus::default(),
         }
     }
 

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -245,7 +245,7 @@ thread_local! {static PER_THREAD_ROCKS_PERF_CONTEXT: RefCell<PerfContext> = RefC
 /// and the PerfContext of the ubsequent RocksDB operation will be collected.
 pub(crate) fn maybe_enable_rocksdb_perf(
     sample_interval: usize,
-    perf_samples_counter: &Arc<AtomicUsize>,
+    perf_samples_counter: &AtomicUsize,
 ) -> bool {
     if sample_interval == 0 {
         return false;
@@ -512,11 +512,11 @@ pub(crate) fn report_rocksdb_write_perf(metric_header: &'static str) {
     });
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 /// A struct that holds the current status of RocksDB perf sampling.
-pub struct BlockstoreRocksDbPerfSamplingStatus {
+pub struct PerfSamplingStatus {
     // The number of RocksDB operations since the last perf sample.
-    pub(crate) op_count: Arc<AtomicUsize>,
+    pub(crate) op_count: AtomicUsize,
 }
 
 pub trait ColumnMetrics {


### PR DESCRIPTION
#### Problem
After #25042, each LedgerColumn has its own BlockstoreRocksDbWritePerfMetrics
and BlockstoreRocksDbReadPerfMetrics instances.  As it has total ownership,
its member field does not need to use Arc.

#### Summary of Changes
Change perf_samples_counter from Arc<AtomicUsize> to AtomicUsize
under BlockstoreRocksDbWritePerfMetrics and BlockstoreRocksDbReadPerfMetrics.

This PR depends on #25042.