### PR TITLE
Credit partial prioritization fee proportional to unused compute

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1302,7 +1302,7 @@ impl BankingStage {
                 .iter()
                 .map(|execution_result| match execution_result.details() {
                     Some(details) => CommitTransactionDetails::Committed {
-                        compute_units: details.executed_units,
+                        compute_units: details.consumed_compute_units,
                     },
                     None => CommitTransactionDetails::NotCommitted,
                 })

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3495,7 +3495,8 @@ fn test_program_fees() {
         &fee_structure,
         true,
         true,
-    );
+    )
+    .total();
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
         .unwrap();
@@ -3518,7 +3519,8 @@ fn test_program_fees() {
         &fee_structure,
         true,
         true,
-    );
+    )
+    .total();
     assert!(expected_min_fee < expected_max_fee);
 
     bank_client

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -216,7 +216,9 @@ pub(crate) mod tests {
         dashmap::DashMap,
         solana_account_decoder::parse_token::token_amount_to_ui_amount,
         solana_ledger::{genesis_utils::create_genesis_config, get_tmp_ledger_path},
-        solana_runtime::bank::{Bank, NonceFull, NoncePartial, RentDebits, TransactionBalancesSet},
+        solana_runtime::bank::{
+            Bank, NonceFull, NoncePartial, RentDebits, TransactionBalancesSet, TransactionFee,
+        },
         solana_sdk::{
             account_utils::StateMut,
             clock::Slot,
@@ -351,7 +353,9 @@ pub(crate) mod tests {
                 .unwrap(),
             )),
             return_data: None,
-            executed_units: 0u64,
+            consumed_compute_units: 0u64,
+            compute_unit_limit: 0u64,
+            fee: TransactionFee::default(),
         });
 
         let balances = TransactionBalancesSet {


### PR DESCRIPTION
#### Problem
Since unused compute doesn't result in a credit back to the fee payer, transaction senders will be incentivized to request as few compute units as possible. I believe this will lead to a poor user experience where too much responsibility falls on users to determine how much compute their tx will use. It's very hard to accurately predict compute because your tx could be front-run and computations could get slightly more expensive between the time you simulate your tx and it is actually processed. In that case, your tx will fail and you will have lost out on all your fees. I think it's much better to allow senders to set a conservatively high amount of compute with the expectation that unused compute will be refunded.

#### Summary of Changes
- Add `TransactionFee` struct to track congestion and prioritization fees separately
- Credit partial prioritization fee back to fee payer if the account wasn't deleted

#### TODOs
- [ ] the runtime should impose a min compute unit consumption for each tx of ~1000 compute units to ensure that prioritization fee credits cannot be abused
- [ ] invoking builtin programs should always consume compute units

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
