### PR TITLE
Fix typo: upgradable to upgradEable

### DIFF
--- a/program-test/tests/builtins.rs
+++ b/program-test/tests/builtins.rs
@@ -8,7 +8,7 @@ use {
 };
 
 #[tokio::test]
-async fn test_bpf_loader_upgradable_present() {
+async fn test_bpf_loader_upgradeable_present() {
     // Arrange
     let (mut banks_client, payer, recent_blockhash) = ProgramTest::default().start().await;
 


### PR DESCRIPTION
#### Problem


#### Summary of Changes
test_bpf_loader_upgradable_present => test_bpf_loader_upgradEable_present to be consistent with spelling of upgradeable elsewhere.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
