### PR TITLE
fix: stop double counting execution timings

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -6,7 +6,7 @@ use {
         invoke_context::{BuiltinProgram, Executors, InvokeContext},
         log_collector::LogCollector,
         sysvar_cache::SysvarCache,
-        timings::ExecuteTimings,
+        timings::{ExecuteDetailsTimings, ExecuteTimings},
     },
     solana_sdk::{
         account::WritableAccount,
@@ -173,7 +173,10 @@ impl MessageProcessor {
                     compute_units_consumed,
                     result.is_err(),
                 );
-                timings.details.accumulate(&invoke_context.timings);
+                invoke_context.timings = {
+                    timings.details.accumulate(&invoke_context.timings);
+                    ExecuteDetailsTimings::default()
+                };
                 saturating_add_assign!(
                     timings.execute_accessories.process_instructions.total_us,
                     time.as_us()


### PR DESCRIPTION
#### Problem
`ExecuteDetailsTimings` are re-accumulated after each tx instruction meaning that metrics like `create_executor_jit_compile_us` are much higher than they actually are.

#### Summary of Changes
- Clear invoke context timings after they are accumulated into higher level timings

cc @t-nelson @carllin 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
