### PR TITLE
Add sanitized types for use in banking stage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1737,12 +1737,11 @@ impl BankingStage {
             return None;
         }
 
-        let tx = SanitizedTransaction::try_create(
-            deserialized_packet.versioned_transaction().clone(),
+        let tx = SanitizedTransaction::try_new(
+            deserialized_packet.transaction().clone(),
             *deserialized_packet.message_hash(),
-            Some(deserialized_packet.is_simple_vote()),
+            deserialized_packet.is_simple_vote(),
             address_loader,
-            feature_set.is_active(&feature_set::require_static_program_ids_in_transaction::ID),
         )
         .ok()?;
         tx.verify_precompiles(feature_set).ok()?;

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -15,7 +15,10 @@ use {
     std::fmt,
 };
 
+mod sanitized;
 pub mod v0;
+
+pub use sanitized::*;
 
 /// Bit mask that indicates whether a serialized message is versioned.
 pub const MESSAGE_VERSION_PREFIX: u8 = 0x80;

--- a/sdk/program/src/message/versions/sanitized.rs
+++ b/sdk/program/src/message/versions/sanitized.rs
@@ -1,0 +1,46 @@
+use {
+    super::VersionedMessage,
+    crate::{instruction::CompiledInstruction, pubkey::Pubkey, sanitize::SanitizeError},
+};
+
+/// Wraps a sanitized `VersionedMessage` to provide a safe API
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SanitizedVersionedMessage {
+    pub message: VersionedMessage,
+}
+
+impl TryFrom<VersionedMessage> for SanitizedVersionedMessage {
+    type Error = SanitizeError;
+    fn try_from(message: VersionedMessage) -> Result<Self, Self::Error> {
+        Self::try_new(message)
+    }
+}
+
+impl SanitizedVersionedMessage {
+    pub fn try_new(message: VersionedMessage) -> Result<Self, SanitizeError> {
+        message.sanitize(true /* require_static_program_ids */)?;
+        Ok(Self { message })
+    }
+
+    /// Program instructions that will be executed in sequence and committed in
+    /// one atomic transaction if all succeed.
+    pub fn instructions(&self) -> &[CompiledInstruction] {
+        self.message.instructions()
+    }
+
+    /// Program instructions iterator which includes each instruction's program
+    /// id.
+    pub fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, &CompiledInstruction)> {
+        self.message.instructions().iter().map(move |ix| {
+            (
+                self.message
+                    .static_account_keys()
+                    .get(usize::from(ix.program_id_index))
+                    .expect("program id index is sanitized"),
+                ix,
+            )
+        })
+    }
+}

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -17,6 +17,10 @@ use {
     std::cmp::Ordering,
 };
 
+mod sanitized;
+
+pub use sanitized::*;
+
 /// Type that serializes to the string "legacy"
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -95,7 +99,11 @@ impl VersionedTransaction {
         require_static_program_ids: bool,
     ) -> std::result::Result<(), SanitizeError> {
         self.message.sanitize(require_static_program_ids)?;
+        self.sanitize_signatures()?;
+        Ok(())
+    }
 
+    pub(crate) fn sanitize_signatures(&self) -> std::result::Result<(), SanitizeError> {
         let num_required_signatures = usize::from(self.message.header().num_required_signatures);
         match num_required_signatures.cmp(&self.signatures.len()) {
             Ordering::Greater => Err(SanitizeError::IndexOutOfBounds),

--- a/sdk/src/transaction/versioned/sanitized.rs
+++ b/sdk/src/transaction/versioned/sanitized.rs
@@ -1,0 +1,79 @@
+use {
+    super::VersionedTransaction,
+    crate::{sanitize::SanitizeError, signature::Signature},
+    solana_program::message::SanitizedVersionedMessage,
+};
+
+/// Wraps a sanitized `VersionedTransaction` to provide a safe API
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SanitizedVersionedTransaction {
+    /// List of signatures
+    pub(crate) signatures: Vec<Signature>,
+    /// Message to sign.
+    pub(crate) message: SanitizedVersionedMessage,
+}
+
+impl TryFrom<VersionedTransaction> for SanitizedVersionedTransaction {
+    type Error = SanitizeError;
+    fn try_from(tx: VersionedTransaction) -> Result<Self, Self::Error> {
+        Self::try_new(tx)
+    }
+}
+
+impl SanitizedVersionedTransaction {
+    pub fn try_new(tx: VersionedTransaction) -> Result<Self, SanitizeError> {
+        tx.sanitize_signatures()?;
+        Ok(Self {
+            signatures: tx.signatures,
+            message: SanitizedVersionedMessage::try_from(tx.message)?,
+        })
+    }
+
+    pub fn get_message(&self) -> &SanitizedVersionedMessage {
+        &self.message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_program::{
+            hash::Hash,
+            message::{v0, VersionedMessage},
+            pubkey::Pubkey,
+        },
+    };
+
+    #[test]
+    fn test_try_new_with_invalid_signatures() {
+        let tx = VersionedTransaction {
+            signatures: vec![],
+            message: VersionedMessage::V0(
+                v0::Message::try_compile(&Pubkey::new_unique(), &[], &[], Hash::default()).unwrap(),
+            ),
+        };
+
+        assert_eq!(
+            SanitizedVersionedTransaction::try_new(tx),
+            Err(SanitizeError::IndexOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn test_try_new() {
+        let mut message =
+            v0::Message::try_compile(&Pubkey::new_unique(), &[], &[], Hash::default()).unwrap();
+        message.header.num_readonly_signed_accounts += 1;
+
+        let tx = VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V0(message),
+        };
+
+        assert_eq!(
+            SanitizedVersionedTransaction::try_new(tx),
+            Err(SanitizeError::InvalidValue)
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
The banking stage needs to efficiently sanitize transactions and messages to extract fee information. There is a `SanitizedTransaction` type but it requires using a bank to load addresses from an on-chain lookup table which is expensive and shouldn't be done before collecting fee information for tx prioritization.

#### Summary of Changes
- Add `SanitizedVersionedTransaction` and `SanitizedVersionedMessage` types which are lightweight and allow banking stage to efficiently collect fee information without address loading.
- Integrate the new sanitized types with the existing `SanitizedTransaction` type to avoid redoing any sanitization work.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
