### PR TITLE
move rent collection time into datapoint

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5187,8 +5187,8 @@ impl Bank {
                 self.rewrites_skipped_this_slot.read().unwrap().len(),
                 i64
             ),
+            ("total_time_us", measure.as_us(), i64),
         );
-        inc_new_counter_info!("collect_rent_eagerly-ms", measure.as_ms() as usize);
     }
 
     #[cfg(test)]


### PR DESCRIPTION
#### Problem

I believe counters are less efficient.
We are already reporting metrics per bank for rent collection. Add total time to the existing metric and remove the counter.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
