### PR TITLE
embeds versioning into shred binary

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3180,7 +3180,7 @@ pub(crate) mod tests {
             create_new_tmp_ledger,
             genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
             get_tmp_ledger_path,
-            shred::{Shred, ShredFlags, SIZE_OF_DATA_SHRED_PAYLOAD},
+            shred::{Shred, ShredFlags, LEGACY_SHRED_DATA_CAPACITY},
         },
         solana_rpc::{
             optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
@@ -3779,7 +3779,7 @@ pub(crate) mod tests {
     fn test_dead_fork_entry_deserialize_failure() {
         // Insert entry that causes deserialization failure
         let res = check_dead_fork(|_, bank| {
-            let gibberish = [0xa5u8; SIZE_OF_DATA_SHRED_PAYLOAD];
+            let gibberish = [0xa5u8; LEGACY_SHRED_DATA_CAPACITY];
             let parent_offset = bank.slot() - bank.parent_slot();
             let shred = Shred::new_from_data(
                 bank.slot(),

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -43,7 +43,7 @@ impl ShredSigVerifier {
         batches
             .iter()
             .flat_map(PacketBatch::iter)
-            .map(shred::layout::get_shred)
+            .filter_map(shred::layout::get_shred)
             .filter_map(shred::layout::get_slot)
             .collect()
     }

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -3,7 +3,7 @@
 extern crate test;
 use {
     solana_ledger::{
-        shred::{Shred, ShredFlags, SIZE_OF_DATA_SHRED_PAYLOAD},
+        shred::{Shred, ShredFlags, LEGACY_SHRED_DATA_CAPACITY},
         sigverify_shreds::{sign_shreds_cpu, sign_shreds_gpu, sign_shreds_gpu_pinned_keypair},
     },
     solana_perf::{
@@ -29,7 +29,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
             slot,
             0xc0de,
             0xdead,
-            &[5; SIZE_OF_DATA_SHRED_PAYLOAD],
+            &[5; LEGACY_SHRED_DATA_CAPACITY],
             ShredFlags::LAST_SHRED_IN_SLOT,
             1,
             2,
@@ -60,7 +60,7 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
             slot,
             0xc0de,
             0xdead,
-            &[5; SIZE_OF_DATA_SHRED_PAYLOAD],
+            &[5; LEGACY_SHRED_DATA_CAPACITY],
             ShredFlags::LAST_SHRED_IN_SLOT,
             1,
             2,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -14,7 +14,10 @@ use {
         },
         leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
-        shred::{self, max_ticks_per_n_shreds, ErasureSetId, Shred, ShredId, ShredType, Shredder},
+        shred::{
+            self, max_ticks_per_n_shreds, ErasureSetId, Shred, ShredData, ShredId, ShredType,
+            Shredder,
+        },
         slot_stats::{ShredSource, SlotsStats},
     },
     bincode::deserialize,
@@ -1648,7 +1651,7 @@ impl Blockstore {
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
         let shred = self.data_shred_cf.get_bytes((slot, index))?;
-        let shred = shred.map(Shred::resize_stored_shred).transpose();
+        let shred = shred.map(ShredData::resize_stored_shred).transpose();
         shred.map_err(|err| {
             let err = format!("Invalid stored shred: {}", err);
             let err = Box::new(bincode::ErrorKind::Custom(err));

--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -1,0 +1,63 @@
+macro_rules! dispatch {
+    ($vis:vis fn $name:ident(&self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
+        #[inline]
+        $vis fn $name(&self $(, $arg:$ty)?) $(-> $out)? {
+            match self {
+                Self::Legacy(shred) => shred.$name($($arg, )?),
+            }
+        }
+    };
+    ($vis:vis fn $name:ident(self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
+        #[inline]
+        $vis fn $name(self $(, $arg:$ty)?) $(-> $out)? {
+            match self {
+                Self::Legacy(shred) => shred.$name($($arg, )?),
+            }
+        }
+    };
+    ($vis:vis fn $name:ident(&mut self $(, $arg:ident : $ty:ty)?) $(-> $out:ty)?) => {
+        #[inline]
+        $vis fn $name(&mut self $(, $arg:$ty)?) $(-> $out)? {
+            match self {
+                Self::Legacy(shred) => shred.$name($($arg, )?),
+            }
+        }
+    }
+}
+
+macro_rules! impl_shred_common {
+    () => {
+        #[inline]
+        fn common_header(&self) -> &ShredCommonHeader {
+            &self.common_header
+        }
+
+        #[inline]
+        fn payload(&self) -> &Vec<u8> {
+            &self.payload
+        }
+
+        fn into_payload(self) -> Vec<u8> {
+            self.payload
+        }
+
+        fn set_signature(&mut self, signature: Signature) {
+            bincode::serialize_into(&mut self.payload[..], &signature).unwrap();
+            self.common_header.signature = signature;
+        }
+
+        // Only for tests.
+        fn set_index(&mut self, index: u32) {
+            self.common_header.index = index;
+            bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
+        }
+
+        // Only for tests.
+        fn set_slot(&mut self, slot: Slot) {
+            self.common_header.slot = slot;
+            bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
+        }
+    };
+}
+
+pub(super) use {dispatch, impl_shred_common};

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -1,0 +1,128 @@
+use {
+    crate::shred::{
+        common::dispatch,
+        legacy,
+        traits::{Shred, ShredCode as ShredCodeTrait},
+        CodingShredHeader, Error, ShredCommonHeader, MAX_DATA_SHREDS_PER_FEC_BLOCK, SIZE_OF_NONCE,
+    },
+    solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
+    static_assertions::const_assert_eq,
+};
+
+const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ShredCode {
+    Legacy(legacy::ShredCode),
+}
+
+impl ShredCode {
+    pub(super) const SIZE_OF_PAYLOAD: usize = PACKET_DATA_SIZE - SIZE_OF_NONCE;
+
+    dispatch!(fn coding_header(&self) -> &CodingShredHeader);
+
+    dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
+    dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
+    dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
+    dispatch!(pub(super) fn first_coding_index(&self) -> Option<u32>);
+    dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
+    dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
+    dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
+    dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
+    dispatch!(pub(super) fn signed_message(&self) -> &[u8]);
+
+    // Only for tests.
+    dispatch!(pub(super) fn set_index(&mut self, index: u32));
+    dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
+
+    pub(super) fn new_from_parity_shard(
+        slot: Slot,
+        index: u32,
+        parity_shard: &[u8],
+        fec_set_index: u32,
+        num_data_shreds: u16,
+        num_coding_shreds: u16,
+        position: u16,
+        version: u16,
+    ) -> Self {
+        Self::from(legacy::ShredCode::new_from_parity_shard(
+            slot,
+            index,
+            parity_shard,
+            fec_set_index,
+            num_data_shreds,
+            num_coding_shreds,
+            position,
+            version,
+        ))
+    }
+
+    pub(super) fn num_data_shreds(&self) -> u16 {
+        self.coding_header().num_data_shreds
+    }
+
+    pub(super) fn num_coding_shreds(&self) -> u16 {
+        self.coding_header().num_coding_shreds
+    }
+
+    // Returns true if the erasure coding of the two shreds mismatch.
+    pub(super) fn erasure_mismatch(&self, other: &ShredCode) -> bool {
+        match (self, other) {
+            (Self::Legacy(shred), Self::Legacy(other)) => erasure_mismatch(shred, other),
+        }
+    }
+}
+
+impl From<legacy::ShredCode> for ShredCode {
+    fn from(shred: legacy::ShredCode) -> Self {
+        Self::Legacy(shred)
+    }
+}
+
+#[inline]
+pub(super) fn erasure_shard_index<T: ShredCodeTrait>(shred: &T) -> Option<usize> {
+    // Assert that the last shred index in the erasure set does not
+    // overshoot u32.
+    let common_header = shred.common_header();
+    let coding_header = shred.coding_header();
+    common_header
+        .fec_set_index
+        .checked_add(u32::from(coding_header.num_data_shreds.checked_sub(1)?))?;
+    shred
+        .first_coding_index()?
+        .checked_add(u32::from(coding_header.num_coding_shreds.checked_sub(1)?))?;
+    let num_data_shreds = usize::from(coding_header.num_data_shreds);
+    let num_coding_shreds = usize::from(coding_header.num_coding_shreds);
+    let position = usize::from(coding_header.position);
+    let fec_set_size = num_data_shreds.checked_add(num_coding_shreds)?;
+    let index = position.checked_add(num_data_shreds)?;
+    (index < fec_set_size).then(|| index)
+}
+
+pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
+    if shred.payload().len() != T::SIZE_OF_PAYLOAD {
+        return Err(Error::InvalidPayloadSize(shred.payload().len()));
+    }
+    let coding_header = shred.coding_header();
+    let _shard_index = shred.erasure_shard_index()?;
+    let _erasure_shard = shred.erasure_shard_as_slice()?;
+    let num_coding_shreds = u32::from(coding_header.num_coding_shreds);
+    if num_coding_shreds > 8 * MAX_DATA_SHREDS_PER_FEC_BLOCK {
+        return Err(Error::InvalidNumCodingShreds(
+            coding_header.num_coding_shreds,
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn erasure_mismatch<T: ShredCodeTrait>(shred: &T, other: &T) -> bool {
+    let CodingShredHeader {
+        num_data_shreds,
+        num_coding_shreds,
+        position: _,
+    } = shred.coding_header();
+    *num_coding_shreds != other.coding_header().num_coding_shreds
+        || *num_data_shreds != other.coding_header().num_data_shreds
+        || shred.first_coding_index() != other.first_coding_index()
+}

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -1,0 +1,130 @@
+use {
+    crate::shred::{
+        self,
+        common::dispatch,
+        legacy,
+        traits::{Shred as _, ShredData as ShredDataTrait},
+        DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredVariant,
+        MAX_DATA_SHREDS_PER_SLOT,
+    },
+    solana_sdk::{clock::Slot, signature::Signature},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ShredData {
+    Legacy(legacy::ShredData),
+}
+
+impl ShredData {
+    dispatch!(fn data_header(&self) -> &DataShredHeader);
+
+    dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
+    dispatch!(pub(super) fn data(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard(self) -> Result<Vec<u8>, Error>);
+    dispatch!(pub(super) fn erasure_shard_as_slice(&self) -> Result<&[u8], Error>);
+    dispatch!(pub(super) fn erasure_shard_index(&self) -> Result<usize, Error>);
+    dispatch!(pub(super) fn into_payload(self) -> Vec<u8>);
+    dispatch!(pub(super) fn parent(&self) -> Result<Slot, Error>);
+    dispatch!(pub(super) fn payload(&self) -> &Vec<u8>);
+    dispatch!(pub(super) fn sanitize(&self) -> Result<(), Error>);
+    dispatch!(pub(super) fn set_last_in_slot(&mut self));
+    dispatch!(pub(super) fn set_signature(&mut self, signature: Signature));
+    dispatch!(pub(super) fn signed_message(&self) -> &[u8]);
+
+    // Only for tests.
+    dispatch!(pub(super) fn set_index(&mut self, index: u32));
+    dispatch!(pub(super) fn set_slot(&mut self, slot: Slot));
+
+    pub(super) fn new_from_data(
+        slot: Slot,
+        index: u32,
+        parent_offset: u16,
+        data: &[u8],
+        flags: ShredFlags,
+        reference_tick: u8,
+        version: u16,
+        fec_set_index: u32,
+    ) -> Self {
+        Self::from(legacy::ShredData::new_from_data(
+            slot,
+            index,
+            parent_offset,
+            data,
+            flags,
+            reference_tick,
+            version,
+            fec_set_index,
+        ))
+    }
+
+    pub(super) fn last_in_slot(&self) -> bool {
+        let flags = self.data_header().flags;
+        flags.contains(ShredFlags::LAST_SHRED_IN_SLOT)
+    }
+
+    pub(super) fn data_complete(&self) -> bool {
+        let flags = self.data_header().flags;
+        flags.contains(ShredFlags::DATA_COMPLETE_SHRED)
+    }
+
+    pub(super) fn reference_tick(&self) -> u8 {
+        let flags = self.data_header().flags;
+        (flags & ShredFlags::SHRED_TICK_REFERENCE_MASK).bits()
+    }
+
+    // Possibly trimmed payload;
+    // Should only be used when storing shreds to blockstore.
+    pub(super) fn bytes_to_store(&self) -> &[u8] {
+        match self {
+            Self::Legacy(shred) => shred.bytes_to_store(),
+        }
+    }
+
+    // Possibly zero pads bytes stored in blockstore.
+    pub(crate) fn resize_stored_shred(shred: Vec<u8>) -> Result<Vec<u8>, Error> {
+        match shred::layout::get_shred_variant(&shred)? {
+            ShredVariant::LegacyCode => Err(Error::InvalidShredType),
+            ShredVariant::LegacyData => legacy::ShredData::resize_stored_shred(shred),
+        }
+    }
+
+    // Maximum size of ledger data that can be embedded in a data-shred.
+    pub(crate) fn capacity() -> Result<usize, Error> {
+        Ok(legacy::ShredData::CAPACITY)
+    }
+}
+
+impl From<legacy::ShredData> for ShredData {
+    fn from(shred: legacy::ShredData) -> Self {
+        Self::Legacy(shred)
+    }
+}
+
+#[inline]
+pub(super) fn erasure_shard_index<T: ShredDataTrait>(shred: &T) -> Option<usize> {
+    let fec_set_index = shred.common_header().fec_set_index;
+    let index = shred.common_header().index.checked_sub(fec_set_index)?;
+    usize::try_from(index).ok()
+}
+
+pub(super) fn sanitize<T: ShredDataTrait>(shred: &T) -> Result<(), Error> {
+    if shred.payload().len() != T::SIZE_OF_PAYLOAD {
+        return Err(Error::InvalidPayloadSize(shred.payload().len()));
+    }
+    let common_header = shred.common_header();
+    let data_header = shred.data_header();
+    let _shard_index = shred.erasure_shard_index()?;
+    let _erasure_shard = shred.erasure_shard_as_slice()?;
+    if common_header.index as usize >= MAX_DATA_SHREDS_PER_SLOT {
+        return Err(Error::InvalidDataShredIndex(common_header.index));
+    }
+    let _data = shred.data()?;
+    let _parent = shred.parent()?;
+    let flags = data_header.flags;
+    if flags.intersects(ShredFlags::LAST_SHRED_IN_SLOT)
+        && !flags.contains(ShredFlags::DATA_COMPLETE_SHRED)
+    {
+        return Err(Error::InvalidShredFlags(data_header.flags.bits()));
+    }
+    Ok(())
+}

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -1,7 +1,6 @@
 use {
     crate::shred::{
-        Error, ProcessShredsStats, Shred, ShredFlags, MAX_DATA_SHREDS_PER_FEC_BLOCK,
-        SIZE_OF_DATA_SHRED_PAYLOAD,
+        Error, ProcessShredsStats, Shred, ShredData, ShredFlags, MAX_DATA_SHREDS_PER_FEC_BLOCK,
     },
     lazy_static::lazy_static,
     rayon::{prelude::*, ThreadPool},
@@ -110,9 +109,9 @@ impl Shredder {
         serialize_time.stop();
 
         let mut gen_data_time = Measure::start("shred_gen_data_time");
-        let payload_capacity = SIZE_OF_DATA_SHRED_PAYLOAD;
+        let data_buffer_size = ShredData::capacity().unwrap();
         // Integer division to ensure we have enough shreds to fit all the data
-        let num_shreds = (serialized_shreds.len() + payload_capacity - 1) / payload_capacity;
+        let num_shreds = (serialized_shreds.len() + data_buffer_size - 1) / data_buffer_size;
         let last_shred_index = next_shred_index + num_shreds as u32 - 1;
         // 1) Generate data shreds
         let make_data_shred = |shred_index: u32, data| {
@@ -141,7 +140,7 @@ impl Shredder {
         };
         let data_shreds: Vec<Shred> = PAR_THREAD_POOL.install(|| {
             serialized_shreds
-                .par_chunks(payload_capacity)
+                .par_chunks(data_buffer_size)
                 .enumerate()
                 .map(|(i, shred_data)| {
                     let shred_index = next_shred_index + i as u32;
@@ -298,7 +297,7 @@ impl Shredder {
         let mut shards = vec![None; fec_set_size];
         for shred in shreds {
             let index = match shred.erasure_shard_index() {
-                Some(index) if index < fec_set_size => index,
+                Ok(index) if index < fec_set_size => index,
                 _ => return Err(Error::from(InvalidIndex)),
             };
             shards[index] = Some(shred.erasure_shard()?);
@@ -316,8 +315,8 @@ impl Shredder {
                 shred.slot() == slot
                     && shred.is_data()
                     && match shred.erasure_shard_index() {
-                        Some(index) => index < num_data_shreds,
-                        None => false,
+                        Ok(index) => index < num_data_shreds,
+                        Err(_) => false,
                     }
             })
             .collect();
@@ -341,7 +340,8 @@ impl Shredder {
             // For backward compatibility. This is needed when the data shred
             // payload is None, so that deserializing to Vec<Entry> results in
             // an empty vector.
-            Ok(vec![0u8; SIZE_OF_DATA_SHRED_PAYLOAD])
+            let data_buffer_size = ShredData::capacity().unwrap();
+            Ok(vec![0u8; data_buffer_size])
         } else {
             Ok(data)
         }
@@ -402,13 +402,13 @@ mod tests {
             })
             .collect();
 
-        let size = serialized_size(&entries).unwrap();
+        let size = serialized_size(&entries).unwrap() as usize;
         // Integer division to ensure we have enough shreds to fit all the data
-        let payload_capacity = SIZE_OF_DATA_SHRED_PAYLOAD as u64;
-        let num_expected_data_shreds = (size + payload_capacity - 1) / payload_capacity;
+        let data_buffer_size = ShredData::capacity().unwrap();
+        let num_expected_data_shreds = (size + data_buffer_size - 1) / data_buffer_size;
         let num_expected_coding_shreds = (2 * MAX_DATA_SHREDS_PER_FEC_BLOCK as usize)
-            .saturating_sub(num_expected_data_shreds as usize)
-            .max(num_expected_data_shreds as usize);
+            .saturating_sub(num_expected_data_shreds)
+            .max(num_expected_data_shreds);
         let start_index = 0;
         let (data_shreds, coding_shreds) = shredder.entries_to_shreds(
             &keypair,
@@ -418,14 +418,14 @@ mod tests {
             start_index, // next_code_index
         );
         let next_index = data_shreds.last().unwrap().index() + 1;
-        assert_eq!(next_index as u64, num_expected_data_shreds);
+        assert_eq!(next_index as usize, num_expected_data_shreds);
 
         let mut data_shred_indexes = HashSet::new();
         let mut coding_shred_indexes = HashSet::new();
         for shred in data_shreds.iter() {
             assert_eq!(shred.shred_type(), ShredType::Data);
             let index = shred.index();
-            let is_last = index as u64 == num_expected_data_shreds - 1;
+            let is_last = index as usize == num_expected_data_shreds - 1;
             verify_test_data_shred(
                 shred,
                 index,
@@ -456,7 +456,7 @@ mod tests {
             assert!(coding_shred_indexes.contains(&i));
         }
 
-        assert_eq!(data_shred_indexes.len() as u64, num_expected_data_shreds);
+        assert_eq!(data_shred_indexes.len(), num_expected_data_shreds);
         assert_eq!(coding_shred_indexes.len(), num_expected_coding_shreds);
 
         // Test reassembly
@@ -574,8 +574,8 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
         let shredder = Shredder::new(slot, slot - 5, 0, 0).unwrap();
         // Create enough entries to make > 1 shred
-        let payload_capacity = SIZE_OF_DATA_SHRED_PAYLOAD;
-        let num_entries = max_ticks_per_n_shreds(1, Some(payload_capacity)) + 1;
+        let data_buffer_size = ShredData::capacity().unwrap();
+        let num_entries = max_ticks_per_n_shreds(1, Some(data_buffer_size)) + 1;
         let entries: Vec<_> = (0..num_entries)
             .map(|_| {
                 let keypair0 = Keypair::new();
@@ -623,9 +623,9 @@ mod tests {
         let entry = Entry::new(&Hash::default(), 1, vec![tx0]);
 
         let num_data_shreds: usize = 5;
-        let payload_capacity = SIZE_OF_DATA_SHRED_PAYLOAD;
+        let data_buffer_size = ShredData::capacity().unwrap();
         let num_entries =
-            max_entries_per_n_shred(&entry, num_data_shreds as u64, Some(payload_capacity));
+            max_entries_per_n_shred(&entry, num_data_shreds as u64, Some(data_buffer_size));
         let entries: Vec<_> = (0..num_entries)
             .map(|_| {
                 let keypair0 = Keypair::new();

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -3,7 +3,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::shred::{
         max_entries_per_n_shred, verify_test_data_shred, Shred, Shredder,
-        MAX_DATA_SHREDS_PER_FEC_BLOCK, SIZE_OF_DATA_SHRED_PAYLOAD,
+        LEGACY_SHRED_DATA_CAPACITY, MAX_DATA_SHREDS_PER_FEC_BLOCK,
     },
     solana_sdk::{
         clock::Slot,
@@ -34,7 +34,7 @@ fn test_multi_fec_block_coding() {
     let num_entries = max_entries_per_n_shred(
         &entry,
         num_data_shreds as u64,
-        Some(SIZE_OF_DATA_SHRED_PAYLOAD),
+        Some(LEGACY_SHRED_DATA_CAPACITY),
     );
 
     let entries: Vec<_> = (0..num_entries)
@@ -200,7 +200,7 @@ fn setup_different_sized_fec_blocks(
     let num_entries = max_entries_per_n_shred(
         &entry,
         num_shreds_per_iter as u64,
-        Some(SIZE_OF_DATA_SHRED_PAYLOAD),
+        Some(LEGACY_SHRED_DATA_CAPACITY),
     );
     let entries: Vec<_> = (0..num_entries)
         .map(|_| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -413,7 +413,7 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr]) -> Option<u16> {
     for entrypoint in entrypoints {
         match solana_net_utils::get_cluster_shred_version(entrypoint) {
             Err(err) => eprintln!("get_cluster_shred_version failed: {}, {}", entrypoint, err),
-            Ok(0) => eprintln!("zero sherd-version from entrypoint: {}", entrypoint),
+            Ok(0) => eprintln!("zero shred-version from entrypoint: {}", entrypoint),
             Ok(shred_version) => {
                 info!(
                     "obtained shred-version {} from {}",


### PR DESCRIPTION
```diff
- This is the versioning part extracted out of:
- https://github.com/solana-labs/solana/pull/25237
```


#### Problem
Need backward compatible way to change binary layout of shreds;
which requires some form of versioning embedded into shred binary

#### Summary of Changes

**First commit:**
In preparation of https://github.com/solana-labs/solana/pull/25237
which adds a new shred variant with merkle tree branches, the commit
embeds versioning into shred binary by encoding a new `ShredVariant`
type at byte 65 of payload replacing previously `ShredType` at this
offset.
```rust
enum ShredVariant {
    LegacyCode, // 0b0101_1010
    LegacyData, // 0b1010_0101
}
```

* `0b0101_1010` indicates a legacy coding shred, which is also equal to
  `ShredType::Code` for backward compatibility.
* `0b1010_0101` indicates a legacy data shred, which is also equal to
  `ShredType::Data` for backward compatibility.

Following commits will add merkle variants to this type:

```diff
 enum ShredVariant {
     LegacyCode, // 0b0101_1010
     LegacyData, // 0b1010_0101
+    MerkleCode(/*proof_size:*/ u8), // 0b0100_????
+    MerkleData(/*proof_size:*/ u8), // 0b1000_????
}
```


**Second commit:**
Adds support for different variants for ShredCode and ShredData by adding two
new types:
```rust
pub enum ShredCode {
    Legacy(legacy::ShredCode),
}
pub enum ShredData {
    Legacy(legacy::ShredData),
}
```
https://github.com/solana-labs/solana/pull/25237 will extend these types by adding merkle variants:
```diff
 pub enum ShredCode {
     Legacy(legacy::ShredCode),
+    Merkle(merkle::ShredCode),
 }
 pub enum ShredData {
     Legacy(legacy::ShredData),
+    Merkle(merkle::ShredData),
 }
```