### PR TITLE
Add --target-rocksdb-shred-compaction to ledger tool copy command

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,9 +1,15 @@
 use {
     assert_cmd::prelude::*,
+    solana_entry::entry,
     solana_ledger::{
-        create_new_tmp_ledger, create_new_tmp_ledger_fifo, genesis_utils::create_genesis_config,
+        blockstore, blockstore::Blockstore, create_new_tmp_ledger, create_new_tmp_ledger_fifo,
+        genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
     },
-    std::process::{Command, Output},
+    solana_sdk::hash::Hash,
+    std::{
+        path::Path,
+        process::{Command, Output},
+    },
 };
 
 fn run_ledger_tool(args: &[&str]) -> Output {
@@ -65,4 +71,74 @@ fn nominal_fifo() {
         ledger_path.to_str().unwrap(),
         genesis_config.ticks_per_slot as usize,
     );
+}
+
+fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {
+    let blockstore = Blockstore::open(ledger_path).unwrap();
+    for i in 1..ending_slot {
+        let entries = entry::create_ticks(1, 0, Hash::default());
+        let shreds = blockstore::entries_to_test_shreds(&entries, i, 0, false, 0);
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+    }
+}
+
+fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str) {
+    let genesis_config = create_genesis_config(100).genesis_config;
+
+    let (ledger_path, _blockhash) = match src_shred_compaction {
+        "fifo" => create_new_tmp_ledger_fifo!(&genesis_config),
+        _ => create_new_tmp_ledger!(&genesis_config),
+    };
+    const LEDGER_TOOL_COPY_TEST_SHRED_COUNT: u64 = 25;
+    const LEDGER_TOOL_COPY_TEST_ENDING_SLOT: u64 = LEDGER_TOOL_COPY_TEST_SHRED_COUNT + 1;
+    insert_test_shreds(&ledger_path, LEDGER_TOOL_COPY_TEST_ENDING_SLOT);
+    let ledger_path = ledger_path.to_str().unwrap();
+
+    let target_ledger_path = get_tmp_ledger_path_auto_delete!();
+    let target_ledger_path = target_ledger_path.path().to_str().unwrap();
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path,
+        "--rocksdb-shred-compaction",
+        src_shred_compaction,
+        "copy",
+        "--target-db",
+        target_ledger_path,
+        "--target-rocksdb-shred-compaction",
+        dst_shred_compaction,
+        "--ending-slot",
+        &(LEDGER_TOOL_COPY_TEST_ENDING_SLOT).to_string(),
+    ]);
+    assert!(output.status.success());
+    for slot_id in 0..LEDGER_TOOL_COPY_TEST_ENDING_SLOT {
+        let src_slot_output = run_ledger_tool(&[
+            "-l",
+            ledger_path,
+            "--rocksdb-shred-compaction",
+            src_shred_compaction,
+            "slot",
+            &slot_id.to_string(),
+        ]);
+
+        let dst_slot_output = run_ledger_tool(&[
+            "-l",
+            target_ledger_path,
+            "--rocksdb-shred-compaction",
+            dst_shred_compaction,
+            "slot",
+            &slot_id.to_string(),
+        ]);
+        assert!(src_slot_output.status.success());
+        assert!(dst_slot_output.status.success());
+        assert!(!src_slot_output.stdout.is_empty());
+        assert_eq!(src_slot_output.stdout, dst_slot_output.stdout);
+    }
+}
+
+#[test]
+fn copy_test() {
+    ledger_tool_copy_test("level", "level");
+    ledger_tool_copy_test("level", "fifo");
+    ledger_tool_copy_test("fifo", "level");
+    ledger_tool_copy_test("fifo", "fifo");
 }


### PR DESCRIPTION
#### Summary of Changes
This PR adds `--target-rocksdb-shred-compaction` and `--target-rocksdb-fifo-shred-storage-size`
under the copy command of the ledger-tool to enable copying between different shred storage
compaction styles.

New tests covering ledger-tool copy are also added in this PR.
