### PR TITLE
bench-tps: Increase default lamports-per-account to 10 SOL

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -10,7 +10,7 @@ use {
     std::{net::SocketAddr, process::exit, time::Duration},
 };
 
-const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;
+const NUM_LAMPORTS_PER_ACCOUNT_DEFAULT: u64 = 10 * solana_sdk::native_token::LAMPORTS_PER_SOL;
 
 pub enum ExternalClientType {
     // Submits transactions to an Rpc node using an RpcClient

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -19,12 +19,16 @@ use {
     solana_rpc::rpc::JsonRpcConfig,
     solana_sdk::{
         commitment_config::CommitmentConfig,
+        native_token::LAMPORTS_PER_SOL,
         signature::{Keypair, Signer},
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_test_validator::TestValidator,
     std::{sync::Arc, time::Duration},
 };
+
+const DEFAULT_CLUSTER_LAMPORTS: u64 = 10_000_000 * LAMPORTS_PER_SOL;
+const DEFAULT_NODE_STAKE: u64 = 10 * LAMPORTS_PER_SOL;
 
 fn test_bench_tps_local_cluster(config: Config) {
     let native_instruction_processors = vec![];
@@ -38,8 +42,8 @@ fn test_bench_tps_local_cluster(config: Config) {
     const NUM_NODES: usize = 1;
     let cluster = LocalCluster::new(
         &mut ClusterConfig {
-            node_stakes: vec![999_990; NUM_NODES],
-            cluster_lamports: 200_000_000,
+            node_stakes: vec![DEFAULT_NODE_STAKE; NUM_NODES],
+            cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,
             validator_configs: make_identical_validator_configs(
                 &ValidatorConfig {
                     rpc_config: JsonRpcConfig {


### PR DESCRIPTION
#### Problem

Bench-tps fails with default stake amount because it is too low. See linked issue for more context.

#### Summary of Changes

Increase default stake amount.

Fixes #22559
