### PR TITLE
pass exit by ref

### DIFF
--- a/core/src/poh_timing_report_service.rs
+++ b/core/src/poh_timing_report_service.rs
@@ -24,8 +24,8 @@ pub struct PohTimingReportService {
 }
 
 impl PohTimingReportService {
-    pub fn new(receiver: PohTimingReceiver, exit: Arc<AtomicBool>) -> Self {
-        let exit_signal = exit;
+    pub fn new(receiver: PohTimingReceiver, exit: &Arc<AtomicBool>) -> Self {
+        let exit_signal = exit.clone();
         let mut poh_timing_reporter = PohTimingReporter::default();
         let t_poh_timing = Builder::new()
             .name("poh_timing_report".to_string())
@@ -65,7 +65,7 @@ mod test {
         let exit = Arc::new(AtomicBool::new(false));
         // Create the service
         let poh_timing_report_service =
-            PohTimingReportService::new(poh_timing_point_receiver, exit.clone());
+            PohTimingReportService::new(poh_timing_point_receiver, &exit);
 
         // Send SlotPohTimingPoint
         let _ = poh_timing_point_sender.send(SlotPohTimingInfo::new_slot_start_poh_time_point(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -501,7 +501,7 @@ impl Validator {
 
         let (poh_timing_point_sender, poh_timing_point_receiver) = unbounded();
         let poh_timing_report_service =
-            PohTimingReportService::new(poh_timing_point_receiver, exit.clone());
+            PohTimingReportService::new(poh_timing_point_receiver, &exit);
 
         let (
             genesis_config,


### PR DESCRIPTION
#### Problem

PohTimingReportService takes exit as Arc. The caller have to clone the Arc and move it to the service. Instead, the service can take a reference and clone inside itself. Passing a reference is cheaper and it will save a move of Arc.


#### Summary of Changes
Make PohTimingReportService take ref of Arc.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
