### PR TITLE
Add size_of const fns for upgradeable loader states

### DIFF
--- a/account-decoder/src/parse_bpf_loader.rs
+++ b/account-decoder/src/parse_bpf_loader.rs
@@ -17,11 +17,11 @@ pub fn parse_bpf_upgradeable_loader(
         UpgradeableLoaderState::Uninitialized => BpfUpgradeableLoaderAccountType::Uninitialized,
         UpgradeableLoaderState::Buffer { authority_address } => {
             let offset = if authority_address.is_some() {
-                UpgradeableLoaderState::buffer_data_offset().unwrap()
+                UpgradeableLoaderState::size_of_buffer_metadata()
             } else {
                 // This case included for code completeness; in practice, a Buffer account will
                 // always have authority_address.is_some()
-                UpgradeableLoaderState::buffer_data_offset().unwrap()
+                UpgradeableLoaderState::size_of_buffer_metadata()
                     - serialized_size(&Pubkey::default()).unwrap() as usize
             };
             BpfUpgradeableLoaderAccountType::Buffer(UiBuffer {
@@ -42,9 +42,9 @@ pub fn parse_bpf_upgradeable_loader(
             upgrade_authority_address,
         } => {
             let offset = if upgrade_authority_address.is_some() {
-                UpgradeableLoaderState::programdata_data_offset().unwrap()
+                UpgradeableLoaderState::size_of_programdata_metadata()
             } else {
-                UpgradeableLoaderState::programdata_data_offset().unwrap()
+                UpgradeableLoaderState::size_of_programdata_metadata()
                     - serialized_size(&Pubkey::default()).unwrap() as usize
             };
             BpfUpgradeableLoaderAccountType::ProgramData(UiProgramData {

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -954,7 +954,7 @@ fn process_program_deploy(
         program_len * 2
     };
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
-        UpgradeableLoaderState::programdata_len(buffer_data_len)?,
+        UpgradeableLoaderState::size_of_programdata(buffer_data_len),
     )?;
 
     let result = if do_deploy {
@@ -1066,7 +1066,7 @@ fn process_write_buffer(
         program_data.len()
     };
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
-        UpgradeableLoaderState::programdata_len(buffer_data_len)?,
+        UpgradeableLoaderState::size_of_programdata(buffer_data_len),
     )?;
 
     let result = do_process_program_write_and_deploy(
@@ -1281,7 +1281,7 @@ fn get_programs(
                     .unwrap_or_else(|| "none".to_string()),
                 last_deploy_slot: slot,
                 data_len: programdata_account.data.len()
-                    - UpgradeableLoaderState::programdata_data_offset()?,
+                    - UpgradeableLoaderState::size_of_programdata_metadata(),
                 lamports: programdata_account.lamports,
                 use_lamports_unit,
             });
@@ -1363,7 +1363,7 @@ fn process_show(
                                         .unwrap_or_else(|| "none".to_string()),
                                     last_deploy_slot: slot,
                                     data_len: programdata_account.data.len()
-                                        - UpgradeableLoaderState::programdata_data_offset()?,
+                                        - UpgradeableLoaderState::size_of_programdata_metadata(),
                                     lamports: programdata_account.lamports,
                                     use_lamports_unit,
                                 }))
@@ -1384,7 +1384,7 @@ fn process_show(
                                 .map(|pubkey| pubkey.to_string())
                                 .unwrap_or_else(|| "none".to_string()),
                             data_len: account.data.len()
-                                - UpgradeableLoaderState::buffer_data_offset()?,
+                                - UpgradeableLoaderState::size_of_buffer_metadata(),
                             lamports: account.lamports,
                             use_lamports_unit,
                         }))
@@ -1441,8 +1441,7 @@ fn process_dump(
                         if let Ok(UpgradeableLoaderState::ProgramData { .. }) =
                             programdata_account.state()
                         {
-                            let offset =
-                                UpgradeableLoaderState::programdata_data_offset().unwrap_or(0);
+                            let offset = UpgradeableLoaderState::size_of_programdata_metadata();
                             let program_data = &programdata_account.data[offset..];
                             let mut f = File::create(output_location)?;
                             f.write_all(program_data)?;
@@ -1454,7 +1453,7 @@ fn process_dump(
                         Err(format!("Program {} has been closed", account_pubkey).into())
                     }
                 } else if let Ok(UpgradeableLoaderState::Buffer { .. }) = account.state() {
-                    let offset = UpgradeableLoaderState::buffer_data_offset().unwrap_or(0);
+                    let offset = UpgradeableLoaderState::size_of_buffer_metadata();
                     let program_data = &account.data[offset..];
                     let mut f = File::create(output_location)?;
                     f.write_all(program_data)?;
@@ -1758,7 +1757,7 @@ fn do_process_program_write_and_deploy(
                     buffer_pubkey,
                     &account,
                     if loader_id == &bpf_loader_upgradeable::id() {
-                        UpgradeableLoaderState::buffer_len(buffer_data_len)?
+                        UpgradeableLoaderState::size_of_buffer(buffer_data_len)
                     } else {
                         buffer_data_len
                     },
@@ -1848,7 +1847,7 @@ fn do_process_program_write_and_deploy(
                     buffer_pubkey,
                     &program_signers[1].pubkey(),
                     rpc_client.get_minimum_balance_for_rent_exemption(
-                        UpgradeableLoaderState::program_len()?,
+                        UpgradeableLoaderState::size_of_program(),
                     )?,
                     programdata_len,
                 )?,
@@ -1911,7 +1910,7 @@ fn do_process_program_upgrade(
     let loader_id = bpf_loader_upgradeable::id();
     let data_len = program_data.len();
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
-        UpgradeableLoaderState::programdata_len(data_len)?,
+        UpgradeableLoaderState::size_of_programdata(data_len),
     )?;
 
     // Build messages to calculate fees
@@ -1930,7 +1929,7 @@ fn do_process_program_upgrade(
                     &config.signers[0].pubkey(),
                     &buffer_signer.pubkey(),
                     &account,
-                    UpgradeableLoaderState::buffer_len(data_len)?,
+                    UpgradeableLoaderState::size_of_buffer(data_len),
                     minimum_balance,
                     true,
                 )?

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -166,12 +166,12 @@ fn test_cli_program_deploy_no_authority() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_programdata = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
     let minimum_balance_for_program = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::program_len().unwrap())
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .unwrap();
     let upgrade_authority = Keypair::new();
 
@@ -252,12 +252,12 @@ fn test_cli_program_deploy_with_authority() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_programdata = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
     let minimum_balance_for_program = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::program_len().unwrap())
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .unwrap();
     let upgrade_authority = Keypair::new();
 
@@ -316,7 +316,7 @@ fn test_cli_program_deploy_with_authority() {
     assert_eq!(programdata_account.owner, bpf_loader_upgradeable::id());
     assert!(!programdata_account.executable);
     assert_eq!(
-        programdata_account.data[UpgradeableLoaderState::programdata_data_offset().unwrap()..],
+        programdata_account.data[UpgradeableLoaderState::size_of_programdata_metadata()..],
         program_data[..]
     );
 
@@ -358,7 +358,7 @@ fn test_cli_program_deploy_with_authority() {
     assert_eq!(programdata_account.owner, bpf_loader_upgradeable::id());
     assert!(!programdata_account.executable);
     assert_eq!(
-        programdata_account.data[UpgradeableLoaderState::programdata_data_offset().unwrap()..],
+        programdata_account.data[UpgradeableLoaderState::size_of_programdata_metadata()..],
         program_data[..]
     );
 
@@ -391,7 +391,7 @@ fn test_cli_program_deploy_with_authority() {
     assert_eq!(programdata_account.owner, bpf_loader_upgradeable::id());
     assert!(!programdata_account.executable);
     assert_eq!(
-        programdata_account.data[UpgradeableLoaderState::programdata_data_offset().unwrap()..],
+        programdata_account.data[UpgradeableLoaderState::size_of_programdata_metadata()..],
         program_data[..]
     );
 
@@ -446,7 +446,7 @@ fn test_cli_program_deploy_with_authority() {
     assert_eq!(programdata_account.owner, bpf_loader_upgradeable::id());
     assert!(!programdata_account.executable);
     assert_eq!(
-        programdata_account.data[UpgradeableLoaderState::programdata_data_offset().unwrap()..],
+        programdata_account.data[UpgradeableLoaderState::size_of_programdata_metadata()..],
         program_data[..]
     );
 
@@ -591,12 +591,12 @@ fn test_cli_program_close_program() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_programdata = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
     let minimum_balance_for_program = rpc_client
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::program_len().unwrap())
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .unwrap();
     let upgrade_authority = Keypair::new();
 
@@ -680,14 +680,14 @@ fn test_cli_program_write_buffer() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
     let minimum_balance_for_buffer_default = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
 
     let mut config = CliConfig::recent_for_tests();
@@ -730,7 +730,7 @@ fn test_cli_program_write_buffer() {
         panic!("not a buffer account");
     }
     assert_eq!(
-        buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..],
+        buffer_account.data[UpgradeableLoaderState::size_of_buffer_metadata()..],
         program_data[..]
     );
 
@@ -767,7 +767,7 @@ fn test_cli_program_write_buffer() {
         panic!("not a buffer account");
     }
     assert_eq!(
-        buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..],
+        buffer_account.data[UpgradeableLoaderState::size_of_buffer_metadata()..],
         program_data[..]
     );
 
@@ -829,7 +829,7 @@ fn test_cli_program_write_buffer() {
         panic!("not a buffer account");
     }
     assert_eq!(
-        buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..],
+        buffer_account.data[UpgradeableLoaderState::size_of_buffer_metadata()..],
         program_data[..]
     );
 
@@ -864,7 +864,7 @@ fn test_cli_program_write_buffer() {
         panic!("not a buffer account");
     }
     assert_eq!(
-        buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..],
+        buffer_account.data[UpgradeableLoaderState::size_of_buffer_metadata()..],
         program_data[..]
     );
 
@@ -1004,9 +1004,9 @@ fn test_cli_program_set_buffer_authority() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
 
     let mut config = CliConfig::recent_for_tests();
@@ -1119,9 +1119,9 @@ fn test_cli_program_mismatch_buffer_authority() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
 
     let mut config = CliConfig::recent_for_tests();
@@ -1212,9 +1212,9 @@ fn test_cli_program_show() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
 
     let mut config = CliConfig::recent_for_tests();
@@ -1399,9 +1399,9 @@ fn test_cli_program_dump() {
     file.read_to_end(&mut program_data).unwrap();
     let max_len = program_data.len();
     let minimum_balance_for_buffer = rpc_client
-        .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
-        )
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_programdata(
+            max_len,
+        ))
         .unwrap();
 
     let mut config = CliConfig::recent_for_tests();

--- a/program-test/tests/builtins.rs
+++ b/program-test/tests/builtins.rs
@@ -16,7 +16,7 @@ async fn test_bpf_loader_upgradable_present() {
     let upgrade_authority_keypair = Keypair::new();
 
     let rent = banks_client.get_rent().await.unwrap();
-    let buffer_rent = rent.minimum_balance(UpgradeableLoaderState::programdata_len(1).unwrap());
+    let buffer_rent = rent.minimum_balance(UpgradeableLoaderState::size_of_programdata(1));
 
     let create_buffer_instructions = bpf_loader_upgradeable::create_buffer(
         &payer.pubkey(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -366,7 +366,7 @@ fn process_instruction_common(
                     ic_logger_msg!(log_collector, "Program has been closed");
                     return Err(InstructionError::InvalidAccountData);
                 }
-                UpgradeableLoaderState::programdata_data_offset()?
+                UpgradeableLoaderState::size_of_programdata_metadata()
             } else {
                 ic_logger_msg!(log_collector, "Invalid Program account");
                 return Err(InstructionError::InvalidAccountData);
@@ -492,7 +492,7 @@ fn process_loader_upgradeable_instruction(
             drop(buffer);
             write_program_data(
                 first_instruction_account,
-                UpgradeableLoaderState::buffer_data_offset()?.saturating_add(offset as usize),
+                UpgradeableLoaderState::size_of_buffer_metadata().saturating_add(offset as usize),
                 &bytes,
                 invoke_context,
             )?;
@@ -525,7 +525,7 @@ fn process_loader_upgradeable_instruction(
                 ic_logger_msg!(log_collector, "Program account already initialized");
                 return Err(InstructionError::AccountAlreadyInitialized);
             }
-            if program.get_data().len() < UpgradeableLoaderState::program_len()? {
+            if program.get_data().len() < UpgradeableLoaderState::size_of_program() {
                 ic_logger_msg!(log_collector, "Program account too small");
                 return Err(InstructionError::AccountDataTooSmall);
             }
@@ -555,11 +555,11 @@ fn process_loader_upgradeable_instruction(
             }
             let buffer_key = *buffer.get_key();
             let buffer_lamports = buffer.get_lamports();
-            let buffer_data_offset = UpgradeableLoaderState::buffer_data_offset()?;
+            let buffer_data_offset = UpgradeableLoaderState::size_of_buffer_metadata();
             let buffer_data_len = buffer.get_data().len().saturating_sub(buffer_data_offset);
-            let programdata_data_offset = UpgradeableLoaderState::programdata_data_offset()?;
-            let programdata_len = UpgradeableLoaderState::programdata_len(max_data_len)?;
-            if buffer.get_data().len() < UpgradeableLoaderState::buffer_data_offset()?
+            let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
+            let programdata_len = UpgradeableLoaderState::size_of_programdata(max_data_len);
+            if buffer.get_data().len() < UpgradeableLoaderState::size_of_buffer_metadata()
                 || buffer_data_len == 0
             {
                 ic_logger_msg!(log_collector, "Buffer account too small");
@@ -750,9 +750,9 @@ fn process_loader_upgradeable_instruction(
                 return Err(InstructionError::InvalidArgument);
             }
             let buffer_lamports = buffer.get_lamports();
-            let buffer_data_offset = UpgradeableLoaderState::buffer_data_offset()?;
+            let buffer_data_offset = UpgradeableLoaderState::size_of_buffer_metadata();
             let buffer_data_len = buffer.get_data().len().saturating_sub(buffer_data_offset);
-            if buffer.get_data().len() < UpgradeableLoaderState::buffer_data_offset()?
+            if buffer.get_data().len() < UpgradeableLoaderState::size_of_buffer_metadata()
                 || buffer_data_len == 0
             {
                 ic_logger_msg!(log_collector, "Buffer account too small");
@@ -764,11 +764,11 @@ fn process_loader_upgradeable_instruction(
 
             let programdata =
                 instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-            let programdata_data_offset = UpgradeableLoaderState::programdata_data_offset()?;
+            let programdata_data_offset = UpgradeableLoaderState::size_of_programdata_metadata();
             let programdata_balance_required =
                 1.max(rent.minimum_balance(programdata.get_data().len()));
             if programdata.get_data().len()
-                < UpgradeableLoaderState::programdata_len(buffer_data_len)?
+                < UpgradeableLoaderState::size_of_programdata(buffer_data_len)
             {
                 ic_logger_msg!(log_collector, "ProgramData account not large enough");
                 return Err(InstructionError::AccountDataTooSmall);
@@ -1726,17 +1726,11 @@ mod tests {
     fn test_bpf_loader_upgradeable_initialize_buffer() {
         let loader_id = bpf_loader_upgradeable::id();
         let buffer_address = Pubkey::new_unique();
-        let buffer_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(9).unwrap(),
-            &loader_id,
-        );
+        let buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
         let authority_address = Pubkey::new_unique();
-        let authority_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(9).unwrap(),
-            &loader_id,
-        );
+        let authority_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
         let instruction_data =
             bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
         let instruction_accounts = vec![
@@ -1797,11 +1791,8 @@ mod tests {
     fn test_bpf_loader_upgradeable_write() {
         let loader_id = bpf_loader_upgradeable::id();
         let buffer_address = Pubkey::new_unique();
-        let mut buffer_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(9).unwrap(),
-            &loader_id,
-        );
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: buffer_address,
@@ -1861,7 +1852,7 @@ mod tests {
                 .first()
                 .unwrap()
                 .data()
-                .get(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+                .get(UpgradeableLoaderState::size_of_buffer_metadata()..)
                 .unwrap(),
             &[42; 9]
         );
@@ -1872,11 +1863,8 @@ mod tests {
             bytes: vec![42; 6],
         })
         .unwrap();
-        let mut buffer_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(9).unwrap(),
-            &loader_id,
-        );
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(9), &loader_id);
         buffer_account
             .set_state(&UpgradeableLoaderState::Buffer {
                 authority_address: Some(buffer_address),
@@ -1902,7 +1890,7 @@ mod tests {
                 .first()
                 .unwrap()
                 .data()
-                .get(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+                .get(UpgradeableLoaderState::size_of_buffer_metadata()..)
                 .unwrap(),
             &[0, 0, 0, 42, 42, 42, 42, 42, 42]
         );
@@ -2070,20 +2058,20 @@ mod tests {
 
         // Compute rent exempt balances
         let program_len = elf.len();
-        let min_program_balance = bank
-            .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::program_len().unwrap());
+        let min_program_balance =
+            bank.get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program());
         let min_buffer_balance = bank.get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::buffer_len(program_len).unwrap(),
+            UpgradeableLoaderState::size_of_buffer(program_len),
         );
         let min_programdata_balance = bank.get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(program_len).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(program_len),
         );
 
         // Setup accounts
         let buffer_account = {
             let mut account = AccountSharedData::new(
                 min_buffer_balance,
-                UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
+                UpgradeableLoaderState::size_of_buffer(elf.len()),
                 &bpf_loader_upgradeable::id(),
             );
             account
@@ -2093,19 +2081,19 @@ mod tests {
                 .unwrap();
             account
                 .data_as_mut_slice()
-                .get_mut(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+                .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
                 .unwrap()
                 .copy_from_slice(&elf);
             account
         };
         let program_account = AccountSharedData::new(
             min_programdata_balance,
-            UpgradeableLoaderState::program_len().unwrap(),
+            UpgradeableLoaderState::size_of_program(),
             &bpf_loader_upgradeable::id(),
         );
         let programdata_account = AccountSharedData::new(
             1,
-            UpgradeableLoaderState::programdata_len(elf.len()).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
 
@@ -2158,7 +2146,7 @@ mod tests {
         assert_eq!(post_program_account.owner(), &bpf_loader_upgradeable::id());
         assert_eq!(
             post_program_account.data().len(),
-            UpgradeableLoaderState::program_len().unwrap()
+            UpgradeableLoaderState::size_of_program()
         );
         let state: UpgradeableLoaderState = post_program_account.state().unwrap();
         assert_eq!(
@@ -2183,7 +2171,7 @@ mod tests {
         );
         for (i, byte) in post_programdata_account
             .data()
-            .get(UpgradeableLoaderState::programdata_data_offset().unwrap()..)
+            .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
             .unwrap()
             .iter()
             .enumerate()
@@ -2398,7 +2386,7 @@ mod tests {
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
             min_program_balance,
-            (UpgradeableLoaderState::program_len().unwrap() as u64).saturating_add(1),
+            (UpgradeableLoaderState::size_of_program() as u64).saturating_add(1),
             &id(),
         );
         let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -2431,7 +2419,7 @@ mod tests {
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
             min_program_balance,
-            (UpgradeableLoaderState::program_len().unwrap() as u64).saturating_sub(1),
+            (UpgradeableLoaderState::size_of_program() as u64).saturating_sub(1),
             &id(),
         );
         let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
@@ -2586,7 +2574,7 @@ mod tests {
         let mut modified_buffer_account = buffer_account;
         truncate_data(
             &mut modified_buffer_account,
-            UpgradeableLoaderState::buffer_len(1).unwrap(),
+            UpgradeableLoaderState::size_of_buffer(1),
         );
         bank.store_account(&buffer_address, &modified_buffer_account);
         bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
@@ -2618,7 +2606,7 @@ mod tests {
         bank.clear_signatures();
         let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
-            UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
+            UpgradeableLoaderState::size_of_buffer(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
         modified_buffer_account
@@ -2628,7 +2616,7 @@ mod tests {
             .unwrap();
         modified_buffer_account
             .data_as_mut_slice()
-            .get_mut(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+            .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
             .unwrap()
             .copy_from_slice(&elf);
         truncate_data(&mut modified_buffer_account, 5);
@@ -2662,7 +2650,7 @@ mod tests {
         bank.clear_signatures();
         let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
-            UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
+            UpgradeableLoaderState::size_of_buffer(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
         modified_buffer_account
@@ -2672,7 +2660,7 @@ mod tests {
             .unwrap();
         modified_buffer_account
             .data_as_mut_slice()
-            .get_mut(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+            .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
             .unwrap()
             .copy_from_slice(&elf);
         bank.store_account(&buffer_address, &modified_buffer_account);
@@ -2705,7 +2693,7 @@ mod tests {
         bank.clear_signatures();
         let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
-            UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
+            UpgradeableLoaderState::size_of_buffer(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
         modified_buffer_account
@@ -2715,7 +2703,7 @@ mod tests {
             .unwrap();
         modified_buffer_account
             .data_as_mut_slice()
-            .get_mut(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+            .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
             .unwrap()
             .copy_from_slice(&elf);
         bank.store_account(&buffer_address, &modified_buffer_account);
@@ -2770,15 +2758,15 @@ mod tests {
             let spill_address = Pubkey::new_unique();
             let rent = Rent::default();
             let min_program_balance =
-                1.max(rent.minimum_balance(UpgradeableLoaderState::program_len().unwrap()));
+                1.max(rent.minimum_balance(UpgradeableLoaderState::size_of_program()));
             let min_programdata_balance = 1.max(rent.minimum_balance(
-                UpgradeableLoaderState::programdata_len(elf_orig.len().max(elf_new.len())).unwrap(),
+                UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
             ));
             let (programdata_address, _) =
                 Pubkey::find_program_address(&[program_address.as_ref()], &loader_id);
             let mut buffer_account = AccountSharedData::new(
                 1,
-                UpgradeableLoaderState::buffer_len(elf_new.len()).unwrap(),
+                UpgradeableLoaderState::size_of_buffer(elf_new.len()),
                 &bpf_loader_upgradeable::id(),
             );
             buffer_account
@@ -2788,12 +2776,12 @@ mod tests {
                 .unwrap();
             buffer_account
                 .data_as_mut_slice()
-                .get_mut(UpgradeableLoaderState::buffer_data_offset().unwrap()..)
+                .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
                 .unwrap()
                 .copy_from_slice(elf_new);
             let mut programdata_account = AccountSharedData::new(
                 min_programdata_balance,
-                UpgradeableLoaderState::programdata_len(elf_orig.len().max(elf_new.len())).unwrap(),
+                UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
                 &bpf_loader_upgradeable::id(),
             );
             programdata_account
@@ -2804,7 +2792,7 @@ mod tests {
                 .unwrap();
             let mut program_account = AccountSharedData::new(
                 min_program_balance,
-                UpgradeableLoaderState::program_len().unwrap(),
+                UpgradeableLoaderState::size_of_program(),
                 &bpf_loader_upgradeable::id(),
             );
             program_account.set_executable(true);
@@ -2899,7 +2887,7 @@ mod tests {
         );
         let accounts = process_instruction(transaction_accounts, instruction_accounts, Ok(()));
         let min_programdata_balance = Rent::default().minimum_balance(
-            UpgradeableLoaderState::programdata_len(elf_orig.len().max(elf_new.len())).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(elf_orig.len().max(elf_new.len())),
         );
         assert_eq!(
             min_programdata_balance,
@@ -2920,10 +2908,8 @@ mod tests {
             .unwrap()
             .data()
             .get(
-                UpgradeableLoaderState::programdata_data_offset().unwrap()
-                    ..UpgradeableLoaderState::programdata_data_offset()
-                        .unwrap()
-                        .saturating_add(elf_new.len()),
+                UpgradeableLoaderState::size_of_programdata_metadata()
+                    ..UpgradeableLoaderState::size_of_programdata(elf_new.len()),
             )
             .unwrap()
             .iter()
@@ -3107,8 +3093,9 @@ mod tests {
         );
         transaction_accounts.get_mut(2).unwrap().1 = AccountSharedData::new(
             1,
-            UpgradeableLoaderState::buffer_len(elf_orig.len().max(elf_new.len()).saturating_add(1))
-                .unwrap(),
+            UpgradeableLoaderState::size_of_buffer(
+                elf_orig.len().max(elf_new.len()).saturating_add(1),
+            ),
             &bpf_loader_upgradeable::id(),
         );
         transaction_accounts
@@ -3232,7 +3219,7 @@ mod tests {
         );
         let mut programdata_account = AccountSharedData::new(
             1,
-            UpgradeableLoaderState::programdata_len(0).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(0),
             &bpf_loader_upgradeable::id(),
         );
         programdata_account
@@ -3401,11 +3388,8 @@ mod tests {
         let new_authority_address = Pubkey::new_unique();
         let new_authority_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
         let buffer_address = Pubkey::new_unique();
-        let mut buffer_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(0).unwrap(),
-            &loader_id,
-        );
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(0), &loader_id);
         buffer_account
             .set_state(&UpgradeableLoaderState::Buffer {
                 authority_address: Some(authority_address),
@@ -3576,11 +3560,8 @@ mod tests {
         let recipient_address = Pubkey::new_unique();
         let recipient_account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
         let buffer_address = Pubkey::new_unique();
-        let mut buffer_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::buffer_len(0).unwrap(),
-            &loader_id,
-        );
+        let mut buffer_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_buffer(0), &loader_id);
         buffer_account
             .set_state(&UpgradeableLoaderState::Buffer {
                 authority_address: Some(authority_address),
@@ -3589,7 +3570,7 @@ mod tests {
         let uninitialized_address = Pubkey::new_unique();
         let mut uninitialized_account = AccountSharedData::new(
             1,
-            UpgradeableLoaderState::programdata_len(0).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(0),
             &loader_id,
         );
         uninitialized_account
@@ -3598,7 +3579,7 @@ mod tests {
         let programdata_address = Pubkey::new_unique();
         let mut programdata_account = AccountSharedData::new(
             1,
-            UpgradeableLoaderState::programdata_len(0).unwrap(),
+            UpgradeableLoaderState::size_of_programdata(0),
             &loader_id,
         );
         programdata_account
@@ -3608,11 +3589,8 @@ mod tests {
             })
             .unwrap();
         let program_address = Pubkey::new_unique();
-        let mut program_account = AccountSharedData::new(
-            1,
-            UpgradeableLoaderState::program_len().unwrap(),
-            &loader_id,
-        );
+        let mut program_account =
+            AccountSharedData::new(1, UpgradeableLoaderState::size_of_program(), &loader_id);
         program_account.set_executable(true);
         program_account
             .set_state(&UpgradeableLoaderState::Program {

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -140,7 +140,7 @@ pub fn load_upgradeable_program<T: Client>(
             1.max(
                 bank_client
                     .get_minimum_balance_for_rent_exemption(
-                        UpgradeableLoaderState::program_len().unwrap(),
+                        UpgradeableLoaderState::size_of_program(),
                     )
                     .unwrap(),
             ),

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -15,14 +15,11 @@
 //!
 //! [`loader_upgradeable_instruction`]: crate::loader_upgradeable_instruction
 
-use {
-    crate::{
-        instruction::{AccountMeta, Instruction, InstructionError},
-        loader_upgradeable_instruction::UpgradeableLoaderInstruction,
-        pubkey::Pubkey,
-        system_instruction, sysvar,
-    },
-    bincode::serialized_size,
+use crate::{
+    instruction::{AccountMeta, Instruction, InstructionError},
+    loader_upgradeable_instruction::UpgradeableLoaderInstruction,
+    pubkey::Pubkey,
+    system_instruction, sysvar,
 };
 
 crate::declare_id!("BPFLoaderUpgradeab1e11111111111111111111111");
@@ -55,40 +52,65 @@ pub enum UpgradeableLoaderState {
     },
 }
 impl UpgradeableLoaderState {
-    /// Length of an buffer account's data.
+    /// Size of a buffer account's serialized metadata.
+    pub const fn size_of_buffer_metadata() -> usize {
+        37 // see test_state_size_of_buffer_metadata
+    }
+
+    /// Size of a programdata account's serialized metadata.
+    pub const fn size_of_programdata_metadata() -> usize {
+        45 // see test_state_size_of_programdata_metadata
+    }
+
+    /// Size of a serialized program account.
+    pub const fn size_of_program() -> usize {
+        36 // see test_state_size_of_program
+    }
+
+    /// Size of a serialized buffer account.
+    pub const fn size_of_buffer(program_len: usize) -> usize {
+        Self::size_of_buffer_metadata().saturating_add(program_len)
+    }
+
+    /// Size of a serialized programdata account.
+    pub const fn size_of_programdata(program_len: usize) -> usize {
+        Self::size_of_programdata_metadata().saturating_add(program_len)
+    }
+
+    /// Length of a Buffer account's data.
+    #[deprecated(since = "1.11.0", note = "Please use `size_of_buffer` instead")]
     pub fn buffer_len(program_len: usize) -> Result<usize, InstructionError> {
-        Ok(serialized_size(&Self::Buffer {
-            authority_address: Some(Pubkey::default()),
-        })
-        .map(|len| len as usize)
-        .map_err(|_| InstructionError::InvalidInstructionData)?
-        .saturating_add(program_len))
+        Ok(Self::size_of_buffer(program_len))
     }
-    /// Offset into the ProgramData account's data of the program bits.
+
+    /// Offset into the Buffer account's data of the program bits.
+    #[deprecated(
+        since = "1.11.0",
+        note = "Please use `size_of_buffer_metadata` instead"
+    )]
     pub fn buffer_data_offset() -> Result<usize, InstructionError> {
-        Self::buffer_len(0)
+        Ok(Self::size_of_buffer_metadata())
     }
-    /// Length of an executable account's data.
+
+    /// Length of a Program account's data.
+    #[deprecated(since = "1.11.0", note = "Please use `size_of_program` instead")]
     pub fn program_len() -> Result<usize, InstructionError> {
-        serialized_size(&Self::Program {
-            programdata_address: Pubkey::default(),
-        })
-        .map(|len| len as usize)
-        .map_err(|_| InstructionError::InvalidInstructionData)
+        Ok(Self::size_of_program())
     }
+
     /// Length of a ProgramData account's data.
+    #[deprecated(since = "1.11.0", note = "Please use `size_of_programdata` instead")]
     pub fn programdata_len(program_len: usize) -> Result<usize, InstructionError> {
-        Ok(serialized_size(&Self::ProgramData {
-            slot: 0,
-            upgrade_authority_address: Some(Pubkey::default()),
-        })
-        .map(|len| len as usize)
-        .map_err(|_| InstructionError::InvalidInstructionData)?
-        .saturating_add(program_len))
+        Ok(Self::size_of_programdata(program_len))
     }
+
     /// Offset into the ProgramData account's data of the program bits.
+    #[deprecated(
+        since = "1.11.0",
+        note = "Please use `size_of_programdata_metadata` instead"
+    )]
     pub fn programdata_data_offset() -> Result<usize, InstructionError> {
-        Self::programdata_len(0)
+        Ok(Self::size_of_programdata_metadata())
     }
 }
 
@@ -105,7 +127,7 @@ pub fn create_buffer(
             payer_address,
             buffer_address,
             lamports,
-            UpgradeableLoaderState::buffer_len(program_len)? as u64,
+            UpgradeableLoaderState::size_of_buffer(program_len) as u64,
             &id(),
         ),
         Instruction::new_with_bincode(
@@ -154,7 +176,7 @@ pub fn deploy_with_max_program_len(
             payer_address,
             program_address,
             program_lamports,
-            UpgradeableLoaderState::program_len()? as u64,
+            UpgradeableLoaderState::size_of_program() as u64,
             &id(),
         ),
         Instruction::new_with_bincode(
@@ -280,9 +302,44 @@ pub fn close_any(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, bincode::serialized_size};
 
     #[test]
+    fn test_state_size_of_buffer_metadata() {
+        let buffer_state = UpgradeableLoaderState::Buffer {
+            authority_address: Some(Pubkey::default()),
+        };
+        let size = serialized_size(&buffer_state).unwrap();
+        assert_eq!(
+            UpgradeableLoaderState::size_of_buffer_metadata() as u64,
+            size
+        );
+    }
+
+    #[test]
+    fn test_state_size_of_programdata_metadata() {
+        let programdata_state = UpgradeableLoaderState::ProgramData {
+            upgrade_authority_address: Some(Pubkey::default()),
+            slot: 0,
+        };
+        let size = serialized_size(&programdata_state).unwrap();
+        assert_eq!(
+            UpgradeableLoaderState::size_of_programdata_metadata() as u64,
+            size
+        );
+    }
+
+    #[test]
+    fn test_state_size_of_program() {
+        let program_state = UpgradeableLoaderState::Program {
+            programdata_address: Pubkey::default(),
+        };
+        let size = serialized_size(&program_state).unwrap();
+        assert_eq!(UpgradeableLoaderState::size_of_program() as u64, size);
+    }
+
+    #[test]
+    #[allow(deprecated)]
     fn test_account_lengths() {
         assert_eq!(
             4,


### PR DESCRIPTION
#### Problem
The functions for returning the length of various upgradeable loader states are expensive and fallible.

#### Summary of Changes
Add new `const fn` methods to make size checks inexpensive and infallible

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
