### PR TITLE
Add feature to remove timestamp bounding

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2418,20 +2418,30 @@ impl Bank {
 
     fn update_clock(&self, parent_epoch: Option<Epoch>) {
         let mut unix_timestamp = self.clock().unix_timestamp;
-        let warp_timestamp_again = self
+        let epoch_start_timestamp = if self
             .feature_set
-            .activated_slot(&feature_set::warp_timestamp_again::id());
-        let epoch_start_timestamp = if warp_timestamp_again == Some(self.slot()) {
+            .is_active(&feature_set::disable_timestamp_bounding::id())
+        {
             None
         } else {
-            let epoch = if let Some(epoch) = parent_epoch {
-                epoch
+            let warp_timestamp_again = self
+                .feature_set
+                .activated_slot(&feature_set::warp_timestamp_again::id());
+            if warp_timestamp_again == Some(self.slot()) {
+                None
             } else {
-                self.epoch()
-            };
-            let first_slot_in_epoch = self.epoch_schedule().get_first_slot_in_epoch(epoch);
-            Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+                let epoch = if let Some(epoch) = parent_epoch {
+                    epoch
+                } else {
+                    self.epoch()
+                };
+                let first_slot_in_epoch = self.epoch_schedule().get_first_slot_in_epoch(epoch);
+                Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+            }
         };
+
+        // MaxAllowableDrift handling can be removed when the `disable_timestamp_bounding` feature
+        // is active
         let max_allowable_drift = if self
             .feature_set
             .is_active(&feature_set::warp_timestamp_again::id())
@@ -14969,6 +14979,10 @@ pub(crate) mod tests {
             .accounts
             .remove(&feature_set::warp_timestamp_again::id())
             .unwrap();
+        genesis_config
+            .accounts
+            .remove(&feature_set::disable_timestamp_bounding::id())
+            .unwrap();
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
         let mut bank = Bank::new_for_tests(&genesis_config);
 
@@ -15063,6 +15077,10 @@ pub(crate) mod tests {
             ..
         } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
         let slots_in_epoch = 32;
+        genesis_config
+            .accounts
+            .remove(&feature_set::disable_timestamp_bounding::id())
+            .unwrap();
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
         let mut bank = Bank::new_for_tests(&genesis_config);
 

--- a/runtime/src/stake_weighted_timestamp.rs
+++ b/runtime/src/stake_weighted_timestamp.rs
@@ -63,6 +63,7 @@ where
             break;
         }
     }
+    // This block can be removed when the `disable_timestamp_bounding` feature is active
     // Bound estimate by `max_allowable_drift` since the start of the epoch
     if let Some((epoch_start_slot, epoch_start_timestamp)) = epoch_start_timestamp {
         let poh_estimate_offset =

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -412,6 +412,10 @@ pub mod add_shred_type_to_shred_seed {
     solana_sdk::declare_id!("Ds87KVeqhbv7Jw8W6avsS1mqz3Mw5J3pRTpPoDQ2QdiJ");
 }
 
+pub mod disable_timestamp_bounding {
+    solana_sdk::declare_id!("BrsvrB9o9294NN9En2HbC1a44TN4a8e8dMNpHFmPX9fy");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -508,6 +512,7 @@ lazy_static! {
         (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
+        (disable_timestamp_bounding::id(), "disable bank timestamp bounding according to MaxAllowableDrift #25627"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
People don't like that the Bank timestamp drifts when blocks are slow.

#### Summary of Changes
Remove timestamp bounding so that the stake-weighted median timestamp is always returned as-is from `calculate_stake_weighted_timestamp()`. (Bank's logic that enforces a monotonic increasing timestamp remains unchanged.)


Fixes #18992
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
