### PR TITLE
Fix forwarding of transactions over QUIC

### DIFF
--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -19,7 +19,7 @@ pub struct UdpTpuConnection {
 }
 
 impl UdpTpuConnection {
-    pub fn new(tpu_addr: SocketAddr, _connection_stats: Arc<ConnectionCacheStats>) -> Self {
+    pub fn new_from_addr(tpu_addr: SocketAddr) -> Self {
         let (_, client_socket) = solana_net_utils::bind_in_range(
             IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
             VALIDATOR_PORT_RANGE,
@@ -30,6 +30,10 @@ impl UdpTpuConnection {
             socket: client_socket,
             addr: tpu_addr,
         }
+    }
+
+    pub fn new(tpu_addr: SocketAddr, _connection_stats: Arc<ConnectionCacheStats>) -> Self {
+        Self::new_from_addr(tpu_addr)
     }
 }
 

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -7,7 +7,7 @@ mod tests {
             tpu_connection::TpuConnection,
         },
         solana_sdk::{packet::PACKET_DATA_SIZE, quic::QUIC_PORT_OFFSET, signature::Keypair},
-        solana_streamer::quic::spawn_server,
+        solana_streamer::quic::{spawn_server, StreamStats},
         std::{
             collections::HashMap,
             net::{SocketAddr, UdpSocket},
@@ -28,6 +28,7 @@ mod tests {
         let keypair = Keypair::new();
         let ip = "127.0.0.1".parse().unwrap();
         let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
+        let stats = Arc::new(StreamStats::default());
         let t = spawn_server(
             s.try_clone().unwrap(),
             &keypair,
@@ -38,6 +39,7 @@ mod tests {
             staked_nodes,
             10,
             10,
+            stats,
         )
         .unwrap();
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4118,6 +4118,7 @@ mod tests {
                         vec![deserialized_packet.clone()].into_iter(),
                         1,
                     );
+                let stats = BankingStageStats::default();
                 BankingStage::handle_forwarding(
                     &ForwardOption::ForwardTransaction,
                     &cluster_info,
@@ -4126,6 +4127,7 @@ mod tests {
                     true,
                     &data_budget,
                     &mut LeaderSlotMetricsTracker::new(0),
+                    &stats,
                 );
 
                 recv_socket
@@ -4225,6 +4227,7 @@ mod tests {
             ];
 
             for (name, forward_option, hold, expected_ids, expected_num_unprocessed) in test_cases {
+                let stats = BankingStageStats::default();
                 BankingStage::handle_forwarding(
                     &forward_option,
                     &cluster_info,
@@ -4233,6 +4236,7 @@ mod tests {
                     hold,
                     &DataBudget::default(),
                     &mut LeaderSlotMetricsTracker::new(0),
+                    &stats,
                 );
 
                 recv_socket

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -5,9 +5,12 @@ use {
         banking_stage::HOLD_TRANSACTIONS_SLOT_OFFSET,
         result::{Error, Result},
     },
-    crossbeam_channel::{unbounded, RecvTimeoutError},
+    crossbeam_channel::{unbounded, RecvTimeoutError, Sender},
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
-    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
+    solana_perf::{
+        packet::{PacketBatch, PacketBatchRecycler},
+        recycler::Recycler,
+    },
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{
         clock::DEFAULT_TICKS_PER_SLOT,
@@ -29,6 +32,7 @@ use {
 
 pub struct FetchStage {
     thread_hdls: Vec<JoinHandle<()>>,
+    pub forward_sender: Sender<PacketBatch>,
 }
 
 impl FetchStage {
@@ -240,6 +244,7 @@ impl FetchStage {
             .into_iter()
             .flatten()
             .collect(),
+            forward_sender,
         }
     }
 

--- a/core/src/fetch_stage.rs
+++ b/core/src/fetch_stage.rs
@@ -5,12 +5,9 @@ use {
         banking_stage::HOLD_TRANSACTIONS_SLOT_OFFSET,
         result::{Error, Result},
     },
-    crossbeam_channel::{unbounded, RecvTimeoutError, Sender},
+    crossbeam_channel::{unbounded, RecvTimeoutError},
     solana_metrics::{inc_new_counter_debug, inc_new_counter_info},
-    solana_perf::{
-        packet::{PacketBatch, PacketBatchRecycler},
-        recycler::Recycler,
-    },
+    solana_perf::{packet::PacketBatchRecycler, recycler::Recycler},
     solana_poh::poh_recorder::PohRecorder,
     solana_sdk::{
         clock::DEFAULT_TICKS_PER_SLOT,
@@ -32,7 +29,6 @@ use {
 
 pub struct FetchStage {
     thread_hdls: Vec<JoinHandle<()>>,
-    pub forward_sender: Sender<PacketBatch>,
 }
 
 impl FetchStage {
@@ -47,6 +43,7 @@ impl FetchStage {
     ) -> (Self, PacketBatchReceiver, PacketBatchReceiver) {
         let (sender, receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
+        let (forward_sender, forward_receiver) = unbounded();
         (
             Self::new_with_sender(
                 sockets,
@@ -55,6 +52,8 @@ impl FetchStage {
                 exit,
                 &sender,
                 &vote_sender,
+                &forward_sender,
+                forward_receiver,
                 poh_recorder,
                 coalesce_ms,
                 None,
@@ -64,6 +63,7 @@ impl FetchStage {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_sender(
         sockets: Vec<UdpSocket>,
         tpu_forwards_sockets: Vec<UdpSocket>,
@@ -71,6 +71,8 @@ impl FetchStage {
         exit: &Arc<AtomicBool>,
         sender: &PacketBatchSender,
         vote_sender: &PacketBatchSender,
+        forward_sender: &PacketBatchSender,
+        forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
@@ -85,6 +87,8 @@ impl FetchStage {
             exit,
             sender,
             vote_sender,
+            forward_sender,
+            forward_receiver,
             poh_recorder,
             coalesce_ms,
             in_vote_only_mode,
@@ -133,6 +137,7 @@ impl FetchStage {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_multi_socket(
         tpu_sockets: Vec<Arc<UdpSocket>>,
         tpu_forwards_sockets: Vec<Arc<UdpSocket>>,
@@ -140,6 +145,8 @@ impl FetchStage {
         exit: &Arc<AtomicBool>,
         sender: &PacketBatchSender,
         vote_sender: &PacketBatchSender,
+        forward_sender: &PacketBatchSender,
+        forward_receiver: PacketBatchReceiver,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         coalesce_ms: u64,
         in_vote_only_mode: Option<Arc<AtomicBool>>,
@@ -164,7 +171,6 @@ impl FetchStage {
             .collect();
 
         let tpu_forward_stats = Arc::new(StreamerReceiveStats::new("tpu_forwards_receiver"));
-        let (forward_sender, forward_receiver) = unbounded();
         let tpu_forwards_threads: Vec<_> = tpu_forwards_sockets
             .into_iter()
             .map(|socket| {
@@ -244,7 +250,6 @@ impl FetchStage {
             .into_iter()
             .flatten()
             .collect(),
-            forward_sender,
         }
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -53,6 +53,7 @@ pub struct TpuSockets {
     pub vote: Vec<UdpSocket>,
     pub broadcast: Vec<UdpSocket>,
     pub transactions_quic: UdpSocket,
+    pub transactions_forwards_quic: UdpSocket,
 }
 
 pub struct Tpu {
@@ -63,6 +64,7 @@ pub struct Tpu {
     cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
     tpu_quic_t: thread::JoinHandle<()>,
+    tpu_forwards_quic_t: thread::JoinHandle<()>,
     find_packet_sender_stake_stage: FindPacketSenderStakeStage,
     vote_find_packet_sender_stake_stage: FindPacketSenderStakeStage,
     staked_nodes_updater_service: StakedNodesUpdaterService,
@@ -100,6 +102,7 @@ impl Tpu {
             vote: tpu_vote_sockets,
             broadcast: broadcast_sockets,
             transactions_quic: transactions_quic_sockets,
+            transactions_forwards_quic: transactions_forwards_quic_sockets,
         } = sockets;
 
         let (packet_sender, packet_receiver) = unbounded();
@@ -150,6 +153,19 @@ impl Tpu {
             keypair,
             cluster_info.my_contact_info().tpu.ip(),
             packet_sender,
+            exit.clone(),
+            MAX_QUIC_CONNECTIONS_PER_IP,
+            staked_nodes.clone(),
+            MAX_STAKED_CONNECTIONS,
+            MAX_UNSTAKED_CONNECTIONS,
+        )
+        .unwrap();
+
+        let tpu_forwards_quic_t = spawn_server(
+            transactions_forwards_quic_sockets,
+            keypair,
+            cluster_info.my_contact_info().tpu.ip(),
+            fetch_stage.forward_sender.clone(),
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_IP,
             staked_nodes,
@@ -223,6 +239,7 @@ impl Tpu {
             cluster_info_vote_listener,
             broadcast_stage,
             tpu_quic_t,
+            tpu_forwards_quic_t,
             find_packet_sender_stake_stage,
             vote_find_packet_sender_stake_stage,
             staked_nodes_updater_service,
@@ -257,6 +274,7 @@ impl Tpu {
             self.staked_nodes_updater_service.join(),
         ];
         self.tpu_quic_t.join()?;
+        self.tpu_forwards_quic_t.join()?;
         let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -983,6 +983,7 @@ impl Validator {
                 vote: node.sockets.tpu_vote,
                 broadcast: node.sockets.broadcast,
                 transactions_quic: node.sockets.tpu_quic,
+                transactions_forwards_quic: node.sockets.tpu_forwards_quic,
             },
             &rpc_subscriptions,
             transaction_status_sender,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2719,6 +2719,7 @@ pub struct Sockets {
     pub serve_repair: UdpSocket,
     pub ancestor_hashes_requests: UdpSocket,
     pub tpu_quic: UdpSocket,
+    pub tpu_forwards_quic: UdpSocket,
 }
 
 #[derive(Debug)]
@@ -2741,7 +2742,8 @@ impl Node {
         let gossip_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), gossip_port);
         let tvu = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tvu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let tpu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let ((_tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
+            bind_two_consecutive_in_range(bind_ip_addr, (1024, 65535)).unwrap();
         let tpu_vote = UdpSocket::bind("127.0.0.1:0").unwrap();
         let repair = UdpSocket::bind("127.0.0.1:0").unwrap();
         let rpc_port = find_available_port_in_range(bind_ip_addr, (1024, 65535)).unwrap();
@@ -2786,6 +2788,7 @@ impl Node {
                 serve_repair,
                 ancestor_hashes_requests,
                 tpu_quic,
+                tpu_forwards_quic,
             },
         }
     }
@@ -2822,7 +2825,8 @@ impl Node {
         let (tvu_forwards_port, tvu_forwards) = Self::bind(bind_ip_addr, port_range);
         let ((tpu_port, tpu), (_tpu_quic_port, tpu_quic)) =
             bind_two_consecutive_in_range(bind_ip_addr, port_range).unwrap();
-        let (tpu_forwards_port, tpu_forwards) = Self::bind(bind_ip_addr, port_range);
+        let ((tpu_forwards_port, tpu_forwards), (_tpu_forwards_quic_port, tpu_forwards_quic)) =
+            bind_two_consecutive_in_range(bind_ip_addr, port_range).unwrap();
         let (tpu_vote_port, tpu_vote) = Self::bind(bind_ip_addr, port_range);
         let (_, retransmit_socket) = Self::bind(bind_ip_addr, port_range);
         let (repair_port, repair) = Self::bind(bind_ip_addr, port_range);
@@ -2866,6 +2870,7 @@ impl Node {
                 serve_repair,
                 ancestor_hashes_requests,
                 tpu_quic,
+                tpu_forwards_quic,
             },
         }
     }
@@ -2896,6 +2901,14 @@ impl Node {
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tpu_forwards multi_bind");
+
+        let (_tpu_forwards_port_quic, tpu_forwards_quic) = Self::bind(
+            bind_ip_addr,
+            (
+                tpu_forwards_port + QUIC_PORT_OFFSET,
+                tpu_forwards_port + QUIC_PORT_OFFSET + 1,
+            ),
+        );
 
         let (tpu_vote_port, tpu_vote_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 1).expect("tpu_vote multi_bind");
@@ -2944,6 +2957,7 @@ impl Node {
                 ip_echo: Some(ip_echo),
                 ancestor_hashes_requests,
                 tpu_quic,
+                tpu_forwards_quic,
             },
         }
     }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -29,7 +29,7 @@ pub struct UdpSocketPair {
 pub type PortRange = (u16, u16);
 
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
-pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 12; // VALIDATOR_PORT_RANGE must be at least this wide
+pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 13; // VALIDATOR_PORT_RANGE must be at least this wide
 
 pub(crate) const HEADER_LENGTH: usize = 4;
 pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -152,6 +152,7 @@ fn verify_reachable_ports(
     }
     if ContactInfo::is_valid_address(&node.info.tpu_forwards, socket_addr_space) {
         udp_sockets.extend(node.sockets.tpu_forwards.iter());
+        udp_sockets.push(&node.sockets.tpu_forwards_quic);
     }
     if ContactInfo::is_valid_address(&node.info.tpu_vote, socket_addr_space) {
         udp_sockets.extend(node.sockets.tpu_vote.iter());


### PR DESCRIPTION
#### Problem
QUIC server to receive forwarded transactions is not running. This causes the transactions to be dropped when forwarded using QUIC.

#### Summary of Changes
Added code to spawn QUIC server to receive forwarded transaction.
Updated `banking_stage` code to forward votes using UDP specific connection.
Ensure only staked nodes are able to connect to QUIC forwarding port.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
