### PR TITLE
choose highest incremental snapshot first

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1108,7 +1108,7 @@ mod with_incremental_snapshots {
     /// The result is a vector of peers with snapshot hashes that:
     /// 1. match a snapshot hash from the known validators
     /// 2. have the highest incremental snapshot slot
-    /// 3. if highest incremental snapshot slot is none then have the highest full snapshot slot
+    /// 3. have the highest full snapshot slot of (2)
     fn get_peer_snapshot_hashes(
         cluster_info: &ClusterInfo,
         validator_config: &ValidatorConfig,
@@ -1126,10 +1126,7 @@ mod with_incremental_snapshots {
         retain_peer_snapshot_hashes_with_highest_incremental_snapshot_slot(
             &mut peer_snapshot_hashes,
         );
-        if !peer_snapshot_hashes.is_empty() && peer_snapshot_hashes[0].snapshot_hash.incr.is_none()
-        {
-            retain_peer_snapshot_hashes_with_highest_full_snapshot_slot(&mut peer_snapshot_hashes);
-        }
+        retain_peer_snapshot_hashes_with_highest_full_snapshot_slot(&mut peer_snapshot_hashes);
 
         peer_snapshot_hashes
     }

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -1422,22 +1422,12 @@ mod with_incremental_snapshots {
 
         // It is a programmer bug if the assert fires!  By the time this function is called, the
         // only remaining `incremental_snapshot_hashes` should all be the same.
-        if final_peer_snapshot_hash.snapshot_hash.incr.is_some() {
-            assert!(
-                peer_snapshot_hashes.iter().all(|peer_snapshot_hash| {
-                    peer_snapshot_hash.snapshot_hash.incr == final_peer_snapshot_hash.snapshot_hash.incr
-                }),
-                "To safely pick a peer at random, all the incremental snapshot hashes must be the same"
-            );
-        } else {
-            assert!(
-                peer_snapshot_hashes.iter().all(|peer_snapshot_hash| {
-                    peer_snapshot_hash.snapshot_hash.full
-                        == final_peer_snapshot_hash.snapshot_hash.full
-                }),
-                "To safely pick a peer at random, all the full snapshot hashes must be the same"
-            );
-        }
+        assert!(
+            peer_snapshot_hashes.iter().all(|peer_snapshot_hash| {
+                peer_snapshot_hash.snapshot_hash == final_peer_snapshot_hash.snapshot_hash
+            }),
+            "To safely pick a peer at random, all the snapshot hashes must be the same"
+        );
 
         trace!("final peer snapshot hash: {:?}", final_peer_snapshot_hash);
         final_peer_snapshot_hash.clone()


### PR DESCRIPTION
#### Problem

I see following on the testnet.
Some nodes save full snapshots more often then every default 25K blocks (and/or don't produce incremental snapshots at all).

This leads to an error in choosing the highest snapshot.

#### Summary of Changes

Choose highest incremental snapshot first.
If all incremental are none, then choose highest full.
Else it does not matter which one will be full. 

