### PR TITLE
Refactor Sigverify trait to prepare for tracer metrics

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -373,7 +373,9 @@ fn main() {
                     packet_batch_index,
                     timestamp(),
                 );
-                verified_sender.send(vec![packet_batch.clone()]).unwrap();
+                verified_sender
+                    .send((vec![packet_batch.clone()], None))
+                    .unwrap();
             }
 
             for tx in &packets_for_this_iteration.transactions {

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -256,7 +256,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
                 for xv in v {
                     sent += xv.len();
                 }
-                verified_sender.send(v.to_vec()).unwrap();
+                verified_sender.send((v.to_vec(), None)).unwrap();
             }
             check_txs(&signal_receiver2, txes / CHUNKS);
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -8,9 +8,12 @@ use {
             LeaderExecuteAndCommitTimings, RecordTransactionsTimings,
         },
         qos_service::QosService,
+        sigverify::TransactionTracerPacketStats,
         unprocessed_packet_batches::{self, *},
     },
-    crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError},
+    crossbeam_channel::{
+        Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
+    },
     histogram::Histogram,
     itertools::Itertools,
     min_max_heap::MinMaxHeap,
@@ -86,6 +89,9 @@ const MIN_TOTAL_THREADS: u32 = NUM_VOTE_PROCESSING_THREADS + MIN_THREADS_BANKING
 const UNPROCESSED_BUFFER_STEP_SIZE: usize = 128;
 
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
+pub type BankingPacketBatch = (Vec<PacketBatch>, Option<TransactionTracerPacketStats>);
+pub type BankingPacketSender = CrossbeamSender<BankingPacketBatch>;
+pub type BankingPacketReceiver = CrossbeamReceiver<BankingPacketBatch>;
 
 pub struct ProcessTransactionBatchOutput {
     // The number of transactions filtered out by the cost model
@@ -380,9 +386,9 @@ impl BankingStage {
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        verified_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
-        tpu_verified_vote_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
-        verified_vote_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
+        verified_receiver: BankingPacketReceiver,
+        tpu_verified_vote_receiver: BankingPacketReceiver,
+        verified_vote_receiver: BankingPacketReceiver,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
         cost_model: Arc<RwLock<CostModel>>,
@@ -404,9 +410,9 @@ impl BankingStage {
     pub fn new_num_threads(
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-        verified_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
-        tpu_verified_vote_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
-        verified_vote_receiver: CrossbeamReceiver<Vec<PacketBatch>>,
+        verified_receiver: BankingPacketReceiver,
+        tpu_verified_vote_receiver: BankingPacketReceiver,
+        verified_vote_receiver: BankingPacketReceiver,
         num_threads: u32,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: ReplayVoteSender,
@@ -988,7 +994,7 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     fn process_loop(
-        verified_receiver: &CrossbeamReceiver<Vec<PacketBatch>>,
+        verified_receiver: &BankingPacketReceiver,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         cluster_info: &ClusterInfo,
         recv_start: &mut Instant,
@@ -1977,14 +1983,15 @@ impl BankingStage {
     }
 
     fn receive_until(
-        verified_receiver: &CrossbeamReceiver<Vec<PacketBatch>>,
+        verified_receiver: &BankingPacketReceiver,
         recv_timeout: Duration,
         packet_count_upperbound: usize,
     ) -> Result<Vec<PacketBatch>, RecvTimeoutError> {
         let start = Instant::now();
-        let mut packet_batches = verified_receiver.recv_timeout(recv_timeout)?;
+        let (mut packet_batches, _tracer_packet_stats_option) =
+            verified_receiver.recv_timeout(recv_timeout)?;
         let mut num_packets_received: usize = packet_batches.iter().map(|batch| batch.len()).sum();
-        while let Ok(packet_batch) = verified_receiver.try_recv() {
+        while let Ok((packet_batch, _tracer_packet_stats_option)) = verified_receiver.try_recv() {
             trace!("got more packet batches in banking stage");
             let (packets_received, packet_count_overflowed) = num_packets_received
                 .overflowing_add(packet_batch.iter().map(|batch| batch.len()).sum());
@@ -2006,7 +2013,7 @@ impl BankingStage {
     #[allow(clippy::too_many_arguments)]
     /// Receive incoming packets, push into unprocessed buffer with packet indexes
     fn receive_and_buffer_packets(
-        verified_receiver: &CrossbeamReceiver<Vec<PacketBatch>>,
+        verified_receiver: &BankingPacketReceiver,
         recv_start: &mut Instant,
         recv_timeout: Duration,
         id: u32,
@@ -2407,7 +2414,7 @@ mod tests {
                 .collect();
             let packet_batches = convert_from_old_verified(packet_batches);
             verified_sender // no_ver, anf, tx
-                .send(packet_batches)
+                .send((packet_batches, None))
                 .unwrap();
 
             drop(verified_sender);
@@ -2479,7 +2486,7 @@ mod tests {
             .map(|batch| (batch, vec![1u8]))
             .collect();
         let packet_batches = convert_from_old_verified(packet_batches);
-        verified_sender.send(packet_batches).unwrap();
+        verified_sender.send((packet_batches, None)).unwrap();
 
         // Process a second batch that uses the same from account, so conflicts with above TX
         let tx =
@@ -2490,7 +2497,7 @@ mod tests {
             .map(|batch| (batch, vec![1u8]))
             .collect();
         let packet_batches = convert_from_old_verified(packet_batches);
-        verified_sender.send(packet_batches).unwrap();
+        verified_sender.send((packet_batches, None)).unwrap();
 
         let (vote_sender, vote_receiver) = unbounded();
         let (tpu_vote_sender, tpu_vote_receiver) = unbounded();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        banking_stage::BankingPacketSender,
         optimistic_confirmation_verifier::OptimisticConfirmationVerifier,
         replay_stage::DUPLICATE_THRESHOLD,
         result::{Error, Result},
@@ -18,7 +19,7 @@ use {
     solana_ledger::blockstore::Blockstore,
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_debug,
-    solana_perf::packet::{self, PacketBatch},
+    solana_perf::packet,
     solana_poh::poh_recorder::PohRecorder,
     solana_rpc::{
         optimistically_confirmed_bank_tracker::{BankNotification, BankNotificationSender},
@@ -190,7 +191,7 @@ impl ClusterInfoVoteListener {
     pub fn new(
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        verified_packets_sender: Sender<Vec<PacketBatch>>,
+        verified_packets_sender: BankingPacketSender,
         poh_recorder: Arc<Mutex<PohRecorder>>,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
@@ -333,7 +334,7 @@ impl ClusterInfoVoteListener {
         exit: Arc<AtomicBool>,
         verified_vote_label_packets_receiver: VerifiedLabelVotePacketsReceiver,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        verified_packets_sender: &Sender<Vec<PacketBatch>>,
+        verified_packets_sender: &BankingPacketSender,
     ) -> Result<()> {
         let mut verified_vote_packets = VerifiedVotePackets::default();
         let mut time_since_lock = Instant::now();
@@ -382,7 +383,7 @@ impl ClusterInfoVoteListener {
     fn check_for_leader_bank_and_send_votes(
         bank_vote_sender_state_option: &mut Option<BankVoteSenderState>,
         current_working_bank: Arc<Bank>,
-        verified_packets_sender: &Sender<Vec<PacketBatch>>,
+        verified_packets_sender: &BankingPacketSender,
         verified_vote_packets: &VerifiedVotePackets,
     ) -> Result<()> {
         // We will take this lock at most once every `BANK_SEND_VOTES_LOOP_SLEEP_MS`
@@ -423,7 +424,7 @@ impl ClusterInfoVoteListener {
         for single_validator_votes in gossip_votes_iterator {
             bank_send_votes_stats.num_votes_sent += single_validator_votes.len();
             bank_send_votes_stats.num_batches_sent += 1;
-            verified_packets_sender.send(single_validator_votes)?;
+            verified_packets_sender.send((single_validator_votes, None))?;
         }
         filter_gossip_votes_timing.stop();
         bank_send_votes_stats.total_elapsed += filter_gossip_votes_timing.as_us();

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -8,30 +8,45 @@ pub use solana_perf::sigverify::{
     count_packets_in_batches, ed25519_verify_cpu, ed25519_verify_disabled, init, TxOffset,
 };
 use {
-    crate::sigverify_stage::SigVerifier,
+    crate::{
+        banking_stage::BankingPacketBatch,
+        sigverify_stage::{SigVerifier, SigVerifyServiceError},
+    },
+    crossbeam_channel::Sender,
     solana_perf::{cuda_runtime::PinnedVec, packet::PacketBatch, recycler::Recycler, sigverify},
+    solana_sdk::packet::Packet,
 };
+
+#[derive(Debug, Default, Clone)]
+pub struct TransactionTracerPacketStats {
+    pub total_removed_before_sigverify_stage: usize,
+    pub total_tracer_packets_received_in_sigverify_stage: usize,
+    pub total_tracer_packets_deduped: usize,
+    pub total_excess_tracer_packets: usize,
+    pub total_tracker_packets_passed_sigverify: usize,
+}
 
 #[derive(Clone)]
 pub struct TransactionSigVerifier {
+    packet_sender: Sender<<Self as SigVerifier>::SendType>,
+    tracer_packet_stats: TransactionTracerPacketStats,
     recycler: Recycler<TxOffset>,
     recycler_out: Recycler<PinnedVec<u8>>,
     reject_non_vote: bool,
 }
 
 impl TransactionSigVerifier {
-    pub fn new_reject_non_vote() -> Self {
-        TransactionSigVerifier {
-            reject_non_vote: true,
-            ..TransactionSigVerifier::default()
-        }
+    pub fn new_reject_non_vote(packet_sender: Sender<<Self as SigVerifier>::SendType>) -> Self {
+        let mut new_self = Self::new(packet_sender);
+        new_self.reject_non_vote = true;
+        new_self
     }
-}
 
-impl Default for TransactionSigVerifier {
-    fn default() -> Self {
+    pub fn new(packet_sender: Sender<<Self as SigVerifier>::SendType>) -> Self {
         init();
         Self {
+            packet_sender,
+            tracer_packet_stats: TransactionTracerPacketStats::default(),
             recycler: Recycler::warmed(50, 4096),
             recycler_out: Recycler::warmed(50, 4096),
             reject_non_vote: false,
@@ -40,6 +55,58 @@ impl Default for TransactionSigVerifier {
 }
 
 impl SigVerifier for TransactionSigVerifier {
+    type SendType = BankingPacketBatch;
+
+    #[inline(always)]
+    fn process_received_packet(
+        &mut self,
+        packet: &mut Packet,
+        removed_before_sigverify_stage: bool,
+        is_dup: bool,
+    ) {
+        if packet.meta.is_tracer_packet() {
+            if removed_before_sigverify_stage {
+                self.tracer_packet_stats
+                    .total_removed_before_sigverify_stage += 1;
+            } else {
+                self.tracer_packet_stats
+                    .total_tracer_packets_received_in_sigverify_stage += 1;
+                if is_dup {
+                    self.tracer_packet_stats.total_tracer_packets_deduped += 1;
+                }
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn process_excess_packet(&mut self, packet: &Packet) {
+        if packet.meta.is_tracer_packet() {
+            self.tracer_packet_stats.total_excess_tracer_packets += 1;
+        }
+    }
+
+    #[inline(always)]
+    fn process_passed_sigverify_packet(&mut self, packet: &Packet) {
+        if packet.meta.is_tracer_packet() {
+            self.tracer_packet_stats
+                .total_tracker_packets_passed_sigverify += 1;
+        }
+    }
+
+    fn send_packets(
+        &mut self,
+        packet_batches: Vec<PacketBatch>,
+    ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
+        let mut tracer_packet_stats_to_send = TransactionTracerPacketStats::default();
+        std::mem::swap(
+            &mut tracer_packet_stats_to_send,
+            &mut self.tracer_packet_stats,
+        );
+        self.packet_sender
+            .send((packet_batches, Some(tracer_packet_stats_to_send)))?;
+        Ok(())
+    }
+
     fn verify_batches(
         &self,
         mut batches: Vec<PacketBatch>,

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -159,22 +159,17 @@ impl Tpu {
         .unwrap();
 
         let sigverify_stage = {
-            let verifier = TransactionSigVerifier::default();
-            SigVerifyStage::new(
-                find_packet_sender_stake_receiver,
-                verified_sender,
-                verifier,
-                "tpu-verifier",
-            )
+            let verifier = TransactionSigVerifier::new(verified_sender);
+            SigVerifyStage::new(find_packet_sender_stake_receiver, verifier, "tpu-verifier")
         };
 
         let (verified_tpu_vote_packets_sender, verified_tpu_vote_packets_receiver) = unbounded();
 
         let vote_sigverify_stage = {
-            let verifier = TransactionSigVerifier::new_reject_non_vote();
+            let verifier =
+                TransactionSigVerifier::new_reject_non_vote(verified_tpu_vote_packets_sender);
             SigVerifyStage::new(
                 vote_find_packet_sender_stake_receiver,
-                verified_tpu_vote_packets_sender,
                 verifier,
                 "tpu-vote-verifier",
             )

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -161,8 +161,11 @@ impl Tvu {
         let (verified_sender, verified_receiver) = unbounded();
         let sigverify_stage = SigVerifyStage::new(
             fetch_receiver,
-            verified_sender,
-            ShredSigVerifier::new(bank_forks.clone(), leader_schedule_cache.clone()),
+            ShredSigVerifier::new(
+                bank_forks.clone(),
+                leader_schedule_cache.clone(),
+                verified_sender,
+            ),
             "shred-verifier",
         );
 

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -26,7 +26,7 @@ fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) 
     // verify packets
     let mut deduper = sigverify::Deduper::new(1_000_000, Duration::from_millis(2_000));
     bencher.iter(|| {
-        let _ans = deduper.dedup_packets_and_count_discards(&mut batches);
+        let _ans = deduper.dedup_packets_and_count_discards(&mut batches, |_, _, _| ());
         deduper.reset();
         batches
             .iter_mut()

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -79,6 +79,6 @@ fn bench_shrink_count_packets(bencher: &mut Bencher) {
     });
 
     bencher.iter(|| {
-        let _ = sigverify::count_valid_packets(&batches);
+        let _ = sigverify::count_valid_packets(&batches, |_| ());
     });
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -19,6 +19,7 @@ use {
         hash::Hash,
         message::{MESSAGE_HEADER_LENGTH, MESSAGE_VERSION_PREFIX},
         pubkey::Pubkey,
+        saturating_add_assign,
         short_vec::decode_shortu16_len,
         signature::Signature,
     },
@@ -152,10 +153,10 @@ fn verify_packet(packet: &mut Packet, reject_non_vote: bool) {
         }
 
         // Check for tracer pubkey
-        if !packet.meta.is_tracer_tx()
+        if !packet.meta.is_tracer_packet()
             && &packet.data[pubkey_start..pubkey_end] == TRACER_KEY.as_ref()
         {
-            packet.meta.flags |= PacketFlags::TRACER_TX;
+            packet.meta.flags |= PacketFlags::TRACER_PACKET;
         }
 
         pubkey_start = pubkey_end;
@@ -167,10 +168,24 @@ pub fn count_packets_in_batches(batches: &[PacketBatch]) -> usize {
     batches.iter().map(|batch| batch.len()).sum()
 }
 
-pub fn count_valid_packets(batches: &[PacketBatch]) -> usize {
+pub fn count_valid_packets(
+    batches: &[PacketBatch],
+    mut process_valid_packet: impl FnMut(&Packet),
+) -> usize {
     batches
         .iter()
-        .map(|batch| batch.iter().filter(|p| !p.meta.discard()).count())
+        .map(|batch| {
+            batch
+                .iter()
+                .filter(|p| {
+                    let should_keep = !p.meta.discard();
+                    if should_keep {
+                        process_valid_packet(p);
+                    }
+                    should_keep
+                })
+                .count()
+        })
         .sum()
 }
 
@@ -495,11 +510,23 @@ impl Deduper {
         0
     }
 
-    pub fn dedup_packets_and_count_discards(&self, batches: &mut [PacketBatch]) -> u64 {
-        batches
-            .iter_mut()
-            .flat_map(|batch| batch.iter_mut().map(|p| self.dedup_packet(p)))
-            .sum()
+    pub fn dedup_packets_and_count_discards(
+        &self,
+        batches: &mut [PacketBatch],
+        mut process_received_packet: impl FnMut(&mut Packet, bool, bool),
+    ) -> u64 {
+        let mut num_removed: u64 = 0;
+        batches.iter_mut().for_each(|batch| {
+            batch.iter_mut().for_each(|p| {
+                let removed_before_sigverify = p.meta.discard();
+                let is_duplicate = self.dedup_packet(p);
+                if is_duplicate == 1 {
+                    saturating_add_assign!(num_removed, 1);
+                }
+                process_received_packet(p, removed_before_sigverify, is_duplicate == 1);
+            })
+        });
+        num_removed
     }
 }
 
@@ -1401,7 +1428,14 @@ mod tests {
             to_packet_batches(&std::iter::repeat(tx).take(1024).collect::<Vec<_>>(), 128);
         let packet_count = sigverify::count_packets_in_batches(&batches);
         let filter = Deduper::new(1_000_000, Duration::from_millis(0));
-        let discard = filter.dedup_packets_and_count_discards(&mut batches) as usize;
+        let mut num_deduped = 0;
+        let discard = filter.dedup_packets_and_count_discards(
+            &mut batches,
+            |_deduped_packet, _removed_before_sigverify_stage, _is_dup| {
+                num_deduped += 1;
+            },
+        ) as usize;
+        assert_eq!(num_deduped, discard + 1);
         assert_eq!(packet_count, discard + 1);
     }
 
@@ -1409,8 +1443,7 @@ mod tests {
     fn test_dedup_diff() {
         let mut filter = Deduper::new(1_000_000, Duration::from_millis(0));
         let mut batches = to_packet_batches(&(0..1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
-
-        let discard = filter.dedup_packets_and_count_discards(&mut batches) as usize;
+        let discard = filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
         // because dedup uses a threadpool, there maybe up to N threads of txs that go through
         assert_eq!(discard, 0);
         filter.reset();
@@ -1428,7 +1461,7 @@ mod tests {
         for i in 0..1000 {
             let mut batches =
                 to_packet_batches(&(0..1000).map(|_| test_tx()).collect::<Vec<_>>(), 128);
-            discard += filter.dedup_packets_and_count_discards(&mut batches) as usize;
+            discard += filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
             debug!("{} {}", i, discard);
             if filter.saturated.load(Ordering::Relaxed) {
                 break;
@@ -1444,7 +1477,7 @@ mod tests {
         for i in 0..10 {
             let mut batches =
                 to_packet_batches(&(0..1024).map(|_| test_tx()).collect::<Vec<_>>(), 128);
-            discard += filter.dedup_packets_and_count_discards(&mut batches) as usize;
+            discard += filter.dedup_packets_and_count_discards(&mut batches, |_, _, _| ()) as usize;
             debug!("false positive rate: {}/{}", discard, i * 1024);
         }
         //allow for 1 false positive even if extremely unlikely
@@ -1473,7 +1506,7 @@ mod tests {
             });
             start.sort_by_key(|p| p.data);
 
-            let packet_count = count_valid_packets(&batches);
+            let packet_count = count_valid_packets(&batches, |_| ());
             let res = shrink_batches(&mut batches);
             batches.truncate(res);
 
@@ -1485,7 +1518,7 @@ mod tests {
                     .for_each(|p| end.push(p.clone()))
             });
             end.sort_by_key(|p| p.data);
-            let packet_count2 = count_valid_packets(&batches);
+            let packet_count2 = count_valid_packets(&batches, |_| ());
             assert_eq!(packet_count, packet_count2);
             assert_eq!(start, end);
         }
@@ -1642,13 +1675,13 @@ mod tests {
                 PACKETS_PER_BATCH,
             );
             assert_eq!(batches.len(), BATCH_COUNT);
-            assert_eq!(count_valid_packets(&batches), PACKET_COUNT);
+            assert_eq!(count_valid_packets(&batches, |_| ()), PACKET_COUNT);
             batches.iter_mut().enumerate().for_each(|(i, b)| {
                 b.iter_mut()
                     .enumerate()
                     .for_each(|(j, p)| p.meta.set_discard(set_discard(i, j)))
             });
-            assert_eq!(count_valid_packets(&batches), *expect_valid_packets);
+            assert_eq!(count_valid_packets(&batches, |_| ()), *expect_valid_packets);
             debug!("show valid packets for case {}", i);
             batches.iter_mut().enumerate().for_each(|(i, b)| {
                 b.iter_mut().enumerate().for_each(|(j, p)| {
@@ -1662,7 +1695,7 @@ mod tests {
             debug!("shrunk batch test {} count: {}", i, shrunken_batch_count);
             assert_eq!(shrunken_batch_count, *expect_batch_count);
             batches.truncate(shrunken_batch_count);
-            assert_eq!(count_valid_packets(&batches), *expect_valid_packets);
+            assert_eq!(count_valid_packets(&batches, |_| ()), *expect_valid_packets);
         }
     }
 }

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -21,7 +21,7 @@ bitflags! {
         const FORWARDED      = 0b0000_0010;
         const REPAIR         = 0b0000_0100;
         const SIMPLE_VOTE_TX = 0b0000_1000;
-        const TRACER_TX      = 0b0001_0000;
+        const TRACER_PACKET  = 0b0001_0000;
     }
 }
 
@@ -134,8 +134,8 @@ impl Meta {
     }
 
     #[inline]
-    pub fn is_tracer_tx(&self) -> bool {
-        self.flags.contains(PacketFlags::TRACER_TX)
+    pub fn is_tracer_packet(&self) -> bool {
+        self.flags.contains(PacketFlags::TRACER_PACKET)
     }
 }
 


### PR DESCRIPTION
#### Problem
Tracer transactions and the associated logic is only necessary in the transaction sigverify pipeline, but not in the shred sigverify pipeline.

#### Summary of Changes
1. Introduce a `TransactionTracerPacketStats` tracking the tracer transactions detected in Sigverify. This struct is created in Sigverify and passed to BankingStage to be logged by the leader
2. Refactor `SigVerifier` trait to encapsulate the `Sender` and stub out a trait method `process_received_packet `https://github.com/carllin/solana/blob/a5d8399e03399e181e29b185f399fe043b6aae0e/core/src/sigverify.rs#L58-L62 for detecting tracer transactions before dedup in the transaction Sigverify pipeline

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
