### PR TITLE
Enable 0rtt

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -63,6 +63,18 @@ impl ConnectionCacheStats {
             client_stats.connection_reuse.load(Ordering::Relaxed),
             Ordering::Relaxed,
         );
+        self.total_client_stats.connection_errors.fetch_add(
+            client_stats.connection_errors.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        self.total_client_stats.zero_rtt_accepts.fetch_add(
+            client_stats.zero_rtt_accepts.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        self.total_client_stats.zero_rtt_rejects.fetch_add(
+            client_stats.zero_rtt_rejects.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
         self.sent_packets
             .fetch_add(num_packets as u64, Ordering::Relaxed);
         self.total_batches.fetch_add(1, Ordering::Relaxed);
@@ -127,6 +139,27 @@ impl ConnectionCacheStats {
                 "connection_reuse",
                 self.total_client_stats
                     .connection_reuse
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "connection_errors",
+                self.total_client_stats
+                    .connection_errors
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "zero_rtt_accepts",
+                self.total_client_stats
+                    .zero_rtt_accepts
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "zero_rtt_rejects",
+                self.total_client_stats
+                    .zero_rtt_rejects
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -214,8 +214,7 @@ impl QuicClient {
             Ok((connection, zero_rtt)) => {
                 if zero_rtt.await {
                     stats.zero_rtt_accepts.fetch_add(1, Ordering::Relaxed);
-                }
-                else {
+                } else {
                     stats.zero_rtt_rejects.fetch_add(1, Ordering::Relaxed);
                 }
                 connection

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -220,7 +220,10 @@ impl QuicClient {
 
     // Attempts to make a faster connection by taking advantage of pre-existing key material.
     // Only works if connection to this endpoint was previously established.
-    async fn make_connection_0rtt(&self, stats: &ClientStats) -> Result<Arc<NewConnection>, WriteError> {
+    async fn make_connection_0rtt(
+        &self,
+        stats: &ClientStats
+    ) -> Result<Arc<NewConnection>, WriteError> {
         let connecting = self.endpoint.connect(self.addr, "connect").unwrap();
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
         let connection = match connecting.into_0rtt() {

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -222,7 +222,7 @@ impl QuicClient {
     // Only works if connection to this endpoint was previously established.
     async fn make_connection_0rtt(
         &self,
-        stats: &ClientStats
+        stats: &ClientStats,
     ) -> Result<Arc<NewConnection>, WriteError> {
         let connecting = self.endpoint.connect(self.addr, "connect").unwrap();
         stats.total_connections.fetch_add(1, Ordering::Relaxed);

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -210,15 +210,15 @@ impl QuicClient {
     async fn make_connection(&self, stats: &ClientStats) -> Result<Arc<NewConnection>, WriteError> {
         let connecting = self.endpoint.connect(self.addr, "connect").unwrap();
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
-        let new_conn = match connecting.into_0rtt() {
-            Ok((new_conn, zero_rtt)) => {
+        let connection = match connecting.into_0rtt() {
+            Ok((connection, zero_rtt)) => {
                 if zero_rtt.await {
                     stats.zero_rtt_accepts.fetch_add(1, Ordering::Relaxed);
                 }
                 else {
                     stats.zero_rtt_rejects.fetch_add(1, Ordering::Relaxed);
                 }
-                new_conn
+                connection
             }
             Err(connecting) => {
                 stats.connection_errors.fetch_add(1, Ordering::Relaxed);
@@ -227,7 +227,6 @@ impl QuicClient {
             }
         };
 
-        let connection = connecting_result?;
         Ok(Arc::new(connection))
     }
 

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -13,6 +13,8 @@ pub struct ClientStats {
     pub total_connections: AtomicU64,
     pub connection_reuse: AtomicU64,
     pub connection_errors: AtomicU64,
+    pub zero_rtt_accepts: AtomicU64,
+    pub zero_rtt_rejects: AtomicU64,
 
     // these will be the last values of these stats
     pub congestion_events: MovingStat,


### PR DESCRIPTION
#### Problem
TLS handshake for resumed session can require 1 round trip, which costs latency. See #25011 

#### Summary of Changes

- Enable 0rtt quic connections when possible
- Add metrics for tracking connection & 0rtt success
