### PR TITLE
Allow metric tag values to be runtime configurable

### DIFF
--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -46,7 +46,7 @@ pub struct DataPoint {
     pub name: &'static str,
     pub timestamp: SystemTime,
     /// tags are eligible for group-by operations.
-    pub tags: Vec<(&'static str, &'static str)>,
+    pub tags: Vec<(&'static str, String)>,
     pub fields: Vec<(&'static str, String)>,
 }
 
@@ -60,8 +60,8 @@ impl DataPoint {
         }
     }
 
-    pub fn add_tag(&mut self, name: &'static str, value: &'static str) -> &mut Self {
-        self.tags.push((name, value));
+    pub fn add_tag(&mut self, name: &'static str, value: &str) -> &mut Self {
+        self.tags.push((name, value.to_string()));
         self
     }
 
@@ -321,8 +321,8 @@ mod test {
         );
         assert_eq!(point.fields[2], ("f64", "12.34".to_string()));
         assert_eq!(point.fields[3], ("bool", "true".to_string()));
-        assert_eq!(point.tags[0], ("tag1", "tag-value-1"));
-        assert_eq!(point.tags[1], ("tag2", "tag-value-2"));
-        assert_eq!(point.tags[2], ("tag3", "tag-value-3"));
+        assert_eq!(point.tags[0], ("tag1", "tag-value-1".to_string()));
+        assert_eq!(point.tags[1], ("tag2", "tag-value-2".to_string()));
+        assert_eq!(point.tags[2], ("tag3", "tag-value-3".to_string()));
     }
 }


### PR DESCRIPTION
#### Problem
Initially when I reviewed https://github.com/solana-labs/solana/pull/25385, I thought having static tag values would suffice for the use cases I had in mind. Now that I actually took a look, my thoughts on that have changed and I want the flexibility of a String so values can be chosen at runtime.

In terms of runtime cost, the tags that I'll be adding are currently fields. Fields are owned `String`s so these cases will have the same total number of `String`s when I shift it from a field to a tag. And in general, we use `String`s for all field values, so I think my previous concerns about runtime cost over using static strings might have been overblown.
#### Summary of Changes