### PR TITLE
keep track of oldest slot used by last hash calculation

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -147,6 +147,14 @@ impl AccountsHashVerifier {
             )
             .unwrap();
 
+        accounts_package
+            .accounts
+            .accounts_db
+            .notify_accounts_hash_calculated_complete(
+                sorted_storages.max_slot_inclusive(),
+                &accounts_package.epoch_schedule,
+            );
+
         assert_eq!(accounts_package.expected_capitalization, lamports);
         if let Some(expected_hash) = accounts_package.accounts_hash_for_testing {
             assert_eq!(expected_hash, accounts_hash);


### PR DESCRIPTION
#### Problem

Squashing slots into ancient append vecs messes up rewrite skipping rehash code for ongoing hash calculations. The idea here is that when a hash calculation is done, it can note the slot it ran at so that squashing can occur on any slot older than an epoch from that slot.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
