### PR TITLE
Fix bootstrap without known validators

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1114,14 +1114,15 @@ mod with_incremental_snapshots {
         validator_config: &ValidatorConfig,
         rpc_peers: &[ContactInfo],
     ) -> Vec<PeerSnapshotHash> {
-        let known_snapshot_hashes =
-            get_snapshot_hashes_from_known_validators(cluster_info, validator_config);
-
         let mut peer_snapshot_hashes = get_eligible_peer_snapshot_hashes(cluster_info, rpc_peers);
-        retain_peer_snapshot_hashes_that_match_known_snapshot_hashes(
-            &known_snapshot_hashes,
-            &mut peer_snapshot_hashes,
-        );
+        if validator_config.known_validators.is_some() {
+            let known_snapshot_hashes =
+                get_snapshot_hashes_from_known_validators(cluster_info, validator_config);
+            retain_peer_snapshot_hashes_that_match_known_snapshot_hashes(
+                &known_snapshot_hashes,
+                &mut peer_snapshot_hashes,
+            );
+        }
         retain_peer_snapshot_hashes_with_highest_full_snapshot_slot(&mut peer_snapshot_hashes);
         retain_peer_snapshot_hashes_with_highest_incremental_snapshot_slot(
             &mut peer_snapshot_hashes,


### PR DESCRIPTION
#### Problem

Validator with --incremental-snapshots can't start to download snapshot if no one --known-validator set (not depended from --only-known-rpc)

#### Summary of Changes

Do not match snapshot hashes with snapshot hashes of known validators if no one is set.

Fixes #23927
