### PR TITLE
Record solana-validator ver to metrics at startup

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,6 +56,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-send-transaction-service = { path = "../send-transaction-service", version = "=1.11.0" }
 solana-streamer = { path = "../streamer", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
+solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
 sys-info = "0.9.1"
 tempfile = "3.3.0"
@@ -72,7 +73,6 @@ serial_test = "0.6.0"
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.11.0" }
-solana-version = { path = "../version", version = "=1.11.0" }
 static_assertions = "1.1.0"
 systemstat = "0.1.11"
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1003,7 +1003,11 @@ impl Validator {
             &identity_keypair,
         );
 
-        datapoint_info!("validator-new", ("id", id.to_string(), String));
+        datapoint_info!(
+            "validator-new",
+            ("id", id.to_string(), String),
+            ("version", solana_version::version!(), String)
+        );
 
         *start_progress.write().unwrap() = ValidatorStartProgress::Running;
         Self {

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
  "solana-send-transaction-service",
  "solana-streamer",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
  "sys-info",
  "sysctl",


### PR DESCRIPTION
#### Problem

it's hard to reconcile which `solana-validator` version were running for any given past period of time.

#### Summary of Changes

Make influxdb to retain _historical_ version update along with node restarts.

Especially, this is needed for my rainbow tool.

sample:

```
[2022-05-30T03:44:41.833277386Z INFO  solana_metrics::metrics] datapoint: validator-new id="7eVT4kj1gJ7dij8bDEeqmAYcWPP7jyDV7hgBhAN68zVm" version="1.11.0 (src:d2816cb5; feat:2888452000)"
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
