### PR TITLE
clippy: Use `unsigned_abs()`

### DIFF
--- a/program-runtime/src/accounts_data_meter.rs
+++ b/program-runtime/src/accounts_data_meter.rs
@@ -175,7 +175,7 @@ mod tests {
         let result = accounts_data_meter.adjust_delta(amount);
         assert!(result.is_ok());
         let remaining_after = accounts_data_meter.remaining();
-        assert_eq!(remaining_after, remaining_before + amount.abs() as u64);
+        assert_eq!(remaining_after, remaining_before + amount.unsigned_abs());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

From nightly clippy:

```
warning: casting the result of `i64::abs()` to u64
   --> program-runtime/src/accounts_data_meter.rs:178:56
    |
178 |         assert_eq!(remaining_after, remaining_before + amount.abs() as u64);
    |                                                        ^^^^^^^^^^^^^^^^^^^ help: replace with: `amount.unsigned_abs()`
    |
    = note: `#[warn(clippy::cast_abs_to_unsigned)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_abs_to_unsigned
```

#### Summary of Changes

Use `unsigned_abs()`.
