### PR TITLE
Slightly refactor start_verify_transactions to avoid an unnecessary loop through the vector.

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -501,7 +501,7 @@ pub fn start_verify_transactions(
                     // We use set_len here instead of resize(vec_size, Packet::default()), to save
                     // memory bandwidth and avoid writing a large amount of data that will be overwritten
                     // soon afterwards. As well, Packet::default() actually leaves the packet data
-                    // uninitialized anyway, so the initilization would simply write junk into
+                    // uninitialized, so the initialization would simply write junk into
                     // the vector anyway.
                     unsafe {
                         packet_batch.set_len(vec_size);

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -473,24 +473,6 @@ pub fn start_verify_transactions(
     let entries = verify_transactions(entries, Arc::new(verify_func));
     match entries {
         Ok(entries) => {
-            let num_transactions: usize = entries
-                .iter()
-                .map(|entry: &EntryType| -> usize {
-                    match entry {
-                        EntryType::Transactions(transactions) => transactions.len(),
-                        EntryType::Tick(_) => 0,
-                    }
-                })
-                .sum();
-
-            if num_transactions == 0 {
-                return Ok(EntrySigVerificationState {
-                    verification_status: EntryVerificationStatus::Success,
-                    entries: Some(entries),
-                    device_verification_data: DeviceSigVerificationData::Cpu(),
-                    gpu_verify_duration_us: 0,
-                });
-            }
             let entry_txs: Vec<&SanitizedTransaction> = entries
                 .iter()
                 .filter_map(|entry_type| match entry_type {
@@ -499,6 +481,16 @@ pub fn start_verify_transactions(
                 })
                 .flatten()
                 .collect::<Vec<_>>();
+
+            if entry_txs.is_empty() {
+                return Ok(EntrySigVerificationState {
+                    verification_status: EntryVerificationStatus::Success,
+                    entries: Some(entries),
+                    device_verification_data: DeviceSigVerificationData::Cpu(),
+                    gpu_verify_duration_us: 0,
+                });
+            }
+
             let total_packets = AtomicUsize::new(0);
             let mut packet_batches = entry_txs
                 .par_iter()
@@ -511,7 +503,7 @@ pub fn start_verify_transactions(
                         vec_size,
                         "entry-sig-verify",
                     );
-                    // We use set_len here instead of resize(num_transactions, Packet::default()), to save
+                    // We use set_len here instead of resize(vec_size, Packet::default()), to save
                     // memory bandwidth and avoid writing a large amount of data that will be overwritten
                     // soon afterwards. As well, Packet::default() actually leaves the packet data
                     // uninitialized anyway, so the initilization would simply write junk into


### PR DESCRIPTION
#### Problem
 We're currently looping through the entire vector of txs just to see if it has a non-zero number of non-tick txs. This is suboptimal, since we loop through the vector again right afterwards, and collect references to all the non-tick txs. Even if collecting the refs was more expensive, the only time where we wouldn't do that anyway (early return due to zero non-tick txs) is when there are no non-tick txs, and we simply loop through the possibly empty vector doing nothing. So the earlier loop to count the non-tick txs is unnecessary and slow.

#### Summary of Changes
Remove the loop to count the non-tick txs.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
