### PR TITLE
fix typo: BlockheightBasedTransactionConfimationStrategy, Confimation => Confirmation

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -293,7 +293,7 @@ export type BlockhashWithExpiryBlockHeight = Readonly<{
  * A strategy for confirming transactions that uses the last valid
  * block height for a given blockhash to check for transaction expiration.
  */
-export type BlockheightBasedTransactionConfimationStrategy = {
+export type BlockheightBasedTransactionConfirmationStrategy = {
   signature: TransactionSignature;
 } & BlockhashWithExpiryBlockHeight;
 
@@ -2842,7 +2842,7 @@ export class Connection {
   }
 
   confirmTransaction(
-    strategy: BlockheightBasedTransactionConfimationStrategy,
+    strategy: BlockheightBasedTransactionConfirmationStrategy,
     commitment?: Commitment,
   ): Promise<RpcResponseAndContext<SignatureResult>>;
 
@@ -2856,7 +2856,7 @@ export class Connection {
   // eslint-disable-next-line no-dupe-class-members
   async confirmTransaction(
     strategy:
-      | BlockheightBasedTransactionConfimationStrategy
+      | BlockheightBasedTransactionConfirmationStrategy
       | TransactionSignature,
     commitment?: Commitment,
   ): Promise<RpcResponseAndContext<SignatureResult>> {
@@ -2865,7 +2865,7 @@ export class Connection {
     if (typeof strategy == 'string') {
       rawSignature = strategy;
     } else {
-      const config = strategy as BlockheightBasedTransactionConfimationStrategy;
+      const config = strategy as BlockheightBasedTransactionConfirmationStrategy;
       rawSignature = config.signature;
     }
 
@@ -2942,7 +2942,7 @@ export class Connection {
           timeoutMs,
         );
       } else {
-        let config = strategy as BlockheightBasedTransactionConfimationStrategy;
+        let config = strategy as BlockheightBasedTransactionConfirmationStrategy;
         (async () => {
           let currentBlockHeight = await checkBlockHeight();
           if (done) return;

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2865,7 +2865,8 @@ export class Connection {
     if (typeof strategy == 'string') {
       rawSignature = strategy;
     } else {
-      const config = strategy as BlockheightBasedTransactionConfirmationStrategy;
+      const config =
+        strategy as BlockheightBasedTransactionConfirmationStrategy;
       rawSignature = config.signature;
     }
 
@@ -2942,7 +2943,8 @@ export class Connection {
           timeoutMs,
         );
       } else {
-        let config = strategy as BlockheightBasedTransactionConfirmationStrategy;
+        let config =
+          strategy as BlockheightBasedTransactionConfirmationStrategy;
         (async () => {
           let currentBlockHeight = await checkBlockHeight();
           if (done) return;

--- a/web3.js/src/util/send-and-confirm-raw-transaction.ts
+++ b/web3.js/src/util/send-and-confirm-raw-transaction.ts
@@ -1,7 +1,7 @@
 import type {Buffer} from 'buffer';
 
 import {
-  BlockheightBasedTransactionConfimationStrategy,
+  BlockheightBasedTransactionConfirmationStrategy,
   Connection,
 } from '../connection';
 import type {TransactionSignature} from '../transaction';
@@ -14,14 +14,14 @@ import type {ConfirmOptions} from '../connection';
  *
  * @param {Connection} connection
  * @param {Buffer} rawTransaction
- * @param {BlockheightBasedTransactionConfimationStrategy} confirmationStrategy
+ * @param {BlockheightBasedTransactionConfirmationStrategy} confirmationStrategy
  * @param {ConfirmOptions} [options]
  * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
-  confirmationStrategy: BlockheightBasedTransactionConfimationStrategy,
+  confirmationStrategy: BlockheightBasedTransactionConfirmationStrategy,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature>;
 
@@ -41,13 +41,13 @@ export async function sendAndConfirmRawTransaction(
   connection: Connection,
   rawTransaction: Buffer,
   confirmationStrategyOrConfirmOptions:
-    | BlockheightBasedTransactionConfimationStrategy
+    | BlockheightBasedTransactionConfirmationStrategy
     | ConfirmOptions
     | undefined,
   maybeConfirmOptions?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   let confirmationStrategy:
-    | BlockheightBasedTransactionConfimationStrategy
+    | BlockheightBasedTransactionConfirmationStrategy
     | undefined;
   let options: ConfirmOptions | undefined;
   if (
@@ -58,7 +58,7 @@ export async function sendAndConfirmRawTransaction(
     )
   ) {
     confirmationStrategy =
-      confirmationStrategyOrConfirmOptions as BlockheightBasedTransactionConfimationStrategy;
+      confirmationStrategyOrConfirmOptions as BlockheightBasedTransactionConfirmationStrategy;
     options = maybeConfirmOptions;
   } else {
     options = confirmationStrategyOrConfirmOptions as


### PR DESCRIPTION
#### Problem
I think there is a typo in `BlockheightBasedTransactionConfimationStrategy`

#### Summary of Changes
Rename `BlockheightBasedTransactionConfimationStrategy` to `BlockheightBasedTransactionConfirmationStrategy`
