### PR TITLE
Update RpcSimulateTransactionConfig for rpc_client::get_stake_minimum_delegation()

### DIFF
--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -4517,8 +4517,17 @@ impl RpcClient {
     /// Returns the stake minimum delegation, in lamports.
     pub async fn get_stake_minimum_delegation(&self) -> ClientResult<u64> {
         let instruction = solana_sdk::stake::instruction::get_minimum_delegation();
-        let transaction = Transaction::new_with_payer(&[instruction], None);
-        let response = self.simulate_transaction(&transaction).await?;
+        let transaction = Transaction::new_with_payer(&[instruction], Some(&Pubkey::default()));
+        let response = self
+            .simulate_transaction_with_config(
+                &transaction,
+                RpcSimulateTransactionConfig {
+                    sig_verify: false,
+                    replace_recent_blockhash: true,
+                    ..RpcSimulateTransactionConfig::default()
+                },
+            )
+            .await?;
         let RpcTransactionReturnData {
             program_id,
             data: (data, encoding),


### PR DESCRIPTION
#### Problem

When calling `rpc_client::get_stake_minimum_delegation()` from CLI, the `simulate_transaction()` fails.

#### Summary of Changes

Need to customize the RPC Simulate Transaction Config to:
- have a payer
- skip sig verify
- replace the blockhash

Further fix for #24690