### PR TITLE
use iterator instead of vec to iterate accounts

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -38,7 +38,9 @@ use {
         active_stats::{ActiveStatItem, ActiveStats},
         ancestors::Ancestors,
         ancient_append_vecs::is_ancient,
-        append_vec::{AppendVec, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion},
+        append_vec::{
+            AccountsInAppendVec, AppendVec, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
+        },
         bank::Rewrites,
         cache_hash_data::CacheHashData,
         contains::Contains,
@@ -5413,8 +5415,7 @@ impl AccountsDb {
         let mut progress = Vec::with_capacity(len);
         let mut current = Vec::with_capacity(len);
         for storage in storages {
-            let accounts = storage.accounts.accounts(0);
-            let mut iterator: std::vec::IntoIter<StoredAccountMeta<'_>> = accounts.into_iter();
+            let mut iterator = AccountsInAppendVec::new(&storage.accounts);
             if let Some(item) = iterator
                 .next()
                 .map(|stored_account| (stored_account.meta.write_version, Some(stored_account)))

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -39,7 +39,7 @@ use {
         ancestors::Ancestors,
         ancient_append_vecs::is_ancient,
         append_vec::{
-            AccountsInAppendVec, AppendVec, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
+            AppendVec, AppendVecAccountsIter, StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
         },
         bank::Rewrites,
         cache_hash_data::CacheHashData,
@@ -5415,7 +5415,7 @@ impl AccountsDb {
         let mut progress = Vec::with_capacity(len);
         let mut current = Vec::with_capacity(len);
         for storage in storages {
-            let mut iterator = AccountsInAppendVec::new(&storage.accounts);
+            let mut iterator = AppendVecAccountsIter::new(&storage.accounts);
             if let Some(item) = iterator
                 .next()
                 .map(|stored_account| (stored_account.meta.write_version, Some(stored_account)))

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -136,6 +136,33 @@ impl<'a> StoredAccountMeta<'a> {
     }
 }
 
+pub struct AccountsInAppendVec<'a> {
+    append_vec: &'a AppendVec,
+    offset: usize,
+}
+
+impl<'a> AccountsInAppendVec<'a> {
+    pub fn new(append_vec: &'a AppendVec) -> Self {
+        Self {
+            append_vec,
+            offset: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for AccountsInAppendVec<'a> {
+    type Item = StoredAccountMeta<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((account, next_offset)) = self.append_vec.get_account(self.offset) {
+            self.offset = next_offset;
+            Some(account)
+        } else {
+            None
+        }
+    }
+}
+
 /// A thread-safe, file-backed block of memory used to store `Account` instances. Append operations
 /// are serialized such that only one thread updates the internal `append_lock` at a time. No
 /// restrictions are placed on reading. That is, one may read items from one thread while another

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -136,12 +136,12 @@ impl<'a> StoredAccountMeta<'a> {
     }
 }
 
-pub struct AccountsInAppendVec<'a> {
+pub struct AppendVecAccountsIter<'a> {
     append_vec: &'a AppendVec,
     offset: usize,
 }
 
-impl<'a> AccountsInAppendVec<'a> {
+impl<'a> AppendVecAccountsIter<'a> {
     pub fn new(append_vec: &'a AppendVec) -> Self {
         Self {
             append_vec,
@@ -150,7 +150,7 @@ impl<'a> AccountsInAppendVec<'a> {
     }
 }
 
-impl<'a> Iterator for AccountsInAppendVec<'a> {
+impl<'a> Iterator for AppendVecAccountsIter<'a> {
     type Item = StoredAccountMeta<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
#### Problem

avoid creating a vector just to iterate

#### Summary of Changes

create an iterator over contents of an append vec
a follow on pr will replace 2 more sites with this.
This particular caller is already in code that is very expensive at high account counts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
