### PR TITLE
Bugfix: snapshot-archive-format should not conflict with no-snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1533,7 +1533,6 @@ fn main() {
                     .value_name("ARCHIVE_TYPE")
                     .takes_value(true)
                     .help("Snapshot archive format to use.")
-                    .conflicts_with("no_snapshot")
             )
     ).subcommand(
             SubCommand::with_name("accounts")


### PR DESCRIPTION
#### Problem
new CLI argument --snapshot-archive-format conflicted with --no-snapshot. Since --snapshot-archive-format had a default value, this effectively disables --no-snapshot.

They shouldn't conflict as --snapshot-archive-format only changes the format we save a snapshot in, while no-snapshot controls if we load from a snapshot.

#### Summary of Changes
Remove the conflict.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
