### PR TITLE
fix: serializing transactions; sort that takes less time and memory

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -395,13 +395,16 @@ export class Transaction {
 
     // Sort. Prioritizing first by signer, then by writable
     uniqueMetas.sort(function (x, y) {
-      const pubkeySorting = x.pubkey
-        .toBase58()
-        .localeCompare(y.pubkey.toBase58());
-      const checkSigner = x.isSigner === y.isSigner ? 0 : x.isSigner ? -1 : 1;
-      const checkWritable =
-        x.isWritable === y.isWritable ? pubkeySorting : x.isWritable ? -1 : 1;
-      return checkSigner || checkWritable;
+      if (x.isSigner !== y.isSigner) {
+        // Signers always come before non-signers
+        return x.isSigner ? -1 : 1;
+      }
+      if (x.isWritable !== y.isWritable) {
+        // Writable accounts always come before read-only accounts
+        return x.isWritable ? -1 : 1;
+      }
+      // Otherwise, sort by pubkey.
+      return x.pubkey._bn.cmp(y.pubkey._bn);
     });
 
     // Move fee payer to the front


### PR DESCRIPTION
#### Problem

When compiling messages, we sort accounts. The sort involves producing and comparing pubkey _strings_, which takes time and memory.

#### Summary of Changes

* Short circuit pub key comparisons at all when you can determine the sort order based on `isSigner` and `isWriteable` alone.
* Compare pubkeys without producing strings, copying them, or mutating them. The `cmp` method scans the 8-bit words in big-endian order and bails as soon as it finds that one is larger than the other.

#### Test plan

Run the tests in `transaction.test.ts`. Sort orders still the same.