### PR TITLE
Add total transactions metric to replay-slot-stats

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -41,6 +41,7 @@ impl ReplaySlotStats {
         slot: Slot,
         num_entries: usize,
         num_shreds: u64,
+        num_transactions: usize,
         bank_complete_time_us: u64,
     ) {
         datapoint_info!(
@@ -70,6 +71,7 @@ impl ReplaySlotStats {
             ),
             ("total_entries", num_entries as i64, i64),
             ("total_shreds", num_shreds as i64, i64),
+            ("total_transactions", num_transactions as i64, i64),
             (
                 "check_us",
                 *self

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2353,6 +2353,7 @@ impl ReplayStage {
                     bank.slot(),
                     bank_progress.replay_progress.num_entries,
                     bank_progress.replay_progress.num_shreds,
+                    bank_progress.replay_progress.num_txs,
                     bank_complete_time.as_us(),
                 );
             } else {


### PR DESCRIPTION
#### Problem

Want to see transactions/shred or transactions/entry stats, but there's no transaction metric that correlates to entries and shreds.

#### Summary of Changes

Add transaction count to replay-slot-stats.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
