### PR TITLE
separates durable nonce and blockhash domains

### DIFF
--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -20,7 +20,7 @@ pub fn parse_nonce(data: &[u8]) -> Result<UiNonceState, ParseAccountError> {
         )),
         State::Initialized(data) => Ok(UiNonceState::Initialized(UiNonceData {
             authority: data.authority.to_string(),
-            blockhash: data.blockhash.to_string(),
+            blockhash: data.blockhash().to_string(),
             fee_calculator: data.fee_calculator.into(),
         })),
     }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -333,10 +333,10 @@ pub fn check_nonce_account(
 ) -> Result<(), CliError> {
     match state_from_account(nonce_account)? {
         State::Initialized(ref data) => {
-            if &data.blockhash != nonce_hash {
+            if &data.blockhash() != nonce_hash {
                 Err(Error::InvalidHash {
                     provided: *nonce_hash,
-                    expected: data.blockhash,
+                    expected: data.blockhash(),
                 }
                 .into())
             } else if nonce_authority != &data.authority {
@@ -524,7 +524,7 @@ pub fn process_get_nonce(
         .and_then(|ref a| state_from_account(a))?
     {
         State::Uninitialized => Ok("Nonce account is uninitialized".to_string()),
-        State::Initialized(ref data) => Ok(format!("{:?}", data.blockhash)),
+        State::Initialized(ref data) => Ok(format!("{:?}", data.blockhash())),
     }
 }
 
@@ -598,7 +598,7 @@ pub fn process_show_nonce_account(
             ..CliNonceAccount::default()
         };
         if let Some(data) = data {
-            nonce_account.nonce = Some(data.blockhash.to_string());
+            nonce_account.nonce = Some(data.blockhash().to_string());
             nonce_account.lamports_per_signature = Some(data.fee_calculator.lamports_per_signature);
             nonce_account.authority = Some(data.authority.to_string());
         }
@@ -665,7 +665,11 @@ mod tests {
             account::Account,
             account_utils::StateMut,
             hash::hash,
-            nonce::{self, state::Versions, State},
+            nonce::{
+                self,
+                state::{DurableNonce, Versions},
+                State,
+            },
             nonce_account,
             signature::{read_keypair_file, write_keypair, Keypair, Signer},
             system_program,
@@ -925,11 +929,13 @@ mod tests {
 
     #[test]
     fn test_check_nonce_account() {
-        let blockhash = Hash::default();
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::default(), /*separate_domains:*/ true);
+        let blockhash = *durable_nonce.as_hash();
         let nonce_pubkey = solana_sdk::pubkey::new_rand();
         let data = Versions::new_current(State::Initialized(nonce::state::Data::new(
             nonce_pubkey,
-            blockhash,
+            durable_nonce,
             0,
         )));
         let valid = Account::new_data(1, &data, &system_program::ID);
@@ -949,9 +955,11 @@ mod tests {
             assert_eq!(err, Error::InvalidAccountData,);
         }
 
+        let invalid_durable_nonce =
+            DurableNonce::from_blockhash(&hash(b"invalid"), /*separate_domains:*/ true);
         let data = Versions::new_current(State::Initialized(nonce::state::Data::new(
             nonce_pubkey,
-            hash(b"invalid"),
+            invalid_durable_nonce,
             0,
         )));
         let invalid_hash = Account::new_data(1, &data, &system_program::ID).unwrap();
@@ -962,7 +970,7 @@ mod tests {
                 err,
                 Error::InvalidHash {
                     provided: blockhash,
-                    expected: hash(b"invalid"),
+                    expected: *invalid_durable_nonce.as_hash(),
                 }
             );
         }
@@ -970,7 +978,7 @@ mod tests {
         let new_nonce_authority = solana_sdk::pubkey::new_rand();
         let data = Versions::new_current(State::Initialized(nonce::state::Data::new(
             new_nonce_authority,
-            blockhash,
+            durable_nonce,
             0,
         )));
         let invalid_authority = Account::new_data(1, &data, &system_program::ID);
@@ -1019,7 +1027,9 @@ mod tests {
         let mut nonce_account = nonce_account::create_account(1).into_inner();
         assert_eq!(state_from_account(&nonce_account), Ok(State::Uninitialized));
 
-        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), Hash::new(&[42u8; 32]), 42);
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new(&[42u8; 32]), /*separate_domains:*/ true);
+        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), durable_nonce, 42);
         nonce_account
             .set_state(&Versions::new_current(State::Initialized(data.clone())))
             .unwrap();
@@ -1048,7 +1058,9 @@ mod tests {
             Err(Error::InvalidStateForOperation)
         );
 
-        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), Hash::new(&[42u8; 32]), 42);
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new(&[42u8; 32]), /*separate_domains:*/ true);
+        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), durable_nonce, 42);
         nonce_account
             .set_state(&Versions::new_current(State::Initialized(data.clone())))
             .unwrap();

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -325,7 +325,7 @@ fn test_create_account_with_seed() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Test by creating transfer TX with nonce, fully offline
     let mut authority_config = CliConfig::recent_for_tests();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -539,7 +539,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Delegate stake
     config.signers = vec![&config_keypair];
@@ -569,7 +569,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Deactivate stake
     config.command = CliCommand::DeactivateStake {
@@ -838,7 +838,7 @@ fn test_stake_authorize() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Nonced assignment of new online stake authority
     let online_authority = Keypair::new();
@@ -906,7 +906,7 @@ fn test_stake_authorize() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
     assert_ne!(nonce_hash, new_nonce_hash);
 }
 
@@ -1188,7 +1188,7 @@ fn test_stake_split() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Nonced offline split
     let split_account = keypair_from_seed(&[2u8; 32]).unwrap();
@@ -1458,7 +1458,7 @@ fn test_stake_set_lockup() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Nonced offline set lockup
     let lockup = LockupArgs {
@@ -1584,7 +1584,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Create stake account offline
     let stake_keypair = keypair_from_seed(&[4u8; 32]).unwrap();
@@ -1645,7 +1645,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Offline, nonced stake-withdraw
     let recipient = keypair_from_seed(&[5u8; 32]).unwrap();
@@ -1699,7 +1699,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Create another stake account. This time with seed
     let seed = "seedy";

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -200,7 +200,7 @@ fn test_transfer() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Nonced transfer
     config.signers = vec![&default_signer];
@@ -237,7 +237,7 @@ fn test_transfer() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
     assert_ne!(nonce_hash, new_nonce_hash);
 
     // Assign nonce authority to offline
@@ -263,7 +263,7 @@ fn test_transfer() {
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
-    .blockhash;
+    .blockhash();
 
     // Offline, nonced transfer
     offline.signers = vec![&default_offline_signer];

--- a/client/src/nonce_utils.rs
+++ b/client/src/nonce_utils.rs
@@ -199,7 +199,7 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 ///     // network's latest blockhash.
 ///     let nonce_account = client.get_account(nonce_account_pubkey)?;
 ///     let nonce_data = nonce_utils::data_from_account(&nonce_account)?;
-///     let blockhash = nonce_data.blockhash;
+///     let blockhash = nonce_data.blockhash();
 ///
 ///     tx.try_sign(&[payer], blockhash)?;
 ///

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4570,7 +4570,8 @@ pub mod tests {
             hash::{hash, Hash},
             instruction::InstructionError,
             message::{v0, v0::MessageAddressTableLookup, MessageHeader, VersionedMessage},
-            nonce, rpc_port,
+            nonce::{self, state::DurableNonce},
+            rpc_port,
             signature::{Keypair, Signer},
             slot_hashes::SlotHashes,
             system_program, system_transaction,
@@ -5550,7 +5551,7 @@ pub mod tests {
                     42,
                     &nonce::state::Versions::new_current(nonce::State::new_initialized(
                         &authority,
-                        &Hash::default(),
+                        DurableNonce::default(),
                         1000,
                     )),
                     &system_program::id(),

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -223,7 +223,8 @@ pub(crate) mod tests {
             hash::Hash,
             instruction::CompiledInstruction,
             message::{Message, MessageHeader, SanitizedMessage},
-            nonce, nonce_account,
+            nonce::{self, state::DurableNonce},
+            nonce_account,
             pubkey::Pubkey,
             signature::{Keypair, Signature, Signer},
             system_transaction,
@@ -323,7 +324,9 @@ pub(crate) mod tests {
         let pubkey = Pubkey::new_unique();
 
         let mut nonce_account = nonce_account::create_account(1).into_inner();
-        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), Hash::new(&[42u8; 32]), 42);
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new(&[42u8; 32]), /*separate_domains:*/ true);
+        let data = nonce::state::Data::new(Pubkey::new(&[1u8; 32]), durable_nonce, 42);
         nonce_account
             .set_state(&nonce::state::Versions::new_current(
                 nonce::State::Initialized(data),

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -40,7 +40,10 @@ use {
             SanitizedMessage,
         },
         native_loader,
-        nonce::{state::Versions as NonceVersions, State as NonceState},
+        nonce::{
+            state::{DurableNonce, Versions as NonceVersions},
+            State as NonceState,
+        },
         pubkey::Pubkey,
         slot_hashes::SlotHashes,
         system_program,
@@ -1193,7 +1196,7 @@ impl Accounts {
         res: &'a [TransactionExecutionResult],
         loaded: &'a mut [TransactionLoadResult],
         rent_collector: &RentCollector,
-        blockhash: &Hash,
+        durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
         leave_nonce_on_success: bool,
     ) {
@@ -1202,7 +1205,7 @@ impl Accounts {
             res,
             loaded,
             rent_collector,
-            blockhash,
+            durable_nonce,
             lamports_per_signature,
             leave_nonce_on_success,
         );
@@ -1225,7 +1228,7 @@ impl Accounts {
         execution_results: &'a [TransactionExecutionResult],
         load_results: &'a mut [TransactionLoadResult],
         rent_collector: &RentCollector,
-        blockhash: &Hash,
+        durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
         leave_nonce_on_success: bool,
     ) -> Vec<(&'a Pubkey, &'a AccountSharedData)> {
@@ -1279,7 +1282,7 @@ impl Accounts {
                         execution_status,
                         is_fee_payer,
                         maybe_nonce,
-                        blockhash,
+                        durable_nonce,
                         lamports_per_signature,
                     );
 
@@ -1306,13 +1309,13 @@ impl Accounts {
     }
 }
 
-pub fn prepare_if_nonce_account<'a>(
+fn prepare_if_nonce_account<'a>(
     address: &Pubkey,
     account: &mut AccountSharedData,
     execution_result: &Result<()>,
     is_fee_payer: bool,
     maybe_nonce: Option<(&'a NonceFull, bool)>,
-    blockhash: &Hash,
+    durable_nonce: &DurableNonce,
     lamports_per_signature: u64,
 ) -> bool {
     if let Some((nonce, rollback)) = maybe_nonce {
@@ -1338,7 +1341,7 @@ pub fn prepare_if_nonce_account<'a>(
                 account
                     .set_state(&NonceVersions::new_current(NonceState::new_initialized(
                         &data.authority,
-                        blockhash,
+                        *durable_nonce,
                         lamports_per_signature,
                     )))
                     .unwrap();
@@ -3025,7 +3028,7 @@ mod tests {
             &execution_results,
             loaded.as_mut_slice(),
             &rent_collector,
-            &Hash::default(),
+            &DurableNonce::default(),
             0,
             true, // leave_nonce_on_success
         );
@@ -3171,7 +3174,7 @@ mod tests {
         Pubkey,
         AccountSharedData,
         AccountSharedData,
-        Hash,
+        DurableNonce,
         u64,
         Option<AccountSharedData>,
     ) {
@@ -3184,7 +3187,7 @@ mod tests {
             Pubkey::default(),
             pre_account,
             account,
-            Hash::new(&[1u8; 32]),
+            DurableNonce::from_blockhash(&Hash::new(&[1u8; 32]), /*separate_domains:*/ true),
             1234,
             None,
         )
@@ -3196,7 +3199,7 @@ mod tests {
         tx_result: &Result<()>,
         is_fee_payer: bool,
         maybe_nonce: Option<(&NonceFull, bool)>,
-        blockhash: &Hash,
+        durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
         expect_account: &AccountSharedData,
     ) -> bool {
@@ -3216,7 +3219,7 @@ mod tests {
             tx_result,
             is_fee_payer,
             maybe_nonce,
-            blockhash,
+            durable_nonce,
             lamports_per_signature,
         );
         assert_eq!(expect_account, account);
@@ -3370,7 +3373,7 @@ mod tests {
             )),
             false,
             Some((&nonce, true)),
-            &Hash::default(),
+            &DurableNonce::default(),
             1,
             &post_fee_payer_account.clone(),
         ));
@@ -3381,7 +3384,7 @@ mod tests {
             &Ok(()),
             true,
             Some((&nonce, true)),
-            &Hash::default(),
+            &DurableNonce::default(),
             1,
             &post_fee_payer_account.clone(),
         ));
@@ -3395,7 +3398,7 @@ mod tests {
             )),
             true,
             None,
-            &Hash::default(),
+            &DurableNonce::default(),
             1,
             &post_fee_payer_account.clone(),
         ));
@@ -3409,7 +3412,7 @@ mod tests {
             )),
             true,
             Some((&nonce, true)),
-            &Hash::default(),
+            &DurableNonce::default(),
             1,
             &pre_fee_payer_account,
         ));
@@ -3424,8 +3427,10 @@ mod tests {
         let from = keypair_from_seed(&[1; 32]).unwrap();
         let from_address = from.pubkey();
         let to_address = Pubkey::new_unique();
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let nonce_state = NonceVersions::new_current(NonceState::Initialized(
-            nonce::state::Data::new(nonce_authority.pubkey(), Hash::new_unique(), 0),
+            nonce::state::Data::new(nonce_authority.pubkey(), durable_nonce, 0),
         ));
         let nonce_account_post =
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
@@ -3449,8 +3454,10 @@ mod tests {
         ];
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let nonce_state = NonceVersions::new_current(NonceState::Initialized(
-            nonce::state::Data::new(nonce_authority.pubkey(), Hash::new_unique(), 0),
+            nonce::state::Data::new(nonce_authority.pubkey(), durable_nonce, 0),
         ));
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
@@ -3474,7 +3481,8 @@ mod tests {
 
         let mut loaded = vec![loaded];
 
-        let next_blockhash = Hash::new_unique();
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let accounts = Accounts::new_with_config_for_tests(
             Vec::new(),
             &ClusterType::Development,
@@ -3495,7 +3503,7 @@ mod tests {
             &execution_results,
             loaded.as_mut_slice(),
             &rent_collector,
-            &next_blockhash,
+            &durable_nonce,
             0,
             true, // leave_nonce_on_success
         );
@@ -3521,7 +3529,7 @@ mod tests {
         );
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
-            &next_blockhash
+            durable_nonce.as_hash(),
         ));
     }
 
@@ -3534,8 +3542,10 @@ mod tests {
         let from = keypair_from_seed(&[1; 32]).unwrap();
         let from_address = from.pubkey();
         let to_address = Pubkey::new_unique();
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let nonce_state = NonceVersions::new_current(NonceState::Initialized(
-            nonce::state::Data::new(nonce_authority.pubkey(), Hash::new_unique(), 0),
+            nonce::state::Data::new(nonce_authority.pubkey(), durable_nonce, 0),
         ));
         let nonce_account_post =
             AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
@@ -3559,8 +3569,10 @@ mod tests {
         ];
         let tx = new_sanitized_tx(&[&nonce_authority, &from], message, blockhash);
 
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let nonce_state = NonceVersions::new_current(NonceState::Initialized(
-            nonce::state::Data::new(nonce_authority.pubkey(), Hash::new_unique(), 0),
+            nonce::state::Data::new(nonce_authority.pubkey(), durable_nonce, 0),
         ));
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
@@ -3583,7 +3595,8 @@ mod tests {
 
         let mut loaded = vec![loaded];
 
-        let next_blockhash = Hash::new_unique();
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let accounts = Accounts::new_with_config_for_tests(
             Vec::new(),
             &ClusterType::Development,
@@ -3604,7 +3617,7 @@ mod tests {
             &execution_results,
             loaded.as_mut_slice(),
             &rent_collector,
-            &next_blockhash,
+            &durable_nonce,
             0,
             true, // leave_nonce_on_success
         );
@@ -3621,7 +3634,7 @@ mod tests {
         );
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
-            &next_blockhash
+            durable_nonce.as_hash(),
         ));
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -124,7 +124,8 @@ use {
         message::{AccountKeys, SanitizedMessage},
         native_loader,
         native_token::sol_to_lamports,
-        nonce, nonce_account,
+        nonce::{self, state::DurableNonce},
+        nonce_account,
         packet::PACKET_DATA_SIZE,
         precompiles::get_precompiles,
         pubkey::Pubkey,
@@ -4908,13 +4909,19 @@ impl Bank {
         }
 
         let mut write_time = Measure::start("write_time");
+        let durable_nonce = {
+            let separate_nonce_from_blockhash = self
+                .feature_set
+                .is_active(&feature_set::separate_nonce_from_blockhash::id());
+            DurableNonce::from_blockhash(&last_blockhash, separate_nonce_from_blockhash)
+        };
         self.rc.accounts.store_cached(
             self.slot(),
             sanitized_txs,
             &execution_results,
             loaded_txs,
             &self.rent_collector,
-            &last_blockhash,
+            &durable_nonce,
             lamports_per_signature,
             self.leave_nonce_on_success(),
         );
@@ -7570,14 +7577,12 @@ pub(crate) mod tests {
         let from_address = from.pubkey();
         let to_address = Pubkey::new_unique();
 
+        let durable_nonce =
+            DurableNonce::from_blockhash(&Hash::new_unique(), /*separate_domains:*/ true);
         let nonce_account = AccountSharedData::new_data(
             43,
             &nonce::state::Versions::new_current(nonce::State::Initialized(
-                nonce::state::Data::new(
-                    Pubkey::default(),
-                    Hash::new_unique(),
-                    lamports_per_signature,
-                ),
+                nonce::state::Data::new(Pubkey::default(), durable_nonce, lamports_per_signature),
             )),
             &system_program::id(),
         )
@@ -12295,7 +12300,7 @@ pub(crate) mod tests {
             let state =
                 StateMut::<nonce::state::Versions>::state(&acc).map(|v| v.convert_to_current());
             match state {
-                Ok(nonce::State::Initialized(ref data)) => Some(data.blockhash),
+                Ok(nonce::State::Initialized(ref data)) => Some(data.blockhash()),
                 _ => None,
             }
         })
@@ -12997,7 +13002,7 @@ pub(crate) mod tests {
                     StateMut::<nonce::state::Versions>::state(&acc).map(|v| v.convert_to_current());
                 match state {
                     Ok(nonce::State::Initialized(ref data)) => {
-                        Some((data.blockhash, data.fee_calculator))
+                        Some((data.blockhash(), data.fee_calculator))
                     }
                     _ => None,
                 }
@@ -13034,7 +13039,7 @@ pub(crate) mod tests {
                     StateMut::<nonce::state::Versions>::state(&acc).map(|v| v.convert_to_current());
                 match state {
                     Ok(nonce::State::Initialized(ref data)) => {
-                        Some((data.blockhash, data.fee_calculator))
+                        Some((data.blockhash(), data.fee_calculator))
                     }
                     _ => None,
                 }
@@ -13067,7 +13072,7 @@ pub(crate) mod tests {
                     StateMut::<nonce::state::Versions>::state(&acc).map(|v| v.convert_to_current());
                 match state {
                     Ok(nonce::State::Initialized(ref data)) => {
-                        Some((data.blockhash, data.fee_calculator))
+                        Some((data.blockhash(), data.fee_calculator))
                     }
                     _ => None,
                 }
@@ -13104,7 +13109,7 @@ pub(crate) mod tests {
                     StateMut::<nonce::state::Versions>::state(&acc).map(|v| v.convert_to_current());
                 match state {
                     Ok(nonce::State::Initialized(ref data)) => {
-                        Some((data.blockhash, data.fee_calculator))
+                        Some((data.blockhash(), data.fee_calculator))
                     }
                     _ => None,
                 }
@@ -13146,13 +13151,13 @@ pub(crate) mod tests {
             &[&custodian_keypair, &nonce_keypair],
             nonce_hash,
         );
-        // Caught by the system program because the tx hash is valid
+        // SanitizedMessage::get_durable_nonce returns None because nonce
+        // account is not writable. Durable nonce and blockhash domains are
+        // separate, so the recent_blockhash (== durable nonce) in the
+        // transaction is not found in the hash queue.
         assert_eq!(
             bank.process_transaction(&tx),
-            Err(TransactionError::InstructionError(
-                0,
-                InstructionError::InvalidArgument
-            ))
+            Err(TransactionError::BlockhashNotFound),
         );
         // Kick nonce hash off the blockhash_queue
         for _ in 0..MAX_RECENT_BLOCKHASHES + 1 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4053,6 +4053,13 @@ impl Bank {
         max_age: usize,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
+        let separate_nonce_from_blockhash = self
+            .feature_set
+            .is_active(&feature_set::separate_nonce_from_blockhash::id());
+        let enable_durable_nonce = separate_nonce_from_blockhash
+            && self
+                .feature_set
+                .is_active(&feature_set::enable_durable_nonce::id());
         let hash_queue = self.blockhash_queue.read().unwrap();
         txs.zip(lock_results)
             .map(|(tx, lock_res)| match lock_res {
@@ -4060,7 +4067,9 @@ impl Bank {
                     let recent_blockhash = tx.message().recent_blockhash();
                     if hash_queue.is_hash_valid_for_age(recent_blockhash, max_age) {
                         (Ok(()), None)
-                    } else if let Some((address, account)) = self.check_transaction_for_nonce(tx) {
+                    } else if let Some((address, account)) =
+                        self.check_transaction_for_nonce(tx, enable_durable_nonce)
+                    {
                         (Ok(()), Some(NoncePartial::new(address, account)))
                     } else {
                         error_counters.blockhash_not_found += 1;
@@ -4130,19 +4139,16 @@ impl Bank {
             })
     }
 
-    pub fn check_transaction_for_nonce(
+    fn check_transaction_for_nonce(
         &self,
         tx: &SanitizedTransaction,
+        enable_durable_nonce: bool,
     ) -> Option<TransactionAccount> {
-        if self.cluster_type() == ClusterType::MainnetBeta {
-            if self.slot() <= 135986379 {
-                self.check_message_for_nonce(tx.message())
-            } else {
-                None
-            }
-        } else {
-            self.check_message_for_nonce(tx.message())
-        }
+        (enable_durable_nonce
+            || self.slot() <= 135986379
+            || self.cluster_type() != ClusterType::MainnetBeta)
+            .then(|| self.check_message_for_nonce(tx.message()))
+            .flatten()
     }
 
     pub fn check_transactions(
@@ -12395,7 +12401,10 @@ pub(crate) mod tests {
         );
         let nonce_account = bank.get_account(&nonce_pubkey).unwrap();
         assert_eq!(
-            bank.check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx)),
+            bank.check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            ),
             Some((nonce_pubkey, nonce_account))
         );
     }
@@ -12421,7 +12430,10 @@ pub(crate) mod tests {
             nonce_hash,
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx,))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx,),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12447,7 +12459,10 @@ pub(crate) mod tests {
         );
         tx.message.instructions[0].accounts.clear();
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12474,7 +12489,10 @@ pub(crate) mod tests {
             nonce_hash,
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -12498,7 +12516,10 @@ pub(crate) mod tests {
             Hash::default(),
         );
         assert!(bank
-            .check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx))
+            .check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            )
             .is_none());
     }
 
@@ -13170,7 +13191,10 @@ pub(crate) mod tests {
             Err(TransactionError::BlockhashNotFound)
         );
         assert_eq!(
-            bank.check_transaction_for_nonce(&SanitizedTransaction::from_transaction_for_tests(tx)),
+            bank.check_transaction_for_nonce(
+                &SanitizedTransaction::from_transaction_for_tests(tx),
+                true, // enable_durable_nonce
+            ),
             None
         );
     }

--- a/sdk/program/src/example_mocks.rs
+++ b/sdk/program/src/example_mocks.rs
@@ -24,9 +24,9 @@ pub mod solana_client {
     pub mod nonce_utils {
         use {
             super::super::solana_sdk::{
-                account::ReadableAccount, account_utils::StateMut, hash::Hash, pubkey::Pubkey,
+                account::ReadableAccount, account_utils::StateMut, pubkey::Pubkey,
             },
-            crate::nonce::state::{Data, Versions},
+            crate::nonce::state::{Data, DurableNonce, Versions},
         };
 
         #[derive(thiserror::Error, Debug)]
@@ -36,7 +36,11 @@ pub mod solana_client {
         pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
             _account: &T,
         ) -> Result<Data, Error> {
-            Ok(Data::new(Pubkey::new_unique(), Hash::default(), 5000))
+            Ok(Data::new(
+                Pubkey::new_unique(),
+                DurableNonce::default(),
+                5000,
+            ))
         }
     }
 

--- a/sdk/program/src/nonce/state/current.rs
+++ b/sdk/program/src/nonce/state/current.rs
@@ -1,7 +1,16 @@
 use {
-    crate::{fee_calculator::FeeCalculator, hash::Hash, pubkey::Pubkey},
+    crate::{
+        fee_calculator::FeeCalculator,
+        hash::{hashv, Hash},
+        pubkey::Pubkey,
+    },
     serde_derive::{Deserialize, Serialize},
 };
+
+const DURABLE_NONCE_HASH_PREFIX: &[u8] = "DURABLE_NONCE".as_bytes();
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DurableNonce(Hash);
 
 /// Initialized data of a durable transaction nonce account.
 ///
@@ -10,25 +19,51 @@ use {
 pub struct Data {
     /// Address of the account that signs transactions using the nonce account.
     pub authority: Pubkey,
-    /// A valid previous blockhash.
-    pub blockhash: Hash,
+    /// Durable nonce value derived from a valid previous blockhash.
+    pub durable_nonce: DurableNonce,
     /// The fee calculator associated with the blockhash.
     pub fee_calculator: FeeCalculator,
 }
 
 impl Data {
     /// Create new durable transaction nonce data.
-    pub fn new(authority: Pubkey, blockhash: Hash, lamports_per_signature: u64) -> Self {
+    pub fn new(
+        authority: Pubkey,
+        durable_nonce: DurableNonce,
+        lamports_per_signature: u64,
+    ) -> Self {
         Data {
             authority,
-            blockhash,
+            durable_nonce,
             fee_calculator: FeeCalculator::new(lamports_per_signature),
         }
+    }
+
+    /// Hash value used as recent_blockhash field in Transactions.
+    /// Named blockhash for legacy reasons, but durable nonce and blockhash
+    /// have separate domains.
+    pub fn blockhash(&self) -> Hash {
+        self.durable_nonce.0
     }
 
     /// Get the cost per signature for the next transaction to use this nonce.
     pub fn get_lamports_per_signature(&self) -> u64 {
         self.fee_calculator.lamports_per_signature
+    }
+}
+
+impl DurableNonce {
+    pub fn from_blockhash(blockhash: &Hash, separate_domains: bool) -> Self {
+        Self(if separate_domains {
+            hashv(&[DURABLE_NONCE_HASH_PREFIX, blockhash.as_ref()])
+        } else {
+            *blockhash
+        })
+    }
+
+    /// Hash value used as recent_blockhash field in Transactions.
+    pub fn as_hash(&self) -> &Hash {
+        &self.0
     }
 }
 
@@ -52,10 +87,10 @@ impl State {
     /// Create new durable transaction nonce state.
     pub fn new_initialized(
         authority: &Pubkey,
-        blockhash: &Hash,
+        durable_nonce: DurableNonce,
         lamports_per_signature: u64,
     ) -> Self {
-        Self::Initialized(Data::new(*authority, *blockhash, lamports_per_signature))
+        Self::Initialized(Data::new(*authority, durable_nonce, lamports_per_signature))
     }
 
     /// Get the serialized size of the nonce state.

--- a/sdk/program/src/nonce/state/mod.rs
+++ b/sdk/program/src/nonce/state/mod.rs
@@ -1,7 +1,7 @@
 //! State for durable transaction nonces.
 
 mod current;
-pub use current::{Data, State};
+pub use current::{Data, DurableNonce, State};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -736,7 +736,7 @@ pub fn create_nonce_account(
 ///     # });
 ///     let nonce_account = client.get_account(nonce_account_pubkey)?;
 ///     let nonce_data = nonce_utils::data_from_account(&nonce_account)?;
-///     let blockhash = nonce_data.blockhash;
+///     let blockhash = nonce_data.blockhash();
 ///
 ///     tx.try_sign(&[payer], blockhash)?;
 ///

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -416,6 +416,10 @@ pub mod warp_timestamp_with_a_vengeance {
     solana_sdk::declare_id!("3BX6SBeEBibHaVQXywdkcgyUk6evfYZkHdztXiDtEpFS");
 }
 
+pub mod separate_nonce_from_blockhash {
+    solana_sdk::declare_id!("Gea3ZkK2N4pHuVZVxWcnAtS6UEDdyumdYt4pFcKjA3ar");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -513,6 +517,7 @@ lazy_static! {
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
+        (separate_nonce_from_blockhash::id(), "separate durable nonce and blockhash domains #25744"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -420,6 +420,10 @@ pub mod separate_nonce_from_blockhash {
     solana_sdk::declare_id!("Gea3ZkK2N4pHuVZVxWcnAtS6UEDdyumdYt4pFcKjA3ar");
 }
 
+pub mod enable_durable_nonce {
+    solana_sdk::declare_id!("4EJQtF2pkRyawwcTVfQutzq4Sa5hRhibF6QAK1QXhtEX");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -518,6 +522,7 @@ lazy_static! {
         (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
         (separate_nonce_from_blockhash::id(), "separate durable nonce and blockhash domains #25744"),
+        (enable_durable_nonce::id(), "enable durable nonce #25744"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/nonce_account.rs
+++ b/sdk/src/nonce_account.rs
@@ -20,12 +20,13 @@ pub fn create_account(lamports: u64) -> RefCell<AccountSharedData> {
     )
 }
 
+// TODO: Consider changing argument from Hash to DurableNonce.
 pub fn verify_nonce_account(acc: &AccountSharedData, hash: &Hash) -> bool {
     if acc.owner() != &crate::system_program::id() {
         return false;
     }
     match StateMut::<Versions>::state(acc).map(|v| v.convert_to_current()) {
-        Ok(State::Initialized(ref data)) => *hash == data.blockhash,
+        Ok(State::Initialized(ref data)) => hash == &data.blockhash(),
         _ => false,
     }
 }


### PR DESCRIPTION
#### Problem
`AdvanceNonceAccount` instruction updates nonce to blockhash. This makes it
possible that a durable transaction is executed twice both as a normal
transaction and a nonce transaction if it uses a recent blockhash (as opposed to 
the durable nonce) for its `recent_blockhash` field.



#### Summary of Changes
The commit prevents this double execution by separating nonce and blockhash
domains; when advancing nonce account, blockhash is hashed with a fixed string.
As a result a blockhash cannot be a valid nonce value; and if transaction was
once executed as a normal transaction it cannot be re-executed as a durable
transaction again and vice-versa.

To add type-safety and prevent old blockhash `Hash` values creeping into nonce
accounts the commit adds a new `DurableNonce` type replacing previous
blockhash value in nonce accounts state.

The code to separate durable nonce and blockhash domains is feature gated. 
A 2nd feature will enable durable nonce at least one epoch after 1st feature is
activated.
By the time 2nd feature is activated, some nonce accounts will have an
old blockhash, but no nonce account can have a recent blockhash.
As a result no transaction (durable or normal) can be executed twice.

closes #25711 
Feature Gate Issue: https://github.com/solana-labs/solana/issues/25772 https://github.com/solana-labs/solana/issues/25773
