### PR TITLE
Extend the datapoint macro to support group-by operations.

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -87,6 +87,9 @@ pub fn serialize_points(points: &Vec<DataPoint>, host_id: &str) -> String {
         for (name, value) in &point.fields {
             len += name.len() + value.len() + EXTRA_LEN;
         }
+        for (name, value) in &point.tags {
+            len += name.len() + value.len() + EXTRA_LEN;
+        }
         len += point.name.len();
         len += TIMESTAMP_LEN;
         len += host_id.len() + HOST_ID_LEN;
@@ -94,6 +97,9 @@ pub fn serialize_points(points: &Vec<DataPoint>, host_id: &str) -> String {
     let mut line = String::with_capacity(len);
     for point in points {
         let _ = write!(line, "{},host_id={}", &point.name, host_id);
+        for (name, value) in point.tags.iter() {
+            let _ = write!(line, ",{}={}", name, value);
+        }
 
         let mut first = true;
         for (name, value) in point.fields.iter() {


### PR DESCRIPTION
#### Problem
Our existing datapoint macro syntax does directly not support group-by tags.
The existing workaround is to embed the group-by tags into the metric name which does not scale well.

#### Summary of Changes
This PR extends the existing syntax to support group-by tags as follows.  The new syntax is also compatible with the existing syntax:
```
datapoint_debug!(
   "metric_name",
   "tag" => "tag-value",
   "tag2" => "tag-value2",
   ....
   ("field1", 100, i64),  // field syntax is the same as the current syntax.
   ("field2", "hello", String),  
   ...
);
```
