### PR TITLE
remove par_iter on update index below threshold

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6910,34 +6910,43 @@ impl AccountsDb {
         // using a thread pool here results in deadlock panics from bank_hashes.write()
         // so, instead we limit how many threads will be created to the same size as the bg thread pool
         let len = std::cmp::min(accounts.len(), infos.len());
-        let chunk_size = std::cmp::max(1, len / quarter_thread_count()); // # pubkeys/thread
-        let batches = 1 + len / chunk_size;
-        (0..batches)
-            .into_par_iter()
-            .map(|batch| {
-                let start = batch * chunk_size;
-                let end = std::cmp::min(start + chunk_size, len);
-                let mut reclaims = Vec::with_capacity((end - start) / 2);
-                (start..end).into_iter().for_each(|i| {
-                    let info = infos[i];
-                    let pubkey_account = (accounts.pubkey(i), accounts.account(i));
-                    let pubkey = pubkey_account.0;
-                    let old_slot = accounts.slot(i);
-                    self.accounts_index.upsert(
-                        target_slot,
-                        old_slot,
-                        pubkey,
-                        pubkey_account.1,
-                        &self.account_indexes,
-                        info,
-                        &mut reclaims,
-                        previous_slot_entry_was_cached,
-                    );
-                });
-                reclaims
-            })
-            .flatten()
-            .collect::<Vec<_>>()
+        let threshold = 1;
+        let update = |start, end| {
+            let mut reclaims = Vec::with_capacity((end - start) / 2);
+
+            (start..end).into_iter().for_each(|i| {
+                let info = infos[i];
+                let pubkey_account = (accounts.pubkey(i), accounts.account(i));
+                let pubkey = pubkey_account.0;
+                let old_slot = accounts.slot(i);
+                self.accounts_index.upsert(
+                    target_slot,
+                    old_slot,
+                    pubkey,
+                    pubkey_account.1,
+                    &self.account_indexes,
+                    info,
+                    &mut reclaims,
+                    previous_slot_entry_was_cached,
+                );
+            });
+            reclaims
+        };
+        if len > threshold {
+            let chunk_size = std::cmp::max(1, len / quarter_thread_count()); // # pubkeys/thread
+            let batches = 1 + len / chunk_size;
+            (0..batches)
+                .into_par_iter()
+                .map(|batch| {
+                    let start = batch * chunk_size;
+                    let end = std::cmp::min(start + chunk_size, len);
+                    update(start, end)
+                })
+                .flatten()
+                .collect::<Vec<_>>()
+        } else {
+            update(0, len)
+        }
     }
 
     fn should_not_shrink(aligned_bytes: u64, total_bytes: u64, num_stores: usize) -> bool {


### PR DESCRIPTION
#### Problem

Improve perf for common call with low # accounts to update.
See #24692

The largest call I saw on a mnb snapshot and brief ledger replay was 302 accounts being updated at a time.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
