### PR TITLE
Award one credit per dequeued vote when processing VoteStateUpdate in…

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1048,7 +1048,7 @@ impl ProgramTestContext {
 
         let epoch = bank.epoch();
         for _ in 0..number_of_credits {
-            vote_state.increment_credits(epoch);
+            vote_state.increment_credits(epoch, 1);
         }
         let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -6554,7 +6554,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            reference_vote_state.increment_credits(epoch as Epoch);
+            reference_vote_state.increment_credits(epoch as Epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6574,7 +6574,7 @@ mod tests {
         // Instruction will fail
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         assert_eq!(
             reference_vote_state.epoch_credits[current_epoch as usize - 2].0,
@@ -6604,7 +6604,7 @@ mod tests {
         // Instruction will succeed
         let mut reference_vote_state = VoteState::default();
         for epoch in 0..=current_epoch {
-            reference_vote_state.increment_credits(epoch);
+            reference_vote_state.increment_credits(epoch, 1);
         }
         reference_vote_account
             .borrow_mut()
@@ -6633,7 +6633,7 @@ mod tests {
 
         let mut vote_state = VoteState::default();
         for epoch in 0..MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION / 2 {
-            vote_state.increment_credits(epoch as Epoch);
+            vote_state.increment_credits(epoch as Epoch, 1);
         }
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
@@ -6687,8 +6687,10 @@ mod tests {
         // `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION` ago.
         // Instruction will succeed
         let mut vote_state = VoteState::default();
-        vote_state
-            .increment_credits(current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch);
+        vote_state.increment_credits(
+            current_epoch - MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION as Epoch,
+            1,
+        );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))
             .unwrap();
@@ -6706,6 +6708,7 @@ mod tests {
         let mut vote_state = VoteState::default();
         vote_state.increment_credits(
             current_epoch - (MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION - 1) as Epoch,
+            1,
         );
         vote_account
             .serialize_data(&VoteStateVersions::new_current(vote_state))

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2373,8 +2373,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2435,7 +2435,7 @@ mod tests {
         // put 193,536,000 credits in at epoch 0, typical for a 14-day epoch
         //  this loop takes a few seconds...
         for _ in 0..epoch_slots {
-            vote_state.increment_credits(0);
+            vote_state.increment_credits(0, 1);
         }
 
         // no overflow on points
@@ -2476,8 +2476,8 @@ mod tests {
         );
 
         // put 2 credits in at epoch 0
-        vote_state.increment_credits(0);
-        vote_state.increment_credits(0);
+        vote_state.increment_credits(0, 1);
+        vote_state.increment_credits(0, 1);
 
         // this one should be able to collect exactly 2
         assert_eq!(
@@ -2523,7 +2523,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 1
-        vote_state.increment_credits(1);
+        vote_state.increment_credits(1, 1);
 
         stake.credits_observed = 2;
         // this one should be able to collect the one just added
@@ -2548,7 +2548,7 @@ mod tests {
         );
 
         // put 1 credit in epoch 2
-        vote_state.increment_credits(2);
+        vote_state.increment_credits(2, 1);
         // this one should be able to collect 2 now
         assert_eq!(
             Some(CalculatedStakeRewards {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -87,6 +87,7 @@ pub fn process_instruction(
                     &clock,
                     vote_state_update,
                     &signers,
+                    &invoke_context.feature_set,
                 )
             } else {
                 Err(InstructionError::InvalidInstructionData)

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -425,7 +425,7 @@ pub mod enable_durable_nonce {
 }
 
 pub mod vote_state_update_credit_per_dequeue {
-    solana_sdk::declare_id!("CPFKGKaoDHQFwHjj5pd2sCPXxksSWJFgUDSda5LRJFck");
+    solana_sdk::declare_id!("CveezY6FDLVBToHDcvJRmtMouqzsmj4UXYh5ths5G5Uv");
 }
 
 lazy_static! {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -424,6 +424,10 @@ pub mod enable_durable_nonce {
     solana_sdk::declare_id!("4EJQtF2pkRyawwcTVfQutzq4Sa5hRhibF6QAK1QXhtEX");
 }
 
+pub mod vote_state_update_credit_per_dequeue {
+    solana_sdk::declare_id!("CPFKGKaoDHQFwHjj5pd2sCPXxksSWJFgUDSda5LRJFck");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -523,6 +527,7 @@ lazy_static! {
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
         (separate_nonce_from_blockhash::id(), "separate durable nonce and blockhash domains #25744"),
         (enable_durable_nonce::id(), "enable durable nonce #25744"),
+        (vote_state_update_credit_per_dequeue::id(), "Calculate vote credits for VoteStateUpdate per vote dequeue to match credit awards for Vote instruction"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
…struction,

to match vote rewards of Vote instruction.

#### Problem

VoteStateUpdate instruction processing does not award one credit per vote dequeued from the Tower.  This is a difference in how vote credits are awarded and has not received community consensus nor governance permissions.

This change will bring the VoteStateUpdate instruction processing in line with how Vote instructions are processed with regards to credit award.

#### Summary of Changes

Modified VoteStateUpdate processing to count dequeued slots and then award that many credits.  Added some unit tests.
