### PR TITLE
fix: speed up transaction signing by removing code that does nothing

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -599,7 +599,6 @@ export class Transaction {
 
     const message = this._compile();
     this._partialSign(message, ...uniqueSigners);
-    this._verifySignatures(message.serialize(), true);
   }
 
   /**


### PR DESCRIPTION
#### Problem

This `_verifySignatures()` step runs verification, returns the result of that verification to nobody, and does nothing. We're essentially paying the cost of `Message#serialize` and `Transaction#_verifySignatures` and then throwing out the result.

#### Summary of Changes

* We've gone 2 years without this code throwing if the result is `false` or otherwise making use of the result. Let's just get rid of it?

Fixes #24822.