### PR TITLE
removes raw indexing into packet data

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -37,7 +37,8 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         for p in packet_batch.iter() {
             let a = p.meta.socket_addr();
             assert!(p.meta.size <= PACKET_DATA_SIZE);
-            send.send_to(p.data(), &a).unwrap();
+            let data = p.data(..).unwrap_or_default();
+            send.send_to(data, &a).unwrap();
             num += 1;
         }
         assert_eq!(num, 10);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -541,7 +541,7 @@ impl BankingStage {
             .iter()
             .filter_map(|p| {
                 if !p.meta.forwarded() && data_budget.take(p.meta.size) {
-                    Some(p.data().to_vec())
+                    Some(p.data(..)?.to_vec())
                 } else {
                     None
                 }

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -26,7 +26,7 @@ impl Default for PacketHasher {
 
 impl PacketHasher {
     pub(crate) fn hash_packet(&self, packet: &Packet) -> u64 {
-        self.hash_data(packet.data())
+        self.hash_data(packet.data(..).unwrap_or_default())
     }
 
     pub(crate) fn hash_shred(&self, shred: &Shred) -> u64 {

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -814,7 +814,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|p| {
                     assert_eq!(repair_response::nonce(p).unwrap(), nonce);
-                    Shred::new_from_serialized_shred(p.data().to_vec()).ok()
+                    Shred::new_from_serialized_shred(p.data(..).unwrap().to_vec()).ok()
                 })
                 .collect();
             assert!(!rv.is_empty());
@@ -898,7 +898,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|p| {
                     assert_eq!(repair_response::nonce(p).unwrap(), nonce);
-                    Shred::new_from_serialized_shred(p.data().to_vec()).ok()
+                    Shred::new_from_serialized_shred(p.data(..).unwrap().to_vec()).ok()
                 })
                 .collect();
             assert_eq!(rv[0].index(), 1);
@@ -1347,7 +1347,7 @@ mod tests {
 
     fn verify_responses<'a>(request: &ShredRepairType, packets: impl Iterator<Item = &'a Packet>) {
         for packet in packets {
-            let shred_payload = packet.data().to_vec();
+            let shred_payload = packet.data(..).unwrap().to_vec();
             let shred = Shred::new_from_serialized_shred(shred_payload).unwrap();
             request.verify_response(&shred);
         }

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -368,12 +368,14 @@ pub fn deserialize_packets<'a>(
 
 /// Read the transaction message from packet data
 pub fn packet_message(packet: &Packet) -> Result<&[u8], DeserializedPacketError> {
-    let (sig_len, sig_size) =
-        decode_shortu16_len(packet.data()).map_err(DeserializedPacketError::ShortVecError)?;
+    let (sig_len, sig_size) = packet
+        .data(..)
+        .and_then(|bytes| decode_shortu16_len(bytes).ok())
+        .ok_or(DeserializedPacketError::ShortVecError(()))?;
     sig_len
         .checked_mul(size_of::<Signature>())
         .and_then(|v| v.checked_add(sig_size))
-        .and_then(|msg_start| packet.data().get(msg_start..))
+        .and_then(|msg_start| packet.data(msg_start..))
         .ok_or(DeserializedPacketError::SignatureOverflowed(sig_size))
 }
 

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -363,7 +363,7 @@ where
             inc_new_counter_debug!("streamer-recv_window-invalid_or_unnecessary_packet", 1);
             return None;
         }
-        let serialized_shred = packet.data().to_vec();
+        let serialized_shred = packet.data(..)?.to_vec();
         let shred = Shred::new_from_serialized_shred(serialized_shred).ok()?;
         if !shred_filter(&shred, working_bank.clone(), last_root) {
             return None;

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -260,7 +260,7 @@ pub fn cluster_info_retransmit() {
     let retransmit_peers: Vec<_> = peers.iter().collect();
     retransmit_to(
         &retransmit_peers,
-        p.data(),
+        p.data(..).unwrap(),
         &tn1,
         false,
         &SocketAddrSpace::Unspecified,

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -281,7 +281,7 @@ fn sign_shred_cpu(keypair: &Keypair, packet: &mut Packet) {
         packet.meta.size >= sig.end,
         "packet is not large enough for a signature"
     );
-    let signature = keypair.sign_message(&packet.data()[msg]);
+    let signature = keypair.sign_message(packet.data(msg).unwrap());
     trace!("signature {:?}", signature);
     packet.buffer_mut()[sig].copy_from_slice(signature.as_ref());
 }

--- a/streamer/src/nonblocking/sendmmsg.rs
+++ b/streamer/src/nonblocking/sendmmsg.rs
@@ -138,9 +138,13 @@ mod tests {
 
         let packet = Packet::default();
 
-        let sent = multi_target_send(&sender, packet.data(), &[&addr, &addr2, &addr3, &addr4])
-            .await
-            .ok();
+        let sent = multi_target_send(
+            &sender,
+            packet.data(..).unwrap(),
+            &[&addr, &addr2, &addr3, &addr4],
+        )
+        .await
+        .ok();
         assert_eq!(sent, Some(()));
 
         let mut packets = vec![Packet::default(); 32];

--- a/streamer/src/packet.rs
+++ b/streamer/src/packet.rs
@@ -67,7 +67,9 @@ pub fn send_to(
     for p in batch.iter() {
         let addr = p.meta.socket_addr();
         if socket_addr_space.check(&addr) {
-            socket.send_to(p.data(), &addr)?;
+            if let Some(data) = p.data(..) {
+                socket.send_to(data, &addr)?;
+            }
         }
     }
     Ok(())

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -242,7 +242,12 @@ mod tests {
 
         let packet = Packet::default();
 
-        let sent = multi_target_send(&sender, packet.data(), &[&addr, &addr2, &addr3, &addr4]).ok();
+        let sent = multi_target_send(
+            &sender,
+            packet.data(..).unwrap(),
+            &[&addr, &addr2, &addr3, &addr4],
+        )
+        .ok();
         assert_eq!(sent, Some(()));
 
         let mut packets = vec![Packet::default(); 32];

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -279,7 +279,7 @@ impl StreamerSendStats {
     fn record(&mut self, pkt: &Packet) {
         let ent = self.host_map.entry(pkt.meta.addr).or_default();
         ent.count += 1;
-        ent.bytes += pkt.data().len() as u64;
+        ent.bytes += pkt.data(..).map(<[u8]>::len).unwrap_or_default() as u64;
     }
 }
 
@@ -296,7 +296,8 @@ fn recv_send(
     }
     let packets = packet_batch.iter().filter_map(|pkt| {
         let addr = pkt.meta.socket_addr();
-        socket_addr_space.check(&addr).then(|| (pkt.data(), addr))
+        let data = pkt.data(..)?;
+        socket_addr_space.check(&addr).then(|| (data, addr))
     });
     batch_send(sock, &packets.collect::<Vec<_>>())?;
     Ok(())


### PR DESCRIPTION
#### Problem
Packets are at the boundary of the system where, vast majority of the
time, they are received from an untrusted source. Raw indexing into the
data buffer can open attack vectors if the offsets are invalid.
Validating offsets beforehand is verbose and error prone.



#### Summary of Changes
The commit updates `Packet::data()` api to take a `SliceIndex` and always to
return an `Option`. The call-sites are so forced to explicitly handle the
case where the offsets are invalid.
