### PR TITLE
Fix alignment check

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3984,6 +3984,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-inner_instruction_alignment_check"
+version = "1.11.0"
+dependencies = [
+ "solana-program 1.11.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-instruction-introspection"
 version = "1.11.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "rust/external_spend",
     "rust/get_minimum_delegation",
     "rust/finalize",
+    "rust/inner_instruction_alignment_check",
     "rust/instruction_introspection",
     "rust/invoke",
     "rust/invoke_and_error",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -71,6 +71,7 @@ fn main() {
             "external_spend",
             "finalize",
             "get_minimum_delegation",
+            "inner_instruction_alignment_check",
             "instruction_introspection",
             "invoke",
             "invoke_and_error",

--- a/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/bpf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "solana-bpf-rust-inner_instruction_alignment_check"
+version = "1.11.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-inner_instruction_alignment_check"
+edition = "2021"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "=1.11.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/inner_instruction_alignment_check/src/lib.rs
+++ b/programs/bpf/rust/inner_instruction_alignment_check/src/lib.rs
@@ -1,15 +1,21 @@
-//! Invokes an instruction and return ok no matter what, the instruction invoked
-//! uses the instruction data provided and all the accounts
+//! Example Rust-based BPF noop program
 
 use solana_program::{
     account_info::AccountInfo,
-    entrypoint::ProgramResult,
+    entrypoint_deprecated::ProgramResult,
     instruction::{AccountMeta, Instruction},
+    msg,
     program::invoke,
     pubkey::Pubkey,
 };
 
-solana_program::entrypoint!(process_instruction);
+#[no_mangle]
+fn custom_panic(info: &core::panic::PanicInfo<'_>) {
+    // Full panic reporting
+    msg!(&format!("{}", info));
+}
+
+solana_program::entrypoint_deprecated!(process_instruction);
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
@@ -19,17 +25,16 @@ fn process_instruction(
     let to_call = accounts[0].key;
     let infos = accounts;
     let instruction = Instruction {
-        accounts: accounts[1..]
-            .iter()
-            .map(|acc| AccountMeta {
-                pubkey: *acc.key,
-                is_signer: acc.is_signer,
-                is_writable: acc.is_writable,
-            })
-            .collect(),
+        accounts: vec![AccountMeta {
+            pubkey: *accounts[1].key,
+            is_signer: accounts[1].is_signer,
+            is_writable: accounts[1].is_writable,
+        }],
         data: instruction_data.to_owned(),
         program_id: *to_call,
     };
+
+    let _ = invoke(&instruction, infos);
     let _ = invoke(&instruction, infos);
 
     Ok(())

--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -1,4 +1,4 @@
-//! Invokes an instruction and returns an error, the instruction invoked
+//! Invokes an instruction and returns the invoke result, the instruction invoked
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -384,30 +384,28 @@ pub fn bind_syscall_context_objects<'a, 'b>(
     vm: &mut EbpfVm<'a, BpfError, crate::ThisInstructionMeter>,
     invoke_context: &'a mut InvokeContext<'b>,
     heap: AlignedMemory,
+    orig_account_lengths: Vec<usize>,
 ) -> Result<(), EbpfError<BpfError>> {
-    invoke_context.set_check_aligned(
-        bpf_loader_deprecated::id()
-            != invoke_context
-                .transaction_context
-                .get_current_instruction_context()
-                .and_then(|instruction_context| {
-                    instruction_context
-                        .try_borrow_program_account(invoke_context.transaction_context)
-                })
-                .map(|program_account| *program_account.get_owner())
-                .map_err(SyscallError::InstructionError)?,
-    );
-    invoke_context.set_check_size(
-        invoke_context
-            .feature_set
-            .is_active(&check_slice_translation_size::id()),
-    );
+    let check_aligned = bpf_loader_deprecated::id()
+        != invoke_context
+            .transaction_context
+            .get_current_instruction_context()
+            .and_then(|instruction_context| {
+                instruction_context.try_borrow_program_account(invoke_context.transaction_context)
+            })
+            .map(|program_account| *program_account.get_owner())
+            .map_err(SyscallError::InstructionError)?;
+    let check_size = invoke_context
+        .feature_set
+        .is_active(&check_slice_translation_size::id());
 
     invoke_context
-        .set_allocator(Rc::new(RefCell::new(BpfAllocator::new(
-            heap,
-            ebpf::MM_HEAP_START,
-        ))))
+        .set_syscall_context(
+            check_aligned,
+            check_size,
+            orig_account_lengths,
+            Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+        )
         .map_err(SyscallError::InstructionError)?;
 
     let invoke_context = Rc::new(RefCell::new(invoke_context));
@@ -3253,7 +3251,7 @@ fn call<'a, 'b: 'a>(
                     memory_mapping,
                     caller_account.vm_data_addr,
                     new_len as u64,
-                    invoke_context.get_check_aligned(),
+                    false, // Don't care since it is byte aligned
                     invoke_context.get_check_size(),
                 )?;
                 *caller_account.ref_to_len_in_vm = new_len as u64;
@@ -4329,10 +4327,12 @@ mod tests {
             )
             .unwrap();
             invoke_context
-                .set_allocator(Rc::new(RefCell::new(BpfAllocator::new(
-                    heap,
-                    ebpf::MM_HEAP_START,
-                ))))
+                .set_syscall_context(
+                    true,
+                    true,
+                    vec![],
+                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                )
                 .unwrap();
             let mut syscall = SyscallAllocFree {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -4369,12 +4369,13 @@ mod tests {
             )
             .unwrap();
             invoke_context
-                .set_allocator(Rc::new(RefCell::new(BpfAllocator::new(
-                    heap,
-                    ebpf::MM_HEAP_START,
-                ))))
+                .set_syscall_context(
+                    false,
+                    true,
+                    vec![],
+                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                )
                 .unwrap();
-            invoke_context.set_check_aligned(false);
             let mut syscall = SyscallAllocFree {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
             };
@@ -4409,10 +4410,12 @@ mod tests {
             )
             .unwrap();
             invoke_context
-                .set_allocator(Rc::new(RefCell::new(BpfAllocator::new(
-                    heap,
-                    ebpf::MM_HEAP_START,
-                ))))
+                .set_syscall_context(
+                    true,
+                    true,
+                    vec![],
+                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                )
                 .unwrap();
             let mut syscall = SyscallAllocFree {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
@@ -4450,10 +4453,12 @@ mod tests {
             )
             .unwrap();
             invoke_context
-                .set_allocator(Rc::new(RefCell::new(BpfAllocator::new(
-                    heap,
-                    ebpf::MM_HEAP_START,
-                ))))
+                .set_syscall_context(
+                    true,
+                    true,
+                    vec![],
+                    Rc::new(RefCell::new(BpfAllocator::new(heap, ebpf::MM_HEAP_START))),
+                )
                 .unwrap();
             let mut syscall = SyscallAllocFree {
                 invoke_context: Rc::new(RefCell::new(&mut invoke_context)),

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -313,12 +313,10 @@ native machine code before execting it in the virtual machine.",
         _ => {}
     }
 
-    invoke_context
-        .set_orig_account_lengths(account_lengths)
-        .unwrap();
     let mut vm = create_vm(
         &executable,
         parameter_bytes.as_slice_mut(),
+        account_lengths,
         &mut invoke_context,
     )
     .unwrap();


### PR DESCRIPTION
#### Problem

Recent syscall context considation wasn't handling the changes between instructions correctly.  In particular, alignment checking that depends on the loader being used was being set and stayed at the last program loaded rather than returning to the caller's setting.

This caused a bank hash mismatch on master due to some txs failing.

#### Summary of Changes

Track the syscall context per-instruction


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
