### PR TITLE
Set up solana logger in cargo-build-sbf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ dependencies = [
  "regex",
  "serial_test",
  "solana-download-utils",
+ "solana-logger 1.11.0",
  "solana-sdk 1.11.0",
  "tar",
 ]

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -72,7 +72,9 @@ if [[ $CI_OS_NAME = windows ]]; then
   # yet available on windows
   BINS=(
     cargo-build-bpf
+    cargo-build-sbf
     cargo-test-bpf
+    cargo-test-sbf
     solana
     solana-install
     solana-install-init
@@ -103,7 +105,9 @@ else
   if [[ -z "$validatorOnly" ]]; then
     BINS+=(
       cargo-build-bpf
+      cargo-build-sbf
       cargo-test-bpf
+      cargo-test-sbf
       solana-dos
       solana-install-init
       solana-stake-accounts

--- a/sdk/cargo-build-sbf/Cargo.toml
+++ b/sdk/cargo-build-sbf/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "3.1.5", features = ["cargo", "env"] }
 log = { version = "0.4.14", features = ["std"] }
 regex = "1.5.6"
 solana-download-utils = { path = "../../download-utils", version = "=1.11.0" }
+solana-logger = { path = "../../logger", version = "=1.11.0" }
 solana-sdk = { path = "..", version = "=1.11.0" }
 tar = "0.4.38"
 

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -700,6 +700,7 @@ fn build_sbf(config: Config, manifest_path: Option<PathBuf>) {
 }
 
 fn main() {
+    solana_logger::setup();
     let default_config = Config::default();
     let default_sbf_sdk = format!("{}", default_config.sbf_sdk.display());
 


### PR DESCRIPTION
#### Problem

cargo-build-sbf uses logger for all diagnostic messages.  The logger must be initialized.

#### Summary of Changes

Add a statement that sets up a solana logger at the beginning of main in cargo-build-sbf.

