### PR TITLE
parallelize rent collection

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1664,7 +1664,7 @@ impl ShrinkAncientStats {
     }
 }
 
-fn quarter_thread_count() -> usize {
+pub fn quarter_thread_count() -> usize {
     std::cmp::max(2, num_cpus::get() / 4)
 }
 


### PR DESCRIPTION
#### Problem

Rent collection is serialized currently. 1 account after another.
This process takes longer with growing # accounts.
Rent collection occurs in Bank::freeze() after all tx processing is done. The bank cannot finish until rent collection completes.

#### Summary of Changes
parallelize loading, collection and storing.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
