### PR TITLE
removes shred wire layout specs from sigverify

### DIFF
--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -92,20 +92,17 @@ mod test {
             .iter()
             .cloned()
             .collect();
-        let rv = verify_shred_cpu(&packet, &leader_slots);
-        assert_eq!(rv, Some(1));
+        assert!(verify_shred_cpu(&packet, &leader_slots));
 
         let wrong_keypair = Keypair::new();
         let leader_slots = [(slot, wrong_keypair.pubkey().to_bytes())]
             .iter()
             .cloned()
             .collect();
-        let rv = verify_shred_cpu(&packet, &leader_slots);
-        assert_eq!(rv, Some(0));
+        assert!(!verify_shred_cpu(&packet, &leader_slots));
 
         let leader_slots = HashMap::new();
-        let rv = verify_shred_cpu(&packet, &leader_slots);
-        assert_eq!(rv, None);
+        assert!(!verify_shred_cpu(&packet, &leader_slots));
     }
 
     #[test]

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -7,8 +7,7 @@ use {
     },
     crossbeam_channel::Sender,
     solana_ledger::{
-        leader_schedule_cache::LeaderScheduleCache, shred::Shred,
-        sigverify_shreds::verify_shreds_gpu,
+        leader_schedule_cache::LeaderScheduleCache, shred, sigverify_shreds::verify_shreds_gpu,
     },
     solana_perf::{self, packet::PacketBatch, recycler_cache::RecyclerCache},
     solana_runtime::bank_forks::BankForks,
@@ -43,7 +42,9 @@ impl ShredSigVerifier {
     fn read_slots(batches: &[PacketBatch]) -> HashSet<u64> {
         batches
             .iter()
-            .flat_map(|batch| batch.iter().filter_map(Shred::get_slot_from_packet))
+            .flat_map(PacketBatch::iter)
+            .map(shred::layout::get_shred)
+            .filter_map(shred::layout::get_slot)
             .collect()
     }
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1859,7 +1859,7 @@ impl Blockstore {
             let upper_index = cmp::min(current_index, end_index);
             // the tick that will be used to figure out the timeout for this hole
             let data = db_iterator.value().expect("couldn't read value");
-            let reference_tick = u64::from(Shred::reference_tick_from_data(data).unwrap());
+            let reference_tick = u64::from(shred::layout::get_reference_tick(data).unwrap());
             if ticks_since_first_insert < reference_tick + MAX_TURBINE_DELAY_IN_TICKS {
                 // The higher index holes have not timed out yet
                 break 'outer;

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -353,7 +353,8 @@ mod tests {
     use {
         super::*,
         crate::shred::{
-            max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred, ShredType,
+            self, max_entries_per_n_shred, max_ticks_per_n_shreds, verify_test_data_shred,
+            ShredType,
         },
         bincode::serialized_size,
         matches::assert_matches,
@@ -519,7 +520,7 @@ mod tests {
         );
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), 5);
-            assert_eq!(Shred::reference_tick_from_data(s.payload()).unwrap(), 5);
+            assert_eq!(shred::layout::get_reference_tick(s.payload()).unwrap(), 5);
         });
 
         let deserialized_shred =
@@ -555,7 +556,7 @@ mod tests {
                 ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
             );
             assert_eq!(
-                Shred::reference_tick_from_data(s.payload()).unwrap(),
+                shred::layout::get_reference_tick(s.payload()).unwrap(),
                 ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
             );
         });


### PR DESCRIPTION
#### Problem
`sigverify_shreds` relies on wire layout of shreds:
https://github.com/solana-labs/solana/blob/0376ab41a/ledger/src/sigverify_shreds.rs#L39-L46
https://github.com/solana-labs/solana/blob/0376ab41a/ledger/src/sigverify_shreds.rs#L298-L305

In preparation of https://github.com/solana-labs/solana/pull/25237
which adds a new shred variant with different layout and signed message,
this commit removes shred layout specification from sigverify and
instead encapsulate that in shred module.


#### Summary of Changes
removed shred wire layout specs from sigverify