### PR TITLE
Bumps solana_rbpf to v0.2.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6290,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab642ccfa31bfd4389387019a6b1204ad93f9528d2ac8e1e36c8de62bdf1f8"
+checksum = "4df28dcb607dd56ab0022f99d3a9ff1ee0d87951315762c0b89e946c087ebbea"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,7 +42,7 @@ solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.0" }
 solana-version = { path = "../version", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
-solana_rbpf = "=0.2.29"
+solana_rbpf = "=0.2.30"
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0.31"
 tiny-bip39 = "0.8.2"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5517,9 +5517,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab642ccfa31bfd4389387019a6b1204ad93f9528d2ac8e1e36c8de62bdf1f8"
+checksum = "4df28dcb607dd56ab0022f99d3a9ff1ee0d87951315762c0b89e946c087ebbea"
 dependencies = [
  "byteorder 1.4.3",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,7 +33,7 @@ solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.1
 solana-cli-output = { path = "../../cli-output", version = "=1.11.0" }
 solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-measure = { path = "../../measure", version = "=1.11.0" }
-solana_rbpf = "=0.2.29"
+solana_rbpf = "=0.2.30"
 solana-runtime = { path = "../../runtime", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -19,7 +19,7 @@ solana-metrics = { path = "../../metrics", version = "=1.11.0" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../../sdk", version = "=1.11.0" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.29"
+solana_rbpf = "=0.2.30"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -137,7 +137,7 @@ pub fn create_executor(
             .feature_set
             .is_active(&disable_bpf_unresolved_symbols_at_runtime::id()),
         reject_broken_elfs: reject_deployment_of_broken_elfs,
-        noop_instruction_ratio: 1.0 / 256.0,
+        noop_instruction_rate: 256,
         sanitize_user_provided_values: true,
         encrypt_environment_registers: true,
         disable_deprecated_load_instructions: reject_deployment_of_broken_elfs

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -17,4 +17,4 @@ solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.11.
 solana-logger = { path = "../logger", version = "=1.11.0" }
 solana-program-runtime = { path = "../program-runtime", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
-solana_rbpf = "=0.2.29"
+solana_rbpf = "=0.2.30"


### PR DESCRIPTION
#### Problem
[solana_rbpf v0.2.30](https://github.com/solana-labs/rbpf/releases/tag/v0.2.30) was released.

#### Summary of Changes
`Config::noop_instruction_ratio` => `Config::noop_instruction_rate` (from `f32` to `u32`).