### PR TITLE
Increase Vote Timestamp Granularity

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -536,7 +536,7 @@ impl Tower {
         if current_slot > self.last_timestamp.slot
             || self.last_timestamp.slot == 0 && current_slot == self.last_timestamp.slot
         {
-            let timestamp = Utc::now().timestamp();
+            let timestamp = Utc::now().timestamp_millis();
             if timestamp >= self.last_timestamp.timestamp {
                 self.last_timestamp = BlockTimestamp {
                     slot: current_slot,
@@ -2360,7 +2360,7 @@ pub mod test {
         let vote = Vote {
             slots: vec![0],
             hash: Hash::default(),
-            timestamp: None,
+            timestamp_ms: None,
         };
         local.process_vote_unchecked(vote);
         assert_eq!(local.votes.len(), 1);
@@ -2376,7 +2376,7 @@ pub mod test {
         let vote = Vote {
             slots: vec![0],
             hash: Hash::default(),
-            timestamp: None,
+            timestamp_ms: None,
         };
         local.process_vote_unchecked(vote);
         assert_eq!(local.votes.len(), 1);
@@ -2477,7 +2477,7 @@ pub mod test {
             tower.record_vote(i as u64, Hash::default());
         }
 
-        expected.timestamp = tower.last_vote.timestamp();
+        expected.timestamp_ms = tower.last_vote.timestamp();
         assert_eq!(VoteTransaction::from(expected), tower.last_vote)
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -89,15 +89,15 @@ impl VoteTransaction {
 
     pub fn timestamp(&self) -> Option<UnixTimestamp> {
         match self {
-            VoteTransaction::Vote(vote) => vote.timestamp,
-            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp,
+            VoteTransaction::Vote(vote) => vote.timestamp_ms,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp_ms,
         }
     }
 
     pub fn set_timestamp(&mut self, ts: Option<UnixTimestamp>) {
         match self {
-            VoteTransaction::Vote(vote) => vote.timestamp = ts,
-            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp = ts,
+            VoteTransaction::Vote(vote) => vote.timestamp_ms = ts,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp_ms = ts,
         }
     }
 
@@ -135,7 +135,7 @@ pub struct Vote {
     /// signature of the bank's state at the last slot
     pub hash: Hash,
     /// processing timestamp of last slot
-    pub timestamp: Option<UnixTimestamp>,
+    pub timestamp_ms: Option<UnixTimestamp>,
 }
 
 impl Vote {
@@ -143,7 +143,7 @@ impl Vote {
         Self {
             slots,
             hash,
-            timestamp: None,
+            timestamp_ms: None,
         }
     }
 }
@@ -189,7 +189,7 @@ pub struct VoteStateUpdate {
     /// signature of the bank's state at the last slot
     pub hash: Hash,
     /// processing timestamp of last slot
-    pub timestamp: Option<UnixTimestamp>,
+    pub timestamp_ms: Option<UnixTimestamp>,
 }
 
 impl From<Vec<(Slot, u32)>> for VoteStateUpdate {
@@ -205,7 +205,7 @@ impl From<Vec<(Slot, u32)>> for VoteStateUpdate {
             lockouts,
             root: None,
             hash: Hash::default(),
-            timestamp: None,
+            timestamp_ms: None,
         }
     }
 }
@@ -216,7 +216,7 @@ impl VoteStateUpdate {
             lockouts,
             root,
             hash,
-            timestamp: None,
+            timestamp_ms: None,
         }
     }
 
@@ -1372,7 +1372,7 @@ pub fn process_vote<S: std::hash::BuildHasher>(
     let mut vote_state = verify_and_get_vote_state(vote_account, clock, signers)?;
 
     vote_state.process_vote(vote, slot_hashes, clock.epoch, Some(feature_set))?;
-    if let Some(timestamp) = vote.timestamp {
+    if let Some(timestamp) = vote.timestamp_ms {
         vote.slots
             .iter()
             .max()
@@ -1394,7 +1394,7 @@ pub fn process_vote_state_update<S: std::hash::BuildHasher>(
     vote_state.process_new_vote_state(
         vote_state_update.lockouts,
         vote_state_update.root,
-        vote_state_update.timestamp,
+        vote_state_update.timestamp_ms,
         clock.epoch,
     )?;
     vote_account.set_state(&VoteStateVersions::new_current(vote_state))

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -97,7 +97,9 @@ impl VoteTransaction {
     pub fn set_timestamp(&mut self, ts: Option<UnixTimestamp>) {
         match self {
             VoteTransaction::Vote(vote) => vote.timestamp_ms = ts,
-            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp_ms = ts,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => {
+                vote_state_update.timestamp_ms = ts
+            }
         }
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -7018,7 +7018,7 @@ pub mod tests {
                     Vote {
                         slots: vec![bank.slot()],
                         hash: bank.hash(),
-                        timestamp: None,
+                        timestamp_ms: None,
                     },
                 ),
                 vote_instruction::vote(
@@ -7027,7 +7027,7 @@ pub mod tests {
                     Vote {
                         slots: vec![bank.slot()],
                         hash: bank.hash(),
-                        timestamp: None,
+                        timestamp_ms: None,
                     },
                 ),
             ];

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -1338,7 +1338,7 @@ mod tests {
         let vote = Vote {
             slots: vec![1, 2],
             hash: Hash::default(),
-            timestamp: None,
+            timestamp_ms: None,
         };
         subscriptions.notify_vote(Pubkey::default(), VoteTransaction::from(vote));
 

--- a/runtime/src/vote_transaction.rs
+++ b/runtime/src/vote_transaction.rs
@@ -42,8 +42,8 @@ impl VoteTransaction {
 
     pub fn timestamp(&self) -> Option<UnixTimestamp> {
         match self {
-            VoteTransaction::Vote(vote) => vote.timestamp,
-            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp,
+            VoteTransaction::Vote(vote) => vote.timestamp_ms,
+            VoteTransaction::VoteStateUpdate(vote_state_update) => vote_state_update.timestamp_ms,
         }
     }
 

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -148,7 +148,7 @@ pub fn parse_vote(
             let vote = json!({
                 "slots": vote.slots,
                 "hash": vote.hash.to_string(),
-                "timestamp": vote.timestamp,
+                "timestamp_ms": vote.timestamp_ms,
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "voteSwitch".to_string(),

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -57,7 +57,7 @@ pub fn parse_vote(
             let vote = json!({
                 "slots": vote.slots,
                 "hash": vote.hash.to_string(),
-                "timestamp": vote.timestamp,
+                "timestamp_ms": vote.timestamp_ms,
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "vote".to_string(),
@@ -76,7 +76,7 @@ pub fn parse_vote(
                 "lockouts": vote_state_update.lockouts,
                 "root": vote_state_update.root,
                 "hash": vote_state_update.hash.to_string(),
-                "timestamp": vote_state_update.timestamp,
+                "timestamp_ms": vote_state_update.timestamp_ms,
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "updatevotestate".to_string(),
@@ -95,7 +95,7 @@ pub fn parse_vote(
                 "lockouts": vote_state_update.lockouts,
                 "root": vote_state_update.root,
                 "hash": vote_state_update.hash.to_string(),
-                "timestamp": vote_state_update.timestamp,
+                "timestamp_ms": vote_state_update.timestamp_ms,
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "updatevotestateswitch".to_string(),
@@ -285,7 +285,7 @@ mod test {
         let vote = Vote {
             slots: vec![1, 2, 4],
             hash,
-            timestamp: Some(1_234_567_890),
+            timestamp_ms: Some(1_234_567_890),
         };
 
         let vote_pubkey = Pubkey::new_unique();
@@ -308,7 +308,7 @@ mod test {
                     "vote": {
                         "slots": [1, 2, 4],
                         "hash": hash.to_string(),
-                        "timestamp": 1_234_567_890,
+                        "timestamp_ms": 1_234_567_890,
                     },
                 }),
             }
@@ -428,7 +428,7 @@ mod test {
         let vote = Vote {
             slots: vec![1, 2, 4],
             hash,
-            timestamp: Some(1_234_567_890),
+            timestamp_ms: Some(1_234_567_890),
         };
 
         let vote_pubkey = Pubkey::new_unique();
@@ -453,7 +453,7 @@ mod test {
                     "vote": {
                         "slots": [1, 2, 4],
                         "hash": hash.to_string(),
-                        "timestamp": 1_234_567_890,
+                        "timestamp_ms": 1_234_567_890,
                     },
                     "hash": proof_hash.to_string(),
                 }),


### PR DESCRIPTION
#### Problem
Voting timestamp is currently snapshotted at second granularity, which is too coarse for meaningfully understanding vote latency. With finer granularity, we could collect metrics around latency of votes landing to/from different nodes

#### Summary of Changes
Increase granularity from seconds to milliseconds.
