### PR TITLE
Serialize lamports per signature in snapshots

### DIFF
--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -60,6 +60,8 @@ struct DeserializableVersionedBank {
     unused_accounts: UnusedAccounts,
     epoch_stakes: HashMap<Epoch, EpochStakes>,
     is_delta: bool,
+    #[serde(deserialize_with = "default_on_eof")]
+    lamports_per_signature: u64,
 }
 
 impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
@@ -88,7 +90,10 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             collector_id: dvb.collector_id,
             collector_fees: dvb.collector_fees,
             fee_calculator: dvb.fee_calculator,
-            fee_rate_governor: dvb.fee_rate_governor,
+            fee_rate_governor: FeeRateGovernor::copy_with_new_lamports_per_signature(
+                dvb.fee_rate_governor,
+                dvb.lamports_per_signature,
+            ),
             collected_rent: dvb.collected_rent,
             rent_collector: dvb.rent_collector,
             epoch_schedule: dvb.epoch_schedule,
@@ -137,10 +142,12 @@ struct SerializableVersionedBank<'a> {
     unused_accounts: UnusedAccounts,
     epoch_stakes: &'a HashMap<Epoch, EpochStakes>,
     is_delta: bool,
+    lamports_per_signature: u64,
 }
 
 impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedBank<'a> {
     fn from(rhs: crate::bank::BankFieldsToSerialize<'a>) -> Self {
+        let lamports_per_signature = rhs.fee_rate_governor.lamports_per_signature;
         Self {
             blockhash_queue: rhs.blockhash_queue,
             ancestors: rhs.ancestors,
@@ -174,6 +181,7 @@ impl<'a> From<crate::bank::BankFieldsToSerialize<'a>> for SerializableVersionedB
             unused_accounts: UnusedAccounts::default(),
             epoch_stakes: rhs.epoch_stakes,
             is_delta: rhs.is_delta,
+            lamports_per_signature,
         }
     }
 }
@@ -311,6 +319,7 @@ impl<'a> TypeContext<'a> for Context {
         let rhs = bank_fields;
         let blockhash_queue = RwLock::new(rhs.blockhash_queue.clone());
         let hard_forks = RwLock::new(rhs.hard_forks.clone());
+        let lamports_per_signature = rhs.fee_rate_governor.lamports_per_signature;
         let bank = SerializableVersionedBank {
             blockhash_queue: &blockhash_queue,
             ancestors: &rhs.ancestors,
@@ -344,6 +353,7 @@ impl<'a> TypeContext<'a> for Context {
             unused_accounts: UnusedAccounts::default(),
             epoch_stakes: &rhs.epoch_stakes,
             is_delta: rhs.is_delta,
+            lamports_per_signature,
         };
 
         bincode::serialize_into(stream_writer, &(bank, accounts_db_fields))

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -90,10 +90,9 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             collector_id: dvb.collector_id,
             collector_fees: dvb.collector_fees,
             fee_calculator: dvb.fee_calculator,
-            fee_rate_governor: FeeRateGovernor::copy_with_new_lamports_per_signature(
-                dvb.fee_rate_governor,
-                dvb.lamports_per_signature,
-            ),
+            fee_rate_governor: dvb
+                .fee_rate_governor
+                .clone_with_lamports_per_signature(dvb.lamports_per_signature),
             collected_rent: dvb.collected_rent,
             rent_collector: dvb.rent_collector,
             epoch_schedule: dvb.epoch_schedule,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -367,7 +367,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "HT9yewU4zJ6ZAgJ7aDSbHPtzZGZqASpq6rkq6ET42Kki")]
+    #[frozen_abi(digest = "3PiYioYfEPzm2u64FZLsLx1SUTGE3NUvALXvwqhxZuRF")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -165,6 +165,20 @@ impl FeeRateGovernor {
         me
     }
 
+    pub fn copy_with_new_lamports_per_signature(
+        old: FeeRateGovernor,
+        lamports_per_signature: u64,
+    ) -> FeeRateGovernor {
+        FeeRateGovernor {
+            lamports_per_signature,
+            target_lamports_per_signature: old.target_lamports_per_signature,
+            target_signatures_per_slot: old.target_signatures_per_slot,
+            min_lamports_per_signature: old.min_lamports_per_signature,
+            max_lamports_per_signature: old.max_lamports_per_signature,
+            burn_percent: old.burn_percent,
+        }
+    }
+
     /// calculate unburned fee from a fee total, returns (unburned, burned)
     pub fn burn(&self, fees: u64) -> (u64, u64) {
         let burned = fees * u64::from(self.burn_percent) / 100;

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -165,17 +165,10 @@ impl FeeRateGovernor {
         me
     }
 
-    pub fn copy_with_new_lamports_per_signature(
-        old: FeeRateGovernor,
-        lamports_per_signature: u64,
-    ) -> FeeRateGovernor {
-        FeeRateGovernor {
+    pub fn clone_with_lamports_per_signature(&self, lamports_per_signature: u64) -> Self {
+        Self {
             lamports_per_signature,
-            target_lamports_per_signature: old.target_lamports_per_signature,
-            target_signatures_per_slot: old.target_signatures_per_slot,
-            min_lamports_per_signature: old.min_lamports_per_signature,
-            max_lamports_per_signature: old.max_lamports_per_signature,
-            burn_percent: old.burn_percent,
+            ..*self
         }
     }
 


### PR DESCRIPTION
#### Problem
The `FeeRateGovernor` in a bank does not serialize its current `lamports_per_signature` on snapshot. This causes issues if the block that we start a snapshot from is lined up with a fee increase, it is possible for this `lamports_per_signature` to be invalid. 

#### Summary of Changes
Serialize and deserialize this field by accessing it from the `FeeRateGovernor`

Fixes #23545 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
