### PR TITLE
(Ledger-Tool) Allow ledger-tool to specify RocksDB shred compaction.

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -15,8 +15,9 @@ use {
         OutputFormat,
     },
     solana_ledger::{
-        bigtable_upload::ConfirmedBlockUploadConfig, blockstore::Blockstore,
-        blockstore_options::AccessType,
+        bigtable_upload::ConfirmedBlockUploadConfig,
+        blockstore::Blockstore,
+        blockstore_options::{AccessType, ShredStorageType},
     },
     solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
     solana_storage_bigtable::CredentialType,
@@ -559,7 +560,11 @@ impl BigTableSubCommand for App<'_, '_> {
     }
 }
 
-pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+pub fn bigtable_process_command(
+    ledger_path: &Path,
+    matches: &ArgMatches<'_>,
+    shred_storage_type: &ShredStorageType,
+) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let verbose = matches.is_present("verbose");
@@ -595,6 +600,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 &canonicalize_ledger_path(ledger_path),
                 AccessType::Secondary,
                 None,
+                shred_storage_type,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -27,6 +27,7 @@ use {
         blockstore_db::{self, Database},
         blockstore_options::{
             AccessType, BlockstoreOptions, BlockstoreRecoveryMode, LedgerColumnOptions,
+            ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
         },
         blockstore_processor::{BlockstoreProcessorError, ProcessOptions},
         shred::Shred,
@@ -723,6 +724,7 @@ fn open_blockstore(
     ledger_path: &Path,
     access_type: AccessType,
     wal_recovery_mode: Option<BlockstoreRecoveryMode>,
+    shred_storage_type: &ShredStorageType,
 ) -> Blockstore {
     match Blockstore::open_with_options(
         ledger_path,
@@ -730,7 +732,10 @@ fn open_blockstore(
             access_type,
             recovery_mode: wal_recovery_mode,
             enforce_ulimit_nofile: true,
-            ..BlockstoreOptions::default()
+            column_options: LedgerColumnOptions {
+                shred_storage_type: shred_storage_type.clone(),
+                ..LedgerColumnOptions::default()
+            },
         },
     ) {
         Ok(blockstore) => blockstore,
@@ -738,6 +743,31 @@ fn open_blockstore(
             eprintln!("Failed to open ledger at {:?}: {:?}", ledger_path, err);
             exit(1);
         }
+    }
+}
+
+fn shred_storage_type_from_matches(
+    matches: &ArgMatches,
+    arg_rocksdb_shred_compaction: &str,
+    arg_rocksdb_fifo_shred_storage_size: &str,
+) -> ShredStorageType {
+    match matches.value_of(arg_rocksdb_shred_compaction) {
+        None => ShredStorageType::default(),
+        Some(shred_compaction_string) => match shred_compaction_string {
+            "level" => ShredStorageType::RocksLevel,
+            "fifo" => {
+                let shred_storage_size = match matches.value_of(arg_rocksdb_fifo_shred_storage_size)
+                {
+                    Some(_) => value_t_or_exit!(matches, arg_rocksdb_fifo_shred_storage_size, u64),
+                    None => DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+                };
+                ShredStorageType::rocks_fifo(shred_storage_size)
+            }
+            _ => panic!(
+                "Unrecognized rocksdb-shred-compaction: {}",
+                shred_compaction_string
+            ),
+        },
     }
 }
 
@@ -947,6 +977,8 @@ fn main() {
     const DEFAULT_LATEST_OPTIMISTIC_SLOTS_COUNT: &str = "1";
     const DEFAULT_MAX_SLOTS_ROOT_REPAIR: &str = "2000";
     solana_logger::setup_with_default("solana=info");
+    let default_rocksdb_fifo_shred_storage_size =
+        &DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES.to_string();
 
     let starting_slot_arg = Arg::with_name("starting_slot")
         .long("starting-slot")
@@ -1135,7 +1167,6 @@ fn main() {
     let default_bootstrap_validator_stake_lamports = &sol_to_lamports(0.5)
         .max(rent.minimum_balance(StakeState::size_of()))
         .to_string();
-
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -1151,6 +1182,35 @@ fn main() {
                 .global(true)
                 .default_value("ledger")
                 .help("Use DIR as ledger location"),
+        )
+        .arg(
+            Arg::with_name("rocksdb_shred_compaction")
+                .hidden(true)
+                .long("rocksdb-shred-compaction")
+                .value_name("ROCKSDB_COMPACTION_STYLE")
+                .takes_value(true)
+                .possible_values(&["level", "fifo"])
+                .default_value("level")
+                .help("The rocksdb compaction style used for storing shreds in the ledger store. \
+                       This value should be the same as the one you specified in the validator arg \
+                       --rocksdb-shred-compaction when you started the validator.  \
+                       Possible values are: \
+                       'level': stores shreds using RocksDB's default (level) compaction. \
+                       'fifo': stores shreds under RocksDB's FIFO compaction. \
+                           This option is more efficient on disk-write-bytes of the ledger store."),
+        )
+        .arg(
+            Arg::with_name("rocksdb_fifo_shred_storage_size")
+                .hidden(true)
+                .long("rocksdb-fifo-shred-storage-size")
+                .value_name("SHRED_STORAGE_SIZE_BYTES")
+                .takes_value(true)
+                .validator(is_parsable::<u64>)
+                .default_value(default_rocksdb_fifo_shred_storage_size)
+                .help("The shred storage size in bytes. \
+                       The suggested value is 50% of your ledger storage size in bytes. \
+                       This value should be the same as the one you specified in the validator arg \
+                       --rocksdb-fifo-shred-storage-size when you started the validator."),
         )
         .arg(
             Arg::with_name("wal_recovery_mode")
@@ -1828,8 +1888,14 @@ fn main() {
         .map(BlockstoreRecoveryMode::from);
     let verbose_level = matches.occurrences_of("verbose");
 
+    let shred_storage_type = shred_storage_type_from_matches(
+        &matches,
+        "rocksdb_shred_compaction",
+        "rocksdb_fifo_shred_storage_size",
+    );
+
     if let ("bigtable", Some(arg_matches)) = matches.subcommand() {
-        bigtable_process_command(&ledger_path, arg_matches)
+        bigtable_process_command(&ledger_path, arg_matches, &shred_storage_type)
     } else {
         let ledger_path = canonicalize_ledger_path(&ledger_path);
 
@@ -1841,7 +1907,12 @@ fn main() {
                 let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
                 let only_rooted = arg_matches.is_present("only_rooted");
                 output_ledger(
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode),
+                    open_blockstore(
+                        &ledger_path,
+                        AccessType::Secondary,
+                        wal_recovery_mode,
+                        &shred_storage_type,
+                    ),
                     starting_slot,
                     ending_slot,
                     allow_dead_slots,
@@ -1855,8 +1926,14 @@ fn main() {
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
                 let target_db = PathBuf::from(value_t_or_exit!(arg_matches, "target_db", String));
-                let source = open_blockstore(&ledger_path, AccessType::Secondary, None);
-                let target = open_blockstore(&target_db, AccessType::Primary, None);
+                let source = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    None,
+                    &shred_storage_type,
+                );
+                let target =
+                    open_blockstore(&target_db, AccessType::Primary, None, &shred_storage_type);
                 for (slot, _meta) in source.slot_meta_iterator(starting_slot).unwrap() {
                     if slot > ending_slot {
                         break;
@@ -1929,8 +2006,12 @@ fn main() {
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 match load_bank_forks(
                     arg_matches,
                     &genesis_config,
@@ -1977,7 +2058,12 @@ fn main() {
                 }
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 let ending_slot = value_t!(arg_matches, "ending_slot", Slot).unwrap_or(Slot::MAX);
-                let ledger = open_blockstore(&ledger_path, AccessType::Secondary, None);
+                let ledger = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    None,
+                    &shred_storage_type,
+                );
                 for (slot, _meta) in ledger
                     .slot_meta_iterator(starting_slot)
                     .unwrap()
@@ -2011,8 +2097,12 @@ fn main() {
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 match load_bank_forks(
                     arg_matches,
                     &genesis_config,
@@ -2033,8 +2123,12 @@ fn main() {
             ("slot", Some(arg_matches)) => {
                 let slots = values_t_or_exit!(arg_matches, "slots", Slot);
                 let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 for slot in slots {
                     println!("Slot {}", slot);
                     if let Err(err) = output_slot(
@@ -2053,7 +2147,12 @@ fn main() {
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
                 output_ledger(
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode),
+                    open_blockstore(
+                        &ledger_path,
+                        AccessType::Secondary,
+                        wal_recovery_mode,
+                        &shred_storage_type,
+                    ),
                     starting_slot,
                     Slot::MAX,
                     allow_dead_slots,
@@ -2064,16 +2163,24 @@ fn main() {
                 );
             }
             ("dead-slots", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 for slot in blockstore.dead_slots_iterator(starting_slot).unwrap() {
                     println!("{}", slot);
                 }
             }
             ("duplicate-slots", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 for slot in blockstore.duplicate_slots_iterator(starting_slot).unwrap() {
                     println!("{}", slot);
@@ -2081,8 +2188,12 @@ fn main() {
             }
             ("set-dead-slot", Some(arg_matches)) => {
                 let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Primary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Primary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 for slot in slots {
                     match blockstore.set_dead_slot(slot) {
                         Ok(_) => println!("Slot {} dead", slot),
@@ -2092,8 +2203,12 @@ fn main() {
             }
             ("remove-dead-slot", Some(arg_matches)) => {
                 let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Primary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Primary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 for slot in slots {
                     match blockstore.remove_dead_slot(slot) {
                         Ok(_) => println!("Slot {} not longer marked dead", slot),
@@ -2106,8 +2221,12 @@ fn main() {
             ("parse_full_frozen", Some(arg_matches)) => {
                 let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
                 let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let mut ancestors = BTreeSet::new();
                 assert!(
                     blockstore.meta(ending_slot).unwrap().is_some(),
@@ -2259,8 +2378,12 @@ fn main() {
                     open_genesis_config_by(&ledger_path, arg_matches).hash()
                 );
 
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let (bank_forks, ..) = load_bank_forks(
                     arg_matches,
                     &open_genesis_config_by(&ledger_path, arg_matches),
@@ -2291,8 +2414,12 @@ fn main() {
                     ..ProcessOptions::default()
                 };
 
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 match load_bank_forks(
                     arg_matches,
                     &open_genesis_config_by(&ledger_path, arg_matches),
@@ -2403,8 +2530,12 @@ fn main() {
                     usize
                 );
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
 
                 let snapshot_slot = if Some("ROOT") == arg_matches.value_of("snapshot_slot") {
                     blockstore
@@ -2736,8 +2867,12 @@ fn main() {
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
                 let include_sysvars = arg_matches.is_present("include_sysvars");
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let (bank_forks, ..) = load_bank_forks(
                     arg_matches,
                     &genesis_config,
@@ -2796,8 +2931,12 @@ fn main() {
                     ..ProcessOptions::default()
                 };
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 match load_bank_forks(
                     arg_matches,
                     &genesis_config,
@@ -3327,7 +3466,12 @@ fn main() {
                 } else {
                     AccessType::PrimaryForMaintenance
                 };
-                let blockstore = open_blockstore(&ledger_path, access_type, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    access_type,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
 
                 let end_slot = match end_slot {
                     Some(end_slot) => end_slot,
@@ -3398,8 +3542,12 @@ fn main() {
                 }
             }
             ("list-roots", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let max_height = if let Some(height) = arg_matches.value_of("max_height") {
                     usize::from_str(height).expect("Maximum height must be a number")
                 } else {
@@ -3461,8 +3609,12 @@ fn main() {
                     });
             }
             ("latest-optimistic-slots", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let num_slots = value_t_or_exit!(arg_matches, "num_slots", usize);
                 let slots = blockstore
                     .get_latest_optimistic_slots(num_slots)
@@ -3481,8 +3633,12 @@ fn main() {
                 }
             }
             ("repair-roots", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Primary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Primary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 let start_root = if let Some(root) = arg_matches.value_of("start_root") {
                     Slot::from_str(root).expect("Before root must be a number")
                 } else {
@@ -3530,8 +3686,12 @@ fn main() {
                 }
             }
             ("bounds", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
                 match blockstore.slot_meta_iterator(0) {
                     Ok(metas) => {
                         let all = arg_matches.is_present("all");
@@ -3592,13 +3752,23 @@ fn main() {
             }
             ("analyze-storage", _) => {
                 analyze_storage(
-                    &open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode).db(),
+                    &open_blockstore(
+                        &ledger_path,
+                        AccessType::Secondary,
+                        wal_recovery_mode,
+                        &shred_storage_type,
+                    )
+                    .db(),
                 );
                 println!("Ok.");
             }
             ("compute-slot-cost", Some(arg_matches)) => {
-                let blockstore =
-                    open_blockstore(&ledger_path, AccessType::Secondary, wal_recovery_mode);
+                let blockstore = open_blockstore(
+                    &ledger_path,
+                    AccessType::Secondary,
+                    wal_recovery_mode,
+                    &shred_storage_type,
+                );
 
                 let mut slots: Vec<u64> = vec![];
                 if !arg_matches.is_present("slots") {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,6 +1,8 @@
 use {
     assert_cmd::prelude::*,
-    solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config},
+    solana_ledger::{
+        create_new_tmp_ledger, create_new_tmp_ledger_fifo, genesis_utils::create_genesis_config,
+    },
     std::process::{Command, Output},
 };
 
@@ -27,27 +29,104 @@ fn bad_arguments() {
         .success());
 }
 
-#[test]
-fn nominal() {
-    let genesis_config = create_genesis_config(100).genesis_config;
-    let ticks_per_slot = genesis_config.ticks_per_slot;
+fn nominal_test_helper(
+    ledger_path: &str,
+    ticks: usize,
+    use_default_shred_compaction: bool,
+    compatible_shred_compaction: &str,
+    incompatible_shred_compaction: &str,
+) {
     let meta_lines = 2;
     let summary_lines = 1;
 
-    let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
-    let ticks = ticks_per_slot as usize;
-
-    let ledger_path = ledger_path.to_str().unwrap();
-
     // Basic validation
-    let output = run_ledger_tool(&["-l", ledger_path, "verify"]);
+    if use_default_shred_compaction {
+        let output = run_ledger_tool(&["-l", ledger_path, "verify"]);
+        assert!(output.status.success());
+    }
+
+    // Repeat by manually specifying rocksdb-shred-compaction
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        compatible_shred_compaction,
+        "verify",
+    ]);
+    assert!(output.status.success());
+
+    // Repeat with an incompatible shred compaction setting and expect failure
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        incompatible_shred_compaction,
+        "verify",
+    ]);
+    assert!(!output.status.success());
+
+    // Repeat the same verification with the correct rocksdb-shred-compaction
+    // to make sure opening with incompatible shred compaction previously
+    // will not ruin the existing blockstore.
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        compatible_shred_compaction,
+        "verify",
+    ]);
     assert!(output.status.success());
 
     // Print everything
-    let output = run_ledger_tool(&["-l", ledger_path, "print", "-vvv"]);
+    if use_default_shred_compaction {
+        let output = run_ledger_tool(&["-l", ledger_path, "print", "-vvv"]);
+        assert!(output.status.success());
+        assert_eq!(
+            count_newlines(&output.stdout)
+                .saturating_sub(meta_lines)
+                .saturating_sub(summary_lines),
+            ticks
+        );
+    }
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        compatible_shred_compaction,
+        "print",
+        "-vvv",
+    ]);
     assert!(output.status.success());
     assert_eq!(
-        count_newlines(&output.stdout),
-        ticks + meta_lines + summary_lines
+        count_newlines(&output.stdout)
+            .saturating_sub(meta_lines)
+            .saturating_sub(summary_lines),
+        ticks
+    );
+}
+
+#[test]
+fn nominal_default() {
+    let genesis_config = create_genesis_config(100).genesis_config;
+    let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
+    nominal_test_helper(
+        ledger_path.to_str().unwrap(),
+        genesis_config.ticks_per_slot as usize,
+        true, // use_default_shred_compaction
+        "level",
+        "fifo",
+    );
+}
+
+#[test]
+fn nominal_fifo() {
+    let genesis_config = create_genesis_config(100).genesis_config;
+    let (ledger_path, _blockhash) = create_new_tmp_ledger_fifo!(&genesis_config);
+    nominal_test_helper(
+        ledger_path.to_str().unwrap(),
+        genesis_config.ticks_per_slot as usize,
+        false, // use_default_shred_compaction
+        "fifo",
+        "level",
     );
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3919,6 +3919,22 @@ macro_rules! create_new_tmp_ledger {
 }
 
 #[macro_export]
+macro_rules! create_new_tmp_ledger_fifo {
+    ($genesis_config:expr) => {
+        $crate::blockstore::create_new_ledger_from_name(
+            $crate::tmp_ledger_name!(),
+            $genesis_config,
+            $crate::blockstore_options::LedgerColumnOptions {
+                shred_storage_type: $crate::blockstore_options::ShredStorageType::RocksFifo(
+                    $crate::blockstore_options::BlockstoreRocksFifoOptions::default(),
+                ),
+                ..$crate::blockstore_options::LedgerColumnOptions::default()
+            },
+        )
+    };
+}
+
+#[macro_export]
 macro_rules! create_new_tmp_ledger_auto_delete {
     ($genesis_config:expr) => {
         $crate::blockstore::create_new_ledger_from_name_auto_delete(

--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -133,6 +133,15 @@ impl Default for ShredStorageType {
     }
 }
 
+impl ShredStorageType {
+    /// Returns ShredStorageType::RocksFifo where the specified
+    /// `shred_storage_size` is equally allocated to shred_data_cf_size
+    /// and shred_code_cf_size.
+    pub fn rocks_fifo(shred_storage_size: u64) -> ShredStorageType {
+        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::new(shred_storage_size))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BlockstoreRocksFifoOptions {
     // The maximum storage size for storing data shreds in column family
@@ -162,11 +171,15 @@ pub const DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES: u64 = 250 * 1024 * 1024 *
 
 impl Default for BlockstoreRocksFifoOptions {
     fn default() -> Self {
+        BlockstoreRocksFifoOptions::new(DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES)
+    }
+}
+
+impl BlockstoreRocksFifoOptions {
+    fn new(shred_storage_size: u64) -> Self {
         Self {
-            // Maximum size of cf::ShredData.
-            shred_data_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
-            // Maximum size of cf::ShredCode.
-            shred_code_cf_size: DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES / 2,
+            shred_data_cf_size: shred_storage_size / 2,
+            shred_code_cf_size: shred_storage_size / 2,
         }
     }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -31,8 +31,8 @@ use {
     },
     solana_gossip::{cluster_info::Node, contact_info::ContactInfo},
     solana_ledger::blockstore_options::{
-        BlockstoreCompressionType, BlockstoreRecoveryMode, BlockstoreRocksFifoOptions,
-        LedgerColumnOptions, ShredStorageType, DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
+        BlockstoreCompressionType, BlockstoreRecoveryMode, LedgerColumnOptions, ShredStorageType,
+        DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES,
     },
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_perf::recycler::enable_recycler_warming,
@@ -2765,10 +2765,7 @@ pub fn main() {
                 "fifo" => {
                     let shred_storage_size =
                         value_t_or_exit!(matches, "rocksdb_fifo_shred_storage_size", u64);
-                    ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions {
-                        shred_data_cf_size: shred_storage_size / 2,
-                        shred_code_cf_size: shred_storage_size / 2,
-                    })
+                    ShredStorageType::rocks_fifo(shred_storage_size)
                 }
                 _ => panic!(
                     "Unrecognized rocksdb-shred-compaction: {}",


### PR DESCRIPTION
#### Problem
The current ledger tool does not have arguments for specifying rocksdb shred compaction.

#### Summary of Changes
This PR adds `--rocksdb-shred-compaction` argument to the ledger tool.
Tests are also extended to cover the new argument.
