### PR TITLE
20 byte merkle proof with direct buffer verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5407,6 +5407,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk 1.11.0",
  "solana-vote-program",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5401,6 +5401,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
+ "sha2 0.10.2",
  "solana-logger 1.11.0",
  "solana-metrics",
  "solana-rayon-threadlimit",

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -150,6 +150,8 @@ pub enum Error {
     InvalidShredVariant,
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    TurbineMerkleError(#[from] solana_perf::turbine_merkle::Error),
 }
 
 #[repr(u8)]

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -503,15 +503,14 @@ mod test {
             size: u16::try_from(SIZE_OF_DATA_SHRED_HEADERS + capacity).unwrap(),
         };
         let mut payload = vec![0u8; ShredData::SIZE_OF_PAYLOAD];
-        for i in 0..payload.len() {
-            payload[i] = u8::try_from(i % 256).unwrap();
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = u8::try_from(i % 256).unwrap();
         }
-        let shred = ShredData {
+        ShredData {
             common_header,
             data_header,
             payload,
-        };
-        shred
+        }
     }
 
     #[test]

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -100,7 +100,7 @@ impl ShredData {
     }
 
     fn verify_merkle_proof(&self) -> Result<bool, Error> {
-        let root_hash = TurbineMerkleHash::from(self.merkle_root_slice()?);
+        let root_hash = TurbineMerkleHash::try_from(self.merkle_root_slice()?)?;
         Ok(TurbineMerkleProof::verify_buf(
             &root_hash,
             self.merkle_proof_slice()?,
@@ -162,7 +162,7 @@ impl ShredCode {
     }
 
     fn verify_merkle_proof(&self) -> Result<bool, Error> {
-        let root_hash = TurbineMerkleHash::from(self.merkle_root_slice()?);
+        let root_hash = TurbineMerkleHash::try_from(self.merkle_root_slice()?)?;
         Ok(TurbineMerkleProof::verify_buf(
             &root_hash,
             self.merkle_proof_slice()?,
@@ -460,7 +460,7 @@ mod test {
         let bytes: [u8; 32] = rng.gen();
         let hash = Hash::from(bytes);
         let entry = &hash.as_ref()[..TURBINE_MERKLE_HASH_BYTES];
-        let entry = TurbineMerkleHash::from(entry);
+        let entry = TurbineMerkleHash::try_from(entry).unwrap();
         assert_eq!(entry.as_ref(), &bytes[..TURBINE_MERKLE_HASH_BYTES]);
     }
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.17"
 rand = "0.7.0"
 rayon = "1.5.3"
 serde = "1.0.137"
+sha2 = "0.10.2"
 solana-metrics = { path = "../metrics", version = "=1.11.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -27,6 +27,7 @@ solana-metrics = { path = "../metrics", version = "=1.11.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "=1.11.0" }
 solana-sdk = { path = "../sdk", version = "=1.11.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.0" }
+thiserror = "1.0"
 
 [target."cfg(target_os = \"linux\")".dependencies]
 caps = "0.5.3"

--- a/perf/benches/turbine_merkle.rs
+++ b/perf/benches/turbine_merkle.rs
@@ -79,7 +79,7 @@ fn bench_merkle_verify_proofs_96_single(b: &mut Bencher) {
     let proof = tree.prove(7);
 
     b.iter(|| {
-        proof.verify(&tree.root(), &tree.node(7), 7);
+        assert!(proof.verify(&tree.root(), &leaves[7], 7));
     });
 }
 
@@ -97,15 +97,8 @@ fn bench_merkle_verify_proofs_96_batch(b: &mut Bencher) {
 
     b.iter(|| {
         let _results: Vec<_> = (0..96)
-            .map(|i| proofs[i].verify(&tree.root(), &tree.node(i), i))
+            .map(|i| proofs[i].verify(&tree.root(), &leaves[i], i))
             .collect();
-    });
-}
-
-fn bench_merkle_create_tree_from_bufs(b: &mut Bencher, pkt_count: usize) {
-    let packets = create_random_packets(pkt_count);
-    b.iter(|| {
-        let _tree = TurbineMerkleTree::new_from_bufs(&packets);
     });
 }
 
@@ -115,11 +108,6 @@ fn bench_merkle_create_tree_from_bufs_vec_par(b: &mut Bencher, pkt_count: usize,
     b.iter(|| {
         let _tree = TurbineMerkleTree::new_from_bufs_vec_par(&packets_buf_vec, chunk);
     });
-}
-
-#[bench]
-fn bench_merkle_create_tree_from_bufs_vec_64(b: &mut Bencher) {
-    bench_merkle_create_tree_from_bufs(b, 64);
 }
 
 #[ignore]

--- a/perf/benches/turbine_merkle.rs
+++ b/perf/benches/turbine_merkle.rs
@@ -1,0 +1,253 @@
+#![feature(test)]
+
+extern crate test;
+
+use {
+    rayon::{iter::ParallelIterator, prelude::*},
+    solana_perf::turbine_merkle::{TurbineMerkleHash, TurbineMerkleTree},
+    solana_sdk::signature::{Keypair, Signer},
+    test::Bencher,
+};
+
+fn create_random_packets(npackets: usize) -> Vec<Vec<u8>> {
+    let mut packets = Vec::default();
+    for _i in 0..npackets {
+        let buf: Vec<u8> = (0..1024).map(|_| rand::random::<u8>()).collect();
+        packets.push(buf);
+    }
+    packets
+}
+
+fn bench_merkle_create_tree_from_leaves(b: &mut Bencher, pkt_count: usize) {
+    let packets = create_random_packets(pkt_count);
+    b.iter(|| {
+        let leaves: Vec<TurbineMerkleHash> = packets
+            .iter()
+            .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+            .collect();
+        let _tree = TurbineMerkleTree::new_from_leaves(&leaves);
+    });
+}
+
+#[bench]
+fn bench_merkle_create_tree_from_leaves_64(b: &mut Bencher) {
+    bench_merkle_create_tree_from_leaves(b, 64);
+}
+
+#[bench]
+fn bench_merkle_create_proofs_96_single(b: &mut Bencher) {
+    let packets = create_random_packets(96);
+
+    let mut leaves: Vec<TurbineMerkleHash> = packets
+        .iter()
+        .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+        .collect();
+    leaves.extend(std::iter::repeat(TurbineMerkleHash::default()).take(32));
+    let tree = TurbineMerkleTree::new_from_leaves(&leaves);
+
+    b.iter(|| {
+        let _proof = tree.prove(7);
+    });
+}
+
+#[bench]
+fn bench_merkle_create_proofs_96_batch(b: &mut Bencher) {
+    let packets = create_random_packets(96);
+
+    let mut leaves: Vec<TurbineMerkleHash> = packets
+        .iter()
+        .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+        .collect();
+    leaves.extend(std::iter::repeat(TurbineMerkleHash::default()).take(32));
+    let tree = TurbineMerkleTree::new_from_leaves(&leaves);
+
+    b.iter(|| {
+        let _proofs: Vec<_> = (0..96).map(|i| tree.prove(i)).collect();
+    });
+}
+
+#[bench]
+fn bench_merkle_verify_proofs_96_single(b: &mut Bencher) {
+    let packets = create_random_packets(96);
+
+    let mut leaves: Vec<TurbineMerkleHash> = packets
+        .iter()
+        .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+        .collect();
+    leaves.extend(std::iter::repeat(TurbineMerkleHash::default()).take(32));
+    let tree = TurbineMerkleTree::new_from_leaves(&leaves);
+    let proof = tree.prove(7);
+
+    b.iter(|| {
+        proof.verify(&tree.root(), &tree.node(7), 7);
+    });
+}
+
+#[bench]
+fn bench_merkle_verify_proofs_96_batch(b: &mut Bencher) {
+    let packets = create_random_packets(96);
+
+    let mut leaves: Vec<TurbineMerkleHash> = packets
+        .iter()
+        .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+        .collect();
+    leaves.extend(std::iter::repeat(TurbineMerkleHash::default()).take(32));
+    let tree = TurbineMerkleTree::new_from_leaves(&leaves);
+    let proofs: Vec<_> = (0..96).map(|i| tree.prove(i)).collect();
+
+    b.iter(|| {
+        let _results: Vec<_> = (0..96)
+            .map(|i| proofs[i].verify(&tree.root(), &tree.node(i), i))
+            .collect();
+    });
+}
+
+fn bench_merkle_create_tree_from_bufs(b: &mut Bencher, pkt_count: usize) {
+    let packets = create_random_packets(pkt_count);
+    b.iter(|| {
+        let _tree = TurbineMerkleTree::new_from_bufs(&packets);
+    });
+}
+
+fn bench_merkle_create_tree_from_bufs_vec_par(b: &mut Bencher, pkt_count: usize, chunk: usize) {
+    let packets = create_random_packets(pkt_count);
+    let packets_buf_vec: Vec<_> = packets.iter().map(|p| vec![&p[..100], &p[100..]]).collect();
+    b.iter(|| {
+        let _tree = TurbineMerkleTree::new_from_bufs_vec_par(&packets_buf_vec, chunk);
+    });
+}
+
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_64(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs(b, 64);
+}
+
+#[ignore]
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_par_128_32(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs_vec_par(b, 128, 32);
+}
+
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_par_128_16(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs_vec_par(b, 128, 16);
+}
+
+#[ignore]
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_par_64_32(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs_vec_par(b, 64, 32);
+}
+
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_par_64_16(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs_vec_par(b, 64, 16);
+}
+
+#[ignore]
+#[bench]
+fn bench_merkle_create_tree_from_bufs_vec_par_64_8(b: &mut Bencher) {
+    bench_merkle_create_tree_from_bufs_vec_par(b, 64, 8);
+}
+
+// Simulate work required for one batch of outgoing shreds.
+#[bench]
+fn bench_merkle_fec64_outgoing(b: &mut Bencher) {
+    let keypair = Keypair::new();
+    let packets = create_random_packets(64);
+    b.iter(|| {
+        let bufs_vec: Vec<_> = packets.iter().map(|p| vec![&p[..333], &p[333..]]).collect();
+        let tree = TurbineMerkleTree::new_from_bufs_vec_par(&bufs_vec, 16);
+        let root_hash = tree.root();
+        let _signature = keypair.sign_message(root_hash.as_ref());
+        let _proofs: Vec<_> = (0..64).map(|i| (i, tree.prove(i))).collect();
+    });
+}
+
+// Simulate work required for one batch of incoming shreds verifying each
+// shred individually.
+#[bench]
+fn bench_merkle_fec64_incoming_individual(b: &mut Bencher) {
+    let keypair = Keypair::new();
+    let packets = create_random_packets(64);
+    let bufs_vec: Vec<_> = packets.iter().map(|p| vec![&p[..333], &p[333..]]).collect();
+    let tree = TurbineMerkleTree::new_from_bufs_vec_par(&bufs_vec, 16);
+    let root_hash = tree.root();
+    let signature = keypair.sign_message(root_hash.as_ref());
+    let proof_data: Vec<_> = bufs_vec
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, v, root_hash, signature, tree.prove(i)))
+        .collect();
+    b.iter(|| {
+        proof_data.par_chunks(16).for_each(|slice| {
+            slice.iter().for_each(|(i, v, root_hash, sig, proof)| {
+                let leaf_hash = TurbineMerkleHash::hash_leaf(v);
+                assert!(proof.verify(root_hash, &leaf_hash, *i));
+                assert!(sig.verify(keypair.pubkey().as_ref(), root_hash.as_ref()));
+            });
+        });
+    });
+}
+
+// Simulate work required for one batch of incoming shreds comparing each
+// root/signature pair to a verified value.
+#[bench]
+fn bench_merkle_fec64_incoming_saved_hash(b: &mut Bencher) {
+    let keypair = Keypair::new();
+    let packets = create_random_packets(64);
+    let bufs_vec: Vec<_> = packets.iter().map(|p| vec![&p[..333], &p[333..]]).collect();
+    let tree = TurbineMerkleTree::new_from_bufs_vec_par(&bufs_vec, 16);
+    let root_hash = tree.root();
+    let signature = keypair.sign_message(root_hash.as_ref());
+    let proof_data: Vec<_> = bufs_vec
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, v, root_hash, signature, tree.prove(i)))
+        .collect();
+    b.iter(|| {
+        let (fec_set_root_hash, fec_set_sig) = proof_data
+            .first()
+            .map(|(_, _, root_hash, sig, _)| (root_hash, sig))
+            .unwrap();
+        assert!(fec_set_sig.verify(keypair.pubkey().as_ref(), root_hash.as_ref()));
+        proof_data.par_chunks(16).for_each(|slice| {
+            slice.iter().for_each(|(i, v, root_hash, sig, proof)| {
+                let leaf_hash = TurbineMerkleHash::hash_leaf(v);
+                assert_eq!(sig, fec_set_sig);
+                assert_eq!(root_hash, fec_set_root_hash);
+                assert!(proof.verify(root_hash, &leaf_hash, *i));
+            });
+        });
+    });
+}
+
+#[bench]
+fn bench_signature_fec64_outgoing(b: &mut Bencher) {
+    let keypair = Keypair::new();
+    let packets = create_random_packets(64);
+    b.iter(|| {
+        packets.par_chunks(16).for_each(|slice| {
+            for p in slice {
+                keypair.sign_message(p);
+            }
+        });
+    });
+}
+
+#[bench]
+fn bench_signature_fec64_incoming(b: &mut Bencher) {
+    let keypair = Keypair::new();
+    let packets = create_random_packets(64);
+    let sig_data: Vec<_> = packets
+        .iter()
+        .map(|p| (p, keypair.sign_message(p)))
+        .collect();
+    b.iter(|| {
+        sig_data.par_chunks(16).for_each(|slice| {
+            for (p, s) in slice {
+                assert!(s.verify(keypair.pubkey().as_ref(), p));
+            }
+        });
+    });
+}

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -8,6 +8,7 @@ pub mod recycler_cache;
 pub mod sigverify;
 pub mod test_tx;
 pub mod thread;
+pub mod turbine_merkle;
 
 #[macro_use]
 extern crate lazy_static;

--- a/perf/src/turbine_merkle.rs
+++ b/perf/src/turbine_merkle.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use {
     rayon::{iter::ParallelIterator, prelude::*},
     serde::{Deserialize, Serialize},

--- a/perf/src/turbine_merkle.rs
+++ b/perf/src/turbine_merkle.rs
@@ -1,0 +1,402 @@
+use {
+    rayon::{iter::ParallelIterator, prelude::*},
+    serde::{Deserialize, Serialize},
+    sha2::{Digest, Sha256},
+};
+
+pub const TURBINE_MERKLE_HASH_BYTES: usize = 20;
+pub const TURBINE_MERKLE_ROOT_BYTES: usize = TURBINE_MERKLE_HASH_BYTES;
+
+// Defense against second preimage attack:
+// https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack
+const LEAF_PREFIX: &[u8] = &[0];
+const INTERMEDIATE_PREFIX: &[u8] = &[1];
+
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TurbineMerkleHash([u8; TURBINE_MERKLE_HASH_BYTES]);
+
+impl TurbineMerkleHash {
+    pub fn hash<T, U>(bufs: &[T], prefix: Option<U>) -> TurbineMerkleHash
+    where
+        T: AsRef<[u8]> + Sync,
+        U: AsRef<[u8]> + Sync,
+    {
+        let mut hasher = Sha256::new();
+        if let Some(prefix) = prefix {
+            hasher.update(prefix);
+        }
+        bufs.iter().for_each(|b| hasher.update(b));
+        let h = hasher.finalize();
+        let mut ret = TurbineMerkleHash::default();
+        ret.0[..].copy_from_slice(&h.as_slice()[0..TURBINE_MERKLE_HASH_BYTES]);
+        ret
+    }
+
+    #[inline]
+    pub fn hash_leaf<T>(bufs: &[T]) -> TurbineMerkleHash
+    where
+        T: AsRef<[u8]> + Sync,
+    {
+        Self::hash(bufs, Some(LEAF_PREFIX))
+    }
+
+    #[inline]
+    pub fn hash_intermediate<T>(bufs: &[T]) -> TurbineMerkleHash
+    where
+        T: AsRef<[u8]> + Sync,
+    {
+        Self::hash(bufs, Some(INTERMEDIATE_PREFIX))
+    }
+}
+
+impl AsRef<[u8]> for TurbineMerkleHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl From<&[u8]> for TurbineMerkleHash {
+    fn from(buf: &[u8]) -> Self {
+        assert!(buf.len() == TURBINE_MERKLE_HASH_BYTES);
+        TurbineMerkleHash(buf.try_into().unwrap())
+    }
+}
+
+impl From<[u8; TURBINE_MERKLE_HASH_BYTES]> for TurbineMerkleHash {
+    fn from(buf: [u8; TURBINE_MERKLE_HASH_BYTES]) -> Self {
+        TurbineMerkleHash(buf)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurbineMerkleProof(Vec<TurbineMerkleHash>);
+
+impl TurbineMerkleProof {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut v = vec![0u8; TURBINE_MERKLE_HASH_BYTES * self.0.len()];
+        v.chunks_exact_mut(TURBINE_MERKLE_HASH_BYTES)
+            .enumerate()
+            .for_each(|(i, b)| b.copy_from_slice(self.0[i].as_ref()));
+        v
+    }
+
+    fn generic_compute_root(
+        proof: &[TurbineMerkleHash],
+        leaf_hash: &TurbineMerkleHash,
+        leaf_index: usize,
+    ) -> TurbineMerkleHash {
+        let mut hash = *leaf_hash;
+        let mut idx = leaf_index;
+        for elem in proof {
+            hash = if idx & 1 == 0 {
+                TurbineMerkleHash::hash_intermediate(&[&hash.0, &elem.0])
+            } else {
+                TurbineMerkleHash::hash_intermediate(&[&elem.0, &hash.0])
+            };
+            idx >>= 1;
+        }
+        hash
+    }
+
+    pub fn compute_root_buf(
+        proof: &[u8],
+        leaf_hash: &TurbineMerkleHash,
+        leaf_index: usize,
+    ) -> TurbineMerkleHash {
+        let mut hash = *leaf_hash;
+        let mut idx = leaf_index;
+        for chunk in proof.chunks_exact(TURBINE_MERKLE_HASH_BYTES) {
+            hash = if idx & 1 == 0 {
+                TurbineMerkleHash::hash_intermediate(&[&hash.0[..], chunk])
+            } else {
+                TurbineMerkleHash::hash_intermediate(&[chunk, &hash.0[..]])
+            };
+            idx >>= 1;
+        }
+        hash
+    }
+
+    #[inline]
+    pub fn compute_root(
+        &self,
+        leaf_hash: &TurbineMerkleHash,
+        leaf_index: usize,
+    ) -> TurbineMerkleHash {
+        Self::generic_compute_root(&self.0, leaf_hash, leaf_index)
+    }
+
+    #[inline]
+    pub fn verify(
+        &self,
+        root_hash: &TurbineMerkleHash,
+        leaf_hash: &TurbineMerkleHash,
+        leaf_index: usize,
+    ) -> bool {
+        &Self::generic_compute_root(&self.0, leaf_hash, leaf_index) == root_hash
+    }
+
+    #[inline]
+    pub fn verify_buf(
+        root_hash: &TurbineMerkleHash,
+        proof: &[u8],
+        leaf_hash: &TurbineMerkleHash,
+        leaf_index: usize,
+    ) -> bool {
+        &Self::compute_root_buf(proof, leaf_hash, leaf_index) == root_hash
+    }
+}
+
+impl From<&[u8]> for TurbineMerkleProof {
+    fn from(buf: &[u8]) -> Self {
+        assert_eq!(buf.len() % TURBINE_MERKLE_HASH_BYTES, 0);
+        let v: Vec<TurbineMerkleHash> = buf
+            .chunks_exact(TURBINE_MERKLE_HASH_BYTES)
+            .map(|x| x.into())
+            .collect();
+        TurbineMerkleProof(v)
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct TurbineMerkleTree {
+    tree: Vec<TurbineMerkleHash>,
+}
+
+impl TurbineMerkleTree {
+    pub fn new_from_leaves(leaves: &[TurbineMerkleHash]) -> Self {
+        let leaves_len = leaves.len().next_power_of_two();
+        let tree_size = leaves_len * 2 - 1;
+        let mut tree = Vec::with_capacity(tree_size);
+        for leaf in leaves {
+            tree.push(*leaf);
+        }
+        if leaves_len != leaves.len() {
+            let empty_leaf = TurbineMerkleHash([0u8; TURBINE_MERKLE_HASH_BYTES]);
+            for _ in 0..(leaves_len - leaves.len()) {
+                tree.push(empty_leaf);
+            }
+        }
+        let mut base = 0;
+        let mut level_leaves = leaves_len;
+        while level_leaves > 1 {
+            for i in (0..level_leaves).step_by(2) {
+                let hash = TurbineMerkleHash::hash_intermediate(&[
+                    &tree[base + i].0,
+                    &tree[base + i + 1].0,
+                ]);
+                tree.push(hash);
+            }
+            base += level_leaves;
+            level_leaves >>= 1;
+        }
+        Self { tree }
+    }
+
+    pub fn new_from_bufs<T>(bufs: &[T]) -> Self
+    where
+        T: Sync + AsRef<[u8]>,
+    {
+        let leaves: Vec<_> = bufs
+            .iter()
+            .map(|b| TurbineMerkleHash::hash_leaf(&[b.as_ref()]))
+            .collect();
+        Self::new_from_leaves(&leaves)
+    }
+
+    pub fn new_from_bufs_vec_par<T>(bufs_vec: &Vec<Vec<T>>, chunk: usize) -> Self
+    where
+        T: AsRef<[u8]> + Sync,
+    {
+        let base_width = bufs_vec.len().next_power_of_two();
+        assert!(chunk == chunk.next_power_of_two());
+        assert_eq!(base_width % chunk, 0);
+        assert!(chunk <= base_width);
+
+        let empty_vec = vec![];
+        let mut expanded_bufs_vec = Vec::with_capacity(base_width);
+        for b in bufs_vec {
+            expanded_bufs_vec.push(b);
+        }
+        for _ in 0..(base_width - bufs_vec.len()) {
+            expanded_bufs_vec.push(&empty_vec);
+        }
+
+        // compute subtrees of chunk width in parallel
+        let sub_trees: Vec<Vec<TurbineMerkleHash>> = expanded_bufs_vec
+            .par_chunks(chunk)
+            .map(|slice: &[&Vec<T>]| {
+                let mut tree = Vec::with_capacity(chunk * 2 - 1);
+                slice.iter().for_each(|v: &&Vec<T>| {
+                    if v.is_empty() {
+                        tree.push(TurbineMerkleHash([0u8; TURBINE_MERKLE_HASH_BYTES]));
+                    } else {
+                        tree.push(TurbineMerkleHash::hash_leaf(v));
+                    }
+                });
+
+                let mut base = 0;
+                let mut level_leaves = slice.len();
+                while level_leaves > 1 {
+                    for i in (0..level_leaves).step_by(2) {
+                        let hash = TurbineMerkleHash::hash_intermediate(&[
+                            &tree[base + i].0,
+                            &tree[base + i + 1].0,
+                        ]);
+                        tree.push(hash);
+                    }
+                    base += level_leaves;
+                    level_leaves >>= 1;
+                }
+                tree
+            })
+            .collect();
+
+        let tree_size = base_width * 2 - 1;
+        let mut tree = Vec::with_capacity(tree_size);
+        let mut level_nodes = chunk;
+        let mut base = 0;
+        while level_nodes >= 1 {
+            for sub_tree in sub_trees.iter() {
+                for i in 0..level_nodes {
+                    tree.push(sub_tree[base + i]);
+                }
+            }
+            base += level_nodes;
+            level_nodes >>= 1;
+        }
+
+        // compute final levels of tree
+        level_nodes = base_width / chunk;
+        base = (chunk * 2 - 1) * level_nodes - level_nodes;
+        while level_nodes > 1 {
+            for i in (0..level_nodes).step_by(2) {
+                let hash = TurbineMerkleHash::hash_intermediate(&[
+                    &tree[base + i].0,
+                    &tree[base + i + 1].0,
+                ]);
+                tree.push(hash);
+            }
+            base += level_nodes;
+            level_nodes >>= 1;
+        }
+
+        Self { tree }
+    }
+
+    pub fn leaf_count(&self) -> usize {
+        (self.tree.len() + 1) / 2
+    }
+
+    pub fn root(&self) -> TurbineMerkleHash {
+        self.tree[self.tree.len() - 1]
+    }
+
+    pub fn node(&self, index: usize) -> TurbineMerkleHash {
+        self.tree[index]
+    }
+
+    pub fn prove(&self, leaf_index: usize) -> TurbineMerkleProof {
+        let mut proof = Vec::new();
+        let mut level_nodes = self.leaf_count();
+        let mut i = leaf_index;
+        let mut base = 0;
+        while level_nodes > 1 {
+            if i & 1 == 0 {
+                proof.push(self.tree[base + i + 1]);
+            } else {
+                proof.push(self.tree[base + i - 1]);
+            }
+            base += level_nodes;
+            i >>= 1;
+            level_nodes >>= 1;
+        }
+        TurbineMerkleProof(proof)
+    }
+
+    fn _print(&self) {
+        let mut base = 0;
+        let mut level_nodes = self.leaf_count();
+        while level_nodes > 0 {
+            println!("{:?}", &self.tree[base..base + level_nodes]);
+            base += level_nodes;
+            level_nodes /= 2;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_random_packets(npackets: usize) -> Vec<Vec<u8>> {
+        let mut packets = Vec::default();
+        for _i in 0..npackets {
+            let buf: Vec<u8> = (0..1024).map(|_| rand::random::<u8>()).collect();
+            packets.push(buf);
+        }
+        packets
+    }
+
+    #[test]
+    fn test_merkle() {
+        let npackets = 64;
+        let packets = create_random_packets(npackets);
+        let leaves: Vec<TurbineMerkleHash> = packets
+            .iter()
+            .map(|p| TurbineMerkleHash::hash_leaf(&[p]))
+            .collect();
+
+        let tree = TurbineMerkleTree::new_from_leaves(&leaves);
+        let root = tree.root();
+
+        for i in 0..npackets {
+            let proof = tree.prove(i);
+            assert!(proof.verify(&root, &tree.node(i), i));
+        }
+
+        for i in 0..npackets {
+            let proof = tree.prove(i);
+            let proof_buf = proof.to_bytes();
+            assert!(TurbineMerkleProof::verify_buf(
+                &root,
+                &proof_buf,
+                &tree.node(i),
+                i
+            ));
+        }
+    }
+
+    fn test_merkle_from_buf_vecs_par_width(leaf_count: usize, chunk: usize) {
+        let packets = create_random_packets(leaf_count);
+        let ref_tree = TurbineMerkleTree::new_from_bufs(&packets[..]);
+        let bufs_vec: Vec<_> = packets.iter().map(|p| vec![&p[..20], &p[20..]]).collect();
+        let tree = TurbineMerkleTree::new_from_bufs_vec_par(&bufs_vec, chunk);
+        assert_eq!(&ref_tree, &tree);
+    }
+
+    #[test]
+    fn test_merkle_from_buf_vecs_par() {
+        let packets = create_random_packets(64);
+        let ref_tree = TurbineMerkleTree::new_from_bufs(&packets[..]);
+        let bufs_vec: Vec<_> = packets.iter().map(|p| vec![&p[..20], &p[20..]]).collect();
+        let mut chunk_width = 1;
+        while chunk_width <= 64 {
+            let tree = TurbineMerkleTree::new_from_bufs_vec_par(&bufs_vec, chunk_width);
+            assert_eq!(&ref_tree, &tree);
+            chunk_width *= 2;
+        }
+    }
+
+    #[test]
+    fn test_merkle_from_buf_vecs_par_widths() {
+        for leaf_count in [1, 2, 5, 9, 16, 29, 64, 96, 111, 128] {
+            for chunk in [4, 8, 16, 32] {
+                if chunk <= leaf_count {
+                    test_merkle_from_buf_vecs_par_width(leaf_count, chunk);
+                }
+            }
+        }
+    }
+}

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4787,6 +4787,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
+ "sha2 0.10.2",
  "solana-metrics",
  "solana-rayon-threadlimit",
  "solana-sdk 1.11.0",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4792,6 +4792,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk 1.11.0",
  "solana-vote-program",
+ "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
add 20 byte merkle proof support for turbine with parallel tree construction and direct verification of payload buffer.

#### Summary of Changes
- 20 byte merkle hash
- direct buffer proof verification
- parallel merkle tree construction

I removed the additional merkle buffers in favor of directly accessing the underlying buffer. deserializing merkle data into separate buffers should be unnecessary.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
