### PR TITLE
fix: mark the socket as closed when receiving a close/error message

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4174,6 +4174,7 @@ export class Connection {
    * @internal
    */
   _wsOnError(err: Error) {
+    this._rpcWebSocketConnected = false;
     console.error('ws error:', err.message);
   }
 
@@ -4181,6 +4182,7 @@ export class Connection {
    * @internal
    */
   _wsOnClose(code: number) {
+    this._rpcWebSocketConnected = false;
     this._rpcWebSocketGeneration++;
     if (this._rpcWebSocketHeartbeat) {
       clearInterval(this._rpcWebSocketHeartbeat);

--- a/web3.js/test/connection-subscriptions.test.ts
+++ b/web3.js/test/connection-subscriptions.test.ts
@@ -518,9 +518,35 @@ describe('Subscriptions', () => {
                   );
                 });
               });
+              describe('then having the socket connection error', () => {
+                beforeEach(() => {
+                  stubbedSocket.emit(
+                    'error',
+                    new Error('A bad thing happened to the socket'),
+                  );
+                });
+                describe('making another subscription while disconnected', () => {
+                  beforeEach(() => {
+                    stubbedSocket.call.resetHistory();
+                    setupListener(spy());
+                  });
+                  it('does not issue an RPC call', () => {
+                    expect(stubbedSocket.call).not.to.have.been.called;
+                  });
+                });
+              });
               describe('then having the socket connection drop unexpectedly', () => {
                 beforeEach(() => {
                   stubbedSocket.emit('close');
+                });
+                describe('making another subscription while disconnected', () => {
+                  beforeEach(() => {
+                    stubbedSocket.call.resetHistory();
+                    setupListener(spy());
+                  });
+                  it('does not issue an RPC call', () => {
+                    expect(stubbedSocket.call).not.to.have.been.called;
+                  });
                 });
                 describe('upon the socket connection reopening', () => {
                   let fatalPriorUnubscribe;


### PR DESCRIPTION
#### Problem

In #25133 @awojciak noticed that the subscriptions manager would keep trying to slam a closed socket with requests. I believe this is because we were not properly marking the socket as closed when receiving a `'close'` event.

#### Summary of Changes

Toggle the connectedness flag when we get a close/error event.

Fixes #25133.