### PR TITLE
Add `get_confirmed_transactions` to `storage-bigtable`

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -566,7 +566,7 @@ impl LedgerStorage {
             .await?;
 
         // Collect by slot
-        let mut slots: HashMap<Slot, HashMap<u32, String>> = Default::default();
+        let mut slots: HashMap<Slot, HashMap<u32, String>> = HashMap::new();
         for cell in cells {
             if let (signature, Ok(TransactionInfo { slot, index, .. })) = cell {
                 slots.entry(slot).or_default().insert(index, signature);

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -574,13 +574,13 @@ impl LedgerStorage {
         }
 
         // Fetch blocks and extract transactions
+        let slots_ref = &slots;
         let keys = slots.keys().copied().collect::<Vec<_>>();
         let data = self
             .get_confirmed_blocks_with_data(&keys)
             .await?
-            .zip(std::iter::repeat(&slots))
-            .filter_map(move |((slot, block), slots)| {
-                slots.get(&slot).map(move |block_txs| {
+            .filter_map(move |(slot, block)| {
+                slots_ref.get(&slot).map(move |block_txs| {
                     let block_time = block.block_time;
                     block.transactions.into_iter().enumerate().filter_map(
                         move |(index, tx_with_meta)| {


### PR DESCRIPTION
#### Problem

It's possible to get few blocks with `get_confirmed_blocks_with_data` but there is no method for get few transactions.

#### Summary of Changes

Add `LedgerStorage::get_confirmed_transactions` to `solana-storage-bigtable`.