### PR TITLE
Do not hold vote_state lock guard in match statement

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -153,7 +153,7 @@ use {
         collections::{HashMap, HashSet},
         convert::{TryFrom, TryInto},
         fmt, mem,
-        ops::{Deref, Div, RangeInclusive},
+        ops::{Div, RangeInclusive},
         path::PathBuf,
         rc::Rc,
         sync::{
@@ -2932,13 +2932,14 @@ impl Bank {
                 invalid_vote_keys.insert(vote_pubkey, InvalidCacheEntryReason::WrongOwner);
                 return None;
             }
-            let vote_state = match vote_account.vote_state().deref() {
-                Ok(vote_state) => vote_state.clone(),
-                Err(_) => {
+            let vote_state = vote_account
+                .vote_state()
+                .as_ref()
+                .map_err(|_| {
                     invalid_vote_keys.insert(vote_pubkey, InvalidCacheEntryReason::BadState);
-                    return None;
-                }
-            };
+                })
+                .ok()?
+                .clone();
             let vote_with_stake_delegations = VoteWithStakeDelegations {
                 vote_state: Arc::new(vote_state),
                 vote_account: AccountSharedData::from(vote_account),


### PR DESCRIPTION
#### Problem

The `vote_state` lock guard is held in a match statement. Refer to #24836 for more info, and https://github.com/solana-labs/solana/issues/24836#issuecomment-1121460537 for the clippy output pertaining to this PR.

#### Summary of Changes

Do not hold `vote_state` lock guard in match scrutinee.