### PR TITLE
Greedy receive in banking stage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1989,7 +1989,11 @@ impl BankingStage {
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) -> Result<(), RecvTimeoutError> {
         let mut recv_time = Measure::start("receive_and_buffer_packets_recv");
-        let packet_batches = verified_receiver.recv_timeout(recv_timeout)?;
+        let mut packet_batches = verified_receiver.recv_timeout(recv_timeout)?;
+        while let Ok(packet_batch) = verified_receiver.try_recv() {
+            trace!("got more packets");
+            packet_batches.extend(packet_batch);
+        }
         recv_time.stop();
 
         let packet_batches_len = packet_batches.len();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2469,29 +2469,7 @@ mod tests {
         } = create_slow_genesis_config(2);
         let (verified_sender, verified_receiver) = unbounded();
 
-        // Process a batch that includes a transaction that receives two lamports.
         let alice = Keypair::new();
-        let tx =
-            system_transaction::transfer(&mint_keypair, &alice.pubkey(), 2, genesis_config.hash());
-
-        let packet_batches = to_packet_batches(&[tx], 1);
-        let packet_batches = packet_batches
-            .into_iter()
-            .map(|batch| (batch, vec![1u8]))
-            .collect();
-        let packet_batches = convert_from_old_verified(packet_batches);
-        verified_sender.send(packet_batches).unwrap();
-
-        // Process a second batch that uses the same from account, so conflicts with above TX
-        let tx =
-            system_transaction::transfer(&mint_keypair, &alice.pubkey(), 1, genesis_config.hash());
-        let packet_batches = to_packet_batches(&[tx], 1);
-        let packet_batches = packet_batches
-            .into_iter()
-            .map(|batch| (batch, vec![1u8]))
-            .collect();
-        let packet_batches = convert_from_old_verified(packet_batches);
-        verified_sender.send(packet_batches).unwrap();
 
         let (vote_sender, vote_receiver) = unbounded();
         let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
@@ -2527,6 +2505,38 @@ mod tests {
                     gossip_vote_sender,
                     Arc::new(RwLock::new(CostModel::default())),
                 );
+
+                // Process a batch that includes a transaction that receives two lamports.
+                let tx = system_transaction::transfer(
+                    &mint_keypair,
+                    &alice.pubkey(),
+                    2,
+                    genesis_config.hash(),
+                );
+
+                let packet_batches = to_packet_batches(&[tx], 1);
+                let packet_batches = packet_batches
+                    .into_iter()
+                    .map(|batch| (batch, vec![1u8]))
+                    .collect();
+                let packet_batches = convert_from_old_verified(packet_batches);
+                verified_sender.send(packet_batches).unwrap();
+
+                sleep(Duration::from_millis(200));
+                // Process a second batch that uses the same from account, so conflicts with above TX
+                let tx = system_transaction::transfer(
+                    &mint_keypair,
+                    &alice.pubkey(),
+                    1,
+                    genesis_config.hash(),
+                );
+                let packet_batches = to_packet_batches(&[tx], 1);
+                let packet_batches = packet_batches
+                    .into_iter()
+                    .map(|batch| (batch, vec![1u8]))
+                    .collect();
+                let packet_batches = convert_from_old_verified(packet_batches);
+                verified_sender.send(packet_batches).unwrap();
 
                 // wait for banking_stage to eat the packets
                 while bank.get_balance(&alice.pubkey()) < 2 {


### PR DESCRIPTION
#### Problem
`BankingStage` is not able to keep up with `SigVerify` stage in case of QUIC.

#### Summary of Changes
The QUIC transactions are received as a packet batch of size 1. This is causing the channel between sigverify stage and banking stage to back up, as the banking stage is not doing greedy receive (all other stages in the pipeline are doing it via use of `recv_packet_batches`). This PR adds the greedy receive to the banking stage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
