### PR TITLE
FindPacketSenderStake: Remove parallelism to improve performance

### DIFF
--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -1,6 +1,5 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    lazy_static::lazy_static,
     solana_measure::measure::Measure,
     solana_perf::packet::PacketBatch,
     solana_sdk::timing::timestamp,
@@ -148,7 +147,7 @@ impl FindPacketSenderStakeStage {
 
     fn apply_sender_stakes(batches: &mut [PacketBatch], ip_to_stake: &HashMap<IpAddr, u64>) {
         batches
-            .into_iter()
+            .iter_mut()
             .flat_map(|batch| batch.iter_mut())
             .for_each(|packet| {
                 packet.meta.sender_stake = ip_to_stake

--- a/core/src/find_packet_sender_stake_stage.rs
+++ b/core/src/find_packet_sender_stake_stage.rs
@@ -1,10 +1,8 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     lazy_static::lazy_static,
-    rayon::{prelude::*, ThreadPool},
     solana_measure::measure::Measure,
     solana_perf::packet::PacketBatch,
-    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::timing::timestamp,
     solana_streamer::streamer::{self, StreamerError},
     std::{
@@ -15,18 +13,10 @@ use {
     },
 };
 
-lazy_static! {
-    static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
-        .num_threads(get_thread_count())
-        .thread_name(|ix| format!("transaction_sender_stake_stage_{}", ix))
-        .build()
-        .unwrap();
-}
-
-// Try to target 50ms, rough timings from mainnet machines
+// Try to target 50ms, rough timings from a testnet validator
 //
-// 50ms/(1us/packet) = 50k packets
-const MAX_FINDPACKETSENDERSTAKE_BATCH: usize = 50_000;
+// 50ms/(200ns/packet) = 250k packets
+const MAX_FINDPACKETSENDERSTAKE_BATCH: usize = 250_000;
 
 pub type FindPacketSenderStakeSender = Sender<Vec<PacketBatch>>;
 pub type FindPacketSenderStakeReceiver = Receiver<Vec<PacketBatch>>;
@@ -157,17 +147,15 @@ impl FindPacketSenderStakeStage {
     }
 
     fn apply_sender_stakes(batches: &mut [PacketBatch], ip_to_stake: &HashMap<IpAddr, u64>) {
-        PAR_THREAD_POOL.install(|| {
-            batches
-                .into_par_iter()
-                .flat_map(|batch| batch.par_iter_mut())
-                .for_each(|packet| {
-                    packet.meta.sender_stake = ip_to_stake
-                        .get(&packet.meta.addr)
-                        .copied()
-                        .unwrap_or_default();
-                });
-        });
+        batches
+            .into_iter()
+            .flat_map(|batch| batch.iter_mut())
+            .for_each(|packet| {
+                packet.meta.sender_stake = ip_to_stake
+                    .get(&packet.meta.addr)
+                    .copied()
+                    .unwrap_or_default();
+            });
     }
 
     pub fn join(self) -> thread::Result<()> {


### PR DESCRIPTION
#### Problem

The work unit sizes were so small that using the thread pool slowed down this stage significantly.

The existing 1.10 mainnet nodes showed around 30us/packet:
![image](https://user-images.githubusercontent.com/833306/170362804-8f0a87fe-ffc9-486e-ad9b-0363182a37ce.png)

But local tests indicate this should take 10-100ns.

Even when limiting to datapoints with at least 500k packets the processing time per packet stayed above 2us:
![image](https://user-images.githubusercontent.com/833306/170363012-8af28c63-c7ed-47c2-8c92-855c69fe21eb.png)


#### Summary of Changes

Drop the thread pool and `par_iter()`s.

I've tested this on testnet: Before, with 1.10.13:

```
find_packet_sender_stake-services_stats
apply_sender_stakes_time=83549i
total_batches=267i 
total_packets=4902i
```

and with a patched 1.10.19:
```
tpu-vote-find-packet-sender-stake
apply_sender_stakes_time_us=971i
total_batches=299i
total_packets=7752i
```

That means it improved from 17us/packet to 125ns/packet.

@sakridge 