### PR TITLE
Create-snapshot check if slot is available on startup

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -758,11 +758,9 @@ fn load_bank_forks(
                 snapshot_utils::get_highest_incremental_snapshot_archive_slot(
                     &incremental_snapshot_archives_dir,
                     full_snapshot_slot,
-                );
-            starting_slot = std::cmp::max(
-                full_snapshot_slot,
-                incremental_snapshot_slot.unwrap_or_default(),
-            );
+                )
+                .unwrap_or_default();
+            starting_slot = std::cmp::max(full_snapshot_slot, incremental_snapshot_slot);
         }
 
         Some(SnapshotConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -777,12 +777,15 @@ fn load_bank_forks(
         for slot in starting_slot..=halt_slot {
             if let Ok(Some(slot_meta)) = blockstore.meta(slot) {
                 if !slot_meta.is_full() {
-                    eprintln!("blockstore slot {} is not full which is required for replaying slots {}..={}",
-                        slot, starting_slot, halt_slot);
+                    eprintln!("Unable to process from slot {} to {} due to blockstore slot {} not being full",
+                        starting_slot, halt_slot, slot);
                     exit(1);
                 }
             } else {
-                eprintln!("blockstore missing data for slot {} which is required for replaying slots {}..={}", slot, starting_slot, halt_slot);
+                eprintln!(
+                    "Unable to process from slot {} to {} due to blockstore missing slot {}",
+                    starting_slot, halt_slot, slot
+                );
                 exit(1);
             }
         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2332,6 +2332,11 @@ fn main() {
                     value_t_or_exit!(arg_matches, "snapshot_slot", Slot)
                 };
 
+                if blockstore.meta(snapshot_slot).unwrap().is_none() {
+                    eprintln!("snapshot slot {} is not available in the blockstore. Cannot create a snapshot at this slot", snapshot_slot);
+                    exit(1);
+                }
+
                 info!(
                     "Creating {}snapshot of slot {} in {}",
                     if is_incremental { "incremental " } else { "" },


### PR DESCRIPTION
#### Problem
create-snapshot will load bank_forks from a snapshot and try to replay up to snapshot_slot. If snapshot_slot does not exist, it will replay everything available and then fail. This can be slow.

#### Summary of Changes
Add a check to see if `snapshot_slot` is available in the blockstore BEFORE trying to load the bank_forks. If it's not we exit since we won't be able to create a snapshot.

Preliminary PR for minimized snapshot mode.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
