### PR TITLE
set active state to shrink_ancient when doing interesting work

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3410,7 +3410,7 @@ impl AccountsDb {
         if sorted_slots.is_empty() {
             return;
         }
-        let _guard = self.active_stats.activate(ActiveStatItem::SquashAncient);
+        let mut guard = None;
 
         // the ancient append vec currently being written to
         let mut current_ancient = None;
@@ -3433,6 +3433,11 @@ impl AccountsDb {
                         continue;
                     }
                 };
+
+            if guard.is_none() {
+                // we are now doing interesting work in squashing ancient
+                guard = Some(self.active_stats.activate(ActiveStatItem::SquashAncient))
+            }
 
             // this code is copied from shrink. I would like to combine it into a helper function, but the borrow checker has defeated my efforts so far.
             let (stored_accounts, _num_stores, _original_bytes) =


### PR DESCRIPTION
#### Problem

we can return quickly from this function causing noise in the metrics.
So, delay setting the active state until we're actually finding interesting work to do.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
