### PR TITLE
Grab read-lock instead of write-lock in From<PreAllocatedAccountMapEntry<T>> for (Slot, T)

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -369,7 +369,7 @@ impl<T: IndexValue> ZeroLamport for PreAllocatedAccountMapEntry<T> {
 impl<T: IndexValue> From<PreAllocatedAccountMapEntry<T>> for (Slot, T) {
     fn from(source: PreAllocatedAccountMapEntry<T>) -> (Slot, T) {
         match source {
-            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list.write().unwrap().remove(0),
+            PreAllocatedAccountMapEntry::Entry(entry) => entry.slot_list.read().unwrap()[0],
             PreAllocatedAccountMapEntry::Raw(raw) => raw,
         }
     }


### PR DESCRIPTION
#### Problem

From<PreAllocatedAccountMapEntry<T>> for (Slot, T) grabs a write lock unnecessarily. (Also, the element doesn't need to be removed, so could save on any Vec memory management calls.) 

Since indexing the first element performs a copy, I wanted to check the size of the object to ensure it was small. For the case where `T = AccountInfo`, this is `(Slot, AccountInfo)`. Sizes are `Slot = 8B` and `AccountInfo = 12B`. So in total 20 bytes. I think the read-lock + memcpy of 20B is faster than the write-lock + move + any Vec memory management due to `remove()`.

#### Summary of Changes

Change write-lock to read-lock.