### PR TITLE
Reduce admin rpc service thread count from the number of available cores to 3

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -288,6 +288,7 @@ pub fn run(ledger_path: &Path, metadata: AdminRpcRequestMetadata) {
 
     let event_loop = tokio::runtime::Builder::new_multi_thread()
         .thread_name("sol-adminrpc-el")
+        .worker_threads(3) // Three still seems like a lot, and better than the default of available core count
         .enable_all()
         .build()
         .unwrap();


### PR DESCRIPTION
Reduce the number of threads used by the admin rpc service to a reasonable amount. If it turns out this new default is too small for some fringe use cases, a new `solana-validator` argument can be added to make the thread count configurable.