### PR TITLE
Helper function for creating ShredStorageType::RocksFifo

### DIFF
--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -133,6 +133,15 @@ impl Default for ShredStorageType {
     }
 }
 
+impl ShredStorageType {
+    /// Returns ShredStorageType::RocksFifo where the specified
+    /// `shred_storage_size` is equally allocated to shred_data_cf_size
+    /// and shred_code_cf_size.
+    pub fn rocks_fifo(shred_storage_size: u64) -> ShredStorageType {
+        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::new(shred_storage_size))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BlockstoreRocksFifoOptions {
     // The maximum storage size for storing data shreds in column family
@@ -162,11 +171,15 @@ pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 *
 
 impl Default for BlockstoreRocksFifoOptions {
     fn default() -> Self {
+        BlockstoreRocksFifoOptions::new(DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES)
+    }
+}
+
+impl BlockstoreRocksFifoOptions {
+    fn new(shred_storage_size: u64) -> Self {
         Self {
-            // Maximum size of cf::ShredData.
-            shred_data_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
-            // Maximum size of cf::ShredCode.
-            shred_code_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
+            shred_data_cf_size: shred_storage_size / 2,
+            shred_code_cf_size: shred_storage_size / 2,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -31,8 +31,8 @@ use {
     },
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::blockstore_options::{
-        BlockstoreCompressionType, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-        LedgerColumnOptions, ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+        BlockstoreCompressionType, BlockstoreRecoveryMode, LedgerColumnOptions, ShredStorageType,
+        DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_perf::recycler::enable_recycler_warming,
@@ -2765,10 +2765,7 @@ pub fn main() {
                 "fifo" => {
                     let shred_storage_size =
                         value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);
-                    ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
-                        shred_data_cf_size: shred_storage_size / 2,
-                        shred_code_cf_size: shred_storage_size / 2,
-                    })
+                    ShredStorageType::rocks_fifo(shred_storage_size)
                 }
                 _ => panic!(
                     "Unrecognized rocksdb-shred-compaction: {}",


### PR DESCRIPTION
#### Problem
Currently, the creation of ShredStorageType::RocksFifo is hard coded in validator/src/main.rs.
But this common code will also need to be used in other places like ledger-tool.

#### Summary of Changes
This PR creates a helper functionShredStorageType::rocks_fifo that takes a total shred_storage_size
and equally allocates to data-shred and coding-shred storage.

This PR depends on #25778.
