### PR TITLE
feat: a nonce-based transaction confirmation strategy for web3.js

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -3433,22 +3433,20 @@ export class Connection {
 
     assert(decodedSignature.length === 64, 'signature has invalid length');
 
-    if (
-      Object.prototype.hasOwnProperty.call(strategy, 'lastValidBlockHeight')
-    ) {
-      return await this.confirmTransactionUsingBlockHeightExceedanceStrategy({
-        commitment: commitment || this.commitment,
-        strategy: strategy as BlockheightBasedTransactionConfirmationStrategy,
-      });
-    } else if (Object.prototype.hasOwnProperty.call(strategy, 'nonceValue')) {
-      return await this.confirmTransactionUsingDurableNonceStrategy({
-        commitment: commitment || this.commitment,
-        strategy: strategy as DurableNonceTransactionConfirmationStrategy,
-      });
-    } else {
+    if (typeof strategy === 'string') {
       return await this.confirmTransactionUsingLegacyTimeoutStrategy({
         commitment: commitment || this.commitment,
         signature: rawSignature,
+      });
+    } else if ('lastValidBlockHeight' in strategy) {
+      return await this.confirmTransactionUsingBlockHeightExceedanceStrategy({
+        commitment: commitment || this.commitment,
+        strategy,
+      });
+    } else {
+      return await this.confirmTransactionUsingDurableNonceStrategy({
+        commitment: commitment || this.commitment,
+        strategy,
       });
     }
   }

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2439,6 +2439,26 @@ export type GetTransactionCountConfig = {
 };
 
 /**
+ * Configuration object for `getNonce`
+ */
+export type GetNonceConfig = {
+  /** Optional commitment level */
+  commitment?: Commitment;
+  /** The minimum slot that the request can be evaluated at */
+  minContextSlot?: number;
+};
+
+/**
+ * Configuration object for `getNonceAndContext`
+ */
+export type GetNonceAndContextConfig = {
+  /** Optional commitment level */
+  commitment?: Commitment;
+  /** The minimum slot that the request can be evaluated at */
+  minContextSlot?: number;
+};
+
+/**
  * Information describing an account
  */
 export type AccountInfo<T> = {
@@ -4773,11 +4793,11 @@ export class Connection {
    */
   async getNonceAndContext(
     nonceAccount: PublicKey,
-    commitment?: Commitment,
+    commitmentOrConfig?: Commitment | GetNonceAndContextConfig,
   ): Promise<RpcResponseAndContext<NonceAccount | null>> {
     const {context, value: accountInfo} = await this.getAccountInfoAndContext(
       nonceAccount,
-      commitment,
+      commitmentOrConfig,
     );
 
     let value = null;
@@ -4796,9 +4816,9 @@ export class Connection {
    */
   async getNonce(
     nonceAccount: PublicKey,
-    commitment?: Commitment,
+    commitmentOrConfig?: Commitment | GetNonceConfig,
   ): Promise<NonceAccount | null> {
-    return await this.getNonceAndContext(nonceAccount, commitment)
+    return await this.getNonceAndContext(nonceAccount, commitmentOrConfig)
       .then(x => x.value)
       .catch(e => {
         throw new Error(

--- a/web3.js/src/nonce-account.ts
+++ b/web3.js/src/nonce-account.ts
@@ -1,7 +1,6 @@
 import * as BufferLayout from '@solana/buffer-layout';
 import {Buffer} from 'buffer';
 
-import type {Blockhash} from './blockhash';
 import * as Layout from './layout';
 import {PublicKey} from './publickey';
 import type {FeeCalculator} from './fee-calculator';
@@ -36,9 +35,14 @@ const NonceAccountLayout = BufferLayout.struct<
 
 export const NONCE_ACCOUNT_LENGTH = NonceAccountLayout.span;
 
+/**
+ * A durable nonce is a 32 byte value encoded as a base58 string.
+ */
+export type DurableNonce = string;
+
 type NonceAccountArgs = {
   authorizedPubkey: PublicKey;
-  nonce: Blockhash;
+  nonce: DurableNonce;
   feeCalculator: FeeCalculator;
 };
 
@@ -47,7 +51,7 @@ type NonceAccountArgs = {
  */
 export class NonceAccount {
   authorizedPubkey: PublicKey;
-  nonce: Blockhash;
+  nonce: DurableNonce;
   feeCalculator: FeeCalculator;
 
   /**

--- a/web3.js/src/transaction/expiry-custom-errors.ts
+++ b/web3.js/src/transaction/expiry-custom-errors.ts
@@ -33,3 +33,16 @@ export class TransactionExpiredTimeoutError extends Error {
 Object.defineProperty(TransactionExpiredTimeoutError.prototype, 'name', {
   value: 'TransactionExpiredTimeoutError',
 });
+
+export class TransactionExpiredNonceInvalidError extends Error {
+  signature: string;
+
+  constructor(signature: string) {
+    super(`Signature ${signature} has expired: the nonce is no longer valid.`);
+    this.signature = signature;
+  }
+}
+
+Object.defineProperty(TransactionExpiredNonceInvalidError.prototype, 'name', {
+  value: 'TransactionExpiredNonceInvalidError',
+});

--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -22,6 +22,7 @@ export const enum TransactionStatus {
   BLOCKHEIGHT_EXCEEDED,
   PROCESSED,
   TIMED_OUT,
+  NONCE_INVALID,
 }
 
 /**
@@ -145,7 +146,7 @@ export type TransactionCtorFields_DEPRECATED = {
 export type TransactionCtorFields = TransactionCtorFields_DEPRECATED;
 
 /**
- * List of Transaction object fields that may be initialized at construction
+ * Use these options to construct a transaction that incoporates a recent blockhash.
  */
 export type TransactionBlockhashCtor = {
   /** The transaction fee payer */
@@ -156,6 +157,18 @@ export type TransactionBlockhashCtor = {
   blockhash: Blockhash;
   /** the last block chain can advance to before tx is declared expired */
   lastValidBlockHeight: number;
+};
+
+/**
+ * Use these options to construct a durable nonce transaction.
+ */
+export type TransactionNonceCtor = {
+  /** The transaction fee payer */
+  feePayer?: PublicKey | null;
+  minContextSlot: number;
+  nonceInfo: NonceInformation;
+  /** One or more signatures */
+  signatures?: Array<SignaturePubkeyPair>;
 };
 
 /**
@@ -229,6 +242,15 @@ export class Transaction {
   nonceInfo?: NonceInformation;
 
   /**
+   * If this is a nonce transaction this represents the minimum slot from which
+   * to evaluate if the nonce has advanced when attempting to confirm the
+   * transaction. This protects against a case where the transaction confirmation
+   * logic loads the nonce account from an old slot and assumes the mismatch in
+   * nonce value implies that the nonce has been advanced.
+   */
+  minNonceContextSlot?: number;
+
+  /**
    * @internal
    */
   _message?: Message;
@@ -241,6 +263,9 @@ export class Transaction {
   // Construct a transaction with a blockhash and lastValidBlockHeight
   constructor(opts?: TransactionBlockhashCtor);
 
+  // Construct a transaction using a durable nonce
+  constructor(opts?: TransactionNonceCtor);
+
   /**
    * @deprecated `TransactionCtorFields` has been deprecated and will be removed in a future version.
    * Please supply a `TransactionBlockhashCtor` instead.
@@ -251,7 +276,10 @@ export class Transaction {
    * Construct an empty Transaction
    */
   constructor(
-    opts?: TransactionBlockhashCtor | TransactionCtorFields_DEPRECATED,
+    opts?:
+      | TransactionBlockhashCtor
+      | TransactionNonceCtor
+      | TransactionCtorFields_DEPRECATED,
   ) {
     if (!opts) {
       return;
@@ -262,7 +290,13 @@ export class Transaction {
     if (opts.signatures) {
       this.signatures = opts.signatures;
     }
-    if (Object.prototype.hasOwnProperty.call(opts, 'lastValidBlockHeight')) {
+    if (Object.prototype.hasOwnProperty.call(opts, 'nonceInfo')) {
+      const {minContextSlot, nonceInfo} = opts as TransactionNonceCtor;
+      this.minNonceContextSlot = minContextSlot;
+      this.nonceInfo = nonceInfo;
+    } else if (
+      Object.prototype.hasOwnProperty.call(opts, 'lastValidBlockHeight')
+    ) {
       const {blockhash, lastValidBlockHeight} =
         opts as TransactionBlockhashCtor;
       this.recentBlockhash = blockhash;

--- a/web3.js/src/transaction/legacy.ts
+++ b/web3.js/src/transaction/legacy.ts
@@ -146,7 +146,9 @@ export type TransactionCtorFields_DEPRECATED = {
 export type TransactionCtorFields = TransactionCtorFields_DEPRECATED;
 
 /**
- * Use these options to construct a transaction that incoporates a recent blockhash.
+ * Blockhash-based transactions have a lifetime that are defined by
+ * the blockhash they include. Any transaction whose blockhash is
+ * too old will be rejected.
  */
 export type TransactionBlockhashCtor = {
   /** The transaction fee payer */

--- a/web3.js/src/utils/send-and-confirm-raw-transaction.ts
+++ b/web3.js/src/utils/send-and-confirm-raw-transaction.ts
@@ -3,7 +3,7 @@ import type {Buffer} from 'buffer';
 import {
   BlockheightBasedTransactionConfirmationStrategy,
   Connection,
-  NonceBasedTransactionConfirmationStrategy,
+  DurableNonceTransactionConfirmationStrategy,
 } from '../connection';
 import type {TransactionSignature} from '../transaction';
 import type {ConfirmOptions} from '../connection';
@@ -43,14 +43,14 @@ export async function sendAndConfirmRawTransaction(
   rawTransaction: Buffer,
   confirmationStrategyOrConfirmOptions:
     | BlockheightBasedTransactionConfirmationStrategy
-    | NonceBasedTransactionConfirmationStrategy
+    | DurableNonceTransactionConfirmationStrategy
     | ConfirmOptions
     | undefined,
   maybeConfirmOptions?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   let confirmationStrategy:
     | BlockheightBasedTransactionConfirmationStrategy
-    | NonceBasedTransactionConfirmationStrategy
+    | DurableNonceTransactionConfirmationStrategy
     | undefined;
   let options: ConfirmOptions | undefined;
   if (
@@ -71,7 +71,7 @@ export async function sendAndConfirmRawTransaction(
     )
   ) {
     confirmationStrategy =
-      confirmationStrategyOrConfirmOptions as NonceBasedTransactionConfirmationStrategy;
+      confirmationStrategyOrConfirmOptions as DurableNonceTransactionConfirmationStrategy;
     options = maybeConfirmOptions;
   } else {
     options = confirmationStrategyOrConfirmOptions as

--- a/web3.js/src/utils/send-and-confirm-raw-transaction.ts
+++ b/web3.js/src/utils/send-and-confirm-raw-transaction.ts
@@ -3,6 +3,7 @@ import type {Buffer} from 'buffer';
 import {
   BlockheightBasedTransactionConfirmationStrategy,
   Connection,
+  NonceBasedTransactionConfirmationStrategy,
 } from '../connection';
 import type {TransactionSignature} from '../transaction';
 import type {ConfirmOptions} from '../connection';
@@ -42,12 +43,14 @@ export async function sendAndConfirmRawTransaction(
   rawTransaction: Buffer,
   confirmationStrategyOrConfirmOptions:
     | BlockheightBasedTransactionConfirmationStrategy
+    | NonceBasedTransactionConfirmationStrategy
     | ConfirmOptions
     | undefined,
   maybeConfirmOptions?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   let confirmationStrategy:
     | BlockheightBasedTransactionConfirmationStrategy
+    | NonceBasedTransactionConfirmationStrategy
     | undefined;
   let options: ConfirmOptions | undefined;
   if (
@@ -59,6 +62,16 @@ export async function sendAndConfirmRawTransaction(
   ) {
     confirmationStrategy =
       confirmationStrategyOrConfirmOptions as BlockheightBasedTransactionConfirmationStrategy;
+    options = maybeConfirmOptions;
+  } else if (
+    confirmationStrategyOrConfirmOptions &&
+    Object.prototype.hasOwnProperty.call(
+      confirmationStrategyOrConfirmOptions,
+      'nonceValue',
+    )
+  ) {
+    confirmationStrategy =
+      confirmationStrategyOrConfirmOptions as NonceBasedTransactionConfirmationStrategy;
     options = maybeConfirmOptions;
   } else {
     options = confirmationStrategyOrConfirmOptions as

--- a/web3.js/test/mocks/rpc-http.ts
+++ b/web3.js/test/mocks/rpc-http.ts
@@ -71,6 +71,7 @@ export const mockRpcResponse = async ({
   params,
   value,
   error,
+  slot,
   withContext,
   withHeaders,
 }: {
@@ -78,6 +79,7 @@ export const mockRpcResponse = async ({
   params: Array<any>;
   value?: Promise<any> | any;
   error?: any;
+  slot?: number;
   withContext?: boolean;
   withHeaders?: HttpHeaders;
 }) => {
@@ -98,7 +100,7 @@ export const mockRpcResponse = async ({
         if (withContext) {
           result = {
             context: {
-              slot: 11,
+              slot: slot != null ? slot : 11,
             },
             value: unwrappedValue,
           };

--- a/web3.js/test/transaction.test.ts
+++ b/web3.js/test/transaction.test.ts
@@ -732,6 +732,28 @@ describe('Transaction', () => {
     expect(transaction.lastValidBlockHeight).to.eq(lastValidBlockHeight);
   });
 
+  it('constructs a transaction with nonce information', () => {
+    const nonceAuthority = new PublicKey(1);
+    const nonceAccountPubkey = new PublicKey(2);
+    const nonceValue = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k';
+    const nonceInfo = {
+      nonce: nonceValue,
+      nonceInstruction: SystemProgram.nonceAdvance({
+        noncePubkey: nonceAccountPubkey,
+        authorizedPubkey: nonceAuthority,
+      }),
+    };
+    const minContextSlot = 1234;
+    const transaction = new Transaction({
+      nonceInfo,
+      minContextSlot,
+    });
+    expect(transaction.recentBlockhash).to.be.undefined;
+    expect(transaction.lastValidBlockHeight).to.be.undefined;
+    expect(transaction.minNonceContextSlot).to.eq(minContextSlot);
+    expect(transaction.nonceInfo).to.eq(nonceInfo);
+  });
+
   it('constructs a transaction with only a recent blockhash', () => {
     const recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k';
     const transaction = new Transaction({


### PR DESCRIPTION
#### Usage

```typescript
const tx = new Transaction({nonceInfo});
const signature = connection.sendTransaction(tx, [/* ... */]);
await connection.confirmTransaction({
  minContextSlot, // A slot where the nonce was known to be the candidate value.
  nonceAccountPubkey,  // The account where we can expect to find the latest nonce value.
  nonceValue: nonceInfo.nonce,  // Whatever nonce value the `tx` contained when it was signed.
  signature,
});
```

Closes #25303.