### PR TITLE
load_account_into_read_cache

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4143,6 +4143,10 @@ impl AccountsDb {
         self.do_load(ancestors, pubkey, None, load_hint)
     }
 
+    pub fn load_account_into_read_cache(&self, ancestors: &Ancestors, pubkey: &Pubkey) {
+        self.do_load_with_populate_read_cache(ancestors, pubkey, None, LoadHint::Unspecified, true);
+    }
+
     pub fn load_with_fixed_root(
         &self,
         ancestors: &Ancestors,
@@ -4476,6 +4480,19 @@ impl AccountsDb {
         max_root: Option<Slot>,
         load_hint: LoadHint,
     ) -> Option<(AccountSharedData, Slot)> {
+        self.do_load_with_populate_read_cache(ancestors, pubkey, max_root, load_hint, false)
+    }
+
+    /// if 'load_into_read_cache_only', then return value is meaningless.
+    ///   The goal is to get the account into the read-only cache.
+    fn do_load_with_populate_read_cache(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+        max_root: Option<Slot>,
+        load_hint: LoadHint,
+        load_into_read_cache_only: bool,
+    ) -> Option<(AccountSharedData, Slot)> {
         #[cfg(not(test))]
         assert!(max_root.is_none());
 
@@ -4483,10 +4500,25 @@ impl AccountsDb {
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, max_root, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
 
-        if self.caching_enabled && !storage_location.is_cached() {
-            let result = self.read_only_accounts_cache.load(*pubkey, slot);
-            if let Some(account) = result {
-                return Some((account, slot));
+        if self.caching_enabled {
+            let in_write_cache = storage_location.is_cached();
+            if !load_into_read_cache_only {
+                if !in_write_cache {
+                    let result = self.read_only_accounts_cache.load(*pubkey, slot);
+                    if let Some(account) = result {
+                        return Some((account, slot));
+                    }
+                }
+            } else {
+                // goal is to load into read cache
+                if in_write_cache {
+                    // no reason to load in read cache. already in write cache
+                    return None;
+                }
+                if self.read_only_accounts_cache.in_cache(pubkey, slot) {
+                    // already in read cache
+                    return None;
+                }
             }
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6641,6 +6641,13 @@ impl Bank {
         &self.rc.accounts.accounts_db.thread_pool_clean
     }
 
+    pub fn load_account_into_read_cache(&self, key: &Pubkey) {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_account_into_read_cache(&self.ancestors, key);
+    }
+
     pub fn update_accounts_hash_with_index_option(
         &self,
         use_index: bool,

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -52,6 +52,11 @@ impl ReadOnlyAccountsCache {
         }
     }
 
+    /// true if pubkey is in cache at slot
+    pub fn in_cache(&self, pubkey: &Pubkey, slot: Slot) -> bool {
+        self.cache.contains_key(&(*pubkey, slot))
+    }
+
     pub(crate) fn load(&self, pubkey: Pubkey, slot: Slot) -> Option<AccountSharedData> {
         let key = (pubkey, slot);
         let mut entry = match self.cache.get_mut(&key) {


### PR DESCRIPTION
#### Problem

Adds the ability to load an account into the read cache.
This is useful for prefetch situations. Examples: prior to tx processing and rent collection. In these cases, we know which accounts will be loaded.
I have built this functionality and repeatedly needed to use it. Now that rent scanning is taking ever longer (and unacceptably so), this will be used.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
