### PR TITLE
Revert using memory map for reading snapshot

### DIFF
--- a/runtime/src/shared_buffer_reader.rs
+++ b/runtime/src/shared_buffer_reader.rs
@@ -24,7 +24,7 @@ use {
 // # bytes allocated and populated by reading ahead
 const TOTAL_BUFFER_BUDGET_DEFAULT: usize = 2_000_000_000;
 // data is read-ahead and saved in chunks of this many bytes
-const CHUNK_SIZE_DEFAULT: usize = 50_000_000;
+const CHUNK_SIZE_DEFAULT: usize = 100_000_000;
 
 type OneSharedBuffer = Arc<Vec<u8>>;
 


### PR DESCRIPTION
#### Problem

It turns out that memory map helps most for "uncompressed" snapshot. For compressed snapshot, memory map doesn't make any noticeable improvement. Further investigation is needed.  


#### Summary of Changes
Revert the mmap change for reading snapshot. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
