### PR TITLE
doc: update build instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ $ rustup install VERSION
 ```
 Note that if this is not the latest rust version on your machine, cargo commands may require an [override](https://rust-lang.github.io/rustup/overrides.html) in order to use the correct version.
 
-On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, etc.  On Ubuntu:
+On Linux systems you may need to install libssl-dev, pkg-config, zlib1g-dev, protobuf etc.  On Ubuntu:
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make
+$ sudo apt-get install libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
 ```
 
 ## **2. Download the source code.**


### PR DESCRIPTION
#### Problem

cargo build has a dependency on protobuf, which depends on protobuf-compiler package.


#### Summary of Changes
update the build dependency commands in Readme.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
