### PR TITLE
Add new replay metrics for replay blockstore_into_bank and complete

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -36,7 +36,13 @@ impl std::ops::DerefMut for ReplaySlotStats {
 }
 
 impl ReplaySlotStats {
-    pub fn report_stats(&self, slot: Slot, num_entries: usize, num_shreds: u64) {
+    pub fn report_stats(
+        &self,
+        slot: Slot,
+        num_entries: usize,
+        num_shreds: u64,
+        bank_complete_time_us: u64,
+    ) {
         datapoint_info!(
             "replay-slot-stats",
             ("slot", slot as i64, i64),
@@ -104,6 +110,7 @@ impl ReplaySlotStats {
                     .index(ExecuteTimingType::UpdateStakesCacheUs),
                 i64
             ),
+            ("bank_complete_time_us", bank_complete_time_us, i64),
             (
                 "total_batches_len",
                 *self


### PR DESCRIPTION
#### Problem

Inter-block replay time could be significant and replay_active_banks metric captures a lot of work.

#### Summary of Changes

Break down the work to see what is actual transaction replay time vs. freeze or other time.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
