### PR TITLE
records number of residual data shreds which don't make a full batch

### DIFF
--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -153,6 +153,7 @@ impl Shredder {
 
         process_stats.serialize_elapsed += serialize_time.as_us();
         process_stats.gen_data_elapsed += gen_data_time.as_us();
+        process_stats.record_num_residual_data_shreds(data_shreds.len());
 
         data_shreds
     }


### PR DESCRIPTION
#### Problem
Data shreds are batched into `MAX_DATA_SHREDS_PER_FEC_BLOCK` shreds for
each erasure batch. If there are residual shreds not making a full
batch, then we cannot generate coding shreds and need to buffer shreds
until there is a full batch; This may add latency to coding shreds
generation and broadcast.


#### Summary of Changes
In order to evaluate upcoming changes removing this buffering logic,
this commit adds metrics tracking residual number of data shreds which
don't make a full batch.
