### PR TITLE
Speed up build-cli-usage.sh script via adding background processes

### DIFF
--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+start=$(date +%s)
 
 cd "$(dirname "$0")"
 cargo=../cargo
@@ -40,6 +41,13 @@ in_subcommands=0
 while read -r subcommand rest; do
   [[ $subcommand == "SUBCOMMANDS:" ]] && in_subcommands=1 && continue
   if ((in_subcommands)); then
-      section "$("$cargo" stable -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$out"
+      section "$("$cargo" stable -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$subcommand"._txt &
   fi
-done <<<"$usage">>"$out"
+done <<<"$usage"
+wait
+# Combine all separately created txt generated docs into one & remove all the previously created ones
+cat ./*._txt >> "$out"
+rm -rf ./*._txt
+
+end=$(date +%s)
+echo "Total Cli Usage Generation Time Took $((end - start)) seconds."


### PR DESCRIPTION
**Problem**
#13562 
```
docs/build-cli-usage.sh takes several minutes to output the help messages of each subcommand, which doesn't seem like it should be the case
```

**Proposed Solution**
Parallelize the subcommand help generation to reduce docs generation time. Because waiting is painful!


Added Timing to docs generation & compared on Macbook Pro 13 inch


1. base case (**sequential**) no changes --> 97 seconds
2. use of `parallel` to spawn processes
3. spawn background processes & leverage a wait

Details of tests can be found below

Sequential 
```
+ exec cargo +1.60.0 build -p solana-cli
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
+ exec cargo +1.60.0 -q run -p solana-cli -- -C /Users/ryanyang/.foo --help
+ exec cargo +1.60.0 -q run -p solana-cli -- help account

<snip>

+ exec cargo +1.60.0 -q run -p solana-cli -- help withdraw-from-vote-account
+ exec cargo +1.60.0 -q run -p solana-cli -- help withdraw-stake
Total Cli Usage Generation Time Took 97 seconds.
```

W/ Parallel 
```
./build-cli-usage.sh
+ exec cargo +1.60.0 build -p solana-cli
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
+ exec cargo +1.60.0 -q run -p solana-cli -- -C /Users/ryanyang/.foo --help
+ exec cargo +1.60.0 -q run -p solana-cli -- help airdrop
+ exec cargo +1.60.0 -q run -p solana-cli -- help address

<snip>

+ exec cargo +1.60.0 -q run -p solana-cli -- help withdraw-from-nonce-account
Total Cli Usage Generation Time Took 67 seconds.
```

Wait + Background process

```
+ exec cargo +1.60.0 build -p solana-cli
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
+ exec cargo +1.60.0 -q run -p solana-cli -- -C /Users/ryanyang/.foo --help
+ exec cargo +1.60.0 -q run -p solana-cli -- help account
+ exec cargo +1.60.0 -q run -p solana-cli -- help address

<snip>

+ exec cargo +1.60.0 -q run -p solana-cli -- help vote-update-commission
+ exec cargo +1.60.0 -q run -p solana-cli -- help supply
Total Cli Usage Generation Time Took 52 seconds.
```

