### PR TITLE
add ledger-tool accounts-db-skip-initial-hash-calc

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -992,6 +992,11 @@ fn main() {
                   This produces snapshots that older versions cannot read.",
         )
         .hidden(true);
+    let accounts_db_skip_initial_hash_calc_arg =
+        Arg::with_name("accounts_db_skip_initial_hash_calculation")
+            .long("accounts-db-skip-initial-hash-calculation")
+            .help("Do not verify accounts hash at startup.")
+            .hidden(true);
     let ancient_append_vecs = Arg::with_name("accounts_db_ancient_append_vecs")
         .long("accounts-db-ancient-append-vecs")
         .help("AppendVecs that are older than an epoch are squashed together.")
@@ -1337,6 +1342,7 @@ fn main() {
             .arg(&accounts_filler_size)
             .arg(&verify_index_arg)
             .arg(&skip_rewrites_arg)
+            .arg(&accounts_db_skip_initial_hash_calc_arg)
             .arg(&ancient_append_vecs)
             .arg(&hard_forks_arg)
             .arg(&no_accounts_db_caching_arg)
@@ -2143,6 +2149,8 @@ fn main() {
                     filler_accounts_config,
                     skip_rewrites: matches.is_present("accounts_db_skip_rewrites"),
                     ancient_append_vecs: matches.is_present("accounts_db_ancient_append_vecs"),
+                    skip_initial_hash_calc: matches
+                        .is_present("accounts_db_skip_initial_hash_calculation"),
                     ..AccountsDbConfig::default()
                 });
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -137,6 +137,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     write_cache_limit_bytes: None,
     skip_rewrites: false,
     ancient_append_vecs: false,
+    skip_initial_hash_calc: false,
 };
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS),
@@ -146,6 +147,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     write_cache_limit_bytes: None,
     skip_rewrites: false,
     ancient_append_vecs: false,
+    skip_initial_hash_calc: false,
 };
 
 pub type BinnedHashData = Vec<Vec<CalculateHashIntermediate>>;
@@ -185,6 +187,7 @@ pub struct AccountsDbConfig {
     pub write_cache_limit_bytes: Option<u64>,
     pub skip_rewrites: bool,
     pub ancient_append_vecs: bool,
+    pub skip_initial_hash_calc: bool,
 }
 
 pub struct FoundStoredAccount<'a> {
@@ -1009,6 +1012,9 @@ pub struct AccountsDb {
     /// true iff we want to squash old append vecs together into 'ancient append vecs'
     pub ancient_append_vecs: bool,
 
+    /// true iff we want to skip the initial hash calculation on startup
+    pub skip_initial_hash_calc: bool,
+
     pub storage: AccountStorage,
 
     pub accounts_cache: AccountsCache,
@@ -1617,6 +1623,7 @@ impl AccountsDb {
             active_stats: ActiveStats::default(),
             accounts_hash_complete_one_epoch_old: RwLock::default(),
             skip_rewrites: false,
+            skip_initial_hash_calc: false,
             ancient_append_vecs: false,
             accounts_index,
             storage: AccountStorage::default(),
@@ -1714,6 +1721,11 @@ impl AccountsDb {
             .as_ref()
             .map(|config| config.skip_rewrites)
             .unwrap_or_default();
+        let skip_initial_hash_calc = accounts_db_config
+            .as_ref()
+            .map(|config| config.skip_initial_hash_calc)
+            .unwrap_or_default();
+
         let ancient_append_vecs = accounts_db_config
             .as_ref()
             .map(|config| config.ancient_append_vecs)
@@ -1728,6 +1740,7 @@ impl AccountsDb {
         let mut new = Self {
             paths,
             skip_rewrites,
+            skip_initial_hash_calc,
             ancient_append_vecs,
             cluster_type: Some(*cluster_type),
             account_indexes,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6511,10 +6511,15 @@ impl Bank {
         }
         shrink_all_slots_time.stop();
 
-        info!("verify_bank_hash..");
-        let mut verify_time = Measure::start("verify_bank_hash");
-        let mut verify = self.verify_bank_hash(test_hash_calculation, false);
-        verify_time.stop();
+        let (mut verify, verify_time_us) = if !self.rc.accounts.accounts_db.skip_initial_hash_calc {
+            info!("verify_bank_hash..");
+            let mut verify_time = Measure::start("verify_bank_hash");
+            let verify = self.verify_bank_hash(test_hash_calculation, false);
+            verify_time.stop();
+            (verify, verify_time.as_us())
+        } else {
+            (true, 0)
+        };
 
         info!("verify_hash..");
         let mut verify2_time = Measure::start("verify_hash");
@@ -6526,7 +6531,7 @@ impl Bank {
             "verify_snapshot_bank",
             ("clean_us", clean_time.as_us(), i64),
             ("shrink_all_slots_us", shrink_all_slots_time.as_us(), i64),
-            ("verify_bank_hash_us", verify_time.as_us(), i64),
+            ("verify_bank_hash_us", verify_time_us, i64),
             ("verify_hash_us", verify2_time.as_us(), i64),
         );
 


### PR DESCRIPTION
#### Problem

When using ledger-tool to track down a bug, it costs something to verify the accounts hash of the snapshot each load. Eliminating this unnecessary calculation improves the debugging cycle time.

#### Summary of Changes

passing `--accounts-db-skip-initial-hash-calc` allows ledger-tool verify to complete faster.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
