### PR TITLE
Connection pool support in connection cache and QUIC connection reliability improvement

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -5,7 +5,7 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     rayon::prelude::*,
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
     solana_core::banking_stage::BankingStage,
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -352,7 +352,10 @@ fn main() {
             None,
             replay_vote_sender,
             Arc::new(RwLock::new(CostModel::default())),
-            Arc::new(ConnectionCache::new(tpu_use_quic)),
+            Arc::new(ConnectionCache::new(
+                tpu_use_quic,
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
+            )),
         );
         poh_recorder.lock().unwrap().set_bank(&bank);
 

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -2,7 +2,7 @@ use {
     clap::{crate_description, crate_name, App, Arg, ArgMatches},
     solana_clap_utils::input_validators::{is_url, is_url_or_moniker},
     solana_cli_config::{ConfigInput, CONFIG_FILE},
-    solana_client::connection_cache::DEFAULT_TPU_USE_QUIC,
+    solana_client::connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
     solana_sdk::{
         fee_calculator::FeeRateGovernor,
         pubkey::Pubkey,
@@ -53,6 +53,7 @@ pub struct Config {
     pub target_node: Option<Pubkey>,
     pub external_client_type: ExternalClientType,
     pub use_quic: bool,
+    pub tpu_connection_pool_size: usize,
 }
 
 impl Default for Config {
@@ -79,6 +80,7 @@ impl Default for Config {
             target_node: None,
             external_client_type: ExternalClientType::default(),
             use_quic: DEFAULT_TPU_USE_QUIC,
+            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
         }
     }
 }
@@ -294,6 +296,13 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .help("Submit transactions via QUIC; only affects ThinClient (default) \
                     or TpuClient sends"),
         )
+        .arg(
+            Arg::with_name("tpu_connection_pool_size")
+                .long("tpu-connection-pool-size")
+                .takes_value(true)
+                .help("Controls the connection pool size per remote address; only affects ThinClient (default) \
+                    or TpuClient sends"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -341,6 +350,13 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
 
     if matches.is_present("tpu_use_quic") {
         args.use_quic = true;
+    }
+
+    if let Some(v) = matches.value_of("tpu_connection_pool_size") {
+        args.tpu_connection_pool_size = v
+            .to_string()
+            .parse()
+            .expect("can't parse tpu_connection_pool_size");
     }
 
     if let Some(addr) = matches.value_of("entrypoint") {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
         target_node,
         external_client_type,
         use_quic,
+        tpu_connection_pool_size,
         ..
     } = &cli_config;
 
@@ -102,7 +103,9 @@ fn main() {
             do_bench_tps(client, cli_config, keypairs);
         }
         ExternalClientType::ThinClient => {
-            let connection_cache = Arc::new(ConnectionCache::new(*use_quic));
+            let connection_cache =
+                Arc::new(ConnectionCache::new(*use_quic, *tpu_connection_pool_size));
+
             let client = if let Ok(rpc_addr) = value_t!(matches, "rpc_addr", String) {
                 let rpc = rpc_addr.parse().unwrap_or_else(|e| {
                     eprintln!("RPC address should parse as socketaddr {:?}", e);
@@ -172,7 +175,9 @@ fn main() {
                 json_rpc_url.to_string(),
                 CommitmentConfig::confirmed(),
             ));
-            let connection_cache = Arc::new(ConnectionCache::new(*use_quic));
+            let connection_cache =
+                Arc::new(ConnectionCache::new(*use_quic, *tpu_connection_pool_size));
+
             let client = Arc::new(
                 TpuClient::new_with_connection_cache(
                     rpc_client,

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -1,17 +1,18 @@
 use {
     crate::{
+        nonblocking::quic_client::QuicLazyInitializedEndpoint,
         quic_client::QuicTpuConnection,
         tpu_connection::{ClientStats, Connection},
         udp_client::UdpTpuConnection,
     },
-    indexmap::map::IndexMap,
+    indexmap::map::{Entry, IndexMap},
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
-    solana_sdk::timing::AtomicInterval,
+    solana_sdk::{quic::QUIC_PORT_OFFSET, timing::AtomicInterval},
     std::{
         net::SocketAddr,
         sync::{
-            atomic::{AtomicBool, AtomicU64, Ordering},
+            atomic::{AtomicU64, Ordering},
             Arc, RwLock,
         },
     },
@@ -23,6 +24,9 @@ static MAX_CONNECTIONS: usize = 1024;
 /// Used to decide whether the TPU and underlying connection cache should use
 /// QUIC connections.
 pub const DEFAULT_TPU_USE_QUIC: bool = false;
+
+/// Default TPU connection pool size per remote address
+pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 4;
 
 #[derive(Default)]
 pub struct ConnectionCacheStats {
@@ -214,28 +218,142 @@ impl ConnectionCacheStats {
 }
 
 pub struct ConnectionCache {
-    map: RwLock<IndexMap<SocketAddr, Arc<Connection>>>,
+    map: RwLock<IndexMap<SocketAddr, ConnectionPool>>,
     stats: Arc<ConnectionCacheStats>,
     last_stats: AtomicInterval,
-    use_quic: AtomicBool,
+    use_quic: bool,
+    connection_pool_size: usize,
+}
+
+/// Models the pool of connections
+struct ConnectionPool {
+    /// The connections in the pool
+    connections: Vec<Arc<Connection>>,
+
+    /// Connections in this pool share the same endpoint
+    endpoint: Arc<QuicLazyInitializedEndpoint>,
+}
+
+impl ConnectionPool {
+    /// Get a connection from the pool. It must have at least one connection in the pool.
+    /// This randomly picks a connection in the pool.
+    fn borrow_connection(&self) -> Arc<Connection> {
+        let mut rng = thread_rng();
+        let n = rng.gen_range(0, self.connections.len());
+        self.connections[n].clone()
+    }
+
+    /// Check if we need to create a new connection. If the count of the connections
+    /// is smaller than the pool size.
+    fn need_new_connection(&self, required_pool_size: usize) -> bool {
+        self.connections.len() < required_pool_size
+    }
 }
 
 impl ConnectionCache {
-    pub fn new(use_quic: bool) -> Self {
+    pub fn new(use_quic: bool, connection_pool_size: usize) -> Self {
+        // The minimum pool size is 1.
+        let connection_pool_size = 1.max(connection_pool_size);
         Self {
-            use_quic: AtomicBool::new(use_quic),
+            use_quic,
+            connection_pool_size,
             ..Self::default()
         }
     }
 
     pub fn get_use_quic(&self) -> bool {
-        self.use_quic.load(Ordering::Relaxed)
+        self.use_quic
+    }
+
+    /// Create a lazy connection object under the exclusive lock of the cache map if there is not
+    /// enough unsed connections in the connection pool for the specified address.
+    /// Returns CreateConnectionResult.
+    fn create_connection(
+        &self,
+        lock_timing_ms: &mut u64,
+        addr: &SocketAddr,
+    ) -> CreateConnectionResult {
+        let mut get_connection_map_lock_measure = Measure::start("get_connection_map_lock_measure");
+        let mut map = self.map.write().unwrap();
+        get_connection_map_lock_measure.stop();
+        *lock_timing_ms = lock_timing_ms.saturating_add(get_connection_map_lock_measure.as_ms());
+        // Read again, as it is possible that between read lock dropped and the write lock acquired
+        // another thread could have setup the connection.
+
+        let (to_create_connection, endpoint) = map.get(addr).map_or(
+            (true, Arc::new(QuicLazyInitializedEndpoint::new())),
+            |pool| {
+                (
+                    pool.need_new_connection(self.connection_pool_size),
+                    pool.endpoint.clone(),
+                )
+            },
+        );
+
+        let (cache_hit, connection_cache_stats, num_evictions, eviction_timing_ms) =
+            if to_create_connection {
+                let connection: Connection = if self.use_quic {
+                    QuicTpuConnection::new(endpoint, *addr, self.stats.clone()).into()
+                } else {
+                    UdpTpuConnection::new(*addr, self.stats.clone()).into()
+                };
+
+                let connection = Arc::new(connection);
+
+                // evict a connection if the cache is reaching upper bounds
+                let mut num_evictions = 0;
+                let mut get_connection_cache_eviction_measure =
+                    Measure::start("get_connection_cache_eviction_measure");
+                while map.len() >= MAX_CONNECTIONS {
+                    let mut rng = thread_rng();
+                    let n = rng.gen_range(0, MAX_CONNECTIONS);
+                    map.swap_remove_index(n);
+                    num_evictions += 1;
+                }
+                get_connection_cache_eviction_measure.stop();
+
+                match map.entry(*addr) {
+                    Entry::Occupied(mut entry) => {
+                        let pool = entry.get_mut();
+                        pool.connections.push(connection);
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(ConnectionPool {
+                            connections: vec![connection],
+                            endpoint: Arc::new(QuicLazyInitializedEndpoint::new()),
+                        });
+                    }
+                }
+                (
+                    false,
+                    self.stats.clone(),
+                    num_evictions,
+                    get_connection_cache_eviction_measure.as_ms(),
+                )
+            } else {
+                (true, self.stats.clone(), 0, 0)
+            };
+
+        let pool = map.get(addr).unwrap();
+        let connection = pool.borrow_connection();
+
+        CreateConnectionResult {
+            connection,
+            cache_hit,
+            connection_cache_stats,
+            num_evictions,
+            eviction_timing_ms,
+        }
     }
 
     fn get_or_add_connection(&self, addr: &SocketAddr) -> GetConnectionResult {
         let mut get_connection_map_lock_measure = Measure::start("get_connection_map_lock_measure");
         let map = self.map.read().unwrap();
         get_connection_map_lock_measure.stop();
+
+        let port_offset = if self.use_quic { QUIC_PORT_OFFSET } else { 0 };
+
+        let addr = SocketAddr::new(addr.ip(), addr.port() + port_offset);
 
         let mut lock_timing_ms = get_connection_map_lock_measure.as_ms();
 
@@ -244,57 +362,35 @@ impl ConnectionCache {
             .should_update(CONNECTION_STAT_SUBMISSION_INTERVAL);
 
         let mut get_connection_map_measure = Measure::start("get_connection_hit_measure");
-        let (connection, cache_hit, connection_cache_stats, num_evictions, eviction_timing_ms) =
-            match map.get(addr) {
-                Some(connection) => (connection.clone(), true, self.stats.clone(), 0, 0),
-                None => {
-                    // Upgrade to write access by dropping read lock and acquire write lock
+        let CreateConnectionResult {
+            connection,
+            cache_hit,
+            connection_cache_stats,
+            num_evictions,
+            eviction_timing_ms,
+        } = match map.get(&addr) {
+            Some(pool) => {
+                if pool.need_new_connection(self.connection_pool_size) {
+                    // create more connection and put it in the pool
                     drop(map);
-                    let mut get_connection_map_lock_measure =
-                        Measure::start("get_connection_map_lock_measure");
-                    let mut map = self.map.write().unwrap();
-                    get_connection_map_lock_measure.stop();
-
-                    lock_timing_ms =
-                        lock_timing_ms.saturating_add(get_connection_map_lock_measure.as_ms());
-
-                    // Read again, as it is possible that between read lock dropped and the write lock acquired
-                    // another thread could have setup the connection.
-                    match map.get(addr) {
-                        Some(connection) => (connection.clone(), true, self.stats.clone(), 0, 0),
-                        None => {
-                            let connection: Connection = if self.use_quic.load(Ordering::Relaxed) {
-                                QuicTpuConnection::new(*addr, self.stats.clone()).into()
-                            } else {
-                                UdpTpuConnection::new(*addr, self.stats.clone()).into()
-                            };
-
-                            let connection = Arc::new(connection);
-
-                            // evict a connection if the cache is reaching upper bounds
-                            let mut num_evictions = 0;
-                            let mut get_connection_cache_eviction_measure =
-                                Measure::start("get_connection_cache_eviction_measure");
-                            while map.len() >= MAX_CONNECTIONS {
-                                let mut rng = thread_rng();
-                                let n = rng.gen_range(0, MAX_CONNECTIONS);
-                                map.swap_remove_index(n);
-                                num_evictions += 1;
-                            }
-                            get_connection_cache_eviction_measure.stop();
-
-                            map.insert(*addr, connection.clone());
-                            (
-                                connection,
-                                false,
-                                self.stats.clone(),
-                                num_evictions,
-                                get_connection_cache_eviction_measure.as_ms(),
-                            )
-                        }
+                    self.create_connection(&mut lock_timing_ms, &addr)
+                } else {
+                    let connection = pool.borrow_connection();
+                    CreateConnectionResult {
+                        connection,
+                        cache_hit: true,
+                        connection_cache_stats: self.stats.clone(),
+                        num_evictions: 0,
+                        eviction_timing_ms: 0,
                     }
                 }
-            };
+            }
+            None => {
+                // Upgrade to write access by dropping read lock and acquire write lock
+                drop(map);
+                self.create_connection(&mut lock_timing_ms, &addr)
+            }
+        };
         get_connection_map_measure.stop();
 
         GetConnectionResult {
@@ -359,13 +455,15 @@ impl ConnectionCache {
         connection
     }
 }
+
 impl Default for ConnectionCache {
     fn default() -> Self {
         Self {
             map: RwLock::new(IndexMap::with_capacity(MAX_CONNECTIONS)),
             stats: Arc::new(ConnectionCacheStats::default()),
             last_stats: AtomicInterval::default(),
-            use_quic: AtomicBool::new(DEFAULT_TPU_USE_QUIC),
+            use_quic: DEFAULT_TPU_USE_QUIC,
+            connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
         }
     }
 }
@@ -376,6 +474,14 @@ struct GetConnectionResult {
     report_stats: bool,
     map_timing_ms: u64,
     lock_timing_ms: u64,
+    connection_cache_stats: Arc<ConnectionCacheStats>,
+    num_evictions: u64,
+    eviction_timing_ms: u64,
+}
+
+struct CreateConnectionResult {
+    connection: Arc<Connection>,
+    cache_hit: bool,
     connection_cache_stats: Arc<ConnectionCacheStats>,
     num_evictions: u64,
     eviction_timing_ms: u64,
@@ -432,7 +538,7 @@ mod tests {
             let map = connection_cache.map.read().unwrap();
             assert!(map.len() == MAX_CONNECTIONS);
             addrs.iter().for_each(|a| {
-                let conn = map.get(a).expect("Address not found");
+                let conn = &map.get(a).expect("Address not found").connections[0];
                 assert!(a.ip() == conn.tpu_addr().ip());
             });
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -381,6 +381,7 @@ impl Validator {
         start_progress: Arc<RwLock<ValidatorStartProgress>>,
         socket_addr_space: SocketAddrSpace,
         use_quic: bool,
+        tpu_connection_pool_size: usize,
     ) -> Self {
         let id = identity_keypair.pubkey();
         assert_eq!(id, node.info.id);
@@ -748,7 +749,7 @@ impl Validator {
         };
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
-        let connection_cache = Arc::new(ConnectionCache::new(use_quic));
+        let connection_cache = Arc::new(ConnectionCache::new(use_quic, tpu_connection_pool_size));
 
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let (
@@ -2054,7 +2055,7 @@ mod tests {
     use {
         super::*,
         crossbeam_channel::{bounded, RecvTimeoutError},
-        solana_client::connection_cache::DEFAULT_TPU_USE_QUIC,
+        solana_client::connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
         solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader},
         solana_sdk::{genesis_config::create_genesis_config, poh_config::PohConfig},
         std::{fs::remove_dir_all, thread, time::Duration},
@@ -2091,6 +2092,7 @@ mod tests {
             start_progress.clone(),
             SocketAddrSpace::Unspecified,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );
         assert_eq!(
             *start_progress.read().unwrap(),
@@ -2186,6 +2188,7 @@ mod tests {
                     Arc::new(RwLock::new(ValidatorStartProgress::default())),
                     SocketAddrSpace::Unspecified,
                     DEFAULT_TPU_USE_QUIC,
+                    DEFAULT_TPU_CONNECTION_POOL_SIZE,
                 )
             })
             .collect();

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -44,7 +44,10 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     solana_bench_tps::{bench::generate_and_fund_keypairs, bench_tps_client::BenchTpsClient},
-    solana_client::{connection_cache::ConnectionCache, rpc_client::RpcClient},
+    solana_client::{
+        connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
+        rpc_client::RpcClient,
+    },
     solana_core::serve_repair::RepairProtocol,
     solana_dos::cli::*,
     solana_gossip::{
@@ -598,7 +601,10 @@ fn main() {
             exit(1);
         });
 
-        let connection_cache = Arc::new(ConnectionCache::new(cmd_params.tpu_use_quic));
+        let connection_cache = Arc::new(ConnectionCache::new(
+            cmd_params.tpu_use_quic,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
+        ));
         let (client, num_clients) =
             get_multi_client(&validators, &SocketAddrSpace::Unspecified, connection_cache);
         if validators.len() < num_clients {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -7,7 +7,9 @@ use {
     itertools::izip,
     log::*,
     solana_client::{
-        connection_cache::{ConnectionCache, DEFAULT_TPU_USE_QUIC},
+        connection_cache::{
+            ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
+        },
         thin_client::ThinClient,
     },
     solana_core::{
@@ -80,6 +82,7 @@ pub struct ClusterConfig {
     pub poh_config: PohConfig,
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
     pub tpu_use_quic: bool,
+    pub tpu_connection_pool_size: usize,
 }
 
 impl Default for ClusterConfig {
@@ -100,6 +103,7 @@ impl Default for ClusterConfig {
             skip_warmup_slots: false,
             additional_accounts: vec![],
             tpu_use_quic: DEFAULT_TPU_USE_QUIC,
+            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
         }
     }
 }
@@ -255,6 +259,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );
 
         let mut validators = HashMap::new();
@@ -277,7 +282,10 @@ impl LocalCluster {
             entry_point_info: leader_contact_info,
             validators,
             genesis_config,
-            connection_cache: Arc::new(ConnectionCache::new(config.tpu_use_quic)),
+            connection_cache: Arc::new(ConnectionCache::new(
+                config.tpu_use_quic,
+                config.tpu_connection_pool_size,
+            )),
         };
 
         let node_pubkey_to_vote_key: HashMap<Pubkey, Arc<Keypair>> = keys_in_genesis
@@ -450,6 +458,7 @@ impl LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );
 
         let validator_pubkey = validator_keypair.pubkey();
@@ -797,6 +806,7 @@ impl Cluster for LocalCluster {
             Arc::new(RwLock::new(ValidatorStartProgress::default())),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );
         cluster_validator_info.validator = Some(restarted_node);
         cluster_validator_info

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -8,7 +8,7 @@ use {
     solana_account_decoder::UiAccount,
     solana_client::{
         client_error::{ClientErrorKind, Result as ClientResult},
-        connection_cache::ConnectionCache,
+        connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
         nonblocking::pubsub_client::PubsubClient,
         rpc_client::RpcClient,
         rpc_config::{RpcAccountInfoConfig, RpcSignatureSubscribeConfig},
@@ -420,7 +420,10 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
         test_validator.rpc_url(),
         CommitmentConfig::processed(),
     ));
-    let connection_cache = Arc::new(ConnectionCache::new(tpu_use_quic));
+    let connection_cache = Arc::new(ConnectionCache::new(
+        tpu_use_quic,
+        DEFAULT_TPU_CONNECTION_POOL_SIZE,
+    ));
     let tpu_client = TpuClient::new_with_connection_cache(
         rpc_client.clone(),
         &test_validator.rpc_pubsub_url(),

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -2,7 +2,11 @@
 use {
     log::*,
     solana_cli_output::CliAccount,
-    solana_client::{connection_cache::DEFAULT_TPU_USE_QUIC, nonblocking, rpc_client::RpcClient},
+    solana_client::{
+        connection_cache::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC},
+        nonblocking,
+        rpc_client::RpcClient,
+    },
     solana_core::{
         tower_storage::TowerStorage,
         validator::{Validator, ValidatorConfig, ValidatorStartProgress},
@@ -749,6 +753,7 @@ impl TestValidator {
             config.start_progress.clone(),
             socket_addr_space,
             DEFAULT_TPU_USE_QUIC,
+            DEFAULT_TPU_CONNECTION_POOL_SIZE,
         ));
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of


### PR DESCRIPTION
#### Problem
To improve QUIC transaction send throughput and connection reliability. 

#### Summary of Changes

1. Connection pool is devised which is per address in the connection cache. The count is configurable. The default is 4 which is found to offer best balance of performance improvement and the additional memory overhead.  Each address now in the connection cache map points to a pool of connections. The pool consists of a number connection pool entries. The pool entry is checked out randomly to ensure even usage for the connections for the same address.

2.  Optimization has been done to share the Endpoint for QUIC -- connections from the same address now share the same LazyInitialized endpoint.

3. The quic_client is improved to handle connection errors. Care has been take to avoid the situation where large number of tasks retry creating the connections when running into connection send errors. One connection established will be retried only once across all asynchronous tasks using the connection.

4. In case of tpu-client, it is found that the changes offers 3X of the quic throughput over the result of master code. And for thin-client, the quic throughput is improved about 40% improvement. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
