### PR TITLE
include exception identifier in `catch` blocks

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4847,7 +4847,7 @@ export class Connection {
             try {
               this.removeSignatureListener(clientSubscriptionId);
               // eslint-disable-next-line no-empty
-            } catch {
+            } catch(_err) {
               // Already removed.
             }
           }
@@ -4895,7 +4895,7 @@ export class Connection {
           try {
             this.removeSignatureListener(clientSubscriptionId);
             // eslint-disable-next-line no-empty
-          } catch {
+          } catch(_err) {
             // Already removed.
           }
         },

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4847,7 +4847,7 @@ export class Connection {
             try {
               this.removeSignatureListener(clientSubscriptionId);
               // eslint-disable-next-line no-empty
-            } catch(_err) {
+            } catch (_err) {
               // Already removed.
             }
           }
@@ -4895,7 +4895,7 @@ export class Connection {
           try {
             this.removeSignatureListener(clientSubscriptionId);
             // eslint-disable-next-line no-empty
-          } catch(_err) {
+          } catch (_err) {
             // Already removed.
           }
         },

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3614,7 +3614,7 @@ describe('Connection', function () {
             await connection._rpcWebSocket.notify('ping');
             break;
             // eslint-disable-next-line no-empty
-          } catch {}
+          } catch(_err) {}
           await sleep(100);
         }
       });

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3614,7 +3614,7 @@ describe('Connection', function () {
             await connection._rpcWebSocket.notify('ping');
             break;
             // eslint-disable-next-line no-empty
-          } catch(_err) {}
+          } catch (_err) {}
           await sleep(100);
         }
       });


### PR DESCRIPTION
#### Problem

when the try/catch exception identifier is excluded, during the build phase, `rollup` is throwing the error

`SyntaxError: Unexpected token in node_modules/@solana/web3.js/lib/index.browser.esm.js`

#### Summary of Changes

change

`try {} catch {}`

to

`try {} catch(_err) {}`
