### PR TITLE
Change `WaitableCondvar`'s mutex to hold `()`

### DIFF
--- a/runtime/src/waitable_condvar.rs
+++ b/runtime/src/waitable_condvar.rs
@@ -7,7 +7,7 @@ use std::{
 // this will likely be wrapped in an arc somehow
 #[derive(Default, Debug)]
 pub struct WaitableCondvar {
-    pub mutex: Mutex<u8>,
+    pub mutex: Mutex<()>,
     pub event: Condvar,
 }
 


### PR DESCRIPTION
#### Problem

`WaitableCondvar` has a mutex so it can use `Condvar`, but doesn't need a value. It stores a `u8`, but doesn't need to.

#### Summary of Changes

Change what the mutex holds to nothing, i.e. the unit type: `()`.
