### PR TITLE
cli: Speed up fee check on program deployment

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -68,6 +68,22 @@ pub fn check_account_for_spend_multiple_fees_with_commitment(
     commitment: CommitmentConfig,
 ) -> Result<(), CliError> {
     let fee = get_fee_for_messages(rpc_client, messages)?;
+    check_account_for_spend_and_fee_with_commitment(
+        rpc_client,
+        account_pubkey,
+        balance,
+        fee,
+        commitment,
+    )
+}
+
+pub fn check_account_for_spend_and_fee_with_commitment(
+    rpc_client: &RpcClient,
+    account_pubkey: &Pubkey,
+    balance: u64,
+    fee: u64,
+    commitment: CommitmentConfig,
+) -> Result<(), CliError> {
     if !check_account_for_balance_with_commitment(
         rpc_client,
         account_pubkey,


### PR DESCRIPTION
#### Problem

Deploying programs often doesn't work during times of congestion because the blockhash expires by the time the fees are checked, which has forced many people to use the `--skip-fee-check` flag, which is dangerous in the long run.

#### Summary of Changes

Assuming that all write messages cost the same, only get the fee for the initial message, final message, and one write message, and figure out the total cost as:

```
cost = rent_exempt_balances + initial_message_fee + final_message_fee + write_message_fee * num_write_messages
```

Fixes #23427
