### PR TITLE
Parse most token-2022 instructions

### DIFF
--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -2,7 +2,7 @@ use {
     crate::parse_instruction::{
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
-    extension::default_account_state::*,
+    extension::{default_account_state::*, memo_transfer::*},
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{
         pubkey_from_spl_token, token_amount_to_ui_amount, UiAccountState,
@@ -516,9 +516,18 @@ pub fn parse_token(
         TokenInstruction::Reallocate { .. } => Err(ParseInstructionError::InstructionNotParsable(
             ParsableProgram::SplToken,
         )),
-        TokenInstruction::MemoTransferExtension => Err(
-            ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
-        ),
+        TokenInstruction::MemoTransferExtension => {
+            if instruction.data.len() < 2 {
+                return Err(ParseInstructionError::InstructionNotParsable(
+                    ParsableProgram::SplToken,
+                ));
+            }
+            parse_memo_transfer_instruction(
+                &instruction.data[1..],
+                &instruction.accounts,
+                account_keys,
+            )
+        }
         TokenInstruction::CreateNativeMint => Err(ParseInstructionError::InstructionNotParsable(
             ParsableProgram::SplToken,
         )),

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -2,7 +2,9 @@ use {
     crate::parse_instruction::{
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
-    extension::{default_account_state::*, memo_transfer::*, reallocate::*},
+    extension::{
+        default_account_state::*, memo_transfer::*, mint_close_authority::*, reallocate::*,
+    },
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{
         pubkey_from_spl_token, token_amount_to_ui_amount, UiAccountState,
@@ -492,9 +494,13 @@ pub fn parse_token(
                 }),
             })
         }
-        TokenInstruction::InitializeMintCloseAuthority { .. } => Err(
-            ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
-        ),
+        TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
+            parse_initialize_mint_close_authority_instruction(
+                close_authority,
+                &instruction.accounts,
+                account_keys,
+            )
+        }
         TokenInstruction::TransferFeeExtension(_) => Err(
             ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
         ),

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -4,6 +4,7 @@ use {
     },
     extension::{
         default_account_state::*, memo_transfer::*, mint_close_authority::*, reallocate::*,
+        transfer_fee::*,
     },
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{
@@ -501,9 +502,13 @@ pub fn parse_token(
                 account_keys,
             )
         }
-        TokenInstruction::TransferFeeExtension(_) => Err(
-            ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
-        ),
+        TokenInstruction::TransferFeeExtension(transfer_fee_instruction) => {
+            parse_transfer_fee_instruction(
+                transfer_fee_instruction,
+                &instruction.accounts,
+                account_keys,
+            )
+        }
         TokenInstruction::ConfidentialTransferExtension => Err(
             ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
         ),

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -13,6 +13,7 @@ use {
         instruction::{AuthorityType, TokenInstruction},
         solana_program::{
             instruction::Instruction as SplTokenInstruction, program_option::COption,
+            pubkey::Pubkey,
         },
     },
 };
@@ -224,10 +225,7 @@ pub fn parse_token(
             let mut value = json!({
                 owned: account_keys[instruction.accounts[0] as usize].to_string(),
                 "authorityType": Into::<UiAuthorityType>::into(authority_type),
-                "newAuthority": match new_authority {
-                    COption::Some(authority) => Some(authority.to_string()),
-                    COption::None => None,
-                },
+                "newAuthority": map_coption_pubkey(new_authority),
             });
             let map = value.as_object_mut().unwrap();
             parse_signers(
@@ -614,6 +612,13 @@ pub fn spl_token_instruction(instruction: SplTokenInstruction) -> Instruction {
             })
             .collect(),
         data: instruction.data,
+    }
+}
+
+fn map_coption_pubkey(pubkey: COption<Pubkey>) -> Option<String> {
+    match pubkey {
+        COption::Some(pubkey) => Some(pubkey.to_string()),
+        COption::None => None,
     }
 }
 

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -2,7 +2,7 @@ use {
     crate::parse_instruction::{
         check_num_accounts, ParsableProgram, ParseInstructionError, ParsedInstructionEnum,
     },
-    extension::{default_account_state::*, memo_transfer::*},
+    extension::{default_account_state::*, memo_transfer::*, reallocate::*},
     serde_json::{json, Map, Value},
     solana_account_decoder::parse_token::{
         pubkey_from_spl_token, token_amount_to_ui_amount, UiAccountState,
@@ -513,9 +513,9 @@ pub fn parse_token(
                 account_keys,
             )
         }
-        TokenInstruction::Reallocate { .. } => Err(ParseInstructionError::InstructionNotParsable(
-            ParsableProgram::SplToken,
-        )),
+        TokenInstruction::Reallocate { extension_types } => {
+            parse_reallocate_instruction(extension_types, &instruction.accounts, account_keys)
+        }
         TokenInstruction::MemoTransferExtension => {
             if instruction.data.len() < 2 {
                 return Err(ParseInstructionError::InstructionNotParsable(

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -1,0 +1,158 @@
+use {
+    super::*,
+    spl_token_2022::extension::default_account_state::instruction::{
+        decode_instruction, DefaultAccountStateInstruction,
+    },
+};
+
+pub(in crate::parse_token) fn parse_default_account_state_instruction(
+    instruction_data: &[u8],
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    let (default_account_state_instruction, account_state) = decode_instruction(instruction_data)
+        .map_err(|_| {
+        ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
+    })?;
+    let instruction_type = "DefaultAccountState";
+    match default_account_state_instruction {
+        DefaultAccountStateInstruction::Initialize => {
+            check_num_token_accounts(account_indexes, 1)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: format!("initialize{}", instruction_type),
+                info: json!({
+                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "accountState": UiAccountState::from(account_state),
+                }),
+            })
+        }
+        DefaultAccountStateInstruction::Update => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "accountState": UiAccountState::from(account_state),
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                1,
+                account_keys,
+                account_indexes,
+                "freezeAuthority",
+                "multisigFreezeAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: format!("update{}", instruction_type),
+                info: value,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{
+            extension::default_account_state::instruction::{
+                initialize_default_account_state, update_default_account_state,
+            },
+            solana_program::message::Message,
+            state::AccountState,
+        },
+    };
+
+    #[test]
+    fn test_parse_default_account_state_instruction() {
+        let mint_pubkey = Pubkey::new_unique();
+        let init_default_account_state_ix = initialize_default_account_state(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &AccountState::Frozen,
+        )
+        .unwrap();
+        let message = Message::new(&[init_default_account_state_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeDefaultAccountState".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "accountState": "frozen",
+                })
+            }
+        );
+
+        // Single mint freeze_authority
+        let mint_freeze_authority = Pubkey::new_unique();
+        let update_default_account_state_ix = update_default_account_state(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(mint_freeze_authority),
+            &[],
+            &AccountState::Initialized,
+        )
+        .unwrap();
+        let message = Message::new(&[update_default_account_state_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateDefaultAccountState".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "accountState": "initialized",
+                    "freezeAuthority": mint_freeze_authority.to_string(),
+                })
+            }
+        );
+
+        // Multisig mint freeze_authority
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let update_default_account_state_ix = update_default_account_state(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+            &AccountState::Initialized,
+        )
+        .unwrap();
+        let message = Message::new(&[update_default_account_state_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "updateDefaultAccountState".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "accountState": "initialized",
+                    "multisigFreezeAuthority": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -1,0 +1,178 @@
+use {
+    super::*,
+    spl_token_2022::{
+        extension::memo_transfer::instruction::RequiredMemoTransfersInstruction,
+        instruction::decode_instruction_type,
+    },
+};
+
+pub(in crate::parse_token) fn parse_memo_transfer_instruction(
+    instruction_data: &[u8],
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 2)?;
+    let instruction_type_str = match decode_instruction_type(instruction_data)
+        .map_err(|_| ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken))?
+    {
+        RequiredMemoTransfersInstruction::Enable => "enable",
+        RequiredMemoTransfersInstruction::Disable => "disable",
+    };
+    let mut value = json!({
+        "account": account_keys[account_indexes[0] as usize].to_string(),
+    });
+    let map = value.as_object_mut().unwrap();
+    parse_signers(
+        map,
+        1,
+        account_keys,
+        account_indexes,
+        "owner",
+        "multisigOwner",
+    );
+    Ok(ParsedInstructionEnum {
+        instruction_type: format!("{}RequiredMemoTransfers", instruction_type_str),
+        info: value,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{
+            extension::memo_transfer::instruction::{
+                disable_required_transfer_memos, enable_required_transfer_memos,
+            },
+            solana_program::message::Message,
+        },
+    };
+
+    #[test]
+    fn test_parse_memo_transfer_instruction() {
+        let account_pubkey = Pubkey::new_unique();
+
+        // Enable, single owner
+        let owner_pubkey = Pubkey::new_unique();
+        let enable_memo_transfers_ix = enable_required_transfer_memos(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_memo_transfers_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableRequiredMemoTransfers".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_memo_transfers_ix = enable_required_transfer_memos(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_memo_transfers_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "enableRequiredMemoTransfers".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Disable, single owner
+        let enable_memo_transfers_ix = disable_required_transfer_memos(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_memo_transfers_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableRequiredMemoTransfers".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                })
+            }
+        );
+
+        // Enable, multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let enable_memo_transfers_ix = disable_required_transfer_memos(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[enable_memo_transfers_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "disableRequiredMemoTransfers".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -1,0 +1,81 @@
+use {
+    super::*,
+    spl_token_2022::solana_program::{program_option::COption, pubkey::Pubkey},
+};
+
+pub(in crate::parse_token) fn parse_initialize_mint_close_authority_instruction(
+    close_authority: COption<Pubkey>,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 1)?;
+    Ok(ParsedInstructionEnum {
+        instruction_type: "initializeMintCloseAuthority".to_string(),
+        info: json!({
+            "mint": account_keys[account_indexes[0] as usize].to_string(),
+            "newAuthority": map_coption_pubkey(close_authority),
+        }),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        serde_json::Value,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{instruction::*, solana_program::message::Message},
+    };
+
+    #[test]
+    fn test_parse_initialize_mint_close_authority_instruction() {
+        let mint_pubkey = Pubkey::new_unique();
+        let close_authority = Pubkey::new_unique();
+        let mint_close_authority_ix = initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            Some(&convert_pubkey(close_authority)),
+        )
+        .unwrap();
+        let message = Message::new(&[mint_close_authority_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeMintCloseAuthority".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "newAuthority": close_authority.to_string(),
+                })
+            }
+        );
+
+        let mint_close_authority_ix = initialize_mint_close_authority(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            None,
+        )
+        .unwrap();
+        let message = Message::new(&[mint_close_authority_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeMintCloseAuthority".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "newAuthority": Value::Null,
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -1,0 +1,3 @@
+use super::*;
+
+pub(super) mod default_account_state;

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -4,3 +4,4 @@ pub(super) mod default_account_state;
 pub(super) mod memo_transfer;
 pub(super) mod mint_close_authority;
 pub(super) mod reallocate;
+pub(super) mod transfer_fee;

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -2,3 +2,4 @@ use super::*;
 
 pub(super) mod default_account_state;
 pub(super) mod memo_transfer;
+pub(super) mod reallocate;

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -2,4 +2,5 @@ use super::*;
 
 pub(super) mod default_account_state;
 pub(super) mod memo_transfer;
+pub(super) mod mint_close_authority;
 pub(super) mod reallocate;

--- a/transaction-status/src/parse_token/extension/mod.rs
+++ b/transaction-status/src/parse_token/extension/mod.rs
@@ -1,3 +1,4 @@
 use super::*;
 
 pub(super) mod default_account_state;
+pub(super) mod memo_transfer;

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -1,0 +1,120 @@
+use {super::*, spl_token_2022::extension::ExtensionType};
+
+pub(in crate::parse_token) fn parse_reallocate_instruction(
+    extension_types: Vec<ExtensionType>,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    check_num_token_accounts(account_indexes, 4)?;
+    let mut value = json!({
+        "account": account_keys[account_indexes[0] as usize].to_string(),
+        "payer": account_keys[account_indexes[1] as usize].to_string(),
+        "systemProgram": account_keys[account_indexes[2] as usize].to_string(),
+        "extensionTypes": extension_types.into_iter().map(UiExtensionType::from).collect::<Vec<_>>(),
+    });
+    let map = value.as_object_mut().unwrap();
+    parse_signers(
+        map,
+        3,
+        account_keys,
+        account_indexes,
+        "owner",
+        "multisigOwner",
+    );
+    Ok(ParsedInstructionEnum {
+        instruction_type: "reallocate".to_string(),
+        info: value,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{instruction::reallocate, solana_program::message::Message},
+    };
+
+    #[test]
+    fn test_parse_reallocate_instruction() {
+        let account_pubkey = Pubkey::new_unique();
+        let payer_pubkey = Pubkey::new_unique();
+
+        let extension_types = vec![
+            ExtensionType::TransferFeeAmount,
+            ExtensionType::MemoTransfer,
+        ];
+
+        // Single owner
+        let owner_pubkey = Pubkey::new_unique();
+        let reallocate_ix = reallocate(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(payer_pubkey),
+            &convert_pubkey(owner_pubkey),
+            &[],
+            &extension_types,
+        )
+        .unwrap();
+        let message = Message::new(&[reallocate_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "reallocate".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "payer": payer_pubkey.to_string(),
+                    "owner": owner_pubkey.to_string(),
+                    "systemProgram": solana_sdk::system_program::id().to_string(),
+                    "extensionTypes": ["transferFeeAmount", "memoTransfer"],
+                })
+            }
+        );
+
+        // Multisig owner
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let reallocate_ix = reallocate(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(payer_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+            &extension_types,
+        )
+        .unwrap();
+        let message = Message::new(&[reallocate_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "reallocate".to_string(),
+                info: json!({
+                    "account": account_pubkey.to_string(),
+                    "payer": payer_pubkey.to_string(),
+                    "multisigOwner": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                    "systemProgram": solana_sdk::system_program::id().to_string(),
+                    "extensionTypes": ["transferFeeAmount", "memoTransfer"],
+                })
+            }
+        );
+    }
+}

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -1,0 +1,563 @@
+use {super::*, spl_token_2022::extension::transfer_fee::instruction::TransferFeeInstruction};
+
+pub(in crate::parse_token) fn parse_transfer_fee_instruction(
+    transfer_fee_instruction: TransferFeeInstruction,
+    account_indexes: &[u8],
+    account_keys: &AccountKeys,
+) -> Result<ParsedInstructionEnum, ParseInstructionError> {
+    match transfer_fee_instruction {
+        TransferFeeInstruction::InitializeTransferFeeConfig {
+            transfer_fee_config_authority,
+            withdraw_withheld_authority,
+            transfer_fee_basis_points,
+            maximum_fee,
+        } => {
+            check_num_token_accounts(account_indexes, 1)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "transferFeeBasisPoints": transfer_fee_basis_points,
+                "maximumFee": maximum_fee,
+            });
+            let map = value.as_object_mut().unwrap();
+            if let COption::Some(transfer_fee_config_authority) = transfer_fee_config_authority {
+                map.insert(
+                    "transferFeeConfigAuthority".to_string(),
+                    json!(transfer_fee_config_authority.to_string()),
+                );
+            }
+            if let COption::Some(withdraw_withheld_authority) = withdraw_withheld_authority {
+                map.insert(
+                    "withdrawWithheldAuthority".to_string(),
+                    json!(withdraw_withheld_authority.to_string()),
+                );
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeTransferFeeConfig".to_string(),
+                info: value,
+            })
+        }
+        TransferFeeInstruction::TransferCheckedWithFee {
+            amount,
+            decimals,
+            fee,
+        } => {
+            check_num_token_accounts(account_indexes, 4)?;
+            let mut value = json!({
+                "source": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "destination": account_keys[account_indexes[2] as usize].to_string(),
+                "tokenAmount": token_amount_to_ui_amount(amount, decimals),
+                "feeAmount": token_amount_to_ui_amount(fee, decimals),
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                3,
+                account_keys,
+                account_indexes,
+                "authority",
+                "multisigAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "transferCheckedWithFee".to_string(),
+                info: value,
+            })
+        }
+        TransferFeeInstruction::WithdrawWithheldTokensFromMint => {
+            check_num_token_accounts(account_indexes, 3)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                2,
+                account_keys,
+                account_indexes,
+                "withdrawWithheldAuthority",
+                "multisigWithdrawWithheldAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromMint".to_string(),
+                info: value,
+            })
+        }
+        TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts } => {
+            check_num_token_accounts(account_indexes, 3 + num_token_accounts as usize)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            let mut source_accounts: Vec<String> = vec![];
+            let first_source_account_index = account_indexes
+                .len()
+                .saturating_sub(num_token_accounts as usize);
+            for i in account_indexes[first_source_account_index..].iter() {
+                source_accounts.push(account_keys[*i as usize].to_string());
+            }
+            map.insert("sourceAccounts".to_string(), json!(source_accounts));
+            parse_signers(
+                map,
+                2,
+                account_keys,
+                &account_indexes[..first_source_account_index],
+                "withdrawWithheldAuthority",
+                "multisigWithdrawWithheldAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromAccounts".to_string(),
+                info: value,
+            })
+        }
+        TransferFeeInstruction::HarvestWithheldTokensToMint => {
+            check_num_token_accounts(account_indexes, 1)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            let mut source_accounts: Vec<String> = vec![];
+            for i in account_indexes.iter().skip(1) {
+                source_accounts.push(account_keys[*i as usize].to_string());
+            }
+            map.insert("sourceAccounts".to_string(), json!(source_accounts));
+            Ok(ParsedInstructionEnum {
+                instruction_type: "harvestWithheldTokensToMint".to_string(),
+                info: value,
+            })
+        }
+        TransferFeeInstruction::SetTransferFee {
+            transfer_fee_basis_points,
+            maximum_fee,
+        } => {
+            check_num_token_accounts(account_indexes, 2)?;
+            let mut value = json!({
+                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "transferFeeBasisPoints": transfer_fee_basis_points,
+                "maximumFee": maximum_fee,
+            });
+            let map = value.as_object_mut().unwrap();
+            parse_signers(
+                map,
+                1,
+                account_keys,
+                account_indexes,
+                "transferFeeConfigAuthority",
+                "multisigtransferFeeConfigAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "setTransferFee".to_string(),
+                info: value,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        crate::parse_token::test::*,
+        solana_sdk::pubkey::Pubkey,
+        spl_token_2022::{
+            extension::transfer_fee::instruction::*, solana_program::message::Message,
+        },
+    };
+
+    #[test]
+    fn test_parse_transfer_fee_instruction() {
+        let mint_pubkey = Pubkey::new_unique();
+        let transfer_fee_config_authority = Pubkey::new_unique();
+        let withdraw_withheld_authority = Pubkey::new_unique();
+        let transfer_fee_basis_points = 42;
+        let maximum_fee = 2121;
+
+        // InitializeTransferFeeConfig variations
+        let init_transfer_fee_config_ix = initialize_transfer_fee_config(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            Some(&convert_pubkey(transfer_fee_config_authority)),
+            Some(&convert_pubkey(withdraw_withheld_authority)),
+            transfer_fee_basis_points,
+            maximum_fee,
+        )
+        .unwrap();
+        let message = Message::new(&[init_transfer_fee_config_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTransferFeeConfig".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "transferFeeConfigAuthority": transfer_fee_config_authority.to_string(),
+                    "withdrawWithheldAuthority": withdraw_withheld_authority.to_string(),
+                    "transferFeeBasisPoints": transfer_fee_basis_points,
+                    "maximumFee": maximum_fee,
+                })
+            }
+        );
+
+        let init_transfer_fee_config_ix = initialize_transfer_fee_config(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            None,
+            None,
+            transfer_fee_basis_points,
+            maximum_fee,
+        )
+        .unwrap();
+        let message = Message::new(&[init_transfer_fee_config_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeTransferFeeConfig".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "transferFeeBasisPoints": transfer_fee_basis_points,
+                    "maximumFee": maximum_fee,
+                })
+            }
+        );
+
+        // Single owner TransferCheckedWithFee
+        let account_pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let amount = 55;
+        let decimals = 2;
+        let fee = 5;
+        let transfer_checked_with_fee_ix = transfer_checked_with_fee(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(owner),
+            &[],
+            amount,
+            decimals,
+            fee,
+        )
+        .unwrap();
+        let message = Message::new(&[transfer_checked_with_fee_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "transferCheckedWithFee".to_string(),
+                info: json!({
+                    "source": account_pubkey.to_string(),
+                    "mint": mint_pubkey.to_string(),
+                    "destination": recipient.to_string(),
+                    "authority": owner.to_string(),
+                    "tokenAmount": {
+                        "uiAmount": 0.55,
+                        "decimals": 2,
+                        "amount": "55",
+                        "uiAmountString": "0.55",
+                   },
+                    "feeAmount": {
+                        "uiAmount": 0.05,
+                        "decimals": 2,
+                        "amount": "5",
+                        "uiAmountString": "0.05",
+                   },
+                })
+            }
+        );
+
+        // Multisig TransferCheckedWithFee
+        let multisig_pubkey = Pubkey::new_unique();
+        let multisig_signer0 = Pubkey::new_unique();
+        let multisig_signer1 = Pubkey::new_unique();
+        let transfer_checked_with_fee_ix = transfer_checked_with_fee(
+            &spl_token_2022::id(),
+            &convert_pubkey(account_pubkey),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+            amount,
+            decimals,
+            fee,
+        )
+        .unwrap();
+        let message = Message::new(&[transfer_checked_with_fee_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "transferCheckedWithFee".to_string(),
+                info: json!({
+                    "source": account_pubkey.to_string(),
+                    "mint": mint_pubkey.to_string(),
+                    "destination": recipient.to_string(),
+                    "multisigAuthority": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                    "tokenAmount": {
+                        "uiAmount": 0.55,
+                        "decimals": 2,
+                        "amount": "55",
+                        "uiAmountString": "0.55",
+                   },
+                    "feeAmount": {
+                        "uiAmount": 0.05,
+                        "decimals": 2,
+                        "amount": "5",
+                        "uiAmountString": "0.05",
+                   },
+                })
+            }
+        );
+
+        // Single authority WithdrawWithheldTokensFromMint
+        let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(withdraw_withheld_authority),
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[withdraw_withheld_tokens_from_mint_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromMint".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "feeRecipient": recipient.to_string(),
+                    "withdrawWithheldAuthority": withdraw_withheld_authority.to_string(),
+                })
+            }
+        );
+
+        // Multisig WithdrawWithheldTokensFromMint
+        let withdraw_withheld_tokens_from_mint_ix = withdraw_withheld_tokens_from_mint(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+        )
+        .unwrap();
+        let message = Message::new(&[withdraw_withheld_tokens_from_mint_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromMint".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "feeRecipient": recipient.to_string(),
+                    "multisigWithdrawWithheldAuthority": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Single authority WithdrawWithheldTokensFromAccounts
+        let fee_account0 = Pubkey::new_unique();
+        let fee_account1 = Pubkey::new_unique();
+        let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(withdraw_withheld_authority),
+            &[],
+            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+        )
+        .unwrap();
+        let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromAccounts".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "feeRecipient": recipient.to_string(),
+                    "withdrawWithheldAuthority": withdraw_withheld_authority.to_string(),
+                    "sourceAccounts": vec![
+                        fee_account0.to_string(),
+                        fee_account1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Multisig WithdrawWithheldTokensFromAccounts
+        let withdraw_withheld_tokens_from_accounts_ix = withdraw_withheld_tokens_from_accounts(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(recipient),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+        )
+        .unwrap();
+        let message = Message::new(&[withdraw_withheld_tokens_from_accounts_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "withdrawWithheldTokensFromAccounts".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "feeRecipient": recipient.to_string(),
+                    "multisigWithdrawWithheldAuthority": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                    "sourceAccounts": vec![
+                        fee_account0.to_string(),
+                        fee_account1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // HarvestWithheldTokensToMint
+        let harvest_withheld_tokens_to_mint_ix = harvest_withheld_tokens_to_mint(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &[&convert_pubkey(fee_account0), &convert_pubkey(fee_account1)],
+        )
+        .unwrap();
+        let message = Message::new(&[harvest_withheld_tokens_to_mint_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "harvestWithheldTokensToMint".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "sourceAccounts": vec![
+                        fee_account0.to_string(),
+                        fee_account1.to_string(),
+                    ],
+                })
+            }
+        );
+
+        // Single authority SetTransferFee
+        let set_transfer_fee_ix = set_transfer_fee(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(transfer_fee_config_authority),
+            &[],
+            transfer_fee_basis_points,
+            maximum_fee,
+        )
+        .unwrap();
+        let message = Message::new(&[set_transfer_fee_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "setTransferFee".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "transferFeeBasisPoints": transfer_fee_basis_points,
+                    "maximumFee": maximum_fee,
+                    "transferFeeConfigAuthority": transfer_fee_config_authority.to_string(),
+                })
+            }
+        );
+
+        // Multisig WithdrawWithheldTokensFromMint
+        let set_transfer_fee_ix = set_transfer_fee(
+            &spl_token_2022::id(),
+            &convert_pubkey(mint_pubkey),
+            &convert_pubkey(multisig_pubkey),
+            &[
+                &convert_pubkey(multisig_signer0),
+                &convert_pubkey(multisig_signer1),
+            ],
+            transfer_fee_basis_points,
+            maximum_fee,
+        )
+        .unwrap();
+        let message = Message::new(&[set_transfer_fee_ix], None);
+        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        assert_eq!(
+            parse_token(
+                &compiled_instruction,
+                &AccountKeys::new(&convert_account_keys(&message), None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "setTransferFee".to_string(),
+                info: json!({
+                    "mint": mint_pubkey.to_string(),
+                    "transferFeeBasisPoints": transfer_fee_basis_points,
+                    "maximumFee": maximum_fee,
+                    "multisigtransferFeeConfigAuthority": multisig_pubkey.to_string(),
+                    "signers": vec![
+                        multisig_signer0.to_string(),
+                        multisig_signer1.to_string(),
+                    ],
+                })
+            }
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
RPC now recognizes the spl_token_2022 program id, but cannot parse all its instructions.

#### Summary of Changes
Add parsing for various extension instructions: DefaultAccountState, MemoTransfer, MintCloseAuthority, Reallocate, TransferFee
Also parse CreateNativeMint instructions

I'm still kicking the ConfidentialTransfers-can down the road, but this should be everything else.