### PR TITLE
fix intermittent bucket age test failure

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -446,7 +446,7 @@ pub mod tests {
         let bins = 1;
         let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         let threads = 2;
-        let time = AGE_MS * 5 / 2;
+        let time = AGE_MS * 8 / 3;
         let expected = (time / AGE_MS) as Age;
         let now = Instant::now();
         test.bucket_flushed_at_current_age(); // done with age 0

--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -446,7 +446,7 @@ pub mod tests {
         let bins = 1;
         let test = BucketMapHolder::<u64>::new(bins, &Some(AccountsIndexConfig::default()), 1);
         let threads = 2;
-        let time = AGE_MS * 8 / 3;
+        let time = AGE_MS * 5 / 2;
         let expected = (time / AGE_MS) as Age;
         let now = Instant::now();
         test.bucket_flushed_at_current_age(); // done with age 0

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -282,10 +282,9 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                     // if someone else holds the arc,
                     //  then they think the item is still in the index and can make modifications.
                     // We have to have a write lock to the map here, which means nobody else can get
-                    //  the arc, but someone may already have retreived a clone of it.
+                    //  the arc, but someone may already have retrieved a clone of it.
                     // account index in_mem flushing is one such possibility
                     self.delete_disk_key(occupied.key());
-                    self.stats().insert_or_delete_mem(false, self.bin);
                     occupied.remove();
                 }
                 result

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -247,7 +247,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                         let (add_to_cache, rt) = callback(Some(&disk_entry));
 
                         if add_to_cache {
-                            stats.insert_or_delete_mem(true, self.bin);
+                            stats.inc_mem_count(self.bin);
                             vacant.insert(disk_entry);
                         }
                         rt
@@ -259,7 +259,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
 
     fn remove_if_slot_list_empty_value(&self, slot_list: SlotSlice<T>) -> bool {
         if slot_list.is_empty() {
-            self.stats().insert_or_delete(false, self.bin);
+            self.stats().inc_delete(self.bin);
             true
         } else {
             false
@@ -408,7 +408,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                                 previous_slot_entry_was_cached,
                             );
                             if !already_existed {
-                                self.stats().insert_or_delete(true, self.bin);
+                                self.stats().inc_insert(self.bin);
                             }
                         } else {
                             // go to in-mem cache first
@@ -425,12 +425,11 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                                 disk_entry
                             } else {
                                 // not on disk, so insert new thing
-                                self.stats().insert_or_delete(true, self.bin);
                                 new_value.into_account_map_entry(&self.storage)
                             };
                             assert!(new_value.dirty());
                             vacant.insert(new_value);
-                            self.stats().insert_or_delete_mem(true, self.bin);
+                            self.stats().inc_mem_count(self.bin);
                         }
                     }
                 }
@@ -623,7 +622,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                     (false, already_existed)
                 } else {
                     let disk_entry = self.load_account_entry_from_disk(vacant.key());
-                    self.stats().insert_or_delete_mem(true, self.bin);
+                    self.stats().inc_mem_count(self.bin);
                     if let Some(disk_entry) = disk_entry {
                         let (slot, account_info) = new_entry.into();
                         InMemAccountsIndex::lock_and_update_slot_list(
@@ -655,7 +654,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         self.update_entry_stats(m, found_in_mem);
         let stats = self.stats();
         if !already_existed {
-            stats.insert_or_delete(true, self.bin);
+            stats.inc_insert(self.bin);
         } else {
             Self::update_stat(&stats.updates_in_mem, 1);
         }
@@ -706,7 +705,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
             existed
         } else {
             // not using disk, so insert into mem
-            self.stats().insert_or_delete_mem(true, self.bin);
+            self.stats().inc_mem_count(self.bin);
             let new_entry: AccountMapEntry<T> = new_entry.into_account_map_entry(&self.storage);
             assert!(new_entry.dirty());
             vacant.insert(new_entry);
@@ -863,8 +862,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 }
             }
         }
-        self.stats()
-            .insert_or_delete_mem_count(true, self.bin, added_to_mem);
+        self.stats().add_mem_count(self.bin, added_to_mem);
 
         Self::update_time_stat(&self.stats().get_range_us, m);
     }
@@ -1208,8 +1206,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 map.shrink_to_fit();
             }
         }
-        self.stats()
-            .insert_or_delete_mem_count(false, self.bin, evicted);
+        self.stats().sub_mem_count(self.bin, evicted);
         Self::update_stat(&self.stats().flush_entries_evicted_from_mem, evicted as u64);
         Self::update_stat(&self.stats().failed_to_evict, failed as u64);
     }

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -425,6 +425,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                                 disk_entry
                             } else {
                                 // not on disk, so insert new thing
+                                self.stats().inc_insert(self.bin);
                                 new_value.into_account_map_entry(&self.storage)
                             };
                             assert!(new_value.dirty());


### PR DESCRIPTION
#### Problem

`bucket_map_holder::tests::test_age_time` fails intermittently, i.e.
https://buildkite.com/solana-labs/solana/builds/75341#01813b58-9c10-4e40-84a4-fccda52386bb

#### Summary of Changes

Increase the test timing tolerance for `bucket_map_holder::tests::test_age_time` to fix the intermittent test failure.

This is a follow up pull request for https://github.com/solana-labs/solana/pull/25800


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
