### PR TITLE
(LedgerStore) Report total nanos and downsize the perf metric for RocksDB read/write

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -534,17 +534,20 @@ impl Rocks {
     }
 
     fn write(&self, batch: RWriteBatch) -> Result<()> {
-        let is_perf_enabled = maybe_enable_rocksdb_perf(
+        let op_start_instant = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_batch_perf_status,
         );
         let result = self.db.write(batch);
-        if is_perf_enabled {
-            report_rocksdb_write_perf(rocksdb_metric_header!(
-                "blockstore_rocksdb_write_perf,op=write_batch",
-                "write_batch",
-                self.column_options
-            ));
+        if let Some(op_start_instant) = op_start_instant {
+            report_rocksdb_write_perf(
+                &op_start_instant.elapsed(),
+                rocksdb_metric_header!(
+                    "blockstore_rocksdb_write_perf,op=write_batch",
+                    "write_batch",
+                    self.column_options
+                ),
+            );
         }
         match result {
             Ok(_) => Ok(()),
@@ -1305,8 +1308,11 @@ where
             &self.read_perf_status,
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
-        if is_perf_enabled {
-            report_rocksdb_read_perf(C::rocksdb_get_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_read_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_get_perf_metric_header(&self.column_options),
+            );
         }
         result
     }
@@ -1383,8 +1389,11 @@ where
             &self.write_perf_status,
         );
         let result = self.backend.put_cf(self.handle(), &C::key(key), value);
-        if is_perf_enabled {
-            report_rocksdb_write_perf(C::rocksdb_put_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_write_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_put_perf_metric_header(&self.column_options),
+            );
         }
         result
     }
@@ -1415,8 +1424,11 @@ where
             result = Ok(Some(value))
         }
 
-        if is_perf_enabled {
-            report_rocksdb_read_perf(C::rocksdb_get_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_read_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_get_perf_metric_header(&self.column_options),
+            );
         }
         result
     }
@@ -1432,8 +1444,11 @@ where
             .backend
             .put_cf(self.handle(), &C::key(key), &serialized_value);
 
-        if is_perf_enabled {
-            report_rocksdb_write_perf(C::rocksdb_put_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_write_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_put_perf_metric_header(&self.column_options),
+            );
         }
         result
     }
@@ -1444,8 +1459,11 @@ where
             &self.write_perf_status,
         );
         let result = self.backend.delete_cf(self.handle(), &C::key(key));
-        if is_perf_enabled {
-            report_rocksdb_write_perf(C::rocksdb_delete_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_write_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_delete_perf_metric_header(&self.column_options),
+            );
         }
         result
     }
@@ -1464,8 +1482,11 @@ where
             &self.read_perf_status,
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
-        if is_perf_enabled {
-            report_rocksdb_read_perf(C::rocksdb_get_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_read_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_get_perf_metric_header(&self.column_options),
+            );
         }
 
         if let Some(serialized_value) = result? {
@@ -1485,8 +1506,11 @@ where
             &self.read_perf_status,
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
-        if is_perf_enabled {
-            report_rocksdb_read_perf(C::rocksdb_get_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_read_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_get_perf_metric_header(&self.column_options),
+            );
         }
 
         if let Some(serialized_value) = result? {
@@ -1505,8 +1529,11 @@ where
             &self.write_perf_status,
         );
         let result = self.backend.put_cf(self.handle(), &C::key(key), &buf);
-        if is_perf_enabled {
-            report_rocksdb_write_perf(C::rocksdb_put_perf_metric_header(&self.column_options));
+        if let Some(op_start_instant) = is_perf_enabled {
+            report_rocksdb_write_perf(
+                &op_start_instant.elapsed(),
+                C::rocksdb_put_perf_metric_header(&self.column_options),
+            );
         }
 
         result


### PR DESCRIPTION
#### Problem
The current RocksDB read/write perf metrics do not include the total operation nanos
and thus we have to include all fields that might contribute to the total operation nanos.

#### Summary of Changes
This PR includes the total operation nanos in RocksDB's read/write perf and reduces the
number of reported fields in its perf metric.

This PR depends on #25093.