### PR TITLE
Vote state update processing will award one credit per voted-on final…

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1045,7 +1045,7 @@ impl ProgramTestContext {
 
         let epoch = bank.epoch();
         for _ in 0..number_of_credits {
-            vote_state.increment_credits(epoch);
+            vote_state.increment_credits(epoch, 1);
         }
         let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -6551,7 +6551,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            reference_vote_state.increment_credits(epoch as Epoch);
+            reference_vote_state.increment_credits(epoch as Epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6571,7 +6571,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         assert_eq!(
             reference_vote_state.epoch_credits[current_epoch as usize - 2].0,
@@ -6601,7 +6601,7 @@ mod tests {
         // Instruction will succeed
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6630,7 +6630,7 @@ mod tests {
 
         let mut vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            vote_state.increment_credits(epoch as Epoch);
+            vote_state.increment_credits(epoch as Epoch, 1);
         }
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
@@ -6684,8 +6684,10 @@ mod tests {
         // `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` ago.
         // Instruction will succeed
         let mut vote_state = VoteState::default();
-        vote_state
-            .increment_credits(current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch);
+        vote_state.increment_credits(
+            current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch,
+            1,
+        );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
             .unwrap();
@@ -6703,6 +6705,7 @@ mod tests {
         let mut vote_state = VoteState::default();
         vote_state.increment_credits(
             current_epoch - (MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION - 1) as Epoch,
+            1,
         );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2373,8 +2373,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2435,7 +2435,7 @@ mod tests {
         // put 193,536,000 credits in at epoch 0, typical for a 14-day epoch
         //  this loop takes a few seconds...
         for _ in 0..epoch_slots {
-            vote_state.increment_credits(0);
+            vote_state.increment_credits(0, 1);
         }
 
         // no overflow on points
@@ -2476,8 +2476,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2523,7 +2523,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 1
-        vote_state.increment_credits(1);
+        vote_state.increment_credits(1, 1);
 
         stake.credits_observed = 2;
         // this one should be able to collect the one just added
@@ -2548,7 +2548,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 2
-        vote_state.increment_credits(2);
+        vote_state.increment_credits(2, 1);
         // this one should be able to collect 2 now
         assert_eq!(
             Some(CalculatedStakeRewards {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -87,6 +87,7 @@ pub fn process_instruction(
                     &clock,
                     vote_state_update,
                     &signers,
+                    &invoke_context.feature_set,
                 )
             } else {
                 Err(InstructionError::InvalidInstructionData)

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1922,7 +1922,7 @@ mod tests {
         assert!(vote_state.epoch_credits().len() <= MAX_EPOCH_CREDITS_HISTORY);
     }
 
-    fn slots_to_lockouts(votes: &Vec<Slot>) -> VecDeque<Lockout> {
+    fn slots_to_lockouts(votes: &[Slot]) -> VecDeque<Lockout> {
         let mut lockouts = VecDeque::<Lockout>::from(
             votes
                 .iter()
@@ -1944,6 +1944,8 @@ mod tests {
 
     // Test vote credit updates before and after "one credit per slot" feature is enabled
     #[test]
+    #[allow(clippy::type_complexity)]
+    #[allow(clippy::field_reassign_with_default)]
     fn test_vote_state_update_increment_credits() {
         // Each element of test data is:
         // (vote_state_votes: Vec<Slot>,
@@ -2111,7 +2113,7 @@ mod tests {
             assert_eq!(
                 vote_state.process_new_vote_state(
                     vote_state_update_votes.clone(),
-                    vote_state_update_root.clone(),
+                    vote_state_update_root,
                     None,
                     100,
                     slot_hashes.as_slice(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -412,6 +412,10 @@ pub mod add_shred_type_to_shred_seed {
     solana_sdk::declare_id!("Ds87KVeqhbv7Jw8W6avsS1mqz3Mw5J3pRTpPoDQ2QdiJ");
 }
 
+pub mod vote_state_update_award_one_credit_per_slot {
+    solana_sdk::declare_id!("B9y9J9XtJ2gZ6zVc6AMNQ3QWFGoFxDQhJQi9wb4WbkeU");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [


### PR DESCRIPTION
…ized slot.

#### Problem

VoteStateUpdate instruction processing only awards one credit per transaction, regardless of the number of voted-on slots that have been finalized.  As a result validators will be incentivized to issue one transaction per voted slot, which is inefficient.

#### Summary of Changes

Update the vote state update instruction processing to add one credit per slot that has been "retired" from the tower and that is in slot_hashes, which mirrors the vote credits award mechanism of the Vote instruction.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
