### PR TITLE
Dos tool: generate requests using several threads 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,6 +4774,7 @@ version = "1.11.0"
 dependencies = [
  "bincode",
  "clap 3.1.12",
+ "crossbeam-channel",
  "itertools",
  "log",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4787,6 +4787,7 @@ dependencies = [
  "solana-gossip",
  "solana-local-cluster",
  "solana-logger 1.11.0",
+ "solana-measure",
  "solana-net-utils",
  "solana-perf",
  "solana-rpc",

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4.17"
 rand = "0.7.0"
 serde = "1.0.137"
 itertools = "0.10.3"
+crossbeam-channel = "0.5.4"
 solana-client = { path = "../client", version = "=1.11.0" }
 solana-core = { path = "../core", version = "=1.11.0" }
 solana-gossip = { path = "../gossip", version = "=1.11.0" }

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
 publish = false
-description = "Tool to send various requests to cluster in order to evaluate the effect on performance"
+description = "Tool to send various requests to cluster in order to evaluate the effect on performance."
 
 [dependencies]
 bincode = "1.3.3"

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -29,6 +29,7 @@ solana-version = { path = "../version", version = "=1.11.0" }
 solana-bench-tps = { path = "../bench-tps", version = "=1.11.0" }
 solana-faucet = { path = "../faucet", version = "=1.11.0" }
 solana-rpc = { path = "../rpc", version = "=1.11.0" }
+solana-measure = { path = "../measure", version = "=1.11.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -5,10 +5,27 @@ use {
     std::{net::SocketAddr, process::exit, str::FromStr},
 };
 
+macro_rules! dos_tool_long_about {
+    () => {
+        concat!(crate_description!(),
+        "\n\n\
+        Example 1: generate one transaction request with 2 valid signatures (no blockhash) and send it indefinitely to tpu:\n\
+        solana-dos --mode tpu --data-type transaction --valid-signature --num-signatures 2\n\n\
+        Example 2: generate unique transactions requests with invalid signatures:\n\
+        solana-dos --mode tpu --data-type transaction --num-signatures 2 --unique-transactions-coefficient 0\n\n\
+        Example 3: as above but send each request 4 times:\n\
+        solana-dos --mode tpu --data-type transaction --num-signatures 2 --unique-transactions-coefficient 3\n\n\
+        Example 4: generate create-account requests with valid blockhash and send each 2 times\n \
+        solana-dos --mode tpu --data-type transaction --transaction-type account-creation --valid-blockhash --unique-transactions-coefficient 1\n\
+        ")
+    }
+}
+
 #[derive(Parser, Debug, PartialEq)]
 #[clap(name = crate_name!(),
     version = crate_version!(),
     about = crate_description!(),
+    long_about = dos_tool_long_about!(),
     rename_all = "kebab-case"
 )]
 pub struct DosClientParameters {

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -59,7 +59,7 @@ pub struct DosClientParameters {
     pub transaction_params: TransactionParams,
 }
 
-#[derive(Args, Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Args, Clone, Serialize, Deserialize, Debug, Default, PartialEq)]
 #[clap(rename_all = "kebab-case")]
 pub struct TransactionParams {
     #[clap(

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -48,6 +48,13 @@ pub struct DosClientParameters {
     #[clap(long, help = "Allow contacting private ip addresses")]
     pub allow_private_addr: bool,
 
+    #[clap(
+        long,
+        default_value = "1",
+        help = "Number of threads generating transactions"
+    )]
+    pub num_gen_threads: usize,
+
     #[clap(flatten)]
     pub transaction_params: TransactionParams,
 }
@@ -210,6 +217,7 @@ mod tests {
                 data_input: Some(pubkey),
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default()
             },
         );
@@ -240,6 +248,7 @@ mod tests {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: Some(8),
                     valid_blockhash: false,
@@ -279,6 +288,7 @@ mod tests {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,
@@ -333,6 +343,7 @@ mod tests {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,
@@ -370,6 +381,7 @@ mod tests {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -84,8 +84,11 @@ pub struct TransactionParams {
     )]
     pub valid_signatures: bool,
 
-    #[clap(long, help = "Generate unique transactions")]
-    pub unique_transactions: bool,
+    #[clap(
+        long,
+        help = "Unique transactions ratio coefficient, 0 means that all transactions are unique. If unset, all transactions are the same"
+    )]
+    pub unique_transactions_coefficient: Option<usize>,
 
     #[clap(
         long,
@@ -158,8 +161,9 @@ fn validate_input(params: &DosClientParameters) {
 
     if params.data_type != DataType::Transaction {
         let tp = &params.transaction_params;
-        if tp.valid_blockhash || tp.valid_signatures || tp.unique_transactions {
-            eprintln!("Arguments valid-blockhash, valid-sign, unique-transactions are ignored if data-type != transaction");
+        if tp.valid_blockhash || tp.valid_signatures || tp.unique_transactions_coefficient.is_some()
+        {
+            eprintln!("Arguments valid-blockhash, valid-sign, unique-transactions-coefficient are ignored if data-type != transaction");
             exit(1);
         }
     }
@@ -232,7 +236,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--valid-signatures",
             "--num-signatures",
             "8",
@@ -253,7 +258,7 @@ mod tests {
                     num_signatures: Some(8),
                     valid_blockhash: false,
                     valid_signatures: true,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: None,
                     num_instructions: None,
                 },
@@ -270,7 +275,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--valid-blockhash",
             "--transaction-type",
             "transfer",
@@ -293,7 +299,7 @@ mod tests {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: false,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
@@ -306,7 +312,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--transaction-type",
             "transfer",
             "--num-instructions",
@@ -325,7 +332,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--valid-blockhash",
             "--transaction-type",
             "transfer",
@@ -348,7 +356,7 @@ mod tests {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: false,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(8),
                 },
@@ -365,7 +373,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--valid-blockhash",
             "--transaction-type",
             "account-creation",
@@ -386,7 +395,7 @@ mod tests {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: false,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::AccountCreation),
                     num_instructions: None,
                 },
@@ -404,7 +413,8 @@ mod tests {
             "tpu",
             "--data-type",
             "transaction",
-            "--unique-transactions",
+            "--unique-transactions-coefficient",
+            "0",
             "--valid-signatures",
             "--num-signatures",
             "8",

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -72,6 +72,7 @@ use {
         net::{SocketAddr, UdpSocket},
         process::exit,
         sync::Arc,
+        thread,
         time::{Duration, Instant},
     },
 };
@@ -98,6 +99,7 @@ fn get_repair_contact(nodes: &[ContactInfo]) -> ContactInfo {
 /// 2.1 Transfer from 1 payer to multiple destinations (many instructions per transaction)
 /// 2.2 Create an account
 ///
+#[derive(Clone)]
 struct TransactionGenerator {
     blockhash: Hash,
     last_generated: Instant,
@@ -235,7 +237,111 @@ impl TransactionGenerator {
     }
 }
 
+// Multithreading-related functions
+//
+// The most computationally expensive work is signing new transactions.
+// Here we generate them in `num_gen_threads` threads.
+//
+/// number of transactions in one batch for sendmmsg
 const SEND_BATCH_MAX_SIZE: usize = 1 << 10;
+
+fn get_send_batch_size(max_iterations_per_thread: usize, total_count: usize) -> usize {
+    if max_iterations_per_thread == 0 {
+        return SEND_BATCH_MAX_SIZE
+    }
+    min(max_iterations_per_thread - total_count, SEND_BATCH_MAX_SIZE)
+}
+
+fn create_generator_thread<T: 'static + BenchTpsClient + Send + Sync>(
+    max_iterations_per_thread: usize,
+    transaction_generator: &mut TransactionGenerator,
+    client: Option<Arc<T>>,
+    payer: Option<Keypair>,
+    target: &SocketAddr,
+) -> thread::JoinHandle<()> {
+    let target = target.clone();
+    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+
+    let mut transaction_generator = transaction_generator.clone();
+    let transaction_params: &TransactionParams = &transaction_generator.transaction_params;
+    let client = client.clone();
+
+    // Generate n=1000 unique keypairs
+    // The number of chunks is described by binomial coefficient
+    // and hence this choice of n provides large enough number of permutations
+    let mut keypairs_flat: Vec<Keypair> = Vec::new();
+    // 1000 is arbitrary number. In case of permutation_size > 1,
+    // this guaranties large enough set of unique permutations
+    let permutation_size = get_permutation_size(
+        transaction_params.num_signatures.as_ref(),
+        transaction_params.num_instructions.as_ref(),
+    );
+    let num_keypairs = 1000 * permutation_size;
+
+    let generate_keypairs =
+        transaction_params.valid_signatures || transaction_params.valid_blockhash;
+    if generate_keypairs {
+        keypairs_flat = (0..num_keypairs).map(|_| Keypair::new()).collect();
+    }
+
+    thread::Builder::new().name("Generator".to_string()).spawn(move || {
+        let indexes: Vec<usize> = (0..keypairs_flat.len()).collect();
+        let mut it = indexes.iter().permutations(permutation_size);
+
+        let udp_client = UdpTpuConnection::new(socket, target);
+        let client_stats = ClientStats::default();
+
+        let mut count = 0;
+        let mut total_count = 0;
+        let mut error_count = 0;
+        let mut last_log = Instant::now();
+
+        let mut data = Vec::<Vec<u8>>::with_capacity(SEND_BATCH_MAX_SIZE);
+        loop {
+            let send_batch_size = get_send_batch_size(max_iterations_per_thread, total_count);
+            data.clear();
+            for _ in 0..send_batch_size {
+                let chunk_keypairs = if generate_keypairs {
+                    let mut permutation = it.next();
+                    if permutation.is_none() {
+                        // if ran out of permutations, regenerate keys
+                        keypairs_flat.iter_mut().for_each(|v| *v = Keypair::new());
+                        info!("Regenerate keypairs");
+                        permutation = it.next();
+                    }
+                    let permutation = permutation.unwrap();
+                    Some(apply_permutation(permutation, &keypairs_flat))
+                } else {
+                    None
+                };
+                let tx =
+                    transaction_generator.generate(payer.as_ref(), chunk_keypairs, client.as_ref());
+                data.push(bincode::serialize(&tx).unwrap());
+            }
+
+            let res = udp_client.send_wire_transaction_batch(&data, &client_stats);
+
+            if res.is_err() {
+                error_count += send_batch_size;
+            }
+            count += send_batch_size;
+            total_count += send_batch_size;
+            if last_log.elapsed().as_millis() > SAMPLE_PERIOD_MS as u128 {
+                info!(
+                    "count: {}, errors: {}, rps: {}",
+                    count,
+                    error_count,
+                    compute_rate_per_second(count)
+                );
+                last_log = Instant::now();
+                count = 0;
+            }
+            if max_iterations_per_thread != 0 && total_count >= max_iterations_per_thread {
+                break;
+            }
+        }
+    }).unwrap()
+}
 
 fn get_target(
     nodes: &[ContactInfo],
@@ -389,87 +495,41 @@ fn run_dos_transactions<T: 'static + BenchTpsClient + Send + Sync>(
     iterations: usize,
     client: Option<Arc<T>>,
     transaction_params: TransactionParams,
+    num_gen_threads: usize,
 ) {
-    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-
-    // Number of payers is the number of generating threads, for now it is 1
+    let max_iterations_per_thread = iterations / num_gen_threads;
+    // Number of payers is the number of generating threads
     // Later, we will create a new payer for each thread since Keypair is not clonable
-    let payers: Vec<Option<Keypair>> =
-        create_payers(transaction_params.valid_blockhash, 1, client.as_ref());
-    let payer = payers[0].as_ref();
-
-    // Generate n=1000 unique keypairs
-    // The number of chunks is described by binomial coefficient
-    // and hence this choice of n provides large enough number of permutations
-    let mut keypairs_flat: Vec<Keypair> = Vec::new();
-    // 1000 is arbitrary number. In case of permutation_size > 1,
-    // this guaranties large enough set of unique permutations
-    let permutation_size = get_permutation_size(
-        transaction_params.num_signatures.as_ref(),
-        transaction_params.num_instructions.as_ref(),
+    let payers: Vec<Option<Keypair>> = create_payers(
+        transaction_params.valid_blockhash,
+        num_gen_threads,
+        client.as_ref(),
     );
-    let num_keypairs = 1000 * permutation_size;
-
-    let generate_keypairs =
-        transaction_params.valid_signatures || transaction_params.valid_blockhash;
-    if generate_keypairs {
-        keypairs_flat = (0..num_keypairs).map(|_| Keypair::new()).collect();
-    }
-
-    let indexes: Vec<usize> = (0..keypairs_flat.len()).collect();
-    let mut it = indexes.iter().permutations(permutation_size);
 
     let mut transaction_generator = TransactionGenerator::new(transaction_params);
+    let mut thread_id = 0;
+    let tx_generator_threads: Vec<_> = payers
+        .into_iter()
+        .map(|payer| {
+            let mut num_iterations = max_iterations_per_thread;
+            // last thread will handle remaining iterations
+            if thread_id+1 == num_gen_threads {
+                num_iterations += iterations%num_gen_threads;
+            }
+            thread_id += 1;
 
-    let udp_client = UdpTpuConnection::new(socket, target);
-    let client_stats = ClientStats::default();
-
-    let mut count = 0;
-    let mut total_count = 0;
-    let mut error_count = 0;
-    let mut last_log = Instant::now();
-
-    let mut data = Vec::<Vec<u8>>::with_capacity(SEND_BATCH_MAX_SIZE);
-    loop {
-        let send_batch_size = min(iterations - total_count, SEND_BATCH_MAX_SIZE);
-        data.clear();
-        for _ in 0..send_batch_size {
-            let chunk_keypairs = if generate_keypairs {
-                let mut permutation = it.next();
-                if permutation.is_none() {
-                    // if ran out of permutations, regenerate keys
-                    keypairs_flat.iter_mut().for_each(|v| *v = Keypair::new());
-                    info!("Regenerate keypairs");
-                    permutation = it.next();
-                }
-                let permutation = permutation.unwrap();
-                Some(apply_permutation(permutation, &keypairs_flat))
-            } else {
-                None
-            };
-            let tx = transaction_generator.generate(payer, chunk_keypairs, client.as_ref());
-            data.push(bincode::serialize(&tx).unwrap());
-        }
-
-        let res = udp_client.send_wire_transaction_batch(&data, &client_stats);
-        
-        if res.is_err() {
-            error_count += send_batch_size;
-        }
-        count += send_batch_size;
-        total_count += send_batch_size;
-        if last_log.elapsed().as_millis() > SAMPLE_PERIOD_MS as u128 {
-            info!(
-                "count: {}, errors: {}, rps: {}",
-                count,
-                error_count,
-                compute_rate_per_second(count)
-            );
-            last_log = Instant::now();
-            count = 0;
-        }
-        if iterations != 0 && total_count >= iterations {
-            break;
+            create_generator_thread(
+                num_iterations,
+                &mut transaction_generator,
+                client.clone(),
+                payer,
+                &target.clone(),
+            )
+        })
+        .collect();
+    for t_generator in tx_generator_threads {
+        if let Err(err) = t_generator.join() {
+            println!("join() failed with: {:?}", err);
         }
     }
 }
@@ -498,7 +558,13 @@ fn run_dos<T: 'static + BenchTpsClient + Send + Sync>(
     {
         let target = target.expect("should have target");
         info!("Targeting {}", target);
-        run_dos_transactions(target, iterations, client, params.transaction_params);
+        run_dos_transactions(
+            target,
+            iterations,
+            client,
+            params.transaction_params,
+            params.num_gen_threads,
+        );
     } else {
         let target = target.expect("should have target");
         info!("Targeting {}", target);

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -45,8 +45,8 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     solana_bench_tps::{bench::generate_and_fund_keypairs, bench_tps_client::BenchTpsClient},
-    solana_client::rpc_client::RpcClient,
     solana_client::{
+        rpc_client::RpcClient,
         tpu_connection::{ClientStats, TpuConnection},
         udp_client::UdpTpuConnection,
     },
@@ -254,10 +254,9 @@ const SEND_BATCH_MAX_SIZE: usize = 1 << 14;
 fn create_sender_thread(
     tx_receiver: Receiver<TransactionMsg>,
     mut n_alive_threads: usize,
-    target: &SocketAddr,
+    target: SocketAddr,
     num_send: usize,
 ) -> thread::JoinHandle<()> {
-    let target = target.clone();
     let timer_receiver = tick(Duration::from_millis(SAMPLE_PERIOD_MS as u64));
 
     let client = UdpTpuConnection::new(target);
@@ -334,7 +333,6 @@ fn create_generator_thread<T: 'static + BenchTpsClient + Send + Sync>(
 
     let mut transaction_generator = transaction_generator.clone();
     let transaction_params: &TransactionParams = &transaction_generator.transaction_params;
-    let client = client.clone();
 
     // Generate n=1000 unique keypairs
     // The number of chunks is described by binomial coefficient
@@ -572,7 +570,7 @@ fn run_dos_transactions<T: 'static + BenchTpsClient + Send + Sync>(
     let mut transaction_generator = TransactionGenerator::new(transaction_params);
     let (tx_sender, tx_receiver) = unbounded();
 
-    let sender_thread = create_sender_thread(tx_receiver, num_gen_threads, &target, num_send);
+    let sender_thread = create_sender_thread(tx_receiver, num_gen_threads, target, num_send);
     let mut thread_id = 0;
     let tx_generator_threads: Vec<_> = payers
         .into_iter()

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -56,6 +56,7 @@ use {
         contact_info::ContactInfo,
         gossip_service::{discover, get_multi_client},
     },
+    solana_measure::measure::Measure,
     solana_sdk::{
         hash::Hash,
         instruction::CompiledInstruction,
@@ -244,7 +245,7 @@ impl TransactionGenerator {
 // Here we generate them in `num_gen_threads` threads.
 //
 enum TransactionMsg {
-    Transaction(Vec<Vec<u8>>),
+    Transaction(Vec<Vec<u8>>, u64),
     Exit,
 }
 /// number of transactions in one batch for sendmmsg
@@ -260,6 +261,8 @@ fn create_sender_thread(
     let timer_receiver = tick(Duration::from_millis(SAMPLE_PERIOD_MS as u64));
 
     let client = UdpTpuConnection::new(socket, target);
+    let mut time_send_ns = 0;
+    let mut time_generate_ns = 0;
 
     thread::Builder::new().name("Sender".to_string()).spawn(move || {
         let mut count: usize = 0;
@@ -270,8 +273,12 @@ fn create_sender_thread(
             select! {
                 recv(tx_receiver) -> msg => {
                     match msg {
-                        Ok(TransactionMsg::Transaction(data)) => {
+                        Ok(TransactionMsg::Transaction(data, time)) => {
+                            let mut measure_send_txs = Measure::start("measure_send_txs");
                             let res = client.send_wire_transaction_batch(&data, &client_stats);
+                            measure_send_txs.stop();
+                            time_send_ns += measure_send_txs.as_ns();
+                            time_generate_ns += time;
 
                             if res.is_err() {
                                 error_count += data.len();
@@ -290,13 +297,17 @@ fn create_sender_thread(
                 },
                 recv(timer_receiver) -> _ => {
                     info!("tx_receiver queue len: {}", tx_receiver.len());
-                    info!("Count: {}, error count: {}, rps: {}",
+                    info!("Count: {}, error count: {}, send mean time: {}, generate mean time: {}, rps: {}",
                         count,
                         error_count,
+                        time_send_ns.checked_div(count as u64).unwrap_or(0),
+                        time_generate_ns.checked_div(count as u64).unwrap_or(0),
                         compute_rate_per_second(count),
                     );
                     count = 0;
                     error_count = 0;
+                    time_send_ns = 0;
+                    time_generate_ns = 0;
                 }
             }
         }
@@ -349,6 +360,7 @@ fn create_generator_thread<T: 'static + BenchTpsClient + Send + Sync>(
         loop {
             let send_batch_size = get_send_batch_size(max_iterations_per_thread, total_count);
             let mut data = Vec::<Vec<u8>>::with_capacity(SEND_BATCH_MAX_SIZE);
+            let mut measure_generate_txs = Measure::start("measure_generate_txs");
             for _ in 0..send_batch_size {
                 let chunk_keypairs = if generate_keypairs {
                     let mut permutation = it.next();
@@ -367,8 +379,9 @@ fn create_generator_thread<T: 'static + BenchTpsClient + Send + Sync>(
                     transaction_generator.generate(payer.as_ref(), chunk_keypairs, client.as_ref());
                 data.push(bincode::serialize(&tx).unwrap());
             }
+            measure_generate_txs.stop();
 
-            let _ = tx_sender.send(TransactionMsg::Transaction(data));
+            let _ = tx_sender.send(TransactionMsg::Transaction(data, measure_generate_txs.as_ns()));
 
             total_count += send_batch_size;
             if max_iterations_per_thread != 0 && total_count >= max_iterations_per_thread {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -14,7 +14,7 @@
 //!
 //! To limit the number of possible options and simplify the usage of the tool,
 //! The following configurations are suggested:
-//! Let `COMMON="--mode tpu --data-type transaction --unique-transactions"`
+//! Let `COMMON="--mode tpu --data-type transaction --unique-transactions-coefficient 0"`
 //! 1. Without blockhash or payer:
 //! 1.1 With invalid signatures
 //! ```bash

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -609,7 +609,7 @@ fn run_dos<T: 'static + BenchTpsClient + Send + Sync>(
             &params.data_input.unwrap(),
         );
     } else if params.data_type == DataType::Transaction
-        && params.transaction_params.unique_transactions
+        && params.transaction_params.unique_transactions_coefficient.is_some()
     {
         let target = target.expect("should have target");
         info!("Targeting {}", target);
@@ -914,7 +914,7 @@ pub mod test {
                     num_signatures: Some(8),
                     valid_blockhash: false,
                     valid_signatures: true,
-                    unique_transactions: false,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: None,
                     num_instructions: None,
                 },
@@ -939,7 +939,7 @@ pub mod test {
                     num_signatures: Some(8),
                     valid_blockhash: false,
                     valid_signatures: false,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: None,
                     num_instructions: None,
                 },
@@ -964,7 +964,7 @@ pub mod test {
                     num_signatures: Some(8),
                     valid_blockhash: false,
                     valid_signatures: true,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: None,
                     num_instructions: None,
                 },
@@ -1041,7 +1041,7 @@ pub mod test {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: true,
-                    unique_transactions: false,
+                    unique_transactions_coefficient: None,
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
@@ -1068,7 +1068,7 @@ pub mod test {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: true,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(1),
                 },
@@ -1094,7 +1094,7 @@ pub mod test {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: true,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::Transfer),
                     num_instructions: Some(8),
                 },
@@ -1120,7 +1120,7 @@ pub mod test {
                     num_signatures: None,
                     valid_blockhash: true,
                     valid_signatures: true,
-                    unique_transactions: true,
+                    unique_transactions_coefficient: Some(0),
                     transaction_type: Some(TransactionType::AccountCreation),
                     num_instructions: None,
                 },

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -673,6 +673,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
             },
         );
@@ -688,6 +689,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
             },
         );
@@ -703,6 +705,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
             },
         );
@@ -718,6 +721,7 @@ pub mod test {
                 data_input: Some(Pubkey::default()),
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
             },
         );
@@ -748,6 +752,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams::default(),
             },
         );
@@ -783,6 +788,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: Some(8),
                     valid_blockhash: false,
@@ -807,6 +813,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: Some(8),
                     valid_blockhash: false,
@@ -831,6 +838,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: Some(8),
                     valid_blockhash: false,
@@ -907,6 +915,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,
@@ -933,6 +942,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,
@@ -958,6 +968,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,
@@ -983,6 +994,7 @@ pub mod test {
                 data_input: None,
                 skip_gossip: false,
                 allow_private_addr: false,
+                num_gen_threads: 1,
                 transaction_params: TransactionParams {
                     num_signatures: None,
                     valid_blockhash: true,

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -257,11 +257,10 @@ fn create_sender_thread(
     target: &SocketAddr,
     num_send: usize,
 ) -> thread::JoinHandle<()> {
-    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let target = target.clone();
     let timer_receiver = tick(Duration::from_millis(SAMPLE_PERIOD_MS as u64));
 
-    let client = UdpTpuConnection::new(socket, target);
+    let client = UdpTpuConnection::new(target);
     let mut time_send_ns = 0;
     let mut time_generate_ns = 0;
 


### PR DESCRIPTION
This PR was split into several smaller PRs:
1. https://github.com/solana-labs/solana/pull/25585
2. To be added

#### Problem

DoS tool generates and sends requests in one thread which limits it's pps.

#### Summary of Changes

* sends batches of requests instead of individual requests (use `sendmmsg` wrapper)
* add multithreading request generation
* adds options to send duplicating requests. In this case unique request might be send 1-N times.

What is not implemented:
* back-pressure on the crossbeam channel to prevent it's growth
* sending requests in several threads. Sending in 2 threads gives x2 pps for the case with > 3 duplicates per request
* support of other types of clients to work with testnet [issue#25108](https://github.com/solana-labs/solana/issues/25108)

Result of one of the test runs `./solana-dos --num-signatures 2 --valid-signatures --unique-transactions-coefficient 5` on gce cluster with 2 nodes and 1 client:

![bla](https://user-images.githubusercontent.com/687962/169100030-864efc6e-eec2-4493-a26f-1735a5726b9d.png)

