### PR TITLE
Refactor: Remove `visit_each_account_once()`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -378,22 +378,20 @@ impl<'a> InvokeContext<'a> {
                     continue; // Skip duplicate account
                 }
                 if instruction_account.index_in_transaction
-                    < self.transaction_context.get_number_of_accounts()
+                    >= self.transaction_context.get_number_of_accounts()
                 {
-                    let account = self
-                        .transaction_context
-                        .get_account_at_index(instruction_account.index_in_transaction)?
-                        .borrow()
-                        .clone();
-                    self.pre_accounts.push(PreAccount::new(
-                        self.transaction_context.get_key_of_account_at_index(
-                            instruction_account.index_in_transaction,
-                        )?,
-                        account,
-                    ));
-                    continue;
+                    return Err(InstructionError::MissingAccount);
                 }
-                return Err(InstructionError::MissingAccount);
+                let account = self
+                    .transaction_context
+                    .get_account_at_index(instruction_account.index_in_transaction)?
+                    .borrow()
+                    .clone();
+                self.pre_accounts.push(PreAccount::new(
+                    self.transaction_context
+                        .get_key_of_account_at_index(instruction_account.index_in_transaction)?,
+                    account,
+                ));
             }
         } else {
             let contains = (0..self
@@ -594,9 +592,7 @@ impl<'a> InvokeContext<'a> {
 
         // Verify the per-account instruction results
         let (mut pre_sum, mut post_sum) = (0_u128, 0_u128);
-        'outer_loop: for (index_in_instruction, instruction_account) in
-            instruction_accounts.iter().enumerate()
-        {
+        for (index_in_instruction, instruction_account) in instruction_accounts.iter().enumerate() {
             if index_in_instruction != instruction_account.index_in_callee {
                 continue; // Skip duplicate account
             }
@@ -666,7 +662,7 @@ impl<'a> InvokeContext<'a> {
                                 .adjust_delta_unchecked(data_len_delta);
                         }
 
-                        continue 'outer_loop;
+                        break;
                     }
                 }
             }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -481,6 +481,9 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Verify the results of an instruction
+    ///
+    /// Note: `instruction_accounts` must be the same as passed to `InvokeContext::push()`,
+    /// so that they match the order of `pre_accounts`.
     fn verify(
         &mut self,
         instruction_accounts: &[InstructionAccount],
@@ -573,6 +576,9 @@ impl<'a> InvokeContext<'a> {
     }
 
     /// Verify and update PreAccount state based on program execution
+    ///
+    /// Note: `instruction_accounts` must be the same as passed to `InvokeContext::push()`,
+    /// so that they match the order of `pre_accounts`.
     fn verify_and_update(
         &mut self,
         instruction_accounts: &[InstructionAccount],

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -736,7 +736,8 @@ impl<'a> InvokeContext<'a> {
     ) -> Result<(Vec<InstructionAccount>, Vec<usize>), InstructionError> {
         // Finds the index of each account in the instruction by its pubkey.
         // Then normalizes / unifies the privileges of duplicate accounts.
-        // Note: This works like visit_each_account_once() and is an O(n^2) algorithm too.
+        // Note: This is an O(n^2) algorithm,
+        // but performed on a very small slice and requires no heap allocations.
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
         let mut deduplicated_instruction_accounts: Vec<InstructionAccount> = Vec::new();
         let mut duplicate_indicies = Vec::with_capacity(instruction.accounts.len());
@@ -1260,32 +1261,6 @@ pub fn mock_process_instruction(
     transaction_accounts
 }
 
-/// Visit each unique instruction account index once
-pub fn visit_each_account_once<E>(
-    instruction_accounts: &[InstructionAccount],
-    work: &mut dyn FnMut(usize, &InstructionAccount) -> Result<(), E>,
-    inner_error: E,
-) -> Result<(), E> {
-    // Note: This is an O(n^2) algorithm,
-    // but performed on a very small slice and requires no heap allocations
-    'root: for (index, instruction_account) in instruction_accounts.iter().enumerate() {
-        match instruction_accounts.get(..index) {
-            Some(range) => {
-                for (before_index, before) in range.iter().enumerate() {
-                    if before.index_in_transaction == instruction_account.index_in_transaction {
-                        debug_assert_eq!(before_index, instruction_account.index_in_callee);
-                        continue 'root; // skip dups
-                    }
-                }
-                debug_assert_eq!(index, instruction_account.index_in_callee);
-                work(index, instruction_account)?;
-            }
-            None => return Err(inner_error),
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -1309,59 +1284,6 @@ mod tests {
         Resize {
             new_len: usize,
         },
-    }
-
-    #[test]
-    fn test_visit_each_account_once() {
-        let do_work = |accounts: &[InstructionAccount]| -> (usize, usize, usize) {
-            let mut unique_entries = 0;
-            let mut index_sum_a = 0;
-            let mut index_sum_b = 0;
-            let mut work = |index_in_instruction: usize, entry: &InstructionAccount| {
-                unique_entries += 1;
-                index_sum_a += index_in_instruction;
-                index_sum_b += entry.index_in_transaction;
-                Ok(())
-            };
-            visit_each_account_once(accounts, &mut work, InstructionError::NotEnoughAccountKeys)
-                .unwrap();
-
-            (unique_entries, index_sum_a, index_sum_b)
-        };
-
-        assert_eq!(
-            (3, 3, 19),
-            do_work(&[
-                InstructionAccount {
-                    index_in_transaction: 7,
-                    index_in_caller: 0,
-                    index_in_callee: 0,
-                    is_signer: false,
-                    is_writable: false,
-                },
-                InstructionAccount {
-                    index_in_transaction: 3,
-                    index_in_caller: 1,
-                    index_in_callee: 1,
-                    is_signer: false,
-                    is_writable: false,
-                },
-                InstructionAccount {
-                    index_in_transaction: 9,
-                    index_in_caller: 2,
-                    index_in_callee: 2,
-                    is_signer: false,
-                    is_writable: false,
-                },
-                InstructionAccount {
-                    index_in_transaction: 3,
-                    index_in_caller: 1,
-                    index_in_callee: 1,
-                    is_signer: false,
-                    is_writable: false,
-                },
-            ])
-        );
     }
 
     #[test]

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2968,73 +2968,70 @@ where
         if index_in_instruction != instruction_account.index_in_callee {
             continue; // Skip duplicate account
         }
-            let account = invoke_context
-                .transaction_context
-                .get_account_at_index(instruction_account.index_in_transaction)
-                .map_err(SyscallError::InstructionError)?;
-            let account_key = invoke_context
-                .transaction_context
-                .get_key_of_account_at_index(instruction_account.index_in_transaction)
-                .map_err(SyscallError::InstructionError)?;
-            if account.borrow().executable() {
-                // Use the known account
-                if invoke_context
-                    .feature_set
-                    .is_active(&executables_incur_cpi_data_cost::id())
-                {
-                    invoke_context
-                        .get_compute_meter()
-                        .consume((account.borrow().data().len() as u64).saturating_div(
-                            invoke_context.get_compute_budget().cpi_bytes_per_unit,
-                        ))?;
-                }
-                accounts.push((instruction_account.index_in_transaction, None));
-            } else if let Some(caller_account_index) =
-                account_info_keys.iter().position(|key| *key == account_key)
+        let account = invoke_context
+            .transaction_context
+            .get_account_at_index(instruction_account.index_in_transaction)
+            .map_err(SyscallError::InstructionError)?;
+        let account_key = invoke_context
+            .transaction_context
+            .get_key_of_account_at_index(instruction_account.index_in_transaction)
+            .map_err(SyscallError::InstructionError)?;
+        if account.borrow().executable() {
+            // Use the known account
+            if invoke_context
+                .feature_set
+                .is_active(&executables_incur_cpi_data_cost::id())
             {
-                let mut caller_account = do_translate(
-                    account_infos
-                        .get(caller_account_index)
-                        .ok_or(SyscallError::InvalidLength)?,
-                    invoke_context,
+                invoke_context.get_compute_meter().consume(
+                    (account.borrow().data().len() as u64)
+                        .saturating_div(invoke_context.get_compute_budget().cpi_bytes_per_unit),
                 )?;
-                {
-                    let mut account = account.borrow_mut();
-                    account.copy_into_owner_from_slice(caller_account.owner.as_ref());
-                    account.set_data_from_slice(caller_account.data);
-                    account.set_lamports(*caller_account.lamports);
-                    account.set_executable(caller_account.executable);
-                    account.set_rent_epoch(caller_account.rent_epoch);
-                }
-                let caller_account = if instruction_account.is_writable {
-                    let orig_data_lens = invoke_context
-                        .get_orig_account_lengths()
-                        .map_err(SyscallError::InstructionError)?;
-                    caller_account.original_data_len = *orig_data_lens
-                        .get(instruction_account.index_in_caller)
-                        .ok_or_else(|| {
-                            ic_msg!(
-                                invoke_context,
-                                "Internal error: index mismatch for account {}",
-                                account_key
-                            );
-                            SyscallError::InstructionError(InstructionError::MissingAccount)
-                        })?;
-                    Some(caller_account)
-                } else {
-                    None
-                };
-                accounts.push((instruction_account.index_in_transaction, caller_account));
-            } else {
-                ic_msg!(
-                    invoke_context,
-                    "Instruction references an unknown account {}",
-                    account_key
-                );
-                return Err(
-                    SyscallError::InstructionError(InstructionError::MissingAccount).into(),
-                );
             }
+            accounts.push((instruction_account.index_in_transaction, None));
+        } else if let Some(caller_account_index) =
+            account_info_keys.iter().position(|key| *key == account_key)
+        {
+            let mut caller_account = do_translate(
+                account_infos
+                    .get(caller_account_index)
+                    .ok_or(SyscallError::InvalidLength)?,
+                invoke_context,
+            )?;
+            {
+                let mut account = account.borrow_mut();
+                account.copy_into_owner_from_slice(caller_account.owner.as_ref());
+                account.set_data_from_slice(caller_account.data);
+                account.set_lamports(*caller_account.lamports);
+                account.set_executable(caller_account.executable);
+                account.set_rent_epoch(caller_account.rent_epoch);
+            }
+            let caller_account = if instruction_account.is_writable {
+                let orig_data_lens = invoke_context
+                    .get_orig_account_lengths()
+                    .map_err(SyscallError::InstructionError)?;
+                caller_account.original_data_len = *orig_data_lens
+                    .get(instruction_account.index_in_caller)
+                    .ok_or_else(|| {
+                        ic_msg!(
+                            invoke_context,
+                            "Internal error: index mismatch for account {}",
+                            account_key
+                        );
+                        SyscallError::InstructionError(InstructionError::MissingAccount)
+                    })?;
+                Some(caller_account)
+            } else {
+                None
+            };
+            accounts.push((instruction_account.index_in_transaction, caller_account));
+        } else {
+            ic_msg!(
+                invoke_context,
+                "Instruction references an unknown account {}",
+                account_key
+            );
+            return Err(SyscallError::InstructionError(InstructionError::MissingAccount).into());
+        }
     }
 
     Ok(accounts)


### PR DESCRIPTION
#### Problem
Continuation of #25490.

#### Summary of Changes
- Removes `is_duplicate()`. (Fixes #25416)
- Removes `visit_each_account_once()`.
- Adds comments to clarify the order of `pre_accounts` and `instruction_accounts`. (Fixes #25421)
