### PR TITLE
fix: allow mutating transactions

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -267,12 +267,10 @@ export class Transaction {
    * Compile transaction data
    */
   compileMessage(): Message {
-    if (this._message) {
-      if (JSON.stringify(this.toJSON()) !== JSON.stringify(this._json)) {
-        throw new Error(
-          'Transaction message mutated after being populated from Message',
-        );
-      }
+    if (
+      this._message &&
+      JSON.stringify(this.toJSON()) === JSON.stringify(this._json)
+    ) {
       return this._message;
     }
 


### PR DESCRIPTION
#### Problem
After deserializing a transaction, it's not possible to sign and send because sending the transaction could mutate the transaction's blockhash and cause a mutation error.

#### Summary of Changes
Allow mutating the recent blockhash of a deserialized transaction

Fixes https://github.com/solana-labs/solana/issues/25137
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
