### PR TITLE
Reject durable nonce transactions not signed by authority

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -3530,7 +3530,8 @@ mod tests {
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
             durable_nonce.as_hash(),
-        ));
+        )
+        .is_some());
     }
 
     #[test]
@@ -3635,7 +3636,8 @@ mod tests {
         assert!(nonce_account::verify_nonce_account(
             &collected_nonce_account,
             durable_nonce.as_hash(),
-        ));
+        )
+        .is_some());
     }
 
     #[test]

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -1214,7 +1214,8 @@ mod test {
                 .unwrap()
                 .borrow(),
             get_durable_nonce(&invoke_context).as_hash(),
-        ));
+        )
+        .is_some());
     }
 
     #[test]
@@ -1226,13 +1227,14 @@ mod test {
             _instruction_context,
             instruction_accounts
         );
-        assert!(!verify_nonce_account(
+        assert!(verify_nonce_account(
             &transaction_context
                 .get_account_at_index(NONCE_ACCOUNT_INDEX)
                 .unwrap()
                 .borrow(),
             &Hash::default()
-        ));
+        )
+        .is_none());
     }
 
     #[test]
@@ -1263,12 +1265,13 @@ mod test {
         .unwrap();
         set_invoke_context_blockhash!(invoke_context, 1);
         drop(nonce_account);
-        assert!(!verify_nonce_account(
+        assert!(verify_nonce_account(
             &transaction_context
                 .get_account_at_index(NONCE_ACCOUNT_INDEX)
                 .unwrap()
                 .borrow(),
             get_durable_nonce(&invoke_context).as_hash(),
-        ));
+        )
+        .is_none());
     }
 }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -225,6 +225,21 @@ impl SanitizedMessage {
         }
     }
 
+    /// Get a list of signers for the instruction at the given index
+    pub fn get_ix_signers(&self, ix_index: usize) -> impl Iterator<Item = &Pubkey> {
+        self.instructions()
+            .get(ix_index)
+            .into_iter()
+            .flat_map(|ix| {
+                ix.accounts
+                    .iter()
+                    .copied()
+                    .map(usize::from)
+                    .filter(|index| self.is_signer(*index))
+                    .filter_map(|signer_index| self.account_keys().get(signer_index))
+            })
+    }
+
     /// If the message uses a durable nonce, return the pubkey of the nonce account
     pub fn get_durable_nonce(&self, nonce_must_be_writable: bool) -> Option<&Pubkey> {
         self.instructions()
@@ -256,7 +271,7 @@ impl SanitizedMessage {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::message::v0};
+    use {super::*, crate::message::v0, std::collections::HashSet};
 
     #[test]
     fn test_try_from_message() {
@@ -335,5 +350,45 @@ mod tests {
         ));
 
         assert_eq!(v0_message.num_readonly_accounts(), 3);
+    }
+
+    #[test]
+    fn test_get_ix_signers() {
+        let signer0 = Pubkey::new_unique();
+        let signer1 = Pubkey::new_unique();
+        let non_signer = Pubkey::new_unique();
+        let loader_key = Pubkey::new_unique();
+        let instructions = vec![
+            CompiledInstruction::new(3, &(), vec![2, 0]),
+            CompiledInstruction::new(3, &(), vec![0, 1]),
+            CompiledInstruction::new(3, &(), vec![0, 0]),
+        ];
+
+        let message = SanitizedMessage::try_from(LegacyMessage::new_with_compiled_instructions(
+            2,
+            1,
+            2,
+            vec![signer0, signer1, non_signer, loader_key],
+            Hash::default(),
+            instructions,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            message.get_ix_signers(0).collect::<HashSet<_>>(),
+            HashSet::from_iter([&signer0])
+        );
+        assert_eq!(
+            message.get_ix_signers(1).collect::<HashSet<_>>(),
+            HashSet::from_iter([&signer0, &signer1])
+        );
+        assert_eq!(
+            message.get_ix_signers(2).collect::<HashSet<_>>(),
+            HashSet::from_iter([&signer0])
+        );
+        assert_eq!(
+            message.get_ix_signers(3).collect::<HashSet<_>>(),
+            HashSet::default()
+        );
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -432,6 +432,10 @@ pub mod quick_bail_on_panic {
     solana_sdk::declare_id!("DpJREPyuMZ5nDfU6H3WTqSqUFSXAfw8u7xqmWtEwJDcP");
 }
 
+pub mod nonce_must_be_authorized {
+    solana_sdk::declare_id!("HxrEu1gXuH7iD3Puua1ohd5n4iUKJyFNtNxk9DVJkvgr");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -533,6 +537,7 @@ lazy_static! {
         (enable_durable_nonce::id(), "enable durable nonce #25744"),
         (vote_state_update_credit_per_dequeue::id(), "Calculate vote credits for VoteStateUpdate per vote dequeue to match credit awards for Vote instruction"),
         (quick_bail_on_panic::id(), "quick bail on panic"),
+        (nonce_must_be_authorized::id(), "nonce must be authorized"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -597,7 +597,7 @@ impl SendTransactionService {
                     .last_sent_time
                     .map(|last| now.duration_since(last) >= retry_rate)
                     .unwrap_or(false);
-                if !nonce_account::verify_nonce_account(&nonce_account, &durable_nonce)
+                if nonce_account::verify_nonce_account(&nonce_account, &durable_nonce).is_none()
                     && signature_status.is_none()
                     && expired
                 {


### PR DESCRIPTION
#### Problem
A transaction should only be processed as a durable nonce transaction if the used nonce account's authority signed the transaction.

#### Summary of Changes
- Add a feature gate for only processing durable nonce transactions that have been signed by the nonce authority

Feature Gate Issue: https://github.com/solana-labs/solana/issues/25835
<!-- Don't forget to add the "feature-gate" label -->
