### PR TITLE
Opt: optimize dedup hash filter reset

### DIFF
--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -1,0 +1,41 @@
+#![feature(test)]
+
+extern crate test;
+
+use {
+    std::sync::atomic::{AtomicU64, Ordering},
+    test::Bencher,
+};
+
+const N: usize = 1000_000;
+
+// test bench_reset1 ... bench:     436,240 ns/iter (+/- 176,714)
+// test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
+#[bench]
+fn bench_reset1(bencher: &mut Bencher) {
+    solana_logger::setup();
+
+    let mut v = Vec::with_capacity(N);
+    v.resize_with(N, AtomicU64::default);
+
+    bencher.iter(|| {
+        test::black_box(for i in &v {
+            i.store(0, Ordering::Relaxed);
+        });
+    });
+}
+
+#[bench]
+fn bench_reset2(bencher: &mut Bencher) {
+    solana_logger::setup();
+
+    let mut v = Vec::with_capacity(N);
+    v.resize_with(N, AtomicU64::default);
+
+    bencher.iter(|| {
+        test::black_box({
+            v.clear();
+            v.resize_with(N, AtomicU64::default);
+        });
+    });
+}

--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -13,7 +13,6 @@ const N: usize = 1_000_000;
 // test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
 
 #[bench]
-#[allow(clippy::unit_arg)]
 fn bench_reset1(bencher: &mut Bencher) {
     solana_logger::setup();
 
@@ -21,14 +20,16 @@ fn bench_reset1(bencher: &mut Bencher) {
     v.resize_with(N, AtomicU64::default);
 
     bencher.iter(|| {
-        test::black_box(for i in &v {
-            i.store(0, Ordering::Relaxed);
+        test::black_box({
+            for i in &v {
+                i.store(0, Ordering::Relaxed);
+            }
+            0
         });
     });
 }
 
 #[bench]
-#[allow(clippy::unit_arg)]
 fn bench_reset2(bencher: &mut Bencher) {
     solana_logger::setup();
 
@@ -39,6 +40,7 @@ fn bench_reset2(bencher: &mut Bencher) {
         test::black_box({
             v.clear();
             v.resize_with(N, AtomicU64::default);
+            0
         });
     });
 }

--- a/perf/benches/reset.rs
+++ b/perf/benches/reset.rs
@@ -7,11 +7,13 @@ use {
     test::Bencher,
 };
 
-const N: usize = 1000_000;
+const N: usize = 1_000_000;
 
 // test bench_reset1 ... bench:     436,240 ns/iter (+/- 176,714)
 // test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
+
 #[bench]
+#[allow(clippy::unit_arg)]
 fn bench_reset1(bencher: &mut Bencher) {
     solana_logger::setup();
 
@@ -26,6 +28,7 @@ fn bench_reset1(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[allow(clippy::unit_arg)]
 fn bench_reset2(bencher: &mut Bencher) {
     solana_logger::setup();
 

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -476,9 +476,9 @@ impl Deduper {
         //false positive rate is 1/1000 at that point
         let saturated = self.saturated.load(Ordering::Relaxed);
         if saturated || now.duration_since(self.age) > self.max_age {
-            for i in &self.filter {
-                i.store(0, Ordering::Relaxed);
-            }
+            let len = self.filter.len();
+            self.filter.clear();
+            self.filter.resize_with(len, AtomicU64::default);
             self.seed = thread_rng().gen();
             self.age = now;
             self.saturated.store(false, Ordering::Relaxed);

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -485,17 +485,23 @@ impl Deduper {
         }
     }
 
+    /// Compute hash from packet data, returns (hash, bin_pos).
+    fn compute_hash(&self, packet: &Packet) -> (u64, usize) {
+        let mut hasher = AHasher::new_with_keys(self.seed.0, self.seed.1);
+        hasher.write(&packet.data[0..packet.meta.size]);
+        let h = hasher.finish();
+        let len = self.filter.len();
+        let pos = (usize::try_from(h).unwrap()).wrapping_rem(len);
+        (h, pos)
+    }
+
     // Deduplicates packets and returns 1 if packet is to be discarded. Else, 0.
     fn dedup_packet(&self, packet: &mut Packet) -> u64 {
         // If this packet was already marked as discard, drop it
         if packet.meta.discard() {
             return 1;
         }
-        let mut hasher = AHasher::new_with_keys(self.seed.0, self.seed.1);
-        hasher.write(&packet.data[0..packet.meta.size]);
-        let hash = hasher.finish();
-        let len = self.filter.len();
-        let pos = (usize::try_from(hash).unwrap()).wrapping_rem(len);
+        let (hash, pos) = self.compute_hash(packet);
         // saturate each position with or
         let prev = self.filter[pos].fetch_or(hash, Ordering::Relaxed);
         if prev == u64::MAX {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -485,23 +485,17 @@ impl Deduper {
         }
     }
 
-    /// Compute hash from packet data, returns (hash, bin_pos).
-    fn compute_hash(&self, packet: &Packet) -> (u64, usize) {
-        let mut hasher = AHasher::new_with_keys(self.seed.0, self.seed.1);
-        hasher.write(&packet.data[0..packet.meta.size]);
-        let h = hasher.finish();
-        let len = self.filter.len();
-        let pos = (usize::try_from(h).unwrap()).wrapping_rem(len);
-        (h, pos)
-    }
-
     // Deduplicates packets and returns 1 if packet is to be discarded. Else, 0.
     fn dedup_packet(&self, packet: &mut Packet) -> u64 {
         // If this packet was already marked as discard, drop it
         if packet.meta.discard() {
             return 1;
         }
-        let (hash, pos) = self.compute_hash(packet);
+        let mut hasher = AHasher::new_with_keys(self.seed.0, self.seed.1);
+        hasher.write(&packet.data[0..packet.meta.size]);
+        let hash = hasher.finish();
+        let len = self.filter.len();
+        let pos = (usize::try_from(hash).unwrap()).wrapping_rem(len);
         // saturate each position with or
         let prev = self.filter[pos].fetch_or(hash, Ordering::Relaxed);
         if prev == u64::MAX {


### PR DESCRIPTION
#### Problem

Looping over 1m AtomicU64 during reset is inefficient. 
Instead, "clear and resize" are more efficient. 


#### Summary of Changes
Use "clear and resize" to reset dedup filters.

```
// test bench_reset1 ... bench:     436,240 ns/iter (+/- 176,714)
// test bench_reset2 ... bench:     274,007 ns/iter (+/- 129,552)
```


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
