### PR TITLE
Update release doc

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,7 +83,6 @@ Alternatively use the Github UI.
 1. After the new branch has been created and pushed, update the Cargo.toml files on **master** to the next semantic version (e.g. 0.9.0 -> 0.10.0) with:
      ```
      $ scripts/increment-cargo-version.sh minor
-     $ ./scripts/cargo-for-all-lock-files.sh update
      ```
 1. Push all the changed Cargo.toml and Cargo.lock files to the `master` branch with something like:
     ```


### PR DESCRIPTION
#### Problem
The [release doc](https://github.com/solana-labs/solana/blob/master/RELEASE.md#update-master-branch-to-the-next-release-minor-version) says to run `cargo update` with the minor version bump. This is potentially combines functional changes with our internal version number bumps

#### Summary of Changes
Remove cargo update command from doc.


For context, see the Discord discussions in #devops on [2022-06-07](https://discord.com/channels/428295358100013066/560503042458517505/983825110152642610) and [2022-03-23](https://discord.com/channels/428295358100013066/560503042458517505/956249504116518992)