### PR TITLE
Add new error if stake delegation is below the minimum

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -3886,7 +3886,10 @@ mod tests {
         ];
         for (stake_delegation, expected_result) in &[
             (minimum_delegation, Ok(())),
-            (minimum_delegation - 1, Err(StakeError::InsufficientStake)),
+            (
+                minimum_delegation - 1,
+                Err(StakeError::InsufficientDelegation),
+            ),
         ] {
             for stake_state in &[
                 StakeState::Initialized(meta),
@@ -7029,7 +7032,7 @@ mod tests {
         fn test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegation() {
             do_test_behavior_withdrawal_then_redelegate_with_less_than_minimum_stake_delegation(
                 new_feature_set(),
-                Err(StakeError::InsufficientStake.into()),
+                Err(StakeError::InsufficientDelegation.into()),
             );
         }
         #[test]

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1034,7 +1034,7 @@ fn validate_delegated_amount(
         || feature_set.is_active(&feature_set::stake_raise_minimum_delegation_to_1_sol::id()))
         && stake_amount < crate::get_minimum_delegation(feature_set)
     {
-        return Err(StakeError::InsufficientStake.into());
+        return Err(StakeError::InsufficientDelegation.into());
     }
     Ok(ValidatedDelegatedInfo { stake_amount })
 }

--- a/sdk/program/src/stake/instruction.rs
+++ b/sdk/program/src/stake/instruction.rs
@@ -57,6 +57,9 @@ pub enum StakeError {
         "stake account has not been delinquent for the minimum epochs required for deactivation"
     )]
     MinimumDelinquentEpochsForDeactivationNotMet,
+
+    #[error("delegation amount is less than the minimum")]
+    InsufficientDelegation,
 }
 
 impl<E> DecodeError<E> for StakeError {


### PR DESCRIPTION
#### Problem

When the linked features are enabled, delegating a stake amount below the minimum will return with an error saying "Error: split amount is more than is staked", which is misleading since the error was caused during delegate and not split.

See linked Issue for more information.

#### Summary of Changes

Use new error if stake delegation is below the minimum.

Note, _neither_ of the two linked feature are enabled, so no new feature-gate is required.

Fixes #25337 
Feature Gate Issue: #24357 
Feature Gate Issue: #24669 
