### PR TITLE
Implement the "timely vote credits" proposal.

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1045,7 +1045,7 @@ impl ProgramTestContext {
 
         let epoch = bank.epoch();
         for _ in 0..number_of_credits {
-            vote_state.increment_credits(epoch);
+            vote_state.increment_credits(epoch, 1);
         }
         let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -6551,7 +6551,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            reference_vote_state.increment_credits(epoch as Epoch);
+            reference_vote_state.increment_credits(epoch as Epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6571,7 +6571,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         assert_eq!(
             reference_vote_state.epoch_credits[current_epoch as usize - 2].0,
@@ -6601,7 +6601,7 @@ mod tests {
         // Instruction will succeed
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6630,7 +6630,7 @@ mod tests {
 
         let mut vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            vote_state.increment_credits(epoch as Epoch);
+            vote_state.increment_credits(epoch as Epoch, 1);
         }
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
@@ -6684,8 +6684,10 @@ mod tests {
         // `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` ago.
         // Instruction will succeed
         let mut vote_state = VoteState::default();
-        vote_state
-            .increment_credits(current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch);
+        vote_state.increment_credits(
+            current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch,
+            1,
+        );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
             .unwrap();
@@ -6703,6 +6705,7 @@ mod tests {
         let mut vote_state = VoteState::default();
         vote_state.increment_credits(
             current_epoch - (MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION - 1) as Epoch,
+            1,
         );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2373,8 +2373,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2435,7 +2435,7 @@ mod tests {
         // put 193,536,000 credits in at epoch 0, typical for a 14-day epoch
         //  this loop takes a few seconds...
         for _ in 0..epoch_slots {
-            vote_state.increment_credits(0);
+            vote_state.increment_credits(0, 1);
         }
 
         // no overflow on points
@@ -2476,8 +2476,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2523,7 +2523,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 1
-        vote_state.increment_credits(1);
+        vote_state.increment_credits(1, 1);
 
         stake.credits_observed = 2;
         // this one should be able to collect the one just added
@@ -2548,7 +2548,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 2
-        vote_state.increment_credits(2);
+        vote_state.increment_credits(2, 1);
         // this one should be able to collect 2 now
         assert_eq!(
             Some(CalculatedStakeRewards {

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -52,7 +52,7 @@ fn create_accounts() -> (
         );
 
         for next_vote_slot in 0..num_initial_votes {
-            vote_state.process_next_vote_slot(next_vote_slot, 0);
+            vote_state.process_next_vote_slot(next_vote_slot, 0, None);
         }
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
         let versioned = VoteStateVersions::new_current(vote_state);

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -87,6 +87,7 @@ pub fn process_instruction(
                     &clock,
                     vote_state_update,
                     &signers,
+                    &invoke_context.feature_set,
                 )
             } else {
                 Err(InstructionError::InvalidInstructionData)

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4585,7 +4585,10 @@ pub mod tests {
         },
         solana_vote_program::{
             vote_instruction,
-            vote_state::{Vote, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY},
+            vote_state::{
+                Vote, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+                VOTE_CREDITS_MAXIMUM_PER_SLOT,
+            },
         },
         spl_token_2022::{
             extension::{
@@ -7074,12 +7077,18 @@ pub mod tests {
             .unwrap();
         assert_ne!(leader_info.activated_stake, 0);
         // Subtract one because the last vote always carries over to the next epoch
-        let expected_credits = TEST_SLOTS_PER_EPOCH - MAX_LOCKOUT_HISTORY as u64 - 1;
+        // Timely vote credits feature enabled, vote credits are maximum per slot
+        let expected_credits =
+            (TEST_SLOTS_PER_EPOCH - MAX_LOCKOUT_HISTORY as u64 - 1) * VOTE_CREDITS_MAXIMUM_PER_SLOT;
         assert_eq!(
             leader_info.epoch_credits,
             vec![
                 (0, expected_credits, 0),
-                (1, expected_credits + 1, expected_credits) // one vote in current epoch
+                (
+                    1,
+                    expected_credits + VOTE_CREDITS_MAXIMUM_PER_SLOT,
+                    expected_credits
+                ) // one vote in current epoch
             ]
         );
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -412,6 +412,10 @@ pub mod add_shred_type_to_shred_seed {
     solana_sdk::declare_id!("Ds87KVeqhbv7Jw8W6avsS1mqz3Mw5J3pRTpPoDQ2QdiJ");
 }
 
+pub mod timely_vote_credits {
+    solana_sdk::declare_id!("CPFKGKaoDHQFwHjj5pd2sCPXxksSWJFgUDSda5LRJFck");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -508,6 +512,8 @@ lazy_static! {
         (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
+        (timely_vote_credits::id(), "Calculate vote credits based on distance from voted-on slot"),
+
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
This has two effects:

- VoteStateUpdate instruction processing now adds credits per vote dequed from the tower.  This matches existing vote credit awards for Vote instruction processing.
- For both Vote and VoteStateUpadte instruction processing, credits are awarded based on latency: votes which land closer to the slot they are voting on result in
  more credits awarded than those that land further.  This is intended to disincentivize intentional vote "lagging".

#### Problem

Two problems:

1. VoteStateUpdate did not award credits the same way that Vote instruction processing did; VoteStateUpdate awarded 1 credit per instruction, which incentivizes sending more instructions instead of multiple vote slots per instruction.
2. Vote credits awarded the same credits for votes cast after significant latency as it did for votes cast in a more timely manner.  This has enabled a "lagging" voting strategy that earns more credits but is bad for the cluster.

See this proposal for more details:

https://www.shinobi-systems.com/timely_voting_proposal/


#### Summary of Changes

See change description
