### PR TITLE
avoid zeroing out root stats with empty data

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1257,22 +1257,22 @@ struct LatestAccountsIndexRootsStats {
 
 impl LatestAccountsIndexRootsStats {
     fn update(&self, accounts_index_roots_stats: &AccountsIndexRootsStats) {
-        self.roots_len
-            .store(accounts_index_roots_stats.roots_len, Ordering::Relaxed);
-        self.uncleaned_roots_len.store(
-            accounts_index_roots_stats.uncleaned_roots_len,
-            Ordering::Relaxed,
-        );
-        self.previous_uncleaned_roots_len.store(
-            accounts_index_roots_stats.previous_uncleaned_roots_len,
-            Ordering::Relaxed,
-        );
-        self.historical_roots_len.store(
-            accounts_index_roots_stats.historical_roots_len,
-            Ordering::Relaxed,
-        );
-        self.roots_range
-            .store(accounts_index_roots_stats.roots_range, Ordering::Relaxed);
+        if let Some(value) = accounts_index_roots_stats.roots_len {
+            self.roots_len.store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.uncleaned_roots_len {
+            self.uncleaned_roots_len.store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.previous_uncleaned_roots_len {
+            self.previous_uncleaned_roots_len
+                .store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.historical_roots_len {
+            self.historical_roots_len.store(value, Ordering::Relaxed);
+        }
+        if let Some(value) = accounts_index_roots_stats.roots_range {
+            self.roots_range.store(value, Ordering::Relaxed);
+        }
         self.rooted_cleaned_count.fetch_add(
             accounts_index_roots_stats.rooted_cleaned_count,
             Ordering::Relaxed,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -458,11 +458,11 @@ impl RootsTracker {
 
 #[derive(Debug, Default)]
 pub struct AccountsIndexRootsStats {
-    pub roots_len: usize,
-    pub uncleaned_roots_len: usize,
-    pub previous_uncleaned_roots_len: usize,
-    pub roots_range: u64,
-    pub historical_roots_len: usize,
+    pub roots_len: Option<usize>,
+    pub uncleaned_roots_len: Option<usize>,
+    pub previous_uncleaned_roots_len: Option<usize>,
+    pub roots_range: Option<u64>,
+    pub historical_roots_len: Option<usize>,
     pub rooted_cleaned_count: usize,
     pub unrooted_cleaned_count: usize,
     pub clean_unref_from_storage_us: u64,
@@ -1832,11 +1832,12 @@ impl<T: IndexValue> AccountsIndex<T> {
             }
             false
         } else {
-            stats.roots_len = w_roots_tracker.alive_roots.len();
-            stats.uncleaned_roots_len = w_roots_tracker.uncleaned_roots.len();
-            stats.previous_uncleaned_roots_len = w_roots_tracker.previous_uncleaned_roots.len();
-            stats.roots_range = w_roots_tracker.alive_roots.range_width();
-            stats.historical_roots_len = w_roots_tracker.historical_roots.len();
+            stats.roots_len = Some(w_roots_tracker.alive_roots.len());
+            stats.uncleaned_roots_len = Some(w_roots_tracker.uncleaned_roots.len());
+            stats.previous_uncleaned_roots_len =
+                Some(w_roots_tracker.previous_uncleaned_roots.len());
+            stats.roots_range = Some(w_roots_tracker.alive_roots.range_width());
+            stats.historical_roots_len = Some(w_roots_tracker.historical_roots.len());
             true
         }
     }


### PR DESCRIPTION
#### Problem

Some code paths don't clean any roots. That results in stats being empty for some roots stats.
Distinguish 'missing' vs present.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
