### PR TITLE
update ubuntu image 

### DIFF
--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -182,7 +182,7 @@ cloud_CreateInstances() {
     imageName="ubuntu-2004-focal-v20201211-with-cuda-10-2 --image-project principal-lane-200702"
   else
     # Upstream Ubuntu 20.04 LTS image
-    imageName="ubuntu-2004-focal-v20201201 --image-project ubuntu-os-cloud"
+    imageName="ubuntu-2004-focal-v20220419 --image-project ubuntu-os-cloud"
   fi
 
   declare -a nodes


### PR DESCRIPTION
#### Problem

The current version of image uses kerne version `5.4.0-1030-gcp`.
Problem is that there is no dpkg for linux-tools for this kernel version in ubuntu artifactory (to check `apt-cache search linux-tools-5.4.0-1030-gcp`).
It means that it is not possible to install perf for the following PR https://github.com/solana-labs/solana/pull/25624

#### Summary of Changes

Updates ubuntu image 
