### PR TITLE
Quic Re-batch incoming transactions

### DIFF
--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -58,6 +58,8 @@ fn build_randomized_packet_batch(packet_per_batch_count: usize) -> (PacketBatch,
     (packet_batch, packet_indexes)
 }
 
+// todo: make this work again
+/*
 fn insert_packet_batches(
     buffer_max_size: usize,
     batch_count: usize,
@@ -83,7 +85,7 @@ fn insert_packet_batches(
         buffer_max_size,
         timer.as_us()
     );
-}
+}*/
 
 #[bench]
 #[allow(clippy::unit_arg)]

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -345,12 +345,11 @@ impl UnprocessedPacketBatches {
 }
 
 pub fn deserialize_packets<'a>(
-    packet_batch: &'a PacketBatch,
-    packet_indexes: &'a [usize],
+    packet_batch: &'a [&'a Packet],
     bank: Option<&'a Arc<Bank>>,
 ) -> impl Iterator<Item = DeserializedPacket> + 'a {
-    packet_indexes.iter().filter_map(move |packet_index| {
-        DeserializedPacket::new(packet_batch.packets[*packet_index].clone(), bank).ok()
+    packet_batch.iter().filter_map(move |pkt| {
+        DeserializedPacket::new((*pkt).clone(), bank).ok()
     })
 }
 


### PR DESCRIPTION
#### Problem
Quic sends incoming packets to banking-stage in very small batches.

#### Summary of Changes
Re-batch the incoming packets.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
