### PR TITLE
Increase broadcast receiver timeout to mitigate test flakiness.

### DIFF
--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -193,7 +193,7 @@ pub struct TestBroadcastReceiver {
 #[cfg(test)]
 impl TestBroadcastReceiver {
     pub fn recv(&mut self) -> String {
-        return match self.recv_timeout(std::time::Duration::from_secs(5)) {
+        return match self.recv_timeout(std::time::Duration::from_secs(10)) {
             Err(err) => panic!("broadcast receiver error: {}", err),
             Ok(str) => str,
         };


### PR DESCRIPTION

#### Problem
https://buildkite.com/solana-labs/solana/builds/73576#2847bbc5-6af4-4968-817d-f32b03d2f16d
The current timeout is 5 sec.  The timeout happened in this test run.
But it is not easy to manually reproduce this error.  I saw it
happened once out of about 20 runs.

#### Summary of Changes
Increase broadcast receiver timeout to mitigate test flakiness.
The chance of exceeding the 10sec timeout should be much lower.


We can debug the timeout further once we have the cargo nextest
stress run set up.
****
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
