### PR TITLE
Update docs for validator identity change to include --no-wait-for-vote-to-start-leader

### DIFF
--- a/docs/src/running-validator/vote-accounts.md
+++ b/docs/src/running-validator/vote-accounts.md
@@ -181,7 +181,7 @@ added to the leader schedule.
 
 After your validator is restarted with the new identity keypair, per step 4,
 start a second non-voting validator on a different machine with the old identity keypair
-without providing the `--vote-account` argument.
+without providing the `--vote-account` argument, as well as with the `--no-wait-for-vote-to-start-leader` argument.
 
 This temporary validator should be run for two full epochs. During this time it will:
 * Produce blocks for the remaining slots that are assigned to your old validator identity


### PR DESCRIPTION


Updating docs to include usage of --no-wait-for-vote-to-start-leader flag for validator identity rotation to ensure the secondary validator with the original identity produces blocks.
