### PR TITLE
ci: Remove downstream anchor projects

### DIFF
--- a/ci/buildkite-pipeline-in-disk.sh
+++ b/ci/buildkite-pipeline-in-disk.sh
@@ -241,31 +241,6 @@ EOF
       "downstream-projects skipped as no relevant files were modified"
   fi
 
-  # Downstream Anchor projects backwards compatibility
-  if affects \
-             .rs$ \
-             Cargo.lock$ \
-             Cargo.toml$ \
-             ^ci/rust-version.sh \
-             ^ci/test-stable-perf.sh \
-             ^ci/test-stable.sh \
-             ^ci/test-local-cluster.sh \
-             ^core/build.rs \
-             ^fetch-perf-libs.sh \
-             ^programs/ \
-             ^sdk/ \
-             ^scripts/build-downstream-anchor-projects.sh \
-      ; then
-    cat >> "$output_file" <<"EOF"
-  - command: "scripts/build-downstream-anchor-projects.sh"
-    name: "downstream-anchor-projects"
-    timeout_in_minutes: 10
-EOF
-  else
-    annotate --style info \
-      "downstream-anchor-projects skipped as no relevant files were modified"
-  fi
-
   # Wasm support
   if affects \
              ^ci/test-wasm.sh \

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -243,33 +243,6 @@ EOF
       "downstream-projects skipped as no relevant files were modified"
   fi
 
-  # Downstream Anchor projects backwards compatibility
-  if affects \
-             .rs$ \
-             Cargo.lock$ \
-             Cargo.toml$ \
-             ^ci/rust-version.sh \
-             ^ci/test-stable-perf.sh \
-             ^ci/test-stable.sh \
-             ^ci/test-local-cluster.sh \
-             ^core/build.rs \
-             ^fetch-perf-libs.sh \
-             ^programs/ \
-             ^sdk/ \
-             ^scripts/build-downstream-anchor-projects.sh \
-      ; then
-    cat >> "$output_file" <<"EOF"
-  - command: "scripts/build-downstream-anchor-projects.sh"
-    name: "downstream-anchor-projects"
-    timeout_in_minutes: 10
-    agents:
-      - "queue=solana"
-EOF
-  else
-    annotate --style info \
-      "downstream-anchor-projects skipped as no relevant files were modified"
-  fi
-
   # Wasm support
   if affects \
              ^ci/test-wasm.sh \

--- a/ci/buildkite-solana-private.sh
+++ b/ci/buildkite-solana-private.sh
@@ -243,33 +243,6 @@ EOF
       "downstream-projects skipped as no relevant files were modified"
   fi
 
-  # Downstream Anchor projects backwards compatibility
-  if affects \
-             .rs$ \
-             Cargo.lock$ \
-             Cargo.toml$ \
-             ^ci/rust-version.sh \
-             ^ci/test-stable-perf.sh \
-             ^ci/test-stable.sh \
-             ^ci/test-local-cluster.sh \
-             ^core/build.rs \
-             ^fetch-perf-libs.sh \
-             ^programs/ \
-             ^sdk/ \
-             ^scripts/build-downstream-anchor-projects.sh \
-      ; then
-    cat >> "$output_file" <<"EOF"
-  - command: "scripts/build-downstream-anchor-projects.sh"
-    name: "downstream-anchor-projects"
-    timeout_in_minutes: 10
-    agents:
-      - "queue=sol-private"
-EOF
-  else
-    annotate --style info \
-      "downstream-anchor-projects skipped as no relevant files were modified"
-  fi
-
   # Wasm support
   if affects \
              ^ci/test-wasm.sh \


### PR DESCRIPTION
#### Problem

Downstream anchor is failing in CI because the bumped dependency on spl-token 3.3.0 is not compatible with the strict version in anchor.

#### Summary of Changes

This isn't going to be fixable because of dependencies in the anchor repo.  This build should get moved downstream to SPL to properly override those dependencies.  To start, let's disable it in the monorepo.