### PR TITLE
zk-token-sdk: Convert traits for elgamal ciphertexts and ristretto points

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -1,12 +1,48 @@
-use super::pod;
 pub use target_arch::*;
+use {super::pod, crate::curve25519::ristretto::PodRistrettoPoint};
 
 impl From<(pod::PedersenCommitment, pod::DecryptHandle)> for pod::ElGamalCiphertext {
-    fn from((comm, decrypt_handle): (pod::PedersenCommitment, pod::DecryptHandle)) -> Self {
+    fn from((commitment, handle): (pod::PedersenCommitment, pod::DecryptHandle)) -> Self {
         let mut buf = [0_u8; 64];
-        buf[..32].copy_from_slice(&comm.0);
-        buf[32..].copy_from_slice(&decrypt_handle.0);
+        buf[..32].copy_from_slice(&commitment.0);
+        buf[32..].copy_from_slice(&handle.0);
         pod::ElGamalCiphertext(buf)
+    }
+}
+
+impl From<pod::ElGamalCiphertext> for (pod::PedersenCommitment, pod::DecryptHandle) {
+    fn from(ciphertext: pod::ElGamalCiphertext) -> Self {
+        let commitment: [u8; 32] = ciphertext.0[..32].try_into().unwrap();
+        let handle: [u8; 32] = ciphertext.0[32..].try_into().unwrap();
+
+        (
+            pod::PedersenCommitment(commitment),
+            pod::DecryptHandle(handle),
+        )
+    }
+}
+
+impl From<pod::PedersenCommitment> for PodRistrettoPoint {
+    fn from(commitment: pod::PedersenCommitment) -> Self {
+        PodRistrettoPoint(commitment.0)
+    }
+}
+
+impl From<PodRistrettoPoint> for pod::PedersenCommitment {
+    fn from(point: PodRistrettoPoint) -> Self {
+        pod::PedersenCommitment(point.0)
+    }
+}
+
+impl From<pod::DecryptHandle> for PodRistrettoPoint {
+    fn from(handle: pod::DecryptHandle) -> Self {
+        PodRistrettoPoint(handle.0)
+    }
+}
+
+impl From<PodRistrettoPoint> for pod::DecryptHandle {
+    fn from(point: PodRistrettoPoint) -> Self {
+        pod::DecryptHandle(point.0)
     }
 }
 


### PR DESCRIPTION
#### Summary of Changes

Implementing standard `From` traits for converting between `ElGamalCiphertext` and `PodRistrettoPoint` types. This will simplifiy the syscall ciphertext arithmetic in applications such as spl.