### PR TITLE
Use default if there is no config file

### DIFF
--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -234,7 +234,7 @@ fn send_and_confirm_messages<S: Signers>(
 
 fn main() -> Result<(), Box<dyn Error>> {
     let command_args = parse_args(env::args_os());
-    let config = Config::load(&command_args.config_file)?;
+    let config = Config::load(&command_args.config_file).unwrap_or_default();
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
     let client = RpcClient::new(json_rpc_url);
 


### PR DESCRIPTION
#### Problem

Running `solana-stake-accounts` will error if a config file is not already present.

#### Summary of Changes

If there's no config file, just use the defaults.

Fixes #20414