### PR TITLE
Fix flakey `streamer_send_test`

### DIFF
--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -492,8 +492,8 @@ mod test {
         get_packet_batches(r_reader, &mut packets_remaining);
         assert_eq!(packets_remaining, 0);
         exit.store(true, Ordering::Relaxed);
+        assert!(stats.packet_batches_count.load(Ordering::Relaxed) >= 1);
         assert_eq!(stats.packets_count.load(Ordering::Relaxed), NUM_PACKETS);
-        assert_eq!(stats.packet_batches_count.load(Ordering::Relaxed), 1);
         assert_eq!(stats.full_packet_batches_count.load(Ordering::Relaxed), 0);
         t_receiver.join().expect("join");
         t_responder.join().expect("join");


### PR DESCRIPTION
#### Problem
Packets received over the test's udp socket are sometimes split across multiple batches and cause the test to fail

#### Summary of Changes
Loosen the test assertion to check that at least one packet batch was received

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
