### PR TITLE
Refactor: instruction account index

### DIFF
--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -186,10 +186,9 @@ pub mod get_sysvar_with_account_check {
         instruction_context: &InstructionContext,
         instruction_account_index: usize,
     ) -> Result<(), InstructionError> {
-        if !S::check_id(
-            instruction_context
-                .get_instruction_account_key(transaction_context, instruction_account_index)?,
-        ) {
+        let index_in_transaction = instruction_context
+            .get_index_of_instruction_account_in_transaction(instruction_account_index)?;
+        if !S::check_id(transaction_context.get_key_of_account_at_index(index_in_transaction)?) {
             return Err(InstructionError::InvalidArgument);
         }
         Ok(())
@@ -198,12 +197,12 @@ pub mod get_sysvar_with_account_check {
     pub fn clock(
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
     ) -> Result<Arc<Clock>, InstructionError> {
         check_sysvar_account::<Clock>(
             invoke_context.transaction_context,
             instruction_context,
-            index_in_instruction,
+            instruction_account_index,
         )?;
         invoke_context.get_sysvar_cache().get_clock()
     }
@@ -211,12 +210,12 @@ pub mod get_sysvar_with_account_check {
     pub fn rent(
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
     ) -> Result<Arc<Rent>, InstructionError> {
         check_sysvar_account::<Rent>(
             invoke_context.transaction_context,
             instruction_context,
-            index_in_instruction,
+            instruction_account_index,
         )?;
         invoke_context.get_sysvar_cache().get_rent()
     }
@@ -224,12 +223,12 @@ pub mod get_sysvar_with_account_check {
     pub fn slot_hashes(
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
     ) -> Result<Arc<SlotHashes>, InstructionError> {
         check_sysvar_account::<SlotHashes>(
             invoke_context.transaction_context,
             instruction_context,
-            index_in_instruction,
+            instruction_account_index,
         )?;
         invoke_context.get_sysvar_cache().get_slot_hashes()
     }
@@ -238,12 +237,12 @@ pub mod get_sysvar_with_account_check {
     pub fn recent_blockhashes(
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
     ) -> Result<Arc<RecentBlockhashes>, InstructionError> {
         check_sysvar_account::<RecentBlockhashes>(
             invoke_context.transaction_context,
             instruction_context,
-            index_in_instruction,
+            instruction_account_index,
         )?;
         invoke_context.get_sysvar_cache().get_recent_blockhashes()
     }
@@ -251,12 +250,12 @@ pub mod get_sysvar_with_account_check {
     pub fn stake_history(
         invoke_context: &InvokeContext,
         instruction_context: &InstructionContext,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
     ) -> Result<Arc<StakeHistory>, InstructionError> {
         check_sysvar_account::<StakeHistory>(
             invoke_context.transaction_context,
             instruction_context,
-            index_in_instruction,
+            instruction_account_index,
         )?;
         invoke_context.get_sysvar_cache().get_stake_history()
     }

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -18,7 +18,7 @@ use {
 };
 
 pub fn process_instruction(
-    first_instruction_account: usize,
+    _first_instruction_account: usize,
     invoke_context: &mut InvokeContext,
 ) -> Result<(), InstructionError> {
     let transaction_context = &invoke_context.transaction_context;
@@ -28,24 +28,15 @@ pub fn process_instruction(
         ProgramInstruction::CreateLookupTable {
             recent_slot,
             bump_seed,
-        } => Processor::create_lookup_table(
-            invoke_context,
-            first_instruction_account,
-            recent_slot,
-            bump_seed,
-        ),
-        ProgramInstruction::FreezeLookupTable => {
-            Processor::freeze_lookup_table(invoke_context, first_instruction_account)
-        }
+        } => Processor::create_lookup_table(invoke_context, recent_slot, bump_seed),
+        ProgramInstruction::FreezeLookupTable => Processor::freeze_lookup_table(invoke_context),
         ProgramInstruction::ExtendLookupTable { new_addresses } => {
-            Processor::extend_lookup_table(invoke_context, first_instruction_account, new_addresses)
+            Processor::extend_lookup_table(invoke_context, new_addresses)
         }
         ProgramInstruction::DeactivateLookupTable => {
-            Processor::deactivate_lookup_table(invoke_context, first_instruction_account)
+            Processor::deactivate_lookup_table(invoke_context)
         }
-        ProgramInstruction::CloseLookupTable => {
-            Processor::close_lookup_table(invoke_context, first_instruction_account)
-        }
+        ProgramInstruction::CloseLookupTable => Processor::close_lookup_table(invoke_context),
     }
 }
 
@@ -57,7 +48,6 @@ pub struct Processor;
 impl Processor {
     fn create_lookup_table(
         invoke_context: &mut InvokeContext,
-        _first_instruction_account: usize,
         untrusted_recent_slot: Slot,
         bump_seed: u8,
     ) -> Result<(), InstructionError> {
@@ -161,10 +151,7 @@ impl Processor {
         Ok(())
     }
 
-    fn freeze_lookup_table(
-        invoke_context: &mut InvokeContext,
-        _first_instruction_account: usize,
-    ) -> Result<(), InstructionError> {
+    fn freeze_lookup_table(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -217,7 +204,6 @@ impl Processor {
 
     fn extend_lookup_table(
         invoke_context: &mut InvokeContext,
-        _first_instruction_account: usize,
         new_addresses: Vec<Pubkey>,
     ) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
@@ -335,10 +321,7 @@ impl Processor {
         Ok(())
     }
 
-    fn deactivate_lookup_table(
-        invoke_context: &mut InvokeContext,
-        _first_instruction_account: usize,
-    ) -> Result<(), InstructionError> {
+    fn deactivate_lookup_table(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -387,10 +370,7 @@ impl Processor {
         Ok(())
     }
 
-    fn close_lookup_table(
-        invoke_context: &mut InvokeContext,
-        _first_instruction_account: usize,
-    ) -> Result<(), InstructionError> {
+    fn close_lookup_table(invoke_context: &mut InvokeContext) -> Result<(), InstructionError> {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
@@ -411,13 +391,8 @@ impl Processor {
         drop(authority_account);
 
         instruction_context.check_number_of_instruction_accounts(3)?;
-        if instruction_context
-            .get_index_in_transaction(instruction_context.get_number_of_program_accounts())?
-            == instruction_context.get_index_in_transaction(
-                instruction_context
-                    .get_number_of_program_accounts()
-                    .saturating_add(2),
-            )?
+        if instruction_context.get_index_of_instruction_account_in_transaction(0)?
+            == instruction_context.get_index_of_instruction_account_in_transaction(2)?
         {
             ic_msg!(
                 invoke_context,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -246,7 +246,7 @@ fn run_program(name: &str) -> u64 {
                 .get_current_instruction_context()
                 .unwrap();
             let caller = *instruction_context
-                .get_program_key(transaction_context)
+                .get_last_program_key(transaction_context)
                 .unwrap();
             transaction_context
                 .set_return_data(caller, Vec::new())

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -92,12 +92,12 @@ fn create_inputs() -> TransactionContext {
         .into_iter()
         .enumerate()
         .map(
-            |(index_in_instruction, index_in_transaction)| InstructionAccount {
-                index_in_caller: index_in_instruction,
+            |(instruction_account_index, index_in_transaction)| InstructionAccount {
+                index_in_caller: instruction_account_index,
                 index_in_transaction,
-                index_in_callee: index_in_instruction,
+                index_in_callee: instruction_account_index,
                 is_signer: false,
-                is_writable: index_in_instruction >= 4,
+                is_writable: instruction_account_index >= 4,
             },
         )
         .collect::<Vec<_>>();

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -20,11 +20,9 @@ pub fn process_instruction(
     let data = instruction_context.get_instruction_data();
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
-    let config_account_key =
-        transaction_context
-            .get_key_of_account_at_index(instruction_context.get_index_in_transaction(
-                instruction_context.get_number_of_program_accounts(),
-            )?)?;
+    let config_account_key = transaction_context.get_key_of_account_at_index(
+        instruction_context.get_index_of_instruction_account_in_transaction(0)?,
+    )?;
     let config_account =
         instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
     let is_config_account_signer = config_account.is_signer();

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -81,10 +81,10 @@ fn create_accounts() -> (
         (authority_pubkey, AccountSharedData::default()),
     ];
     let mut instruction_accounts = (0..4)
-        .map(|index_in_instruction| InstructionAccount {
-            index_in_transaction: 1usize.saturating_add(index_in_instruction),
-            index_in_caller: index_in_instruction,
-            index_in_callee: index_in_instruction,
+        .map(|index_in_callee| InstructionAccount {
+            index_in_transaction: 1usize.saturating_add(index_in_callee),
+            index_in_caller: index_in_callee,
+            index_in_callee,
             is_signer: false,
             is_writable: false,
         })

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1309,8 +1309,8 @@ pub fn withdraw<S: std::hash::BuildHasher>(
     rent_sysvar: Option<&Rent>,
     clock: Option<&Clock>,
 ) -> Result<(), InstructionError> {
-    let mut vote_account =
-        instruction_context.try_borrow_account(transaction_context, vote_account_index)?;
+    let mut vote_account = instruction_context
+        .try_borrow_instruction_account(transaction_context, vote_account_index)?;
     let vote_state: VoteState = vote_account
         .get_state::<VoteStateVersions>()?
         .convert_to_current();
@@ -1351,8 +1351,8 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 
     vote_account.checked_sub_lamports(lamports)?;
     drop(vote_account);
-    let mut to_account =
-        instruction_context.try_borrow_account(transaction_context, to_account_index)?;
+    let mut to_account = instruction_context
+        .try_borrow_instruction_account(transaction_context, to_account_index)?;
     to_account.checked_add_lamports(lamports)?;
     Ok(())
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -120,16 +120,16 @@ impl MessageProcessor {
             }
 
             let mut instruction_accounts = Vec::with_capacity(instruction.accounts.len());
-            for (index_in_instruction, index_in_transaction) in
+            for (instruction_account_index, index_in_transaction) in
                 instruction.accounts.iter().enumerate()
             {
                 let index_in_callee = instruction
                     .accounts
-                    .get(0..index_in_instruction)
+                    .get(0..instruction_account_index)
                     .ok_or(TransactionError::InvalidAccountIndex)?
                     .iter()
                     .position(|account_index| account_index == index_in_transaction)
-                    .unwrap_or(index_in_instruction);
+                    .unwrap_or(instruction_account_index);
                 let index_in_transaction = *index_in_transaction as usize;
                 instruction_accounts.push(InstructionAccount {
                     index_in_transaction,

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -104,8 +104,8 @@ pub fn withdraw_nonce_account(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
 ) -> Result<(), InstructionError> {
-    let mut from =
-        instruction_context.try_borrow_account(transaction_context, from_account_index)?;
+    let mut from = instruction_context
+        .try_borrow_instruction_account(transaction_context, from_account_index)?;
     let merge_nonce_error_into_system_error = invoke_context
         .feature_set
         .is_active(&feature_set::merge_nonce_error_into_system_error::id());
@@ -180,7 +180,8 @@ pub fn withdraw_nonce_account(
     from.checked_sub_lamports(lamports)
         .map_err(|_| InstructionError::ArithmeticOverflow)?;
     drop(from);
-    let mut to = instruction_context.try_borrow_account(transaction_context, to_account_index)?;
+    let mut to = instruction_context
+        .try_borrow_instruction_account(transaction_context, to_account_index)?;
     to.checked_add_lamports(lamports)
         .map_err(|_| InstructionError::ArithmeticOverflow)?;
 
@@ -450,9 +451,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -621,9 +622,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -666,9 +667,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -698,9 +699,9 @@ mod test {
         let withdraw_lamports = nonce_account.get_lamports() + 1;
         drop(nonce_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -734,9 +735,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -760,9 +761,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -815,9 +816,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -847,9 +848,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -893,9 +894,9 @@ mod test {
         drop(nonce_account);
         drop(to_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -926,9 +927,9 @@ mod test {
         let withdraw_lamports = nonce_account.get_lamports() + 1;
         drop(nonce_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -959,9 +960,9 @@ mod test {
         let withdraw_lamports = 42 + 1;
         drop(nonce_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,
@@ -992,9 +993,9 @@ mod test {
         let withdraw_lamports = u64::MAX - 54;
         drop(nonce_account);
         let result = withdraw_nonce_account(
-            1 + NONCE_ACCOUNT_INDEX,
+            NONCE_ACCOUNT_INDEX,
             withdraw_lamports,
-            1 + WITHDRAW_TO_ACCOUNT_INDEX,
+            WITHDRAW_TO_ACCOUNT_INDEX,
             &rent,
             &signers,
             &invoke_context,

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -301,16 +301,6 @@ impl InstructionContext {
         self.program_accounts.len()
     }
 
-    /// Get the index of the instruction's program id
-    pub fn get_program_id_index(&self) -> usize {
-        self.program_accounts.last().cloned().unwrap_or_default()
-    }
-
-    /// Get the instruction's program id
-    pub fn get_program_id(&self, transaction_context: &TransactionContext) -> Pubkey {
-        transaction_context.account_keys[self.program_accounts.last().cloned().unwrap_or_default()]
-    }
-
     /// Number of accounts in this Instruction (without program accounts)
     pub fn get_number_of_instruction_accounts(&self) -> usize {
         self.instruction_accounts.len()
@@ -326,13 +316,6 @@ impl InstructionContext {
         } else {
             Ok(())
         }
-    }
-
-    /// Number of accounts in this Instruction
-    pub fn get_number_of_accounts(&self) -> usize {
-        self.program_accounts
-            .len()
-            .saturating_add(self.instruction_accounts.len())
     }
 
     /// Data parameter for the programs `process_instruction` handler
@@ -353,8 +336,8 @@ impl InstructionContext {
             })
     }
 
-    /// Searches for an account by its key
-    pub fn find_index_of_account(
+    /// Searches for an instruction account by its key
+    pub fn find_index_of_instruction_account(
         &self,
         transaction_context: &TransactionContext,
         pubkey: &Pubkey,
@@ -365,82 +348,75 @@ impl InstructionContext {
                 &transaction_context.account_keys[instruction_account.index_in_transaction]
                     == pubkey
             })
-            .map(|index| index.saturating_add(self.program_accounts.len()))
     }
 
-    /// Translates the given instruction wide index into a transaction wide index
-    pub fn get_index_in_transaction(
+    /// Translates the given instruction wide program_account_index into a transaction wide index
+    pub fn get_index_of_program_account_in_transaction(
         &self,
-        index_in_instruction: usize,
+        program_account_index: usize,
     ) -> Result<usize, InstructionError> {
-        if index_in_instruction < self.program_accounts.len() {
-            Ok(self.program_accounts[index_in_instruction])
-        } else if index_in_instruction < self.get_number_of_accounts() {
-            Ok(self.instruction_accounts
-                [index_in_instruction.saturating_sub(self.program_accounts.len())]
-            .index_in_transaction)
-        } else {
-            Err(InstructionError::NotEnoughAccountKeys)
-        }
+        Ok(*self
+            .program_accounts
+            .get(program_account_index)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?)
     }
 
-    /// Returns `Some(index_in_instruction)` if this is a duplicate
-    /// and `None` if it is the first account with this key
-    pub fn is_duplicate(
+    /// Translates the given instruction wide instruction_account_index into a transaction wide index
+    pub fn get_index_of_instruction_account_in_transaction(
         &self,
-        index_in_instruction: usize,
+        instruction_account_index: usize,
+    ) -> Result<usize, InstructionError> {
+        Ok(self
+            .instruction_accounts
+            .get(instruction_account_index)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .index_in_transaction)
+    }
+
+    /// Returns `Some(instruction_account_index)` if this is a duplicate
+    /// and `None` if it is the first account with this key
+    pub fn is_instruction_account_duplicate(
+        &self,
+        instruction_account_index: usize,
     ) -> Result<Option<usize>, InstructionError> {
-        if index_in_instruction < self.program_accounts.len()
-            || index_in_instruction >= self.get_number_of_accounts()
-        {
-            Err(InstructionError::NotEnoughAccountKeys)
+        let index_in_callee = self
+            .instruction_accounts
+            .get(instruction_account_index)
+            .ok_or(InstructionError::NotEnoughAccountKeys)?
+            .index_in_callee;
+        Ok(if index_in_callee == instruction_account_index {
+            None
         } else {
-            let index_in_instruction =
-                index_in_instruction.saturating_sub(self.program_accounts.len());
-            let index_in_callee = self.instruction_accounts[index_in_instruction].index_in_callee;
-            Ok(if index_in_callee == index_in_instruction {
-                None
-            } else {
-                Some(index_in_callee)
-            })
-        }
+            Some(index_in_callee)
+        })
     }
 
     /// Gets the key of the last program account of this Instruction
-    pub fn get_program_key<'a, 'b: 'a>(
+    pub fn get_last_program_key<'a, 'b: 'a>(
         &'a self,
         transaction_context: &'b TransactionContext,
     ) -> Result<&'b Pubkey, InstructionError> {
-        let index_in_transaction =
-            self.get_index_in_transaction(self.program_accounts.len().saturating_sub(1))?;
-        transaction_context.get_key_of_account_at_index(index_in_transaction)
+        let result = self
+            .get_index_of_program_account_in_transaction(
+                self.program_accounts.len().saturating_sub(1),
+            )
+            .and_then(|index_in_transaction| {
+                transaction_context.get_key_of_account_at_index(index_in_transaction)
+            });
+        debug_assert!(result.is_ok());
+        result
     }
 
-    /// Gets the key of an instruction account (skipping program accounts)
-    pub fn get_instruction_account_key<'a, 'b: 'a>(
+    fn try_borrow_account<'a, 'b: 'a>(
         &'a self,
         transaction_context: &'b TransactionContext,
-        instruction_account_index: usize,
-    ) -> Result<&'b Pubkey, InstructionError> {
-        let index_in_transaction = self.get_index_in_transaction(
-            self.program_accounts
-                .len()
-                .saturating_add(instruction_account_index),
-        )?;
-        transaction_context.get_key_of_account_at_index(index_in_transaction)
-    }
-
-    /// Tries to borrow an account from this Instruction
-    pub fn try_borrow_account<'a, 'b: 'a>(
-        &'a self,
-        transaction_context: &'b TransactionContext,
+        index_in_transaction: usize,
         index_in_instruction: usize,
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
-        let index_in_transaction = self.get_index_in_transaction(index_in_instruction)?;
-        if index_in_transaction >= transaction_context.accounts.len() {
-            return Err(InstructionError::MissingAccount);
-        }
-        let account = transaction_context.accounts[index_in_transaction]
+        let account = transaction_context
+            .accounts
+            .get(index_in_transaction)
+            .ok_or(InstructionError::MissingAccount)?
             .try_borrow_mut()
             .map_err(|_| InstructionError::AccountBorrowFailed)?;
         Ok(BorrowedAccount {
@@ -453,13 +429,30 @@ impl InstructionContext {
     }
 
     /// Gets the last program account of this Instruction
-    pub fn try_borrow_program_account<'a, 'b: 'a>(
+    pub fn try_borrow_last_program_account<'a, 'b: 'a>(
         &'a self,
         transaction_context: &'b TransactionContext,
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
-        self.try_borrow_account(
+        let result = self.try_borrow_program_account(
             transaction_context,
             self.program_accounts.len().saturating_sub(1),
+        );
+        debug_assert!(result.is_ok());
+        result
+    }
+
+    /// Tries to borrow a program account from this Instruction
+    pub fn try_borrow_program_account<'a, 'b: 'a>(
+        &'a self,
+        transaction_context: &'b TransactionContext,
+        program_account_index: usize,
+    ) -> Result<BorrowedAccount<'a>, InstructionError> {
+        let index_in_transaction =
+            self.get_index_of_program_account_in_transaction(program_account_index)?;
+        self.try_borrow_account(
+            transaction_context,
+            index_in_transaction,
+            program_account_index,
         )
     }
 
@@ -469,39 +462,42 @@ impl InstructionContext {
         transaction_context: &'b TransactionContext,
         instruction_account_index: usize,
     ) -> Result<BorrowedAccount<'a>, InstructionError> {
+        let index_in_transaction =
+            self.get_index_of_instruction_account_in_transaction(instruction_account_index)?;
         self.try_borrow_account(
             transaction_context,
+            index_in_transaction,
             self.program_accounts
                 .len()
                 .saturating_add(instruction_account_index),
         )
     }
 
-    /// Returns whether an account is a signer
-    pub fn is_signer(&self, index_in_instruction: usize) -> Result<bool, InstructionError> {
-        Ok(if index_in_instruction < self.program_accounts.len() {
-            false
-        } else {
-            self.instruction_accounts
-                .get(index_in_instruction.saturating_sub(self.program_accounts.len()))
-                .ok_or(InstructionError::MissingAccount)?
-                .is_signer
-        })
+    /// Returns whether an instruction account is a signer
+    pub fn is_instruction_account_signer(
+        &self,
+        instruction_account_index: usize,
+    ) -> Result<bool, InstructionError> {
+        Ok(self
+            .instruction_accounts
+            .get(instruction_account_index)
+            .ok_or(InstructionError::MissingAccount)?
+            .is_signer)
     }
 
-    /// Returns whether an account is writable
-    pub fn is_writable(&self, index_in_instruction: usize) -> Result<bool, InstructionError> {
-        Ok(if index_in_instruction < self.program_accounts.len() {
-            false
-        } else {
-            self.instruction_accounts
-                .get(index_in_instruction.saturating_sub(self.program_accounts.len()))
-                .ok_or(InstructionError::MissingAccount)?
-                .is_writable
-        })
+    /// Returns whether an instruction account is writable
+    pub fn is_instruction_account_writable(
+        &self,
+        instruction_account_index: usize,
+    ) -> Result<bool, InstructionError> {
+        Ok(self
+            .instruction_accounts
+            .get(instruction_account_index)
+            .ok_or(InstructionError::MissingAccount)?
+            .is_writable)
     }
 
-    /// Calculates the set of all keys of signer accounts in this Instruction
+    /// Calculates the set of all keys of signer instruction accounts in this Instruction
     pub fn get_signers(&self, transaction_context: &TransactionContext) -> HashSet<Pubkey> {
         let mut result = HashSet::new();
         for instruction_account in self.instruction_accounts.iter() {
@@ -529,11 +525,6 @@ impl<'a> BorrowedAccount<'a> {
     /// Returns the index of this account (transaction wide)
     pub fn get_index_in_transaction(&self) -> usize {
         self.index_in_transaction
-    }
-
-    /// Returns the index of this account (instruction wide)
-    pub fn get_index_in_instruction(&self) -> usize {
-        self.index_in_instruction
     }
 
     /// Returns the public key of this account (transaction wide)
@@ -646,15 +637,27 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns whether this account is a signer (instruction wide)
     pub fn is_signer(&self) -> bool {
+        if self.index_in_instruction < self.instruction_context.program_accounts.len() {
+            return false;
+        }
         self.instruction_context
-            .is_signer(self.index_in_instruction)
+            .is_instruction_account_signer(
+                self.index_in_instruction
+                    .saturating_sub(self.instruction_context.program_accounts.len()),
+            )
             .unwrap_or_default()
     }
 
     /// Returns whether this account is writable (instruction wide)
     pub fn is_writable(&self) -> bool {
+        if self.index_in_instruction < self.instruction_context.program_accounts.len() {
+            return false;
+        }
         self.instruction_context
-            .is_writable(self.index_in_instruction)
+            .is_instruction_account_writable(
+                self.index_in_instruction
+                    .saturating_sub(self.instruction_context.program_accounts.len()),
+            )
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
#### Problem
`index_in_instruction` is a mixed index, meaning that it maps both program accounts and instruction accounts in one sequence.

`index_in_instruction = program_account_index`
or
`index_in_instruction = number_of_program_accounts + instruction_account_index`

In most cases however, we only want to use one: Either program accounts or instruction accounts.
Thus, it is better to split their interfaces to avoid conflation and also to reduce the index shifting in the code base.
Also, some interfaces were already split, because they only make sense for one of the two account types,
so this PR makes the interfaces more uniform and hopefully less confusing as well.

#### Summary of Changes

Split methods of `InstructionContext`:
- `get_index_in_transaction()` into `get_index_of_program_account_in_transaction()` and `get_index_of_instruction_account_in_transaction()`
- `try_borrow_account()` into `try_borrow_program_account()` and `try_borrow_instruction_account()`

Renamed methods of `InstructionContext`:
- `try_borrow_program_account()` to `try_borrow_last_program_account()`
- `get_program_key()` to `get_last_program_key()`
- `find_index_of_account()` to `find_index_of_instruction_account()`
- `is_duplicate()` to `is_instruction_account_duplicate()`
- `is_signer()` to `is_instruction_account_signer()`
- `is_writer()` to `is_instruction_account_writer()`

Removed methods of `InstructionContext`:
- `get_program_id_index()`, use `get_index_of_program_account_in_transaction()` instead
- `get_program_id()` use `get_last_program_key()` instead
- `get_number_of_accounts()` as it became unused

Removed methods of `BorrowedAccount`:
- `get_index_in_instruction()` as it became unused

The renaming is on purpose to avoid mixing index basis (e.g. when backporting) by making the function names different / incompatible.