### PR TITLE
Fix a possible test hang in runtime::test_shared_buffer_sweep

### DIFF
--- a/runtime/src/shared_buffer_reader.rs
+++ b/runtime/src/shared_buffer_reader.rs
@@ -844,7 +844,12 @@ pub mod tests {
 
                             let parallel_reader = reader_ct > 2;
                             let handle = if parallel_reader {
-                                let threads = 8;
+                                let mut threads = 8;
+                                // Avoid to create more than the number of threads available in the
+                                // current rayon threadpool. Deadlock could happen otherwise.
+                                if threads > rayon::current_num_threads() {
+                                    threads = rayon::current_num_threads();
+                                }
                                 Some({
                                     let parallel = (0..threads)
                                         .into_iter()

--- a/runtime/src/shared_buffer_reader.rs
+++ b/runtime/src/shared_buffer_reader.rs
@@ -844,12 +844,9 @@ pub mod tests {
 
                             let parallel_reader = reader_ct > 2;
                             let handle = if parallel_reader {
-                                let mut threads = 8;
                                 // Avoid to create more than the number of threads available in the
                                 // current rayon threadpool. Deadlock could happen otherwise.
-                                if threads > rayon::current_num_threads() {
-                                    threads = rayon::current_num_threads();
-                                }
+                                let threads = std::cmp::min(8, rayon::current_num_threads());
                                 Some({
                                     let parallel = (0..threads)
                                         .into_iter()


### PR DESCRIPTION
#### Problem

The test may hang if the total number of threads it wants to start
is greater than the number of threads configured in the rayon
threadpool. 

#### Summary of Changes

Check to avoid this situation from happening.

Fixes #