### PR TITLE
disk idx: reduce lock calls

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -68,7 +68,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
     pub fn increment_age(&self) {
         // since we are about to change age, there are now 0 buckets that have been flushed at this age
         // this should happen before the age.fetch_add
-        let previous = self.count_buckets_flushed.swap(0, Ordering::Acquire);
+        let previous = self.count_buckets_flushed.swap(0, Ordering::AcqRel);
         // fetch_add is defined to wrap.
         // That's what we want. 0..255, then back to 0.
         self.age.fetch_add(1, Ordering::Release);
@@ -124,7 +124,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
     }
 
     pub fn bucket_flushed_at_current_age(&self) {
-        let count_buckets_flushed = 1 + self.count_buckets_flushed.fetch_add(1, Ordering::Release);
+        let count_buckets_flushed = 1 + self.count_buckets_flushed.fetch_add(1, Ordering::AcqRel);
         self.maybe_advance_age_internal(
             self.all_buckets_flushed_at_current_age_internal(count_buckets_flushed),
         );

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -124,22 +124,35 @@ impl<T: IndexValue> BucketMapHolder<T> {
     }
 
     pub fn bucket_flushed_at_current_age(&self) {
-        self.count_buckets_flushed.fetch_add(1, Ordering::Release);
-        self.maybe_advance_age();
+        let count_buckets_flushed = 1 + self.count_buckets_flushed.fetch_add(1, Ordering::Release);
+        self.maybe_advance_age_internal(
+            self.all_buckets_flushed_at_current_age_internal(count_buckets_flushed),
+        );
     }
 
     /// have all buckets been flushed at the current age?
     pub fn all_buckets_flushed_at_current_age(&self) -> bool {
-        self.count_buckets_flushed() >= self.bins
+        self.all_buckets_flushed_at_current_age_internal(self.count_buckets_flushed())
+    }
+
+    /// have all buckets been flushed at the current age?
+    fn all_buckets_flushed_at_current_age_internal(&self, count_buckets_flushed: usize) -> bool {
+        count_buckets_flushed >= self.bins
     }
 
     pub fn count_buckets_flushed(&self) -> usize {
         self.count_buckets_flushed.load(Ordering::Acquire)
     }
 
+    /// if all buckets are flushed at the current age and time has elapsed, then advanced age
     pub fn maybe_advance_age(&self) -> bool {
-        // check has_age_interval_elapsed last as calling it modifies state on success
-        if self.all_buckets_flushed_at_current_age() && self.has_age_interval_elapsed() {
+        self.maybe_advance_age_internal(self.all_buckets_flushed_at_current_age())
+    }
+
+    /// if all buckets are flushed at the current age and time has elapsed, then advanced age
+    fn maybe_advance_age_internal(&self, all_buckets_flushed_at_current_age: bool) -> bool {
+        // call has_age_interval_elapsed last since calling it modifies state on success
+        if all_buckets_flushed_at_current_age && self.has_age_interval_elapsed() {
             self.increment_age();
             true
         } else {


### PR DESCRIPTION
#### Problem

Use the value returned from fetch_add instead of loading it again.
This happens once per bucket.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
