### PR TITLE
feat: support additional compute budget ixs

### DIFF
--- a/web3.js/src/compute-budget.ts
+++ b/web3.js/src/compute-budget.ts
@@ -1,4 +1,5 @@
 import * as BufferLayout from '@solana/buffer-layout';
+import {u64} from '@solana/buffer-layout-utils';
 
 import {
   encodeData,
@@ -77,6 +78,34 @@ export class ComputeBudgetInstruction {
   }
 
   /**
+   * Decode set compute unit limit compute budget instruction and retrieve the instruction params.
+   */
+  static decodeSetComputeUnitLimit(
+    instruction: TransactionInstruction,
+  ): SetComputeUnitLimitParams {
+    this.checkProgramId(instruction.programId);
+    const {units} = decodeData(
+      COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.SetComputeUnitLimit,
+      instruction.data,
+    );
+    return {units};
+  }
+
+  /**
+   * Decode set compute unit price compute budget instruction and retrieve the instruction params.
+   */
+  static decodeSetComputeUnitPrice(
+    instruction: TransactionInstruction,
+  ): SetComputeUnitPriceParams {
+    this.checkProgramId(instruction.programId);
+    const {microLamports} = decodeData(
+      COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.SetComputeUnitPrice,
+      instruction.data,
+    );
+    return {microLamports};
+  }
+
+  /**
    * @internal
    */
   static checkProgramId(programId: PublicKey) {
@@ -96,11 +125,18 @@ export type ComputeBudgetInstructionType =
   // It would be preferable for this type to be `keyof ComputeBudgetInstructionInputData`
   // but Typedoc does not transpile `keyof` expressions.
   // See https://github.com/TypeStrong/typedoc/issues/1894
-  'RequestUnits' | 'RequestHeapFrame';
+  | 'RequestUnits'
+  | 'RequestHeapFrame'
+  | 'SetComputeUnitLimit'
+  | 'SetComputeUnitPrice';
 
 type ComputeBudgetInstructionInputData = {
   RequestUnits: IInstructionInputData & Readonly<RequestUnitsParams>;
   RequestHeapFrame: IInstructionInputData & Readonly<RequestHeapFrameParams>;
+  SetComputeUnitLimit: IInstructionInputData &
+    Readonly<SetComputeUnitLimitParams>;
+  SetComputeUnitPrice: IInstructionInputData &
+    Readonly<SetComputeUnitPriceParams>;
 };
 
 /**
@@ -109,8 +145,7 @@ type ComputeBudgetInstructionInputData = {
 export interface RequestUnitsParams {
   /** Units to request for transaction-wide compute */
   units: number;
-
-  /** Additional fee to pay */
+  /** Prioritization fee lamports */
   additionalFee: number;
 }
 
@@ -121,6 +156,22 @@ export type RequestHeapFrameParams = {
   /** Requested transaction-wide program heap size in bytes. Must be multiple of 1024. Applies to each program, including CPIs. */
   bytes: number;
 };
+
+/**
+ * Set compute unit limit instruction params
+ */
+export interface SetComputeUnitLimitParams {
+  /** Transaction-wide compute unit limit */
+  units: number;
+}
+
+/**
+ * Set compute unit price instruction params
+ */
+export interface SetComputeUnitPriceParams {
+  /** Transaction compute unit price used for prioritization fees */
+  microLamports: number | bigint;
+}
 
 /**
  * An enumeration of valid ComputeBudget InstructionType's
@@ -146,6 +197,18 @@ export const COMPUTE_BUDGET_INSTRUCTION_LAYOUTS = Object.freeze<{
     layout: BufferLayout.struct<
       ComputeBudgetInstructionInputData['RequestHeapFrame']
     >([BufferLayout.u8('instruction'), BufferLayout.u32('bytes')]),
+  },
+  SetComputeUnitLimit: {
+    index: 2,
+    layout: BufferLayout.struct<
+      ComputeBudgetInstructionInputData['SetComputeUnitLimit']
+    >([BufferLayout.u8('instruction'), BufferLayout.u32('units')]),
+  },
+  SetComputeUnitPrice: {
+    index: 3,
+    layout: BufferLayout.struct<
+      ComputeBudgetInstructionInputData['SetComputeUnitPrice']
+    >([BufferLayout.u8('instruction'), u64('microLamports')]),
   },
 });
 
@@ -180,6 +243,32 @@ export class ComputeBudgetProgram {
   ): TransactionInstruction {
     const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.RequestHeapFrame;
     const data = encodeData(type, params);
+    return new TransactionInstruction({
+      keys: [],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  static setComputeUnitLimit(
+    params: SetComputeUnitLimitParams,
+  ): TransactionInstruction {
+    const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.SetComputeUnitLimit;
+    const data = encodeData(type, params);
+    return new TransactionInstruction({
+      keys: [],
+      programId: this.programId,
+      data,
+    });
+  }
+
+  static setComputeUnitPrice(
+    params: SetComputeUnitPriceParams,
+  ): TransactionInstruction {
+    const type = COMPUTE_BUDGET_INSTRUCTION_LAYOUTS.SetComputeUnitPrice;
+    const data = encodeData(type, {
+      microLamports: BigInt(params.microLamports),
+    });
     return new TransactionInstruction({
       keys: [],
       programId: this.programId,


### PR DESCRIPTION
#### Problem
The compute budget interface will be updated before being activated on mainnet and the web3 api needs to be updated to match. For more details see: https://github.com/solana-labs/solana/pull/25178

#### Summary of Changes
- Added support for the new `SetComputeUnitLimit` and `SetComputeUnitPrice` prioritization fee ixs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
