### PR TITLE
Prioritize transactions in banking stage by their compute unit price

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -89,7 +89,7 @@ pub enum CliCommand {
         timeout: Duration,
         blockhash: Option<Hash>,
         print_timestamp: bool,
-        prioritization_fee: Option<u64>,
+        compute_unit_price: Option<u64>,
     },
     Rent {
         data_length: usize,
@@ -877,7 +877,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             blockhash,
             print_timestamp,
-            prioritization_fee,
+            compute_unit_price,
         } => process_ping(
             &rpc_client,
             config,
@@ -886,7 +886,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             blockhash,
             *print_timestamp,
-            prioritization_fee,
+            compute_unit_price,
         ),
         CliCommand::Rent {
             data_length,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1410,7 +1410,7 @@ pub fn process_ping(
                 lamports,
             )];
             if let Some(prioritization_fee) = prioritization_fee {
-                ixs.push(ComputeBudgetInstruction::set_prioritization_fee(
+                ixs.push(ComputeBudgetInstruction::set_prioritization_fee_rate(
                     *prioritization_fee,
                 ));
             }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -271,12 +271,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Wait up to timeout seconds for transaction confirmation"),
                 )
                 .arg(
-                    Arg::with_name("prioritization-fee")
-                        .long("prioritization-fee")
-                        .alias("additional-fee")
-                        .value_name("NUMBER")
+                    Arg::with_name("compute_unit_price")
+                        .long("compute-unit-price")
+                        .value_name("MICRO-LAMPORTS")
                         .takes_value(true)
-                        .help("Set prioritization-fee for transaction"),
+                        .help("Set the price in micro-lamports of each transaction compute unit"),
                 )
                 .arg(blockhash_arg()),
         )
@@ -523,7 +522,7 @@ pub fn parse_cluster_ping(
     let timeout = Duration::from_secs(value_t_or_exit!(matches, "timeout", u64));
     let blockhash = value_of(matches, BLOCKHASH_ARG.name);
     let print_timestamp = matches.is_present("print_timestamp");
-    let prioritization_fee = value_of(matches, "prioritization_fee");
+    let compute_unit_price = value_of(matches, "compute_unit_price");
     Ok(CliCommandInfo {
         command: CliCommand::Ping {
             interval,
@@ -531,7 +530,7 @@ pub fn parse_cluster_ping(
             timeout,
             blockhash,
             print_timestamp,
-            prioritization_fee,
+            compute_unit_price,
         },
         signers: vec![default_signer.signer_from_path(matches, wallet_manager)?],
     })
@@ -1364,7 +1363,7 @@ pub fn process_ping(
     timeout: &Duration,
     fixed_blockhash: &Option<Hash>,
     print_timestamp: bool,
-    prioritization_fee: &Option<u64>,
+    compute_unit_price: &Option<u64>,
 ) -> ProcessResult {
     let (signal_sender, signal_receiver) = unbounded();
     ctrlc::set_handler(move || {
@@ -1409,9 +1408,9 @@ pub fn process_ping(
                 &to,
                 lamports,
             )];
-            if let Some(prioritization_fee) = prioritization_fee {
-                ixs.push(ComputeBudgetInstruction::set_prioritization_fee_rate(
-                    *prioritization_fee,
+            if let Some(compute_unit_price) = compute_unit_price {
+                ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+                    *compute_unit_price,
                 ));
             }
             Message::new(&ixs, Some(&config.signers[0].pubkey()))
@@ -2338,7 +2337,7 @@ mod tests {
                         Hash::from_str("4CCNp28j6AhGq7PkjPDP4wbQWBS8LLbQin2xV5n8frKX").unwrap()
                     ),
                     print_timestamp: true,
-                    prioritization_fee: None,
+                    compute_unit_price: None,
                 },
                 signers: vec![default_keypair.into()],
             }

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -74,7 +74,7 @@ fn insert_packet_batches(
         } else {
             build_packet_batch(packet_per_batch_count)
         };
-        let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes, None);
+        let deserialized_packets = deserialize_packets(&packet_batch, &packet_indexes);
         unprocessed_packet_batches.insert_batch(deserialized_packets);
     });
     timer.stop();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2110,7 +2110,7 @@ impl BankingStage {
 
             let number_of_dropped_packets = unprocessed_packet_batches.insert_batch(
                 // Passing `None` for bank for now will make all packet weights 0
-                unprocessed_packet_batches::deserialize_packets(packet_batch, packet_indexes, None),
+                unprocessed_packet_batches::deserialize_packets(packet_batch, packet_indexes),
             );
 
             saturating_add_assign!(*dropped_packets_count, number_of_dropped_packets);
@@ -3236,7 +3236,7 @@ mod tests {
                 let transaction = system_transaction::transfer(&keypair, &pubkey, 1, blockhash);
                 let mut p = Packet::from_data(None, &transaction).unwrap();
                 p.meta.port = packets_id;
-                DeserializedPacket::new(p, None).unwrap()
+                DeserializedPacket::new(p).unwrap()
             })
             .collect_vec();
 
@@ -4022,7 +4022,7 @@ mod tests {
             Hash::new_unique(),
         );
         let packet = Packet::from_data(None, &tx).unwrap();
-        let deserialized_packet = DeserializedPacket::new(packet, None).unwrap();
+        let deserialized_packet = DeserializedPacket::new(packet).unwrap();
 
         let genesis_config_info = create_slow_genesis_config(10_000);
         let GenesisConfigInfo {
@@ -4101,14 +4101,14 @@ mod tests {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, fwd_block_hash);
             let mut packet = Packet::from_data(None, &transaction).unwrap();
             packet.meta.flags |= PacketFlags::FORWARDED;
-            DeserializedPacket::new(packet, None).unwrap()
+            DeserializedPacket::new(packet).unwrap()
         };
 
         let normal_block_hash = Hash::new_unique();
         let normal_packet = {
             let transaction = system_transaction::transfer(&keypair, &pubkey, 1, normal_block_hash);
             let packet = Packet::from_data(None, &transaction).unwrap();
-            DeserializedPacket::new(packet, None).unwrap()
+            DeserializedPacket::new(packet).unwrap()
         };
 
         let mut unprocessed_packet_batches: UnprocessedPacketBatches =
@@ -4229,7 +4229,7 @@ mod tests {
 
         packet_vector
             .into_iter()
-            .map(|p| DeserializedPacket::new(p, None).unwrap())
+            .map(|p| DeserializedPacket::new(p).unwrap())
             .collect()
     }
 

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -376,7 +376,7 @@ pub fn packet_message(packet: &Packet) -> Result<&[u8], DeserializedPacketError>
 
 fn get_prioritization_fee_rate(message: &SanitizedVersionedMessage) -> Option<u64> {
     let mut compute_budget = ComputeBudget::default();
-    let prioritization_fee_rate = compute_budget
+    let prioritization_fee_details = compute_budget
         .process_instructions(
             message.program_instructions_iter(),
             false, // not request heap size
@@ -384,7 +384,7 @@ fn get_prioritization_fee_rate(message: &SanitizedVersionedMessage) -> Option<u6
             true,  // use changed prioritization fee
         )
         .ok()?;
-    Some(prioritization_fee_rate)
+    Some(prioritization_fee_details.get_priority())
 }
 
 pub fn transactions_to_deserialized_packets(

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -104,13 +104,12 @@ for more information.
 A transaction may set the maximum number of compute units it is allowed to
 consume by including a "request units"
 [`ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
-Note that a transaction's prioritization fee is calculated from the number of
-compute units requested if a transaction also sets a "prioritization fee rate".
-The "prioritization fee rate" is measured in lamports per 10K requested compute
-units so transactions should request the minimum amount of compute units
-required for execution to minimize fees. Fees are not adjusted when the number
-of requested compute units exceeds the number of compute units consumed by an
-executed transaction.
+Note that a transaction's prioritization fee is calculated from multiplying the
+number of compute units requested by the compute unit price (measured in
+milli-lamports) set by the transaction.  So transactions should request the
+minimum amount of compute units required for execution to minimize fees. Also
+note that fees are not adjusted when the number of requested compute units
+exceeds the number of compute units consumed by an executed transaction.
 
 Compute Budget instructions don't require any accounts and don't consume any
 compute units to process.  Transactions can only contain one of each type of
@@ -146,8 +145,12 @@ Clients should request only what they need; requesting the minimum amount of
 units required to process the transaction will reduce overall transaction cost,
 which includes prioritization-fee for every 10K compute-units.
 
-Prioritization_fee is what transaction prioritization based on, it can be set by
-`ComputeBudgetInstruction::set_prioritization_fee` function.
+Transaction prioritization is determined by the transactions prioritization fee
+which itself is the produce of the transaction's compute unit budget and its
+compute unit price (measured in micro-lamports). The compute unit budget and
+compute unit fee can be set by adding instructions created by the
+`ComputeBudgetInstruction::request_compute_units` and
+`ComputeBudgetInstruction::set_compute_unit_price` function, respectively.
 
 ## New Features
 

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -101,12 +101,16 @@ At runtime a program may log how much of the compute budget remains. See
 [debugging](developing/on-chain-programs/debugging.md#monitoring-compute-budget-consumption)
 for more information.
 
-A transaction may request a specific level of `max_units` it is allowed to
-consume by including a
-[``ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
-Transaction overall cost include prioritization-fee for every 10K compute-units,
-so transaction should request the minimum amount of compute units required
-for them to process.
+A transaction may set the maximum number of compute units it is allowed to
+consume by including a "request units"
+[`ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
+Note that a transaction's prioritization fee is calculated from the number of
+compute units requested if a transaction also sets a "prioritization fee rate".
+The "prioritization fee rate" is measured in lamports per 10K requested compute
+units so transactions should request the minimum amount of compute units
+required for execution to minimize fees. Fees are not adjusted when the number
+of requested compute units exceeds the number of compute units consumed by an
+executed transaction.
 
 Compute Budget instructions don't require any accounts and don't consume any
 compute units to process.  Transactions can only contain one of each type of
@@ -132,14 +136,15 @@ Budget](#compute-budget).
 The transaction-wide compute budget applies the `max_units` cap to the entire
 transaction rather than to each instruction within the transaction. The default
 transaction-wide `max_units` will be calculated as the product of the number of
-instructions in the transaction by the default per-instruction units, which is
-currently 200k. During processing, the sum of the compute units used by each
-instruction in the transaction must not exceed that value. This default value
-attempts to retain existing behavior to avoid breaking clients. Transactions can
-request a specific number of `max_units` via [Compute Budget](#compute-budget)
-instructions.  Clients should request only what they need; requesting the
-minimum amount of units required to process the transaction will reduce overall
-transaction cost, which includes prioritization-fee for every 10K compute-units.
+instructions in the transaction (excluding [Compute Budget](#compute-budget)
+instructions) by the default per-instruction units, which is currently 200k.
+During processing, the sum of the compute units used by each instruction in the
+transaction must not exceed that value. This default value attempts to retain
+existing behavior to avoid breaking clients. Transactions can request a specific
+number of `max_units` via [Compute Budget](#compute-budget) instructions.
+Clients should request only what they need; requesting the minimum amount of
+units required to process the transaction will reduce overall transaction cost,
+which includes prioritization-fee for every 10K compute-units.
 
 Prioritization_fee is what transaction prioritization based on, it can be set by
 `ComputeBudgetInstruction::set_prioritization_fee` function.

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -104,8 +104,9 @@ for more information.
 A transaction may request a specific level of `max_units` it is allowed to
 consume by including a
 [``ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
-Transaction prioritization depends on the fee/compute-unit ratio so transaction
-should request the minimum amount of compute units required for them to process.
+Transaction overall cost include prioritization-fee for every 10K compute-units, 
+so transaction should request the minimum amount of compute units required
+for them to process.
 
 Compute Budget instructions don't require any accounts and don't consume any
 compute units to process.  Transactions can only contain one of each type of
@@ -137,8 +138,11 @@ instruction in the transaction must not exceed that value. This default value
 attempts to retain existing behavior to avoid breaking clients. Transactions can
 request a specific number of `max_units` via [Compute Budget](#compute-budget)
 instructions.  Clients should request only what they need; requesting the
-minimum amount of units required to process the transaction will improve their
-fee/compute-unit ratio, which transaction prioritization is based on.
+minimum amount of units required to process the transaction will reduce overall
+transaction cost, which includes prioritization-fee for every 10K compute-units.
+
+Prioritization_fee is what transaction prioritization based on, it can be set by
+`ComputeBudgetInstruction::set_prioritization_fee` function.
 
 ## New Features
 

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -104,7 +104,7 @@ for more information.
 A transaction may request a specific level of `max_units` it is allowed to
 consume by including a
 [``ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
-Transaction overall cost include prioritization-fee for every 10K compute-units, 
+Transaction overall cost include prioritization-fee for every 10K compute-units,
 so transaction should request the minimum amount of compute units required
 for them to process.
 

--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -106,7 +106,7 @@ consume by including a "request units"
 [`ComputeBudgetInstruction`](https://github.com/solana-labs/solana/blob/db32549c00a1b5370fcaf128981ad3323bbd9570/sdk/src/compute_budget.rs#L39).
 Note that a transaction's prioritization fee is calculated from multiplying the
 number of compute units requested by the compute unit price (measured in
-milli-lamports) set by the transaction.  So transactions should request the
+micro-lamports) set by the transaction.  So transactions should request the
 minimum amount of compute units required for execution to minimize fees. Also
 note that fees are not adjusted when the number of requested compute units
 exceeds the number of compute units consumed by an executed transaction.
@@ -143,10 +143,10 @@ existing behavior to avoid breaking clients. Transactions can request a specific
 number of `max_units` via [Compute Budget](#compute-budget) instructions.
 Clients should request only what they need; requesting the minimum amount of
 units required to process the transaction will reduce overall transaction cost,
-which includes prioritization-fee for every 10K compute-units.
+which may include a prioritization-fee charged for every compute unit.
 
 Transaction prioritization is determined by the transactions prioritization fee
-which itself is the produce of the transaction's compute unit budget and its
+which itself is the product of the transaction's compute unit budget and its
 compute unit price (measured in micro-lamports). The compute unit budget and
 compute unit fee can be set by adding instructions created by the
 `ComputeBudgetInstruction::request_compute_units` and

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -170,7 +170,7 @@ impl ComputeBudget {
                             }
                             requested_units = Some(units as u64);
                         }
-                        Ok(ComputeBudgetInstruction::SetPrioritizationFee(fee)) => {
+                        Ok(ComputeBudgetInstruction::SetPrioritizationFeeRate(fee)) => {
                             if prioritization_fee.is_some() {
                                 return Err(duplicate_instruction_error);
                             }
@@ -367,7 +367,7 @@ mod tests {
         test!(
             &[
                 ComputeBudgetInstruction::request_units(1),
-                ComputeBudgetInstruction::set_prioritization_fee(42)
+                ComputeBudgetInstruction::set_prioritization_fee_rate(42)
             ],
             Ok(42),
             ComputeBudget {
@@ -490,7 +490,7 @@ mod tests {
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
                 ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES),
                 ComputeBudgetInstruction::request_units(MAX_UNITS),
-                ComputeBudgetInstruction::set_prioritization_fee(u64::MAX),
+                ComputeBudgetInstruction::set_prioritization_fee_rate(u64::MAX),
             ],
             Ok(u64::MAX),
             ComputeBudget {
@@ -505,7 +505,7 @@ mod tests {
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
                 ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES),
                 ComputeBudgetInstruction::request_units(MAX_UNITS),
-                ComputeBudgetInstruction::set_prioritization_fee(u64::MAX),
+                ComputeBudgetInstruction::set_prioritization_fee_rate(u64::MAX),
             ],
             Err(TransactionError::InstructionError(
                 0,
@@ -520,7 +520,7 @@ mod tests {
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
                 ComputeBudgetInstruction::request_units(1),
                 ComputeBudgetInstruction::request_heap_frame(MAX_HEAP_FRAME_BYTES),
-                ComputeBudgetInstruction::set_prioritization_fee(u64::MAX),
+                ComputeBudgetInstruction::set_prioritization_fee_rate(u64::MAX),
             ],
             Ok(u64::MAX),
             ComputeBudget {
@@ -569,8 +569,8 @@ mod tests {
         test!(
             &[
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
-                ComputeBudgetInstruction::set_prioritization_fee(0),
-                ComputeBudgetInstruction::set_prioritization_fee(u64::MAX),
+                ComputeBudgetInstruction::set_prioritization_fee_rate(0),
+                ComputeBudgetInstruction::set_prioritization_fee_rate(u64::MAX),
             ],
             Err(TransactionError::DuplicateInstruction(2)),
             ComputeBudget::default()

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -132,7 +132,7 @@ impl ComputeBudget {
         default_units_per_instruction: bool,
         prioritization_fee_type_change: bool,
     ) -> Result<PrioritizationFeeDetails, TransactionError> {
-        let mut num_instructions: usize = 0;
+        let mut num_non_compute_budget_instructions: usize = 0;
         let mut requested_units = None;
         let mut requested_heap_size = None;
         let mut prioritization_fee = None;
@@ -205,7 +205,8 @@ impl ComputeBudget {
                 }
             } else {
                 // only include non-request instructions in default max calc
-                num_instructions = num_instructions.saturating_add(1);
+                num_non_compute_budget_instructions =
+                    num_non_compute_budget_instructions.saturating_add(1);
             }
         }
 
@@ -224,8 +225,12 @@ impl ComputeBudget {
         }
 
         self.max_units = if default_units_per_instruction {
-            requested_units
-                .or_else(|| Some(num_instructions.saturating_mul(DEFAULT_UNITS as usize) as u64))
+            requested_units.or_else(|| {
+                Some(
+                    num_non_compute_budget_instructions.saturating_mul(DEFAULT_UNITS as usize)
+                        as u64,
+                )
+            })
         } else {
             requested_units
         }

--- a/program-runtime/src/lib.rs
+++ b/program-runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod invoke_context;
 pub mod log_collector;
 pub mod neon_evm_program;
 pub mod pre_account;
+pub mod prioritization_fee;
 pub mod stable_log;
 pub mod sysvar_cache;
 pub mod timings;

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -1,0 +1,183 @@
+// Prioritization fee rate is 1 lamports per 10K CUs
+const COMPUTE_UNIT_TICK_SIZE: u64 = 10_000;
+
+pub enum PrioritizationFeeType {
+    Rate(u64),
+    Deprecated(u64),
+}
+
+#[derive(Default, Debug, PartialEq)]
+pub struct PrioritizationFeeDetails {
+    fee: u64,
+    priority: u64,
+}
+
+impl PrioritizationFeeDetails {
+    pub fn new(fee_type: PrioritizationFeeType, max_compute_units: u64) -> Self {
+        let mut compute_ticks = max_compute_units
+            .saturating_div(COMPUTE_UNIT_TICK_SIZE)
+            .max(1);
+        match fee_type {
+            PrioritizationFeeType::Deprecated(fee) => Self {
+                fee,
+                priority: fee.saturating_div(compute_ticks),
+            },
+            PrioritizationFeeType::Rate(fee_rate) => {
+                if compute_ticks * COMPUTE_UNIT_TICK_SIZE < max_compute_units {
+                    compute_ticks = compute_ticks.saturating_add(1);
+                }
+
+                Self {
+                    fee: fee_rate.saturating_mul(compute_ticks),
+                    priority: fee_rate,
+                }
+            }
+        }
+    }
+
+    pub fn get_fee(&self) -> u64 {
+        self.fee
+    }
+
+    pub fn get_priority(&self) -> u64 {
+        self.priority
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{PrioritizationFeeDetails as FeeDetails, PrioritizationFeeType as FeeType, *};
+
+    #[test]
+    fn test_new_with_no_fee() {
+        for compute_units in [0, 1, COMPUTE_UNIT_TICK_SIZE, u64::MAX] {
+            assert_eq!(
+                FeeDetails::new(FeeType::Rate(0), compute_units),
+                FeeDetails::default(),
+            );
+            assert_eq!(
+                FeeDetails::new(FeeType::Deprecated(0), compute_units),
+                FeeDetails::default(),
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_with_one_compute_tick() {
+        for compute_units in [
+            0, // zero compute units should be rounded up to 1 tick
+            1, // compute units are rounded up to the nearest tick
+            COMPUTE_UNIT_TICK_SIZE,
+        ] {
+            for fee_type_value in [0, 1, 100, u64::MAX] {
+                let expected_details = FeeDetails {
+                    fee: fee_type_value,
+                    priority: fee_type_value,
+                };
+                assert_eq!(
+                    FeeDetails::new(FeeType::Rate(fee_type_value), compute_units),
+                    expected_details,
+                );
+
+                assert_eq!(
+                    FeeDetails::new(FeeType::Deprecated(fee_type_value), compute_units),
+                    expected_details,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_with_fee_rate() {
+        assert_eq!(
+            FeeDetails::new(FeeType::Rate(2), 42 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: 2 * 42,
+                priority: 2,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Rate(2), 42 * COMPUTE_UNIT_TICK_SIZE - 1),
+            FeeDetails {
+                fee: 2 * 42,
+                priority: 2,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Rate(u64::MAX), 42 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: u64::MAX,
+                priority: u64::MAX,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Rate(u64::MAX), u64::MAX),
+            FeeDetails {
+                fee: u64::MAX,
+                priority: u64::MAX,
+            },
+        );
+    }
+
+    #[test]
+    fn test_new_with_deprecated_fee() {
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(2), 42 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: 2,
+                priority: 0,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(42), 42 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: 42,
+                priority: 1,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(42), 42 * COMPUTE_UNIT_TICK_SIZE - 1),
+            FeeDetails {
+                fee: 42,
+                priority: 1,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(42), 42 * COMPUTE_UNIT_TICK_SIZE + 1),
+            FeeDetails {
+                fee: 42,
+                priority: 1,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(420), 42 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: 420,
+                priority: 10,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(u64::MAX), 2 * COMPUTE_UNIT_TICK_SIZE),
+            FeeDetails {
+                fee: u64::MAX,
+                priority: u64::MAX / 2,
+            },
+        );
+
+        assert_eq!(
+            FeeDetails::new(FeeType::Deprecated(u64::MAX), u64::MAX),
+            FeeDetails {
+                fee: u64::MAX,
+                priority: COMPUTE_UNIT_TICK_SIZE,
+            },
+        );
+    }
+}

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -33,11 +33,9 @@ impl PrioritizationFeeDetails {
                 let fee = {
                     let micro_lamport_fee: MicroLamports =
                         (cu_price as u128).saturating_mul(max_compute_units as u128);
-                    let mut fee =
-                        micro_lamport_fee.saturating_div(MICRO_LAMPORTS_PER_LAMPORT as u128);
-                    if fee.saturating_mul(MICRO_LAMPORTS_PER_LAMPORT as u128) < micro_lamport_fee {
-                        fee = fee.saturating_add(1);
-                    }
+                    let fee = micro_lamport_fee
+                        .saturating_add(MICRO_LAMPORTS_PER_LAMPORT.saturating_sub(1) as u128)
+                        .saturating_div(MICRO_LAMPORTS_PER_LAMPORT as u128);
                     u64::try_from(fee).unwrap_or(u64::MAX)
                 };
 

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -23,7 +23,7 @@ impl PrioritizationFeeDetails {
                 priority: fee.saturating_div(compute_ticks),
             },
             PrioritizationFeeType::Rate(fee_rate) => {
-                if compute_ticks * COMPUTE_UNIT_TICK_SIZE < max_compute_units {
+                if compute_ticks.saturating_mul(COMPUTE_UNIT_TICK_SIZE) < max_compute_units {
                     compute_ticks = compute_ticks.saturating_add(1);
                 }
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3505,7 +3505,7 @@ fn test_program_fees() {
     let pre_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     let message = Message::new(
         &[
-            ComputeBudgetInstruction::set_prioritization_fee_rate(1),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
             Instruction::new_with_bytes(program_id, &[], vec![]),
         ],
         Some(&mint_keypair.pubkey()),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3489,7 +3489,7 @@ fn test_program_fees() {
     );
 
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
-    let expected_max_fee = Bank::calculate_fee(
+    let expected_normal_fee = Bank::calculate_fee(
         &sanitized_message,
         congestion_multiplier,
         &fee_structure,
@@ -3500,32 +3500,32 @@ fn test_program_fees() {
         .send_and_confirm_message(&[&mint_keypair], message)
         .unwrap();
     let post_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
-    assert_eq!(pre_balance - post_balance, expected_max_fee);
+    assert_eq!(pre_balance - post_balance, expected_normal_fee);
 
     let pre_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     let message = Message::new(
         &[
             ComputeBudgetInstruction::request_units(100),
-            ComputeBudgetInstruction::set_prioritization_fee_rate(42),
+            ComputeBudgetInstruction::set_prioritization_fee_rate(1),
             Instruction::new_with_bytes(program_id, &[], vec![]),
         ],
         Some(&mint_keypair.pubkey()),
     );
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
-    let expected_min_fee = Bank::calculate_fee(
+    let expected_prioritized_fee = Bank::calculate_fee(
         &sanitized_message,
         congestion_multiplier,
         &fee_structure,
         true,
         true,
     );
-    assert!(expected_min_fee < expected_max_fee);
+    assert!(expected_normal_fee < expected_prioritized_fee);
 
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
         .unwrap();
     let post_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
-    assert_eq!(pre_balance - post_balance, expected_min_fee);
+    assert_eq!(pre_balance - post_balance, expected_prioritized_fee);
 }
 
 #[test]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3506,7 +3506,7 @@ fn test_program_fees() {
     let message = Message::new(
         &[
             ComputeBudgetInstruction::request_units(100),
-            ComputeBudgetInstruction::set_prioritization_fee(42),
+            ComputeBudgetInstruction::set_prioritization_fee_rate(42),
             Instruction::new_with_bytes(program_id, &[], vec![]),
         ],
         Some(&mint_keypair.pubkey()),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3505,7 +3505,6 @@ fn test_program_fees() {
     let pre_balance = bank_client.get_balance(&mint_keypair.pubkey()).unwrap();
     let message = Message::new(
         &[
-            ComputeBudgetInstruction::request_units(100),
             ComputeBudgetInstruction::set_prioritization_fee_rate(1),
             Instruction::new_with_bytes(program_id, &[], vec![]),
         ],

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -31,7 +31,7 @@ use {
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot, INITIAL_RENT_EPOCH},
-        feature_set::{self, prioritization_fee_type_change, tx_wide_compute_cap, FeatureSet},
+        feature_set::{self, add_set_compute_unit_price_ix, tx_wide_compute_cap, FeatureSet},
         fee::FeeStructure,
         genesis_config::ClusterType,
         hash::Hash,
@@ -525,7 +525,7 @@ impl Accounts {
                             lamports_per_signature,
                             fee_structure,
                             feature_set.is_active(&tx_wide_compute_cap::id()),
-                            feature_set.is_active(&prioritization_fee_type_change::id()),
+                            feature_set.is_active(&add_set_compute_unit_price_ix::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -16792,11 +16792,14 @@ pub(crate) mod tests {
             (1_500_000, 0.0), // ComputeBudget capped
         ];
         for pair in expected_fee_structure.iter() {
-            const PRIORITIZATION_FEE: u64 = 42;
+            const PRIORITIZATION_FEE_RATE: u64 = 42;
+            const PRIORITIZATION_TICK_SIZE: u64 = 10_000;
+            let prioritization_fee =
+                PRIORITIZATION_FEE_RATE.saturating_mul(PRIORITIZATION_TICK_SIZE);
             let message = SanitizedMessage::try_from(Message::new(
                 &[
                     ComputeBudgetInstruction::request_units(pair.0),
-                    ComputeBudgetInstruction::set_prioritization_fee_rate(PRIORITIZATION_FEE),
+                    ComputeBudgetInstruction::set_prioritization_fee_rate(PRIORITIZATION_FEE_RATE),
                     Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
                 ],
                 Some(&Pubkey::new_unique()),
@@ -16805,7 +16808,7 @@ pub(crate) mod tests {
             let fee = Bank::calculate_fee(&message, 1, &fee_structure, true, true);
             assert_eq!(
                 fee,
-                sol_to_lamports(pair.1) + lamports_per_signature + PRIORITIZATION_FEE
+                sol_to_lamports(pair.1) + lamports_per_signature + prioritization_fee
             );
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4632,6 +4632,11 @@ impl Bank {
                     prioritization_fee_type_change,
                 )
                 .unwrap_or_default();
+            let prioritization_fee = if prioritization_fee_type_change {
+                prioritization_fee_rate.saturating_mul(PRIORITIZATION_FEE_RATE_UNITS)
+            } else {
+                prioritization_fee_rate
+            };
             let signature_fee = Self::get_num_signatures_in_message(message)
                 .saturating_mul(fee_structure.lamports_per_signature);
             let write_lock_fee = Self::get_num_write_locks_in_message(message)
@@ -4649,8 +4654,7 @@ impl Bank {
                         .unwrap_or_default()
                 });
 
-            ((prioritization_fee_rate
-                .saturating_mul(PRIORITIZATION_FEE_RATE_UNITS)
+            ((prioritization_fee
                 .saturating_add(signature_fee)
                 .saturating_add(write_lock_fee)
                 .saturating_add(compute_fee) as f64)
@@ -16792,7 +16796,7 @@ pub(crate) mod tests {
             let message = SanitizedMessage::try_from(Message::new(
                 &[
                     ComputeBudgetInstruction::request_units(pair.0),
-                    ComputeBudgetInstruction::set_prioritization_fee(PRIORITIZATION_FEE),
+                    ComputeBudgetInstruction::set_prioritization_fee_rate(PRIORITIZATION_FEE),
                     Instruction::new_with_bincode(Pubkey::new_unique(), &0, vec![]),
                 ],
                 Some(&Pubkey::new_unique()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4389,8 +4389,8 @@ impl Bank {
                         if tx_wide_compute_cap {
                             let mut compute_budget_process_transaction_time =
                                 Measure::start("compute_budget_process_transaction_time");
-                            let process_transaction_result = compute_budget.process_message(
-                                tx.message(),
+                            let process_transaction_result = compute_budget.process_instructions(
+                                tx.message().program_instructions_iter(),
                                 feature_set.is_active(&requestable_heap_size::id()),
                                 feature_set.is_active(&default_units_per_instruction::id()),
                                 feature_set.is_active(&prioritization_fee_type_change::id()),
@@ -4623,7 +4623,12 @@ impl Bank {
 
             let mut compute_budget = ComputeBudget::default();
             let prioritization_fee = compute_budget
-                .process_message(message, false, false, prioritization_fee_type_change)
+                .process_instructions(
+                    message.program_instructions_iter(),
+                    false,
+                    false,
+                    prioritization_fee_type_change,
+                )
                 .unwrap_or_default();
             let signature_fee = Self::get_num_signatures_in_message(message)
                 .saturating_mul(fee_structure.lamports_per_signature);

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -35,9 +35,9 @@ pub enum ComputeBudgetInstruction {
     /// Request a specific maximum number of compute units the transaction is
     /// allowed to consume and an additional fee to pay.
     RequestUnits(u32),
-    /// Set a prioritization fee rate measured in "lamports per 10K CUs" to
-    /// pay a higher transaction fee for higher transaction prioritization.
-    SetPrioritizationFeeRate(u64),
+    /// Set a compute unit price in "micro-lamports" to pay a higher transaction
+    /// fee for higher transaction prioritization.
+    SetComputeUnitPrice(u64),
 }
 
 impl ComputeBudgetInstruction {
@@ -51,8 +51,8 @@ impl ComputeBudgetInstruction {
         Instruction::new_with_borsh(id(), &Self::RequestUnits(units), vec![])
     }
 
-    /// Create a `ComputeBudgetInstruction::SetPrioritizationFeeRate` `Instruction`
-    pub fn set_prioritization_fee_rate(fee_rate: u64) -> Instruction {
-        Instruction::new_with_borsh(id(), &Self::SetPrioritizationFeeRate(fee_rate), vec![])
+    /// Create a `ComputeBudgetInstruction::SetComputeUnitPrice` `Instruction`
+    pub fn set_compute_unit_price(micro_lamports: u64) -> Instruction {
+        Instruction::new_with_borsh(id(), &Self::SetComputeUnitPrice(micro_lamports), vec![])
     }
 }

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -35,8 +35,8 @@ pub enum ComputeBudgetInstruction {
     /// Request a specific maximum number of compute units the transaction is
     /// allowed to consume and an additional fee to pay.
     RequestUnits(u32),
-    /// Additional fee in lamports to charge the payer, used for transaction
-    /// prioritization
+    /// Additional fee in "lamports per 10K CUs" to charge the payer, used for
+    /// transaction prioritization
     SetPrioritizationFee(u64),
 }
 

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -35,8 +35,8 @@ pub enum ComputeBudgetInstruction {
     /// Request a specific maximum number of compute units the transaction is
     /// allowed to consume and an additional fee to pay.
     RequestUnits(u32),
-    /// Set a prioritization fee rate in "lamports per 10K CUs" to charge the payer,
-    /// used for transaction prioritization
+    /// Set a prioritization fee rate measured in "lamports per 10K CUs" to
+    /// pay a higher transaction fee for higher transaction prioritization.
     SetPrioritizationFeeRate(u64),
 }
 

--- a/sdk/src/compute_budget.rs
+++ b/sdk/src/compute_budget.rs
@@ -35,9 +35,9 @@ pub enum ComputeBudgetInstruction {
     /// Request a specific maximum number of compute units the transaction is
     /// allowed to consume and an additional fee to pay.
     RequestUnits(u32),
-    /// Additional fee in "lamports per 10K CUs" to charge the payer, used for
-    /// transaction prioritization
-    SetPrioritizationFee(u64),
+    /// Set a prioritization fee rate in "lamports per 10K CUs" to charge the payer,
+    /// used for transaction prioritization
+    SetPrioritizationFeeRate(u64),
 }
 
 impl ComputeBudgetInstruction {
@@ -51,8 +51,8 @@ impl ComputeBudgetInstruction {
         Instruction::new_with_borsh(id(), &Self::RequestUnits(units), vec![])
     }
 
-    /// Create a `ComputeBudgetInstruction::SetPrioritizationFee` `Instruction`
-    pub fn set_prioritization_fee(fee: u64) -> Instruction {
-        Instruction::new_with_borsh(id(), &Self::SetPrioritizationFee(fee), vec![])
+    /// Create a `ComputeBudgetInstruction::SetPrioritizationFeeRate` `Instruction`
+    pub fn set_prioritization_fee_rate(fee_rate: u64) -> Instruction {
+        Instruction::new_with_borsh(id(), &Self::SetPrioritizationFeeRate(fee_rate), vec![])
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -396,8 +396,12 @@ pub mod stake_raise_minimum_delegation_to_1_sol {
     solana_sdk::declare_id!("4xmyBuR2VCXzy9H6qYpH9ckfgnTuMDQFPFBfTs4eBCY1");
 }
 
-pub mod prioritization_fee_type_change {
+pub mod add_set_compute_unit_price_ix {
     solana_sdk::declare_id!("98std1NSHqXi9WYvFShfVepRdCoq1qvsp8fsR2XZtG8g");
+}
+
+pub mod disable_deploy_of_alloc_free_syscall {
+    solana_sdk::declare_id!("79HWsX9rpnnJBPcdNURVqygpMAfxdrAirzAGAVmf92im");
 }
 
 lazy_static! {
@@ -492,7 +496,8 @@ lazy_static! {
         (stake_allow_zero_undelegated_amount::id(), "Allow zero-lamport undelegated amount for initialized stakes #24670"),
         (require_static_program_ids_in_transaction::id(), "require static program ids in versioned transactions"),
         (stake_raise_minimum_delegation_to_1_sol::id(), "Raise minimum stake delegation to 1.0 SOL #24357"),
-        (prioritization_fee_type_change::id(), "Switch compute budget to prioritization fee"),
+        (add_set_compute_unit_price_ix::id(), "add compute budget ix for setting a compute unit price"),
+        (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problems
- The `ComputeBudget::SetPrioritizationFee` instruction doesn't let users directly set the relative priority of their transactions and it forces banking stage to do extra arithmetic to determine transaction priority
- Banking stage doesn't calculate transaction priority yet.

#### Summary of Changes
- Migrated `ComputeBudget::SetPrioritizationFee` to `ComputeBudget::SetComputeUnitPrice` where compute unit price is measured in "micro-lamports"
- Renamed the `prioritization_fee_type_change` feature to `add_set_compute_unit_price_ix`
- Banking stage now prioritizes transactions based on compute budget instructions (not feature gated)
- Updated prioritization fee calculations for instructions that use the `ComputeBudget::SetComputeUnitPrice` instruction (feature gated)
- Updated docs

Fixes #24615 
(Updated) Feature Gate Issue: https://github.com/solana-labs/solana/issues/25050
<!-- Don't forget to add the "feature-gate" label -->
