### PR TITLE
Banking thread metric tags

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -95,8 +95,11 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 None::<Box<dyn Fn()>>,
                 &BankingStageStats::default(),
                 &recorder,
-                &QosService::new(Arc::new(RwLock::new(CostModel::default())), 1),
-                &mut LeaderSlotMetricsTracker::new(0),
+                &QosService::new(
+                    Arc::new(RwLock::new(CostModel::default())),
+                    String::from("1"),
+                ),
+                &mut LeaderSlotMetricsTracker::new(String::from("0")),
                 10,
             );
         });

--- a/core/src/leader_slot_banking_stage_timing_metrics.rs
+++ b/core/src/leader_slot_banking_stage_timing_metrics.rs
@@ -29,10 +29,10 @@ impl LeaderExecuteAndCommitTimings {
         self.execute_timings.accumulate(&other.execute_timings);
     }
 
-    pub fn report(&self, id: u32, slot: Slot) {
+    pub fn report(&self, id: &str, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_execute_and_commit_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             ("collect_balances_us", self.collect_balances_us as i64, i64),
             ("load_execute_us", self.load_execute_us as i64, i64),
@@ -48,7 +48,7 @@ impl LeaderExecuteAndCommitTimings {
 
         datapoint_info!(
             "banking_stage-leader_slot_record_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             (
                 "execution_results_to_transactions_us",
@@ -110,7 +110,7 @@ impl LeaderSlotTimingMetrics {
         }
     }
 
-    pub(crate) fn report(&self, id: u32, slot: Slot) {
+    pub(crate) fn report(&self, id: &str, slot: Slot) {
         self.outer_loop_timings.report(id, slot);
         self.process_buffered_packets_timings.report(id, slot);
         self.consume_buffered_packets_timings.report(id, slot);
@@ -152,11 +152,11 @@ impl OuterLoopTimings {
         }
     }
 
-    fn report(&self, id: u32, slot: Slot) {
+    fn report(&self, id: &str, slot: Slot) {
         let bank_detected_to_now_us = self.bank_detected_time.elapsed().as_micros() as u64;
         datapoint_info!(
             "banking_stage-leader_slot_loop_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             (
                 "bank_detected_to_slot_end_detected_us",
@@ -201,10 +201,10 @@ pub(crate) struct ProcessBufferedPacketsTimings {
     pub forward_and_hold_us: u64,
 }
 impl ProcessBufferedPacketsTimings {
-    fn report(&self, id: u32, slot: Slot) {
+    fn report(&self, id: &str, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_process_buffered_packets_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             ("make_decision_us", self.make_decision_us as i64, i64),
             (
@@ -231,10 +231,10 @@ pub(crate) struct ConsumeBufferedPacketsTimings {
 }
 
 impl ConsumeBufferedPacketsTimings {
-    fn report(&self, id: u32, slot: Slot) {
+    fn report(&self, id: &str, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_consume_buffered_packets_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             (
                 "poh_recorder_lock_us",
@@ -273,10 +273,10 @@ pub(crate) struct ProcessPacketsTimings {
 }
 
 impl ProcessPacketsTimings {
-    fn report(&self, id: u32, slot: Slot) {
+    fn report(&self, id: &str, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_process_packets_timings",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             (
                 "transactions_from_packets_us",

--- a/core/src/qos_service.rs
+++ b/core/src/qos_service.rs
@@ -63,7 +63,7 @@ impl Drop for QosService {
 }
 
 impl QosService {
-    pub fn new(cost_model: Arc<RwLock<CostModel>>, id: u32) -> Self {
+    pub fn new(cost_model: Arc<RwLock<CostModel>>, id: String) -> Self {
         let (report_sender, report_receiver) = unbounded();
         let running_flag = Arc::new(AtomicBool::new(true));
         let metrics = Arc::new(QosServiceMetrics::new(id));
@@ -354,7 +354,7 @@ struct QosServiceMetrics {
     /// banking_stage creates one QosService instance per working threads, that is uniquely
     /// identified by id. This field allows to categorize metrics for gossip votes, TPU votes
     /// and other transactions.
-    id: u32,
+    id: String,
 
     /// aggregate metrics per slot
     slot: AtomicU64,
@@ -424,7 +424,7 @@ struct QosServiceMetricsErrors {
 }
 
 impl QosServiceMetrics {
-    pub fn new(id: u32) -> Self {
+    pub fn new(id: String) -> Self {
         QosServiceMetrics {
             id,
             ..QosServiceMetrics::default()
@@ -435,7 +435,7 @@ impl QosServiceMetrics {
         if bank_slot != self.slot.load(Ordering::Relaxed) {
             datapoint_info!(
                 "qos-service-stats",
-                ("id", self.id as i64, i64),
+                "id" => &self.id,
                 ("bank_slot", bank_slot as i64, i64),
                 (
                     "compute_cost_time",
@@ -503,7 +503,7 @@ impl QosServiceMetrics {
             );
             datapoint_info!(
                 "qos-service-errors",
-                ("id", self.id as i64, i64),
+                "id" => &self.id,
                 ("bank_slot", bank_slot as i64, i64),
                 (
                     "retried_txs_per_block_limit_count",
@@ -583,7 +583,7 @@ mod tests {
         let txs = vec![transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
 
         let cost_model = Arc::new(RwLock::new(CostModel::default()));
-        let qos_service = QosService::new(cost_model.clone(), 1);
+        let qos_service = QosService::new(cost_model.clone(), String::from("1"));
         let txs_costs = qos_service.compute_transaction_costs(txs.iter());
 
         // verify the size of txs_costs and its contents
@@ -632,7 +632,7 @@ mod tests {
         // make a vec of txs
         let txs = vec![transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
 
-        let qos_service = QosService::new(cost_model, 1);
+        let qos_service = QosService::new(cost_model, String::from("1"));
         let txs_costs = qos_service.compute_transaction_costs(txs.iter());
 
         // set cost tracker limit to fit 1 transfer tx and 1 vote tx
@@ -672,7 +672,10 @@ mod tests {
 
         // assert all tx_costs should be applied to cost_tracker if all execution_results are all committed
         {
-            let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
+            let qos_service = QosService::new(
+                Arc::new(RwLock::new(CostModel::default())),
+                String::from("1"),
+            );
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
             let (qos_results, _num_included) =
@@ -725,7 +728,10 @@ mod tests {
 
         // assert all tx_costs should be removed from cost_tracker if all execution_results are all Not Committed
         {
-            let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
+            let qos_service = QosService::new(
+                Arc::new(RwLock::new(CostModel::default())),
+                String::from("1"),
+            );
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
             let (qos_results, _num_included) =
@@ -765,7 +771,10 @@ mod tests {
 
         // assert only commited tx_costs are applied cost_tracker
         {
-            let qos_service = QosService::new(Arc::new(RwLock::new(CostModel::default())), 1);
+            let qos_service = QosService::new(
+                Arc::new(RwLock::new(CostModel::default())),
+                String::from("1"),
+            );
             let txs_costs = qos_service.compute_transaction_costs(txs.iter());
             let total_txs_cost: u64 = txs_costs.iter().map(|cost| cost.sum()).sum();
             let (qos_results, _num_included) =

--- a/runtime/src/transaction_error_metrics.rs
+++ b/runtime/src/transaction_error_metrics.rs
@@ -56,10 +56,10 @@ impl TransactionErrorMetrics {
         );
     }
 
-    pub fn report(&self, id: u32, slot: Slot) {
+    pub fn report(&self, id: &str, slot: Slot) {
         datapoint_info!(
             "banking_stage-leader_slot_transaction_errors",
-            ("id", id as i64, i64),
+            "id" => id,
             ("slot", slot as i64, i64),
             ("total", self.total as i64, i64),
             ("account_in_use", self.account_in_use as i64, i64),


### PR DESCRIPTION
#### Problem
Currently, working with the banking stage metrics for different thread id's is kind of clunky. For example, you have to manually drop in a `AND "id" = X` if you want to see stats for just one thread id, or you have to copy/paste the same query several times across several tabs in order to see the graphs for each id inline.

#### Summary of Changes
Switch thread id from a field to a tag which will allow "group by" operations in chronograph. Additionally, report a meaningful name instead of just the u32 identifier.

This PR is built on top of https://github.com/solana-labs/solana/pull/25615 which will need to go in first. I ran a test cluster with the change and things looked good; note the "Group By id" option which I selected and which shows a trace per thread (votes are super low because it was a test cluster with 3 nodes)
<img width="2477" alt="image" src="https://user-images.githubusercontent.com/5400107/171038217-9593351d-1bb5-4d53-b8c2-2ee7e977d0e6.png">
