### PR TITLE
Handle transaction forwarding using QUIC

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -235,6 +235,10 @@ impl ConnectionMap {
     pub fn set_use_quic(&mut self, use_quic: bool) {
         self.use_quic = use_quic;
     }
+
+    pub fn get_use_quic(&self) -> bool {
+        self.use_quic
+    }
 }
 
 lazy_static! {
@@ -244,6 +248,11 @@ lazy_static! {
 pub fn set_use_quic(use_quic: bool) {
     let mut map = (*CONNECTION_MAP).write().unwrap();
     map.set_use_quic(use_quic);
+}
+
+pub fn get_use_quic() -> bool {
+    let map = (*CONNECTION_MAP).read().unwrap();
+    map.get_use_quic()
 }
 
 struct GetConnectionResult {

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -210,7 +210,7 @@ impl ThinClient {
                 if num_confirmed == 0 {
                     let conn = get_connection(self.tpu_addr());
                     // Send the transaction if there has been no confirmation (e.g. the first time)
-                    conn.send_wire_transaction(&wire_transaction)?;
+                    conn.send_wire_transaction_async(wire_transaction.clone())?;
                 }
 
                 if let Ok(confirmed_blocks) = self.poll_for_signature_confirmation(

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -35,14 +35,7 @@ pub trait TpuConnection {
     ) -> TransportResult<()> {
         let wire_transaction =
             bincode::serialize(transaction).expect("serialize Transaction in send_batch");
-        self.send_wire_transaction(&wire_transaction)
-    }
-
-    fn send_wire_transaction<T>(&self, wire_transaction: T) -> TransportResult<()>
-    where
-        T: AsRef<[u8]>,
-    {
-        self.send_wire_transaction_batch(&[wire_transaction])
+        self.send_wire_transaction_async(wire_transaction)
     }
 
     fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()>;
@@ -56,12 +49,12 @@ pub trait TpuConnection {
             .map(|tx| bincode::serialize(&tx).expect("serialize Transaction in send_batch"))
             .collect::<Vec<_>>();
 
-        self.send_wire_transaction_batch(&buffers)
+        self.send_wire_transaction_batch_async(buffers)
     }
 
-    fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
-    where
-        T: AsRef<[u8]>;
-
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()>;
+
+    fn forward_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
+        self.send_wire_transaction_batch_async(buffers)
+    }
 }

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -43,14 +43,6 @@ impl TpuConnection for UdpTpuConnection {
         Ok(())
     }
 
-    fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
-    where
-        T: AsRef<[u8]>,
-    {
-        let pkts: Vec<_> = buffers.iter().zip(repeat(self.tpu_addr())).collect();
-        batch_send(&self.socket, &pkts)?;
-        Ok(())
-    }
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let pkts: Vec<_> = buffers.into_iter().zip(repeat(self.tpu_addr())).collect();
         batch_send(&self.socket, &pkts)?;

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -32,6 +32,7 @@ mod tests {
             s.try_clone().unwrap(),
             &keypair,
             ip,
+            sender.clone(),
             sender,
             exit.clone(),
             1,

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -5,9 +5,12 @@ use {
         banking_stage::HOLD_TRANSACTIONS_SLOT_OFFSET,
         result::{Error, Result},
     },
-    crossbeam_channel::{unbounded, RecvTimeoutError},
+    crossbeam_channel::{unbounded, RecvTimeoutError, Sender},
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
-    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
+    solana_perf::{
+        packet::{PacketBatch, PacketBatchRecycler},
+        recycler::Recycler,
+    },
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{
         clock::DEFAULT_TICKS_PER_SLOT,
@@ -29,6 +32,7 @@ use {
 
 pub struct FetchStage {
     thread_hdls: Vec<JoinHandle<()>>,
+    pub forward_sender: Sender<PacketBatch>,
 }
 
 impl FetchStage {
@@ -240,6 +244,7 @@ impl FetchStage {
             .into_iter()
             .flatten()
             .collect(),
+            forward_sender,
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -150,6 +150,7 @@ impl Tpu {
             keypair,
             cluster_info.my_contact_info().tpu.ip(),
             packet_sender,
+            fetch_stage.forward_sender.clone(),
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_IP,
             staked_nodes,

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -49,7 +49,7 @@ impl WarmQuicCacheService {
                                 .lookup_contact_info(&leader_pubkey, |leader| leader.tpu)
                             {
                                 let conn = get_connection(&addr);
-                                if let Err(err) = conn.send_wire_transaction(&[0u8]) {
+                                if let Err(err) = conn.send_wire_transaction_async(vec![0u8]) {
                                     warn!(
                                         "Failed to warmup QUIC connection to the leader {:?}, Error {:?}",
                                         leader_pubkey, err

--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -6,3 +6,6 @@ pub const QUIC_MAX_CONCURRENT_STREAMS: usize = 2048;
 
 pub const QUIC_MAX_TIMEOUT_MS: u32 = 2_000;
 pub const QUIC_KEEP_ALIVE_MS: u64 = 1_000;
+
+pub const QUIC_FORWARDED_PACKET: u8 = 0b0000_0010;
+pub const QUIC_NOT_FORWARDED_PACKET: u8 = 0;


### PR DESCRIPTION
#### Problem
The transactions forwarded using QUIC are getting dropped.

#### Summary of Changes
1. Add a flag to packets transmitted over QUIC to identify if it is a forwarded packet
2. On receiving a packet in QUIC streamer, check if the packet was forwarded. If it was, send it to the forward handler thread.
3. Remove non-async functions from the client APIs, as these APIs were not being used, and adding the extra flag to a slice was an expensive operation.
4. Fix forwarding of vote transactions

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
