### PR TITLE
Use Shared IP to Stake Map

### DIFF
--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -77,7 +77,7 @@ impl FindPacketSenderStakeStage {
     pub fn new(
         packet_receiver: streamer::PacketBatchReceiver,
         sender: FindPacketSenderStakeSender,
-        ip_to_stake: Arc<RwLock<HashMap<IpAddr, u64>>>,
+        staked_nodes: Arc<RwLock<HashMap<IpAddr, u64>>>,
         name: &'static str,
     ) -> Self {
         let mut stats = FindPacketSenderStakeStats::default();
@@ -89,7 +89,9 @@ impl FindPacketSenderStakeStage {
                         let num_batches = batches.len();
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
-                        Self::apply_sender_stakes(&mut batches, &ip_to_stake.read().unwrap());
+                        let ip_to_stake = staked_nodes.read().unwrap();
+                        Self::apply_sender_stakes(&mut batches, &ip_to_stake);
+                        drop(ip_to_stake);
                         apply_sender_stakes_time.stop();
 
                         let mut send_batches_time = Measure::start("send_batches_time");

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -12,7 +12,6 @@ use {
         net::IpAddr,
         sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
-        time,
     },
 };
 

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -89,8 +89,11 @@ impl FindPacketSenderStakeStage {
                         let num_batches = batches.len();
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
-                        let ip_to_stake = || &staked_nodes.read().unwrap();
-                        Self::apply_sender_stakes(&mut batches, ip_to_stake());
+                        let apply_stake = || {
+                            let ip_to_stake = staked_nodes.read().unwrap();
+                            Self::apply_sender_stakes(&mut batches, &ip_to_stake);
+                        };
+                        apply_stake();
                         apply_sender_stakes_time.stop();
 
                         let mut send_batches_time = Measure::start("send_batches_time");

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -91,7 +91,6 @@ impl FindPacketSenderStakeStage {
                             Measure::start("apply_sender_stakes_time");
                         let ip_to_stake = staked_nodes.read().unwrap();
                         Self::apply_sender_stakes(&mut batches, &ip_to_stake);
-                        drop(ip_to_stake);
                         apply_sender_stakes_time.stop();
 
                         let mut send_batches_time = Measure::start("send_batches_time");

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -89,7 +89,7 @@ impl FindPacketSenderStakeStage {
                         let num_batches = batches.len();
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
-                        let apply_stake = || {
+                        let mut apply_stake = || {
                             let ip_to_stake = staked_nodes.read().unwrap();
                             Self::apply_sender_stakes(&mut batches, &ip_to_stake);
                         };

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -90,7 +90,7 @@ impl FindPacketSenderStakeStage {
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
                         let ip_to_stake = || &staked_nodes.read().unwrap();
-                        Self::apply_sender_stakes(&mut batches, ip_to_stake);
+                        Self::apply_sender_stakes(&mut batches, ip_to_stake());
                         apply_sender_stakes_time.stop();
 
                         let mut send_batches_time = Measure::start("send_batches_time");

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -2,11 +2,9 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     lazy_static::lazy_static,
     rayon::{prelude::*, ThreadPool},
-    solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_perf::packet::PacketBatch,
     solana_rayon_threadlimit::get_thread_count,
-    solana_runtime::bank_forks::BankForks,
     solana_sdk::timing::timestamp,
     solana_streamer::streamer::{self, StreamerError},
     std::{
@@ -14,7 +12,7 @@ use {
         net::IpAddr,
         sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
-        time::{Duration, Instant},
+        time,
     },
 };
 

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -89,8 +89,8 @@ impl FindPacketSenderStakeStage {
                         let num_batches = batches.len();
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
-                        let ip_to_stake = staked_nodes.read().unwrap();
-                        Self::apply_sender_stakes(&mut batches, &ip_to_stake);
+                        let ip_to_stake = || &staked_nodes.read().unwrap();
+                        Self::apply_sender_stakes(&mut batches, ip_to_stake);
                         apply_sender_stakes_time.stop();
 
                         let mut send_batches_time = Measure::start("send_batches_time");

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -129,8 +129,6 @@ impl Tpu {
         let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
             packet_receiver,
             find_packet_sender_stake_sender,
-            bank_forks.clone(),
-            cluster_info.clone(),
             staked_nodes.clone(),
             "tpu-find-packet-sender-stake",
         );
@@ -141,8 +139,6 @@ impl Tpu {
         let vote_find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
             vote_packet_receiver,
             vote_find_packet_sender_stake_sender,
-            bank_forks.clone(),
-            cluster_info.clone(),
             staked_nodes.clone(),
             "tpu-vote-find-packet-sender-stake",
         );

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -116,6 +116,14 @@ impl Tpu {
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
         );
 
+        let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
+        let staked_nodes_updater_service = StakedNodesUpdaterService::new(
+            exit.clone(),
+            cluster_info.clone(),
+            bank_forks.clone(),
+            staked_nodes.clone(),
+        );
+
         let (find_packet_sender_stake_sender, find_packet_sender_stake_receiver) = unbounded();
 
         let find_packet_sender_stake_stage = FindPacketSenderStakeStage::new(
@@ -123,6 +131,7 @@ impl Tpu {
             find_packet_sender_stake_sender,
             bank_forks.clone(),
             cluster_info.clone(),
+            staked_nodes.clone(),
             "tpu-find-packet-sender-stake",
         );
 
@@ -134,18 +143,12 @@ impl Tpu {
             vote_find_packet_sender_stake_sender,
             bank_forks.clone(),
             cluster_info.clone(),
+            staked_nodes.clone(),
             "tpu-vote-find-packet-sender-stake",
         );
 
         let (verified_sender, verified_receiver) = unbounded();
 
-        let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
-        let staked_nodes_updater_service = StakedNodesUpdaterService::new(
-            exit.clone(),
-            cluster_info.clone(),
-            bank_forks.clone(),
-            staked_nodes.clone(),
-        );
         let tpu_quic_t = spawn_server(
             transactions_quic_sockets,
             keypair,


### PR DESCRIPTION
#### Problem
Find packet sender stake stages are currently generating their own IP address --> stake map every 5 seconds even though we have a dedicated service generating this map already. Impact is 10s of ms latency impact in these stages every 5 seconds.

#### Summary of Changes
Have find packet sender stake stage use the shared IP address --> stake map that is generated by the staked nodes updater service