### PR TITLE
clippy: fix "this let-binding has unit value" warnings

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -85,7 +85,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         // This tests the performance of buffering packets.
         // If the packet buffers are copied, performance will be poor.
         bencher.iter(move || {
-            let _ignored = BankingStage::consume_buffered_packets(
+            BankingStage::consume_buffered_packets(
                 &my_pubkey,
                 std::u128::MAX,
                 &poh_recorder,

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -159,7 +159,7 @@ pub async fn upload_confirmed_blocks(
         let (sender, receiver) = bounded(config.block_read_ahead_depth);
 
         let (slot_sender, slot_receiver) = unbounded();
-        let _ = blocks_to_upload
+        blocks_to_upload
             .into_iter()
             .for_each(|b| slot_sender.send(b).unwrap());
         drop(slot_sender);

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -31,8 +31,7 @@ fn bench_sigverify_simple(bencher: &mut Bencher) {
     let recycler_out = Recycler::default();
     // verify packets
     bencher.iter(|| {
-        let _ans =
-            sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
     })
 }
 
@@ -79,8 +78,7 @@ fn bench_sigverify_uneven(bencher: &mut Bencher) {
     let recycler_out = Recycler::default();
     // verify packets
     bencher.iter(|| {
-        let _ans =
-            sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
     })
 }
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -183,14 +183,14 @@ pub fn deserialize_parameters_unaligned(
             start += size_of::<u8>(); // is_signer
             start += size_of::<u8>(); // is_writable
             start += size_of::<Pubkey>(); // key
-            let _ = borrowed_account.set_lamports(LittleEndian::read_u64(
+            borrowed_account.set_lamports(LittleEndian::read_u64(
                 buffer
                     .get(start..)
                     .ok_or(InstructionError::InvalidArgument)?,
             ));
             start += size_of::<u64>() // lamports
                 + size_of::<u64>(); // data length
-            let _ = borrowed_account.set_data(
+            borrowed_account.set_data(
                 buffer
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -324,13 +324,13 @@ pub fn deserialize_parameters_aligned(
                 + size_of::<u8>() // executable
                 + 4 // padding to 128-bit aligned
                 + size_of::<Pubkey>(); // key
-            let _ = borrowed_account.set_owner(
+            borrowed_account.set_owner(
                 buffer
                     .get(start..start + size_of::<Pubkey>())
                     .ok_or(InstructionError::InvalidArgument)?,
             );
             start += size_of::<Pubkey>(); // owner
-            let _ = borrowed_account.set_lamports(LittleEndian::read_u64(
+            borrowed_account.set_lamports(LittleEndian::read_u64(
                 buffer
                     .get(start..)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -358,7 +358,7 @@ pub fn deserialize_parameters_aligned(
                 }
                 data_end
             };
-            let _ = borrowed_account.set_data(
+            borrowed_account.set_data(
                 buffer
                     .get(start..data_end)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -575,7 +575,7 @@ mod tests {
             .unwrap()
             .1
             .set_owner(bpf_loader_deprecated::id());
-        let _ = invoke_context
+        invoke_context
             .transaction_context
             .get_current_instruction_context()
             .unwrap()

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -125,7 +125,7 @@ impl AbiExample for StakeAccount<Delegation> {
         let mut account = Account::example();
         account.data.resize(196, 0u8);
         account.owner = solana_stake_program::id();
-        let _ = account.set_state(&stake_state).unwrap();
+        account.set_state(&stake_state).unwrap();
         Self::try_from(AccountSharedData::from(account)).unwrap()
     }
 }

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -446,7 +446,7 @@ impl SendTransactionService {
                     stats
                         .sent_transactions
                         .fetch_add(transactions.len() as u64, Ordering::Relaxed);
-                    let _result = Self::send_transactions_in_batch(
+                    Self::send_transactions_in_batch(
                         &tpu_address,
                         &mut transactions,
                         leader_info_provider.lock().unwrap().get_leader_info(),


### PR DESCRIPTION
#### Problem

Clippy warns for let-bindings with unit values:

```
warning: this let-binding has unit value
   --> core/benches/banking_stage.rs:88:13
    |
88  | /             let _ignored = BankingStage::consume_buffered_packets(
89  | |                 &my_pubkey,
90  | |                 std::u128::MAX,
91  | |                 &poh_recorder,
...   |
100 | |                 10,
101 | |             );
    | |______________^
    |
    = note: `#[warn(clippy::let_unit_value)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value
help: omit the `let` binding
    |
88  ~             BankingStage::consume_buffered_packets(
89  +                 &my_pubkey,
90  +                 std::u128::MAX,
91  +                 &poh_recorder,
92  +                 &mut transaction_buffer,
93  +                 None,
  ...
```

#### Summary of Changes

Remove the `let` bindings.

