### PR TITLE
Partially reverts "clippy: fix "this let-binding has unit value" warnings"

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -183,14 +183,14 @@ pub fn deserialize_parameters_unaligned(
             start += size_of::<u8>(); // is_signer
             start += size_of::<u8>(); // is_writable
             start += size_of::<Pubkey>(); // key
-            borrowed_account.set_lamports(LittleEndian::read_u64(
+            let _ = borrowed_account.set_lamports(LittleEndian::read_u64(
                 buffer
                     .get(start..)
                     .ok_or(InstructionError::InvalidArgument)?,
             ));
             start += size_of::<u64>() // lamports
                 + size_of::<u64>(); // data length
-            borrowed_account.set_data(
+            let _ = borrowed_account.set_data(
                 buffer
                     .get(start..start + pre_len)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -324,13 +324,13 @@ pub fn deserialize_parameters_aligned(
                 + size_of::<u8>() // executable
                 + 4 // padding to 128-bit aligned
                 + size_of::<Pubkey>(); // key
-            borrowed_account.set_owner(
+            let _ = borrowed_account.set_owner(
                 buffer
                     .get(start..start + size_of::<Pubkey>())
                     .ok_or(InstructionError::InvalidArgument)?,
             );
             start += size_of::<Pubkey>(); // owner
-            borrowed_account.set_lamports(LittleEndian::read_u64(
+            let _ = borrowed_account.set_lamports(LittleEndian::read_u64(
                 buffer
                     .get(start..)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -358,7 +358,7 @@ pub fn deserialize_parameters_aligned(
                 }
                 data_end
             };
-            borrowed_account.set_data(
+            let _ = borrowed_account.set_data(
                 buffer
                     .get(start..data_end)
                     .ok_or(InstructionError::InvalidArgument)?,
@@ -575,7 +575,7 @@ mod tests {
             .unwrap()
             .1
             .set_owner(bpf_loader_deprecated::id());
-        invoke_context
+        let _ = invoke_context
             .transaction_context
             .get_current_instruction_context()
             .unwrap()


### PR DESCRIPTION
Partially reverts solana-labs/solana#25429

Apparently CI runs for https://github.com/solana-labs/solana/pull/25429 and https://github.com/solana-labs/solana/pull/25380 have interleaved each other resulting in a broken master.