### PR TITLE
WIP: Quic server - spawn a new task for each connection

### DIFF
--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -527,69 +527,78 @@ pub fn spawn_server(
                     last_datapoint = Instant::now();
                 }
 
-                if let Ok(Some(connection)) = timeout_connection {
-                    if let Ok(new_connection) = connection.await {
-                        stats.total_connections.fetch_add(1, Ordering::Relaxed);
-                        stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
-                        let quinn::NewConnection {
-                            connection,
-                            uni_streams,
-                            ..
-                        } = new_connection;
-
-                        let remote_addr = connection.remote_address();
-
-                        let (mut connection_table_l, stake) = {
-                            let staked_nodes = staked_nodes.read().unwrap();
-                            if let Some(stake) = staked_nodes.get(&remote_addr.ip()) {
-                                let stake = *stake;
-                                drop(staked_nodes);
-                                let mut connection_table_l =
-                                    staked_connection_table.lock().unwrap();
-                                let num_pruned =
-                                    connection_table_l.prune_oldest(max_staked_connections);
-                                stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
-                                (connection_table_l, stake)
+                {
+                    let stats = stats.clone();
+                    let staked_nodes = staked_nodes.clone();
+                    let staked_connection_table = staked_connection_table.clone();
+                    let connection_table = connection_table.clone();
+                    let packet_sender = packet_sender.clone();
+                    tokio::spawn(async move {
+                        if let Ok(Some(connection)) = timeout_connection {
+                            if let Ok(new_connection) = connection.await {
+                                stats.total_connections.fetch_add(1, Ordering::Relaxed);
+                                stats.total_new_connections.fetch_add(1, Ordering::Relaxed);
+                                let quinn::NewConnection {
+                                    connection,
+                                    uni_streams,
+                                    ..
+                                } = new_connection;
+        
+                                let remote_addr = connection.remote_address();
+        
+                                let (mut connection_table_l, stake) = {
+                                    let staked_nodes = staked_nodes.read().unwrap();
+                                    if let Some(stake) = staked_nodes.get(&remote_addr.ip()) {
+                                        let stake = *stake;
+                                        drop(staked_nodes);
+                                        let mut connection_table_l =
+                                            staked_connection_table.lock().unwrap();
+                                        let num_pruned =
+                                            connection_table_l.prune_oldest(max_staked_connections);
+                                        stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+                                        (connection_table_l, stake)
+                                    } else {
+                                        drop(staked_nodes);
+                                        let mut connection_table_l = connection_table.lock().unwrap();
+                                        let num_pruned =
+                                            connection_table_l.prune_oldest(max_unstaked_connections);
+                                        stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
+                                        (connection_table_l, 0)
+                                    }
+                                };
+        
+                                if let Some((last_update, stream_exit)) = connection_table_l
+                                    .try_add_connection(
+                                        &remote_addr,
+                                        timing::timestamp(),
+                                        max_connections_per_ip,
+                                    )
+                                {
+                                    drop(connection_table_l);
+                                    let packet_sender = packet_sender.clone();
+                                    let stats = stats.clone();
+                                    let connection_table1 = connection_table.clone();
+                                    handle_connection(
+                                        uni_streams,
+                                        packet_sender,
+                                        remote_addr,
+                                        last_update,
+                                        connection_table1,
+                                        stream_exit,
+                                        stats,
+                                        stake,
+                                    );
+                                } else {
+                                    stats.connection_add_failed.fetch_add(1, Ordering::Relaxed);
+                                }
                             } else {
-                                drop(staked_nodes);
-                                let mut connection_table_l = connection_table.lock().unwrap();
-                                let num_pruned =
-                                    connection_table_l.prune_oldest(max_unstaked_connections);
-                                stats.num_evictions.fetch_add(num_pruned, Ordering::Relaxed);
-                                (connection_table_l, 0)
+                                stats
+                                    .connection_setup_timeout
+                                    .fetch_add(1, Ordering::Relaxed);
                             }
-                        };
-
-                        if let Some((last_update, stream_exit)) = connection_table_l
-                            .try_add_connection(
-                                &remote_addr,
-                                timing::timestamp(),
-                                max_connections_per_ip,
-                            )
-                        {
-                            drop(connection_table_l);
-                            let packet_sender = packet_sender.clone();
-                            let stats = stats.clone();
-                            let connection_table1 = connection_table.clone();
-                            handle_connection(
-                                uni_streams,
-                                packet_sender,
-                                remote_addr,
-                                last_update,
-                                connection_table1,
-                                stream_exit,
-                                stats,
-                                stake,
-                            );
-                        } else {
-                            stats.connection_add_failed.fetch_add(1, Ordering::Relaxed);
                         }
-                    } else {
-                        stats
-                            .connection_setup_timeout
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                }
+                    });
+            }
             }
         });
         if let Err(e) = runtime.block_on(handle) {


### PR DESCRIPTION
#### Problem
Currently the Quic server loop waits for a connection to finish establishing before moving on to processing other incoming connections.

#### Summary of Changes
Experiment with spinning this out to a separate task to see if it improves performance.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
