### PR TITLE
findpacketsenderstake: add discard after receive

### DIFF
--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -23,6 +23,11 @@ lazy_static! {
         .unwrap();
 }
 
+// Try to target 50ms, rough timings from mainnet machines
+//
+// 50ms/(1us/packet) = 50k packets
+const MAX_FINDPACKETSENDERSTAKE_BATCH: usize = 50_000;
+
 pub type FindPacketSenderStakeSender = Sender<Vec<PacketBatch>>;
 pub type FindPacketSenderStakeReceiver = Receiver<Vec<PacketBatch>>;
 
@@ -35,6 +40,8 @@ struct FindPacketSenderStakeStats {
     receive_batches_time: u64,
     total_batches: u64,
     total_packets: u64,
+    total_discard_random: usize,
+    total_discard_random_time_us: usize,
 }
 
 impl FindPacketSenderStakeStats {
@@ -62,6 +69,12 @@ impl FindPacketSenderStakeStats {
                 ),
                 ("total_batches", self.total_batches as i64, i64),
                 ("total_packets", self.total_packets as i64, i64),
+                ("total_discard_random", self.total_discard_random, i64),
+                (
+                    "total_discard_random_time_us",
+                    self.total_discard_random_time_us,
+                    i64
+                ),
             );
             *self = FindPacketSenderStakeStats::default();
             self.last_print = now;
@@ -87,6 +100,18 @@ impl FindPacketSenderStakeStage {
                 match streamer::recv_packet_batches(&packet_receiver) {
                     Ok((mut batches, num_packets, recv_duration)) => {
                         let num_batches = batches.len();
+
+                        let mut discard_random_time =
+                            Measure::start("findpacketsenderstake_discard_random_time");
+                        let non_discarded_packets = solana_perf::discard::discard_batches_randomly(
+                            &mut batches,
+                            MAX_FINDPACKETSENDERSTAKE_BATCH,
+                            num_packets,
+                        );
+                        let num_discarded_randomly =
+                            num_packets.saturating_sub(non_discarded_packets);
+                        discard_random_time.stop();
+
                         let mut apply_sender_stakes_time =
                             Measure::start("apply_sender_stakes_time");
                         let mut apply_stake = || {
@@ -115,6 +140,8 @@ impl FindPacketSenderStakeStage {
                             stats.total_batches.saturating_add(num_batches as u64);
                         stats.total_packets =
                             stats.total_packets.saturating_add(num_packets as u64);
+                        stats.total_discard_random_time_us += discard_random_time.as_us() as usize;
+                        stats.total_discard_random += num_discarded_randomly;
                     }
                     Err(e) => match e {
                         StreamerError::RecvTimeout(RecvTimeoutError::Disconnected) => break,


### PR DESCRIPTION
#### Problem

The FindPacketSenderStake stage does no load-shedding.

#### Summary of Changes

Randomly discard batches if too many have arrived since the last iteration. This mimics #25388 which did the same for sigverify.

@sakridge @jstarry 