### PR TITLE
Add a --debug-key option to ledger-tool verify

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1065,6 +1065,13 @@ fn main() {
         .takes_value(true)
         .default_value(SnapshotVersion::default().into())
         .help("Output snapshot version");
+    let debug_keys_arg = Arg::with_name("debug_keys")
+        .long("debug-keys")
+        .validator(is_pubkey)
+        .value_name("ADDRESS")
+        .multiple(true)
+        .takes_value(true)
+        .help("Log when transactions are processed which reference the given key(s).");
 
     let default_max_full_snapshot_archives_to_retain =
         &DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
@@ -1370,6 +1377,7 @@ fn main() {
             .arg(&no_bpf_jit_arg)
             .arg(&allow_dead_slots_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(&debug_keys_arg)
             .arg(
                 Arg::with_name("skip_poh_verify")
                     .long("skip-poh-verify")
@@ -2171,10 +2179,14 @@ fn main() {
                     ..AccountsDbConfig::default()
                 });
 
+                let debug_keys = pubkeys_of(arg_matches, "debug_keys")
+                    .map(|pubkeys| Arc::new(pubkeys.into_iter().collect::<HashSet<_>>()));
+
                 let process_options = ProcessOptions {
                     new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                     poh_verify: !arg_matches.is_present("skip_poh_verify"),
                     halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
+                    debug_keys,
                     accounts_db_caching_enabled: !arg_matches.is_present("no_accounts_db_caching"),
                     limit_load_slot_count_from_snapshot: value_t!(
                         arg_matches,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1065,13 +1065,13 @@ fn main() {
         .takes_value(true)
         .default_value(SnapshotVersion::default().into())
         .help("Output snapshot version");
-    let debug_keys_arg = Arg::with_name("debug_keys")
-        .long("debug-keys")
+    let debug_key_arg = Arg::with_name("debug_key")
+        .long("debug-key")
         .validator(is_pubkey)
         .value_name("ADDRESS")
         .multiple(true)
         .takes_value(true)
-        .help("Log when transactions are processed which reference the given key(s).");
+        .help("Log when transactions are processed that reference the given key(s).");
 
     let default_max_full_snapshot_archives_to_retain =
         &DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
@@ -1377,7 +1377,7 @@ fn main() {
             .arg(&no_bpf_jit_arg)
             .arg(&allow_dead_slots_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&debug_keys_arg)
+            .arg(&debug_key_arg)
             .arg(
                 Arg::with_name("skip_poh_verify")
                     .long("skip-poh-verify")
@@ -2179,7 +2179,7 @@ fn main() {
                     ..AccountsDbConfig::default()
                 });
 
-                let debug_keys = pubkeys_of(arg_matches, "debug_keys")
+                let debug_keys = pubkeys_of(arg_matches, "debug_key")
                     .map(|pubkeys| Arc::new(pubkeys.into_iter().collect::<HashSet<_>>()));
 
                 let process_options = ProcessOptions {


### PR DESCRIPTION
#### Problem
ProcessOptions has a debug_keys field but ledger-tool has no way to use it. It's useful for debugging.

#### Summary of Changes
Add a --debug-key option to ledger-tool

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
