### PR TITLE
Error on missing greadlink

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -9,7 +9,14 @@ if [[ $OSTYPE == darwin* ]]; then
   # Mac OS X's version of `readlink` does not support the -f option,
   # But `greadlink` does, which you can get with `brew install coreutils`
   readlink_cmd="greadlink"
+
+  if ! command -v ${readlink_cmd} &> /dev/null
+  then
+    echo "${readlink_cmd} could not be found. You may need to install coreutils: \`brew install coreutils\`"
+    exit 1
+  fi
 fi
+
 cargo="$("${readlink_cmd}" -f "${here}/../cargo")"
 
 set -e


### PR DESCRIPTION
#### Problem
Users installing CLI from source on macOS may not have greadlink. This clarifies the issue if that happens, and prints an error message with instructions on how to resolve the issue.

#### Summary of Changes
Check if greadlink is available. If it's not, print a descriptive message and exit early.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
