### PR TITLE
Weight streams by stake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,22 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
+version = "0.8.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=29d3932953985656bc587caf7e8f813c4760f974#29d3932953985656bc587caf7e8f813c4760f974"
+dependencies = [
+ "bytes",
+ "quinn-proto 0.8.0",
+ "quinn-udp 0.1.0",
+ "rustc-hash",
+ "rustls 0.20.4",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d147472bc9a09f13b06c044787b6683cdffa02e2865b7f0fb53d67c49ed2988e"
@@ -3275,11 +3291,29 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto",
- "quinn-udp",
+ "quinn-proto 0.8.2",
+ "quinn-udp 0.1.1",
  "rustls 0.20.4",
  "thiserror",
  "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=29d3932953985656bc587caf7e8f813c4760f974#29d3932953985656bc587caf7e8f813c4760f974"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.4",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
  "tracing",
  "webpki 0.22.0",
 ]
@@ -3306,6 +3340,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
+version = "0.1.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=29d3932953985656bc587caf7e8f813c4760f974#29d3932953985656bc587caf7e8f813c4760f974"
+dependencies = [
+ "libc",
+ "quinn-proto 0.8.0",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df185e5e5f7611fa6e628ed8f9633df10114b03bbaecab186ec55822c44ac727"
@@ -3313,7 +3359,7 @@ dependencies = [
  "futures-util",
  "libc",
  "mio",
- "quinn-proto",
+ "quinn-proto 0.8.2",
  "socket2",
  "tokio",
  "tracing",
@@ -4602,8 +4648,8 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
- "quinn",
- "quinn-proto",
+ "quinn 0.8.2",
+ "quinn-proto 0.8.2",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
@@ -5903,7 +5949,7 @@ dependencies = [
  "nix",
  "pem",
  "pkcs8",
- "quinn",
+ "quinn 0.8.0",
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.4",

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -17,7 +17,7 @@ use {
     quinn_proto::ConnectionStats,
     solana_sdk::{
         quic::{
-            QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS, QUIC_PORT_OFFSET,
+            QUIC_KEEP_ALIVE_MS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS, QUIC_PORT_OFFSET,
         },
         transport::Result as TransportResult,
     },
@@ -293,7 +293,7 @@ impl QuicClient {
 
         let chunks = buffers[1..buffers.len()]
             .iter()
-            .chunks(QUIC_MAX_CONCURRENT_STREAMS);
+            .chunks(QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS);
 
         let futures: Vec<_> = chunks
             .into_iter()

--- a/core/src/staked_nodes_updater_service.rs
+++ b/core/src/staked_nodes_updater_service.rs
@@ -1,6 +1,7 @@
 use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_runtime::bank_forks::BankForks,
+    solana_streamer::quic::StakedNodes,
     std::{
         collections::HashMap,
         net::IpAddr,
@@ -24,7 +25,7 @@ impl StakedNodesUpdaterService {
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
         bank_forks: Arc<RwLock<BankForks>>,
-        shared_staked_nodes: Arc<RwLock<HashMap<IpAddr, u64>>>,
+        shared_staked_nodes: Arc<RwLock<StakedNodes>>,
     ) -> Self {
         let thread_hdl = Builder::new()
             .name("sol-sn-updater".to_string())
@@ -32,14 +33,17 @@ impl StakedNodesUpdaterService {
                 let mut last_stakes = Instant::now();
                 while !exit.load(Ordering::Relaxed) {
                     let mut new_ip_to_stake = HashMap::new();
+                    let mut total_stake = 0;
                     Self::try_refresh_ip_to_stake(
                         &mut last_stakes,
                         &mut new_ip_to_stake,
+                        &mut total_stake,
                         &bank_forks,
                         &cluster_info,
                     );
                     let mut shared = shared_staked_nodes.write().unwrap();
-                    *shared = new_ip_to_stake;
+                    shared.0 .0 = total_stake as f64;
+                    shared.0 .1 = new_ip_to_stake;
                 }
             })
             .unwrap();
@@ -50,12 +54,17 @@ impl StakedNodesUpdaterService {
     fn try_refresh_ip_to_stake(
         last_stakes: &mut Instant,
         ip_to_stake: &mut HashMap<IpAddr, u64>,
+        total_stake: &mut u64,
         bank_forks: &RwLock<BankForks>,
         cluster_info: &ClusterInfo,
     ) {
         if last_stakes.elapsed() > IP_TO_STAKE_REFRESH_DURATION {
             let root_bank = bank_forks.read().unwrap().root_bank();
             let staked_nodes = root_bank.staked_nodes();
+            *total_stake = staked_nodes
+                .iter()
+                .map(|(_pubkey, stake)| stake)
+                .sum::<u64>();
             *ip_to_stake = cluster_info
                 .tvu_peers()
                 .into_iter()

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -29,9 +29,10 @@ use {
         vote_sender_types::{ReplayVoteReceiver, ReplayVoteSender},
     },
     solana_sdk::signature::Keypair,
-    solana_streamer::quic::{spawn_server, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
+    solana_streamer::quic::{
+        spawn_server, StakedNodes, MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS,
+    },
     std::{
-        collections::HashMap,
         net::UdpSocket,
         sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
         thread,
@@ -136,7 +137,7 @@ impl Tpu {
 
         let (verified_sender, verified_receiver) = unbounded();
 
-        let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(
             exit.clone(),
             cluster_info.clone(),

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -2,7 +2,7 @@ pub const QUIC_PORT_OFFSET: u16 = 6;
 // Empirically found max number of concurrent streams
 // that seems to maximize TPS on GCE (higher values don't seem to
 // give significant improvement or seem to impact stability)
-pub const QUIC_MAX_CONCURRENT_STREAMS: usize = 2048;
+pub const QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS: usize = 128;
 
 pub const QUIC_MAX_TIMEOUT_MS: u32 = 2_000;
 pub const QUIC_KEEP_ALIVE_MS: u64 = 1_000;

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.17"
 nix = "0.24.0"
 pem = "1.0.2"
 pkcs8 = { version = "0.8.0", features = ["alloc"] }
-quinn = "0.8.2"
+quinn = { git = "https://github.com/quinn-rs/quinn.git", rev = "29d3932953985656bc587caf7e8f813c4760f974" }
 rand = "0.7.0"
 rcgen = "0.9.2"
 rustls = { version = "0.20.4", features = ["dangerous_configuration"] }


### PR DESCRIPTION
#### Problem

quic incoming stream throughput should be weighted by stake so that a ton of low staked nodes cannot overwhelm the machine.

#### Summary of Changes

Weight the concurrent streams by stake which will throttle nodes by stake weight.

Needs unreleased quinn version.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
