### PR TITLE
rpc: Support token-2022 in token-specific calls

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -5,7 +5,7 @@ use {
         parse_nonce::parse_nonce,
         parse_stake::parse_stake,
         parse_sysvar::parse_sysvar,
-        parse_token::{parse_token, spl_token_ids},
+        parse_token::{parse_token, spl_token_2022_id, spl_token_id},
         parse_vote::parse_vote,
     },
     inflector::Inflector,
@@ -30,9 +30,8 @@ lazy_static! {
         );
         m.insert(*CONFIG_PROGRAM_ID, ParsableAccount::Config);
         m.insert(*SYSTEM_PROGRAM_ID, ParsableAccount::Nonce);
-        for spl_token_id in spl_token_ids() {
-            m.insert(spl_token_id, ParsableAccount::SplToken);
-        }
+        m.insert(spl_token_id(), ParsableAccount::SplToken);
+        m.insert(spl_token_2022_id(), ParsableAccount::SplToken2022);
         m.insert(*STAKE_PROGRAM_ID, ParsableAccount::Stake);
         m.insert(*SYSVAR_PROGRAM_ID, ParsableAccount::Sysvar);
         m.insert(*VOTE_PROGRAM_ID, ParsableAccount::Vote);
@@ -73,6 +72,7 @@ pub enum ParsableAccount {
     Config,
     Nonce,
     SplToken,
+    SplToken2022,
     Stake,
     Sysvar,
     Vote,
@@ -99,9 +99,9 @@ pub fn parse_account_data(
         }
         ParsableAccount::Config => serde_json::to_value(parse_config(data, pubkey)?)?,
         ParsableAccount::Nonce => serde_json::to_value(parse_nonce(data)?)?,
-        ParsableAccount::SplToken => {
-            serde_json::to_value(parse_token(data, additional_data.spl_token_decimals)?)?
-        }
+        ParsableAccount::SplToken | ParsableAccount::SplToken2022 => serde_json::to_value(
+            parse_token(data, additional_data.spl_token_decimals, program_id)?,
+        )?,
         ParsableAccount::Stake => serde_json::to_value(parse_stake(data)?)?,
         ParsableAccount::Sysvar => serde_json::to_value(parse_sysvar(data, pubkey)?)?,
         ParsableAccount::Vote => serde_json::to_value(parse_vote(data)?)?,

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -99,9 +99,9 @@ pub fn parse_account_data(
         }
         ParsableAccount::Config => serde_json::to_value(parse_config(data, pubkey)?)?,
         ParsableAccount::Nonce => serde_json::to_value(parse_nonce(data)?)?,
-        ParsableAccount::SplToken | ParsableAccount::SplToken2022 => serde_json::to_value(
-            parse_token(data, additional_data.spl_token_decimals, program_id)?,
-        )?,
+        ParsableAccount::SplToken | ParsableAccount::SplToken2022 => {
+            serde_json::to_value(parse_token(data, additional_data.spl_token_decimals)?)?
+        }
         ParsableAccount::Stake => serde_json::to_value(parse_stake(data)?)?,
         ParsableAccount::Sysvar => serde_json::to_value(parse_sysvar(data, pubkey)?)?,
         ParsableAccount::Vote => serde_json::to_value(parse_vote(data)?)?,

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -18,13 +18,13 @@ use {
 
 // A helper function to convert spl_token::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
-fn spl_token_id() -> Pubkey {
+pub(crate) fn spl_token_id() -> Pubkey {
     Pubkey::new_from_array(spl_token::id().to_bytes())
 }
 
 // A helper function to convert spl_token_2022::id() as spl_sdk::pubkey::Pubkey to
 // solana_sdk::pubkey::Pubkey
-fn spl_token_2022_id() -> Pubkey {
+pub(crate) fn spl_token_2022_id() -> Pubkey {
     Pubkey::new_from_array(spl_token_2022::id().to_bytes())
 }
 
@@ -62,6 +62,7 @@ pub fn pubkey_from_spl_token(pubkey: &SplTokenPubkey) -> Pubkey {
 pub fn parse_token(
     data: &[u8],
     mint_decimals: Option<u8>,
+    program_id: &Pubkey,
 ) -> Result<TokenAccountType, ParseAccountError> {
     if let Ok(account) = StateWithExtensions::<Account>::unpack(data) {
         let decimals = mint_decimals.ok_or_else(|| {
@@ -101,6 +102,7 @@ pub fn parse_token(
                 COption::None => None,
             },
             extensions: ui_extensions,
+            program_id: program_id.to_string(),
         }));
     }
     if let Ok(mint) = StateWithExtensions::<Mint>::unpack(data) {
@@ -122,6 +124,7 @@ pub fn parse_token(
                 COption::None => None,
             },
             extensions: ui_extensions,
+            program_id: program_id.to_string(),
         }));
     }
     if data.len() == Multisig::get_packed_len() {
@@ -131,6 +134,7 @@ pub fn parse_token(
             num_required_signers: multisig.m,
             num_valid_signers: multisig.n,
             is_initialized: multisig.is_initialized,
+            program_id: program_id.to_string(),
             signers: multisig
                 .signers
                 .iter()
@@ -169,6 +173,7 @@ pub struct UiTokenAccount {
     pub delegate: Option<String>,
     pub state: UiAccountState,
     pub is_native: bool,
+    pub program_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rent_exempt_reserve: Option<UiTokenAmount>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -268,6 +273,7 @@ pub struct UiMint {
     pub decimals: u8,
     pub is_initialized: bool,
     pub freeze_authority: Option<String>,
+    pub program_id: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub extensions: Vec<UiExtension>,
 }
@@ -278,6 +284,7 @@ pub struct UiMultisig {
     pub num_required_signers: u8,
     pub num_valid_signers: u8,
     pub is_initialized: bool,
+    pub program_id: String,
     pub signers: Vec<String>,
 }
 
@@ -305,6 +312,7 @@ mod test {
 
     #[test]
     fn test_parse_token() {
+        let program_id = Pubkey::new_unique();
         let mint_pubkey = SplTokenPubkey::new(&[2; 32]);
         let owner_pubkey = SplTokenPubkey::new(&[3; 32]);
         let mut account_data = vec![0; Account::get_packed_len()];
@@ -317,9 +325,9 @@ mod test {
         account.close_authority = COption::Some(owner_pubkey);
         Account::pack(account, &mut account_data).unwrap();
 
-        assert!(parse_token(&account_data, None).is_err());
+        assert!(parse_token(&account_data, None, &program_id).is_err());
         assert_eq!(
-            parse_token(&account_data, Some(2)).unwrap(),
+            parse_token(&account_data, Some(2), &program_id).unwrap(),
             TokenAccountType::Account(UiTokenAccount {
                 mint: mint_pubkey.to_string(),
                 owner: owner_pubkey.to_string(),
@@ -336,6 +344,7 @@ mod test {
                 delegated_amount: None,
                 close_authority: Some(owner_pubkey.to_string()),
                 extensions: vec![],
+                program_id: program_id.to_string(),
             }),
         );
 
@@ -349,7 +358,7 @@ mod test {
         Mint::pack(mint, &mut mint_data).unwrap();
 
         assert_eq!(
-            parse_token(&mint_data, None).unwrap(),
+            parse_token(&mint_data, None, &program_id).unwrap(),
             TokenAccountType::Mint(UiMint {
                 mint_authority: Some(owner_pubkey.to_string()),
                 supply: 42.to_string(),
@@ -357,6 +366,7 @@ mod test {
                 is_initialized: true,
                 freeze_authority: Some(owner_pubkey.to_string()),
                 extensions: vec![],
+                program_id: program_id.to_string(),
             }),
         );
 
@@ -376,7 +386,7 @@ mod test {
         Multisig::pack(multisig, &mut multisig_data).unwrap();
 
         assert_eq!(
-            parse_token(&multisig_data, None).unwrap(),
+            parse_token(&multisig_data, None, &program_id).unwrap(),
             TokenAccountType::Multisig(UiMultisig {
                 num_required_signers: 2,
                 num_valid_signers: 3,
@@ -386,11 +396,12 @@ mod test {
                     signer2.to_string(),
                     signer3.to_string()
                 ],
+                program_id: program_id.to_string(),
             }),
         );
 
         let bad_data = vec![0; 4];
-        assert!(parse_token(&bad_data, None).is_err());
+        assert!(parse_token(&bad_data, None, &program_id).is_err());
     }
 
     #[test]
@@ -497,6 +508,7 @@ mod test {
 
     #[test]
     fn test_parse_token_account_with_extensions() {
+        let program_id = Pubkey::new_unique();
         let mint_pubkey = SplTokenPubkey::new(&[2; 32]);
         let owner_pubkey = SplTokenPubkey::new(&[3; 32]);
 
@@ -510,7 +522,7 @@ mod test {
             delegate: COption::None,
             delegated_amount: 0,
         };
-        let account_size = ExtensionType::get_account_len::<Mint>(&[
+        let account_size = ExtensionType::get_account_len::<Account>(&[
             ExtensionType::ImmutableOwner,
             ExtensionType::MemoTransfer,
         ]);
@@ -522,9 +534,9 @@ mod test {
         account_state.pack_base();
         account_state.init_account_type().unwrap();
 
-        assert!(parse_token(&account_data, None).is_err());
+        assert!(parse_token(&account_data, None, &program_id).is_err());
         assert_eq!(
-            parse_token(&account_data, Some(2)).unwrap(),
+            parse_token(&account_data, Some(2), &program_id).unwrap(),
             TokenAccountType::Account(UiTokenAccount {
                 mint: mint_pubkey.to_string(),
                 owner: owner_pubkey.to_string(),
@@ -541,6 +553,7 @@ mod test {
                 delegated_amount: None,
                 close_authority: Some(owner_pubkey.to_string()),
                 extensions: vec![],
+                program_id: program_id.to_string(),
             }),
         );
 
@@ -556,9 +569,9 @@ mod test {
         let mut memo_transfer = account_state.init_extension::<MemoTransfer>().unwrap();
         memo_transfer.require_incoming_transfer_memos = true.into();
 
-        assert!(parse_token(&account_data, None).is_err());
+        assert!(parse_token(&account_data, None, &program_id).is_err());
         assert_eq!(
-            parse_token(&account_data, Some(2)).unwrap(),
+            parse_token(&account_data, Some(2), &program_id).unwrap(),
             TokenAccountType::Account(UiTokenAccount {
                 mint: mint_pubkey.to_string(),
                 owner: owner_pubkey.to_string(),
@@ -580,12 +593,14 @@ mod test {
                         require_incoming_transfer_memos: true,
                     }),
                 ],
+                program_id: program_id.to_string(),
             }),
         );
     }
 
     #[test]
     fn test_parse_token_mint_with_extensions() {
+        let program_id = Pubkey::new_unique();
         let owner_pubkey = SplTokenPubkey::new(&[3; 32]);
         let mint_size =
             ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
@@ -605,7 +620,7 @@ mod test {
         mint_state.init_account_type().unwrap();
 
         assert_eq!(
-            parse_token(&mint_data, None).unwrap(),
+            parse_token(&mint_data, None, &program_id).unwrap(),
             TokenAccountType::Mint(UiMint {
                 mint_authority: Some(owner_pubkey.to_string()),
                 supply: 42.to_string(),
@@ -613,6 +628,7 @@ mod test {
                 is_initialized: true,
                 freeze_authority: Some(owner_pubkey.to_string()),
                 extensions: vec![],
+                program_id: program_id.to_string(),
             }),
         );
 
@@ -629,7 +645,7 @@ mod test {
         mint_state.init_account_type().unwrap();
 
         assert_eq!(
-            parse_token(&mint_data, None).unwrap(),
+            parse_token(&mint_data, None, &program_id).unwrap(),
             TokenAccountType::Mint(UiMint {
                 mint_authority: Some(owner_pubkey.to_string()),
                 supply: 42.to_string(),
@@ -639,6 +655,7 @@ mod test {
                 extensions: vec![UiExtension::MintCloseAuthority(UiMintCloseAuthority {
                     close_authority: Some(owner_pubkey.to_string()),
                 })],
+                program_id: program_id.to_string(),
             }),
         );
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -47,6 +47,7 @@ use {
         bank_forks::BankForks,
         commitment::{BlockCommitmentArray, BlockCommitmentCache, CommitmentSlots},
         inline_spl_token::{SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
+        inline_spl_token_2022::{self, ACCOUNTTYPE_ACCOUNT},
         non_circulating_supply::calculate_non_circulating_supply,
         snapshot_config::SnapshotConfig,
         snapshot_utils,
@@ -87,7 +88,8 @@ use {
         UiConfirmedBlock, UiTransactionEncoding,
     },
     solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY},
-    spl_token::{
+    spl_token_2022::{
+        extension::StateWithExtensions,
         solana_program::program_pack::Pack,
         state::{Account as TokenAccount, Mint},
     },
@@ -1726,12 +1728,12 @@ impl JsonRpcRequestProcessor {
                 "Invalid param: not a Token account".to_string(),
             ));
         }
-        let token_account = TokenAccount::unpack(account.data())
+        let token_account = StateWithExtensions::<TokenAccount>::unpack(account.data())
             .map_err(|_| Error::invalid_params("Invalid param: not a Token account".to_string()))?;
-        let mint = &Pubkey::from_str(&token_account.mint.to_string())
+        let mint = &Pubkey::from_str(&token_account.base.mint.to_string())
             .expect("Token account mint should be convertible to Pubkey");
         let (_, decimals) = get_mint_owner_and_decimals(&bank, mint)?;
-        let balance = token_amount_to_ui_amount(token_account.amount, decimals);
+        let balance = token_amount_to_ui_amount(token_account.base.amount, decimals);
         Ok(new_response(&bank, balance))
     }
 
@@ -1749,11 +1751,11 @@ impl JsonRpcRequestProcessor {
                 "Invalid param: not a Token mint".to_string(),
             ));
         }
-        let mint = Mint::unpack(mint_account.data()).map_err(|_| {
+        let mint = StateWithExtensions::<Mint>::unpack(mint_account.data()).map_err(|_| {
             Error::invalid_params("Invalid param: mint could not be unpacked".to_string())
         })?;
 
-        let supply = token_amount_to_ui_amount(mint.supply, mint.decimals);
+        let supply = token_amount_to_ui_amount(mint.base.supply, mint.base.decimals);
         Ok(new_response(&bank, supply))
     }
 
@@ -1773,8 +1775,8 @@ impl JsonRpcRequestProcessor {
             .get_filtered_spl_token_accounts_by_mint(&bank, &mint_owner, mint, vec![])?
             .into_iter()
             .map(|(address, account)| {
-                let amount = TokenAccount::unpack(account.data())
-                    .map(|account| account.amount)
+                let amount = StateWithExtensions::<TokenAccount>::unpack(account.data())
+                    .map(|account| account.base.amount)
                     .unwrap_or(0);
                 let amount = token_amount_to_ui_amount(amount, decimals);
                 RpcTokenAccountBalance {
@@ -1872,9 +1874,7 @@ impl JsonRpcRequestProcessor {
             self.get_filtered_spl_token_accounts_by_mint(&bank, &token_program_id, &mint, filters)?
         } else {
             // Filter on Token Account state
-            filters.push(RpcFilterType::DataSize(
-                TokenAccount::get_packed_len() as u64
-            ));
+            filters.push(RpcFilterType::TokenAccountState);
             self.get_filtered_program_accounts(&bank, &token_program_id, filters)?
         };
         let accounts = if encoding == UiAccountEncoding::JsonParsed {
@@ -2264,16 +2264,25 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
         return None;
     }
     let mut data_size_filter: Option<u64> = None;
+    let mut memcmp_filter: Option<&[u8]> = None;
     let mut owner_key: Option<Pubkey> = None;
     let mut incorrect_owner_len: Option<usize> = None;
+    let account_packed_len = TokenAccount::get_packed_len();
     for filter in filters {
         match filter {
             RpcFilterType::DataSize(size) => data_size_filter = Some(*size),
             RpcFilterType::Memcmp(Memcmp {
-                offset: SPL_TOKEN_ACCOUNT_OWNER_OFFSET,
+                offset,
                 bytes: MemcmpEncodedBytes::Bytes(bytes),
                 ..
-            }) => {
+            }) if *offset == account_packed_len && *program_id == inline_spl_token_2022::id() => {
+                memcmp_filter = Some(bytes)
+            }
+            RpcFilterType::Memcmp(Memcmp {
+                offset,
+                bytes: MemcmpEncodedBytes::Bytes(bytes),
+                ..
+            }) if *offset == SPL_TOKEN_ACCOUNT_OWNER_OFFSET => {
                 if bytes.len() == PUBKEY_BYTES {
                     owner_key = Some(Pubkey::new(bytes));
                 } else {
@@ -2283,7 +2292,9 @@ fn get_spl_token_owner_filter(program_id: &Pubkey, filters: &[RpcFilterType]) ->
             _ => {}
         }
     }
-    if data_size_filter == Some(TokenAccount::get_packed_len() as u64) {
+    if data_size_filter == Some(account_packed_len as u64)
+        || memcmp_filter == Some(&[ACCOUNTTYPE_ACCOUNT])
+    {
         if let Some(incorrect_owner_len) = incorrect_owner_len {
             info!(
                 "Incorrect num bytes ({:?}) provided for spl_token_owner_filter",
@@ -2306,16 +2317,25 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
         return None;
     }
     let mut data_size_filter: Option<u64> = None;
+    let mut memcmp_filter: Option<&[u8]> = None;
     let mut mint: Option<Pubkey> = None;
     let mut incorrect_mint_len: Option<usize> = None;
+    let account_packed_len = TokenAccount::get_packed_len();
     for filter in filters {
         match filter {
             RpcFilterType::DataSize(size) => data_size_filter = Some(*size),
             RpcFilterType::Memcmp(Memcmp {
-                offset: SPL_TOKEN_ACCOUNT_MINT_OFFSET,
+                offset,
                 bytes: MemcmpEncodedBytes::Bytes(bytes),
                 ..
-            }) => {
+            }) if *offset == account_packed_len && *program_id == inline_spl_token_2022::id() => {
+                memcmp_filter = Some(bytes)
+            }
+            RpcFilterType::Memcmp(Memcmp {
+                offset,
+                bytes: MemcmpEncodedBytes::Bytes(bytes),
+                ..
+            }) if *offset == SPL_TOKEN_ACCOUNT_MINT_OFFSET => {
                 if bytes.len() == PUBKEY_BYTES {
                     mint = Some(Pubkey::new(bytes));
                 } else {
@@ -2325,7 +2345,9 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
             _ => {}
         }
     }
-    if data_size_filter == Some(TokenAccount::get_packed_len() as u64) {
+    if data_size_filter == Some(account_packed_len as u64)
+        || memcmp_filter == Some(&[ACCOUNTTYPE_ACCOUNT])
+    {
         if let Some(incorrect_mint_len) = incorrect_mint_len {
             info!(
                 "Incorrect num bytes ({:?}) provided for spl_token_mint_filter",
@@ -4427,7 +4449,7 @@ pub mod tests {
         },
         solana_runtime::{
             accounts_background_service::AbsRequestSender, commitment::BlockCommitment,
-            non_circulating_supply::non_circulating_accounts,
+            inline_spl_token, non_circulating_supply::non_circulating_accounts,
         },
         solana_sdk::{
             account::{Account, WritableAccount},
@@ -4453,16 +4475,17 @@ pub mod tests {
             vote_instruction,
             vote_state::{Vote, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY},
         },
-        spl_token::{
+        spl_token_2022::{
+            extension::{
+                immutable_owner::ImmutableOwner, memo_transfer::MemoTransfer,
+                mint_close_authority::MintCloseAuthority, ExtensionType, StateWithExtensionsMut,
+            },
+            pod::OptionalNonZeroPubkey,
             solana_program::{program_option::COption, pubkey::Pubkey as SplTokenPubkey},
             state::{AccountState as TokenAccountState, Mint},
         },
         std::{borrow::Cow, collections::HashMap},
     };
-
-    fn spl_token_id() -> Pubkey {
-        solana_account_decoder::parse_token::spl_token_ids()[0]
-    }
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000;
     const TEST_SLOTS_PER_EPOCH: u64 = DELINQUENT_VALIDATOR_SLOT_DISTANCE + 1;
@@ -7069,466 +7092,632 @@ pub mod tests {
 
     #[test]
     fn test_token_rpcs() {
-        let rpc = RpcHandler::start();
-        let bank = rpc.working_bank();
-        let RpcHandler { io, meta, .. } = rpc;
+        for program_id in solana_account_decoder::parse_token::spl_token_ids() {
+            let rpc = RpcHandler::start();
+            let bank = rpc.working_bank();
+            let RpcHandler { io, meta, .. } = rpc;
+            let mint = SplTokenPubkey::new(&[2; 32]);
+            let owner = SplTokenPubkey::new(&[3; 32]);
+            let delegate = SplTokenPubkey::new(&[4; 32]);
+            let token_account_pubkey = solana_sdk::pubkey::new_rand();
+            let token_with_different_mint_pubkey = solana_sdk::pubkey::new_rand();
+            let new_mint = SplTokenPubkey::new(&[5; 32]);
+            if program_id == inline_spl_token_2022::id() {
+                // Add the token account
+                let account_base = TokenAccount {
+                    mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 420,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::None,
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                let account_size = ExtensionType::get_account_len::<TokenAccount>(&[
+                    ExtensionType::ImmutableOwner,
+                    ExtensionType::MemoTransfer,
+                ]);
+                let mut account_data = vec![0; account_size];
+                let mut account_state =
+                    StateWithExtensionsMut::<TokenAccount>::unpack_uninitialized(&mut account_data)
+                        .unwrap();
 
-        let mut account_data = vec![0; TokenAccount::get_packed_len()];
-        let mint = SplTokenPubkey::new(&[2; 32]);
-        let owner = SplTokenPubkey::new(&[3; 32]);
-        let delegate = SplTokenPubkey::new(&[4; 32]);
-        let token_account = TokenAccount {
-            mint,
-            owner,
-            delegate: COption::Some(delegate),
-            amount: 420,
-            state: TokenAccountState::Initialized,
-            is_native: COption::None,
-            delegated_amount: 30,
-            close_authority: COption::Some(owner),
-        };
-        TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: account_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        let token_account_pubkey = solana_sdk::pubkey::new_rand();
-        bank.store_account(&token_account_pubkey, &token_account);
+                account_state.base = account_base;
+                account_state.pack_base();
+                account_state.init_account_type().unwrap();
+                account_state.init_extension::<ImmutableOwner>().unwrap();
+                let mut memo_transfer = account_state.init_extension::<MemoTransfer>().unwrap();
+                memo_transfer.require_incoming_transfer_memos = true.into();
 
-        // Add the mint
-        let mut mint_data = vec![0; Mint::get_packed_len()];
-        let mint_state = Mint {
-            mint_authority: COption::Some(owner),
-            supply: 500,
-            decimals: 2,
-            is_initialized: true,
-            freeze_authority: COption::Some(owner),
-        };
-        Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: mint_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_account_pubkey, &token_account);
 
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenAccountBalance","params":["{}"]}}"#,
-            token_account_pubkey,
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let balance: UiTokenAmount =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        let error = f64::EPSILON;
-        assert!((balance.ui_amount.unwrap() - 4.2).abs() < error);
-        assert_eq!(balance.amount, 420.to_string());
-        assert_eq!(balance.decimals, 2);
-        assert_eq!(balance.ui_amount_string, "4.2".to_string());
+                // Add the mint
+                let mint_size =
+                    ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+                let mint_base = Mint {
+                    mint_authority: COption::Some(owner),
+                    supply: 500,
+                    decimals: 2,
+                    is_initialized: true,
+                    freeze_authority: COption::Some(owner),
+                };
+                let mut mint_data = vec![0; mint_size];
+                let mut mint_state =
+                    StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
 
-        // Test non-existent token account
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenAccountBalance","params":["{}"]}}"#,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
+                mint_state.base = mint_base;
+                mint_state.pack_base();
+                mint_state.init_account_type().unwrap();
+                let mut mint_close_authority =
+                    mint_state.init_extension::<MintCloseAuthority>().unwrap();
+                mint_close_authority.close_authority =
+                    OptionalNonZeroPubkey::try_from(Some(owner)).unwrap();
 
-        // Test get token supply, pulls supply from mint
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenSupply","params":["{}"]}}"#,
-            mint,
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let supply: UiTokenAmount =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        let error = f64::EPSILON;
-        assert!((supply.ui_amount.unwrap() - 5.0).abs() < error);
-        assert_eq!(supply.amount, 500.to_string());
-        assert_eq!(supply.decimals, 2);
-        assert_eq!(supply.ui_amount_string, "5".to_string());
+                let mint_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: mint_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 
-        // Test non-existent mint address
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenSupply","params":["{}"]}}"#,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
+                // Add another token account with the same owner, delegate, and mint
+                let other_token_account_pubkey = solana_sdk::pubkey::new_rand();
+                bank.store_account(&other_token_account_pubkey, &token_account);
 
-        // Add another token account with the same owner, delegate, and mint
-        let other_token_account_pubkey = solana_sdk::pubkey::new_rand();
-        bank.store_account(&other_token_account_pubkey, &token_account);
+                // Add another token account with the same owner and delegate but different mint
+                let mut account_data = vec![0; TokenAccount::get_packed_len()];
+                let token_account = TokenAccount {
+                    mint: new_mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 42,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::None,
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                TokenAccount::pack(token_account, &mut account_data).unwrap();
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_with_different_mint_pubkey, &token_account);
+            } else {
+                // Add the token account
+                let mut account_data = vec![0; TokenAccount::get_packed_len()];
+                let token_account = TokenAccount {
+                    mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 420,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::None,
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                TokenAccount::pack(token_account, &mut account_data).unwrap();
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_account_pubkey, &token_account);
 
-        // Add another token account with the same owner and delegate but different mint
-        let mut account_data = vec![0; TokenAccount::get_packed_len()];
-        let new_mint = SplTokenPubkey::new(&[5; 32]);
-        let token_account = TokenAccount {
-            mint: new_mint,
-            owner,
-            delegate: COption::Some(delegate),
-            amount: 42,
-            state: TokenAccountState::Initialized,
-            is_native: COption::None,
-            delegated_amount: 30,
-            close_authority: COption::Some(owner),
-        };
-        TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: account_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        let token_with_different_mint_pubkey = solana_sdk::pubkey::new_rand();
-        bank.store_account(&token_with_different_mint_pubkey, &token_account);
+                // Add the mint
+                let mut mint_data = vec![0; Mint::get_packed_len()];
+                let mint_state = Mint {
+                    mint_authority: COption::Some(owner),
+                    supply: 500,
+                    decimals: 2,
+                    is_initialized: true,
+                    freeze_authority: COption::Some(owner),
+                };
+                Mint::pack(mint_state, &mut mint_data).unwrap();
+                let mint_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: mint_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 
-        // Test getTokenAccountsByOwner with Token program id returns all accounts, regardless of Mint address
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
-            }}"#,
-            owner,
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(accounts.len(), 3);
+                // Add another token account with the same owner, delegate, and mint
+                let other_token_account_pubkey = solana_sdk::pubkey::new_rand();
+                bank.store_account(&other_token_account_pubkey, &token_account);
 
-        // Test getTokenAccountsByOwner with jsonParsed encoding doesn't return accounts with invalid mints
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"programId": "{}"}}, {{"encoding": "jsonParsed"}}]
-            }}"#,
-            owner,
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(accounts.len(), 2);
+                // Add another token account with the same owner and delegate but different mint
+                let mut account_data = vec![0; TokenAccount::get_packed_len()];
+                let token_account = TokenAccount {
+                    mint: new_mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 42,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::None,
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                TokenAccount::pack(token_account, &mut account_data).unwrap();
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_with_different_mint_pubkey, &token_account);
+            }
 
-        // Test getProgramAccounts with jsonParsed encoding returns mints, but doesn't return accounts with invalid mints
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getProgramAccounts",
-                "params":["{}", {{"encoding": "jsonParsed"}}]
-            }}"#,
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"].clone()).unwrap();
-        assert_eq!(accounts.len(), 4);
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenAccountBalance","params":["{}"]}}"#,
+                token_account_pubkey,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let balance: UiTokenAmount =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            let error = f64::EPSILON;
+            assert!((balance.ui_amount.unwrap() - 4.2).abs() < error);
+            assert_eq!(balance.amount, 420.to_string());
+            assert_eq!(balance.decimals, 2);
+            assert_eq!(balance.ui_amount_string, "4.2".to_string());
 
-        // Test returns only mint accounts
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,"method":"getTokenAccountsByOwner",
-                "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
-            }}"#,
-            owner, mint,
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(accounts.len(), 2);
+            // Test non-existent token account
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenAccountBalance","params":["{}"]}}"#,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
 
-        // Test non-existent Mint/program id
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"programId": "{}"}}]
-            }}"#,
-            owner,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"mint": "{}"}}]
-            }}"#,
-            owner,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
+            // Test get token supply, pulls supply from mint
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenSupply","params":["{}"]}}"#,
+                mint,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let supply: UiTokenAmount =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            let error = f64::EPSILON;
+            assert!((supply.ui_amount.unwrap() - 5.0).abs() < error);
+            assert_eq!(supply.amount, 500.to_string());
+            assert_eq!(supply.decimals, 2);
+            assert_eq!(supply.ui_amount_string, "5".to_string());
 
-        // Test non-existent Owner
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByOwner",
-                "params":["{}", {{"programId": "{}"}}]
-            }}"#,
-            solana_sdk::pubkey::new_rand(),
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert!(accounts.is_empty());
+            // Test non-existent mint address
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenSupply","params":["{}"]}}"#,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
 
-        // Test getTokenAccountsByDelegate with Token program id returns all accounts, regardless of Mint address
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByDelegate",
-                "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
-            }}"#,
-            delegate,
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(accounts.len(), 3);
+            // Test getTokenAccountsByOwner with Token program id returns all accounts, regardless of Mint address
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
+                }}"#,
+                owner, program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(accounts.len(), 3);
 
-        // Test returns only mint accounts
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,"method":
-                "getTokenAccountsByDelegate",
-                "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
-            }}"#,
-            delegate, mint,
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(accounts.len(), 2);
+            // Test getTokenAccountsByOwner with jsonParsed encoding doesn't return accounts with invalid mints
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"programId": "{}"}}, {{"encoding": "jsonParsed"}}]
+                }}"#,
+                owner, program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(accounts.len(), 2);
 
-        // Test non-existent Mint/program id
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByDelegate",
-                "params":["{}", {{"programId": "{}"}}]
-            }}"#,
-            delegate,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByDelegate",
-                "params":["{}", {{"mint": "{}"}}]
-            }}"#,
-            delegate,
-            solana_sdk::pubkey::new_rand(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert!(result.get("error").is_some());
+            // Test getProgramAccounts with jsonParsed encoding returns mints, but doesn't return accounts with invalid mints
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getProgramAccounts",
+                    "params":["{}", {{"encoding": "jsonParsed"}}]
+                }}"#,
+                program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"].clone()).unwrap();
+            if program_id == inline_spl_token::id() {
+                // native mint is included for token-v3
+                assert_eq!(accounts.len(), 4);
+            } else {
+                assert_eq!(accounts.len(), 3);
+            }
 
-        // Test non-existent Delegate
-        let req = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"getTokenAccountsByDelegate",
-                "params":["{}", {{"programId": "{}"}}]
-            }}"#,
-            solana_sdk::pubkey::new_rand(),
-            spl_token_id(),
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert!(accounts.is_empty());
+            // Test returns only mint accounts
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,"method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
+                }}"#,
+                owner, mint,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(accounts.len(), 2);
 
-        // Add new_mint, and another token account on new_mint with different balance
-        let mut mint_data = vec![0; Mint::get_packed_len()];
-        let mint_state = Mint {
-            mint_authority: COption::Some(owner),
-            supply: 500,
-            decimals: 2,
-            is_initialized: true,
-            freeze_authority: COption::Some(owner),
-        };
-        Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: mint_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        bank.store_account(
-            &Pubkey::from_str(&new_mint.to_string()).unwrap(),
-            &mint_account,
-        );
-        let mut account_data = vec![0; TokenAccount::get_packed_len()];
-        let token_account = TokenAccount {
-            mint: new_mint,
-            owner,
-            delegate: COption::Some(delegate),
-            amount: 10,
-            state: TokenAccountState::Initialized,
-            is_native: COption::None,
-            delegated_amount: 30,
-            close_authority: COption::Some(owner),
-        };
-        TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: account_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        let token_with_smaller_balance = solana_sdk::pubkey::new_rand();
-        bank.store_account(&token_with_smaller_balance, &token_account);
+            // Test non-existent Mint/program id
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"programId": "{}"}}]
+                }}"#,
+                owner,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"mint": "{}"}}]
+                }}"#,
+                owner,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
 
-        // Test largest token accounts
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenLargestAccounts","params":["{}"]}}"#,
-            new_mint,
-        );
-        let res = io.handle_request_sync(&req, meta);
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        let largest_accounts: Vec<RpcTokenAccountBalance> =
-            serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(
-            largest_accounts,
-            vec![
-                RpcTokenAccountBalance {
-                    address: token_with_different_mint_pubkey.to_string(),
-                    amount: UiTokenAmount {
-                        ui_amount: Some(0.42),
-                        decimals: 2,
-                        amount: "42".to_string(),
-                        ui_amount_string: "0.42".to_string(),
+            // Test non-existent Owner
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByOwner",
+                    "params":["{}", {{"programId": "{}"}}]
+                }}"#,
+                solana_sdk::pubkey::new_rand(),
+                program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert!(accounts.is_empty());
+
+            // Test getTokenAccountsByDelegate with Token program id returns all accounts, regardless of Mint address
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByDelegate",
+                    "params":["{}", {{"programId": "{}"}}, {{"encoding":"base64"}}]
+                }}"#,
+                delegate, program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(accounts.len(), 3);
+
+            // Test returns only mint accounts
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,"method":
+                    "getTokenAccountsByDelegate",
+                    "params":["{}", {{"mint": "{}"}}, {{"encoding":"base64"}}]
+                }}"#,
+                delegate, mint,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(accounts.len(), 2);
+
+            // Test non-existent Mint/program id
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByDelegate",
+                    "params":["{}", {{"programId": "{}"}}]
+                }}"#,
+                delegate,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByDelegate",
+                    "params":["{}", {{"mint": "{}"}}]
+                }}"#,
+                delegate,
+                solana_sdk::pubkey::new_rand(),
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            assert!(result.get("error").is_some());
+
+            // Test non-existent Delegate
+            let req = format!(
+                r#"{{
+                    "jsonrpc":"2.0",
+                    "id":1,
+                    "method":"getTokenAccountsByDelegate",
+                    "params":["{}", {{"programId": "{}"}}]
+                }}"#,
+                solana_sdk::pubkey::new_rand(),
+                program_id,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let accounts: Vec<RpcKeyedAccount> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert!(accounts.is_empty());
+
+            // Add new_mint, and another token account on new_mint with different balance
+            let mut mint_data = vec![0; Mint::get_packed_len()];
+            let mint_state = Mint {
+                mint_authority: COption::Some(owner),
+                supply: 500,
+                decimals: 2,
+                is_initialized: true,
+                freeze_authority: COption::Some(owner),
+            };
+            Mint::pack(mint_state, &mut mint_data).unwrap();
+            let mint_account = AccountSharedData::from(Account {
+                lamports: 111,
+                data: mint_data.to_vec(),
+                owner: program_id,
+                ..Account::default()
+            });
+            bank.store_account(
+                &Pubkey::from_str(&new_mint.to_string()).unwrap(),
+                &mint_account,
+            );
+            let mut account_data = vec![0; TokenAccount::get_packed_len()];
+            let token_account = TokenAccount {
+                mint: new_mint,
+                owner,
+                delegate: COption::Some(delegate),
+                amount: 10,
+                state: TokenAccountState::Initialized,
+                is_native: COption::None,
+                delegated_amount: 30,
+                close_authority: COption::Some(owner),
+            };
+            TokenAccount::pack(token_account, &mut account_data).unwrap();
+            let token_account = AccountSharedData::from(Account {
+                lamports: 111,
+                data: account_data.to_vec(),
+                owner: program_id,
+                ..Account::default()
+            });
+            let token_with_smaller_balance = solana_sdk::pubkey::new_rand();
+            bank.store_account(&token_with_smaller_balance, &token_account);
+
+            // Test largest token accounts
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenLargestAccounts","params":["{}"]}}"#,
+                new_mint,
+            );
+            let res = io.handle_request_sync(&req, meta);
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let largest_accounts: Vec<RpcTokenAccountBalance> =
+                serde_json::from_value(result["result"]["value"].clone()).unwrap();
+            assert_eq!(
+                largest_accounts,
+                vec![
+                    RpcTokenAccountBalance {
+                        address: token_with_different_mint_pubkey.to_string(),
+                        amount: UiTokenAmount {
+                            ui_amount: Some(0.42),
+                            decimals: 2,
+                            amount: "42".to_string(),
+                            ui_amount_string: "0.42".to_string(),
+                        }
+                    },
+                    RpcTokenAccountBalance {
+                        address: token_with_smaller_balance.to_string(),
+                        amount: UiTokenAmount {
+                            ui_amount: Some(0.1),
+                            decimals: 2,
+                            amount: "10".to_string(),
+                            ui_amount_string: "0.1".to_string(),
+                        }
                     }
-                },
-                RpcTokenAccountBalance {
-                    address: token_with_smaller_balance.to_string(),
-                    amount: UiTokenAmount {
-                        ui_amount: Some(0.1),
-                        decimals: 2,
-                        amount: "10".to_string(),
-                        ui_amount_string: "0.1".to_string(),
-                    }
-                }
-            ]
-        );
+                ]
+            );
+        }
     }
 
     #[test]
     fn test_token_parsing() {
-        let rpc = RpcHandler::start();
-        let bank = rpc.working_bank();
-        let RpcHandler { io, meta, .. } = rpc;
+        for program_id in solana_account_decoder::parse_token::spl_token_ids() {
+            let rpc = RpcHandler::start();
+            let bank = rpc.working_bank();
+            let RpcHandler { io, meta, .. } = rpc;
 
-        let mut account_data = vec![0; TokenAccount::get_packed_len()];
-        let mint = SplTokenPubkey::new(&[2; 32]);
-        let owner = SplTokenPubkey::new(&[3; 32]);
-        let delegate = SplTokenPubkey::new(&[4; 32]);
-        let token_account = TokenAccount {
-            mint,
-            owner,
-            delegate: COption::Some(delegate),
-            amount: 420,
-            state: TokenAccountState::Initialized,
-            is_native: COption::Some(10),
-            delegated_amount: 30,
-            close_authority: COption::Some(owner),
-        };
-        TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: account_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        let token_account_pubkey = solana_sdk::pubkey::new_rand();
-        bank.store_account(&token_account_pubkey, &token_account);
+            let mint = SplTokenPubkey::new(&[2; 32]);
+            let owner = SplTokenPubkey::new(&[3; 32]);
+            let delegate = SplTokenPubkey::new(&[4; 32]);
+            let token_account_pubkey = solana_sdk::pubkey::new_rand();
+            let (program_name, account_size, mint_size) = if program_id
+                == inline_spl_token_2022::id()
+            {
+                let account_base = TokenAccount {
+                    mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 420,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::Some(10),
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                let account_size = ExtensionType::get_account_len::<TokenAccount>(&[
+                    ExtensionType::ImmutableOwner,
+                    ExtensionType::MemoTransfer,
+                ]);
+                let mut account_data = vec![0; account_size];
+                let mut account_state =
+                    StateWithExtensionsMut::<TokenAccount>::unpack_uninitialized(&mut account_data)
+                        .unwrap();
 
-        // Add the mint
-        let mut mint_data = vec![0; Mint::get_packed_len()];
-        let mint_state = Mint {
-            mint_authority: COption::Some(owner),
-            supply: 500,
-            decimals: 2,
-            is_initialized: true,
-            freeze_authority: COption::Some(owner),
-        };
-        Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData::from(Account {
-            lamports: 111,
-            data: mint_data.to_vec(),
-            owner: spl_token_id(),
-            ..Account::default()
-        });
-        bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
+                account_state.base = account_base;
+                account_state.pack_base();
+                account_state.init_account_type().unwrap();
+                account_state.init_extension::<ImmutableOwner>().unwrap();
+                let mut memo_transfer = account_state.init_extension::<MemoTransfer>().unwrap();
+                memo_transfer.require_incoming_transfer_memos = true.into();
 
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["{}", {{"encoding": "jsonParsed"}}]}}"#,
-            token_account_pubkey,
-        );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert_eq!(
-            result["result"]["value"]["data"],
-            json!({
-                "program": "spl-token",
-                "space": TokenAccount::get_packed_len(),
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_account_pubkey, &token_account);
+
+                let mint_size =
+                    ExtensionType::get_account_len::<Mint>(&[ExtensionType::MintCloseAuthority]);
+                let mint_base = Mint {
+                    mint_authority: COption::Some(owner),
+                    supply: 500,
+                    decimals: 2,
+                    is_initialized: true,
+                    freeze_authority: COption::Some(owner),
+                };
+                let mut mint_data = vec![0; mint_size];
+                let mut mint_state =
+                    StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
+
+                mint_state.base = mint_base;
+                mint_state.pack_base();
+                mint_state.init_account_type().unwrap();
+                let mut mint_close_authority =
+                    mint_state.init_extension::<MintCloseAuthority>().unwrap();
+                mint_close_authority.close_authority =
+                    OptionalNonZeroPubkey::try_from(Some(owner)).unwrap();
+
+                let mint_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: mint_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
+                ("spl-token-2022", account_size, mint_size)
+            } else {
+                let account_size = TokenAccount::get_packed_len();
+                let mut account_data = vec![0; account_size];
+                let token_account = TokenAccount {
+                    mint,
+                    owner,
+                    delegate: COption::Some(delegate),
+                    amount: 420,
+                    state: TokenAccountState::Initialized,
+                    is_native: COption::Some(10),
+                    delegated_amount: 30,
+                    close_authority: COption::Some(owner),
+                };
+                TokenAccount::pack(token_account, &mut account_data).unwrap();
+                let token_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: account_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&token_account_pubkey, &token_account);
+
+                // Add the mint
+                let mint_size = Mint::get_packed_len();
+                let mut mint_data = vec![0; mint_size];
+                let mint_state = Mint {
+                    mint_authority: COption::Some(owner),
+                    supply: 500,
+                    decimals: 2,
+                    is_initialized: true,
+                    freeze_authority: COption::Some(owner),
+                };
+                Mint::pack(mint_state, &mut mint_data).unwrap();
+                let mint_account = AccountSharedData::from(Account {
+                    lamports: 111,
+                    data: mint_data.to_vec(),
+                    owner: program_id,
+                    ..Account::default()
+                });
+                bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
+                ("spl-token", account_size, mint_size)
+            };
+
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["{}", {{"encoding": "jsonParsed"}}]}}"#,
+                token_account_pubkey,
+            );
+            let res = io.handle_request_sync(&req, meta.clone());
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let mut expected_value = json!({
+                "program": program_name,
+                "space": account_size,
                 "parsed": {
                     "type": "account",
                     "info": {
@@ -7556,24 +7745,36 @@ pub mod tests {
                             "uiAmountString": "0.3",
                         },
                         "closeAuthority": owner.to_string(),
+                        "programId": program_id.to_string(),
                     }
                 }
-            })
-        );
+            });
+            if program_id == inline_spl_token_2022::id() {
+                expected_value["parsed"]["info"]["extensions"] = json!([
+                    {
+                        "extension": "immutableOwner"
+                    },
+                    {
+                        "extension": "memoTransfer",
+                        "state": {
+                            "requireIncomingTransferMemos": true
+                        }
+                    },
+                ]);
+            }
+            assert_eq!(result["result"]["value"]["data"], expected_value);
 
-        // Test Mint
-        let req = format!(
-            r#"{{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["{}", {{"encoding": "jsonParsed"}}]}}"#,
-            mint,
-        );
-        let res = io.handle_request_sync(&req, meta);
-        let result: Value = serde_json::from_str(&res.expect("actual response"))
-            .expect("actual response deserialization");
-        assert_eq!(
-            result["result"]["value"]["data"],
-            json!({
-                "program": "spl-token",
-                "space": Mint::get_packed_len(),
+            // Test Mint
+            let req = format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"getAccountInfo","params":["{}", {{"encoding": "jsonParsed"}}]}}"#,
+                mint,
+            );
+            let res = io.handle_request_sync(&req, meta);
+            let result: Value = serde_json::from_str(&res.expect("actual response"))
+                .expect("actual response deserialization");
+            let mut expected_value = json!({
+                "program": program_name,
+                "space": mint_size,
                 "parsed": {
                     "type": "mint",
                     "info": {
@@ -7582,14 +7783,27 @@ pub mod tests {
                         "supply": "500".to_string(),
                         "isInitialized": true,
                         "freezeAuthority": owner.to_string(),
+                        "programId": program_id.to_string(),
                     }
                 }
-            })
-        );
+            });
+            if program_id == inline_spl_token_2022::id() {
+                expected_value["parsed"]["info"]["extensions"] = json!([
+                    {
+                        "extension": "mintCloseAuthority",
+                        "state": {
+                            "closeAuthority": owner.to_string(),
+                        }
+                    }
+                ]);
+            }
+            assert_eq!(result["result"]["value"]["data"], expected_value,);
+        }
     }
 
     #[test]
     fn test_get_spl_token_owner_filter() {
+        // Filtering on token-v3 length
         let owner = Pubkey::new_unique();
         assert_eq!(
             get_spl_token_owner_filter(
@@ -7606,6 +7820,45 @@ pub mod tests {
             .unwrap(),
             owner
         );
+
+        // Filtering on token-2022 account type
+        assert_eq!(
+            get_spl_token_owner_filter(
+                &Pubkey::from_str("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb").unwrap(),
+                &[
+                    RpcFilterType::Memcmp(Memcmp {
+                        offset: 32,
+                        bytes: MemcmpEncodedBytes::Bytes(owner.to_bytes().to_vec()),
+                        encoding: None
+                    }),
+                    RpcFilterType::Memcmp(Memcmp {
+                        offset: 165,
+                        bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                        encoding: None
+                    })
+                ],
+            )
+            .unwrap(),
+            owner
+        );
+
+        // Can't filter on account type for token-v3
+        assert!(get_spl_token_owner_filter(
+            &Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 32,
+                    bytes: MemcmpEncodedBytes::Bytes(owner.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 165,
+                    bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                    encoding: None
+                })
+            ],
+        )
+        .is_none());
 
         // Filtering on mint instead of owner
         assert!(get_spl_token_owner_filter(
@@ -7631,6 +7884,126 @@ pub mod tests {
                     encoding: None
                 }),
                 RpcFilterType::DataSize(165)
+            ],
+        )
+        .is_none());
+        assert!(get_spl_token_owner_filter(
+            &Pubkey::new_unique(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 32,
+                    bytes: MemcmpEncodedBytes::Bytes(owner.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 165,
+                    bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                    encoding: None
+                })
+            ],
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_get_spl_token_mint_filter() {
+        // Filtering on token-v3 length
+        let mint = Pubkey::new_unique();
+        assert_eq!(
+            get_spl_token_mint_filter(
+                &Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap(),
+                &[
+                    RpcFilterType::Memcmp(Memcmp {
+                        offset: 0,
+                        bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                        encoding: None
+                    }),
+                    RpcFilterType::DataSize(165)
+                ],
+            )
+            .unwrap(),
+            mint
+        );
+
+        // Filtering on token-2022 account type
+        assert_eq!(
+            get_spl_token_mint_filter(
+                &Pubkey::from_str("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb").unwrap(),
+                &[
+                    RpcFilterType::Memcmp(Memcmp {
+                        offset: 0,
+                        bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                        encoding: None
+                    }),
+                    RpcFilterType::Memcmp(Memcmp {
+                        offset: 165,
+                        bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                        encoding: None
+                    })
+                ],
+            )
+            .unwrap(),
+            mint
+        );
+
+        // Can't filter on account type for token-v3
+        assert!(get_spl_token_mint_filter(
+            &Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 0,
+                    bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 165,
+                    bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                    encoding: None
+                })
+            ],
+        )
+        .is_none());
+
+        // Filtering on owner instead of mint
+        assert!(get_spl_token_mint_filter(
+            &Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 32,
+                    bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::DataSize(165)
+            ],
+        )
+        .is_none());
+
+        // Wrong program id
+        assert!(get_spl_token_mint_filter(
+            &Pubkey::new_unique(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 0,
+                    bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::DataSize(165)
+            ],
+        )
+        .is_none());
+        assert!(get_spl_token_mint_filter(
+            &Pubkey::new_unique(),
+            &[
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 0,
+                    bytes: MemcmpEncodedBytes::Bytes(mint.to_bytes().to_vec()),
+                    encoding: None
+                }),
+                RpcFilterType::Memcmp(Memcmp {
+                    offset: 165,
+                    bytes: MemcmpEncodedBytes::Bytes(vec![ACCOUNTTYPE_ACCOUNT]),
+                    encoding: None
+                })
             ],
         )
         .is_none());

--- a/runtime/src/inline_spl_token_2022.rs
+++ b/runtime/src/inline_spl_token_2022.rs
@@ -4,7 +4,7 @@ use crate::inline_spl_token::{self, GenericTokenAccount};
 solana_sdk::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 
 // `spl_token_program_2022::extension::AccountType::Account` ordinal value
-const ACCOUNTTYPE_ACCOUNT: u8 = 2;
+pub const ACCOUNTTYPE_ACCOUNT: u8 = 2;
 
 pub struct Account;
 impl GenericTokenAccount for Account {


### PR DESCRIPTION
#### Problem

While running tests for https://github.com/solana-labs/solana-program-library/pull/3071 against master, there were still issues recognizing token-2022 accounts for some of the token-specific RPC endpoints.

#### Summary of Changes

Support token-2022 in a few more places in RPC.  Most of the changes are tests.

A few changes that you might disagree with, so I want to flag them:

* the filter resolution logic for token-2022 is a bit tricky, since a token account can *either* have length 165 or `data[165] == 2`. if someone specifies one of those, should we assume that they actually want all token accounts or truly respect what they say?
* added `program_id` to the UiTokenAccount types, which is helpful in the CLI when figuring out dynamically which program id the account belongs to
* added `ParsableAccount::SplToken2022`, and the program name that comes out is `"spl-token-2022"`