### PR TITLE
clippy: is_digit(10) -> is_ascii_digit()

### DIFF
--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -345,7 +345,7 @@ fn all_digits(v: &str) -> bool {
         return false;
     }
     for x in v.chars() {
-        if !x.is_digit(10) {
+        if !x.is_ascii_digit() {
             return false;
         }
     }
@@ -356,7 +356,7 @@ fn like_storage(v: &str) -> bool {
     let mut periods = 0;
     let mut saw_numbers = false;
     for x in v.chars() {
-        if !x.is_digit(10) {
+        if !x.is_ascii_digit() {
             if x == '.' {
                 if periods > 0 || !saw_numbers {
                     return false;


### PR DESCRIPTION
#### Problem

Clippy warns on `is_digit(10)`:
```
warning: use of `char::is_digit` with literal radix of 10
   --> runtime/src/hardened_unpack.rs:359:13
    |
359 |         if !x.is_digit(10) {
    |             ^^^^^^^^^^^^^^ help: try: `x.is_ascii_digit()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#is_digit_ascii_radix
```

#### Summary of Changes

Use `is_ascii_digit()` instead.