### PR TITLE
Bump rBPF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6308,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df28dcb607dd56ab0022f99d3a9ff1ee0d87951315762c0b89e946c087ebbea"
+checksum = "80a28c5dfe7e8af38daa39d6561c8e8b9ed7a2f900951ebe7362ad6348d36c73"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-solana_rbpf = "=0.2.30"
+solana_rbpf = "=0.2.31"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -25,7 +25,11 @@ use {
         tpu_client::{TpuClient, TpuClientConfig},
     },
     solana_program_runtime::invoke_context::InvokeContext,
-    solana_rbpf::{elf::Executable, verifier, vm::Config},
+    solana_rbpf::{
+        elf::Executable,
+        verifier::RequisiteVerifier,
+        vm::{Config, VerifiedExecutable},
+    },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_sdk::{
         account::Account,
@@ -2079,9 +2083,8 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program
-    Executable::<BpfError, ThisInstructionMeter>::from_elf(
+    let executable = Executable::<BpfError, ThisInstructionMeter>::from_elf(
         &program_data,
-        Some(verifier::check),
         Config {
             reject_broken_elfs: true,
             ..Config::default()
@@ -2089,6 +2092,12 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
         register_syscalls(&mut invoke_context, true).unwrap(),
     )
     .map_err(|err| format!("ELF error: {}", err))?;
+
+    let _ =
+        VerifiedExecutable::<RequisiteVerifier, BpfError, ThisInstructionMeter>::from_executable(
+            executable,
+        )
+        .map_err(|err| format!("ELF error: {}", err))?;
 
     Ok(program_data)
 }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5516,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df28dcb607dd56ab0022f99d3a9ff1ee0d87951315762c0b89e946c087ebbea"
+checksum = "80a28c5dfe7e8af38daa39d6561c8e8b9ed7a2f900951ebe7362ad6348d36c73"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.11.0" }
 solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-measure = { path = "../../measure", version = "=1.11.0" }
-solana_rbpf = "=0.2.30"
+solana_rbpf = "=0.2.31"
 solana-runtime = { path = "../../runtime", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.30"
+solana_rbpf = "=0.2.31"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -13,6 +13,7 @@ use {
         error::EbpfError,
         memory_region::{AccessType, MemoryMapping},
         question_mark,
+        verifier::RequisiteVerifier,
         vm::{EbpfVm, SyscallObject, SyscallRegistry},
     },
     solana_sdk::{
@@ -384,7 +385,7 @@ pub fn register_syscalls(
 }
 
 pub fn bind_syscall_context_objects<'a, 'b>(
-    vm: &mut EbpfVm<'a, BpfError, crate::ThisInstructionMeter>,
+    vm: &mut EbpfVm<'a, RequisiteVerifier, BpfError, crate::ThisInstructionMeter>,
     invoke_context: &'a mut InvokeContext<'b>,
     heap: AlignedMemory,
     orig_account_lengths: Vec<usize>,

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.30"
+solana_rbpf = "=0.2.31"

--- a/sdk/bpf/dependencies/sbf-tools
+++ b/sdk/bpf/dependencies/sbf-tools
@@ -1,0 +1,1 @@
+/Users/jack/.cache/solana/v1.27/sbf-tools


### PR DESCRIPTION
#### Problem

The code path to creating a vm allows for the executable to be optional. The executable verification is an integral step in creating a VM and should never be optional. 

The BPF loader currently does verify the ELF, but the rBPF apis don't encourage good behavior or good protection to leaving out the verifier.

#### Summary of Changes

Removes the optional mechanics and requires the caller to provide a verification function in order to create a virtual machine. Doing so will reduce the chance that a mistake is made where the executable is not verified.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
