### PR TITLE
Fix ledger-tool from erroring with unspecified archive_format

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2305,7 +2305,7 @@ fn main() {
 
                 let snapshot_archive_format = {
                     let archive_format_str =
-                        value_t_or_exit!(matches, "snapshot_archive_format", String);
+                        value_t_or_exit!(arg_matches, "snapshot_archive_format", String);
                     ArchiveFormat::from_cli_arg(&archive_format_str).unwrap_or_else(|| {
                         panic!("Archive format not recognized: {}", archive_format_str)
                     })


### PR DESCRIPTION
value_t_or_exit()! will error if the user doesn't specify a value at
runtime, use value_of() instead which will give either the default value
or whatever the user specified.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
