### PR TITLE
Fix new cost tracker with accounts data size limit

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1534,15 +1534,6 @@ impl Bank {
 
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
         bank.accounts_data_size_initial = accounts_data_size_initial;
-        if bank
-            .feature_set
-            .is_active(&feature_set::cap_accounts_data_len::id())
-        {
-            let cost_tracker = CostTracker::new_with_account_data_size_limit(Some(
-                MAX_ACCOUNTS_DATA_LEN.saturating_sub(accounts_data_size_initial),
-            ));
-            *bank.write_cost_tracker().unwrap() = cost_tracker;
-        }
 
         bank
     }
@@ -2190,11 +2181,7 @@ impl Bank {
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
             vote_only_bank: false,
-            cost_tracker: RwLock::new(CostTracker::new_with_account_data_size_limit(
-                feature_set
-                    .is_active(&feature_set::cap_accounts_data_len::id())
-                    .then(|| MAX_ACCOUNTS_DATA_LEN.saturating_sub(accounts_data_size_initial)),
-            )),
+            cost_tracker: RwLock::new(CostTracker::default()),
             sysvar_cache: RwLock::new(SysvarCache::default()),
             accounts_data_size_initial,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
@@ -6285,6 +6272,15 @@ impl Bank {
         self.builtin_feature_transitions = Arc::new(builtins.feature_transitions);
 
         self.apply_feature_activations(true, debug_do_not_add_builtins);
+
+        if self
+            .feature_set
+            .is_active(&feature_set::cap_accounts_data_len::id())
+        {
+            self.cost_tracker = RwLock::new(CostTracker::new_with_account_data_size_limit(Some(
+                MAX_ACCOUNTS_DATA_LEN.saturating_sub(self.accounts_data_size_initial),
+            )));
+        }
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {


### PR DESCRIPTION
#### Problem

When assigning a new cost tracker in `Bank::new_from_fields()` and `Bank::new_with_paths()`, based on the cap-total-accounts-data-size feature, the `Bank::feature_set` that is used for the comparison is still the unpopulated default set. This means the existing code never actually set a new cost tracker to correctly track the total accounts data size in these code paths. The check must occur _after_ `Bank::apply_feature_activations()` as run.

#### Summary of Changes

Move assigning a new cost tracker into `Bank::finish_init()`.

Feature Gate Issue: #24135

