### PR TITLE
Dynamic sigverify threadpool

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -642,7 +642,7 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
     // Current design targets max 8ms verify latency assuming 500us per packet.
     match packet_count {
         0..=16 => {
-            batches.into_iter().for_each(|batch| {
+            batches.iter_mut().for_each(|batch| {
                 batch.iter_mut().for_each(|packet| {
                     if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
                         packet.meta.set_discard(true);

--- a/sdk/bpf/dependencies/sbf-tools
+++ b/sdk/bpf/dependencies/sbf-tools
@@ -1,1 +1,1 @@
-B:/Users/jack/.cache/solana/v1.27/sbf-tools
+/Users/jack/.cache/solana/v1.27/sbf-tools

--- a/sdk/bpf/dependencies/sbf-tools
+++ b/sdk/bpf/dependencies/sbf-tools
@@ -1,1 +1,1 @@
-/Users/jack/.cache/solana/v1.27/sbf-tools
+B:/Users/jack/.cache/solana/v1.27/sbf-tools


### PR DESCRIPTION
#### Problem
When a node is about to become leader, there is a flood of traffic on the TPU port. This causes a spike in verify CPU time consumption, which takes away compute resources from replay and can slow it down. We've observed this slowdown in replay leading to forks and thus skipped slots, especially in lower core count systems.

#### Summary of Changes
Create multiple thread pool sizes and select the pool based on the number of packets that need to be handled. This will reduce the amount of compute consumed by tx verify at lower/medium packet counts (<256) providing more for replay to make consistent progress.

If large number of packets require verification, we will use the same default of half the CPU cores.