### PR TITLE
Use the new datapoint macro for RocksDB column family metrics

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -13,7 +13,6 @@ pub mod blockstore;
 pub mod ancestor_iterator;
 pub mod blockstore_db;
 pub mod blockstore_meta;
-#[macro_use]
 pub mod blockstore_metrics;
 pub mod blockstore_options;
 pub mod blockstore_processor;


### PR DESCRIPTION
#### Summary of Changes
Use the new datapoint macro that supports group-by for RocksDB column family metrics.
By using the new macro, we can further remove large chunks of boilerplate code that try to work around the previous datapoint macro that does not support group-by.

This PR depends on #25385 and #25392.
