### PR TITLE
Transaction Scheduler Prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,15 +4151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skiplist"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa37347a2b4609765d113afe55f16636ccd42dadc1ad0d29030908d1bac4c95b"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,7 +4732,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
- "skiplist",
  "solana-address-lookup-table-program",
  "solana-bloom",
  "solana-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.12"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
 dependencies = [
  "os_str_bytes",
 ]
@@ -3509,7 +3509,7 @@ name = "rbpf-cli"
 version = "1.11.0"
 dependencies = [
  "bv",
- "clap 3.1.12",
+ "clap 3.1.18",
  "gimli",
  "goblin",
  "itertools",
@@ -4300,7 +4300,7 @@ dependencies = [
 name = "solana-banking-bench"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.12",
+ "clap 3.1.18",
  "crossbeam-channel",
  "log",
  "rand 0.7.3",
@@ -4365,7 +4365,7 @@ dependencies = [
 name = "solana-bench-streamer"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.12",
+ "clap 3.1.18",
  "crossbeam-channel",
  "solana-net-utils",
  "solana-streamer",
@@ -4462,7 +4462,7 @@ version = "1.11.0"
 dependencies = [
  "bzip2",
  "cargo_metadata",
- "clap 3.1.12",
+ "clap 3.1.18",
  "regex",
  "serial_test",
  "solana-download-utils",
@@ -4475,7 +4475,7 @@ name = "solana-cargo-test-bpf"
 version = "1.11.0"
 dependencies = [
  "cargo_metadata",
- "clap 3.1.12",
+ "clap 3.1.18",
 ]
 
 [[package]]
@@ -4500,7 +4500,7 @@ name = "solana-clap-v3-utils"
 version = "1.11.0"
 dependencies = [
  "chrono",
- "clap 3.1.12",
+ "clap 3.1.18",
  "rpassword",
  "solana-perf",
  "solana-remote-wallet",
@@ -4773,7 +4773,7 @@ name = "solana-dos"
 version = "1.11.0"
 dependencies = [
  "bincode",
- "clap 3.1.12",
+ "clap 3.1.18",
  "itertools",
  "log",
  "rand 0.7.3",
@@ -5071,7 +5071,7 @@ name = "solana-keygen"
 version = "1.11.0"
 dependencies = [
  "bs58",
- "clap 3.1.12",
+ "clap 3.1.18",
  "dirs-next",
  "num_cpus",
  "solana-clap-v3-utils",
@@ -5210,7 +5210,7 @@ name = "solana-log-analyzer"
 version = "1.11.0"
 dependencies = [
  "byte-unit",
- "clap 3.1.12",
+ "clap 3.1.18",
  "serde",
  "serde_json",
  "solana-logger 1.11.0",
@@ -5287,7 +5287,7 @@ dependencies = [
 name = "solana-net-shaper"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.12",
+ "clap 3.1.18",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -5299,7 +5299,7 @@ name = "solana-net-utils"
 version = "1.11.0"
 dependencies = [
  "bincode",
- "clap 3.1.12",
+ "clap 3.1.18",
  "crossbeam-channel",
  "log",
  "nix",
@@ -5376,7 +5376,7 @@ dependencies = [
 name = "solana-poh-bench"
 version = "1.11.0"
 dependencies = [
- "clap 3.1.12",
+ "clap 3.1.18",
  "log",
  "rand 0.7.3",
  "rayon",
@@ -6040,6 +6040,24 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
+]
+
+[[package]]
+name = "solana-transaction-scheduler-bench"
+version = "1.11.0"
+dependencies = [
+ "bincode",
+ "clap 3.1.18",
+ "crossbeam-channel",
+ "itertools",
+ "log",
+ "rand 0.8.5",
+ "solana-core",
+ "solana-logger 1.11.0",
+ "solana-measure",
+ "solana-perf",
+ "solana-runtime",
+ "solana-sdk 1.11.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,6 +4151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "skiplist"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa37347a2b4609765d113afe55f16636ccd42dadc1ad0d29030908d1bac4c95b"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4732,6 +4741,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
+ "skiplist",
  "solana-address-lookup-table-program",
  "solana-bloom",
  "solana-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,6 @@ exclude = [
 # This prevents a Travis CI error when building for Windows.
 #resolver = "2"
 
-#[profile.release]
-#lto = "fat"
-#opt-level = 3
-
-#debug = true
-#opt-level = 0
+[profile.release]
+lto = "fat"
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,9 +93,9 @@ exclude = [
 # This prevents a Travis CI error when building for Windows.
 #resolver = "2"
 
-[profile.release]
-lto = "fat"
-opt-level = 3
+#[profile.release]
+#lto = "fat"
+#opt-level = 3
 
 #debug = true
 #opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ exclude = [
 # This prevents a Travis CI error when building for Windows.
 #resolver = "2"
 
-#[profile.release]
+[profile.release]
+lto = "fat"
+opt-level = 3
+
 #debug = true
 #opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,6 @@ exclude = [
 # This prevents a Travis CI error when building for Windows.
 #resolver = "2"
 
-[profile.release]
-lto = "fat"
-opt-level = 3
+#[profile.release]
+#lto = "fat"
+#opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,4 @@ exclude = [
 ]
 
 # This prevents a Travis CI error when building for Windows.
-#resolver = "2"
-
-[profile.release]
-lto = "fat"
-opt-level = 3
+resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "test-validator",
     "tokens",
     "transaction-dos",
+    "transaction-scheduler-bench",
     "transaction-status",
     "upload-perf",
     "validator",
@@ -90,4 +91,8 @@ exclude = [
 ]
 
 # This prevents a Travis CI error when building for Windows.
-resolver = "2"
+#resolver = "2"
+
+#[profile.release]
+#debug = true
+#opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,6 @@ exclude = [
 # This prevents a Travis CI error when building for Windows.
 #resolver = "2"
 
-#[profile.release]
-#lto = "fat"
-#opt-level = 3
+[profile.release]
+lto = "fat"
+opt-level = 3

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,6 @@ rayon = "1.5.3"
 retain_mut = "0.1.7"
 serde = "1.0.137"
 serde_derive = "1.0.103"
-skiplist = "0.4.0"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.11.0" }
 solana-bloom = { path = "../bloom", version = "=1.11.0" }
 solana-client = { path = "../client", version = "=1.11.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ rayon = "1.5.3"
 retain_mut = "0.1.7"
 serde = "1.0.137"
 serde_derive = "1.0.103"
+skiplist = "0.4.0"
 solana-address-lookup-table-program = { path = "../programs/address-lookup-table", version = "=1.11.0" }
 solana-bloom = { path = "../bloom", version = "=1.11.0" }
 solana-client = { path = "../client", version = "=1.11.0" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -65,6 +65,7 @@ pub mod system_monitor_service;
 mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;
+pub mod transaction_scheduler;
 pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;

--- a/core/src/transaction_scheduler.rs
+++ b/core/src/transaction_scheduler.rs
@@ -3,6 +3,7 @@
 //! - TPU vote transactions
 //! - Gossip vote transactions
 
+use std::iter::repeat;
 use {
     crate::{
         banking_stage::BatchedTransactionDetails,
@@ -909,19 +910,11 @@ impl TransactionScheduler {
                 .enumerate()
                 .filter_map(|(idx, p)| if !p.meta.discard() { Some(idx) } else { None })
                 .collect();
-            let start = Instant::now();
 
-            for p in unprocessed_packet_batches::deserialize_packets(&packet_batch, &packet_indexes)
-            {
-                unprocessed_packets.insert(p, rand::thread_rng().gen_range(0, 100_000));
-            }
-
-            // info!(
-            //     "packets inserted: {:?}, elapsed: {:?}, len: {}",
-            //     packet_indexes.len(),
-            //     start.elapsed(),
-            //     unprocessed_packets.len()
-            // );
+            unprocessed_packets.extend(
+                unprocessed_packet_batches::deserialize_packets(&packet_batch, &packet_indexes)
+                    .zip(repeat(1)),
+            );
         }
     }
 

--- a/core/src/transaction_scheduler.rs
+++ b/core/src/transaction_scheduler.rs
@@ -398,12 +398,11 @@ impl TransactionScheduler {
         )
         .ok_or_else(|| SchedulerError::InvalidSanitizedTransaction)?;
 
-        let priority = deserialized_packet.priority();
-
         let account_locks = sanitized_tx
             .get_account_locks(&bank.feature_set)
             .map_err(|e| SchedulerError::InvalidTransactionFormat(e))?;
 
+        let priority = deserialized_packet.priority();
         trace!(
             "popped tx w/ priority: {}, readable: {:?}, writeable: {:?}",
             priority,
@@ -682,13 +681,12 @@ impl TransactionScheduler {
         qos_service: &QosService,
         config: &TransactionSchedulerConfig,
     ) -> (Vec<SanitizedTransaction>, Vec<DeserializedPacket>) {
-        let mut sanitized_transactions = Vec::with_capacity(num_txs);
-
         // hashmap representing the highest fee of currently write-locked and read-locked blocked accounts
         // almost a pseudo AccountLocks but fees instead of hashset/read lock count
         let mut highest_wl_blocked_account_fees = HashMap::with_capacity(10_000);
         let mut highest_rl_blocked_account_fees = HashMap::with_capacity(10_000);
 
+        let mut sanitized_transactions = Vec::with_capacity(num_txs);
         let mut packets_to_remove = vec![];
         for deserialized_packet in unprocessed_packets.iter() {
             if sanitized_transactions.len() >= num_txs {

--- a/core/src/transaction_scheduler.rs
+++ b/core/src/transaction_scheduler.rs
@@ -3,7 +3,6 @@
 //! - TPU vote transactions
 //! - Gossip vote transactions
 
-use std::iter::repeat;
 use {
     crate::{
         banking_stage::BatchedTransactionDetails,
@@ -28,6 +27,7 @@ use {
     },
     std::{
         collections::{hash_map::Entry, BTreeMap, HashMap},
+        iter::repeat,
         rc::Rc,
         sync::{
             atomic::{AtomicBool, Ordering},

--- a/core/src/transaction_scheduler.rs
+++ b/core/src/transaction_scheduler.rs
@@ -1,0 +1,1917 @@
+//! Implements a transaction scheduler for the three types of transaction receiving pipelines:
+//! - Normal transactions
+//! - TPU vote transactions
+//! - Gossip vote transactions
+
+use {
+    crate::{
+        banking_stage::BatchedTransactionDetails,
+        qos_service::QosService,
+        unprocessed_packet_batches::{
+            self, DeserializedPacket, ImmutableDeserializedPacket, UnprocessedPacketBatches,
+        },
+    },
+    crossbeam_channel::{select, unbounded, Receiver, RecvError, Sender},
+    solana_perf::packet::PacketBatch,
+    solana_runtime::{
+        accounts::AccountLocks,
+        bank::Bank,
+        cost_model::{CostModel, TransactionCost},
+        transaction_error_metrics::TransactionErrorMetrics,
+    },
+    solana_sdk::{
+        clock::MAX_PROCESSING_AGE,
+        feature_set,
+        pubkey::Pubkey,
+        saturating_add_assign,
+        transaction::{self, AddressLoader, SanitizedTransaction, TransactionError},
+    },
+    std::{
+        collections::{hash_map::Entry, HashMap},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, Mutex, RwLock,
+        },
+        thread::{self, Builder, JoinHandle},
+        time::{Duration, Instant},
+    },
+    thiserror::Error,
+};
+
+#[derive(Debug)]
+pub enum SchedulerMessage {
+    RequestBatch {
+        num_txs: usize,
+        bank: Arc<Bank>,
+    },
+    Ping {
+        id: usize,
+    },
+    ExecutedBatchUpdate {
+        executed_transactions: Vec<SanitizedTransaction>,
+        rescheduled_transactions: Vec<SanitizedTransaction>,
+    },
+}
+
+#[derive(Debug)]
+pub struct SchedulerRequest {
+    msg: SchedulerMessage,
+    response_sender: Sender<SchedulerResponse>,
+}
+
+pub struct ScheduledBatch {
+    pub sanitized_transactions: Vec<SanitizedTransaction>,
+}
+
+pub struct Pong {
+    pub id: usize,
+}
+
+#[derive(Clone)]
+pub struct ExecutedBatchResponse {}
+
+pub enum SchedulerResponse {
+    ScheduledBatch(ScheduledBatch),
+    Pong(Pong),
+    ExecutedBatchResponse(ExecutedBatchResponse),
+}
+
+impl SchedulerResponse {
+    fn pong(self) -> Pong {
+        match self {
+            SchedulerResponse::Pong(pong) => pong,
+            _ => {
+                unreachable!("invalid response expected");
+            }
+        }
+    }
+
+    fn scheduled_batch(self) -> ScheduledBatch {
+        match self {
+            SchedulerResponse::ScheduledBatch(batch) => batch,
+            _ => {
+                unreachable!("invalid response expected");
+            }
+        }
+    }
+
+    fn executed_batch_response(self) -> ExecutedBatchResponse {
+        match self {
+            SchedulerResponse::ExecutedBatchResponse(response) => response,
+            _ => {
+                unreachable!("invalid response expected");
+            }
+        }
+    }
+}
+
+pub enum SchedulerStage {
+    // normal transactions
+    Transactions,
+    // votes coming in on tpu port
+    TpuVotes,
+    // gossip votes
+    GossipVotes,
+}
+
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum SchedulerError {
+    #[error("invalid sanitized transaction")]
+    InvalidSanitizedTransaction,
+
+    #[error("irrecoverable transaction format error: {0}")]
+    InvalidTransactionFormat(TransactionError),
+
+    #[error("account in use")]
+    AccountInUse,
+
+    #[error("account is blocked by higher paying: account {0}")]
+    AccountBlocked(Pubkey),
+
+    #[error("transaction check failed {0}")]
+    TransactionCheckFailed(TransactionError),
+
+    #[error("transaction exceeded QOS limit")]
+    QosExceeded,
+}
+
+pub type Result<T> = std::result::Result<T, SchedulerError>;
+
+#[derive(Clone)]
+pub struct TransactionSchedulerHandle {
+    sender: Sender<SchedulerRequest>,
+}
+
+impl TransactionSchedulerHandle {
+    pub fn new(sender: Sender<SchedulerRequest>) -> TransactionSchedulerHandle {
+        TransactionSchedulerHandle { sender }
+    }
+
+    /// Requests a batch of num_txs transactions from one of the scheduler stages.
+    pub fn request_batch(
+        &self,
+        num_txs: usize,
+        bank: &Arc<Bank>,
+    ) -> std::result::Result<ScheduledBatch, RecvError> {
+        Self::make_scheduler_request(
+            &self.sender,
+            SchedulerMessage::RequestBatch {
+                num_txs,
+                bank: bank.clone(),
+            },
+        )
+        .map(|r| r.scheduled_batch())
+    }
+
+    /// Ping-pong a scheduler stage
+    pub fn send_ping(&self, id: usize) -> std::result::Result<Pong, RecvError> {
+        Self::make_scheduler_request(&self.sender, SchedulerMessage::Ping { id }).map(|r| r.pong())
+    }
+
+    /// Send the scheduler an update on what was scheduled
+    pub fn send_batch_execution_update(
+        &self,
+        executed_transactions: Vec<SanitizedTransaction>,
+        rescheduled_transactions: Vec<SanitizedTransaction>,
+    ) -> std::result::Result<ExecutedBatchResponse, RecvError> {
+        Self::make_scheduler_request(
+            &self.sender,
+            SchedulerMessage::ExecutedBatchUpdate {
+                executed_transactions,
+                rescheduled_transactions,
+            },
+        )
+        .map(|r| r.executed_batch_response())
+    }
+
+    /// Sends a scheduler request and blocks on waiting for a response
+    fn make_scheduler_request(
+        request_sender: &Sender<SchedulerRequest>,
+        msg: SchedulerMessage,
+    ) -> std::result::Result<SchedulerResponse, RecvError> {
+        let (response_sender, response_receiver) = unbounded();
+        let request = SchedulerRequest {
+            msg,
+            response_sender,
+        };
+        let _ = request_sender.send(request).unwrap();
+        response_receiver.recv()
+    }
+}
+
+#[derive(Clone)]
+pub struct TransactionSchedulerConfig {
+    // ensures T(1) is scheduled before T(2) if T(1) pays higher fees than T(2) for all account
+    // accesses except where T(1) and T(2) only accounts overlap are read-only accounts.
+    pub enable_state_auction: bool,
+
+    // max packets to hold in each thread
+    pub max_packets: usize,
+}
+
+impl Default for TransactionSchedulerConfig {
+    fn default() -> Self {
+        return TransactionSchedulerConfig {
+            enable_state_auction: false,
+            max_packets: 700_000,
+        };
+    }
+}
+
+pub struct TransactionScheduler {
+    tx_request_handler_thread: JoinHandle<()>,
+    tx_scheduler_request_sender: Sender<SchedulerRequest>,
+
+    tpu_vote_request_handler_thread: JoinHandle<()>,
+    tpu_vote_scheduler_request_sender: Sender<SchedulerRequest>,
+
+    gossip_vote_request_handler_thread: JoinHandle<()>,
+    gossip_vote_scheduler_request_sender: Sender<SchedulerRequest>,
+}
+
+impl TransactionScheduler {
+    /// Creates a thread for each type of transaction and a handle to the event loop.
+    pub fn new(
+        verified_receiver: Receiver<Vec<PacketBatch>>,
+        verified_tpu_vote_packets_receiver: Receiver<Vec<PacketBatch>>,
+        verified_gossip_vote_packets_receiver: Receiver<Vec<PacketBatch>>,
+        exit: Arc<AtomicBool>,
+        cost_model: Arc<RwLock<CostModel>>,
+        config: TransactionSchedulerConfig,
+    ) -> Self {
+        let scheduled_accounts = Arc::new(Mutex::new(AccountLocks::default()));
+
+        let (tx_scheduler_request_sender, tx_scheduler_request_receiver) = unbounded();
+        let tx_request_handler_thread = Self::start_event_loop(
+            "tx_scheduler_insertion_thread",
+            tx_scheduler_request_receiver,
+            verified_receiver,
+            scheduled_accounts.clone(),
+            QosService::new(cost_model.clone(), 0),
+            &exit,
+            config.clone(),
+        );
+
+        let (tpu_vote_scheduler_request_sender, tpu_vote_scheduler_request_receiver) = unbounded();
+        let tpu_vote_request_handler_thread = Self::start_event_loop(
+            "tpu_vote_scheduler_tx_insertion_thread",
+            tpu_vote_scheduler_request_receiver,
+            verified_tpu_vote_packets_receiver,
+            scheduled_accounts.clone(),
+            QosService::new(cost_model.clone(), 1),
+            &exit,
+            config.clone(),
+        );
+
+        let (gossip_vote_scheduler_request_sender, gossip_vote_scheduler_request_receiver) =
+            unbounded();
+        let gossip_vote_request_handler_thread = Self::start_event_loop(
+            "gossip_vote_scheduler_tx_insertion_thread",
+            gossip_vote_scheduler_request_receiver,
+            verified_gossip_vote_packets_receiver,
+            scheduled_accounts.clone(),
+            QosService::new(cost_model.clone(), 2),
+            &exit,
+            config.clone(),
+        );
+
+        TransactionScheduler {
+            tx_request_handler_thread,
+            tx_scheduler_request_sender,
+            tpu_vote_request_handler_thread,
+            tpu_vote_scheduler_request_sender,
+            gossip_vote_request_handler_thread,
+            gossip_vote_scheduler_request_sender,
+        }
+    }
+
+    // ***************************************************************
+    // Client methods
+    // ***************************************************************
+
+    /// Returns a handle to one of the schedulers
+    pub fn get_handle(&self, scheduler_stage: SchedulerStage) -> TransactionSchedulerHandle {
+        TransactionSchedulerHandle::new(self.get_sender_from_stage(scheduler_stage).clone())
+    }
+
+    /// Clean up the threads
+    pub fn join(self) -> thread::Result<()> {
+        self.tx_request_handler_thread.join()?;
+        self.tpu_vote_request_handler_thread.join()?;
+        self.gossip_vote_request_handler_thread.join()?;
+        Ok(())
+    }
+
+    // ***************************************************************
+    // Internal logic
+    // ***************************************************************
+
+    /// The event loop has two main responsibilities:
+    /// 1. Handle incoming packets and prioritization around them.
+    /// 2. Serve scheduler requests and return responses.
+    fn start_event_loop(
+        t_name: &str,
+        scheduler_request_receiver: Receiver<SchedulerRequest>,
+        packet_receiver: Receiver<Vec<PacketBatch>>,
+        scheduled_accounts: Arc<Mutex<AccountLocks>>,
+        qos_service: QosService,
+        exit: &Arc<AtomicBool>,
+        config: TransactionSchedulerConfig,
+    ) -> JoinHandle<()> {
+        let exit = exit.clone();
+        Builder::new()
+            .name(t_name.to_string())
+            .spawn(move || {
+                let mut unprocessed_packet_batches = UnprocessedPacketBatches::with_capacity(config.max_packets);
+
+                let mut last_log = Instant::now();
+
+                loop {
+                    if last_log.elapsed() > Duration::from_secs(1) {
+                        let num_packets = unprocessed_packet_batches.len();
+                        info!("num_packets: {}", num_packets);
+                        last_log = Instant::now();
+                    }
+                    select! {
+                        recv(packet_receiver) -> maybe_packet_batches => {
+                            match maybe_packet_batches {
+                                Ok(packet_batches) => {
+                                    Self::handle_packet_batches(&mut unprocessed_packet_batches, packet_batches);
+                                }
+                                Err(_) => {
+                                    break;
+                                }
+                            }
+                        }
+                        recv(scheduler_request_receiver) -> maybe_batch_request => {
+                            match maybe_batch_request {
+                                Ok(batch_request) => {
+                                    Self::handle_scheduler_request(&mut unprocessed_packet_batches, &scheduled_accounts, batch_request, &qos_service, &config);
+                                }
+                                Err(_) => {
+                                    break;
+                                }
+                            }
+                        }
+                        default(Duration::from_millis(100)) => {
+                            if exit.load(Ordering::Relaxed) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            })
+            .unwrap()
+    }
+
+    /// Attempts to schedule a transaction to be executed.
+    fn try_schedule(
+        deserialized_packet: &DeserializedPacket,
+        bank: &Arc<Bank>,
+        highest_wl_blocked_account_fees: &mut HashMap<Pubkey, u64>,
+        highest_rl_blocked_account_fees: &mut HashMap<Pubkey, u64>,
+        scheduled_accounts: &Arc<Mutex<AccountLocks>>,
+        qos_service: &QosService,
+        config: &TransactionSchedulerConfig,
+    ) -> Result<SanitizedTransaction> {
+        let sanitized_tx = Self::transaction_from_deserialized_packet(
+            deserialized_packet.immutable_section(),
+            &bank.feature_set,
+            bank.vote_only_bank(),
+            bank.as_ref(),
+        )
+        .ok_or_else(|| SchedulerError::InvalidSanitizedTransaction)?;
+
+        let priority = deserialized_packet.immutable_section().priority();
+
+        let account_locks = sanitized_tx
+            .get_account_locks(&bank.feature_set)
+            .map_err(|e| SchedulerError::InvalidTransactionFormat(e))?;
+
+        trace!(
+            "popped tx w/ priority: {}, readable: {:?}, writeable: {:?}",
+            priority,
+            account_locks.readonly,
+            account_locks.writable
+        );
+
+        // pre-emptively lock the accounts associated with the transaction
+        {
+            let mut scheduled_accounts_l = scheduled_accounts.lock().unwrap();
+            // Make sure that this transaction isn't blocked on another transaction that has a higher
+            // fee for one of its accounts
+            if let Err(e) = Self::check_accounts_not_blocked(
+                &scheduled_accounts_l,
+                highest_wl_blocked_account_fees,
+                highest_rl_blocked_account_fees,
+                &account_locks.writable,
+                &account_locks.readonly,
+                config,
+            ) {
+                Self::upsert_higher_fee_account_lock(
+                    &account_locks.writable,
+                    &account_locks.readonly,
+                    highest_wl_blocked_account_fees,
+                    highest_rl_blocked_account_fees,
+                    priority,
+                    config,
+                );
+                return Err(e);
+            }
+
+            // already checked we can lock accounts in check_accounts_not_blocked
+            Self::lock_accounts(
+                &mut scheduled_accounts_l,
+                &account_locks.writable,
+                &account_locks.readonly,
+            )
+            .unwrap();
+        }
+
+        let mut sanitized_txs = vec![sanitized_tx];
+        let lock_results = vec![Ok(())];
+        let mut error_counters = TransactionErrorMetrics::new();
+
+        // Make sure transaction isn't stale or already executed
+        if let Err(e) = bank
+            .check_transactions(
+                &sanitized_txs,
+                &lock_results,
+                MAX_PROCESSING_AGE,
+                &mut error_counters,
+            )
+            .pop()
+            .unwrap()
+            .0
+        {
+            let mut scheduled_accounts_l = scheduled_accounts.lock().unwrap();
+            let sanitized_tx = sanitized_txs.pop().unwrap();
+            let account_locks = sanitized_tx.get_account_locks(&bank.feature_set).unwrap();
+            Self::drop_account_locks(
+                &mut scheduled_accounts_l,
+                &account_locks.writable,
+                &account_locks.readonly,
+            );
+            return Err(SchedulerError::TransactionCheckFailed(e));
+        }
+
+        // Try to reserve in QoS, rollback account locks if doesn't fit
+        if let Err(e) = Self::reserve_tx_in_qos(&sanitized_txs, qos_service, bank) {
+            let mut scheduled_accounts_l = scheduled_accounts.lock().unwrap();
+            let sanitized_tx = sanitized_txs.pop().unwrap();
+            let account_locks = sanitized_tx.get_account_locks(&bank.feature_set).unwrap();
+            Self::drop_account_locks(
+                &mut scheduled_accounts_l,
+                &account_locks.writable,
+                &account_locks.readonly,
+            );
+            return Err(e);
+        }
+
+        // TODO: check fee payer's balance is high enough
+        // sanitized_tx.message().fee_payer()
+
+        let sanitized_tx = sanitized_txs.pop().unwrap();
+        Ok(sanitized_tx)
+    }
+
+    fn reserve_tx_in_qos(
+        sanitized_txs: &[SanitizedTransaction],
+        qos_service: &QosService,
+        bank: &Arc<Bank>,
+    ) -> Result<()> {
+        let transaction_costs = qos_service.compute_transaction_costs(sanitized_txs.iter());
+
+        let (transactions_qos_results, num_included) = qos_service.select_transactions_per_cost(
+            sanitized_txs.iter(),
+            transaction_costs.iter(),
+            bank,
+        );
+
+        let cost_model_throttled_transactions_count =
+            sanitized_txs.len().saturating_sub(num_included);
+        if cost_model_throttled_transactions_count > 0 {
+            return Err(SchedulerError::QosExceeded);
+        }
+
+        qos_service.accumulate_estimated_transaction_costs(
+            &Self::accumulate_batched_transaction_costs(
+                transaction_costs.iter(),
+                transactions_qos_results.iter(),
+            ),
+        );
+        Ok(())
+    }
+
+    // rollup transaction cost details, eg signature_cost, write_lock_cost, data_bytes_cost and
+    // execution_cost from the batch of transactions selected for block.
+    fn accumulate_batched_transaction_costs<'a>(
+        transactions_costs: impl Iterator<Item = &'a TransactionCost>,
+        transaction_results: impl Iterator<Item = &'a transaction::Result<()>>,
+    ) -> BatchedTransactionDetails {
+        let mut batched_transaction_details = BatchedTransactionDetails::default();
+        transactions_costs
+            .zip(transaction_results)
+            .for_each(|(cost, result)| match result {
+                Ok(_) => {
+                    saturating_add_assign!(
+                        batched_transaction_details.costs.batched_signature_cost,
+                        cost.signature_cost
+                    );
+                    saturating_add_assign!(
+                        batched_transaction_details.costs.batched_write_lock_cost,
+                        cost.write_lock_cost
+                    );
+                    saturating_add_assign!(
+                        batched_transaction_details.costs.batched_data_bytes_cost,
+                        cost.data_bytes_cost
+                    );
+                    saturating_add_assign!(
+                        batched_transaction_details
+                            .costs
+                            .batched_builtins_execute_cost,
+                        cost.builtins_execution_cost
+                    );
+                    saturating_add_assign!(
+                        batched_transaction_details.costs.batched_bpf_execute_cost,
+                        cost.bpf_execution_cost
+                    );
+                }
+                Err(transaction_error) => match transaction_error {
+                    TransactionError::WouldExceedMaxBlockCostLimit => {
+                        saturating_add_assign!(
+                            batched_transaction_details
+                                .errors
+                                .batched_retried_txs_per_block_limit_count,
+                            1
+                        );
+                    }
+                    TransactionError::WouldExceedMaxVoteCostLimit => {
+                        saturating_add_assign!(
+                            batched_transaction_details
+                                .errors
+                                .batched_retried_txs_per_vote_limit_count,
+                            1
+                        );
+                    }
+                    TransactionError::WouldExceedMaxAccountCostLimit => {
+                        saturating_add_assign!(
+                            batched_transaction_details
+                                .errors
+                                .batched_retried_txs_per_account_limit_count,
+                            1
+                        );
+                    }
+                    TransactionError::WouldExceedAccountDataBlockLimit => {
+                        saturating_add_assign!(
+                            batched_transaction_details
+                                .errors
+                                .batched_retried_txs_per_account_data_block_limit_count,
+                            1
+                        );
+                    }
+                    TransactionError::WouldExceedAccountDataTotalLimit => {
+                        saturating_add_assign!(
+                            batched_transaction_details
+                                .errors
+                                .batched_dropped_txs_per_account_data_total_limit_count,
+                            1
+                        );
+                    }
+                    _ => {}
+                },
+            });
+        batched_transaction_details
+    }
+
+    fn upsert_higher_fee_account_lock(
+        writable_keys: &[&Pubkey],
+        readonly_keys: &[&Pubkey],
+        highest_wl_blocked_account_fees: &mut HashMap<Pubkey, u64>,
+        highest_rl_blocked_account_fees: &mut HashMap<Pubkey, u64>,
+        priority: u64,
+        config: &TransactionSchedulerConfig,
+    ) {
+        if config.enable_state_auction {
+            for acc in readonly_keys {
+                match highest_rl_blocked_account_fees.entry(**acc) {
+                    Entry::Occupied(mut e) => {
+                        if priority > *e.get() {
+                            // NOTE: this should never be the case!
+                            e.insert(priority);
+                        }
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(priority);
+                    }
+                }
+            }
+
+            for acc in writable_keys {
+                match highest_wl_blocked_account_fees.entry(**acc) {
+                    Entry::Occupied(mut e) => {
+                        if priority > *e.get() {
+                            // NOTE: this should never be the case!
+                            e.insert(priority);
+                        }
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(priority);
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_accounts_not_blocked(
+        account_locks: &AccountLocks,
+        highest_wl_blocked_account_fees: &HashMap<Pubkey, u64>,
+        highest_rl_blocked_account_fees: &HashMap<Pubkey, u64>,
+        writable_keys: &[&Pubkey],
+        readonly_keys: &[&Pubkey],
+        config: &TransactionSchedulerConfig,
+    ) -> Result<()> {
+        if config.enable_state_auction {
+            // writes are blocked if there's a blocked read or write account already
+            for acc in writable_keys {
+                if highest_wl_blocked_account_fees.get(*acc).is_some()
+                    || highest_rl_blocked_account_fees.get(*acc).is_some()
+                {
+                    trace!("write locked account blocked by another tx: {:?}", acc);
+                    return Err(SchedulerError::AccountBlocked(**acc));
+                }
+            }
+
+            // reads are blocked if the account exists in write blocked state
+            for acc in readonly_keys {
+                if highest_wl_blocked_account_fees.get(*acc).is_some() {
+                    trace!("read locked account blocked by another tx: {:?}", acc);
+                    return Err(SchedulerError::AccountBlocked(**acc));
+                }
+            }
+        }
+
+        // double check to make sure we can lock this against currently executed transactions and
+        // accounts
+        Self::can_lock_accounts(account_locks, writable_keys, readonly_keys)?;
+
+        Ok(())
+    }
+
+    fn get_scheduled_batch(
+        unprocessed_packets: &mut UnprocessedPacketBatches,
+        scheduled_accounts: &Arc<Mutex<AccountLocks>>,
+        num_txs: usize,
+        bank: &Arc<Bank>,
+        qos_service: &QosService,
+        config: &TransactionSchedulerConfig,
+    ) -> (Vec<SanitizedTransaction>, Vec<DeserializedPacket>) {
+        let mut sanitized_transactions = Vec::with_capacity(num_txs);
+        let mut rescheduled_packets = Vec::with_capacity(1_000);
+
+        // hashmap representing the highest fee of currently write-locked and read-locked blocked accounts
+        // almost a pseudo AccountLocks but fees instead of hashset/read lock count
+        let mut highest_wl_blocked_account_fees = HashMap::with_capacity(10_000);
+        let mut highest_rl_blocked_account_fees = HashMap::with_capacity(10_000);
+
+        let mut lookback_count = 0;
+
+        while let Some(deserialized_packet) = unprocessed_packets.pop_max() {
+            match Self::try_schedule(
+                &deserialized_packet,
+                bank,
+                &mut highest_wl_blocked_account_fees,
+                &mut highest_rl_blocked_account_fees,
+                scheduled_accounts,
+                qos_service,
+                config,
+            ) {
+                Ok(sanitized_tx) => {
+                    sanitized_transactions.push(sanitized_tx);
+                    if sanitized_transactions.len() >= num_txs {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    trace!("e: {:?}", e);
+                    match e {
+                        SchedulerError::InvalidSanitizedTransaction
+                        | SchedulerError::InvalidTransactionFormat(_)
+                        | SchedulerError::TransactionCheckFailed(_) => {
+                            // non-recoverable error, drop the packet
+                            continue;
+                        }
+                        SchedulerError::AccountInUse | SchedulerError::AccountBlocked(_) => {
+                            // need to reschedule
+                            // error!("e: {}", e);
+                            rescheduled_packets.push(deserialized_packet);
+                        }
+                        SchedulerError::QosExceeded => {
+                            // TODO: probably want to move this packet to a separate queue
+                        }
+                    }
+                }
+            }
+            lookback_count += 1;
+            if lookback_count >= num_txs * 20 {
+                break;
+            }
+        }
+
+        (sanitized_transactions, rescheduled_packets)
+    }
+
+    /// Handles scheduler requests and sends back a response over the channel
+    fn handle_scheduler_request(
+        unprocessed_packets: &mut UnprocessedPacketBatches,
+        scheduled_accounts: &Arc<Mutex<AccountLocks>>,
+        scheduler_request: SchedulerRequest,
+        qos_service: &QosService,
+        config: &TransactionSchedulerConfig,
+    ) {
+        let response_sender = scheduler_request.response_sender;
+        match scheduler_request.msg {
+            SchedulerMessage::RequestBatch { num_txs, bank } => {
+                trace!("SchedulerMessage::RequestBatch num_txs: {}", num_txs);
+                let (sanitized_transactions, rescheduled_packets) = Self::get_scheduled_batch(
+                    unprocessed_packets,
+                    scheduled_accounts,
+                    num_txs,
+                    &bank,
+                    qos_service,
+                    config,
+                );
+                trace!(
+                    "sanitized_transactions num: {}, rescheduled_packets num: {}, unprocessed_packets num: {}",
+                    sanitized_transactions.len(),
+                    rescheduled_packets.len(),
+                    unprocessed_packets.len()
+                );
+
+                let _ = response_sender
+                    .send(SchedulerResponse::ScheduledBatch(ScheduledBatch {
+                        sanitized_transactions,
+                    }))
+                    .unwrap();
+
+                // push rescheduled back on after sending so execution can start
+                for tx in rescheduled_packets {
+                    unprocessed_packets.push(tx.clone());
+                }
+            }
+            SchedulerMessage::Ping { id } => {
+                let _ = response_sender
+                    .send(SchedulerResponse::Pong(Pong { id }))
+                    .unwrap();
+            }
+            SchedulerMessage::ExecutedBatchUpdate {
+                executed_transactions,
+                rescheduled_transactions,
+            } => {
+                // respond then do work so execution can get back to doing stuff
+                let _ = response_sender
+                    .send(SchedulerResponse::ExecutedBatchResponse(
+                        ExecutedBatchResponse {},
+                    ))
+                    .unwrap();
+
+                {
+                    // drop account locks for ALL transactions
+                    let mut account_locks = scheduled_accounts.lock().unwrap();
+                    for tx in executed_transactions
+                        .iter()
+                        .chain(rescheduled_transactions.iter())
+                    {
+                        let tx_locks = tx.get_account_locks_unchecked();
+                        trace!("unlocking locks: {:?}", tx_locks);
+                        Self::drop_account_locks(
+                            &mut account_locks,
+                            &tx_locks.writable,
+                            &tx_locks.readonly,
+                        );
+                    }
+                    trace!("dropped account locks, account_locks: {:?}", account_locks);
+                }
+
+                // TODO: update QoS transaction costs for executed transactions
+                // need transaction_costs, transactions_qos_results we can cache?
+                // commit_transactions_result + bank we need from channel
+                // QosService::update_or_remove_transaction_costs(
+                //     transaction_costs.iter(),
+                //     transactions_qos_results.iter(),
+                //     commit_transactions_result.as_ref().ok(),
+                //     bank,
+                // );
+                // let (cu, us) = Self::accumulate_execute_units_and_time(
+                //     &execute_and_commit_timings.execute_timings,
+                // );
+                // qos_service.accumulate_actual_execute_cu(cu);
+                // qos_service.accumulate_actual_execute_time(us);
+                //
+                // // reports qos service stats for this batch
+                // qos_service.report_metrics(bank.clone());
+
+                // TODO (LB): reschedule transactions as packet
+                // for tx in rescheduled_transactions {
+                //     unprocessed_packets.push(tx.deser)
+                // }
+            }
+        }
+    }
+
+    fn can_lock_accounts(
+        account_locks: &AccountLocks,
+        writable_keys: &[&Pubkey],
+        readonly_keys: &[&Pubkey],
+    ) -> Result<()> {
+        for k in writable_keys.iter() {
+            if account_locks.is_locked_write(k) || account_locks.is_locked_readonly(k) {
+                debug!("Writable account in use: {:?}", k);
+                return Err(SchedulerError::AccountInUse);
+            }
+        }
+        for k in readonly_keys.iter() {
+            if account_locks.is_locked_write(k) {
+                debug!("Read-only account in use: {:?}", k);
+                return Err(SchedulerError::AccountInUse);
+            }
+        }
+        Ok(())
+    }
+
+    /// NOTE: this is copied from accounts.rs
+    fn lock_accounts(
+        account_locks: &mut AccountLocks,
+        writable_keys: &[&Pubkey],
+        readonly_keys: &[&Pubkey],
+    ) -> Result<()> {
+        Self::can_lock_accounts(account_locks, &writable_keys, &readonly_keys)?;
+
+        for k in writable_keys {
+            account_locks.write_locks.insert(**k);
+        }
+
+        for k in readonly_keys {
+            if !account_locks.lock_readonly(k) {
+                account_locks.insert_new_readonly(k);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn drop_account_locks(
+        account_locks: &mut AccountLocks,
+        writable_keys: &[&Pubkey],
+        readonly_keys: &[&Pubkey],
+    ) {
+        for k in writable_keys {
+            account_locks.unlock_write(k);
+        }
+        for k in readonly_keys {
+            account_locks.unlock_readonly(k);
+        }
+    }
+
+    fn transaction_from_deserialized_packet(
+        deserialized_packet: &ImmutableDeserializedPacket,
+        feature_set: &Arc<feature_set::FeatureSet>,
+        votes_only: bool,
+        address_loader: impl AddressLoader,
+    ) -> Option<SanitizedTransaction> {
+        if votes_only && !deserialized_packet.is_simple_vote() {
+            return None;
+        }
+
+        let tx = SanitizedTransaction::try_new(
+            deserialized_packet.transaction().clone(),
+            *deserialized_packet.message_hash(),
+            deserialized_packet.is_simple_vote(),
+            address_loader,
+        )
+        .ok()?;
+        tx.verify_precompiles(feature_set).ok()?;
+        Some(tx)
+    }
+
+    fn handle_packet_batches(
+        unprocessed_packets: &mut UnprocessedPacketBatches,
+        packet_batches: Vec<PacketBatch>,
+    ) {
+        for packet_batch in packet_batches {
+            let packet_indexes: Vec<usize> = packet_batch
+                .packets
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, p)| if !p.meta.discard() { Some(idx) } else { None })
+                .collect();
+            unprocessed_packets.insert_batch(unprocessed_packet_batches::deserialize_packets(
+                &packet_batch,
+                &packet_indexes,
+            ));
+        }
+    }
+
+    /// Returns sending side of the channel given the scheduler stage
+    fn get_sender_from_stage(&self, stage: SchedulerStage) -> &Sender<SchedulerRequest> {
+        match stage {
+            SchedulerStage::Transactions => &self.tx_scheduler_request_sender,
+            SchedulerStage::TpuVotes => &self.tpu_vote_scheduler_request_sender,
+            SchedulerStage::GossipVotes => &self.gossip_vote_scheduler_request_sender,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::transaction_scheduler::{
+            SchedulerStage, TransactionScheduler, TransactionSchedulerConfig,
+        },
+        crossbeam_channel::{unbounded, Sender},
+        solana_ledger::genesis_utils::create_genesis_config,
+        solana_perf::packet::PacketBatch,
+        solana_runtime::{
+            bank::Bank, bank_forks::BankForks, cost_model::CostModel,
+            genesis_utils::GenesisConfigInfo,
+        },
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction,
+            genesis_config::GenesisConfig,
+            hash::Hash,
+            instruction::{AccountMeta, Instruction},
+            packet::Packet,
+            pubkey::Pubkey,
+            signature::{Keypair, Signer},
+            system_program,
+            transaction::Transaction,
+        },
+        std::{
+            collections::HashMap,
+            sync::{
+                atomic::{AtomicBool, Ordering},
+                Arc, RwLock,
+            },
+        },
+    };
+
+    struct TestHarness {
+        tx_sender: Sender<Vec<PacketBatch>>,
+        tpu_vote_sender: Sender<Vec<PacketBatch>>,
+        gossip_vote_sender: Sender<Vec<PacketBatch>>,
+        exit: Arc<AtomicBool>,
+        scheduler: TransactionScheduler,
+        accounts: HashMap<&'static str, Pubkey>,
+        #[allow(unused)]
+        genesis_config: GenesisConfig,
+        bank: Arc<Bank>,
+    }
+
+    fn get_test_harness() -> TestHarness {
+        let (tx_sender, tx_receiver) = unbounded();
+        let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
+        let (gossip_vote_sender, gossip_vote_receiver) = unbounded();
+        let exit = Arc::new(AtomicBool::new(false));
+        let cost_model = Arc::new(RwLock::new(CostModel::default()));
+        let accounts = get_random_accounts();
+
+        let scheduler = TransactionScheduler::new(
+            tx_receiver,
+            tpu_vote_receiver,
+            gossip_vote_receiver,
+            exit.clone(),
+            cost_model,
+            TransactionSchedulerConfig {
+                enable_state_auction: true,
+                max_packets: 700_000,
+            },
+        );
+
+        let mint_total = 1_000_000_000_000;
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(mint_total);
+
+        let bank0 = Bank::new_for_benches(&genesis_config);
+        let bank_forks = BankForks::new(bank0);
+        let bank = bank_forks.working_bank();
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(u64::MAX, u64::MAX, u64::MAX);
+
+        TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit,
+            scheduler,
+            accounts,
+            genesis_config,
+            bank,
+        }
+    }
+
+    #[test]
+    fn test_start_and_join_channel_dropped() {
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            scheduler,
+            ..
+        } = get_test_harness();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+        let gossip_vote_handle = scheduler.get_handle(SchedulerStage::GossipVotes);
+        let tpu_vote_handle = scheduler.get_handle(SchedulerStage::TpuVotes);
+
+        // check alive
+        assert_eq!(tx_handle.send_ping(1).unwrap().id, 1);
+        assert_eq!(gossip_vote_handle.send_ping(2).unwrap().id, 2);
+        assert_eq!(tpu_vote_handle.send_ping(3).unwrap().id, 3);
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_start_and_join_channel_exit_signal() {
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit,
+            scheduler,
+            ..
+        } = get_test_harness();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+        let gossip_vote_handle = scheduler.get_handle(SchedulerStage::GossipVotes);
+        let tpu_vote_handle = scheduler.get_handle(SchedulerStage::TpuVotes);
+
+        // check alive
+        assert_eq!(tx_handle.send_ping(1).unwrap().id, 1);
+        assert_eq!(gossip_vote_handle.send_ping(2).unwrap().id, 2);
+        assert_eq!(tpu_vote_handle.send_ping(3).unwrap().id, 3);
+
+        exit.store(true, Ordering::Relaxed);
+
+        assert_matches!(scheduler.join(), Ok(()));
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+    }
+
+    #[test]
+    fn test_single_tx() {
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        // main logic
+        {
+            let tx = get_tx(&[get_account_meta(&accounts, "A", true)], 200, &blockhash);
+
+            send_transactions(&[&tx], &tx_sender);
+
+            // should probably have gotten the packet by now
+            let _ = tx_handle.send_ping(1).unwrap();
+
+            // make sure the requested batch is the single packet
+            let mut batch = tx_handle.request_batch(1, &bank).unwrap();
+            assert_eq!(batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                batch.sanitized_transactions.pop().unwrap().signature(),
+                &tx.signatures[0]
+            );
+
+            // make sure the batch is unlocked
+            let _ = tx_handle.send_batch_execution_update(batch.sanitized_transactions, vec![]);
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_conflicting_transactions() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        // main logic
+        {
+            let tx1 = get_tx(&[get_account_meta(&accounts, "A", true)], 200, &blockhash);
+            let tx2 = get_tx(&[get_account_meta(&accounts, "A", true)], 250, &blockhash);
+
+            send_transactions(&[&tx1, &tx2], &tx_sender);
+
+            // should probably have gotten the packet by now
+            let _ = tx_handle.send_ping(1).unwrap();
+
+            // request two transactions, tx2 should be scheduled because it has higher fee for account A
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+
+            // attempt to request another transaction for schedule, won't schedule bc tx2 locked account A
+            assert_eq!(
+                tx_handle
+                    .request_batch(BATCH_SIZE, &bank)
+                    .unwrap()
+                    .sanitized_transactions
+                    .len(),
+                0
+            );
+
+            // make sure the tx2 is unlocked by sending it execution results of that batch
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            // tx1 should schedule now that tx2 is done executing
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_blocked_transactions() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        // main logic
+        {
+            // 300: A, B(RO)
+            // 200:    B,     C (RO), D (RO)
+            // 100:    B(R0), C (RO), D (RO), E
+            // under previous logic, the previous batches would be [(300, 100), (200)] bc 300 and 100 can be parallelized
+            // under this logic, we expect [(300), (200), (100)]
+            // 200 has write priority on B
+            let tx1 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                ],
+                300,
+                &blockhash,
+            );
+            let tx2 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", true),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                ],
+                200,
+                &blockhash,
+            );
+            let tx3 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                100,
+                &blockhash,
+            );
+
+            send_transactions(&[&tx1, &tx2, &tx3], &tx_sender);
+
+            // should probably have gotten the packet by now
+            let _ = tx_handle.send_ping(1).unwrap();
+
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+
+            // attempt to request another transaction for schedule, won't schedule bc tx2 locked account A
+            assert_eq!(
+                tx_handle
+                    .request_batch(BATCH_SIZE, &bank)
+                    .unwrap()
+                    .sanitized_transactions
+                    .len(),
+                0
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(second_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let third_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(third_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                third_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx3.signatures[0]
+            );
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_blocked_transactions_read_locked() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        // main logic
+        {
+            // 300: A, B(RO)
+            // 200: A, B(R0), C (RO), D (RO)
+            // 100:    B(R0), C (RO), D (RO), E
+            // should schedule as [(300, 100), (200)] because while 200 is blocked on 300 bc account A, it read-locks B so the ordering
+            // doesn't matter on 200, 100 or 100, 200
+            let tx1 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                ],
+                300,
+                &blockhash,
+            );
+            let tx2 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                ],
+                200,
+                &blockhash,
+            );
+            let tx3 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                100,
+                &blockhash,
+            );
+
+            send_transactions(&[&tx1, &tx2, &tx3], &tx_sender);
+
+            // should probably have gotten the packet by now
+            let _ = tx_handle.send_ping(1).unwrap();
+
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 2);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(1)
+                    .unwrap()
+                    .signature(),
+                &tx3.signatures[0]
+            );
+
+            // attempt to request another transaction for schedule, won't schedule bc tx2 locked account A
+            assert_eq!(
+                tx_handle
+                    .request_batch(BATCH_SIZE, &bank)
+                    .unwrap()
+                    .sanitized_transactions
+                    .len(),
+                0
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(second_batch.sanitized_transactions, vec![])
+                .unwrap();
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_blocked_transactions_write_lock_released() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        // main logic
+        {
+            // 300: A, B(RO)
+            // 200: A, B(R0), C (RO), D (RO)
+            // 100:    B(R0), C (RO), D (RO), E
+            //  50: A, B(R0), C (RO), D (RO), E
+            // should schedule as [(300, 100), (200), (50)]
+            let tx1 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                ],
+                300,
+                &blockhash,
+            );
+            let tx2 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                ],
+                200,
+                &blockhash,
+            );
+            let tx3 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                100,
+                &blockhash,
+            );
+            let tx4 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", false),
+                    get_account_meta(&accounts, "C", false),
+                    get_account_meta(&accounts, "D", false),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                50,
+                &blockhash,
+            );
+
+            send_transactions(&[&tx1, &tx2, &tx3, &tx4], &tx_sender);
+
+            // should probably have gotten the packet by now
+            let _ = tx_handle.send_ping(1);
+
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 2);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(1)
+                    .unwrap()
+                    .signature(),
+                &tx3.signatures[0]
+            );
+
+            // attempt to request another transaction for schedule, won't schedule bc tx2 locked account A
+            assert_eq!(
+                tx_handle
+                    .request_batch(BATCH_SIZE, &bank)
+                    .unwrap()
+                    .sanitized_transactions
+                    .len(),
+                0
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(second_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let third_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(third_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                third_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx4.signatures[0]
+            );
+
+            let _ = tx_handle
+                .send_batch_execution_update(third_batch.sanitized_transactions, vec![])
+                .unwrap();
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_read_locked_blocks_write() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        {
+            // 300: A, B, C
+            // 200:    B, C, D(RO)
+            // 100:        , D,     E
+            //  50:                 E(RO), F
+            // request schedule: 300
+            // return 300
+            // request schedule: 200
+            // return 200
+            // request schedule: 100
+            // return schedule
+            // request schedule: 50
+            // return schedule
+            let tx1 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", true),
+                    get_account_meta(&accounts, "C", true),
+                ],
+                300,
+                &blockhash,
+            );
+            let tx2 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", true),
+                    get_account_meta(&accounts, "C", true),
+                    get_account_meta(&accounts, "D", false),
+                ],
+                200,
+                &blockhash,
+            );
+            let tx3 = get_tx(
+                &[
+                    get_account_meta(&accounts, "D", true),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                100,
+                &blockhash,
+            );
+            let tx4 = get_tx(
+                &[
+                    get_account_meta(&accounts, "E", false),
+                    get_account_meta(&accounts, "F", true),
+                ],
+                50,
+                &blockhash,
+            );
+
+            send_transactions(&[&tx1, &tx2, &tx3, &tx4], &tx_sender);
+
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(second_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let third_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(third_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                third_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx3.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(third_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let fourth_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(fourth_batch.sanitized_transactions.len(), 1);
+            assert_eq!(
+                fourth_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx4.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(fourth_batch.sanitized_transactions, vec![])
+                .unwrap();
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    #[test]
+    fn test_read_locked_does_not_block_red() {
+        const BATCH_SIZE: usize = 128;
+        solana_logger::setup_with_default("solana_core::transaction_scheduler=trace");
+
+        let TestHarness {
+            tx_sender,
+            tpu_vote_sender,
+            gossip_vote_sender,
+            exit: _,
+            scheduler,
+            accounts,
+            genesis_config: _,
+            bank,
+        } = get_test_harness();
+        let blockhash = bank.last_blockhash();
+
+        let tx_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+        {
+            // 300: A, B, C
+            // 200:    B, C, D(RO)
+            // 100:          D(RO), E
+            //  50:                 E(RO), F
+            // request schedule: 300, 100
+            // return 300, 100
+            // request schedule: 200, 50
+            // return 200, 50
+            let tx1 = get_tx(
+                &[
+                    get_account_meta(&accounts, "A", true),
+                    get_account_meta(&accounts, "B", true),
+                    get_account_meta(&accounts, "C", true),
+                ],
+                300,
+                &blockhash,
+            );
+            let tx2 = get_tx(
+                &[
+                    get_account_meta(&accounts, "B", true),
+                    get_account_meta(&accounts, "C", true),
+                    get_account_meta(&accounts, "D", false),
+                ],
+                200,
+                &blockhash,
+            );
+            let tx3 = get_tx(
+                &[
+                    get_account_meta(&accounts, "D", false),
+                    get_account_meta(&accounts, "E", true),
+                ],
+                100,
+                &blockhash,
+            );
+            let tx4 = get_tx(
+                &[
+                    get_account_meta(&accounts, "E", false),
+                    get_account_meta(&accounts, "F", true),
+                ],
+                50,
+                &blockhash,
+            );
+
+            send_transactions(&[&tx1, &tx2, &tx3, &tx4], &tx_sender);
+
+            let first_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(first_batch.sanitized_transactions.len(), 2);
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx1.signatures[0]
+            );
+            assert_eq!(
+                first_batch
+                    .sanitized_transactions
+                    .get(1)
+                    .unwrap()
+                    .signature(),
+                &tx3.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(first_batch.sanitized_transactions, vec![])
+                .unwrap();
+
+            let second_batch = tx_handle.request_batch(BATCH_SIZE, &bank).unwrap();
+            assert_eq!(second_batch.sanitized_transactions.len(), 2);
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(0)
+                    .unwrap()
+                    .signature(),
+                &tx2.signatures[0]
+            );
+            assert_eq!(
+                second_batch
+                    .sanitized_transactions
+                    .get(1)
+                    .unwrap()
+                    .signature(),
+                &tx4.signatures[0]
+            );
+            let _ = tx_handle
+                .send_batch_execution_update(second_batch.sanitized_transactions, vec![])
+                .unwrap();
+        }
+
+        drop(tx_sender);
+        drop(tpu_vote_sender);
+        drop(gossip_vote_sender);
+        assert_matches!(scheduler.join(), Ok(()));
+    }
+
+    // TODO: need to think of a clear and concise way to test this scheduler!
+
+    // TODO some other tests:
+    // 300: A(R), B, C
+    // 250: A(R), B, C
+    // 200: A(R), D, E
+    // request schedule: (300, 200)
+    // return (300, 200)
+    // request schedule: (250)
+    // return 250
+    // -----------------------
+    // 300: A(R), B, C,
+    // 250: A,    B, C,
+    // 200: A(R),       D, E
+    // request schedule: 300
+    // return 300
+    // request schedule: 250
+    // return 250
+    // request schedule: 200
+    // return 200
+    // -----------------------
+    // 300: A(R), B, C,
+    // 250: A,    B, C,
+    // 200: A(R),       D, E
+    // request schedule: 300
+    // insert:
+    // 275: A(R),       D(R)
+    // request schedule: 275
+    // request schedule: []
+    // return 300
+    // request schedule: 250
+    // return 275
+    // return 250
+    // request schedule: 200
+    // return 200
+
+    /// Converts transactions to packets and sends them to scheduler over channel
+    fn send_transactions(txs: &[&Transaction], tx_sender: &Sender<Vec<PacketBatch>>) {
+        let packets = txs
+            .into_iter()
+            .map(|tx| Packet::from_data(None, *tx).unwrap());
+        tx_sender
+            .send(vec![PacketBatch::new(packets.collect())])
+            .unwrap();
+    }
+
+    /// Builds some arbitrary transaction with given AccountMetas and prioritization fee
+    fn get_tx(
+        account_metas: &[AccountMeta],
+        micro_lamports_fee_per_cu: u64,
+        blockhash: &Hash,
+    ) -> Transaction {
+        let kp = Keypair::new();
+        Transaction::new_signed_with_payer(
+            &[
+                ComputeBudgetInstruction::set_compute_unit_price(micro_lamports_fee_per_cu),
+                Instruction::new_with_bytes(system_program::id(), &[0], account_metas.to_vec()),
+            ],
+            Some(&kp.pubkey()),
+            &[&kp],
+            blockhash.clone(),
+        )
+    }
+
+    /// Gets random accounts w/ alphabetical access for easy testing.
+    fn get_random_accounts() -> HashMap<&'static str, Pubkey> {
+        HashMap::from([
+            ("A", Pubkey::new_unique()),
+            ("B", Pubkey::new_unique()),
+            ("C", Pubkey::new_unique()),
+            ("D", Pubkey::new_unique()),
+            ("E", Pubkey::new_unique()),
+            ("F", Pubkey::new_unique()),
+            ("G", Pubkey::new_unique()),
+            ("H", Pubkey::new_unique()),
+            ("I", Pubkey::new_unique()),
+            ("J", Pubkey::new_unique()),
+            ("K", Pubkey::new_unique()),
+            ("L", Pubkey::new_unique()),
+            ("M", Pubkey::new_unique()),
+            ("N", Pubkey::new_unique()),
+            ("O", Pubkey::new_unique()),
+            ("P", Pubkey::new_unique()),
+            ("Q", Pubkey::new_unique()),
+            ("R", Pubkey::new_unique()),
+            ("S", Pubkey::new_unique()),
+            ("T", Pubkey::new_unique()),
+            ("U", Pubkey::new_unique()),
+            ("V", Pubkey::new_unique()),
+            ("W", Pubkey::new_unique()),
+            ("X", Pubkey::new_unique()),
+            ("Y", Pubkey::new_unique()),
+            ("Z", Pubkey::new_unique()),
+        ])
+    }
+
+    /// Returns pubkey from map created above
+    fn get_pubkey(map: &HashMap<&str, Pubkey>, char: &str) -> Pubkey {
+        return map.get(char).unwrap().clone();
+    }
+
+    /// Returns AccountMeta with pubkey from account above and writeable flag set
+    fn get_account_meta(map: &HashMap<&str, Pubkey>, char: &str, is_writable: bool) -> AccountMeta {
+        if is_writable {
+            AccountMeta::new(get_pubkey(map, char), false)
+        } else {
+            AccountMeta::new_readonly(get_pubkey(map, char), false)
+        }
+    }
+}

--- a/core/src/transaction_scheduler.rs
+++ b/core/src/transaction_scheduler.rs
@@ -3,18 +3,14 @@
 //! - TPU vote transactions
 //! - Gossip vote transactions
 
-use min_max_heap::MinMaxHeap;
-use skiplist::OrderedSkipList;
-use std::rc::Rc;
 use {
     crate::{
         banking_stage::BatchedTransactionDetails,
         qos_service::QosService,
-        unprocessed_packet_batches::{
-            self, DeserializedPacket, ImmutableDeserializedPacket, UnprocessedPacketBatches,
-        },
+        unprocessed_packet_batches::{self, DeserializedPacket, ImmutableDeserializedPacket},
     },
     crossbeam_channel::{select, unbounded, Receiver, RecvError, Sender},
+    skiplist::OrderedSkipList,
     solana_perf::packet::PacketBatch,
     solana_runtime::{
         accounts::AccountLocks,
@@ -31,6 +27,7 @@ use {
     },
     std::{
         collections::{hash_map::Entry, HashMap},
+        rc::Rc,
         sync::{
             atomic::{AtomicBool, Ordering},
             Arc, Mutex, RwLock,

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,6 +1,5 @@
 use {
     min_max_heap::MinMaxHeap,
-    rand::{thread_rng, Rng},
     solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
     solana_program_runtime::compute_budget::ComputeBudget,
     solana_sdk::{

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -128,15 +128,15 @@ impl PartialOrd for DeserializedPacket {
 
 impl Ord for DeserializedPacket {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self
+        match other
             .immutable_section()
             .priority()
-            .cmp(&other.immutable_section().priority())
+            .cmp(&self.immutable_section().priority())
         {
-            Ordering::Equal => self
+            Ordering::Equal => other
                 .immutable_section()
                 .sender_stake()
-                .cmp(&other.immutable_section().sender_stake()),
+                .cmp(&self.immutable_section().sender_stake()),
             ordering => ordering,
         }
     }

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -137,7 +137,8 @@ impl Ord for DeserializedPacket {
             .cmp(&self.immutable_section().priority())
         {
             Ordering::Equal => {
-                other.stamp.cmp(&self.stamp)
+                // priority high-to-low, time low-to-high
+                self.stamp.cmp(&other.stamp)
                 // self
                 //     .immutable_section()
                 //     .sender_stake()

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,3 +1,4 @@
+use rand::{thread_rng, Rng};
 use {
     min_max_heap::MinMaxHeap,
     solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
@@ -133,10 +134,17 @@ impl Ord for DeserializedPacket {
             .priority()
             .cmp(&self.immutable_section().priority())
         {
-            Ordering::Equal => other
-                .immutable_section()
-                .sender_stake()
-                .cmp(&self.immutable_section().sender_stake()),
+            Ordering::Equal => {
+                if thread_rng().gen_bool(0.5) {
+                    Ordering::Greater
+                } else {
+                    Ordering::Less
+                }
+                // self
+                //     .immutable_section()
+                //     .sender_stake()
+                //     .cmp(&other.immutable_section().sender_stake())
+            }
             ordering => ordering,
         }
     }

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,4 +1,5 @@
 use rand::{thread_rng, Rng};
+use std::time::Instant;
 use {
     min_max_heap::MinMaxHeap,
     solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
@@ -76,6 +77,7 @@ impl ImmutableDeserializedPacket {
 pub struct DeserializedPacket {
     immutable_section: Rc<ImmutableDeserializedPacket>,
     pub forwarded: bool,
+    pub stamp: Instant,
 }
 
 impl DeserializedPacket {
@@ -113,6 +115,7 @@ impl DeserializedPacket {
                 priority,
             }),
             forwarded: false,
+            stamp: Instant::now(),
         })
     }
 
@@ -135,11 +138,7 @@ impl Ord for DeserializedPacket {
             .cmp(&self.immutable_section().priority())
         {
             Ordering::Equal => {
-                if thread_rng().gen_bool(0.5) {
-                    Ordering::Greater
-                } else {
-                    Ordering::Less
-                }
+                other.stamp.cmp(&self.stamp)
                 // self
                 //     .immutable_section()
                 //     .sender_stake()

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -1,7 +1,6 @@
-use rand::{thread_rng, Rng};
-use std::time::Instant;
 use {
     min_max_heap::MinMaxHeap,
+    rand::{thread_rng, Rng},
     solana_perf::packet::{limited_deserialize, Packet, PacketBatch},
     solana_program_runtime::compute_budget::ComputeBudget,
     solana_sdk::{
@@ -17,6 +16,7 @@ use {
         collections::{hash_map::Entry, HashMap},
         mem::size_of,
         rc::Rc,
+        time::Instant,
     },
     thiserror::Error,
 };

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -64,33 +64,33 @@ pub type PubkeyAccountSlot = (Pubkey, AccountSharedData, Slot);
 
 #[derive(Debug, Default, AbiExample)]
 pub struct AccountLocks {
-    write_locks: HashSet<Pubkey>,
+    pub write_locks: HashSet<Pubkey>,
     readonly_locks: HashMap<Pubkey, u64>,
 }
 
 impl AccountLocks {
-    fn is_locked_readonly(&self, key: &Pubkey) -> bool {
+    pub fn is_locked_readonly(&self, key: &Pubkey) -> bool {
         self.readonly_locks
             .get(key)
             .map_or(false, |count| *count > 0)
     }
 
-    fn is_locked_write(&self, key: &Pubkey) -> bool {
+    pub fn is_locked_write(&self, key: &Pubkey) -> bool {
         self.write_locks.contains(key)
     }
 
-    fn insert_new_readonly(&mut self, key: &Pubkey) {
+    pub fn insert_new_readonly(&mut self, key: &Pubkey) {
         assert!(self.readonly_locks.insert(*key, 1).is_none());
     }
 
-    fn lock_readonly(&mut self, key: &Pubkey) -> bool {
+    pub fn lock_readonly(&mut self, key: &Pubkey) -> bool {
         self.readonly_locks.get_mut(key).map_or(false, |count| {
             *count += 1;
             true
         })
     }
 
-    fn unlock_readonly(&mut self, key: &Pubkey) {
+    pub fn unlock_readonly(&mut self, key: &Pubkey) {
         if let hash_map::Entry::Occupied(mut occupied_entry) = self.readonly_locks.entry(*key) {
             let count = occupied_entry.get_mut();
             *count -= 1;
@@ -100,7 +100,7 @@ impl AccountLocks {
         }
     }
 
-    fn unlock_write(&mut self, key: &Pubkey) {
+    pub fn unlock_write(&mut self, key: &Pubkey) {
         self.write_locks.remove(key);
     }
 }

--- a/transaction-scheduler-bench/Cargo.toml
+++ b/transaction-scheduler-bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solana-transaction-scheduler-bench"
+authors = ["Solana Maintainers <maintainers@solana.foundation>", "Jito Team <team@jito.wtf>"]
+edition = "2021"
+version = "1.11.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+publish = false
+
+[dependencies]
+clap = { version = "3.1.18", features = ["derive", "env"] }
+bincode = "1.3.3"
+crossbeam-channel = "0.5"
+itertools = "0.10.3"
+log = "0.4.17"
+rand = "0.8.5"
+solana-core = { path = "../core" }
+solana-logger = { path = "../logger" }
+solana-measure = { path = "../measure" }
+solana-perf = { path = "../perf" }
+solana-runtime = { path = "../runtime" }
+solana-sdk = { path = "../sdk" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -348,7 +348,7 @@ fn main() {
         let mut last_log_time = Instant::now();
 
         for msg in stats_receiver {
-            info!("msg: {}", msg);
+            // info!("msg: {}", msg);
             count += msg;
 
             if last_log_time.elapsed() > Duration::from_secs(1) {

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
     batches_per_msg: usize,
 
     /// Number of consuming threads (number of threads requesting batches from scheduler)
-    #[clap(long, env, default_value_t = 6)]
+    #[clap(long, env, default_value_t = 20)]
     num_execution_threads: usize,
 
     /// How long each transaction takes to execution in microseconds

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -37,7 +37,7 @@ use {
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// How many packets per second to send to the scheduler
-    #[clap(long, env, default_value_t = 1_000_000)]
+    #[clap(long, env, default_value_t = 100_000)]
     packet_send_rate: usize,
 
     /// Number of packets per batch
@@ -45,11 +45,11 @@ struct Args {
     packets_per_batch: usize,
 
     /// Number of batches per message
-    #[clap(long, env, default_value_t = 20)]
+    #[clap(long, env, default_value_t = 4)]
     batches_per_msg: usize,
 
     /// Number of consuming threads (number of threads requesting batches from scheduler)
-    #[clap(long, env, default_value_t = 4)]
+    #[clap(long, env, default_value_t = 6)]
     num_execution_threads: usize,
 
     /// How long each transaction takes to execution in microseconds
@@ -305,7 +305,7 @@ fn main() {
 
     let scheduler_config = TransactionSchedulerConfig {
         enable_state_auction,
-        max_packets: 700_000,
+        backlog_size: 700_000,
     };
 
     let SchedulerBench {

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -1,0 +1,382 @@
+use {
+    clap::Parser,
+    crossbeam_channel::{unbounded, Sender},
+    log::*,
+    rand::Rng,
+    solana_core::transaction_scheduler::{
+        SchedulerStage, TransactionScheduler, TransactionSchedulerConfig,
+        TransactionSchedulerHandle,
+    },
+    solana_perf::packet::PacketBatch,
+    solana_runtime::{
+        bank::Bank,
+        bank_forks::BankForks,
+        cost_model::CostModel,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    },
+    solana_sdk::{
+        compute_budget::ComputeBudgetInstruction,
+        hash::Hash,
+        instruction::{AccountMeta, Instruction},
+        packet::Packet,
+        signature::{Keypair, Signer},
+        system_program,
+        transaction::{Transaction, VersionedTransaction},
+    },
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, RwLock,
+        },
+        thread::{sleep, spawn, Builder, JoinHandle},
+        time::{Duration, Instant},
+    },
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// How many packets per second to send to the scheduler
+    #[clap(long, env, default_value_t = 1_000_000)]
+    packet_send_rate: usize,
+
+    /// Number of packets per batch
+    #[clap(long, env, default_value_t = 64)]
+    packets_per_batch: usize,
+
+    /// Number of batches per message
+    #[clap(long, env, default_value_t = 20)]
+    batches_per_msg: usize,
+
+    /// Number of consuming threads (number of threads requesting batches from scheduler)
+    #[clap(long, env, default_value_t = 20)]
+    num_execution_threads: usize,
+
+    /// How long each transaction takes to execution in microseconds
+    #[clap(long, env, default_value_t = 20)]
+    execution_per_tx_us: u64,
+
+    /// Duration of benchmark
+    #[clap(long, env, default_value_t = 20.0)]
+    duration: f32,
+
+    /// Number of accounts to choose from when signing transactions
+    #[clap(long, env, default_value_t = 1000)]
+    num_accounts: usize,
+
+    /// Number of read locks per tx
+    #[clap(long, env, default_value_t = 5)]
+    num_read_locks_per_tx: usize,
+
+    /// Number of write locks per tx
+    #[clap(long, env, default_value_t = 5)]
+    num_read_write_locks_per_tx: usize,
+
+    /// If true, enables state auction on accounts
+    #[clap(long, env)]
+    enable_state_auction: bool,
+}
+
+struct SchedulerBench {
+    tx_sender: Sender<Vec<PacketBatch>>,
+    tpu_vote_sender: Sender<Vec<PacketBatch>>,
+    gossip_vote_sender: Sender<Vec<PacketBatch>>,
+    scheduler: TransactionScheduler,
+    bank: Arc<Bank>,
+    exit: Arc<AtomicBool>,
+}
+
+fn configure_scheduler_bench(config: TransactionSchedulerConfig) -> SchedulerBench {
+    let (tx_sender, tx_receiver) = unbounded();
+    let (tpu_vote_sender, tpu_vote_receiver) = unbounded();
+    let (gossip_vote_sender, gossip_vote_receiver) = unbounded();
+    let exit = Arc::new(AtomicBool::new(false));
+    let cost_model = Arc::new(RwLock::new(CostModel::default()));
+
+    let scheduler = TransactionScheduler::new(
+        tx_receiver,
+        tpu_vote_receiver,
+        gossip_vote_receiver,
+        exit.clone(),
+        cost_model,
+        config,
+    );
+    let mint_total = 1_000_000_000_000;
+    let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(mint_total);
+
+    let bank0 = Bank::new_for_benches(&genesis_config);
+    let bank_forks = BankForks::new(bank0);
+    let bank = bank_forks.working_bank();
+    bank.write_cost_tracker()
+        .unwrap()
+        .set_limits(u64::MAX, u64::MAX, u64::MAX);
+
+    SchedulerBench {
+        tx_sender,
+        tpu_vote_sender,
+        gossip_vote_sender,
+        scheduler,
+        bank,
+        exit,
+    }
+}
+
+fn start_sending_packets(
+    packet_send_rate: usize,
+    packets_per_batch: usize,
+    batches_per_msg: usize,
+    blockhash: Hash,
+    tx_sender: &Sender<Vec<PacketBatch>>,
+    tpu_vote_sender: &Sender<Vec<PacketBatch>>,
+    gossip_vote_sender: &Sender<Vec<PacketBatch>>,
+    exit: Arc<AtomicBool>,
+    num_accounts: usize,
+    num_read_locks_per_tx: usize,
+    num_read_write_locks_per_tx: usize,
+) -> Vec<JoinHandle<()>> {
+    const NUM_SENDERS: usize = 4;
+
+    let tx_sender = tx_sender.clone();
+    let _tpu_vote_sender = tpu_vote_sender.clone();
+    let _gossip_vote_sender = gossip_vote_sender.clone();
+
+    let packets_per_msg = packets_per_batch * batches_per_msg;
+    let loop_freq = packet_send_rate as f64 / packets_per_msg as f64;
+    let loop_duration = Duration::from_secs_f64(1.0 / loop_freq) * NUM_SENDERS as u32;
+
+    info!(
+        "start_sending_packets packet_send_rate: {} \
+        packets_per_batch: {} \
+        batches_per_message: {} \
+        packets_per_message: {} \
+        loop_freq: {}",
+        packet_send_rate, packets_per_batch, batches_per_msg, packets_per_msg, loop_freq
+    );
+
+    // generate some number of accounts shared across all transactions to mimic account contention
+    // Keypair can't be cloned, so reconstruct inside thread
+    let accounts = (0..num_accounts).map(|_| Keypair::new().to_base58_string());
+    (0..NUM_SENDERS)
+        .map(|_| {
+            let accounts = accounts.clone();
+            let exit = exit.clone();
+            let tx_sender = tx_sender.clone();
+
+            Builder::new()
+                .name("packet_sender".into())
+                .spawn(move || {
+                    let keypairs: Vec<_> =
+                        accounts.map(|s| Keypair::from_base58_string(&s)).collect();
+
+                    loop {
+                        if exit.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let start = Instant::now();
+
+                        let packet_batches = (0..batches_per_msg).map(|_| {
+                            PacketBatch::new(
+                                (0..packets_per_batch)
+                                    .map(|_| {
+                                        let sending_kp = &keypairs
+                                            [rand::thread_rng().gen_range(0..keypairs.len())];
+
+                                        let read_account_metas =
+                                            (0..num_read_locks_per_tx).map(|_| {
+                                                AccountMeta::new_readonly(
+                                                    keypairs[rand::thread_rng()
+                                                        .gen_range(0..keypairs.len())]
+                                                    .pubkey(),
+                                                    false,
+                                                )
+                                            });
+                                        let write_account_metas = (0..num_read_write_locks_per_tx)
+                                            .map(|_| {
+                                                AccountMeta::new(
+                                                    keypairs[rand::thread_rng()
+                                                        .gen_range(0..keypairs.len())]
+                                                    .pubkey(),
+                                                    false,
+                                                )
+                                            });
+                                        let ixs = vec![
+                                            ComputeBudgetInstruction::set_compute_unit_price(100),
+                                            Instruction::new_with_bytes(
+                                                system_program::id(),
+                                                &[0],
+                                                read_account_metas
+                                                    .chain(write_account_metas)
+                                                    .collect(),
+                                            ),
+                                        ];
+
+                                        let versioned_tx = VersionedTransaction::from(
+                                            Transaction::new_signed_with_payer(
+                                                &ixs,
+                                                Some(&sending_kp.pubkey()),
+                                                &[sending_kp],
+                                                blockhash.clone(),
+                                            ),
+                                        );
+                                        Packet::from_data(None, &versioned_tx).unwrap()
+                                    })
+                                    .collect(),
+                            )
+                        });
+
+                        packet_batches.into_iter().for_each(|b| {
+                            tx_sender.send(vec![b]).unwrap();
+                        });
+
+                        let sleep_duration = loop_duration
+                            .checked_sub(start.elapsed())
+                            .unwrap_or_default();
+                        sleep(sleep_duration);
+                    }
+                })
+                .unwrap()
+        })
+        .collect()
+}
+
+fn start_execution_threads(
+    scheduler_handle: TransactionSchedulerHandle,
+    num_execution_threads: usize,
+    execution_per_tx_us: u64,
+    exit: Arc<AtomicBool>,
+    bank: Arc<Bank>,
+    stats_sender: Sender<usize>,
+) -> Vec<JoinHandle<()>> {
+    (0..num_execution_threads)
+        .map(|t_id| {
+            let exit = exit.clone();
+            let scheduler_handle = scheduler_handle.clone();
+            let bank = bank.clone();
+            let stats_sender = stats_sender.clone();
+
+            Builder::new()
+                .name(format!("execution_thread_{}", t_id))
+                .spawn(move || loop {
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    let batch = scheduler_handle.request_batch(64, &bank).unwrap();
+
+                    let num_txs = batch.sanitized_transactions.len();
+                    let sleep_duration = if num_txs > 0 {
+                        Duration::from_micros((num_txs * execution_per_tx_us as usize) as u64)
+                    } else {
+                        Duration::from_millis(1)
+                    };
+                    sleep(sleep_duration);
+
+                    if stats_sender
+                        .send(batch.sanitized_transactions.len())
+                        .is_err()
+                    {
+                        break;
+                    }
+
+                    let _response = scheduler_handle
+                        .send_batch_execution_update(batch.sanitized_transactions, vec![]);
+                })
+                .unwrap()
+        })
+        .collect()
+}
+
+fn main() {
+    // solana_logger::setup_with_default("INFO,solana_core::transaction_scheduler=trace");
+    solana_logger::setup_with_default("INFO");
+
+    let Args {
+        packet_send_rate,
+        packets_per_batch,
+        batches_per_msg,
+        num_execution_threads,
+        execution_per_tx_us,
+        duration,
+        num_accounts,
+        num_read_locks_per_tx,
+        num_read_write_locks_per_tx,
+        enable_state_auction,
+    } = Args::parse();
+
+    let scheduler_config = TransactionSchedulerConfig {
+        enable_state_auction,
+        max_packets: 700_000,
+    };
+
+    let SchedulerBench {
+        tx_sender,
+        tpu_vote_sender,
+        gossip_vote_sender,
+        scheduler,
+        bank,
+        exit,
+    } = configure_scheduler_bench(scheduler_config);
+
+    let sending_handles = start_sending_packets(
+        packet_send_rate,
+        packets_per_batch,
+        batches_per_msg,
+        bank.last_blockhash(),
+        &tx_sender,
+        &tpu_vote_sender,
+        &gossip_vote_sender,
+        exit.clone(),
+        num_accounts,
+        num_read_locks_per_tx,
+        num_read_write_locks_per_tx,
+    );
+
+    let scheduler_handle = scheduler.get_handle(SchedulerStage::Transactions);
+
+    let (stats_sender, stats_receiver) = unbounded();
+    let scheduler_stages = start_execution_threads(
+        scheduler_handle,
+        num_execution_threads,
+        execution_per_tx_us,
+        exit.clone(),
+        bank.clone(),
+        stats_sender,
+    );
+
+    let stats_thread = spawn(move || {
+        let mut count = 0;
+        let mut last_log_time = Instant::now();
+
+        for msg in stats_receiver {
+            // info!("msg: {}", msg);
+            count += msg;
+
+            if last_log_time.elapsed() > Duration::from_secs(1) {
+                info!(
+                    "txs/s: {}",
+                    count as f64 / last_log_time.elapsed().as_secs_f64()
+                );
+                count = 0;
+                last_log_time = Instant::now();
+            }
+        }
+    });
+
+    let _ = spawn(move || {
+        sleep(Duration::from_secs_f32(duration));
+        exit.store(true, Ordering::Relaxed);
+    })
+    .join();
+
+    drop(tx_sender);
+    drop(tpu_vote_sender);
+    drop(gossip_vote_sender);
+    let _ = stats_thread.join();
+    let _ = scheduler.join().unwrap();
+    for h in sending_handles {
+        let _ = h.join().unwrap();
+    }
+    for s in scheduler_stages {
+        let _ = s.join().unwrap();
+    }
+}

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -37,7 +37,7 @@ use {
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// How many packets per second to send to the scheduler
-    #[clap(long, env, default_value_t = 100_000)]
+    #[clap(long, env, default_value_t = 200_000)]
     packet_send_rate: usize,
 
     /// Number of packets per batch
@@ -264,12 +264,9 @@ fn start_execution_threads(
                     let batch = scheduler_handle.request_batch(128, &bank).unwrap();
 
                     let num_txs = batch.sanitized_transactions.len();
-                    let sleep_duration = if num_txs > 0 {
-                        Duration::from_micros((num_txs * execution_per_tx_us as usize) as u64)
-                    } else {
-                        Duration::from_millis(1)
-                    };
-                    sleep(sleep_duration);
+                    sleep(Duration::from_micros(
+                        (num_txs * execution_per_tx_us as usize) as u64,
+                    ));
 
                     if stats_sender
                         .send(batch.sanitized_transactions.len())

--- a/transaction-scheduler-bench/src/main.rs
+++ b/transaction-scheduler-bench/src/main.rs
@@ -41,7 +41,7 @@ struct Args {
     packet_send_rate: usize,
 
     /// Number of packets per batch
-    #[clap(long, env, default_value_t = 64)]
+    #[clap(long, env, default_value_t = 128)]
     packets_per_batch: usize,
 
     /// Number of batches per message
@@ -49,11 +49,11 @@ struct Args {
     batches_per_msg: usize,
 
     /// Number of consuming threads (number of threads requesting batches from scheduler)
-    #[clap(long, env, default_value_t = 20)]
+    #[clap(long, env, default_value_t = 4)]
     num_execution_threads: usize,
 
     /// How long each transaction takes to execution in microseconds
-    #[clap(long, env, default_value_t = 20)]
+    #[clap(long, env, default_value_t = 15)]
     execution_per_tx_us: u64,
 
     /// Duration of benchmark
@@ -61,15 +61,15 @@ struct Args {
     duration: f32,
 
     /// Number of accounts to choose from when signing transactions
-    #[clap(long, env, default_value_t = 1000)]
+    #[clap(long, env, default_value_t = 100000)]
     num_accounts: usize,
 
     /// Number of read locks per tx
-    #[clap(long, env, default_value_t = 5)]
+    #[clap(long, env, default_value_t = 4)]
     num_read_locks_per_tx: usize,
 
     /// Number of write locks per tx
-    #[clap(long, env, default_value_t = 5)]
+    #[clap(long, env, default_value_t = 2)]
     num_read_write_locks_per_tx: usize,
 
     /// If true, enables state auction on accounts
@@ -261,7 +261,7 @@ fn start_execution_threads(
                         break;
                     }
 
-                    let batch = scheduler_handle.request_batch(64, &bank).unwrap();
+                    let batch = scheduler_handle.request_batch(128, &bank).unwrap();
 
                     let num_txs = batch.sanitized_transactions.len();
                     let sleep_duration = if num_txs > 0 {
@@ -348,7 +348,7 @@ fn main() {
         let mut last_log_time = Instant::now();
 
         for msg in stats_receiver {
-            // info!("msg: {}", msg);
+            info!("msg: {}", msg);
             count += msg;
 
             if last_log_time.elapsed() > Duration::from_secs(1) {


### PR DESCRIPTION
# About
This is a prototype for a transaction scheduler for BankingStage (and future transaction stages).

The very basic functionality of this scheduler includes scheduling sets of transactions which are validated and can be executed in parallel. It contains a thread for each type of transaction consumer and shares `AccountsLocks` with all of the `stages` to ensure no account contention. The general idea is to ensure that all transactions in the batch will get executed with extremely high level of certainty.

Basic configuration can be passed in to set the backlog size. By default, this scheduler behaves as a more parallelizable version of the current scheduler and addresses https://github.com/solana-labs/solana/issues/22096. Another flag exists in the configuration which allows one to do **state fee auctions** similar to https://github.com/solana-labs/solana/pull/23438. It does this by comparing transactions that are currently locked and checking against RW locks + fees of blocked accounts to ensure that the per-account fee market is respected.

# Next Steps
This needs to be tested and the efficiency needs to be improved more. The best solution would probably require a pretty significant rewrite of banking stage, so wanted to get eyes on this + get thoughts.