### PR TITLE
Revert "Collect stats in streamer receiver and report fetch stage metrics (backport #25010)"

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::integer_arithmetic)]
-
 use {
     clap::{crate_description, crate_name, App, Arg},
     solana_streamer::{
         packet::{Packet, PacketBatch, PacketBatchRecycler, PACKET_DATA_SIZE},
-        streamer::{receiver, PacketBatchReceiver, StreamerReceiveStats},
+        streamer::{receiver, PacketBatchReceiver},
     },
     std::{
         cmp::max,
@@ -83,7 +82,6 @@ fn main() -> Result<()> {
     let mut read_channels = Vec::new();
     let mut read_threads = Vec::new();
     let recycler = PacketBatchRecycler::default();
-    let stats = Arc::new(StreamerReceiveStats::new("bench-streamer-test"));
     for _ in 0..num_sockets {
         let read = solana_net_utils::bind_to(ip_addr, port, false).unwrap();
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
@@ -95,10 +93,10 @@ fn main() -> Result<()> {
         read_channels.push(r_reader);
         read_threads.push(receiver(
             Arc::new(read),
-            exit.clone(),
+            &exit,
             s_reader,
             recycler.clone(),
-            stats.clone(),
+            "bench-streamer-test",
             1,
             true,
         ));

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -23,7 +23,7 @@ use {
         pubkey::Pubkey,
         timing::timestamp,
     },
-    solana_streamer::streamer::{self, PacketBatchReceiver, StreamerReceiveStats},
+    solana_streamer::streamer::{self, PacketBatchReceiver},
     std::{
         collections::HashSet,
         net::UdpSocket,
@@ -150,12 +150,10 @@ impl AncestorHashesService {
         let (response_sender, response_receiver) = channel();
         let t_receiver = streamer::receiver(
             ancestor_hashes_request_socket.clone(),
-            exit.clone(),
+            &exit,
             response_sender,
             Recycler::default(),
-            Arc::new(StreamerReceiveStats::new(
-                "ancestor_hashes_response_receiver",
-            )),
+            "ancestor_hashes_response_receiver",
             1,
             false,
         );
@@ -921,12 +919,10 @@ mod test {
             // Set up response threads
             let t_request_receiver = streamer::receiver(
                 Arc::new(responder_node.sockets.serve_repair),
-                exit.clone(),
+                &exit,
                 requests_sender,
                 Recycler::default(),
-                Arc::new(StreamerReceiveStats::new(
-                    "ancestor_hashes_response_receiver",
-                )),
+                "serve_repair_receiver",
                 1,
                 false,
             );

--- a/core/src/serve_repair_service.rs
+++ b/core/src/serve_repair_service.rs
@@ -2,10 +2,7 @@ use {
     crate::serve_repair::ServeRepair,
     solana_ledger::blockstore::Blockstore,
     solana_perf::recycler::Recycler,
-    solana_streamer::{
-        socket::SocketAddrSpace,
-        streamer::{self, StreamerReceiveStats},
-    },
+    solana_streamer::{socket::SocketAddrSpace, streamer},
     std::{
         net::UdpSocket,
         sync::{atomic::AtomicBool, mpsc::channel, Arc, RwLock},
@@ -34,10 +31,10 @@ impl ServeRepairService {
         );
         let t_receiver = streamer::receiver(
             serve_repair_socket.clone(),
-            exit.clone(),
+            exit,
             request_sender,
             Recycler::default(),
-            Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
+            "serve_repair_receiver",
             1,
             false,
         );

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -11,9 +11,7 @@ use {
     },
     solana_runtime::bank_forks::BankForks,
     solana_sdk::clock::{Slot, DEFAULT_MS_PER_SLOT},
-    solana_streamer::streamer::{
-        self, PacketBatchReceiver, PacketBatchSender, StreamerReceiveStats,
-    },
+    solana_streamer::streamer::{self, PacketBatchReceiver, PacketBatchSender},
     std::{
         net::UdpSocket,
         sync::{atomic::AtomicBool, mpsc::channel, Arc, RwLock},
@@ -150,10 +148,10 @@ impl ShredFetchStage {
             .map(|s| {
                 streamer::receiver(
                     s,
-                    exit.clone(),
+                    exit,
                     packet_sender.clone(),
                     recycler.clone(),
-                    Arc::new(StreamerReceiveStats::new("packet_modifier")),
+                    "packet_modifier",
                     1,
                     true,
                 )

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -13,10 +13,7 @@ use {
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
-    solana_streamer::{
-        socket::SocketAddrSpace,
-        streamer::{self, StreamerReceiveStats},
-    },
+    solana_streamer::{socket::SocketAddrSpace, streamer},
     std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket},
@@ -53,10 +50,10 @@ impl GossipService {
         let socket_addr_space = *cluster_info.socket_addr_space();
         let t_receiver = streamer::receiver(
             gossip_socket.clone(),
-            exit.clone(),
+            exit,
             request_sender,
             Recycler::default(),
-            Arc::new(StreamerReceiveStats::new("gossip_receiver")),
+            "gossip_receiver",
             1,
             false,
         );

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -4,6 +4,7 @@
 use {
     crate::{
         packet::{self, PacketBatch, PacketBatchRecycler, PACKETS_PER_BATCH},
+        recvmmsg::NUM_RCVMMSGS,
         sendmmsg::{batch_send, SendPktsError},
         socket::SocketAddrSpace,
     },
@@ -11,7 +12,7 @@ use {
     std::{
         net::UdpSocket,
         sync::{
-            atomic::{AtomicBool, AtomicUsize, Ordering},
+            atomic::{AtomicBool, Ordering},
             mpsc::{Receiver, RecvTimeoutError, SendError, Sender},
             Arc,
         },
@@ -39,66 +40,24 @@ pub enum StreamerError {
     SendPktsError(#[from] SendPktsError),
 }
 
-pub struct StreamerReceiveStats {
-    pub name: &'static str,
-    pub packets_count: AtomicUsize,
-    pub packet_batches_count: AtomicUsize,
-    pub full_packet_batches_count: AtomicUsize,
-    pub max_channel_len: AtomicUsize,
-}
-
-impl StreamerReceiveStats {
-    pub fn new(name: &'static str) -> Self {
-        Self {
-            name,
-            packets_count: AtomicUsize::default(),
-            packet_batches_count: AtomicUsize::default(),
-            full_packet_batches_count: AtomicUsize::default(),
-            max_channel_len: AtomicUsize::default(),
-        }
-    }
-
-    pub fn report(&self) {
-        datapoint_info!(
-            self.name,
-            (
-                "packets_count",
-                self.packets_count.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
-            (
-                "packet_batches_count",
-                self.packet_batches_count.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
-            (
-                "full_packet_batches_count",
-                self.full_packet_batches_count.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
-            (
-                "channel_len",
-                self.max_channel_len.swap(0, Ordering::Relaxed) as i64,
-                i64
-            ),
-        );
-    }
-}
-
 pub type Result<T> = std::result::Result<T, StreamerError>;
 
 fn recv_loop(
-    socket: &UdpSocket,
+    sock: &UdpSocket,
     exit: Arc<AtomicBool>,
-    packet_batch_sender: &PacketBatchSender,
+    channel: &PacketBatchSender,
     recycler: &PacketBatchRecycler,
-    stats: &StreamerReceiveStats,
+    name: &'static str,
     coalesce_ms: u64,
     use_pinned_memory: bool,
 ) -> Result<()> {
+    let mut recv_count = 0;
+    let mut call_count = 0;
+    let mut now = Instant::now();
+    let mut num_max_received = 0; // Number of times maximum packets were received
     loop {
         let mut packet_batch = if use_pinned_memory {
-            PacketBatch::new_with_recycler(recycler.clone(), PACKETS_PER_BATCH, stats.name)
+            PacketBatch::new_with_recycler(recycler.clone(), PACKETS_PER_BATCH, name)
         } else {
             PacketBatch::with_capacity(PACKETS_PER_BATCH)
         };
@@ -108,49 +67,55 @@ fn recv_loop(
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
-            if let Ok(len) = packet::recv_from(&mut packet_batch, socket, coalesce_ms) {
+            if let Ok(len) = packet::recv_from(&mut packet_batch, sock, coalesce_ms) {
+                if len == NUM_RCVMMSGS {
+                    num_max_received += 1;
+                }
+                recv_count += len;
+                call_count += 1;
                 if len > 0 {
-                    let StreamerReceiveStats {
-                        packets_count,
-                        packet_batches_count,
-                        full_packet_batches_count,
-                        ..
-                    } = stats;
-
-                    packets_count.fetch_add(len, Ordering::Relaxed);
-                    packet_batches_count.fetch_add(1, Ordering::Relaxed);
-                    if len == PACKETS_PER_BATCH {
-                        full_packet_batches_count.fetch_add(1, Ordering::Relaxed);
-                    }
-
-                    packet_batch_sender.send(packet_batch)?;
+                    channel.send(packet_batch)?;
                 }
                 break;
             }
         }
+        if recv_count > 1024 {
+            datapoint_debug!(
+                name,
+                ("received", recv_count as i64, i64),
+                ("call_count", i64::from(call_count), i64),
+                ("elapsed", now.elapsed().as_millis() as i64, i64),
+                ("max_received", i64::from(num_max_received), i64),
+            );
+            recv_count = 0;
+            call_count = 0;
+            num_max_received = 0;
+        }
+        now = Instant::now();
     }
 }
 
 pub fn receiver(
-    socket: Arc<UdpSocket>,
-    exit: Arc<AtomicBool>,
-    packet_batch_sender: PacketBatchSender,
+    sock: Arc<UdpSocket>,
+    exit: &Arc<AtomicBool>,
+    packet_sender: PacketBatchSender,
     recycler: PacketBatchRecycler,
-    stats: Arc<StreamerReceiveStats>,
+    name: &'static str,
     coalesce_ms: u64,
     use_pinned_memory: bool,
 ) -> JoinHandle<()> {
-    let res = socket.set_read_timeout(Some(Duration::new(1, 0)));
-    assert!(res.is_ok(), "streamer::receiver set_read_timeout error");
+    let res = sock.set_read_timeout(Some(Duration::new(1, 0)));
+    assert!(!res.is_err(), "streamer::receiver set_read_timeout error");
+    let exit = exit.clone();
     Builder::new()
         .name("solana-receiver".to_string())
         .spawn(move || {
             let _ = recv_loop(
-                &socket,
+                &sock,
                 exit,
-                &packet_batch_sender,
-                &recycler,
-                &stats,
+                &packet_sender,
+                &recycler.clone(),
+                name,
                 coalesce_ms,
                 use_pinned_memory,
             );
@@ -284,17 +249,15 @@ mod test {
         let send = UdpSocket::bind("127.0.0.1:0").expect("bind");
         let exit = Arc::new(AtomicBool::new(false));
         let (s_reader, r_reader) = channel();
-        let stats = Arc::new(StreamerReceiveStats::new("test"));
         let t_receiver = receiver(
             Arc::new(read),
-            exit.clone(),
+            &exit,
             s_reader,
             Recycler::default(),
-            stats.clone(),
+            "test",
             1,
             true,
         );
-        const NUM_PACKETS: usize = 5;
         let t_responder = {
             let (s_responder, r_responder) = channel();
             let t_responder = responder(
@@ -304,7 +267,7 @@ mod test {
                 SocketAddrSpace::Unspecified,
             );
             let mut packet_batch = PacketBatch::default();
-            for i in 0..NUM_PACKETS {
+            for i in 0..5 {
                 let mut p = Packet::default();
                 {
                     p.data[0] = i as u8;
@@ -317,13 +280,10 @@ mod test {
             t_responder
         };
 
-        let mut packets_remaining = NUM_PACKETS;
+        let mut packets_remaining = 5;
         get_packet_batches(r_reader, &mut packets_remaining);
         assert_eq!(packets_remaining, 0);
         exit.store(true, Ordering::Relaxed);
-        assert_eq!(stats.packets_count.load(Ordering::Relaxed), NUM_PACKETS);
-        assert_eq!(stats.packet_batches_count.load(Ordering::Relaxed), 1);
-        assert_eq!(stats.full_packet_batches_count.load(Ordering::Relaxed), 0);
         t_receiver.join().expect("join");
         t_responder.join().expect("join");
     }


### PR DESCRIPTION
Reverts solana-labs/solana#25021

There were reports of a perf regression on v1.9.21 that could have been caused by this change. It added a lot of contention on atomics in a tight loop.