### PR TITLE
Replace blocking sleep with nonblocking in HttpSender

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -20,9 +20,9 @@ use {
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
         },
-        thread::sleep,
         time::{Duration, Instant},
     },
+    tokio::time::sleep,
 };
 
 pub struct HttpSender {
@@ -147,7 +147,7 @@ impl RpcSender for HttpSender {
                                 response, too_many_requests_retries, duration
                             );
 
-                    sleep(duration);
+                    sleep(duration).await;
                     stats_updater.add_rate_limited_time(duration);
                     continue;
                 }


### PR DESCRIPTION
#### Problem
`HttpSender` calls blocking [`sleep`](https://doc.rust-lang.org/std/thread/fn.sleep.html) in `HttpSender::send` function.  

#### Summary of Changes
Replaced it with [nonblocking version](https://docs.rs/tokio/1.18.2/tokio/time/fn.sleep.html).