### PR TITLE
Clean up logging and make variables consistent

### DIFF
--- a/core/src/cluster_slot_state_verifier.rs
+++ b/core/src/cluster_slot_state_verifier.rs
@@ -753,10 +753,7 @@ pub(crate) fn check_slot_agrees_with_cluster(
     slot_state_update: SlotStateUpdate,
 ) {
     info!(
-        "check_slot_agrees_with_cluster()
-        slot: {},
-        root: {},
-        slot_state_update: {:?}",
+        "check_slot_agrees_with_cluster() slot: {}, root: {}, slot_state_update: {:?}",
         slot, root, slot_state_update
     );
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -209,7 +209,7 @@ fn run_check_duplicate(
     cluster_info: &ClusterInfo,
     blockstore: &Blockstore,
     shred_receiver: &Receiver<Shred>,
-    duplicate_slot_sender: &DuplicateSlotSender,
+    duplicate_slots_sender: &DuplicateSlotSender,
 ) -> Result<()> {
     let check_duplicate = |shred: Shred| -> Result<()> {
         let shred_slot = shred.slot();
@@ -224,7 +224,7 @@ fn run_check_duplicate(
                     shred.into_payload(),
                 )?;
 
-                duplicate_slot_sender.send(shred_slot)?;
+                duplicate_slots_sender.send(shred_slot)?;
             }
         }
 
@@ -530,7 +530,7 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         duplicate_receiver: Receiver<Shred>,
-        duplicate_slot_sender: DuplicateSlotSender,
+        duplicate_slots_sender: DuplicateSlotSender,
     ) -> JoinHandle<()> {
         let handle_error = || {
             inc_new_counter_error!("solana-check-duplicate-error", 1, 1);
@@ -547,7 +547,7 @@ impl WindowService {
                     &cluster_info,
                     &blockstore,
                     &duplicate_receiver,
-                    &duplicate_slot_sender,
+                    &duplicate_slots_sender,
                 ) {
                     if Self::should_exit_on_error(e, &mut noop, &handle_error) {
                         break;


### PR DESCRIPTION
#### Changes
- Change multiline logs to single line
- Make `duplicate_slot_sender` and `duplicate_slots_sender` consistent