### PR TITLE
solana-tokens: add extra error line

### DIFF
--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -145,6 +145,7 @@ pub fn update_finalized_transaction(
                 "Signature not found {} and blockhash expired. Transaction either dropped or the validator purged the transaction status.",
                 signature
             );
+            eprintln!();
 
             // Don't discard the transaction, because we are not certain the
             // blockhash is expired. Instead, return None to signal that
@@ -166,6 +167,7 @@ pub fn update_finalized_transaction(
         // The transaction was finalized, but execution failed. Drop it.
         eprintln!("Error in transaction with signature {}: {}", signature, e);
         eprintln!("Discarding transaction record");
+        eprintln!();
         db.rem(&signature.to_string())?;
         return Ok(None);
     }


### PR DESCRIPTION
#### Problem
When running solana-tokens, the last line of stderr gets lost, probably due to incomplete flush.

#### Summary of Changes
Force flush by printing a new line after errors
