### PR TITLE
Refactor: Adds `index_in_callee` to `InstructionAccount`

### DIFF
--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -95,6 +95,7 @@ fn create_inputs() -> TransactionContext {
             |(index_in_instruction, index_in_transaction)| InstructionAccount {
                 index_in_caller: 1usize.saturating_add(index_in_instruction),
                 index_in_transaction,
+                index_in_callee: index_in_instruction,
                 is_signer: false,
                 is_writable: index_in_instruction >= 4,
             },

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -20,12 +20,16 @@ pub fn is_duplicate(
     index_in_instruction: usize,
 ) -> Option<usize> {
     let index_in_transaction = instruction_context.get_index_in_transaction(index_in_instruction);
-    (instruction_context.get_number_of_program_accounts()..index_in_instruction).position(
-        |index_in_instruction| {
+    let old_approach = (instruction_context.get_number_of_program_accounts()..index_in_instruction)
+        .position(|index_in_instruction| {
             instruction_context.get_index_in_transaction(index_in_instruction)
                 == index_in_transaction
-        },
-    )
+        });
+    let result = instruction_context
+        .is_duplicate(index_in_instruction)
+        .unwrap_or(None);
+    debug_assert_eq!(result, old_approach);
+    old_approach
 }
 
 pub fn serialize_parameters(

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -81,9 +81,10 @@ fn create_accounts() -> (
         (authority_pubkey, AccountSharedData::default()),
     ];
     let mut instruction_accounts = (0..4)
-        .map(|index| InstructionAccount {
-            index_in_transaction: 1usize.saturating_add(index),
-            index_in_caller: 1usize.saturating_add(index),
+        .map(|index_in_instruction| InstructionAccount {
+            index_in_transaction: 1usize.saturating_add(index_in_instruction),
+            index_in_caller: 1usize.saturating_add(index_in_instruction),
+            index_in_callee: index_in_instruction,
             is_signer: false,
             is_writable: false,
         })

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -332,12 +332,14 @@ mod test {
                 InstructionAccount {
                     index_in_transaction: 0,
                     index_in_caller: 0,
+                    index_in_callee: 0,
                     is_signer: true,
                     is_writable: true,
                 },
                 InstructionAccount {
                     index_in_transaction: 1,
                     index_in_caller: 1,
+                    index_in_callee: 1,
                     is_signer: false,
                     is_writable: true,
                 },

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -20,6 +20,7 @@ pub type TransactionAccount = (Pubkey, AccountSharedData);
 pub struct InstructionAccount {
     pub index_in_transaction: usize,
     pub index_in_caller: usize,
+    pub index_in_callee: usize,
     pub is_signer: bool,
     pub is_writable: bool,
 }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -16,12 +16,24 @@ use {
 
 pub type TransactionAccount = (Pubkey, AccountSharedData);
 
+/// Contains account meta data which varies between instruction.
+///
+/// It also contains indices to other structures for faster lookup.
 #[derive(Clone, Debug)]
 pub struct InstructionAccount {
+    /// Points to the account and its key in the `TransactionContext`
     pub index_in_transaction: usize,
+    /// Points to the first occurrence in the parent `InstructionContext`
+    ///
+    /// This includes the program accounts.
     pub index_in_caller: usize,
+    /// Points to the first occurrence in the current `InstructionContext`
+    ///
+    /// This excludes the program accounts.
     pub index_in_callee: usize,
+    /// Is this account supposed to sign
     pub is_signer: bool,
+    /// Is this account allowed to become writable
     pub is_writable: bool,
 }
 

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -384,6 +384,28 @@ impl InstructionContext {
         }
     }
 
+    /// Returns `Some(index_in_instruction)` if this is a duplicate
+    /// and `None` if it is the first account with this key
+    pub fn is_duplicate(
+        &self,
+        index_in_instruction: usize,
+    ) -> Result<Option<usize>, InstructionError> {
+        if index_in_instruction < self.program_accounts.len()
+            || index_in_instruction >= self.get_number_of_accounts()
+        {
+            Err(InstructionError::NotEnoughAccountKeys)
+        } else {
+            let index_in_instruction =
+                index_in_instruction.saturating_sub(self.program_accounts.len());
+            let index_in_callee = self.instruction_accounts[index_in_instruction].index_in_callee;
+            Ok(if index_in_callee == index_in_instruction {
+                None
+            } else {
+                Some(index_in_callee)
+            })
+        }
+    }
+
     /// Gets the key of the last program account of this Instruction
     pub fn get_program_key<'a, 'b: 'a>(
         &'a self,


### PR DESCRIPTION
#### Problem
`visit_each_account_once()` is used to calculate the duplicate accounts multiple times per instruction,
but once would be enough if we simply stored the result.

#### Summary of Changes
Adds `InstructionAccount::index_in_callee` and `InstructionContext::is_duplicate()`.
Both `visit_each_account_once()` and `is_duplicate()` in serialize.rs just check if their calculation matches for now (they will be replaced in the next PR).
Also documents `InstructionAccount` and adjusts affected tests and benches.