### PR TITLE
Support lz4 for snapshot archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,8 @@ dependencies = [
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk 1.11.0",
+ "strum",
+ "strum_macros",
  "symlink",
  "tar",
  "tempfile",
@@ -6372,6 +6374,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "rustversion",
+ "syn 1.0.91",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edcb94251b1c375c459e5abe9fb0168c1c826c3370172684844f8f3f8d1a885"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7be8908e2ed6f31c02db8a9fa962f03e36c53fbfde437363eae3306b85d7e17"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,6 +5649,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
+ "lz4",
  "memmap2",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6391,10 +6391,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.37",
+ "proc-macro2 1.0.38",
  "quote 1.0.18",
  "rustversion",
- "syn 1.0.91",
+ "syn 1.0.93",
 ]
 
 [[package]]

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -281,6 +281,7 @@ pub fn download_snapshot_archive<'a, 'b>(
         ArchiveFormat::TarZstd,
         ArchiveFormat::TarGzip,
         ArchiveFormat::TarBzip2,
+        ArchiveFormat::TarLz4,
         ArchiveFormat::Tar, // `solana-test-validator` creates uncompressed snapshots
     ] {
         let destination_path = match snapshot_type {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1524,7 +1524,17 @@ fn main() {
                           base for the incremental snapshot.")
                     .conflicts_with("no_snapshot")
             )
-        ).subcommand(
+            .arg(
+                Arg::with_name("snapshot_archive_format")
+                    .long("snapshot-archive-format")
+                    .possible_values(&["bz2", "gzip", "zstd", "lz4", "tar", "none"])
+                    .default_value("zstd")
+                    .value_name("ARCHIVE_TYPE")
+                    .takes_value(true)
+                    .help("Snapshot archive format to use.")
+                    .conflicts_with("no_snapshot")
+            )
+    ).subcommand(
             SubCommand::with_name("accounts")
             .about("Print account stats and contents after processing the ledger")
             .arg(&no_snapshot_arg)
@@ -2292,6 +2302,15 @@ fn main() {
                     },
                 );
 
+                let snapshot_archive_format = arg_matches
+                    .value_of("snapshot_archive_format")
+                    .map_or(ArchiveFormat::TarZstd, |s| {
+                        s.parse::<ArchiveFormat>().unwrap_or_else(|e| {
+                            eprintln!("Error: {}", e);
+                            exit(1)
+                        })
+                    });
+
                 let maximum_full_snapshot_archives_to_retain =
                     value_t_or_exit!(arg_matches, "maximum_full_snapshots_to_retain", usize);
                 let maximum_incremental_snapshot_archives_to_retain = value_t_or_exit!(
@@ -2568,7 +2587,7 @@ fn main() {
                                     Some(snapshot_version),
                                     output_directory.clone(),
                                     output_directory,
-                                    ArchiveFormat::TarZstd,
+                                    snapshot_archive_format,
                                     maximum_full_snapshot_archives_to_retain,
                                     maximum_incremental_snapshot_archives_to_retain,
                                 )
@@ -2592,7 +2611,7 @@ fn main() {
                                     Some(snapshot_version),
                                     output_directory.clone(),
                                     output_directory,
-                                    ArchiveFormat::TarZstd,
+                                    snapshot_archive_format,
                                     maximum_full_snapshot_archives_to_retain,
                                     maximum_incremental_snapshot_archives_to_retain,
                                 )

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -44,7 +44,8 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
-            self, ArchiveFormat, SnapshotVersion, DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            self, ArchiveFormat, SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION,
+            DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
@@ -1528,7 +1529,7 @@ fn main() {
                 Arg::with_name("snapshot_archive_format")
                     .long("snapshot-archive-format")
                     .possible_values(SUPPORTED_ARCHIVE_COMPRESSION)
-                    .default_value("zstd")
+                    .default_value(DEFAULT_ARCHIVE_COMPRESSION)
                     .value_name("ARCHIVE_TYPE")
                     .takes_value(true)
                     .help("Snapshot archive format to use.")
@@ -2305,14 +2306,9 @@ fn main() {
                 let snapshot_archive_format = {
                     let archive_format_str =
                         value_t_or_exit!(matches, "snapshot_archive_format", String);
-                    match archive_format_str.as_str() {
-                        "bz2" => ArchiveFormat::TarBzip2,
-                        "gzip" => ArchiveFormat::TarGzip,
-                        "zstd" => ArchiveFormat::TarZstd,
-                        "lz4" => ArchiveFormat::TarLz4,
-                        "tar" | "none" => ArchiveFormat::Tar,
-                        _ => panic!("Archive format not recognized: {}", archive_format_str),
-                    }
+                    ArchiveFormat::from_cli_arg(&archive_format_str).expect(
+                        format!("Archive format not recognized: {}", archive_format_str).as_str(),
+                    )
                 };
 
                 let maximum_full_snapshot_archives_to_retain =

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2306,9 +2306,9 @@ fn main() {
                 let snapshot_archive_format = {
                     let archive_format_str =
                         value_t_or_exit!(matches, "snapshot_archive_format", String);
-                    ArchiveFormat::from_cli_arg(&archive_format_str).expect(
-                        format!("Archive format not recognized: {}", archive_format_str).as_str(),
-                    )
+                    ArchiveFormat::from_cli_arg(&archive_format_str).unwrap_or_else(|| {
+                        panic!("Archive format not recognized: {}", archive_format_str)
+                    })
                 };
 
                 let maximum_full_snapshot_archives_to_retain =

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2302,7 +2302,7 @@ fn main() {
                     },
                 );
 
-                let archive_format = {
+                let snapshot_archive_format = {
                     let archive_format_str =
                         value_t_or_exit!(matches, "snapshot_archive_format", String);
                     match archive_format_str.as_str() {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5048,6 +5048,8 @@ dependencies = [
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk 1.11.0",
+ "strum",
+ "strum_macros",
  "symlink",
  "tar",
  "tempfile",
@@ -5624,6 +5626,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2 1.0.36",
+ "quote 1.0.6",
+ "rustversion",
+ "syn 1.0.91",
+]
 
 [[package]]
 name = "subtle"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5643,10 +5643,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.36",
- "quote 1.0.6",
+ "proc-macro2 1.0.38",
+ "quote 1.0.18",
  "rustversion",
- "syn 1.0.91",
+ "syn 1.0.93",
 ]
 
 [[package]]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2089,6 +2089,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edcb94251b1c375c459e5abe9fb0168c1c826c3370172684844f8f3f8d1a885"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7be8908e2ed6f31c02db8a9fa962f03e36c53fbfde437363eae3306b85d7e17"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,6 +5021,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "lz4",
  "memmap2",
  "num-derive",
  "num-traits",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -57,6 +57,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0"
 zstd = "0.11.2"
+lz4 = "1.23.3"
 
 [lib]
 crate-type = ["lib"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -58,6 +58,8 @@ tempfile = "3.3.0"
 thiserror = "1.0"
 zstd = "0.11.2"
 lz4 = "1.23.3"
+strum_macros = "0.24"
+strum = { version = "0.24", features = ["derive"] }
 
 [lib]
 crate-type = ["lib"]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -408,7 +408,7 @@ pub fn archive_snapshot_package(
         "archive-snapshot-package",
         ("slot", snapshot_package.slot(), i64),
         (
-            "format",
+            "archive_format",
             snapshot_package.archive_format().to_string(),
             String
         ),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1596,6 +1596,12 @@ fn untar_snapshot_mmap(
             account_paths,
             parallel_divisions,
         )?,
+        ArchiveFormat::TarLz4 => unpack_snapshot_local(
+            || lz4::Decoder::new(slice).unwrap(),
+            unpack_dir,
+            account_paths,
+            parallel_divisions,
+        )?,
         ArchiveFormat::Tar => {
             unpack_snapshot_local(|| slice, unpack_dir, account_paths, parallel_divisions)?
         }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -371,7 +371,7 @@ pub fn archive_snapshot_package(
                 encoder.finish()?;
             }
             ArchiveFormat::TarLz4 => {
-                let mut encoder = lz4::EncoderBuilder::new().level(4).build(archive_file)?;
+                let mut encoder = lz4::EncoderBuilder::new().level(1).build(archive_file)?;
                 do_archive_files(&mut encoder)?;
                 let (_output, result) = encoder.finish();
                 result?

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -407,6 +407,11 @@ pub fn archive_snapshot_package(
     datapoint_info!(
         "archive-snapshot-package",
         ("slot", snapshot_package.slot(), i64),
+        (
+            "format",
+            snapshot_package.archive_format().to_string(),
+            String
+        ),
         ("duration_ms", timer.as_ms(), i64),
         (
             if snapshot_package.snapshot_type.is_full_snapshot() {

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -167,10 +167,7 @@ mod tests {
             Some(ArchiveFormat::Tar),
         ];
 
-        for (arg, expected) in zip(
-            SUPPORTED_ARCHIVE_COMPRESSION.into_iter(),
-            golden.into_iter(),
-        ) {
+        for (arg, expected) in zip(SUPPORTED_ARCHIVE_COMPRESSION.iter(), golden.into_iter()) {
             assert_eq!(ArchiveFormat::from_cli_arg(arg), expected);
         }
 

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -101,7 +101,7 @@ mod tests {
         );
         assert_eq!(
             ArchiveFormat::try_from(INVALID_EXTENSION),
-            Err(ParseError::InvalidExtension)
+            Err(ParseError(INVALID_EXTENSION.to_string()))
         );
     }
 
@@ -129,7 +129,7 @@ mod tests {
         );
         assert_eq!(
             ArchiveFormat::from_str(INVALID_EXTENSION),
-            Err(ParseError::InvalidExtension)
+            Err(ParseError(INVALID_EXTENSION.to_string()))
         );
     }
 }

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -145,4 +145,36 @@ mod tests {
             Err(ParseError(INVALID_EXTENSION.to_string()))
         );
     }
+
+    #[test]
+    fn test_to_string() {
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_BZIP2_EXTENSION)
+                .unwrap()
+                .to_string(),
+            "BZIP2"
+        );
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_GZIP_EXTENSION)
+                .unwrap()
+                .to_string(),
+            "GZIP"
+        );
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_ZSTD_EXTENSION)
+                .unwrap()
+                .to_string(),
+            "ZSTD"
+        );
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_LZ4_EXTENSION)
+                .unwrap()
+                .to_string(),
+            "LZ4"
+        );
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_EXTENSION).unwrap().to_string(),
+            "TAR"
+        );
+    }
 }

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -29,6 +29,19 @@ impl ArchiveFormat {
     }
 }
 
+/// Converts to a String
+impl ToString for ArchiveFormat {
+    fn to_string(&self) -> String {
+        match self {
+            ArchiveFormat::TarBzip2 => "BZIP2".to_string(),
+            ArchiveFormat::TarGzip => "GZIP".to_string(),
+            ArchiveFormat::TarZstd => "ZSTD".to_string(),
+            ArchiveFormat::TarLz4 => "LZ4".to_string(),
+            ArchiveFormat::Tar => "TAR".to_string(),
+        }
+    }
+}
+
 // Change this to `impl<S: AsRef<str>> TryFrom<S> for ArchiveFormat [...]`
 // once this Rust bug is fixed: https://github.com/rust-lang/rust/issues/50133
 impl TryFrom<&str> for ArchiveFormat {

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -1,8 +1,9 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 pub const TAR_BZIP2_EXTENSION: &str = "tar.bz2";
 pub const TAR_GZIP_EXTENSION: &str = "tar.gz";
 pub const TAR_ZSTD_EXTENSION: &str = "tar.zst";
+pub const TAR_LZ4_EXTENSION: &str = "tar.lz4";
 pub const TAR_EXTENSION: &str = "tar";
 
 /// The different archive formats used for snapshots
@@ -11,6 +12,7 @@ pub enum ArchiveFormat {
     TarBzip2,
     TarGzip,
     TarZstd,
+    TarLz4,
     Tar,
 }
 
@@ -21,6 +23,7 @@ impl ArchiveFormat {
             ArchiveFormat::TarBzip2 => TAR_BZIP2_EXTENSION,
             ArchiveFormat::TarGzip => TAR_GZIP_EXTENSION,
             ArchiveFormat::TarZstd => TAR_ZSTD_EXTENSION,
+            ArchiveFormat::TarLz4 => TAR_LZ4_EXTENSION,
             ArchiveFormat::Tar => TAR_EXTENSION,
         }
     }
@@ -36,8 +39,9 @@ impl TryFrom<&str> for ArchiveFormat {
             TAR_BZIP2_EXTENSION => Ok(ArchiveFormat::TarBzip2),
             TAR_GZIP_EXTENSION => Ok(ArchiveFormat::TarGzip),
             TAR_ZSTD_EXTENSION => Ok(ArchiveFormat::TarZstd),
+            TAR_LZ4_EXTENSION => Ok(ArchiveFormat::TarLz4),
             TAR_EXTENSION => Ok(ArchiveFormat::Tar),
-            _ => Err(ParseError::InvalidExtension),
+            _ => Err(ParseError(extension.to_string())),
         }
     }
 }
@@ -50,9 +54,13 @@ impl FromStr for ArchiveFormat {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum ParseError {
-    InvalidExtension,
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ParseError(String);
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Invalid archive extension: {}", self.0)
+    }
 }
 
 #[cfg(test)]
@@ -65,6 +73,7 @@ mod tests {
         assert_eq!(ArchiveFormat::TarBzip2.extension(), TAR_BZIP2_EXTENSION);
         assert_eq!(ArchiveFormat::TarGzip.extension(), TAR_GZIP_EXTENSION);
         assert_eq!(ArchiveFormat::TarZstd.extension(), TAR_ZSTD_EXTENSION);
+        assert_eq!(ArchiveFormat::TarLz4.extension(), TAR_LZ4_EXTENSION);
         assert_eq!(ArchiveFormat::Tar.extension(), TAR_EXTENSION);
     }
 
@@ -81,6 +90,10 @@ mod tests {
         assert_eq!(
             ArchiveFormat::try_from(TAR_ZSTD_EXTENSION),
             Ok(ArchiveFormat::TarZstd)
+        );
+        assert_eq!(
+            ArchiveFormat::try_from(TAR_LZ4_EXTENSION),
+            Ok(ArchiveFormat::TarLz4)
         );
         assert_eq!(
             ArchiveFormat::try_from(TAR_EXTENSION),
@@ -105,6 +118,10 @@ mod tests {
         assert_eq!(
             ArchiveFormat::from_str(TAR_ZSTD_EXTENSION),
             Ok(ArchiveFormat::TarZstd)
+        );
+        assert_eq!(
+            ArchiveFormat::from_str(TAR_LZ4_EXTENSION),
+            Ok(ArchiveFormat::TarLz4)
         );
         assert_eq!(
             ArchiveFormat::from_str(TAR_EXTENSION),

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -88,7 +88,7 @@ impl fmt::Display for ParseError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, std::iter::zip};
     const INVALID_EXTENSION: &str = "zip";
 
     #[test]
@@ -157,34 +157,23 @@ mod tests {
     }
 
     #[test]
-    fn test_to_string() {
-        assert_eq!(
-            ArchiveFormat::from_str(TAR_BZIP2_EXTENSION)
-                .unwrap()
-                .to_string(),
-            "TarBzip2"
-        );
-        assert_eq!(
-            ArchiveFormat::from_str(TAR_GZIP_EXTENSION)
-                .unwrap()
-                .to_string(),
-            "TarGzip",
-        );
-        assert_eq!(
-            ArchiveFormat::from_str(TAR_ZSTD_EXTENSION)
-                .unwrap()
-                .to_string(),
-            "TarZstd"
-        );
-        assert_eq!(
-            ArchiveFormat::from_str(TAR_LZ4_EXTENSION)
-                .unwrap()
-                .to_string(),
-            "TarLz4",
-        );
-        assert_eq!(
-            ArchiveFormat::from_str(TAR_EXTENSION).unwrap().to_string(),
-            "Tar"
-        );
+    fn test_from_cli_arg() {
+        let golden = [
+            Some(ArchiveFormat::TarBzip2),
+            Some(ArchiveFormat::TarGzip),
+            Some(ArchiveFormat::TarZstd),
+            Some(ArchiveFormat::TarLz4),
+            Some(ArchiveFormat::Tar),
+            Some(ArchiveFormat::Tar),
+        ];
+
+        for (arg, expected) in zip(
+            SUPPORTED_ARCHIVE_COMPRESSION.into_iter(),
+            golden.into_iter(),
+        ) {
+            assert_eq!(ArchiveFormat::from_cli_arg(arg), expected);
+        }
+
+        assert_eq!(ArchiveFormat::from_cli_arg("bad"), None);
     }
 }

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -4,6 +4,7 @@ use {
 };
 
 pub const SUPPORTED_ARCHIVE_COMPRESSION: &[&str] = &["bz2", "gzip", "zstd", "lz4", "tar", "none"];
+pub const DEFAULT_ARCHIVE_COMPRESSION: &str = "zstd";
 
 pub const TAR_BZIP2_EXTENSION: &str = "tar.bz2";
 pub const TAR_GZIP_EXTENSION: &str = "tar.gz";
@@ -30,6 +31,17 @@ impl ArchiveFormat {
             ArchiveFormat::TarZstd => TAR_ZSTD_EXTENSION,
             ArchiveFormat::TarLz4 => TAR_LZ4_EXTENSION,
             ArchiveFormat::Tar => TAR_EXTENSION,
+        }
+    }
+
+    pub fn from_cli_arg(archive_format_str: &str) -> Option<ArchiveFormat> {
+        match archive_format_str {
+            "bz2" => Some(ArchiveFormat::TarBzip2),
+            "gzip" => Some(ArchiveFormat::TarGzip),
+            "zstd" => Some(ArchiveFormat::TarZstd),
+            "lz4" => Some(ArchiveFormat::TarLz4),
+            "tar" | "none" => Some(ArchiveFormat::Tar),
+            _ => None,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1483,7 +1483,7 @@ pub fn main() {
             Arg::with_name("snapshot_archive_format")
                 .long("snapshot-archive-format")
                 .alias("snapshot-compression") // Legacy name used by Solana v1.5.x and older
-                .possible_values(&["bz2", "gzip", "zstd", "tar", "none"])
+                .possible_values(&["bz2", "gzip", "zstd", "lz4", "tar", "none"])
                 .default_value("zstd")
                 .value_name("ARCHIVE_TYPE")
                 .takes_value(true)
@@ -2657,6 +2657,7 @@ pub fn main() {
             "bz2" => ArchiveFormat::TarBzip2,
             "gzip" => ArchiveFormat::TarGzip,
             "zstd" => ArchiveFormat::TarZstd,
+            "lz4" => ArchiveFormat::TarLz4,
             "tar" | "none" => ArchiveFormat::Tar,
             _ => panic!("Archive format not recognized: {}", archive_format_str),
         }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -57,7 +57,7 @@ use {
             self, ArchiveFormat, SnapshotVersion, DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
-            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN,
+            DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN, SUPPORTED_ARCHIVE_COMPRESSION,
         },
     },
     solana_sdk::{
@@ -1483,7 +1483,7 @@ pub fn main() {
             Arg::with_name("snapshot_archive_format")
                 .long("snapshot-archive-format")
                 .alias("snapshot-compression") // Legacy name used by Solana v1.5.x and older
-                .possible_values(&["bz2", "gzip", "zstd", "lz4", "tar", "none"])
+                .possible_values(SUPPORTED_ARCHIVE_COMPRESSION)
                 .default_value("zstd")
                 .value_name("ARCHIVE_TYPE")
                 .takes_value(true)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2655,7 +2655,7 @@ pub fn main() {
     let archive_format = {
         let archive_format_str = value_t_or_exit!(matches, "snapshot_archive_format", String);
         ArchiveFormat::from_cli_arg(&archive_format_str)
-            .expect(format!("Archive format not recognized: {}", archive_format_str).as_str())
+            .unwrap_or_else(|| panic!("Archive format not recognized: {}", archive_format_str))
     };
 
     let snapshot_version =

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -54,7 +54,8 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_config::SnapshotConfig,
         snapshot_utils::{
-            self, ArchiveFormat, SnapshotVersion, DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+            self, ArchiveFormat, SnapshotVersion, DEFAULT_ARCHIVE_COMPRESSION,
+            DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
             DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN,
             DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN, SUPPORTED_ARCHIVE_COMPRESSION,
@@ -1484,7 +1485,7 @@ pub fn main() {
                 .long("snapshot-archive-format")
                 .alias("snapshot-compression") // Legacy name used by Solana v1.5.x and older
                 .possible_values(SUPPORTED_ARCHIVE_COMPRESSION)
-                .default_value("zstd")
+                .default_value(DEFAULT_ARCHIVE_COMPRESSION)
                 .value_name("ARCHIVE_TYPE")
                 .takes_value(true)
                 .help("Snapshot archive format to use."),
@@ -2653,14 +2654,8 @@ pub fn main() {
 
     let archive_format = {
         let archive_format_str = value_t_or_exit!(matches, "snapshot_archive_format", String);
-        match archive_format_str.as_str() {
-            "bz2" => ArchiveFormat::TarBzip2,
-            "gzip" => ArchiveFormat::TarGzip,
-            "zstd" => ArchiveFormat::TarZstd,
-            "lz4" => ArchiveFormat::TarLz4,
-            "tar" | "none" => ArchiveFormat::Tar,
-            _ => panic!("Archive format not recognized: {}", archive_format_str),
-        }
+        ArchiveFormat::from_cli_arg(&archive_format_str)
+            .expect(format!("Archive format not recognized: {}", archive_format_str).as_str())
     };
 
     let snapshot_version =


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/24998

lz4 provides a good compromise between compress and decompress speed and compression ratio. Compare with zstd, which is the current default option, lz4 can provide **3-4x** speed up for compression and decompression. The downside is that the archive files will be **1/3** larger.

For machine that have large disk space, lz4 will be a good option to choose from.

#### Summary of Changes

Add lz4 support for snapshot archives


Fixes #24998
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
