### PR TITLE
Refactor confirm_slot() to return timings

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -357,8 +357,8 @@ pub struct ForkProgress {
     pub is_dead: bool,
     pub fork_stats: ForkStats,
     pub propagated_stats: PropagatedStats,
-    pub replay_stats: ReplaySlotStats,
-    pub replay_progress: ConfirmationProgress,
+    pub replay_stats: Arc<RwLock<ReplaySlotStats>>,
+    pub replay_progress: Arc<RwLock<ConfirmationProgress>>,
     pub retransmit_info: RetransmitInfo,
     // Note `num_blocks_on_fork` and `num_dropped_blocks_on_fork` only
     // count new blocks replayed since last restart, which won't include
@@ -404,8 +404,8 @@ impl ForkProgress {
         Self {
             is_dead: false,
             fork_stats: ForkStats::default(),
-            replay_stats: ReplaySlotStats::default(),
-            replay_progress: ConfirmationProgress::new(last_entry),
+            replay_stats: Arc::new(RwLock::new(ReplaySlotStats::default())),
+            replay_progress: Arc::new(RwLock::new(ConfirmationProgress::new(last_entry))),
             num_blocks_on_fork,
             num_dropped_blocks_on_fork,
             propagated_stats: PropagatedStats {


### PR DESCRIPTION
#### Problem
Right now replaying entries takes mutable references to the progress map in order to aggregate metrics for a particular slot. To achieve parallel bank replay, we can't hold multiple mutable references into the ReplayStage progress map

#### Summary of Changes
1. Remove mutable references into the progress map, instead return the timing metrics
2. ReplayStage then aggregates these metrics into the progress map

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
