### PR TITLE
Lower default batch size to 64 and add 2 banking threads

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -75,11 +75,11 @@ pub const FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET: u64 = 2;
 pub const HOLD_TRANSACTIONS_SLOT_OFFSET: u64 = 20;
 
 // Fixed thread size seems to be fastest on GCP setup
-pub const NUM_THREADS: u32 = 4;
+pub const NUM_THREADS: u32 = 6;
 
-const TOTAL_BUFFERED_PACKETS: usize = 500_000;
+const TOTAL_BUFFERED_PACKETS: usize = 700_000;
 
-const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 128;
+const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
 
 const NUM_VOTE_PROCESSING_THREADS: u32 = 2;
 const MIN_THREADS_BANKING: u32 = 1;

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -9,8 +9,8 @@ use {
 
 pub const NUM_PACKETS: usize = 1024 * 8;
 
-pub const PACKETS_PER_BATCH: usize = 128;
-pub const NUM_RCVMMSGS: usize = 128;
+pub const PACKETS_PER_BATCH: usize = 64;
+pub const NUM_RCVMMSGS: usize = 64;
 
 #[derive(Debug, Default, Clone)]
 pub struct PacketBatch {


### PR DESCRIPTION
#### Problem

* Banking stage is not getting to some transactions but not filling the block
* With a larger batch size there can be many conflicting or invalid transactions then they can fill up the banking-stage buffers easily because the limits are per-batch.

#### Summary of Changes

* Add 2 more banking threads
* Lower the default batch size to 64
* Increase total buffered packets to 700k

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
