### PR TITLE
tpu-client: Refactor to prep for async client

### DIFF
--- a/client/src/spinner.rs
+++ b/client/src/spinner.rs
@@ -9,3 +9,26 @@ pub(crate) fn new_progress_bar() -> ProgressBar {
     progress_bar.enable_steady_tick(100);
     progress_bar
 }
+
+pub(crate) fn set_message_for_confirmed_transactions(
+    progress_bar: &ProgressBar,
+    confirmed_transactions: u32,
+    total_transactions: usize,
+    block_height: Option<u64>,
+    last_valid_block_height: u64,
+    status: &str,
+) {
+    progress_bar.set_message(format!(
+        "{:>5.1}% | {:<40}{}",
+        confirmed_transactions as f64 * 100. / total_transactions as f64,
+        status,
+        match block_height {
+            Some(block_height) => format!(
+                " [block height {}; re-sign in {} blocks]",
+                block_height,
+                last_valid_block_height.saturating_sub(block_height),
+            ),
+            None => String::new(),
+        },
+    ));
+}


### PR DESCRIPTION
#### Problem

An async TPU client could involve a lot of copied code from the current TPU client, which would be tougher to maintain in the long term.

#### Summary of Changes

No behavior changes, mainly moving some bits around refactoring the internal tpu client types to be reusable.

The biggest change here is to split up the loop of the `LeaderTpuService` to fetch everything needed to update in one place, and then update in another.  This way, the async version only needs to reimplement a subset of the functionality.