### PR TITLE
banks-client: Add `simulate_transaction` implementation

### DIFF
--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -67,6 +67,10 @@ pub trait Banks {
         transaction: Transaction,
         commitment: CommitmentLevel,
     ) -> Option<transaction::Result<()>>;
+    async fn simulate_transaction_with_commitment_and_context(
+        transaction: Transaction,
+        commitment: CommitmentLevel,
+    ) -> BanksTransactionResultWithSimulation;
     async fn get_account_with_commitment_and_context(
         address: Pubkey,
         commitment: CommitmentLevel,


### PR DESCRIPTION
#### Problem

It isn't possible to just simulate a transaction to get the return data on banks-client.

#### Summary of Changes

Add an implementation for it!  It's pretty much a copy of how transactions are currently simulated.  To save some lines of code, we have some `mut`, let me know if that's too weird.

Fixes  #25731