### PR TITLE
filler accounts get a non-zero rent_epoch

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6222,7 +6222,7 @@ impl AccountsDb {
             hashes.retain(|(pubkey, _hash)| !self.is_filler_account(pubkey));
         }
 
-        Self::extend_hashes_with_skipped_rewrites(&mut hashes, skipped_rewrites);
+        self.extend_hashes_with_skipped_rewrites(&mut hashes, skipped_rewrites);
 
         let ret = AccountsHash::accumulate_account_hashes(hashes);
         accumulate.stop();
@@ -6245,6 +6245,7 @@ impl AccountsDb {
 
     /// add all items from 'skipped_rewrites' to 'hashes' where the pubkey doesn't already exist in 'hashes'
     fn extend_hashes_with_skipped_rewrites(
+        &self,
         hashes: &mut Vec<(Pubkey, Hash)>,
         skipped_rewrites: &Rewrites,
     ) {
@@ -6252,6 +6253,21 @@ impl AccountsDb {
         hashes.iter().for_each(|(key, _)| {
             skipped_rewrites.remove(key);
         });
+
+        if self.filler_accounts_enabled() {
+            // simulate the time we would normally spend hashing the filler accounts
+            // this is an over approximation but at least takes a stab at simulating what the validator would spend time doing
+            let _ = AccountsHash::accumulate_account_hashes(
+                skipped_rewrites
+                    .iter()
+                    .map(|(k, v)| (*k, *v))
+                    .collect::<Vec<_>>(),
+            );
+
+            // filler accounts do not get their updated hash values hashed into the delta hash
+            skipped_rewrites.retain(|key, _| !self.is_filler_account(key));
+        }
+
         hashes.extend(skipped_rewrites.into_iter());
     }
 
@@ -7160,7 +7176,12 @@ impl AccountsDb {
     /// The filler accounts are added to each slot in the snapshot after index generation.
     /// The accounts added in a slot are setup to have pubkeys such that rent will be collected from them before (or when?) their slot becomes an epoch old.
     /// Thus, the filler accounts are rewritten by rent and the old slot can be thrown away successfully.
-    pub fn maybe_add_filler_accounts(&self, epoch_schedule: &EpochSchedule, rent: &Rent) {
+    pub fn maybe_add_filler_accounts(
+        &self,
+        epoch_schedule: &EpochSchedule,
+        rent: &Rent,
+        rent_epoch: Epoch,
+    ) {
         if self.filler_accounts_config.count == 0 {
             return;
         }
@@ -7188,7 +7209,9 @@ impl AccountsDb {
         let space = self.filler_accounts_config.size;
         let rent_exempt_reserve = rent.minimum_balance(space);
         let lamports = rent_exempt_reserve;
-        let account = AccountSharedData::new(lamports, space, &owner);
+        let mut account = AccountSharedData::new(lamports, space, &owner);
+        // needs to be non-zero
+        account.set_rent_epoch(rent_epoch);
         let added = AtomicUsize::default();
         for pass in 0..=passes {
             self.accounts_index
@@ -14102,22 +14125,23 @@ pub mod tests {
 
     #[test]
     fn test_extend_hashes_with_skipped_rewrites() {
+        let db = AccountsDb::new_single_for_tests();
         let mut hashes = Vec::default();
         let rewrites = Rewrites::default();
-        AccountsDb::extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
+        db.extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
         assert!(hashes.is_empty());
         let pubkey = Pubkey::new(&[1; 32]);
         let hash = Hash::new(&[2; 32]);
         rewrites.write().unwrap().insert(pubkey, hash);
-        AccountsDb::extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
+        db.extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
         assert_eq!(hashes, vec![(pubkey, hash)]);
         // pubkey is already in hashes, will not be added a second time
-        AccountsDb::extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
+        db.extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
         assert_eq!(hashes, vec![(pubkey, hash)]);
         let pubkey2 = Pubkey::new(&[2; 32]);
         let hash2 = Hash::new(&[3; 32]);
         rewrites.write().unwrap().insert(pubkey2, hash2);
-        AccountsDb::extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
+        db.extend_hashes_with_skipped_rewrites(&mut hashes, &rewrites);
         assert_eq!(hashes, vec![(pubkey, hash), (pubkey2, hash2)]);
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6255,15 +6255,6 @@ impl AccountsDb {
         });
 
         if self.filler_accounts_enabled() {
-            // simulate the time we would normally spend hashing the filler accounts
-            // this is an over approximation but at least takes a stab at simulating what the validator would spend time doing
-            let _ = AccountsHash::accumulate_account_hashes(
-                skipped_rewrites
-                    .iter()
-                    .map(|(k, v)| (*k, *v))
-                    .collect::<Vec<_>>(),
-            );
-
             // filler accounts do not get their updated hash values hashed into the delta hash
             skipped_rewrites.retain(|key, _| !self.is_filler_account(key));
         }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -532,6 +532,10 @@ where
     let num_collisions = AtomicUsize::new(0);
     let next_append_vec_id = AtomicAppendVecId::new(0);
     let mut measure_remap = Measure::start("remap");
+    let a_slot = snapshot_storages
+        .first()
+        .map(|(slot, _)| *slot)
+        .unwrap_or_default();
     let mut storage = (0..snapshot_storages.len())
         .into_par_iter()
         .map(|i| {
@@ -642,7 +646,11 @@ where
         genesis_config,
     );
 
-    accounts_db.maybe_add_filler_accounts(&genesis_config.epoch_schedule, &genesis_config.rent);
+    accounts_db.maybe_add_filler_accounts(
+        &genesis_config.epoch_schedule,
+        &genesis_config.rent,
+        genesis_config.epoch_schedule.get_epoch(a_slot),
+    );
 
     handle.join().unwrap();
     measure_notify.stop();

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -532,10 +532,6 @@ where
     let num_collisions = AtomicUsize::new(0);
     let next_append_vec_id = AtomicAppendVecId::new(0);
     let mut measure_remap = Measure::start("remap");
-    let a_slot = snapshot_storages
-        .first()
-        .map(|(slot, _)| *slot)
-        .unwrap_or_default();
     let mut storage = (0..snapshot_storages.len())
         .into_par_iter()
         .map(|i| {
@@ -649,7 +645,7 @@ where
     accounts_db.maybe_add_filler_accounts(
         &genesis_config.epoch_schedule,
         &genesis_config.rent,
-        genesis_config.epoch_schedule.get_epoch(a_slot),
+        genesis_config.epoch_schedule.get_epoch(snapshot_slot),
     );
 
     handle.join().unwrap();


### PR DESCRIPTION
#### Problem

filler accounts create dummy accounts to simulate high account # systems.
a feature that is hardening is skipping rent rewrites.
because filler accounts were created with rent_epoch=0, we ALWAYS did a rewrite on filler accounts. This means filler accounts are not acting like normal infreqently-updated accounts.

#### Summary of Changes

Create filler accounts with a useful rent epoch so that the skip_rewrite code actually skips rewrites on them.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
