### PR TITLE
Refactor make_connection

### DIFF
--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -15,6 +15,7 @@ use {
         ClientConfig, Endpoint, EndpointConfig, IdleTimeout, NewConnection, VarInt, WriteError,
     },
     quinn_proto::ConnectionStats,
+    solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::{
         quic::{
             QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS, QUIC_PORT_OFFSET,
@@ -22,7 +23,7 @@ use {
         transport::Result as TransportResult,
     },
     std::{
-        net::{SocketAddr, UdpSocket},
+        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::{atomic::Ordering, Arc},
         time::Duration,
     },
@@ -57,9 +58,88 @@ lazy_static! {
         .unwrap();
 }
 
+#[derive(Clone)]
+struct QuicConnection {
+    endpoint: Arc<Endpoint>,
+    connection: Arc<NewConnection>,
+}
+
+impl QuicConnection {
+    async fn make_connection(addr: SocketAddr, stats: &ClientStats) -> Result<Self, WriteError> {
+        let (_, client_socket) = solana_net_utils::bind_in_range(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            VALIDATOR_PORT_RANGE,
+        )
+        .unwrap();
+
+        let mut crypto = rustls::ClientConfig::builder()
+            .with_safe_defaults()
+            .with_custom_certificate_verifier(SkipServerVerification::new())
+            .with_no_client_auth();
+        crypto.enable_early_data = true;
+
+        let mut endpoint =
+            QuicConnection::create_endpoint(EndpointConfig::default(), client_socket).await;
+
+        let mut config = ClientConfig::new(Arc::new(crypto));
+        let transport_config = Arc::get_mut(&mut config.transport).unwrap();
+        let timeout = IdleTimeout::from(VarInt::from_u32(QUIC_MAX_TIMEOUT_MS));
+        transport_config.max_idle_timeout(Some(timeout));
+        transport_config.keep_alive_interval(Some(Duration::from_millis(QUIC_KEEP_ALIVE_MS)));
+
+        endpoint.set_default_client_config(config);
+
+        let connecting = endpoint.connect(addr, "connect").unwrap();
+        stats.total_connections.fetch_add(1, Ordering::Relaxed);
+        let connecting_result = connecting.await;
+        if connecting_result.is_err() {
+            stats.connection_errors.fetch_add(1, Ordering::Relaxed);
+        }
+        let connection = connecting_result?;
+
+        Ok(Self {
+            endpoint: Arc::new(endpoint),
+            connection: Arc::new(connection),
+        })
+    }
+
+    // If this function becomes public, it should be changed to
+    // not expose details of the specific Quic implementation we're using
+    async fn create_endpoint(config: EndpointConfig, client_socket: UdpSocket) -> Endpoint {
+        quinn::Endpoint::new(config, None, client_socket).unwrap().0
+    }
+
+    // Attempts to make a faster connection by taking advantage of pre-existing key material.
+    // Only works if connection to this endpoint was previously established.
+    async fn make_connection_0rtt(
+        &mut self,
+        addr: SocketAddr,
+        stats: &ClientStats,
+    ) -> Result<Arc<NewConnection>, WriteError> {
+        let connecting = self.endpoint.connect(addr, "connect").unwrap();
+        stats.total_connections.fetch_add(1, Ordering::Relaxed);
+        let connection = match connecting.into_0rtt() {
+            Ok((connection, zero_rtt)) => {
+                if zero_rtt.await {
+                    stats.zero_rtt_accepts.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    stats.zero_rtt_rejects.fetch_add(1, Ordering::Relaxed);
+                }
+                connection
+            }
+            Err(connecting) => {
+                stats.connection_errors.fetch_add(1, Ordering::Relaxed);
+                let connecting = connecting.await;
+                connecting?
+            }
+        };
+        self.connection = Arc::new(connection);
+        Ok(self.connection.clone())
+    }
+}
+
 struct QuicClient {
-    endpoint: Endpoint,
-    connection: Arc<Mutex<Option<Arc<NewConnection>>>>,
+    connection: Arc<Mutex<Option<QuicConnection>>>,
     addr: SocketAddr,
     stats: Arc<ClientStats>,
 }
@@ -79,9 +159,9 @@ impl QuicTpuConnection {
 }
 
 impl TpuConnection for QuicTpuConnection {
-    fn new(client_socket: UdpSocket, tpu_addr: SocketAddr) -> Self {
+    fn new(tpu_addr: SocketAddr) -> Self {
         let tpu_addr = SocketAddr::new(tpu_addr.ip(), tpu_addr.port() + QUIC_PORT_OFFSET);
-        let client = Arc::new(QuicClient::new(client_socket, tpu_addr));
+        let client = Arc::new(QuicClient::new(tpu_addr));
 
         Self { client }
     }
@@ -156,29 +236,8 @@ impl TpuConnection for QuicTpuConnection {
 }
 
 impl QuicClient {
-    pub fn new(client_socket: UdpSocket, addr: SocketAddr) -> Self {
-        let _guard = RUNTIME.enter();
-
-        let mut crypto = rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_custom_certificate_verifier(SkipServerVerification::new())
-            .with_no_client_auth();
-        crypto.enable_early_data = true;
-
-        let create_endpoint = QuicClient::create_endpoint(EndpointConfig::default(), client_socket);
-
-        let mut endpoint = RUNTIME.block_on(create_endpoint);
-
-        let mut config = ClientConfig::new(Arc::new(crypto));
-        let transport_config = Arc::get_mut(&mut config.transport).unwrap();
-        let timeout = IdleTimeout::from(VarInt::from_u32(QUIC_MAX_TIMEOUT_MS));
-        transport_config.max_idle_timeout(Some(timeout));
-        transport_config.keep_alive_interval(Some(Duration::from_millis(QUIC_KEEP_ALIVE_MS)));
-
-        endpoint.set_default_client_config(config);
-
+    pub fn new(addr: SocketAddr) -> Self {
         Self {
-            endpoint,
             connection: Arc::new(Mutex::new(None)),
             addr,
             stats: Arc::new(ClientStats::default()),
@@ -188,13 +247,7 @@ impl QuicClient {
     pub fn stats(&self) -> Option<ConnectionStats> {
         let conn_guard = self.connection.lock();
         let x = RUNTIME.block_on(conn_guard);
-        x.as_ref().map(|c| c.connection.stats())
-    }
-
-    // If this function becomes public, it should be changed to
-    // not expose details of the specific Quic implementation we're using
-    async fn create_endpoint(config: EndpointConfig, client_socket: UdpSocket) -> Endpoint {
-        quinn::Endpoint::new(config, None, client_socket).unwrap().0
+        x.as_ref().map(|c| c.connection.connection.stats())
     }
 
     async fn _send_buffer_using_conn(
@@ -207,44 +260,6 @@ impl QuicClient {
         Ok(())
     }
 
-    async fn make_connection(&self, stats: &ClientStats) -> Result<Arc<NewConnection>, WriteError> {
-        let connecting = self.endpoint.connect(self.addr, "connect").unwrap();
-        stats.total_connections.fetch_add(1, Ordering::Relaxed);
-        let connecting_result = connecting.await;
-        if connecting_result.is_err() {
-            stats.connection_errors.fetch_add(1, Ordering::Relaxed);
-        }
-        let connection = connecting_result?;
-        Ok(Arc::new(connection))
-    }
-
-    // Attempts to make a faster connection by taking advantage of pre-existing key material.
-    // Only works if connection to this endpoint was previously established.
-    async fn make_connection_0rtt(
-        &self,
-        stats: &ClientStats,
-    ) -> Result<Arc<NewConnection>, WriteError> {
-        let connecting = self.endpoint.connect(self.addr, "connect").unwrap();
-        stats.total_connections.fetch_add(1, Ordering::Relaxed);
-        let connection = match connecting.into_0rtt() {
-            Ok((connection, zero_rtt)) => {
-                if zero_rtt.await {
-                    stats.zero_rtt_accepts.fetch_add(1, Ordering::Relaxed);
-                } else {
-                    stats.zero_rtt_rejects.fetch_add(1, Ordering::Relaxed);
-                }
-                connection
-            }
-            Err(connecting) => {
-                stats.connection_errors.fetch_add(1, Ordering::Relaxed);
-                let connecting = connecting.await;
-                connecting?
-            }
-        };
-
-        Ok(Arc::new(connection))
-    }
-
     // Attempts to send data, connecting/reconnecting as necessary
     // On success, returns the connection used to successfully send the data
     async fn _send_buffer(
@@ -255,16 +270,16 @@ impl QuicClient {
         let connection = {
             let mut conn_guard = self.connection.lock().await;
 
-            let maybe_conn = (*conn_guard).clone();
+            let maybe_conn = conn_guard.clone();
             match maybe_conn {
                 Some(conn) => {
                     stats.connection_reuse.fetch_add(1, Ordering::Relaxed);
-                    conn.clone()
+                    conn.connection.clone()
                 }
                 None => {
-                    let connection = self.make_connection(stats).await?;
-                    *conn_guard = Some(connection.clone());
-                    connection
+                    let conn = QuicConnection::make_connection(self.addr, stats).await?;
+                    *conn_guard = Some(conn.clone());
+                    conn.connection.clone()
                 }
             }
         };
@@ -272,10 +287,9 @@ impl QuicClient {
             Ok(()) => Ok(connection),
             _ => {
                 let connection = {
-                    let connection = self.make_connection_0rtt(stats).await?;
                     let mut conn_guard = self.connection.lock().await;
-                    *conn_guard = Some(connection.clone());
-                    connection
+                    let conn = conn_guard.as_mut().unwrap();
+                    conn.make_connection_0rtt(self.addr, stats).await?
                 };
                 Self::_send_buffer_using_conn(data, &connection).await?;
                 Ok(connection)

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -60,7 +60,7 @@ lazy_static! {
 
 #[derive(Clone)]
 struct QuicConnection {
-    endpoint: Arc<Endpoint>,
+    endpoint: Endpoint,
     connection: Arc<NewConnection>,
 }
 
@@ -98,7 +98,7 @@ impl QuicConnection {
         let connection = connecting_result?;
 
         Ok(Self {
-            endpoint: Arc::new(endpoint),
+            endpoint,
             connection: Arc::new(connection),
         })
     }

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -3,7 +3,7 @@ use {
     solana_metrics::MovingStat,
     solana_sdk::{transaction::VersionedTransaction, transport::Result as TransportResult},
     std::{
-        net::{SocketAddr, UdpSocket},
+        net::SocketAddr,
         sync::{atomic::AtomicU64, Arc},
     },
 };
@@ -24,7 +24,7 @@ pub struct ClientStats {
 }
 
 pub trait TpuConnection {
-    fn new(client_socket: UdpSocket, tpu_addr: SocketAddr) -> Self;
+    fn new(tpu_addr: SocketAddr) -> Self;
 
     fn tpu_addr(&self) -> &SocketAddr;
 

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -4,10 +4,11 @@
 use {
     crate::tpu_connection::{ClientStats, TpuConnection},
     core::iter::repeat,
+    solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::transport::Result as TransportResult,
     solana_streamer::sendmmsg::batch_send,
     std::{
-        net::{SocketAddr, UdpSocket},
+        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,
     },
 };
@@ -18,7 +19,13 @@ pub struct UdpTpuConnection {
 }
 
 impl TpuConnection for UdpTpuConnection {
-    fn new(client_socket: UdpSocket, tpu_addr: SocketAddr) -> Self {
+    fn new(tpu_addr: SocketAddr) -> Self {
+        let (_, client_socket) = solana_net_utils::bind_in_range(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            VALIDATOR_PORT_RANGE,
+        )
+        .unwrap();
+
         Self {
             socket: client_socket,
             addr: tpu_addr,

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -44,7 +44,7 @@ mod tests {
         let addr = s.local_addr().unwrap().ip();
         let port = s.local_addr().unwrap().port() - QUIC_PORT_OFFSET;
         let tpu_addr = SocketAddr::new(addr, port);
-        let client = QuicTpuConnection::new(UdpSocket::bind("127.0.0.1:0").unwrap(), tpu_addr);
+        let client = QuicTpuConnection::new(tpu_addr);
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;


### PR DESCRIPTION
#### Problem
1. Endpoint creation and connection initiation logic is spread in different places. This change move them together to improve cohesiveness and it achieves real lazy initialization for connections. Other considerations is we want to reduce the sys calls under larger locks such as the connection cache lock.

2. The get_or_add_connection is taking a lock on the cache which is shared across different connections. Under this it is also loading stats for a given connection, which  might not be fully connected yet. This results in that a lengthy connection could impact other working connection being created. 
#### Summary of Changes

1. Move logics related to creating endpoint, creating new connection and retry 0rtt connections into a wrapper construct QuicNewConnection to put the logic together.
2. get_or_add_connection: logic is much simplified to allow manage the connection cache -- the QUIC connection is lazy constructed. get_or_add_connection should no longer be a global hotspot.
3. Per connection stats update is moved out of get_or_add_connection to avoid bad connection impacting good connections.
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
