### PR TITLE
Improve hard fork message with more detail

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6261,8 +6261,15 @@ impl Bank {
             .unwrap()
             .get_hash_data(self.slot(), self.parent_slot());
         if let Some(buf) = buf {
-            info!("hard fork at bank {}", self.slot());
-            hash = extend_and_hash(&hash, &buf)
+            let hard_forked_hash = extend_and_hash(&hash, &buf);
+            warn!(
+                "hard fork at slot {} by hashing {:?}: {} => {}",
+                self.slot(),
+                buf,
+                hash,
+                hard_forked_hash
+            );
+            hash = hard_forked_hash;
         }
 
         info!(


### PR DESCRIPTION
#### Problem

when doing the stressful outage gap block replay recovery on a warehouse node, I encountered a scary bank hash mismatch, which took some time to debug. and, it turned out that I was passing `--hard-fork NN` multiple times... ;)
 
#### Summary of Changes

Print additional info and make the hard fork message stand out:

- ... by showing actually hashed `buf` and pre-/post- bank hash
- ... by promoting it from `info!` to `warn!`

after:

```
[2022-05-14T09:31:13.615540883Z WARN  solana_runtime::bank] hard fork at slot 67 by hashing [1, 0, 0, 0, 0, 0, 0, 0]: 3V5jhy57A1nKj68wd8kbhQgjDg5D61GRemBFM77kM8iL => Dhg58CfgiTHyfEA7nGsETvXvmzazGWkZz7DHxyr7RegV
```

i thnk backport to mb can be justified:

- the change is very tiny and little risk
- it's handy, should another outage happens in near future....