### PR TITLE
Make PacketBatch packets vector non-public

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -367,7 +367,7 @@ fn main() {
             for (packet_batch_index, packet_batch) in
                 packets_for_this_iteration.packet_batches.iter().enumerate()
             {
-                sent += packet_batch.packets.len();
+                sent += packet_batch.len();
                 trace!(
                     "Sending PacketBatch index {}, {}",
                     packet_batch_index,

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -64,7 +64,7 @@ mod tests {
         let mut total_packets = 0;
         while now.elapsed().as_secs() < 5 {
             if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
-                total_packets += packets.packets.len();
+                total_packets += packets.len();
                 all_packets.push(packets)
             }
             if total_packets >= num_expected_packets {
@@ -72,7 +72,7 @@ mod tests {
             }
         }
         for batch in all_packets {
-            for p in &batch.packets {
+            for p in &batch {
                 assert_eq!(p.meta.size, num_bytes);
             }
         }

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -254,7 +254,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
                     v.len(),
                 );
                 for xv in v {
-                    sent += xv.packets.len();
+                    sent += xv.len();
                 }
                 verified_sender.send(v.to_vec()).unwrap();
             }

--- a/core/benches/unprocessed_packet_batches.rs
+++ b/core/benches/unprocessed_packet_batches.rs
@@ -100,7 +100,7 @@ fn bench_packet_clone(bencher: &mut Bencher) {
             let mut outer_packet = Packet::default();
 
             let mut timer = Measure::start("insert_batch");
-            packet_batch.packets.iter().for_each(|packet| {
+            packet_batch.iter().for_each(|packet| {
                 let mut packet = packet.clone();
                 packet.meta.sender_stake *= 2;
                 if packet.meta.sender_stake > 2 {

--- a/core/src/ancestor_hashes_service.rs
+++ b/core/src/ancestor_hashes_service.rs
@@ -252,13 +252,13 @@ impl AncestorHashesService {
     ) -> Result<()> {
         let timeout = Duration::new(1, 0);
         let mut packet_batches = vec![response_receiver.recv_timeout(timeout)?];
-        let mut total_packets = packet_batches[0].packets.len();
+        let mut total_packets = packet_batches[0].len();
 
         let mut dropped_packets = 0;
         while let Ok(batch) = response_receiver.try_recv() {
-            total_packets += batch.packets.len();
+            total_packets += batch.len();
             if packet_threshold.should_drop(total_packets) {
-                dropped_packets += batch.packets.len();
+                dropped_packets += batch.len();
             } else {
                 packet_batches.push(batch);
             }
@@ -292,7 +292,7 @@ impl AncestorHashesService {
         duplicate_slots_reset_sender: &DuplicateSlotsResetSender,
         retryable_slots_sender: &RetryableSlotsSender,
     ) {
-        packet_batch.packets.iter().for_each(|packet| {
+        packet_batch.iter().for_each(|packet| {
             let decision = Self::verify_and_process_ancestor_response(
                 packet,
                 ancestor_hashes_request_statuses,
@@ -1116,7 +1116,7 @@ mod test {
         let mut response_packet = response_receiver
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
-        let packet = &mut response_packet.packets[0];
+        let packet = &mut response_packet[0];
         packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,
@@ -1477,7 +1477,7 @@ mod test {
         let mut response_packet = response_receiver
             .recv_timeout(Duration::from_millis(10_000))
             .unwrap();
-        let packet = &mut response_packet.packets[0];
+        let packet = &mut response_packet[0];
         packet.meta.set_socket_addr(&responder_info.serve_repair);
         let decision = AncestorHashesService::verify_and_process_ancestor_response(
             packet,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -21,7 +21,6 @@ use {
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_info,
     solana_perf::{
-        cuda_runtime::PinnedVec,
         data_budget::DataBudget,
         packet::{Packet, PacketBatch, PACKETS_PER_BATCH},
         perf_libs,
@@ -1969,7 +1968,7 @@ impl BankingStage {
         original_unprocessed_packets_len.saturating_sub(unprocessed_packets.len())
     }
 
-    fn generate_packet_indexes(vers: &PinnedVec<Packet>) -> Vec<usize> {
+    fn generate_packet_indexes(vers: &PacketBatch) -> Vec<usize> {
         vers.iter()
             .enumerate()
             .filter(|(_, pkt)| !pkt.meta.discard())
@@ -1984,12 +1983,11 @@ impl BankingStage {
     ) -> Result<Vec<PacketBatch>, RecvTimeoutError> {
         let start = Instant::now();
         let mut packet_batches = verified_receiver.recv_timeout(recv_timeout)?;
-        let mut num_packets_received: usize =
-            packet_batches.iter().map(|batch| batch.packets.len()).sum();
+        let mut num_packets_received: usize = packet_batches.iter().map(|batch| batch.len()).sum();
         while let Ok(packet_batch) = verified_receiver.try_recv() {
             trace!("got more packet batches in banking stage");
             let (packets_received, packet_count_overflowed) = num_packets_received
-                .overflowing_add(packet_batch.iter().map(|batch| batch.packets.len()).sum());
+                .overflowing_add(packet_batch.iter().map(|batch| batch.len()).sum());
             packet_batches.extend(packet_batch);
 
             // Spend any leftover receive time budget to greedily receive more packet batches,
@@ -2025,7 +2023,7 @@ impl BankingStage {
         recv_time.stop();
 
         let packet_batches_len = packet_batches.len();
-        let packet_count: usize = packet_batches.iter().map(|x| x.packets.len()).sum();
+        let packet_count: usize = packet_batches.iter().map(|x| x.len()).sum();
         debug!(
             "@{:?} process start stalled for: {:?}ms txs: {} id: {}",
             timestamp(),
@@ -2039,14 +2037,11 @@ impl BankingStage {
         let mut dropped_packets_count = 0;
         let mut newly_buffered_packets_count = 0;
         for packet_batch in packet_batch_iter {
-            let packet_indexes = Self::generate_packet_indexes(&packet_batch.packets);
+            let packet_indexes = Self::generate_packet_indexes(&packet_batch);
             // Track all the packets incoming from sigverify, both valid and invalid
             slot_metrics_tracker.increment_total_new_valid_packets(packet_indexes.len() as u64);
             slot_metrics_tracker.increment_newly_failed_sigverify_count(
-                packet_batch
-                    .packets
-                    .len()
-                    .saturating_sub(packet_indexes.len()) as u64,
+                packet_batch.len().saturating_sub(packet_indexes.len()) as u64,
             );
 
             Self::push_unprocessed(
@@ -2332,8 +2327,7 @@ mod tests {
         mut with_vers: Vec<(PacketBatch, Vec<u8>)>,
     ) -> Vec<PacketBatch> {
         with_vers.iter_mut().for_each(|(b, v)| {
-            b.packets
-                .iter_mut()
+            b.iter_mut()
                 .zip(v)
                 .for_each(|(p, f)| p.meta.set_discard(*f == 0))
         });

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -303,8 +303,8 @@ impl ClusterInfoVoteListener {
             .zip(packet_batches)
             .filter(|(_, packet_batch)| {
                 // to_packet_batches() above splits into 1 packet long batches
-                assert_eq!(packet_batch.packets.len(), 1);
-                !packet_batch.packets[0].meta.discard()
+                assert_eq!(packet_batch.len(), 1);
+                !packet_batch[0].meta.discard()
             })
             .filter_map(|(tx, packet_batch)| {
                 let (vote_account_key, vote, ..) = vote_parser::parse_vote_transaction(&tx)?;
@@ -1515,7 +1515,7 @@ mod tests {
     fn verify_packets_len(packets: &[VerifiedVoteMetadata], ref_value: usize) {
         let num_packets: usize = packets
             .iter()
-            .map(|vote_metadata| vote_metadata.packet_batch.packets.len())
+            .map(|vote_metadata| vote_metadata.packet_batch.len())
             .sum();
         assert_eq!(num_packets, ref_value);
     }

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -97,12 +97,12 @@ impl FetchStage {
         };
 
         let mut packet_batch = recvr.recv()?;
-        let mut num_packets = packet_batch.packets.len();
-        packet_batch.packets.iter_mut().for_each(mark_forwarded);
+        let mut num_packets = packet_batch.len();
+        packet_batch.iter_mut().for_each(mark_forwarded);
         let mut packet_batches = vec![packet_batch];
         while let Ok(mut packet_batch) = recvr.try_recv() {
-            packet_batch.packets.iter_mut().for_each(mark_forwarded);
-            num_packets += packet_batch.packets.len();
+            packet_batch.iter_mut().for_each(mark_forwarded);
+            num_packets += packet_batch.len();
             packet_batches.push(packet_batch);
             // Read at most 1K transactions in a loop
             if num_packets > 1024 {

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -133,7 +133,7 @@ impl FindPacketSenderStakeStage {
         PAR_THREAD_POOL.install(|| {
             batches
                 .into_par_iter()
-                .flat_map(|batch| batch.packets.par_iter_mut())
+                .flat_map(|batch| batch.par_iter_mut())
                 .for_each(|packet| {
                     packet.meta.sender_stake = ip_to_stake
                         .get(&packet.meta.addr)

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -327,13 +327,13 @@ impl ServeRepair {
         //TODO cache connections
         let timeout = Duration::new(1, 0);
         let mut reqs_v = vec![requests_receiver.recv_timeout(timeout)?];
-        let mut total_packets = reqs_v[0].packets.len();
+        let mut total_packets = reqs_v[0].len();
 
         let mut dropped_packets = 0;
         while let Ok(more) = requests_receiver.try_recv() {
-            total_packets += more.packets.len();
+            total_packets += more.len();
             if packet_threshold.should_drop(total_packets) {
-                dropped_packets += more.packets.len();
+                dropped_packets += more.len();
             } else {
                 reqs_v.push(more);
             }
@@ -431,7 +431,7 @@ impl ServeRepair {
         stats: &mut ServeRepairStats,
     ) {
         // iter over the packets
-        packet_batch.packets.iter().for_each(|packet| {
+        packet_batch.iter().for_each(|packet| {
             let from_addr = packet.meta.socket_addr();
             limited_deserialize(&packet.data[..packet.meta.size])
                 .into_iter()
@@ -700,11 +700,12 @@ impl ServeRepair {
                     nonce,
                 );
                 if let Some(packet) = packet {
-                    res.packets.push(packet);
+                    res.push(packet);
                 } else {
                     break;
                 }
-                if meta.parent_slot.is_some() && res.packets.len() < max_responses {
+
+                if meta.parent_slot.is_some() && res.len() < max_responses {
                     slot = meta.parent_slot.unwrap();
                 } else {
                     break;
@@ -810,10 +811,9 @@ mod tests {
             )
             .expect("packets");
             let request = ShredRepairType::HighestShred(slot, index);
-            verify_responses(&request, rv.packets.iter());
+            verify_responses(&request, rv.iter());
 
             let rv: Vec<Shred> = rv
-                .packets
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
@@ -896,9 +896,8 @@ mod tests {
             )
             .expect("packets");
             let request = ShredRepairType::Shred(slot, index);
-            verify_responses(&request, rv.packets.iter());
+            verify_responses(&request, rv.iter());
             let rv: Vec<Shred> = rv
-                .packets
                 .into_iter()
                 .filter_map(|b| {
                     assert_eq!(repair_response::nonce(&b.data[..]).unwrap(), nonce);
@@ -1058,7 +1057,6 @@ mod tests {
                 nonce,
             )
             .expect("run_orphan packets")
-            .packets
             .iter()
             .cloned()
             .collect();
@@ -1128,7 +1126,6 @@ mod tests {
                 nonce,
             )
             .expect("run_orphan packets")
-            .packets
             .iter()
             .cloned()
             .collect();
@@ -1179,8 +1176,7 @@ mod tests {
                 slot + num_slots,
                 nonce,
             )
-            .expect("run_ancestor_hashes packets")
-            .packets;
+            .expect("run_ancestor_hashes packets");
             assert_eq!(rv.len(), 1);
             let packet = &rv[0];
             let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
@@ -1195,8 +1191,7 @@ mod tests {
                 slot + num_slots - 1,
                 nonce,
             )
-            .expect("run_ancestor_hashes packets")
-            .packets;
+            .expect("run_ancestor_hashes packets");
             assert_eq!(rv.len(), 1);
             let packet = &rv[0];
             let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);
@@ -1218,8 +1213,7 @@ mod tests {
                 slot + num_slots - 1,
                 nonce,
             )
-            .expect("run_ancestor_hashes packets")
-            .packets;
+            .expect("run_ancestor_hashes packets");
             assert_eq!(rv.len(), 1);
             let packet = &rv[0];
             let ancestor_hashes_response = deserialize_ancestor_hashes_response(packet);

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -226,7 +226,7 @@ impl SigVerifyStage {
         let mut addrs = batches
             .iter_mut()
             .rev()
-            .flat_map(|batch| batch.packets.iter_mut().rev())
+            .flat_map(|batch| batch.iter_mut().rev())
             .filter(|packet| !packet.meta.discard())
             .map(|packet| (packet.meta.addr, packet))
             .into_group_map();
@@ -423,7 +423,6 @@ mod tests {
             .iter()
             .map(|batch| {
                 batch
-                    .packets
                     .iter()
                     .map(|p| if p.meta.discard() { 0 } else { 1 })
                     .sum::<usize>()
@@ -434,18 +433,19 @@ mod tests {
     #[test]
     fn test_packet_discard() {
         solana_logger::setup();
-        let mut batch = PacketBatch::default();
-        batch.packets.resize(10, Packet::default());
-        batch.packets[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
-        batch.packets[3].meta.set_discard(true);
-        batch.packets[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
+        let batch_size = 10;
+        let mut batch = PacketBatch::with_capacity(batch_size);
+        batch.resize(batch_size, Packet::default());
+        batch[3].meta.addr = std::net::IpAddr::from([1u16; 8]);
+        batch[3].meta.set_discard(true);
+        batch[4].meta.addr = std::net::IpAddr::from([2u16; 8]);
         let mut batches = vec![batch];
         let max = 3;
         SigVerifyStage::discard_excess_packets(&mut batches, max);
         assert_eq!(count_non_discard(&batches), max);
-        assert!(!batches[0].packets[0].meta.discard());
-        assert!(batches[0].packets[3].meta.discard());
-        assert!(!batches[0].packets[4].meta.discard());
+        assert!(!batches[0][0].meta.discard());
+        assert!(batches[0][3].meta.discard());
+        assert!(!batches[0][4].meta.discard());
     }
     fn gen_batches(use_same_tx: bool) -> Vec<PacketBatch> {
         let len = 4096;
@@ -480,7 +480,7 @@ mod tests {
         let mut sent_len = 0;
         for _ in 0..batches.len() {
             if let Some(batch) = batches.pop() {
-                sent_len += batch.packets.len();
+                sent_len += batch.len();
                 packet_s.send(vec![batch]).unwrap();
             }
         }
@@ -489,7 +489,7 @@ mod tests {
         loop {
             if let Ok(mut verifieds) = verified_r.recv_timeout(Duration::from_millis(10)) {
                 while let Some(v) = verifieds.pop() {
-                    received += v.packets.len();
+                    received += v.len();
                     batches.push(v);
                 }
                 if use_same_tx || received >= sent_len {

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -350,7 +350,7 @@ pub fn deserialize_packets<'a>(
     packet_indexes: &'a [usize],
 ) -> impl Iterator<Item = DeserializedPacket> + 'a {
     packet_indexes.iter().filter_map(move |packet_index| {
-        DeserializedPacket::new(packet_batch.packets[*packet_index].clone()).ok()
+        DeserializedPacket::new(packet_batch[*packet_index].clone()).ok()
     })
 }
 

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -428,10 +428,10 @@ mod tests {
         for _ in 0..num_expected_batches {
             let validator_batch: Vec<PacketBatch> = gossip_votes_iterator.next().unwrap();
             assert_eq!(validator_batch.len(), slot_hashes.slot_hashes().len());
-            let expected_len = validator_batch[0].packets.len();
+            let expected_len = validator_batch[0].len();
             assert!(validator_batch
                 .iter()
-                .all(|batch| batch.packets.len() == expected_len));
+                .all(|batch| batch.len() == expected_len));
         }
 
         // Should be empty now

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -517,20 +517,16 @@ pub fn start_verify_transactions(
                     // uninitialized anyway, so the initilization would simply write junk into
                     // the vector anyway.
                     unsafe {
-                        packet_batch.packets.set_len(vec_size);
+                        packet_batch.set_len(vec_size);
                     }
                     let entry_tx_iter = slice
                         .into_par_iter()
                         .map(|tx| tx.to_versioned_transaction());
 
-                    let res = packet_batch
-                        .packets
-                        .par_iter_mut()
-                        .zip(entry_tx_iter)
-                        .all(|pair| {
-                            pair.0.meta = Meta::default();
-                            Packet::populate_packet(pair.0, None, &pair.1).is_ok()
-                        });
+                    let res = packet_batch.par_iter_mut().zip(entry_tx_iter).all(|pair| {
+                        pair.0.meta = Meta::default();
+                        Packet::populate_packet(pair.0, None, &pair.1).is_ok()
+                    });
                     if res {
                         Ok(packet_batch)
                     } else {
@@ -552,7 +548,7 @@ pub fn start_verify_transactions(
                 );
                 let verified = packet_batches
                     .iter()
-                    .all(|batch| batch.packets.iter().all(|p| !p.meta.discard()));
+                    .all(|batch| batch.iter().all(|p| !p.meta.discard()));
                 verify_time.stop();
                 (verified, verify_time.as_us())
             });

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -21,13 +21,10 @@ const NUM_BATCHES: usize = 1;
 fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let recycler_cache = RecyclerCache::default();
 
-    let mut packet_batch = PacketBatch::default();
-    packet_batch.packets.set_pinnable();
+    let mut packet_batch = PacketBatch::new_pinned_with_capacity(NUM_PACKETS);
+    packet_batch.resize(NUM_PACKETS, Packet::default());
     let slot = 0xdead_c0de;
-    // need to pin explicitly since the resize will not cause re-allocation
-    packet_batch.packets.reserve_and_pin(NUM_PACKETS);
-    packet_batch.packets.resize(NUM_PACKETS, Packet::default());
-    for p in packet_batch.packets.iter_mut() {
+    for p in packet_batch.iter_mut() {
         let shred = Shred::new_from_data(
             slot,
             0xc0de,
@@ -57,8 +54,8 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
 fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
     let mut packet_batch = PacketBatch::default();
     let slot = 0xdead_c0de;
-    packet_batch.packets.resize(NUM_PACKETS, Packet::default());
-    for p in packet_batch.packets.iter_mut() {
+    packet_batch.resize(NUM_PACKETS, Packet::default());
+    for p in packet_batch.iter_mut() {
         let shred = Shred::new_from_data(
             slot,
             0xc0de,

--- a/perf/benches/dedup.rs
+++ b/perf/benches/dedup.rs
@@ -30,7 +30,7 @@ fn do_bench_dedup_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>) 
         deduper.reset();
         batches
             .iter_mut()
-            .for_each(|b| b.packets.iter_mut().for_each(|p| p.meta.set_discard(false)));
+            .for_each(|b| b.iter_mut().for_each(|p| p.meta.set_discard(false)));
     });
 }
 

--- a/perf/benches/shrink.rs
+++ b/perf/benches/shrink.rs
@@ -26,8 +26,7 @@ fn do_bench_shrink_packets(bencher: &mut Bencher, mut batches: Vec<PacketBatch>)
     bencher.iter(|| {
         let _ans = sigverify::shrink_batches(&mut batches);
         batches.iter_mut().for_each(|b| {
-            b.packets
-                .iter_mut()
+            b.iter_mut()
                 .for_each(|p| p.meta.set_discard(thread_rng().gen()))
         });
     });
@@ -75,8 +74,7 @@ fn bench_shrink_count_packets(bencher: &mut Bencher) {
         PACKETS_PER_BATCH,
     );
     batches.iter_mut().for_each(|b| {
-        b.packets
-            .iter_mut()
+        b.iter_mut()
             .for_each(|p| p.meta.set_discard(thread_rng().gen()))
     });
 

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -56,8 +56,8 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
             current_packets = num_packets;
         }
         let mut batch = PacketBatch::with_capacity(len);
-        batch.packets.resize(len, Packet::default());
-        for packet in batch.packets.iter_mut() {
+        batch.resize(len, Packet::default());
+        for packet in batch.iter_mut() {
             if thread_rng().gen_ratio(1, 2) {
                 tx = simple_tx.clone();
             } else {

--- a/perf/src/discard.rs
+++ b/perf/src/discard.rs
@@ -11,7 +11,7 @@ pub fn discard_batches_randomly(
     while total_packets > max_packets {
         let index = thread_rng().gen_range(0, batches.len());
         let removed = batches.swap_remove(index);
-        total_packets = total_packets.saturating_sub(removed.packets.len());
+        total_packets = total_packets.saturating_sub(removed.len());
     }
     total_packets
 }
@@ -24,7 +24,7 @@ mod tests {
     fn test_batch_discard_random() {
         solana_logger::setup();
         let mut batch = PacketBatch::default();
-        batch.packets.resize(1, Packet::default());
+        batch.resize(1, Packet::default());
         let num_batches = 100;
         let mut batches = vec![batch; num_batches];
         let max = 5;

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -3,8 +3,14 @@ pub use solana_sdk::packet::{Meta, Packet, PacketFlags, PACKET_DATA_SIZE};
 use {
     crate::{cuda_runtime::PinnedVec, recycler::Recycler},
     bincode::config::Options,
+    rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator},
     serde::{de::DeserializeOwned, Serialize},
-    std::{io::Read, net::SocketAddr},
+    std::{
+        io::Read,
+        net::SocketAddr,
+        ops::{Index, IndexMut},
+        slice::{Iter, IterMut, SliceIndex},
+    },
 };
 
 pub const NUM_PACKETS: usize = 1024 * 8;
@@ -14,7 +20,7 @@ pub const NUM_RCVMMSGS: usize = 64;
 
 #[derive(Debug, Default, Clone)]
 pub struct PacketBatch {
-    pub packets: PinnedVec<Packet>,
+    packets: PinnedVec<Packet>,
 }
 
 pub type PacketBatchRecycler = Recycler<PinnedVec<Packet>>;
@@ -30,23 +36,29 @@ impl PacketBatch {
         PacketBatch { packets }
     }
 
+    pub fn new_pinned_with_capacity(capacity: usize) -> Self {
+        let mut batch = Self::with_capacity(capacity);
+        batch.packets.reserve_and_pin(capacity);
+        batch
+    }
+
     pub fn new_unpinned_with_recycler(
         recycler: PacketBatchRecycler,
-        size: usize,
+        capacity: usize,
         name: &'static str,
     ) -> Self {
         let mut packets = recycler.allocate(name);
-        packets.reserve(size);
+        packets.reserve(capacity);
         PacketBatch { packets }
     }
 
     pub fn new_with_recycler(
         recycler: PacketBatchRecycler,
-        size: usize,
+        capacity: usize,
         name: &'static str,
     ) -> Self {
         let mut packets = recycler.allocate(name);
-        packets.reserve_and_pin(size);
+        packets.reserve_and_pin(capacity);
         PacketBatch { packets }
     }
 
@@ -96,14 +108,105 @@ impl PacketBatch {
         batch
     }
 
+    pub fn resize(&mut self, new_len: usize, value: Packet) {
+        self.packets.resize(new_len, value)
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        self.packets.truncate(len);
+    }
+
+    pub fn push(&mut self, packet: Packet) {
+        self.packets.push(packet);
+    }
+
     pub fn set_addr(&mut self, addr: &SocketAddr) {
-        for p in self.packets.iter_mut() {
+        for p in self.iter_mut() {
             p.meta.set_socket_addr(addr);
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.packets.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.packets.capacity()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.packets.is_empty()
+    }
+
+    pub fn as_ptr(&self) -> *const Packet {
+        self.packets.as_ptr()
+    }
+
+    pub fn iter(&self) -> Iter<'_, Packet> {
+        self.packets.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_, Packet> {
+        self.packets.iter_mut()
+    }
+
+    /// See Vector::set_len() for more details
+    ///
+    /// # Safety
+    ///
+    /// - `new_len` must be less than or equal to [`capacity()`].
+    /// - The elements at `old_len..new_len` must be initialized. Packet data
+    ///   will likely be overwritten when populating the packet, but the meta
+    ///   should specifically be initialized to known values.
+    pub unsafe fn set_len(&mut self, new_len: usize) {
+        self.packets.set_len(new_len);
+    }
+}
+
+impl<I: SliceIndex<[Packet]>> Index<I> for PacketBatch {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.packets[index]
+    }
+}
+
+impl<I: SliceIndex<[Packet]>> IndexMut<I> for PacketBatch {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        &mut self.packets[index]
+    }
+}
+
+impl<'a> IntoIterator for &'a PacketBatch {
+    type Item = &'a Packet;
+    type IntoIter = Iter<'a, Packet>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.packets.iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a PacketBatch {
+    type Iter = rayon::slice::Iter<'a, Packet>;
+    type Item = &'a Packet;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter()
+    }
+}
+
+impl<'a> IntoParallelIterator for &'a mut PacketBatch {
+    type Iter = rayon::slice::IterMut<'a, Packet>;
+    type Item = &'a mut Packet;
+    fn into_par_iter(self) -> Self::Iter {
+        self.packets.par_iter_mut()
+    }
+}
+
+impl From<PacketBatch> for Vec<Packet> {
+    fn from(batch: PacketBatch) -> Self {
+        batch.packets.into()
     }
 }
 
@@ -112,7 +215,7 @@ pub fn to_packet_batches<T: Serialize>(items: &[T], chunk_size: usize) -> Vec<Pa
         .chunks(chunk_size)
         .map(|batch_items| {
             let mut batch = PacketBatch::with_capacity(batch_items.len());
-            batch.packets.resize(batch_items.len(), Packet::default());
+            batch.resize(batch_items.len(), Packet::default());
             for (item, packet) in batch_items.iter().zip(batch.packets.iter_mut()) {
                 Packet::populate_packet(packet, None, item).expect("serialize request");
             }
@@ -169,18 +272,18 @@ mod tests {
         let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, hash);
         let rv = to_packet_batches_for_tests(&[tx.clone(); 1]);
         assert_eq!(rv.len(), 1);
-        assert_eq!(rv[0].packets.len(), 1);
+        assert_eq!(rv[0].len(), 1);
 
         #[allow(clippy::useless_vec)]
         let rv = to_packet_batches_for_tests(&vec![tx.clone(); NUM_PACKETS]);
         assert_eq!(rv.len(), 1);
-        assert_eq!(rv[0].packets.len(), NUM_PACKETS);
+        assert_eq!(rv[0].len(), NUM_PACKETS);
 
         #[allow(clippy::useless_vec)]
         let rv = to_packet_batches_for_tests(&vec![tx; NUM_PACKETS + 1]);
         assert_eq!(rv.len(), 2);
-        assert_eq!(rv[0].packets.len(), NUM_PACKETS);
-        assert_eq!(rv[1].packets.len(), 1);
+        assert_eq!(rv[0].len(), NUM_PACKETS);
+        assert_eq!(rv[1].len(), 1);
     }
 
     #[test]

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -180,7 +180,7 @@ fn handle_chunk(
                     let mut packet = Packet::default();
                     packet.meta.set_socket_addr(remote_addr);
                     packet.meta.sender_stake = stake;
-                    batch.packets.push(packet);
+                    batch.push(packet);
                     *maybe_batch = Some(batch);
                     stats
                         .total_packets_allocated
@@ -189,15 +189,15 @@ fn handle_chunk(
 
                 if let Some(batch) = maybe_batch.as_mut() {
                     let end = chunk.offset as usize + chunk.bytes.len();
-                    batch.packets[0].data[chunk.offset as usize..end].copy_from_slice(&chunk.bytes);
-                    batch.packets[0].meta.size = std::cmp::max(batch.packets[0].meta.size, end);
+                    batch[0].data[chunk.offset as usize..end].copy_from_slice(&chunk.bytes);
+                    batch[0].meta.size = std::cmp::max(batch[0].meta.size, end);
                     stats.total_chunks_received.fetch_add(1, Ordering::Relaxed);
                 }
             } else {
                 trace!("chunk is none");
                 // done receiving chunks
                 if let Some(batch) = maybe_batch.take() {
-                    let len = batch.packets[0].meta.size;
+                    let len = batch[0].meta.size;
                     if let Err(e) = packet_sender.send(batch) {
                         stats
                             .total_packet_batch_send_err
@@ -778,7 +778,7 @@ mod test {
         let mut total_packets = 0;
         while now.elapsed().as_secs() < 10 {
             if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
-                total_packets += packets.packets.len();
+                total_packets += packets.len();
                 all_packets.push(packets)
             }
             if total_packets == num_expected_packets {
@@ -786,7 +786,7 @@ mod test {
             }
         }
         for batch in all_packets {
-            for p in &batch.packets {
+            for p in batch.iter() {
                 assert_eq!(p.meta.size, 1);
             }
         }
@@ -850,7 +850,7 @@ mod test {
         let mut total_packets = 0;
         while now.elapsed().as_secs() < 5 {
             if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
-                total_packets += packets.packets.len();
+                total_packets += packets.len();
                 all_packets.push(packets)
             }
             if total_packets > num_expected_packets {
@@ -858,7 +858,7 @@ mod test {
             }
         }
         for batch in all_packets {
-            for p in &batch.packets {
+            for p in batch.iter() {
                 assert_eq!(p.meta.size, num_bytes);
             }
         }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -292,9 +292,9 @@ fn recv_send(
     let timer = Duration::new(1, 0);
     let packet_batch = r.recv_timeout(timer)?;
     if let Some(stats) = stats {
-        packet_batch.packets.iter().for_each(|p| stats.record(p));
+        packet_batch.iter().for_each(|p| stats.record(p));
     }
-    let packets = packet_batch.packets.iter().filter_map(|pkt| {
+    let packets = packet_batch.iter().filter_map(|pkt| {
         let addr = pkt.meta.socket_addr();
         socket_addr_space
             .check(&addr)
@@ -313,13 +313,13 @@ pub fn recv_vec_packet_batches(
     trace!("got packets");
     let mut num_packets = packet_batches
         .iter()
-        .map(|packets| packets.packets.len())
+        .map(|packets| packets.len())
         .sum::<usize>();
     while let Ok(packet_batch) = recvr.try_recv() {
         trace!("got more packets");
         num_packets += packet_batch
             .iter()
-            .map(|packets| packets.packets.len())
+            .map(|packets| packets.len())
             .sum::<usize>();
         packet_batches.extend(packet_batch);
     }
@@ -339,11 +339,11 @@ pub fn recv_packet_batches(
     let packet_batch = recvr.recv_timeout(timer)?;
     let recv_start = Instant::now();
     trace!("got packets");
-    let mut num_packets = packet_batch.packets.len();
+    let mut num_packets = packet_batch.len();
     let mut packet_batches = vec![packet_batch];
     while let Ok(packet_batch) = recvr.try_recv() {
         trace!("got more packets");
-        num_packets += packet_batch.packets.len();
+        num_packets += packet_batch.len();
         packet_batches.push(packet_batch);
     }
     let recv_duration = recv_start.elapsed();
@@ -431,7 +431,7 @@ mod test {
                 continue;
             }
 
-            *num_packets -= packet_batch_res.unwrap().packets.len();
+            *num_packets -= packet_batch_res.unwrap().len();
 
             if *num_packets == 0 {
                 break;
@@ -482,7 +482,7 @@ mod test {
                     p.meta.size = PACKET_DATA_SIZE;
                     p.meta.set_socket_addr(&addr);
                 }
-                packet_batch.packets.push(p);
+                packet_batch.push(p);
             }
             s_responder.send(packet_batch).expect("send");
             t_responder


### PR DESCRIPTION
#### Problem
Upcoming changes to PacketBatch will modify the internals of
PacketBatch.

#### Summary of Changes
This change hides the internals and adds wrappers for the
various operations we want to do on PacketBatch's packets.