### PR TITLE
cli: Fix sort order of staked validators by version breakdown

### DIFF
--- a/cli-output/src/cli_version.rs
+++ b/cli-output/src/cli_version.rs
@@ -1,0 +1,60 @@
+use {
+    serde::{Deserialize, Deserializer, Serialize, Serializer},
+    std::{fmt, str::FromStr},
+};
+
+#[derive(Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
+pub struct CliVersion(Option<semver::Version>);
+
+impl CliVersion {
+    pub fn unknown_version() -> Self {
+        Self(None)
+    }
+}
+
+impl fmt::Display for CliVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match &self.0 {
+            None => "unknown".to_string(),
+            Some(version) => version.to_string(),
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl From<semver::Version> for CliVersion {
+    fn from(version: semver::Version) -> Self {
+        Self(Some(version))
+    }
+}
+
+impl FromStr for CliVersion {
+    type Err = semver::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version_option = if s == "unknown" {
+            None
+        } else {
+            Some(semver::Version::from_str(s)?)
+        };
+        Ok(CliVersion(version_option))
+    }
+}
+
+impl Serialize for CliVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for CliVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        CliVersion::from_str(s).map_err(serde::de::Error::custom)
+    }
+}

--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 mod cli_output;
+pub mod cli_version;
 pub mod display;
 pub use cli_output::*;
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -14,6 +14,7 @@ use {
         offline::{blockhash_arg, BLOCKHASH_ARG},
     },
     solana_cli_output::{
+        cli_version::CliVersion,
         display::{
             build_balance_message, format_labeled_address, new_spinner_progress_bar,
             println_transaction, unix_timestamp_to_string, writeln_name_value,
@@ -1873,13 +1874,13 @@ pub fn process_show_validators(
 
     progress_bar.set_message("Fetching version information...");
     let mut node_version = HashMap::new();
-    let unknown_version = "unknown".to_string();
     for contact_info in rpc_client.get_cluster_nodes()? {
         node_version.insert(
             contact_info.pubkey,
             contact_info
                 .version
-                .unwrap_or_else(|| unknown_version.clone()),
+                .and_then(|version| CliVersion::from_str(&version).ok())
+                .unwrap_or_else(CliVersion::unknown_version),
         );
     }
 
@@ -1908,8 +1909,8 @@ pub fn process_show_validators(
                 epoch_info.epoch,
                 node_version
                     .get(&vote_account.node_pubkey)
-                    .unwrap_or(&unknown_version)
-                    .clone(),
+                    .cloned()
+                    .unwrap_or_else(CliVersion::unknown_version),
                 skip_rate.get(&vote_account.node_pubkey).cloned(),
                 &config.address_labels,
             )
@@ -1924,15 +1925,15 @@ pub fn process_show_validators(
                 epoch_info.epoch,
                 node_version
                     .get(&vote_account.node_pubkey)
-                    .unwrap_or(&unknown_version)
-                    .clone(),
+                    .cloned()
+                    .unwrap_or_else(CliVersion::unknown_version),
                 skip_rate.get(&vote_account.node_pubkey).cloned(),
                 &config.address_labels,
             )
         })
         .collect();
 
-    let mut stake_by_version: BTreeMap<_, CliValidatorsStakeByVersion> = BTreeMap::new();
+    let mut stake_by_version: BTreeMap<CliVersion, CliValidatorsStakeByVersion> = BTreeMap::new();
     for validator in current_validators.iter() {
         let mut entry = stake_by_version
             .entry(validator.version.clone())


### PR DESCRIPTION
#### Problem
The `solana validators` command doesn't sort the breakdown of validators by version correctly because it sorts using strings instead of semver structs.

```
Stake By Version:
1.10.11  -    1 current validators ( 0.01%)
1.10.12  -    5 current validators ( 1.52%)
1.10.13  -    1 current validators ( 0.01%)
1.10.14  -    0 current validators ( 0.00%),   1 delinquent validators ( 0.00%)
1.10.3   -    1 current validators ( 0.02%)
1.10.8   -    0 current validators ( 0.00%),   1 delinquent validators ( 0.00%)
1.9.16   -    1 current validators ( 0.06%)
1.9.17   -    1 current validators ( 0.02%)
1.9.18   -  151 current validators (29.63%),   3 delinquent validators ( 0.00%)
1.9.19   -    3 current validators ( 2.60%),   1 delinquent validators ( 0.00%)
1.9.20   -  116 current validators (11.68%),  14 delinquent validators ( 0.01%)
1.9.21   - 1455 current validators (52.87%),   9 delinquent validators ( 0.07%)
1.9.22   -    1 current validators ( 1.02%)
unknown  -    1 current validators ( 0.00%), 125 delinquent validators ( 0.09%)
```


#### Summary of Changes
- Move `CliVersion` to `solana-cli-output` crate and use it for sorting version breakdown

```
Stake By Version:
1.10.14 -    0 current validators ( 0.00%)   1 delinquent validators ( 0.00%)
1.10.13 -    1 current validators ( 0.01%)
1.10.12 -    5 current validators ( 1.52%)
1.10.11 -    1 current validators ( 0.01%)
1.10.8  -    0 current validators ( 0.00%)   1 delinquent validators ( 0.00%)
1.10.3  -    1 current validators ( 0.02%)
1.9.22  -    1 current validators ( 1.02%)
1.9.21  - 1456 current validators (52.88%)   8 delinquent validators ( 0.05%)
1.9.20  -  116 current validators (11.68%)  14 delinquent validators ( 0.01%)
1.9.19  -    3 current validators ( 2.60%)   1 delinquent validators ( 0.00%)
1.9.18  -  151 current validators (29.63%)   3 delinquent validators ( 0.00%)
1.9.17  -    1 current validators ( 0.02%)
1.9.16  -    1 current validators ( 0.06%)
unknown -    1 current validators ( 0.00%) 125 delinquent validators ( 0.09%)
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
