### PR TITLE
Merge Refactor make_connection (#25225)

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -6,15 +6,13 @@ use {
     },
     indexmap::map::IndexMap,
     lazy_static::lazy_static,
-    quinn_proto::ConnectionStats,
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
-    solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::{
         timing::AtomicInterval, transaction::VersionedTransaction, transport::TransportError,
     },
     std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
+        net::SocketAddr,
         sync::{
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
@@ -227,7 +225,6 @@ struct GetConnectionResult {
     map_timing_ms: u64,
     lock_timing_ms: u64,
     connection_cache_stats: Arc<ConnectionCacheStats>,
-    other_stats: Option<(Arc<ClientStats>, ConnectionStats)>,
     num_evictions: u64,
     eviction_timing_ms: u64,
 }
@@ -244,67 +241,57 @@ fn get_or_add_connection(addr: &SocketAddr) -> GetConnectionResult {
         .should_update(CONNECTION_STAT_SUBMISSION_INTERVAL);
 
     let mut get_connection_map_measure = Measure::start("get_connection_hit_measure");
-    let (
-        connection,
-        cache_hit,
-        connection_cache_stats,
-        maybe_stats,
-        num_evictions,
-        eviction_timing_ms,
-    ) = match map.map.get(addr) {
-        Some(connection) => {
-            let mut stats = None;
-            // update connection stats
-            if let Connection::Quic(conn) = connection {
-                stats = conn.stats().map(|s| (conn.base_stats(), s));
+
+    let (connection, cache_hit, connection_cache_stats, num_evictions, eviction_timing_ms) =
+        match map.map.get(addr) {
+            Some(connection) => (connection.clone(), true, map.stats.clone(), 0, 0),
+            None => {
+                // Upgrade to write access by dropping read lock and acquire write lock
+                drop(map);
+                let mut get_connection_map_lock_measure =
+                    Measure::start("get_connection_map_lock_measure");
+                let mut map = (*CONNECTION_MAP).write().unwrap();
+                get_connection_map_lock_measure.stop();
+
+                lock_timing_ms =
+                    lock_timing_ms.saturating_add(get_connection_map_lock_measure.as_ms());
+
+                // Read again, as it is possible that between read lock dropped and the write lock acquired
+                // another thread could have setup the connection.
+                match map.map.get(addr) {
+                    Some(connection) => (connection.clone(), true, map.stats.clone(), 0, 0),
+                    None => {
+                        let connection = if map.use_quic {
+                            Connection::Quic(Arc::new(QuicTpuConnection::new(*addr)))
+                        } else {
+                            Connection::Udp(Arc::new(UdpTpuConnection::new(*addr)))
+                        };
+
+                        // evict a connection if the cache is reaching upper bounds
+                        let mut num_evictions = 0;
+                        let mut get_connection_cache_eviction_measure =
+                            Measure::start("get_connection_cache_eviction_measure");
+                        while map.map.len() >= MAX_CONNECTIONS {
+                            let mut rng = thread_rng();
+                            let n = rng.gen_range(0, MAX_CONNECTIONS);
+                            map.map.swap_remove_index(n);
+                            num_evictions += 1;
+                        }
+                        get_connection_cache_eviction_measure.stop();
+
+                        map.map.insert(*addr, connection.clone());
+                        (
+                            connection,
+                            false,
+                            map.stats.clone(),
+                            num_evictions,
+                            get_connection_cache_eviction_measure.as_ms(),
+                        )
+                    }
+                }
             }
-            (connection.clone(), true, map.stats.clone(), stats, 0, 0)
-        }
-        None => {
-            let (_, send_socket) = solana_net_utils::bind_in_range(
-                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-                VALIDATOR_PORT_RANGE,
-            )
-            .unwrap();
+        };
 
-            let connection = if map.use_quic {
-                Connection::Quic(Arc::new(QuicTpuConnection::new(send_socket, *addr)))
-            } else {
-                Connection::Udp(Arc::new(UdpTpuConnection::new(send_socket, *addr)))
-            };
-
-            // Upgrade to write access by dropping read lock and acquire write lock
-            drop(map);
-            let mut get_connection_map_lock_measure =
-                Measure::start("get_connection_map_lock_measure");
-            let mut map = (*CONNECTION_MAP).write().unwrap();
-            get_connection_map_lock_measure.stop();
-
-            lock_timing_ms = lock_timing_ms.saturating_add(get_connection_map_lock_measure.as_ms());
-
-            // evict a connection if the cache is reaching upper bounds
-            let mut num_evictions = 0;
-            let mut get_connection_cache_eviction_measure =
-                Measure::start("get_connection_cache_eviction_measure");
-            while map.map.len() >= MAX_CONNECTIONS {
-                let mut rng = thread_rng();
-                let n = rng.gen_range(0, MAX_CONNECTIONS);
-                map.map.swap_remove_index(n);
-                num_evictions += 1;
-            }
-            get_connection_cache_eviction_measure.stop();
-
-            map.map.insert(*addr, connection.clone());
-            (
-                connection,
-                false,
-                map.stats.clone(),
-                None,
-                num_evictions,
-                get_connection_cache_eviction_measure.as_ms(),
-            )
-        }
-    };
     get_connection_map_measure.stop();
 
     GetConnectionResult {
@@ -314,7 +301,6 @@ fn get_or_add_connection(addr: &SocketAddr) -> GetConnectionResult {
         map_timing_ms: get_connection_map_measure.as_ms(),
         lock_timing_ms,
         connection_cache_stats,
-        other_stats: maybe_stats,
         num_evictions,
         eviction_timing_ms,
     }
@@ -331,10 +317,15 @@ fn get_connection(addr: &SocketAddr) -> (Connection, Arc<ConnectionCacheStats>) 
         map_timing_ms,
         lock_timing_ms,
         connection_cache_stats,
-        other_stats,
         num_evictions,
         eviction_timing_ms,
     } = get_or_add_connection(addr);
+
+    let other_stats = if let Connection::Quic(conn) = &connection {
+        conn.stats().map(|s| (conn.base_stats(), s))
+    } else {
+        None
+    };
 
     if report_stats {
         connection_cache_stats.report();

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -3,7 +3,7 @@ use {
     solana_metrics::MovingStat,
     solana_sdk::{transaction::VersionedTransaction, transport::Result as TransportResult},
     std::{
-        net::{SocketAddr, UdpSocket},
+        net::SocketAddr,
         sync::{atomic::AtomicU64, Arc},
     },
 };
@@ -24,7 +24,7 @@ pub struct ClientStats {
 }
 
 pub trait TpuConnection {
-    fn new(client_socket: UdpSocket, tpu_addr: SocketAddr) -> Self;
+    fn new(tpu_addr: SocketAddr) -> Self;
 
     fn tpu_addr(&self) -> &SocketAddr;
 

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -4,10 +4,11 @@
 use {
     crate::tpu_connection::{ClientStats, TpuConnection},
     core::iter::repeat,
+    solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::transport::Result as TransportResult,
     solana_streamer::sendmmsg::batch_send,
     std::{
-        net::{SocketAddr, UdpSocket},
+        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::Arc,
     },
 };
@@ -18,7 +19,13 @@ pub struct UdpTpuConnection {
 }
 
 impl TpuConnection for UdpTpuConnection {
-    fn new(client_socket: UdpSocket, tpu_addr: SocketAddr) -> Self {
+    fn new(tpu_addr: SocketAddr) -> Self {
+        let (_, client_socket) = solana_net_utils::bind_in_range(
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            VALIDATOR_PORT_RANGE,
+        )
+        .unwrap();
+
         Self {
             socket: client_socket,
             addr: tpu_addr,

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -44,7 +44,7 @@ mod tests {
         let addr = s.local_addr().unwrap().ip();
         let port = s.local_addr().unwrap().port() - QUIC_PORT_OFFSET;
         let tpu_addr = SocketAddr::new(addr, port);
-        let client = QuicTpuConnection::new(UdpSocket::bind("127.0.0.1:0").unwrap(), tpu_addr);
+        let client = QuicTpuConnection::new(tpu_addr);
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;


### PR DESCRIPTION
1. Move logics related to creating endpoint, creating new connection and retry 0rtt connections into a wrapper construct QuicNewConnection to put the logic together.
2. get_or_add_connection: logic is much simplified to allow manage the connection cache -- the QUIC connection is lazy constructed. get_or_add_connection should no longer be a global hotspot.
3.  Per connection stats update is moved out of get_or_add_connection to avoid bad connection impacting good connections.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
