### PR TITLE
Fix BankingStage packet starvation (1.9)

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -980,6 +980,7 @@ impl BankingStage {
             let (_, slot_metrics_checker_check_slot_boundary_time) = Measure::this(
                 |_| {
                     let current_poh_bank = {
+                        // TODO (B): constant spinning here may have an impact on poh, discuss in PR
                         let poh = poh_recorder.lock().unwrap();
                         poh.bank_start()
                     };

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -93,7 +93,7 @@ const MAX_NUM_TRANSACTIONS_PER_BATCH: usize = 128;
 const NUM_VOTE_PROCESSING_THREADS: u32 = 2;
 const MIN_THREADS_BANKING: u32 = 1;
 
-const SLOT_BOUNDARY_CHECK_MS: u64 = 10;
+const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -985,7 +985,7 @@ impl BankingStage {
             }
 
             // avoid excessively locking poh_recorder
-            if last_metrics_update.elapsed() >= Duration::from_millis(SLOT_BOUNDARY_CHECK_MS) {
+            if last_metrics_update.elapsed() >= SLOT_BOUNDARY_CHECK_PERIOD {
                 let (_, slot_metrics_checker_check_slot_boundary_time) = Measure::this(
                     |_| {
                         let current_poh_bank = {


### PR DESCRIPTION
#### Problem
- BankingStage gets starved from new packets if it gets stuck with transactions that exceeds the cost model or repeatedly hit AccountInUse/other errors that mark packets as retry-able that take awhile to get drained from the buffer.
- Issue: https://github.com/solana-labs/solana/issues/24163
- BankingStage should attempt to read in new packets more frequently.

#### Summary of Changes
- Remove the looping for process_buffered_packets.
- BankingStage will attempt to go through each threads backlog once before reading new packets.
- If there's packets, set the recv_timeout to 0s so we perform the equivalent of a try_recv

NOTE:
- We are still wasting time trying to pack batches for txs where the cost model is already saturated (serialization, QoS, account locking, etc.) but this seems like a major improvement over the status quo.