### PR TITLE
fix: alias `TransactionCtorFields_DEPRECATED` back to the way it was for back-compat

### DIFF
--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -142,6 +142,11 @@ export type TransactionCtorFields_DEPRECATED = {
   recentBlockhash?: Blockhash;
 };
 
+// For backward compatibility; an unfortunate consequence of being
+// forced to over-export types by the documentation generator.
+// See https://github.com/solana-labs/solana/pull/25820
+export type TransactionCtorFields = TransactionCtorFields_DEPRECATED;
+
 /**
  * List of Transaction object fields that may be initialized at construction
  */


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/commit/375968da3bee9bfc184f7e70be6c9b5caa2d3811 we changed the name of `TransactionCtorFields` without realizing that there were downstream consumers importing this type.

Here's why this happened:

1. Our documentation generator TypeDoc forces us to over-export fundamentally private types from @solana/web3.js just so it can generate documentation for them. This has to stop.
2. I didn't stop to think that someone might have imported `TransactionCtorFields` types for use in their app. It turns out that one such consumer was Metaplex.

#### Summary of Changes

* Alias the type back to its old name.

#### Notes

For anyone reading this, if you ever need the type of a constructor's arguments, you don't have to rely on a library like ours to export it. You can use the `ConstructorParams` utility type, which will _always_ be correct no matter what mistake your library author makes. See https://github.com/metaplex-foundation/js/pull/205.