### PR TITLE
adds system instruction to upgrade legacy nonce versions

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -157,6 +157,10 @@ pub enum CliCommand {
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
+    UpgradeNonceAccount {
+        nonce_account: Pubkey,
+        memo: Option<String>,
+    },
     // Program Deployment
     Deploy {
         program_location: String,
@@ -633,6 +637,7 @@ pub fn parse_command(
         ("withdraw-from-nonce-account", Some(matches)) => {
             parse_withdraw_from_nonce_account(matches, default_signer, wallet_manager)
         }
+        ("upgrade-nonce-account", Some(matches)) => parse_upgrade_nonce_account(matches),
         // Program Deployment
         ("deploy", Some(matches)) => {
             let (address_signer, _address) = signer_of(matches, "address_signer", wallet_manager)?;
@@ -1019,6 +1024,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             destination_account_pubkey,
             *lamports,
         ),
+        // Upgrade nonce account out of blockhash domain.
+        CliCommand::UpgradeNonceAccount {
+            nonce_account,
+            memo,
+        } => process_upgrade_nonce_account(&rpc_client, config, *nonce_account, memo.as_ref()),
 
         // Program Deployment
 

--- a/docs/src/developing/clients/javascript-api.md
+++ b/docs/src/developing/clients/javascript-api.md
@@ -238,6 +238,7 @@ pub enum SystemInstruction {
     /** 9 **/AllocateWithSeed {/**/},
     /** 10 **/AssignWithSeed {/**/},
     /** 11 **/TransferWithSeed {/**/},
+    /** 12 **/UpgradeNonceAccount,
 }
 ```
 

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -483,6 +483,28 @@ pub fn process_instruction(
                 instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
             authorize_nonce_account(&mut me, &nonce_authority, &signers, invoke_context)
         }
+        SystemInstruction::UpgradeNonceAccount => {
+            let separate_nonce_from_blockhash = invoke_context
+                .feature_set
+                .is_active(&feature_set::separate_nonce_from_blockhash::id());
+            if !separate_nonce_from_blockhash {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+            instruction_context.check_number_of_instruction_accounts(1)?;
+            let mut nonce_account =
+                instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+            if !system_program::check_id(nonce_account.get_owner()) {
+                return Err(InstructionError::InvalidAccountOwner);
+            }
+            if !nonce_account.is_writable() {
+                return Err(InstructionError::InvalidArgument);
+            }
+            let nonce_versions: nonce::state::Versions = nonce_account.get_state()?;
+            match nonce_versions.upgrade() {
+                None => Err(InstructionError::InvalidArgument),
+                Some(nonce_versions) => nonce_account.set_state(&nonce_versions),
+            }
+        }
         SystemInstruction::Allocate { space } => {
             instruction_context.check_number_of_instruction_accounts(1)?;
             let mut account = instruction_context
@@ -568,11 +590,18 @@ mod tests {
     use solana_sdk::{
         account::{self, Account, AccountSharedData, ReadableAccount},
         client::SyncClient,
+        fee_calculator::FeeCalculator,
         genesis_config::create_genesis_config,
         hash::{hash, Hash},
         instruction::{AccountMeta, Instruction, InstructionError},
         message::Message,
-        nonce, nonce_account, recent_blockhashes_account,
+        nonce::{
+            self,
+            state::{
+                Data as NonceData, DurableNonce, State as NonceState, Versions as NonceVersions,
+            },
+        },
+        nonce_account, recent_blockhashes_account,
         signature::{Keypair, Signer},
         system_instruction, system_program,
         sysvar::{self, recent_blockhashes::IterItem, rent::Rent},
@@ -2200,6 +2229,147 @@ mod tests {
                 invoke_context.blockhash = hash(&serialize(&0).unwrap());
                 super::process_instruction(first_instruction_account, invoke_context)
             },
+        );
+    }
+
+    #[test]
+    fn test_nonce_account_upgrade_check_owner() {
+        let nonce_address = Pubkey::new_unique();
+        let versions = NonceVersions::Legacy(Box::new(NonceState::Uninitialized));
+        let nonce_account = AccountSharedData::new_data(
+            1_000_000,             // lamports
+            &versions,             // state
+            &Pubkey::new_unique(), // owner
+        )
+        .unwrap();
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account.clone())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: true,
+            }],
+            Err(InstructionError::InvalidAccountOwner),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0], nonce_account);
+    }
+
+    fn new_nonce_account(versions: NonceVersions) -> AccountSharedData {
+        let nonce_account = AccountSharedData::new_data(
+            1_000_000,             // lamports
+            &versions,             // state
+            &system_program::id(), // owner
+        )
+        .unwrap();
+        assert_eq!(
+            nonce_account.deserialize_data::<NonceVersions>().unwrap(),
+            versions
+        );
+        nonce_account
+    }
+
+    #[test]
+    fn test_nonce_account_upgrade() {
+        let nonce_address = Pubkey::new_unique();
+        let versions = NonceVersions::Legacy(Box::new(NonceState::Uninitialized));
+        let nonce_account = new_nonce_account(versions);
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account.clone())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: true,
+            }],
+            Err(InstructionError::InvalidArgument),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0], nonce_account);
+        let versions = NonceVersions::Current(Box::new(NonceState::Uninitialized));
+        let nonce_account = new_nonce_account(versions);
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account.clone())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: true,
+            }],
+            Err(InstructionError::InvalidArgument),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0], nonce_account);
+        let blockhash = Hash::from([171; 32]);
+        let durable_nonce =
+            DurableNonce::from_blockhash(&blockhash, /*separate_domains:*/ false);
+        let data = NonceData {
+            authority: Pubkey::new_unique(),
+            durable_nonce,
+            fee_calculator: FeeCalculator {
+                lamports_per_signature: 2718,
+            },
+        };
+        let versions = NonceVersions::Legacy(Box::new(NonceState::Initialized(data.clone())));
+        let nonce_account = new_nonce_account(versions);
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account.clone())],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: false, // Should fail!
+            }],
+            Err(InstructionError::InvalidArgument),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0], nonce_account);
+        let mut accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account)],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: true,
+            }],
+            Ok(()),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        let nonce_account = accounts.remove(0);
+        let durable_nonce =
+            DurableNonce::from_blockhash(&blockhash, /*separate_domains:*/ true);
+        assert_ne!(data.durable_nonce, durable_nonce);
+        let data = NonceData {
+            durable_nonce,
+            ..data
+        };
+        let upgraded_nonce_account =
+            NonceVersions::Current(Box::new(NonceState::Initialized(data)));
+        assert_eq!(
+            nonce_account.deserialize_data::<NonceVersions>().unwrap(),
+            upgraded_nonce_account
+        );
+        let accounts = process_instruction(
+            &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
+            vec![(nonce_address, nonce_account)],
+            vec![AccountMeta {
+                pubkey: nonce_address,
+                is_signer: false,
+                is_writable: true,
+            }],
+            Err(InstructionError::InvalidArgument),
+            super::process_instruction,
+        );
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(
+            accounts[0].deserialize_data::<NonceVersions>().unwrap(),
+            upgraded_nonce_account
         );
     }
 }

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -142,7 +142,7 @@ pub fn instruction_to_nonce_error(
 /// maximum permitted size of data: 10 MB
 pub const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
 
-#[frozen_abi(digest = "2xnDcizcPKKR7b624FeuuPd1zj5bmnkmVsBWgoKPTh4w")]
+#[frozen_abi(digest = "5e22s2kFu9Do77hdcCyxyhuKHD8ThAB6Q6dNaLTCjL5M")]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, AbiExample, AbiEnumVisitor)]
 pub enum SystemInstruction {
     /// Create a new account
@@ -307,6 +307,13 @@ pub enum SystemInstruction {
         /// Owner to use to derive the funding account address
         from_owner: Pubkey,
     },
+
+    /// One-time idempotent upgrade of legacy nonce versions in order to bump
+    /// them out of chain blockhash domain.
+    ///
+    /// # Account references
+    ///   0. `[WRITE]` Nonce account
+    UpgradeNonceAccount,
 }
 
 pub fn create_account(
@@ -936,6 +943,17 @@ pub fn authorize_nonce_account(
     Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::AuthorizeNonceAccount(*new_authority),
+        account_metas,
+    )
+}
+
+/// One-time idempotent upgrade of legacy nonce versions in order to bump
+/// them out of chain blockhash domain.
+pub fn upgrade_nonce_account(nonce_pubkey: Pubkey) -> Instruction {
+    let account_metas = vec![AccountMeta::new(nonce_pubkey, /*is_signer:*/ false)];
+    Instruction::new_with_bincode(
+        system_program::id(),
+        &SystemInstruction::UpgradeNonceAccount,
         account_metas,
     )
 }

--- a/transaction-status/src/parse_system.rs
+++ b/transaction-status/src/parse_system.rs
@@ -133,6 +133,15 @@ pub fn parse_system(
                 }),
             })
         }
+        SystemInstruction::UpgradeNonceAccount => {
+            check_num_system_accounts(&instruction.accounts, 1)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "upgradeNonce".to_string(),
+                info: json!({
+                    "nonceAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                }),
+            })
+        }
         SystemInstruction::Allocate { space } => {
             check_num_system_accounts(&instruction.accounts, 1)?;
             Ok(ParsedInstructionEnum {

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -566,7 +566,8 @@ export type SystemInstructionType =
   | 'InitializeNonceAccount'
   | 'Transfer'
   | 'TransferWithSeed'
-  | 'WithdrawNonceAccount';
+  | 'WithdrawNonceAccount'
+  | 'UpgradeNonceAccount';
 
 type SystemInstructionInputData = {
   AdvanceNonceAccount: IInstructionInputData;
@@ -616,6 +617,7 @@ type SystemInstructionInputData = {
   WithdrawNonceAccount: IInstructionInputData & {
     lamports: number;
   };
+  UpgradeNonceAccount: IInstructionInputData;
 };
 
 /**
@@ -723,6 +725,12 @@ export const SYSTEM_INSTRUCTION_LAYOUTS = Object.freeze<{
         Layout.publicKey('programId'),
       ],
     ),
+  },
+  UpgradeNonceAccount: {
+    index: 12,
+    layout: BufferLayout.struct<
+      SystemInstructionInputData['UpgradeNonceAccount']
+    >([BufferLayout.u32('instruction')]),
   },
 });
 


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/25788
permanently disables durable transactions with legacy nonce versions
which are within chain blockhash domain.



#### Summary of Changes
This commit adds a new system instruction for a one-time idempotent
upgrade of legacy nonce accounts in order to bump them out of chain
blockhash domain.
