### PR TITLE
Add localhost as cluster endpoint

### DIFF
--- a/web3.js/src/util/cluster.ts
+++ b/web3.js/src/util/cluster.ts
@@ -1,17 +1,19 @@
 const endpoint = {
   http: {
+    localhost: 'http://localhost:8899',
     devnet: 'http://api.devnet.solana.com',
     testnet: 'http://api.testnet.solana.com',
     'mainnet-beta': 'http://api.mainnet-beta.solana.com/',
   },
   https: {
+    localhost: 'https://localhost:8899',
     devnet: 'https://api.devnet.solana.com',
     testnet: 'https://api.testnet.solana.com',
     'mainnet-beta': 'https://api.mainnet-beta.solana.com/',
   },
 };
 
-export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
+export type Cluster = 'localhost' | 'devnet' | 'testnet' | 'mainnet-beta';
 
 /**
  * Retrieves the RPC API URL for the specified cluster


### PR DESCRIPTION
#### Problem
The `clusterApiUrl` method currently lacks support for a localhost RPC endpoint. This makes it difficult for libraries such as the [Wallet Adapter](https://github.com/solana-labs/wallet-adapter) to interact with locally run validators (via the `solana-test-validator` command).

#### Summary of Changes
This PR adds support for localhost as a cluster endpoint.

If this PR is approved and merged, a follow-up PR could be submitted to add localhost as an additional [`WalletAdapterNetwork` enum](https://github.com/solana-labs/wallet-adapter/blob/master/packages/core/base/src/types.ts).