### PR TITLE
Change dashboard to use validator-reported memory metric

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -2089,7 +2089,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT max(\"ram_usage\") as \"ram_usage\" FROM \"$testnet\".\"autogen\".\"system-stats\" WHERE  hostname =~ /$hostid/ AND $timeFilter   GROUP BY time(5s) fill(null)\n",
+          "query": "SELECT 100 - median(\"avail_percent\") as \"ram_usage\" FROM \"$testnet\".\"autogen\".\"memory-stats\" WHERE  hostname =~ /$hostid/ AND $timeFilter   GROUP BY time(5s) fill(null)\n",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",


### PR DESCRIPTION
#### Problem

Dashboard uses the system-stats.sh generated metric which only works on nodes which have an external script running.

#### Summary of Changes

Switch to use the built-in metric which is generally reported by validators.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
