### PR TITLE
Refactor: Rebase offset of `index_in_caller`

### DIFF
--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -93,7 +93,7 @@ fn create_inputs() -> TransactionContext {
         .enumerate()
         .map(
             |(index_in_instruction, index_in_transaction)| InstructionAccount {
-                index_in_caller: 1usize.saturating_add(index_in_instruction),
+                index_in_caller: index_in_instruction,
                 index_in_transaction,
                 index_in_callee: index_in_instruction,
                 is_signer: false,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2955,10 +2955,6 @@ fn get_translated_accounts<'a, T, F>(
 where
     F: Fn(&T, &InvokeContext) -> Result<CallerAccount<'a>, EbpfError<BpfError>>,
 {
-    let instruction_context = invoke_context
-        .transaction_context
-        .get_current_instruction_context()
-        .map_err(SyscallError::InstructionError)?;
     let mut accounts = Vec::with_capacity(instruction_accounts.len().saturating_add(1));
 
     let program_account_index = program_indices
@@ -3010,15 +3006,12 @@ where
                     account.set_rent_epoch(caller_account.rent_epoch);
                 }
                 let caller_account = if instruction_account.is_writable {
-                    let orig_data_len_index = instruction_account
-                        .index_in_caller
-                        .saturating_sub(instruction_context.get_number_of_program_accounts());
                     let orig_data_lens = invoke_context
                         .get_orig_account_lengths()
                         .map_err(SyscallError::InstructionError)?;
-                    if orig_data_len_index < orig_data_lens.len() {
+                    if instruction_account.index_in_caller < orig_data_lens.len() {
                         caller_account.original_data_len = *orig_data_lens
-                            .get(orig_data_len_index)
+                            .get(instruction_account.index_in_caller)
                             .ok_or(SyscallError::InvalidLength)?;
                     } else {
                         ic_msg!(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3009,22 +3009,16 @@ where
                     let orig_data_lens = invoke_context
                         .get_orig_account_lengths()
                         .map_err(SyscallError::InstructionError)?;
-                    if instruction_account.index_in_caller < orig_data_lens.len() {
-                        caller_account.original_data_len = *orig_data_lens
-                            .get(instruction_account.index_in_caller)
-                            .ok_or(SyscallError::InvalidLength)?;
-                    } else {
-                        ic_msg!(
-                            invoke_context,
-                            "Internal error: index mismatch for account {}",
-                            account_key
-                        );
-                        return Err(SyscallError::InstructionError(
-                            InstructionError::MissingAccount,
-                        )
-                        .into());
-                    }
-
+                    caller_account.original_data_len = *orig_data_lens
+                        .get(instruction_account.index_in_caller)
+                        .ok_or_else(|| {
+                            ic_msg!(
+                                invoke_context,
+                                "Internal error: index mismatch for account {}",
+                                account_key
+                            );
+                            SyscallError::InstructionError(InstructionError::MissingAccount)
+                        })?;
                     Some(caller_account)
                 } else {
                     None

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -83,7 +83,7 @@ fn create_accounts() -> (
     let mut instruction_accounts = (0..4)
         .map(|index_in_instruction| InstructionAccount {
             index_in_transaction: 1usize.saturating_add(index_in_instruction),
-            index_in_caller: 1usize.saturating_add(index_in_instruction),
+            index_in_caller: index_in_instruction,
             index_in_callee: index_in_instruction,
             is_signer: false,
             is_writable: false,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -133,7 +133,7 @@ impl MessageProcessor {
                 let index_in_transaction = *index_in_transaction as usize;
                 instruction_accounts.push(InstructionAccount {
                     index_in_transaction,
-                    index_in_caller: program_indices.len().saturating_add(index_in_transaction),
+                    index_in_caller: index_in_transaction,
                     index_in_callee,
                     is_signer: message.is_signer(index_in_transaction),
                     is_writable: message.is_writable(index_in_transaction),

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -25,7 +25,7 @@ pub struct InstructionAccount {
     pub index_in_transaction: usize,
     /// Points to the first occurrence in the parent `InstructionContext`
     ///
-    /// This includes the program accounts.
+    /// This excludes the program accounts.
     pub index_in_caller: usize,
     /// Points to the first occurrence in the current `InstructionContext`
     ///


### PR DESCRIPTION
#### Problem
`index_in_caller` is shifted by the length of the executable chain, even though `InstructionAccount` can't access them.
For the sake of simplicity and consistency with `index_in_callee` the index should be shifted down to start at `0`.

#### Summary of Changes
Subtracts the offset `InstructionContext::get_number_of_program_accounts()` from `InstructionAccount::index_in_caller`.
