### PR TITLE
Add metrics to vote account close feature

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -7,6 +7,7 @@ use {
     bincode::{deserialize, serialize_into, ErrorKind},
     log::*,
     serde_derive::{Deserialize, Serialize},
+    solana_metrics::datapoint_debug,
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         clock::{Epoch, Slot, UnixTimestamp},
@@ -1297,9 +1298,11 @@ pub fn withdraw<S: std::hash::BuildHasher>(
             .unwrap_or(false);
 
         if reject_active_vote_account_close {
+            datapoint_debug!("vote-account-close", ("reject-active", 1, i64));
             return Err(InstructionError::ActiveVoteAccountClose);
         } else {
             // Deinitialize upon zero-balance
+            datapoint_debug!("vote-account-close", ("allow", 1, i64));
             vote_account.set_state(&VoteStateVersions::new_current(VoteState::default()))?;
         }
     } else if let Some(rent_sysvar) = rent_sysvar {


### PR DESCRIPTION
#### Problem
We need to enable `fail vote account withdraw to 0 unless account earned 0 credits in last completed epoch` on testnet, devnet and eventually mainnet-beta and need better monitoring on testnet & devnet to ensure code paths have been exercised.

#### Summary of Changes
Add datapoints.
