### PR TITLE
Ignore sbf-tools in sdk/bpf/dependencies and remove the ignored file

### DIFF
--- a/sdk/bpf/.gitignore
+++ b/sdk/bpf/.gitignore
@@ -3,6 +3,7 @@
 /dependencies/llvm-native*
 /dependencies/rust-bpf-sysroot*
 /dependencies/bpf-tools*
+/dependencies/sbf-tools*
 /dependencies/xargo*
 /dependencies/bin*
 /dependencies/.crates.toml

--- a/sdk/bpf/dependencies/sbf-tools
+++ b/sdk/bpf/dependencies/sbf-tools
@@ -1,1 +1,0 @@
-/Users/jack/.cache/solana/v1.27/sbf-tools


### PR DESCRIPTION
#### Problem

bpf-tools is gradually replaced by sbf-tools. An ignore for the changed name in sdk/dependencies was missing, and
a generated file was accidentally added to the repository.

#### Summary of Changes

Remove the wrongly added file and add it to ignore list

