### PR TITLE
Fix RpcResponseContext in rpc_client test

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4335,7 +4335,10 @@ mod tests {
                         ReturnDataEncoding::Base64,
                     );
                     serde_json::to_value(Response {
-                        context: RpcResponseContext { slot: 1 },
+                        context: RpcResponseContext {
+                            slot: 1,
+                            api_version: None,
+                        },
                         value: RpcSimulateTransactionResult {
                             err: None,
                             logs: None,


### PR DESCRIPTION
#### Problem

I broke the build:

```
error[E0063]: missing field `api_version` in initializer of `rpc_response::RpcResponseContext`
    --> client/src/rpc_client.rs:4338:34
     |
4338 |                         context: RpcResponseContext { slot: 1 },
     |                                  ^^^^^^^^^^^^^^^^^^ missing `api_version`
```

https://buildkite.com/solana-labs/solana/builds/73654#85d3587f-4854-49f1-b3a7-b332bc50680e
PR the introduced the break: #25200 

#### Summary of Changes

Add `api_version`.
