### PR TITLE
Give some tolerance to recv_mmsg test

### DIFF
--- a/streamer/tests/recvmmsg.rs
+++ b/streamer/tests/recvmmsg.rs
@@ -18,6 +18,7 @@ pub fn test_recv_mmsg_batch_size() {
     let sent = TEST_BATCH_SIZE;
 
     let mut elapsed_in_max_batch = 0;
+    let mut num_max_batches = 0;
     (0..1000).for_each(|_| {
         for _ in 0..sent {
             let data = [0; PACKET_DATA_SIZE];
@@ -27,8 +28,11 @@ pub fn test_recv_mmsg_batch_size() {
         let now = Instant::now();
         let recv = recv_mmsg(&reader, &mut packets[..]).unwrap();
         elapsed_in_max_batch += now.elapsed().as_nanos();
-        assert_eq!(TEST_BATCH_SIZE, recv);
+        if recv == TEST_BATCH_SIZE {
+            num_max_batches += 1;
+        }
     });
+    assert!(num_max_batches > 990);
 
     let mut elapsed_in_small_batch = 0;
     (0..1000).for_each(|_| {


### PR DESCRIPTION
#### Problem

recv_mmsg test has an assumption of 0 packet drops.

#### Summary of Changes

Change to allow for 1% batches were drops could occur.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
