### PR TITLE
Net scripts clean up

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -48,7 +48,6 @@ solana-bench-tps)
   clientCommand="\
     solana-bench-tps \
       --entrypoint $entrypointIp:8001 \
-      --faucet $entrypointIp:9900 \
       --duration 7500 \
       --sustained \
       --threads $threadCount \

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -199,7 +199,6 @@ cloud_CreateInstances() {
     --zone "$zone"
     --tags testnet
     --metadata "testnet=$networkName"
-    --image "$imageName"
     --maintenance-policy TERMINATE
     --restart-on-failure
     --scopes compute-rw


### PR DESCRIPTION
#### Problem

#### Summary of Changes

* remove deprecated `--faucet` option for `bench-tps` call
* remove unnecessary duplication of `--imageName` option
