### PR TITLE
Jason speedup sysvar or builtin test

### DIFF
--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -47,15 +47,15 @@ lazy_static! {
 lazy_static! {
     // A simple table to do a lookup based on the first byte of the static keys in question.
     pub static ref BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
-        let mut temp_table [bool; 256] = [false; 256];
-        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key[0] as usize] = true;);
-        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key[0] as usize] = true;);
+        let mut temp_table: [bool; 256] = [false; 256];
+        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true;);
+        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true;);
         temp_table
     };
 }
 
 pub fn is_builtin_key_or_sysvar(key: &Pubkey) -> bool {
-    if BUILTIN_KEY_OR_SYSVAR[key[0] as usize] {
+    if BUILTIN_KEY_OR_SYSVAR[key.0[0] as usize] {
         return sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key);
     }
     false

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -46,7 +46,8 @@ lazy_static! {
 
 lazy_static! {
     // A simple table to do a lookup based on the first byte of the static keys in question.
-    pub static ref BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
+    // Used as a very quick culling test before searching through vectors of keys for a match.
+    pub static ref MAYBE_BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
         let mut temp_table: [bool; 256] = [false; 256];
         BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
         sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
@@ -55,7 +56,7 @@ lazy_static! {
 }
 
 pub fn is_builtin_key_or_sysvar(key: &Pubkey) -> bool {
-    if BUILTIN_KEY_OR_SYSVAR[key.0[0] as usize] {
+    if MAYBE_BUILTIN_KEY_OR_SYSVAR[key.0[0] as usize] {
         return sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key);
     }
     false

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -47,16 +47,15 @@ lazy_static! {
 lazy_static! {
     // A simple table to do a lookup based on the first byte of the static keys in question.
     pub static ref BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
-        for i in 0..255 {
-            BUILTIN_KEY_OR_SYSVAR[i] = false;
-        }
-        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| BUILTIN_KEY_OR_SYSVAR[key[0]] = true;);
-        sysvar::ALL_IDS.iter().for_each(|key| BUILTIN_KEY_OR_SYSVAR[key[0]] = true;);
+        let mut temp_table [bool; 256] = [false; 256];
+        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key[0] as usize] = true;);
+        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key[0] as usize] = true;);
+        temp_table
     };
 }
 
 pub fn is_builtin_key_or_sysvar(key: &Pubkey) -> bool {
-    if BUILTIN_KEY_OR_SYSVAR[key[0]] {
+    if BUILTIN_KEY_OR_SYSVAR[key[0] as usize] {
         return sysvar::is_sysvar_id(&key) || BUILTIN_PROGRAMS_KEYS.contains(&key);
     }
     false

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -48,8 +48,8 @@ lazy_static! {
     // A simple table to do a lookup based on the first byte of the static keys in question.
     pub static ref BUILTIN_KEY_OR_SYSVAR: [bool; 256] = {
         let mut temp_table: [bool; 256] = [false; 256];
-        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true;);
-        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true;);
+        BUILTIN_PROGRAMS_KEYS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
+        sysvar::ALL_IDS.iter().for_each(|key| temp_table[key.0[0] as usize] = true);
         temp_table
     };
 }

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -3,7 +3,6 @@ use {
         bpf_loader_upgradeable,
         message::{legacy::is_builtin_key_or_sysvar, v0, AccountKeys},
         pubkey::Pubkey,
-        sysvar,
     },
     std::{borrow::Cow, collections::HashSet},
 };

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -108,8 +108,6 @@ impl<'a> LoadedMessage<'a> {
     pub fn is_writable(&self, key_index: usize) -> bool {
         if self.is_writable_index(key_index) {
             if let Some(key) = self.account_keys().get(key_index) {
-                let demote_program_id = self.is_key_called_as_program(key_index)
-                    && !self.is_upgradeable_loader_present();
                 return !(is_builtin_key_or_sysvar(key) || self.demote_program_id(key_index));
             }
         }

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     hash::Hash,
     instruction::{CompiledInstruction, Instruction},
     message::{
-        compiled_keys::CompileError, legacy::BUILTIN_PROGRAMS_KEYS, AccountKeys, CompiledKeys,
+        compiled_keys::CompileError, legacy::is_builtin_key_or_sysvar, AccountKeys, CompiledKeys,
         MessageHeader, MESSAGE_VERSION_PREFIX,
     },
     pubkey::Pubkey,
@@ -309,7 +309,7 @@ impl Message {
                 // demote reserved ids
                 self.account_keys
                     .get(key_index)
-                    .map(|key| sysvar::is_sysvar_id(key) || BUILTIN_PROGRAMS_KEYS.contains(key))
+                    .map(|key| is_builtin_key_or_sysvar(key))
                     .unwrap_or_default()
             }
             && !{

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     pubkey::Pubkey,
     sanitize::{Sanitize, SanitizeError},
-    short_vec, sysvar,
+    short_vec,
 };
 pub use loaded::*;
 


### PR DESCRIPTION
#### Problem
Calculate_costs is slower than it appears to be.  In particular here, there are two lists of built-in/system account keys that all account keys are checked against while computing costs (as part of an is_writable check).

#### Summary of Changes
A key is checked against these two lists by running two functions across vectors of keys to see if the key being tested is equal to anything on the list. In the mismatch (normal) case, this is 20 key comparisons. Added an efficient cull in front of this process (and wrapped the two checks into a single function). The cull pre-computes a 256-bool table based on the first byte of each of the 20 static keys. An incoming key's first byte is tested in this table. If it's not marked as "true" in the table, then it's definitely not a match to the 20 static keys and processing is complete. Otherwise, it may be a static key match, and the original linear test is performed.

Resulted in a roughly 25% speedup of the entire compute_costs function for the test case I was using, which had only 3 accounts in each transaction.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
