### PR TITLE
Remove unwrap in `range_scan_accounts()`

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3584,6 +3584,7 @@ impl AccountsDb {
         collector
     }
 
+    /// Only guaranteed to be safe when called from rent collection
     pub fn range_scan_accounts<F, A, R>(
         &self,
         metric_name: &'static str,
@@ -3613,12 +3614,13 @@ impl AccountsDb {
                 // meaning no other subsystems can invalidate the account_info before making their
                 // changes to the index entry.
                 // For details, see the comment in retry_to_get_account_accessor()
-                let account_slot = self
+                if let Some(account_slot) = self
                     .get_account_accessor(slot, pubkey, &account_info.storage_location())
                     .get_loaded_account()
                     .map(|loaded_account| (pubkey, loaded_account.take_account(), slot))
-                    .unwrap();
-                scan_func(&mut collector, Some(account_slot))
+                {
+                    scan_func(&mut collector, Some(account_slot))
+                }
             },
         );
         collector

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1140,6 +1140,7 @@ impl<T: IndexValue> AccountsIndex<T> {
     }
 
     /// call func with every pubkey and index visible from a given set of ancestors with range
+    /// Only guaranteed to be safe when called from rent collection
     pub(crate) fn range_scan_accounts<F, R>(
         &self,
         metric_name: &'static str,


### PR DESCRIPTION
#### Problem
https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_db.rs#L3620 panics

The iterator works as follows:
1. The bin lock is grabbed and a chunk of pubkeys is returned here https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_index.rs#L593. The bin lock is released.
2. The pubkey list is returned here https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_index.rs#L991
3. The lock for the list is grabbed here: https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_index.rs#L997 for a lookup
4. Closure is then applied to the results of the lookup here: https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_index.rs#L1005

Between 2 and 3 however, the key could have been deleted by AccountsBackgroundService, which then causes the closure with the unwrap() https://github.com/jeffwashington/solana/blob/701925352432889d3580f41e29a55d98e6c89897/runtime/src/accounts_db.rs#L3620  to panic

#### Summary of Changes
Because this range scan is only used in rent collection which doesn't set any new roots, any deleted pubkeys should be irrelevant to rent collection, thus it should be safe to ignore deleted keys and not panic.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
