### PR TITLE
flips nonce/non-nonce blockhash check

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4057,13 +4057,30 @@ impl Bank {
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let hash_queue = self.blockhash_queue.read().unwrap();
+        let flip_nonce_blockhash_check = self
+            .feature_set
+            .is_active(&feature_set::flip_nonce_blockhash_check::id());
+        let enable_durable_nonce = flip_nonce_blockhash_check;
         txs.zip(lock_results)
             .map(|(tx, lock_res)| match lock_res {
                 Ok(()) => {
                     let recent_blockhash = tx.message().recent_blockhash();
-                    if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
+                    if flip_nonce_blockhash_check {
+                        if let Some((address, account)) =
+                            self.check_transaction_for_nonce(tx, enable_durable_nonce)
+                        {
+                            (Ok(()), Some(NoncePartial::new(address, account)))
+                        } else if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
+                            (Ok(()), None)
+                        } else {
+                            error_counters.blockhash_not_found += 1;
+                            (Err(TransactionError::BlockhashNotFound), None)
+                        }
+                    } else if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
                         (Ok(()), None)
-                    } else if let Some((address, account)) = self.check_transaction_for_nonce(tx) {
+                    } else if let Some((address, account)) =
+                        self.check_transaction_for_nonce(tx, enable_durable_nonce)
+                    {
                         (Ok(()), Some(NoncePartial::new(address, account)))
                     } else {
                         error_counters.blockhash_not_found += 1;
@@ -4136,16 +4153,13 @@ impl Bank {
     pub fn check_transaction_for_nonce(
         &self,
         tx: &SanitizedTransaction,
+        enable_durable_nonce: bool,
     ) -> Option<TransactionAccount> {
-        if self.cluster_type() == ClusterType::MainnetBeta {
-            if self.slot() <= 135986379 {
-                self.check_message_for_nonce(tx.message())
-            } else {
-                None
-            }
-        } else {
-            self.check_message_for_nonce(tx.message())
-        }
+        (enable_durable_nonce
+            || self.cluster_type() != ClusterType::MainnetBeta
+            || self.slot() <= 135986379)
+            .then(|| self.check_message_for_nonce(tx.message()))
+            .flatten()
     }
 
     pub fn check_transactions(
@@ -12373,7 +12387,10 @@ pub(crate) mod tests {
         );
         let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
         assert_eq!(
-            bank.check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx)),
+            bank.check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            ),
             Some((nonce_pubkey, nonce_account))
         );
     }
@@ -12399,7 +12416,10 @@ pub(crate) mod tests {
             nonce_hash,
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx,))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx,),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12425,7 +12445,10 @@ pub(crate) mod tests {
         );
         tx.message.instructions[0].accounts.clear();
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12452,7 +12475,10 @@ pub(crate) mod tests {
             nonce_hash,
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12476,7 +12502,10 @@ pub(crate) mod tests {
             Hash::default(),
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -13148,7 +13177,10 @@ pub(crate) mod tests {
             Err(TransactionError::BlockhashNotFound)
         );
         assert_eq!(
-            bank.check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx)),
+            bank.check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            ),
             None
         );
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4074,7 +4074,10 @@ impl Bank {
         let flip_nonce_blockhash_check = self
             .feature_set
             .is_active(&feature_set::flip_nonce_blockhash_check::id());
-        let enable_durable_nonce = flip_nonce_blockhash_check;
+        let enable_durable_nonce = flip_nonce_blockhash_check
+            && self
+                .feature_set
+                .is_active(&feature_set::enable_durable_nonce::id());
         let mut check_age = |tx: &SanitizedTransaction| -> TransactionCheckResult {
             let recent_blockhash = tx.message().recent_blockhash();
             if flip_nonce_blockhash_check {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -416,6 +416,10 @@ pub mod warp_timestamp_with_a_vengeance {
     solana_sdk::declare_id!("3BX6SBeEBibHaVQXywdkcgyUk6evfYZkHdztXiDtEpFS");
 }
 
+pub mod flip_nonce_blockhash_check {
+    solana_sdk::declare_id!("Hh2R4QhV84MZJVWdR8TMKan7px4kjJmUNJfJfLcdAc6Z");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -513,6 +517,7 @@ lazy_static! {
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
+        (flip_nonce_blockhash_check::id(), "flip nonce/non-nonce blockhash check"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -420,6 +420,10 @@ pub mod flip_nonce_blockhash_check {
     solana_sdk::declare_id!("Hh2R4QhV84MZJVWdR8TMKan7px4kjJmUNJfJfLcdAc6Z");
 }
 
+pub mod enable_durable_nonce {
+    solana_sdk::declare_id!("4EJQtF2pkRyawwcTVfQutzq4Sa5hRhibF6QAK1QXhtEX");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -517,7 +521,8 @@ lazy_static! {
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
-        (flip_nonce_blockhash_check::id(), "flip nonce/non-nonce blockhash check"),
+        (flip_nonce_blockhash_check::id(), "flip nonce/non-nonce blockhash check #25711"),
+        (enable_durable_nonce::id(), "enable durable nonce #25711"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Durable nonce transactions can be executed twice.

#### Summary of Changes
@t-nelson:
> gist is to flip the nonce/non-nonce blockhash check so that whether a
> durable nonce transaction is flagged is not dependent up whether the
> blockhash is extant in the rbh queue