### PR TITLE
fix: remove @solana/buffer-layout-utils to fix circular dependency build issues

### DIFF
--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
         "@solana/buffer-layout": "^4.0.0",
-        "@solana/buffer-layout-utils": "^0.2.0",
+        "bigint-buffer": "^1.1.5",
         "bn.js": "^5.0.0",
         "borsh": "^0.7.0",
         "bs58": "^4.0.1",
@@ -3291,6 +3291,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
       "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "dev": true,
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/web3.js": "^1.32.0",
@@ -3343,6 +3344,7 @@
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.36.0.tgz",
       "integrity": "sha512-RNT1451iRR7TyW7EJKMCrH/0OXawIe4zVm0DWQASwXlR/u1jmW6FrmH0lujIh7cGTlfOVbH+2ZU9AVUPLBFzwA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
@@ -3367,6 +3369,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz",
       "integrity": "sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==",
+      "dev": true,
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -3378,6 +3381,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3401,6 +3405,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3409,6 +3414,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
       "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "bn.js": "^5.0.0",
@@ -4327,6 +4333,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
       "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -9980,7 +9987,9 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.1.1",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-5.2.0.tgz",
+      "integrity": "sha512-zWV7scFGL0SmpvfQyIWnMFbU/0YgtMNyvJiJwR98kyjUSntJGWFFR0O600d5W+TrDcTg0GyDbY+HdzGEg+GXLg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10103,9 +10112,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/cacache": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.7.tgz",
-      "integrity": "sha512-a4zfQpp5vm4Ipdvbj+ZrPonikRhm6WBEd4zT1Yc1DXsmAxrPgDwWBLF/u/wTVXSFPIgOJ1U3ghSa2Xm4s3h28w==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.0.tgz",
+      "integrity": "sha512-Pk4aQkwCW82A4jGKFvcGkQFqZcMspfP9YWq9Pr87/ldDvlWf718zeI6KWCdKt/jeihu6BytHRUicJPB1K2k8EQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10134,7 +10143,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/cacache/node_modules/lru-cache": {
-      "version": "7.9.0",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+      "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10164,9 +10175,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/glob": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-      "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10175,8 +10186,7 @@
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^5.0.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "once": "^1.3.0"
       },
       "engines": {
         "node": ">=12"
@@ -10202,15 +10212,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/make-fetch-happen": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-      "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.5.tgz",
+      "integrity": "sha512-mucOj2H0Jn/ax7H9K9T1bf0p1nn/mBFa551Os7ed9xRfLEx20aZhZeLslmRYfAaAqXZUGipcs+m5KOKvOH0XKA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.0.2",
+        "cacache": "^16.1.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -10231,7 +10241,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "7.9.0",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+      "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10473,9 +10485,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/pacote": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.3.0.tgz",
-      "integrity": "sha512-auhJAUlfC2TALo6I0s1vFoPvVFgWGx+uz/PnIojTTgkGwlK3Np8sGJ0ghfFhiuzJXTZoTycMLk8uLskdntPbDw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.4.1.tgz",
+      "integrity": "sha512-FqlSWlD8n+ejCE17GF/lf0yasztMGFl4UFzYQk5njaK/qPPWfVDWnfQwqmqeXObWLSmIBew+O+CFD24vxkVDjg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10543,9 +10555,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist/node_modules/ssri": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-      "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10656,6 +10668,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/git/node_modules/lru-cache": {
       "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+      "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10821,9 +10835,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/cacache": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.7.tgz",
-      "integrity": "sha512-a4zfQpp5vm4Ipdvbj+ZrPonikRhm6WBEd4zT1Yc1DXsmAxrPgDwWBLF/u/wTVXSFPIgOJ1U3ghSa2Xm4s3h28w==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.0.tgz",
+      "integrity": "sha512-Pk4aQkwCW82A4jGKFvcGkQFqZcMspfP9YWq9Pr87/ldDvlWf718zeI6KWCdKt/jeihu6BytHRUicJPB1K2k8EQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10873,9 +10887,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/glob": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-      "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10884,8 +10898,7 @@
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^5.0.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "once": "^1.3.0"
       },
       "engines": {
         "node": ">=12"
@@ -10911,7 +10924,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
-      "version": "7.9.0",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+      "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10920,15 +10935,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/make-fetch-happen": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-      "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.5.tgz",
+      "integrity": "sha512-mucOj2H0Jn/ax7H9K9T1bf0p1nn/mBFa551Os7ed9xRfLEx20aZhZeLslmRYfAaAqXZUGipcs+m5KOKvOH0XKA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^16.0.2",
+        "cacache": "^16.1.0",
         "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -11114,9 +11129,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.3.0.tgz",
-      "integrity": "sha512-auhJAUlfC2TALo6I0s1vFoPvVFgWGx+uz/PnIojTTgkGwlK3Np8sGJ0ghfFhiuzJXTZoTycMLk8uLskdntPbDw==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.4.1.tgz",
+      "integrity": "sha512-FqlSWlD8n+ejCE17GF/lf0yasztMGFl4UFzYQk5njaK/qPPWfVDWnfQwqmqeXObWLSmIBew+O+CFD24vxkVDjg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11151,9 +11166,9 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/ssri": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-      "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11747,9 +11762,9 @@
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-4.1.0.tgz",
-      "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
+      "integrity": "sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11757,7 +11772,7 @@
         "mkdirp-infer-owner": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/code-point-at": {
@@ -12249,6 +12264,8 @@
     },
     "node_modules/npm/node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+      "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13233,9 +13250,9 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.0.3.tgz",
-      "integrity": "sha512-KuSbzgejxdsAWbNNyEs8EsyDHsO+nJF6k+9WuWzFbSNh5tFHs4lDApXw7kntKpuehfp8lKRzJkMtz0+WmGvTIw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.0.4.tgz",
+      "integrity": "sha512-G4sCWzzHokHC5oxGD46Q9vCe+eN2tFb+3RfADD/eZbx4nKa7Y1eku1xvIWrw5R3F3hWX7IM2BgdqbQsyBUa3IA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13253,9 +13270,9 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist/node_modules/glob": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-      "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -13264,8 +13281,7 @@
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^5.0.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "once": "^1.3.0"
       },
       "engines": {
         "node": ">=12"
@@ -13614,12 +13630,15 @@
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-2.0.0.tgz",
-      "integrity": "sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-3.0.0.tgz",
+      "integrity": "sha512-KQDVjGqhZk92PPNRj9ZEXEuqg8bUobSKRw+q0YQ3TKI5xkce7bUJobL4Z/OtiEbAAv70yEpYIXp4iQ9L8oPVog==",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "4.1.1",
@@ -20576,6 +20595,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
       "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "dev": true,
       "requires": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/web3.js": "^1.32.0",
@@ -20599,6 +20619,7 @@
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.36.0.tgz",
       "integrity": "sha512-RNT1451iRR7TyW7EJKMCrH/0OXawIe4zVm0DWQASwXlR/u1jmW6FrmH0lujIh7cGTlfOVbH+2ZU9AVUPLBFzwA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
@@ -20620,6 +20641,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz",
           "integrity": "sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==",
+          "dev": true,
           "requires": {
             "buffer": "~6.0.3"
           },
@@ -20628,6 +20650,7 @@
               "version": "6.0.3",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
               "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+              "dev": true,
               "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -20639,6 +20662,7 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -20647,6 +20671,7 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
           "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+          "dev": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
             "bn.js": "^5.0.0",
@@ -21365,7 +21390,8 @@
     "bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -25587,7 +25613,9 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "5.1.1",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-5.2.0.tgz",
+          "integrity": "sha512-zWV7scFGL0SmpvfQyIWnMFbU/0YgtMNyvJiJwR98kyjUSntJGWFFR0O600d5W+TrDcTg0GyDbY+HdzGEg+GXLg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25686,9 +25714,9 @@
               }
             },
             "cacache": {
-              "version": "16.0.7",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.7.tgz",
-              "integrity": "sha512-a4zfQpp5vm4Ipdvbj+ZrPonikRhm6WBEd4zT1Yc1DXsmAxrPgDwWBLF/u/wTVXSFPIgOJ1U3ghSa2Xm4s3h28w==",
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.0.tgz",
+              "integrity": "sha512-Pk4aQkwCW82A4jGKFvcGkQFqZcMspfP9YWq9Pr87/ldDvlWf718zeI6KWCdKt/jeihu6BytHRUicJPB1K2k8EQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -25713,7 +25741,9 @@
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "7.9.0",
+                  "version": "7.10.1",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+                  "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
                   "bundled": true,
                   "dev": true
                 }
@@ -25737,9 +25767,9 @@
               }
             },
             "glob": {
-              "version": "8.0.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-              "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+              "version": "8.0.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+              "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -25747,8 +25777,7 @@
                 "inflight": "^1.0.4",
                 "inherits": "2",
                 "minimatch": "^5.0.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "once": "^1.3.0"
               }
             },
             "http-proxy-agent": {
@@ -25764,14 +25793,14 @@
               }
             },
             "make-fetch-happen": {
-              "version": "10.1.3",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-              "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+              "version": "10.1.5",
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.5.tgz",
+              "integrity": "sha512-mucOj2H0Jn/ax7H9K9T1bf0p1nn/mBFa551Os7ed9xRfLEx20aZhZeLslmRYfAaAqXZUGipcs+m5KOKvOH0XKA==",
               "bundled": true,
               "dev": true,
               "requires": {
                 "agentkeepalive": "^4.2.1",
-                "cacache": "^16.0.2",
+                "cacache": "^16.1.0",
                 "http-cache-semantics": "^4.1.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
@@ -25789,7 +25818,9 @@
               },
               "dependencies": {
                 "lru-cache": {
-                  "version": "7.9.0",
+                  "version": "7.10.1",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+                  "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
                   "bundled": true,
                   "dev": true
                 }
@@ -25965,9 +25996,9 @@
               }
             },
             "pacote": {
-              "version": "13.3.0",
-              "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.3.0.tgz",
-              "integrity": "sha512-auhJAUlfC2TALo6I0s1vFoPvVFgWGx+uz/PnIojTTgkGwlK3Np8sGJ0ghfFhiuzJXTZoTycMLk8uLskdntPbDw==",
+              "version": "13.4.1",
+              "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.4.1.tgz",
+              "integrity": "sha512-FqlSWlD8n+ejCE17GF/lf0yasztMGFl4UFzYQk5njaK/qPPWfVDWnfQwqmqeXObWLSmIBew+O+CFD24vxkVDjg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26017,9 +26048,9 @@
               }
             },
             "ssri": {
-              "version": "9.0.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-              "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+              "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26103,6 +26134,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+              "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
               "bundled": true,
               "dev": true
             },
@@ -26226,9 +26259,9 @@
               }
             },
             "cacache": {
-              "version": "16.0.7",
-              "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.0.7.tgz",
-              "integrity": "sha512-a4zfQpp5vm4Ipdvbj+ZrPonikRhm6WBEd4zT1Yc1DXsmAxrPgDwWBLF/u/wTVXSFPIgOJ1U3ghSa2Xm4s3h28w==",
+              "version": "16.1.0",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.0.tgz",
+              "integrity": "sha512-Pk4aQkwCW82A4jGKFvcGkQFqZcMspfP9YWq9Pr87/ldDvlWf718zeI6KWCdKt/jeihu6BytHRUicJPB1K2k8EQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26270,9 +26303,9 @@
               }
             },
             "glob": {
-              "version": "8.0.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-              "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+              "version": "8.0.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+              "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26280,8 +26313,7 @@
                 "inflight": "^1.0.4",
                 "inherits": "2",
                 "minimatch": "^5.0.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "once": "^1.3.0"
               }
             },
             "http-proxy-agent": {
@@ -26297,19 +26329,21 @@
               }
             },
             "lru-cache": {
-              "version": "7.9.0",
+              "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+              "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
               "bundled": true,
               "dev": true
             },
             "make-fetch-happen": {
-              "version": "10.1.3",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.3.tgz",
-              "integrity": "sha512-s/UjmGjUHn9m52cctFhN2ITObbT+axoUhgeir8xGrOlPbKDyJsdhQzb8PGncPQQ28uduHybFJ6Iumy2OZnreXw==",
+              "version": "10.1.5",
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.1.5.tgz",
+              "integrity": "sha512-mucOj2H0Jn/ax7H9K9T1bf0p1nn/mBFa551Os7ed9xRfLEx20aZhZeLslmRYfAaAqXZUGipcs+m5KOKvOH0XKA==",
               "bundled": true,
               "dev": true,
               "requires": {
                 "agentkeepalive": "^4.2.1",
-                "cacache": "^16.0.2",
+                "cacache": "^16.1.0",
                 "http-cache-semantics": "^4.1.0",
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
@@ -26450,9 +26484,9 @@
               }
             },
             "pacote": {
-              "version": "13.3.0",
-              "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.3.0.tgz",
-              "integrity": "sha512-auhJAUlfC2TALo6I0s1vFoPvVFgWGx+uz/PnIojTTgkGwlK3Np8sGJ0ghfFhiuzJXTZoTycMLk8uLskdntPbDw==",
+              "version": "13.4.1",
+              "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.4.1.tgz",
+              "integrity": "sha512-FqlSWlD8n+ejCE17GF/lf0yasztMGFl4UFzYQk5njaK/qPPWfVDWnfQwqmqeXObWLSmIBew+O+CFD24vxkVDjg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26480,9 +26514,9 @@
               }
             },
             "ssri": {
-              "version": "9.0.0",
-              "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.0.tgz",
-              "integrity": "sha512-Y1Z6J8UYnexKFN1R/hxUaYoY2LVdKEzziPmVAFKiKX8fiwvCJTVzn/xYE9TEWod5OVyNfIHHuVfIEuBClL/uJQ==",
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+              "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26930,8 +26964,9 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-4.1.0.tgz",
-          "integrity": "sha512-lb9L7EM4I/ZRVuljLPEtUJOP+xiQVknZ4ZMpMgEp4JzNldPb27HU03hi6K1/6CoIuit/Zm/LQXySErFeXxDprw==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
+          "integrity": "sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -27314,6 +27349,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.10.1.tgz",
+              "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==",
               "bundled": true,
               "dev": true
             }
@@ -28068,9 +28105,9 @@
           }
         },
         "npm-packlist": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.0.3.tgz",
-          "integrity": "sha512-KuSbzgejxdsAWbNNyEs8EsyDHsO+nJF6k+9WuWzFbSNh5tFHs4lDApXw7kntKpuehfp8lKRzJkMtz0+WmGvTIw==",
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.0.4.tgz",
+          "integrity": "sha512-G4sCWzzHokHC5oxGD46Q9vCe+eN2tFb+3RfADD/eZbx4nKa7Y1eku1xvIWrw5R3F3hWX7IM2BgdqbQsyBUa3IA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -28081,9 +28118,9 @@
           },
           "dependencies": {
             "glob": {
-              "version": "8.0.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
-              "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+              "version": "8.0.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+              "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -28091,8 +28128,7 @@
                 "inflight": "^1.0.4",
                 "inherits": "2",
                 "minimatch": "^5.0.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "once": "^1.3.0"
               }
             }
           }
@@ -28356,8 +28392,9 @@
           }
         },
         "read-cmd-shim": {
-          "version": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-2.0.0.tgz",
-          "integrity": "sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-3.0.0.tgz",
+          "integrity": "sha512-KQDVjGqhZk92PPNRj9ZEXEuqg8bUobSKRw+q0YQ3TKI5xkce7bUJobL4Z/OtiEbAAv70yEpYIXp4iQ9L8oPVog==",
           "bundled": true,
           "dev": true
         },

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -59,7 +59,7 @@
     "@babel/runtime": "^7.12.5",
     "@ethersproject/sha2": "^5.5.0",
     "@solana/buffer-layout": "^4.0.0",
-    "@solana/buffer-layout-utils": "^0.2.0",
+    "bigint-buffer": "^1.1.5",
     "bn.js": "^5.0.0",
     "borsh": "^0.7.0",
     "bs58": "^4.0.1",

--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -55,7 +55,7 @@ function generateConfig(configType, format) {
     config.external = [
       /@babel\/runtime/,
       '@solana/buffer-layout',
-      '@solana/buffer-layout-utils',
+      'bigint-buffer',
       'bn.js',
       'borsh',
       'bs58',
@@ -113,7 +113,7 @@ function generateConfig(configType, format) {
           config.external = [
             /@babel\/runtime/,
             '@solana/buffer-layout',
-            '@solana/buffer-layout-utils',
+            'bigint-buffer',
             'bn.js',
             'borsh',
             'bs58',

--- a/web3.js/src/compute-budget.ts
+++ b/web3.js/src/compute-budget.ts
@@ -1,5 +1,4 @@
 import * as BufferLayout from '@solana/buffer-layout';
-import {u64} from '@solana/buffer-layout-utils';
 
 import {
   encodeData,
@@ -9,6 +8,7 @@ import {
 } from './instruction';
 import {PublicKey} from './publickey';
 import {TransactionInstruction} from './transaction';
+import {u64} from './util/bigint';
 
 /**
  * Compute Budget Instruction class

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -1,5 +1,4 @@
 import * as BufferLayout from '@solana/buffer-layout';
-import {u64} from '@solana/buffer-layout-utils';
 
 import {
   encodeData,
@@ -13,6 +12,7 @@ import {PublicKey} from './publickey';
 import {SYSVAR_RECENT_BLOCKHASHES_PUBKEY, SYSVAR_RENT_PUBKEY} from './sysvar';
 import {Transaction, TransactionInstruction} from './transaction';
 import {toBuffer} from './util/to-buffer';
+import {u64} from './util/bigint';
 
 /**
  * Create account system transaction params

--- a/web3.js/src/util/bigint.ts
+++ b/web3.js/src/util/bigint.ts
@@ -1,0 +1,43 @@
+import {Buffer} from 'buffer';
+import {blob, Layout} from '@solana/buffer-layout';
+import {toBigIntLE, toBufferLE} from 'bigint-buffer';
+
+interface EncodeDecode<T> {
+  decode(buffer: Buffer, offset?: number): T;
+  encode(src: T, buffer: Buffer, offset?: number): number;
+}
+
+const encodeDecode = <T>(layout: Layout<T>): EncodeDecode<T> => {
+  const decode = layout.decode.bind(layout);
+  const encode = layout.encode.bind(layout);
+  return {decode, encode};
+};
+
+const bigInt =
+  (length: number) =>
+  (property?: string): Layout<bigint> => {
+    const layout = blob(length, property);
+    const {encode, decode} = encodeDecode(layout);
+
+    const bigIntLayout = layout as Layout<unknown> as Layout<bigint>;
+
+    bigIntLayout.decode = (buffer: Buffer, offset: number) => {
+      const src = decode(buffer, offset);
+      return toBigIntLE(Buffer.from(src));
+    };
+
+    bigIntLayout.encode = (bigInt: bigint, buffer: Buffer, offset: number) => {
+      const src = toBufferLE(bigInt, length);
+      return encode(src, buffer, offset);
+    };
+
+    return bigIntLayout;
+  };
+
+export const u64 = bigInt(8);
+
+export const u128 = bigInt(16);
+
+export const u192 = bigInt(24);
+
+export const u256 = bigInt(32);


### PR DESCRIPTION
#### Problem
There's a circular dependency from `@solana/web3.js` -> `@solana/buffer-layout-utils` -> `@solana/web3.js`. Also, apps are seeing compile errors due to `@solana/buffer-layout-utils` using an esm style import to import from `@solana/web3.js` when they their `@solana/web3.js` dependency is not an esm module (https://github.com/solana-labs/buffer-layout-utils/issues/6)

#### Summary of Changes
- Copy bigint implementation from `@solana/buffer-layout-utils`
- Remove `@solana/buffer-layout-utils` dependency

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
