### PR TITLE
Add feature to increase timestamp bounding on the slow side to 1s/slot

### DIFF
--- a/runtime/src/stake_weighted_timestamp.rs
+++ b/runtime/src/stake_weighted_timestamp.rs
@@ -13,6 +13,7 @@ use std::{
 pub(crate) const MAX_ALLOWABLE_DRIFT_PERCENTAGE: u32 = 50;
 pub(crate) const MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST: u32 = 25;
 pub(crate) const MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW: u32 = 80;
+pub(crate) const MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2: u32 = 150;
 
 #[derive(Copy, Clone)]
 pub(crate) struct MaxAllowableDrift {
@@ -80,7 +81,7 @@ where
             && estimate_offset.saturating_sub(poh_estimate_offset) > max_allowable_drift_slow
         {
             // estimate offset since the start of the epoch is higher than
-            // `MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW`
+            // `max_allowable_drift_slow`
             estimate = epoch_start_timestamp
                 .saturating_add(poh_estimate_offset.as_secs() as i64)
                 .saturating_add(max_allowable_drift_slow.as_secs() as i64);
@@ -88,7 +89,7 @@ where
             && poh_estimate_offset.saturating_sub(estimate_offset) > max_allowable_drift_fast
         {
             // estimate offset since the start of the epoch is lower than
-            // `MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST`
+            // `max_allowable_drift_fast`
             estimate = epoch_start_timestamp
                 .saturating_add(poh_estimate_offset.as_secs() as i64)
                 .saturating_sub(max_allowable_drift_fast.as_secs() as i64);

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -412,6 +412,10 @@ pub mod add_shred_type_to_shred_seed {
     solana_sdk::declare_id!("Ds87KVeqhbv7Jw8W6avsS1mqz3Mw5J3pRTpPoDQ2QdiJ");
 }
 
+pub mod warp_timestamp_with_a_vengeance {
+    solana_sdk::declare_id!("3BX6SBeEBibHaVQXywdkcgyUk6evfYZkHdztXiDtEpFS");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -508,6 +512,7 @@ lazy_static! {
         (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
+        (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The clock on mainnet-beta has drifted because blocks are slower than the acceptable margin; current 80% of poh-estimate, or 720ms/slot.

#### Summary of Changes
Bump timestamp to the current cluster stake-weighted median on activation
Extend bounding on the slow side to permit up to 150% of poh-estimate, or 1s/slot

Closes #25627
Feature Gate Issue: #25668
<!-- Don't forget to add the "feature-gate" label -->
