### PR TITLE
Use async TPU client in sync TPU client

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -59,7 +59,7 @@ impl HttpSender {
         let client = Arc::new(
             reqwest::Client::builder()
                 .default_headers(default_headers)
-                .timeout(timeout.clone())
+                .timeout(timeout)
                 .build()
                 .expect("build rpc client"),
         );
@@ -69,7 +69,7 @@ impl HttpSender {
             url: url.to_string(),
             request_id: AtomicU64::new(0),
             stats: RwLock::new(RpcTransportStats::default()),
-            timeout
+            timeout,
         }
     }
 }
@@ -227,17 +227,17 @@ impl RpcSender for HttpSender {
         let client = Arc::new(
             reqwest::Client::builder()
                 .default_headers(default_headers)
-                .timeout(self.timeout.clone())
+                .timeout(self.timeout)
                 .build()
                 .expect("build rpc client"),
         );
 
         Box::new(Self {
             client,
-            url: self.url,
+            url: self.url.clone(),
             request_id: AtomicU64::new(0),
             stats: RwLock::new(RpcTransportStats::default()),
-            timeout: self.timeout.clone()
+            timeout: self.timeout,
         })
     }
 }

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -484,6 +484,9 @@ impl RpcSender for MockSender {
         let curr_mocks = self.mocks.read().unwrap();
         let mocks = curr_mocks.clone();
 
-        Box::new(Self { mocks: RwLock::new(mocks), url: self.url.clone()  })
+        Box::new(Self {
+            mocks: RwLock::new(mocks),
+            url: self.url.clone(),
+        })
     }
 }

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -479,4 +479,11 @@ impl RpcSender for MockSender {
     fn url(&self) -> String {
         format!("MockSender: {}", self.url)
     }
+
+    fn clone(&self) -> Box<dyn RpcSender + Send + Sync + 'static> {
+        let curr_mocks = self.mocks.read().unwrap();
+        let mocks = curr_mocks.clone();
+
+        Box::new(Self { mocks: RwLock::new(mocks), url: self.url.clone()  })
+    }
 }

--- a/client/src/nonblocking/pubsub_client.rs
+++ b/client/src/nonblocking/pubsub_client.rs
@@ -64,8 +64,14 @@ pub enum PubsubClientError {
     #[error("subscribe failed: {reason}")]
     SubscribeFailed { reason: String, message: String },
 
+    #[error("unexpected message format: {0}")]
+    UnexpectedMessageError(String),
+
     #[error("request failed: {reason}")]
     RequestFailed { reason: String, message: String },
+
+    #[error("request error: {0}")]
+    RequestError(String),
 }
 
 type UnsubscribeFn = Box<dyn FnOnce() -> BoxFuture<'static, ()> + Send>;

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -161,6 +161,11 @@ impl RpcClient {
         }
     }
 
+    pub async fn copy(&self) -> Self {
+        let node_version = self.node_version.read().await.clone();
+        Self { sender: self.sender.clone(), config: self.config.clone(), node_version: RwLock::new(node_version) }
+    }
+
     /// Create an HTTP `RpcClient`.
     ///
     /// The URL is an HTTP URL, usually for port 8899, as in

--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -163,7 +163,11 @@ impl RpcClient {
 
     pub async fn copy(&self) -> Self {
         let node_version = self.node_version.read().await.clone();
-        Self { sender: self.sender.clone(), config: self.config.clone(), node_version: RwLock::new(node_version) }
+        Self {
+            sender: self.sender.clone(),
+            config: self.config.clone(),
+            node_version: RwLock::new(node_version),
+        }
     }
 
     /// Create an HTTP `RpcClient`.

--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -255,7 +255,10 @@ impl TpuClient {
 
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
-    pub async fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
+    pub async fn try_send_wire_transaction(
+        &self,
+        wire_transaction: Vec<u8>,
+    ) -> TransportResult<()> {
         let leaders = self
             .leader_tpu_service
             .leader_tpu_sockets(self.fanout_slots);

--- a/client/src/pubsub_client.rs
+++ b/client/src/pubsub_client.rs
@@ -1,3 +1,4 @@
+pub use crate::nonblocking::pubsub_client::PubsubClientError;
 use {
     crate::{
         rpc_config::{
@@ -31,28 +32,9 @@ use {
         thread::{sleep, JoinHandle},
         time::Duration,
     },
-    thiserror::Error,
     tungstenite::{connect, stream::MaybeTlsStream, Message, WebSocket},
-    url::{ParseError, Url},
+    url::Url,
 };
-
-#[derive(Debug, Error)]
-pub enum PubsubClientError {
-    #[error("url parse error")]
-    UrlParseError(#[from] ParseError),
-
-    #[error("unable to connect to server")]
-    ConnectionError(#[from] tungstenite::Error),
-
-    #[error("json parse error")]
-    JsonParseError(#[from] serde_json::error::Error),
-
-    #[error("unexpected message format: {0}")]
-    UnexpectedMessageError(String),
-
-    #[error("request error: {0}")]
-    RequestError(String),
-}
 
 pub struct PubsubClientSubscription<T>
 where

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -45,7 +45,7 @@ use {
     std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration},
 };
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RpcClientConfig {
     pub commitment_config: CommitmentConfig,
     pub confirm_transaction_initial_timeout: Option<Duration>,
@@ -157,8 +157,7 @@ pub struct RpcClient {
 
 impl Drop for RpcClient {
     fn drop(&mut self) {
-        //todo: figure out what do do about thiss
-        //self.runtime.shutdown_background();
+        self.runtime.shutdown_background();
     }
 }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -187,8 +187,11 @@ impl RpcClient {
         }
     }
 
-    pub(crate) fn get_nonblocking_client(&self) -> Arc<nonblocking::rpc_client::RpcClient> {
-        self.rpc_client.clone()
+    pub(crate) fn get_nonblocking_client_copy(&self) -> Arc<nonblocking::rpc_client::RpcClient> {
+        let copy = self.rpc_client.copy();
+        Arc::new(tokio::task::block_in_place(move || {
+            self.runtime.as_ref().expect("runtime").block_on(copy)
+        }))
     }
 
     /// Create an HTTP `RpcClient`.

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -187,7 +187,7 @@ impl RpcClient {
         }
     }
 
-    pub fn get_nonblocking_client(&self) -> Arc<nonblocking::rpc_client::RpcClient> {
+    pub(crate) fn get_nonblocking_client(&self) -> Arc<nonblocking::rpc_client::RpcClient> {
         self.rpc_client.clone()
     }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -543,7 +543,7 @@ impl RpcClient {
 
     /// Get the configured url of the client's sender
     pub fn url(&self) -> String {
-        self.rpc_client.url()
+        (self.rpc_client.as_ref()).url()
     }
 
     /// Get the configured default [commitment level][cl].
@@ -562,7 +562,7 @@ impl RpcClient {
     /// explicitly provide a [`CommitmentConfig`], like
     /// [`RpcClient::confirm_transaction_with_commitment`].
     pub fn commitment(&self) -> CommitmentConfig {
-        self.rpc_client.commitment()
+        (self.rpc_client.as_ref()).commitment()
     }
 
     /// Submit a transaction and wait for confirmation.
@@ -630,7 +630,7 @@ impl RpcClient {
         &self,
         transaction: &Transaction,
     ) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.send_and_confirm_transaction(transaction))
+        self.invoke((self.rpc_client.as_ref()).send_and_confirm_transaction(transaction))
     }
 
     pub fn send_and_confirm_transaction_with_spinner(
@@ -638,8 +638,7 @@ impl RpcClient {
         transaction: &Transaction,
     ) -> ClientResult<Signature> {
         self.invoke(
-            self.rpc_client
-                .send_and_confirm_transaction_with_spinner(transaction),
+            (self.rpc_client.as_ref()).send_and_confirm_transaction_with_spinner(transaction),
         )
     }
 
@@ -649,7 +648,7 @@ impl RpcClient {
         commitment: CommitmentConfig,
     ) -> ClientResult<Signature> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .send_and_confirm_transaction_with_spinner_and_commitment(transaction, commitment),
         )
     }
@@ -661,12 +660,11 @@ impl RpcClient {
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
         self.invoke(
-            self.rpc_client
-                .send_and_confirm_transaction_with_spinner_and_config(
-                    transaction,
-                    commitment,
-                    config,
-                ),
+            (self.rpc_client.as_ref()).send_and_confirm_transaction_with_spinner_and_config(
+                transaction,
+                commitment,
+                config,
+            ),
         )
     }
 
@@ -741,7 +739,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.send_transaction(transaction))
+        self.invoke((self.rpc_client.as_ref()).send_transaction(transaction))
     }
 
     /// Submits a signed transaction to the network.
@@ -828,17 +826,14 @@ impl RpcClient {
         transaction: &Transaction,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
-        self.invoke(
-            self.rpc_client
-                .send_transaction_with_config(transaction, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).send_transaction_with_config(transaction, config))
     }
 
     pub fn send<T>(&self, request: RpcRequest, params: Value) -> ClientResult<T>
     where
         T: serde::de::DeserializeOwned,
     {
-        self.invoke(self.rpc_client.send(request, params))
+        self.invoke((self.rpc_client.as_ref()).send(request, params))
     }
 
     /// Check the confirmation status of a transaction.
@@ -894,7 +889,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn confirm_transaction(&self, signature: &Signature) -> ClientResult<bool> {
-        self.invoke(self.rpc_client.confirm_transaction(signature))
+        self.invoke((self.rpc_client.as_ref()).confirm_transaction(signature))
     }
 
     /// Check the confirmation status of a transaction.
@@ -957,7 +952,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<bool> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .confirm_transaction_with_commitment(signature, commitment_config),
         )
     }
@@ -968,7 +963,7 @@ impl RpcClient {
         recent_blockhash: &Hash,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<()> {
-        self.invoke(self.rpc_client.confirm_transaction_with_spinner(
+        self.invoke((self.rpc_client.as_ref()).confirm_transaction_with_spinner(
             signature,
             recent_blockhash,
             commitment_config,
@@ -1033,7 +1028,7 @@ impl RpcClient {
         &self,
         transaction: &Transaction,
     ) -> RpcResult<RpcSimulateTransactionResult> {
-        self.invoke(self.rpc_client.simulate_transaction(transaction))
+        self.invoke((self.rpc_client.as_ref()).simulate_transaction(transaction))
     }
 
     /// Simulates sending a transaction.
@@ -1112,8 +1107,7 @@ impl RpcClient {
         config: RpcSimulateTransactionConfig,
     ) -> RpcResult<RpcSimulateTransactionResult> {
         self.invoke(
-            self.rpc_client
-                .simulate_transaction_with_config(transaction, config),
+            (self.rpc_client.as_ref()).simulate_transaction_with_config(transaction, config),
         )
     }
 
@@ -1140,7 +1134,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_highest_snapshot_slot(&self) -> ClientResult<RpcSnapshotSlotInfo> {
-        self.invoke(self.rpc_client.get_highest_snapshot_slot())
+        self.invoke((self.rpc_client.as_ref()).get_highest_snapshot_slot())
     }
 
     #[deprecated(
@@ -1149,7 +1143,7 @@ impl RpcClient {
     )]
     #[allow(deprecated)]
     pub fn get_snapshot_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_snapshot_slot())
+        self.invoke((self.rpc_client.as_ref()).get_snapshot_slot())
     }
 
     /// Check if a transaction has been processed with the default [commitment level][cl].
@@ -1210,7 +1204,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
     ) -> ClientResult<Option<transaction::Result<()>>> {
-        self.invoke(self.rpc_client.get_signature_status(signature))
+        self.invoke((self.rpc_client.as_ref()).get_signature_status(signature))
     }
 
     /// Gets the statuses of a list of transaction signatures.
@@ -1288,7 +1282,7 @@ impl RpcClient {
         &self,
         signatures: &[Signature],
     ) -> RpcResult<Vec<Option<TransactionStatus>>> {
-        self.invoke(self.rpc_client.get_signature_statuses(signatures))
+        self.invoke((self.rpc_client.as_ref()).get_signature_statuses(signatures))
     }
 
     /// Gets the statuses of a list of transaction signatures.
@@ -1356,10 +1350,7 @@ impl RpcClient {
         &self,
         signatures: &[Signature],
     ) -> RpcResult<Vec<Option<TransactionStatus>>> {
-        self.invoke(
-            self.rpc_client
-                .get_signature_statuses_with_history(signatures),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_signature_statuses_with_history(signatures))
     }
 
     /// Check if a transaction has been processed with the given [commitment level][cl].
@@ -1426,7 +1417,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Option<transaction::Result<()>>> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_signature_status_with_commitment(signature, commitment_config),
         )
     }
@@ -1494,12 +1485,11 @@ impl RpcClient {
         search_transaction_history: bool,
     ) -> ClientResult<Option<transaction::Result<()>>> {
         self.invoke(
-            self.rpc_client
-                .get_signature_status_with_commitment_and_history(
-                    signature,
-                    commitment_config,
-                    search_transaction_history,
-                ),
+            (self.rpc_client.as_ref()).get_signature_status_with_commitment_and_history(
+                signature,
+                commitment_config,
+                search_transaction_history,
+            ),
         )
     }
 
@@ -1525,7 +1515,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_slot())
+        self.invoke((self.rpc_client.as_ref()).get_slot())
     }
 
     /// Returns the slot that has reached the given [commitment level][cl].
@@ -1555,7 +1545,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_slot_with_commitment(commitment_config))
+        self.invoke((self.rpc_client.as_ref()).get_slot_with_commitment(commitment_config))
     }
 
     /// Returns the block height that has reached the configured [commitment level][cl].
@@ -1580,7 +1570,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_block_height(&self) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_block_height())
+        self.invoke((self.rpc_client.as_ref()).get_block_height())
     }
 
     /// Returns the block height that has reached the given [commitment level][cl].
@@ -1612,10 +1602,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_block_height_with_commitment(commitment_config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_block_height_with_commitment(commitment_config))
     }
 
     /// Returns the slot leaders for a given slot range.
@@ -1641,7 +1628,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_slot_leaders(&self, start_slot: Slot, limit: u64) -> ClientResult<Vec<Pubkey>> {
-        self.invoke(self.rpc_client.get_slot_leaders(start_slot, limit))
+        self.invoke((self.rpc_client.as_ref()).get_slot_leaders(start_slot, limit))
     }
 
     /// Get block production for the current epoch.
@@ -1664,7 +1651,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_block_production(&self) -> RpcResult<RpcBlockProduction> {
-        self.invoke(self.rpc_client.get_block_production())
+        self.invoke((self.rpc_client.as_ref()).get_block_production())
     }
 
     /// Get block production for the current or previous epoch.
@@ -1712,7 +1699,7 @@ impl RpcClient {
         &self,
         config: RpcBlockProductionConfig,
     ) -> RpcResult<RpcBlockProduction> {
-        self.invoke(self.rpc_client.get_block_production_with_config(config))
+        self.invoke((self.rpc_client.as_ref()).get_block_production_with_config(config))
     }
 
     /// Returns epoch activation information for a stake account.
@@ -1791,7 +1778,7 @@ impl RpcClient {
         stake_account: Pubkey,
         epoch: Option<Epoch>,
     ) -> ClientResult<RpcStakeActivation> {
-        self.invoke(self.rpc_client.get_stake_activation(stake_account, epoch))
+        self.invoke((self.rpc_client.as_ref()).get_stake_activation(stake_account, epoch))
     }
 
     /// Returns information about the current supply.
@@ -1818,7 +1805,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn supply(&self) -> RpcResult<RpcSupply> {
-        self.invoke(self.rpc_client.supply())
+        self.invoke((self.rpc_client.as_ref()).supply())
     }
 
     /// Returns information about the current supply.
@@ -1848,7 +1835,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<RpcSupply> {
-        self.invoke(self.rpc_client.supply_with_commitment(commitment_config))
+        self.invoke((self.rpc_client.as_ref()).supply_with_commitment(commitment_config))
     }
 
     /// Returns the 20 largest accounts, by lamport balance.
@@ -1885,7 +1872,7 @@ impl RpcClient {
         &self,
         config: RpcLargestAccountsConfig,
     ) -> RpcResult<Vec<RpcAccountBalance>> {
-        self.invoke(self.rpc_client.get_largest_accounts_with_config(config))
+        self.invoke((self.rpc_client.as_ref()).get_largest_accounts_with_config(config))
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1912,7 +1899,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(self.rpc_client.get_vote_accounts())
+        self.invoke((self.rpc_client.as_ref()).get_vote_accounts())
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1945,10 +1932,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(
-            self.rpc_client
-                .get_vote_accounts_with_commitment(commitment_config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_vote_accounts_with_commitment(commitment_config))
     }
 
     /// Returns the account info and associated stake for all the voting accounts
@@ -1994,7 +1978,7 @@ impl RpcClient {
         &self,
         config: RpcGetVoteAccountsConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.invoke(self.rpc_client.get_vote_accounts_with_config(config))
+        self.invoke((self.rpc_client.as_ref()).get_vote_accounts_with_config(config))
     }
 
     pub fn wait_for_max_stake(
@@ -2002,10 +1986,7 @@ impl RpcClient {
         commitment: CommitmentConfig,
         max_stake_percent: f32,
     ) -> ClientResult<()> {
-        self.invoke(
-            self.rpc_client
-                .wait_for_max_stake(commitment, max_stake_percent),
-        )
+        self.invoke((self.rpc_client.as_ref()).wait_for_max_stake(commitment, max_stake_percent))
     }
 
     /// Returns information about all the nodes participating in the cluster.
@@ -2029,7 +2010,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_cluster_nodes(&self) -> ClientResult<Vec<RpcContactInfo>> {
-        self.invoke(self.rpc_client.get_cluster_nodes())
+        self.invoke((self.rpc_client.as_ref()).get_cluster_nodes())
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -2061,7 +2042,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block(slot))
+        self.invoke((self.rpc_client.as_ref()).get_block(slot))
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -2094,7 +2075,7 @@ impl RpcClient {
         slot: Slot,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block_with_encoding(slot, encoding))
+        self.invoke((self.rpc_client.as_ref()).get_block_with_encoding(slot, encoding))
     }
 
     /// Returns identity and transaction information about a confirmed block in the ledger.
@@ -2137,13 +2118,13 @@ impl RpcClient {
         slot: Slot,
         config: RpcBlockConfig,
     ) -> ClientResult<UiConfirmedBlock> {
-        self.invoke(self.rpc_client.get_block_with_config(slot, config))
+        self.invoke((self.rpc_client.as_ref()).get_block_with_config(slot, config))
     }
 
     #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_block() instead")]
     #[allow(deprecated)]
     pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(self.rpc_client.get_confirmed_block(slot))
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_block(slot))
     }
 
     #[deprecated(
@@ -2156,10 +2137,7 @@ impl RpcClient {
         slot: Slot,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedBlock> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_block_with_encoding(slot, encoding),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_block_with_encoding(slot, encoding))
     }
 
     #[deprecated(
@@ -2172,10 +2150,7 @@ impl RpcClient {
         slot: Slot,
         config: RpcConfirmedBlockConfig,
     ) -> ClientResult<UiConfirmedBlock> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_block_with_config(slot, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_block_with_config(slot, config))
     }
 
     /// Returns a list of finalized blocks between two slots.
@@ -2224,7 +2199,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_blocks(&self, start_slot: Slot, end_slot: Option<Slot>) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks(start_slot, end_slot))
+        self.invoke((self.rpc_client.as_ref()).get_blocks(start_slot, end_slot))
     }
 
     /// Returns a list of confirmed blocks between two slots.
@@ -2289,7 +2264,7 @@ impl RpcClient {
         end_slot: Option<Slot>,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_commitment(
+        self.invoke((self.rpc_client.as_ref()).get_blocks_with_commitment(
             start_slot,
             end_slot,
             commitment_config,
@@ -2331,7 +2306,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_blocks_with_limit(&self, start_slot: Slot, limit: usize) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_limit(start_slot, limit))
+        self.invoke((self.rpc_client.as_ref()).get_blocks_with_limit(start_slot, limit))
     }
 
     /// Returns a list of confirmed blocks starting at the given slot.
@@ -2381,11 +2356,13 @@ impl RpcClient {
         limit: usize,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_blocks_with_limit_and_commitment(
-            start_slot,
-            limit,
-            commitment_config,
-        ))
+        self.invoke(
+            (self.rpc_client.as_ref()).get_blocks_with_limit_and_commitment(
+                start_slot,
+                limit,
+                commitment_config,
+            ),
+        )
     }
 
     #[deprecated(since = "1.7.0", note = "Please use RpcClient::get_blocks() instead")]
@@ -2395,7 +2372,7 @@ impl RpcClient {
         start_slot: Slot,
         end_slot: Option<Slot>,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_confirmed_blocks(start_slot, end_slot))
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_blocks(start_slot, end_slot))
     }
 
     #[deprecated(
@@ -2409,11 +2386,13 @@ impl RpcClient {
         end_slot: Option<Slot>,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(self.rpc_client.get_confirmed_blocks_with_commitment(
-            start_slot,
-            end_slot,
-            commitment_config,
-        ))
+        self.invoke(
+            (self.rpc_client.as_ref()).get_confirmed_blocks_with_commitment(
+                start_slot,
+                end_slot,
+                commitment_config,
+            ),
+        )
     }
 
     #[deprecated(
@@ -2426,10 +2405,7 @@ impl RpcClient {
         start_slot: Slot,
         limit: usize,
     ) -> ClientResult<Vec<Slot>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_blocks_with_limit(start_slot, limit),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_blocks_with_limit(start_slot, limit))
     }
 
     #[deprecated(
@@ -2444,12 +2420,11 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
         self.invoke(
-            self.rpc_client
-                .get_confirmed_blocks_with_limit_and_commitment(
-                    start_slot,
-                    limit,
-                    commitment_config,
-                ),
+            (self.rpc_client.as_ref()).get_confirmed_blocks_with_limit_and_commitment(
+                start_slot,
+                limit,
+                commitment_config,
+            ),
         )
     }
 
@@ -2494,7 +2469,7 @@ impl RpcClient {
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(self.rpc_client.get_signatures_for_address(address))
+        self.invoke((self.rpc_client.as_ref()).get_signatures_for_address(address))
     }
 
     /// Get confirmed signatures for transactions involving an address.
@@ -2555,8 +2530,7 @@ impl RpcClient {
         config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         self.invoke(
-            self.rpc_client
-                .get_signatures_for_address_with_config(address, config),
+            (self.rpc_client.as_ref()).get_signatures_for_address_with_config(address, config),
         )
     }
 
@@ -2569,10 +2543,7 @@ impl RpcClient {
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_signatures_for_address2(address),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_signatures_for_address2(address))
     }
 
     #[deprecated(
@@ -2586,7 +2557,7 @@ impl RpcClient {
         config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_confirmed_signatures_for_address2_with_config(address, config),
         )
     }
@@ -2639,7 +2610,7 @@ impl RpcClient {
         signature: &Signature,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(self.rpc_client.get_transaction(signature, encoding))
+        self.invoke((self.rpc_client.as_ref()).get_transaction(signature, encoding))
     }
 
     /// Returns transaction details for a confirmed transaction.
@@ -2700,10 +2671,7 @@ impl RpcClient {
         signature: &Signature,
         config: RpcTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            self.rpc_client
-                .get_transaction_with_config(signature, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_transaction_with_config(signature, config))
     }
 
     #[deprecated(
@@ -2716,10 +2684,7 @@ impl RpcClient {
         signature: &Signature,
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
-        self.invoke(
-            self.rpc_client
-                .get_confirmed_transaction(signature, encoding),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_confirmed_transaction(signature, encoding))
     }
 
     #[deprecated(
@@ -2733,8 +2698,7 @@ impl RpcClient {
         config: RpcConfirmedTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransactionWithStatusMeta> {
         self.invoke(
-            self.rpc_client
-                .get_confirmed_transaction_with_config(signature, config),
+            (self.rpc_client.as_ref()).get_confirmed_transaction_with_config(signature, config),
         )
     }
 
@@ -2760,7 +2724,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
-        self.invoke(self.rpc_client.get_block_time(slot))
+        self.invoke((self.rpc_client.as_ref()).get_block_time(slot))
     }
 
     /// Returns information about the current epoch.
@@ -2787,7 +2751,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_epoch_info(&self) -> ClientResult<EpochInfo> {
-        self.invoke(self.rpc_client.get_epoch_info())
+        self.invoke((self.rpc_client.as_ref()).get_epoch_info())
     }
 
     /// Returns information about the current epoch.
@@ -2817,10 +2781,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<EpochInfo> {
-        self.invoke(
-            self.rpc_client
-                .get_epoch_info_with_commitment(commitment_config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_epoch_info_with_commitment(commitment_config))
     }
 
     /// Returns the leader schedule for an epoch.
@@ -2854,7 +2815,7 @@ impl RpcClient {
         &self,
         slot: Option<Slot>,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.invoke(self.rpc_client.get_leader_schedule(slot))
+        self.invoke((self.rpc_client.as_ref()).get_leader_schedule(slot))
     }
 
     /// Returns the leader schedule for an epoch.
@@ -2888,8 +2849,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
         self.invoke(
-            self.rpc_client
-                .get_leader_schedule_with_commitment(slot, commitment_config),
+            (self.rpc_client.as_ref()).get_leader_schedule_with_commitment(slot, commitment_config),
         )
     }
 
@@ -2928,10 +2888,7 @@ impl RpcClient {
         slot: Option<Slot>,
         config: RpcLeaderScheduleConfig,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.invoke(
-            self.rpc_client
-                .get_leader_schedule_with_config(slot, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_leader_schedule_with_config(slot, config))
     }
 
     /// Returns epoch schedule information from this cluster's genesis config.
@@ -2954,7 +2911,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_epoch_schedule(&self) -> ClientResult<EpochSchedule> {
-        self.invoke(self.rpc_client.get_epoch_schedule())
+        self.invoke((self.rpc_client.as_ref()).get_epoch_schedule())
     }
 
     /// Returns a list of recent performance samples, in reverse slot order.
@@ -2986,7 +2943,7 @@ impl RpcClient {
         &self,
         limit: Option<usize>,
     ) -> ClientResult<Vec<RpcPerfSample>> {
-        self.invoke(self.rpc_client.get_recent_performance_samples(limit))
+        self.invoke((self.rpc_client.as_ref()).get_recent_performance_samples(limit))
     }
 
     /// Returns the identity pubkey for the current node.
@@ -3009,7 +2966,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_identity(&self) -> ClientResult<Pubkey> {
-        self.invoke(self.rpc_client.get_identity())
+        self.invoke((self.rpc_client.as_ref()).get_identity())
     }
 
     /// Returns the current inflation governor.
@@ -3038,7 +2995,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_inflation_governor(&self) -> ClientResult<RpcInflationGovernor> {
-        self.invoke(self.rpc_client.get_inflation_governor())
+        self.invoke((self.rpc_client.as_ref()).get_inflation_governor())
     }
 
     /// Returns the specific inflation values for the current epoch.
@@ -3061,7 +3018,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_inflation_rate(&self) -> ClientResult<RpcInflationRate> {
-        self.invoke(self.rpc_client.get_inflation_rate())
+        self.invoke((self.rpc_client.as_ref()).get_inflation_rate())
     }
 
     /// Returns the inflation reward for a list of addresses for an epoch.
@@ -3101,7 +3058,7 @@ impl RpcClient {
         addresses: &[Pubkey],
         epoch: Option<Epoch>,
     ) -> ClientResult<Vec<Option<RpcInflationReward>>> {
-        self.invoke(self.rpc_client.get_inflation_reward(addresses, epoch))
+        self.invoke((self.rpc_client.as_ref()).get_inflation_reward(addresses, epoch))
     }
 
     /// Returns the current solana version running on the node.
@@ -3128,7 +3085,7 @@ impl RpcClient {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_version(&self) -> ClientResult<RpcVersionInfo> {
-        self.invoke(self.rpc_client.get_version())
+        self.invoke((self.rpc_client.as_ref()).get_version())
     }
 
     /// Returns the lowest slot that the node has information about in its ledger.
@@ -3155,7 +3112,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn minimum_ledger_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.minimum_ledger_slot())
+        self.invoke((self.rpc_client.as_ref()).minimum_ledger_slot())
     }
 
     /// Returns all information associated with the account of the provided pubkey.
@@ -3203,7 +3160,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
-        self.invoke(self.rpc_client.get_account(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_account(pubkey))
     }
 
     /// Returns all information associated with the account of the provided pubkey.
@@ -3251,8 +3208,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<Account>> {
         self.invoke(
-            self.rpc_client
-                .get_account_with_commitment(pubkey, commitment_config),
+            (self.rpc_client.as_ref()).get_account_with_commitment(pubkey, commitment_config),
         )
     }
 
@@ -3307,7 +3263,7 @@ impl RpcClient {
         pubkey: &Pubkey,
         config: RpcAccountInfoConfig,
     ) -> RpcResult<Option<Account>> {
-        self.invoke(self.rpc_client.get_account_with_config(pubkey, config))
+        self.invoke((self.rpc_client.as_ref()).get_account_with_config(pubkey, config))
     }
 
     /// Get the max slot seen from retransmit stage.
@@ -3330,7 +3286,7 @@ impl RpcClient {
     /// let slot = rpc_client.get_max_retransmit_slot()?;
     /// # Ok::<(), ClientError>(())
     pub fn get_max_retransmit_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_max_retransmit_slot())
+        self.invoke((self.rpc_client.as_ref()).get_max_retransmit_slot())
     }
 
     /// Get the max slot seen from after [shred](https://docs.solana.com/terminology#shred) insert.
@@ -3353,7 +3309,7 @@ impl RpcClient {
     /// let slot = rpc_client.get_max_shred_insert_slot()?;
     /// # Ok::<(), ClientError>(())
     pub fn get_max_shred_insert_slot(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_max_shred_insert_slot())
+        self.invoke((self.rpc_client.as_ref()).get_max_shred_insert_slot())
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3387,7 +3343,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> ClientResult<Vec<Option<Account>>> {
-        self.invoke(self.rpc_client.get_multiple_accounts(pubkeys))
+        self.invoke((self.rpc_client.as_ref()).get_multiple_accounts(pubkeys))
     }
 
     /// Returns the account information for a list of pubkeys.
@@ -3427,7 +3383,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_multiple_accounts_with_commitment(pubkeys, commitment_config),
         )
     }
@@ -3475,10 +3431,7 @@ impl RpcClient {
         pubkeys: &[Pubkey],
         config: RpcAccountInfoConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
-        self.invoke(
-            self.rpc_client
-                .get_multiple_accounts_with_config(pubkeys, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_multiple_accounts_with_config(pubkeys, config))
     }
 
     /// Gets the raw data associated with an account.
@@ -3515,7 +3468,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_account_data(&self, pubkey: &Pubkey) -> ClientResult<Vec<u8>> {
-        self.invoke(self.rpc_client.get_account_data(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_account_data(pubkey))
     }
 
     /// Returns minimum balance required to make an account with specified data length rent exempt.
@@ -3540,10 +3493,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> ClientResult<u64> {
-        self.invoke(
-            self.rpc_client
-                .get_minimum_balance_for_rent_exemption(data_len),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_minimum_balance_for_rent_exemption(data_len))
     }
 
     /// Request the balance of the provided account pubkey.
@@ -3575,7 +3525,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_balance(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_balance(pubkey))
     }
 
     /// Request the balance of the provided account pubkey.
@@ -3613,8 +3563,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<u64> {
         self.invoke(
-            self.rpc_client
-                .get_balance_with_commitment(pubkey, commitment_config),
+            (self.rpc_client.as_ref()).get_balance_with_commitment(pubkey, commitment_config),
         )
     }
 
@@ -3648,7 +3597,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.invoke(self.rpc_client.get_program_accounts(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_program_accounts(pubkey))
     }
 
     /// Returns all accounts owned by the provided program pubkey.
@@ -3712,10 +3661,7 @@ impl RpcClient {
         pubkey: &Pubkey,
         config: RpcProgramAccountsConfig,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
-        self.invoke(
-            self.rpc_client
-                .get_program_accounts_with_config(pubkey, config),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_program_accounts_with_config(pubkey, config))
     }
 
     /// Returns the stake minimum delegation, in lamports.
@@ -3738,7 +3684,7 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub fn get_stake_minimum_delegation(&self) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_stake_minimum_delegation())
+        self.invoke((self.rpc_client.as_ref()).get_stake_minimum_delegation())
     }
 
     /// Returns the stake minimum delegation, in lamports, based on the commitment level.
@@ -3774,7 +3720,7 @@ impl RpcClient {
 
     /// Request the transaction count.
     pub fn get_transaction_count(&self) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_transaction_count())
+        self.invoke((self.rpc_client.as_ref()).get_transaction_count())
     }
 
     pub fn get_transaction_count_with_commitment(
@@ -3782,8 +3728,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
         self.invoke(
-            self.rpc_client
-                .get_transaction_count_with_commitment(commitment_config),
+            (self.rpc_client.as_ref()).get_transaction_count_with_commitment(commitment_config),
         )
     }
 
@@ -3793,7 +3738,7 @@ impl RpcClient {
     )]
     #[allow(deprecated)]
     pub fn get_fees(&self) -> ClientResult<Fees> {
-        self.invoke(self.rpc_client.get_fees())
+        self.invoke((self.rpc_client.as_ref()).get_fees())
     }
 
     #[deprecated(
@@ -3802,13 +3747,13 @@ impl RpcClient {
     )]
     #[allow(deprecated)]
     pub fn get_fees_with_commitment(&self, commitment_config: CommitmentConfig) -> RpcResult<Fees> {
-        self.invoke(self.rpc_client.get_fees_with_commitment(commitment_config))
+        self.invoke((self.rpc_client.as_ref()).get_fees_with_commitment(commitment_config))
     }
 
     #[deprecated(since = "1.9.0", note = "Please use `get_latest_blockhash` instead")]
     #[allow(deprecated)]
     pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke(self.rpc_client.get_recent_blockhash())
+        self.invoke((self.rpc_client.as_ref()).get_recent_blockhash())
     }
 
     #[deprecated(
@@ -3821,8 +3766,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<(Hash, FeeCalculator, Slot)> {
         self.invoke(
-            self.rpc_client
-                .get_recent_blockhash_with_commitment(commitment_config),
+            (self.rpc_client.as_ref()).get_recent_blockhash_with_commitment(commitment_config),
         )
     }
 
@@ -3832,7 +3776,7 @@ impl RpcClient {
         &self,
         blockhash: &Hash,
     ) -> ClientResult<Option<FeeCalculator>> {
-        self.invoke(self.rpc_client.get_fee_calculator_for_blockhash(blockhash))
+        self.invoke((self.rpc_client.as_ref()).get_fee_calculator_for_blockhash(blockhash))
     }
 
     #[deprecated(
@@ -3846,7 +3790,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<FeeCalculator>> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_fee_calculator_for_blockhash_with_commitment(blockhash, commitment_config),
         )
     }
@@ -3857,7 +3801,7 @@ impl RpcClient {
     )]
     #[allow(deprecated)]
     pub fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {
-        self.invoke(self.rpc_client.get_fee_rate_governor())
+        self.invoke((self.rpc_client.as_ref()).get_fee_rate_governor())
     }
 
     #[deprecated(
@@ -3866,23 +3810,23 @@ impl RpcClient {
     )]
     #[allow(deprecated)]
     pub fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {
-        self.invoke(self.rpc_client.get_new_blockhash(blockhash))
+        self.invoke((self.rpc_client.as_ref()).get_new_blockhash(blockhash))
     }
 
     pub fn get_first_available_block(&self) -> ClientResult<Slot> {
-        self.invoke(self.rpc_client.get_first_available_block())
+        self.invoke((self.rpc_client.as_ref()).get_first_available_block())
     }
 
     pub fn get_genesis_hash(&self) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_genesis_hash())
+        self.invoke((self.rpc_client.as_ref()).get_genesis_hash())
     }
 
     pub fn get_health(&self) -> ClientResult<()> {
-        self.invoke(self.rpc_client.get_health())
+        self.invoke((self.rpc_client.as_ref()).get_health())
     }
 
     pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
-        self.invoke(self.rpc_client.get_token_account(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_token_account(pubkey))
     }
 
     pub fn get_token_account_with_commitment(
@@ -3891,13 +3835,12 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<UiTokenAccount>> {
         self.invoke(
-            self.rpc_client
-                .get_token_account_with_commitment(pubkey, commitment_config),
+            (self.rpc_client.as_ref()).get_token_account_with_commitment(pubkey, commitment_config),
         )
     }
 
     pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
-        self.invoke(self.rpc_client.get_token_account_balance(pubkey))
+        self.invoke((self.rpc_client.as_ref()).get_token_account_balance(pubkey))
     }
 
     pub fn get_token_account_balance_with_commitment(
@@ -3906,7 +3849,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<UiTokenAmount> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_token_account_balance_with_commitment(pubkey, commitment_config),
         )
     }
@@ -3917,7 +3860,7 @@ impl RpcClient {
         token_account_filter: TokenAccountsFilter,
     ) -> ClientResult<Vec<RpcKeyedAccount>> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .get_token_accounts_by_delegate(delegate, token_account_filter),
         )
     }
@@ -3929,12 +3872,11 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<RpcKeyedAccount>> {
         self.invoke(
-            self.rpc_client
-                .get_token_accounts_by_delegate_with_commitment(
-                    delegate,
-                    token_account_filter,
-                    commitment_config,
-                ),
+            (self.rpc_client.as_ref()).get_token_accounts_by_delegate_with_commitment(
+                delegate,
+                token_account_filter,
+                commitment_config,
+            ),
         )
     }
 
@@ -3944,8 +3886,7 @@ impl RpcClient {
         token_account_filter: TokenAccountsFilter,
     ) -> ClientResult<Vec<RpcKeyedAccount>> {
         self.invoke(
-            self.rpc_client
-                .get_token_accounts_by_owner(owner, token_account_filter),
+            (self.rpc_client.as_ref()).get_token_accounts_by_owner(owner, token_account_filter),
         )
     }
 
@@ -3955,15 +3896,17 @@ impl RpcClient {
         token_account_filter: TokenAccountsFilter,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<RpcKeyedAccount>> {
-        self.invoke(self.rpc_client.get_token_accounts_by_owner_with_commitment(
-            owner,
-            token_account_filter,
-            commitment_config,
-        ))
+        self.invoke(
+            (self.rpc_client.as_ref()).get_token_accounts_by_owner_with_commitment(
+                owner,
+                token_account_filter,
+                commitment_config,
+            ),
+        )
     }
 
     pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
-        self.invoke(self.rpc_client.get_token_supply(mint))
+        self.invoke((self.rpc_client.as_ref()).get_token_supply(mint))
     }
 
     pub fn get_token_supply_with_commitment(
@@ -3972,13 +3915,12 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<UiTokenAmount> {
         self.invoke(
-            self.rpc_client
-                .get_token_supply_with_commitment(mint, commitment_config),
+            (self.rpc_client.as_ref()).get_token_supply_with_commitment(mint, commitment_config),
         )
     }
 
     pub fn request_airdrop(&self, pubkey: &Pubkey, lamports: u64) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.request_airdrop(pubkey, lamports))
+        self.invoke((self.rpc_client.as_ref()).request_airdrop(pubkey, lamports))
     }
 
     pub fn request_airdrop_with_blockhash(
@@ -3987,7 +3929,7 @@ impl RpcClient {
         lamports: u64,
         recent_blockhash: &Hash,
     ) -> ClientResult<Signature> {
-        self.invoke(self.rpc_client.request_airdrop_with_blockhash(
+        self.invoke((self.rpc_client.as_ref()).request_airdrop_with_blockhash(
             pubkey,
             lamports,
             recent_blockhash,
@@ -4001,8 +3943,7 @@ impl RpcClient {
         config: RpcRequestAirdropConfig,
     ) -> ClientResult<Signature> {
         self.invoke(
-            self.rpc_client
-                .request_airdrop_with_config(pubkey, lamports, config),
+            (self.rpc_client.as_ref()).request_airdrop_with_config(pubkey, lamports, config),
         )
     }
 
@@ -4012,8 +3953,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
         self.invoke(
-            self.rpc_client
-                .poll_get_balance_with_commitment(pubkey, commitment_config),
+            (self.rpc_client.as_ref()).poll_get_balance_with_commitment(pubkey, commitment_config),
         )
     }
 
@@ -4023,7 +3963,7 @@ impl RpcClient {
         expected_balance: Option<u64>,
         commitment_config: CommitmentConfig,
     ) -> Option<u64> {
-        self.invoke(self.rpc_client.wait_for_balance_with_commitment(
+        self.invoke((self.rpc_client.as_ref()).wait_for_balance_with_commitment(
             pubkey,
             expected_balance,
             commitment_config,
@@ -4033,7 +3973,7 @@ impl RpcClient {
 
     /// Poll the server to confirm a transaction.
     pub fn poll_for_signature(&self, signature: &Signature) -> ClientResult<()> {
-        self.invoke(self.rpc_client.poll_for_signature(signature))
+        self.invoke((self.rpc_client.as_ref()).poll_for_signature(signature))
     }
 
     /// Poll the server to confirm a transaction.
@@ -4043,7 +3983,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<()> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .poll_for_signature_with_commitment(signature, commitment_config),
         )
     }
@@ -4055,7 +3995,7 @@ impl RpcClient {
         min_confirmed_blocks: usize,
     ) -> ClientResult<usize> {
         self.invoke(
-            self.rpc_client
+            (self.rpc_client.as_ref())
                 .poll_for_signature_confirmation(signature, min_confirmed_blocks),
         )
     }
@@ -4065,13 +4005,12 @@ impl RpcClient {
         signature: &Signature,
     ) -> ClientResult<usize> {
         self.invoke(
-            self.rpc_client
-                .get_num_blocks_since_signature_confirmation(signature),
+            (self.rpc_client.as_ref()).get_num_blocks_since_signature_confirmation(signature),
         )
     }
 
     pub fn get_latest_blockhash(&self) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_latest_blockhash())
+        self.invoke((self.rpc_client.as_ref()).get_latest_blockhash())
     }
 
     #[allow(deprecated)]
@@ -4079,10 +4018,7 @@ impl RpcClient {
         &self,
         commitment: CommitmentConfig,
     ) -> ClientResult<(Hash, u64)> {
-        self.invoke(
-            self.rpc_client
-                .get_latest_blockhash_with_commitment(commitment),
-        )
+        self.invoke((self.rpc_client.as_ref()).get_latest_blockhash_with_commitment(commitment))
     }
 
     #[allow(deprecated)]
@@ -4091,20 +4027,20 @@ impl RpcClient {
         blockhash: &Hash,
         commitment: CommitmentConfig,
     ) -> ClientResult<bool> {
-        self.invoke(self.rpc_client.is_blockhash_valid(blockhash, commitment))
+        self.invoke((self.rpc_client.as_ref()).is_blockhash_valid(blockhash, commitment))
     }
 
     #[allow(deprecated)]
     pub fn get_fee_for_message(&self, message: &Message) -> ClientResult<u64> {
-        self.invoke(self.rpc_client.get_fee_for_message(message))
+        self.invoke((self.rpc_client.as_ref()).get_fee_for_message(message))
     }
 
     pub fn get_new_latest_blockhash(&self, blockhash: &Hash) -> ClientResult<Hash> {
-        self.invoke(self.rpc_client.get_new_latest_blockhash(blockhash))
+        self.invoke((self.rpc_client.as_ref()).get_new_latest_blockhash(blockhash))
     }
 
     pub fn get_transport_stats(&self) -> RpcTransportStats {
-        self.rpc_client.get_transport_stats()
+        (self.rpc_client.as_ref()).get_transport_stats()
     }
 
     fn invoke<T, F: std::future::Future<Output = ClientResult<T>>>(&self, f: F) -> ClientResult<T> {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -155,13 +155,10 @@ pub struct RpcClient {
     runtime: Arc<tokio::runtime::Runtime>,
 }
 
-pub struct RuntimeWrapper {
-    runtime: Arc<tokio::runtime::Runtime>,
-}
-
 impl Drop for RpcClient {
     fn drop(&mut self) {
-        self.runtime.shutdown_background();
+        //todo: figure out what do do about thiss
+        //self.runtime.shutdown_background();
     }
 }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -152,12 +152,12 @@ pub struct GetConfirmedSignaturesForAddress2Config {
 /// [`ClientErrorKind::Reqwest`]: crate::client_error::ClientErrorKind::Reqwest
 pub struct RpcClient {
     rpc_client: Arc<nonblocking::rpc_client::RpcClient>,
-    runtime: Arc<tokio::runtime::Runtime>,
+    runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl Drop for RpcClient {
     fn drop(&mut self) {
-        self.runtime.shutdown_background();
+        self.runtime.take().expect("runtime").shutdown_background();
     }
 }
 
@@ -176,7 +176,7 @@ impl RpcClient {
             rpc_client: Arc::new(nonblocking::rpc_client::RpcClient::new_sender(
                 sender, config,
             )),
-            runtime: Arc::new(
+            runtime: Some(
                 tokio::runtime::Builder::new_current_thread()
                     .thread_name("rpc-client")
                     .enable_io()
@@ -189,10 +189,6 @@ impl RpcClient {
 
     pub(crate) fn get_nonblocking_client(&self) -> Arc<nonblocking::rpc_client::RpcClient> {
         self.rpc_client.clone()
-    }
-
-    pub(crate) fn get_runtime(&self) -> Arc<tokio::runtime::Runtime> {
-        self.runtime.clone()
     }
 
     /// Create an HTTP `RpcClient`.
@@ -4051,7 +4047,7 @@ impl RpcClient {
         // `block_on()` panics if called within an asynchronous execution context. Whereas
         // `block_in_place()` only panics if called from a current_thread runtime, which is the
         // lesser evil.
-        tokio::task::block_in_place(move || self.runtime.as_ref().block_on(f))
+        tokio::task::block_in_place(move || self.runtime.as_ref().expect("runtime").block_on(f))
     }
 }
 

--- a/client/src/rpc_sender.rs
+++ b/client/src/rpc_sender.rs
@@ -33,4 +33,5 @@ pub trait RpcSender {
     ) -> Result<serde_json::Value>;
     fn get_transport_stats(&self) -> RpcTransportStats;
     fn url(&self) -> String;
+    fn clone(&self) -> Box<dyn RpcSender + Send + Sync + 'static>;
 }

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -1,54 +1,24 @@
+pub use crate::nonblocking::tpu_client::TpuSenderError;
 use {
     crate::{
-        client_error::{ClientError, Result as ClientResult},
         connection_cache::ConnectionCache,
-        pubsub_client::{PubsubClient, PubsubClientError, PubsubClientSubscription},
-        rpc_client::RpcClient,
-        rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
-        rpc_response::{RpcContactInfo, SlotUpdate},
-        spinner,
-        tpu_connection::TpuConnection,
+        nonblocking::tpu_client::TpuClient as NonblockingTpuClient, rpc_client::RpcClient,
     },
-    bincode::serialize,
-    log::*,
+    lazy_static::lazy_static,
     solana_sdk::{
         clock::Slot,
-        commitment_config::CommitmentConfig,
-        epoch_info::EpochInfo,
         message::Message,
-        pubkey::Pubkey,
-        signature::SignerError,
         signers::Signers,
         transaction::{Transaction, TransactionError},
-        transport::{Result as TransportResult, TransportError},
+        transport::Result as TransportResult,
     },
     std::{
-        collections::{HashMap, HashSet, VecDeque},
-        net::{SocketAddr, UdpSocket},
-        str::FromStr,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc, RwLock,
-        },
-        thread::{sleep, JoinHandle},
+        collections::VecDeque,
+        net::UdpSocket,
+        sync::{Arc, RwLock},
     },
-    thiserror::Error,
-    tokio::time::{Duration, Instant},
+    tokio::{runtime::Runtime, time::Duration},
 };
-
-#[derive(Error, Debug)]
-pub enum TpuSenderError {
-    #[error("Pubsub error: {0:?}")]
-    PubsubError(#[from] PubsubClientError),
-    #[error("RPC error: {0:?}")]
-    RpcError(#[from] ClientError),
-    #[error("IO error: {0:?}")]
-    IoError(#[from] std::io::Error),
-    #[error("Signer error: {0:?}")]
-    SignerError(#[from] SignerError),
-    #[error("Custom error: {0}")]
-    Custom(String),
-}
 
 type Result<T> = std::result::Result<T, TpuSenderError>;
 
@@ -79,65 +49,54 @@ impl Default for TpuClientConfig {
     }
 }
 
+//todo: does this need to be multithreaded?
+lazy_static! {
+    static ref RUNTIME: Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+}
+
 /// Client which sends transactions directly to the current leader's TPU port over UDP.
 /// The client uses RPC to determine the current leader and fetch node contact info
 pub struct TpuClient {
     _deprecated: UdpSocket, // TpuClient now uses the connection_cache to choose a send_socket
-    fanout_slots: u64,
-    leader_tpu_service: LeaderTpuService,
-    exit: Arc<AtomicBool>,
+    //todo: get rid of this field
     rpc_client: Arc<RpcClient>,
-    connection_cache: Arc<ConnectionCache>,
+    tpu_client: Arc<NonblockingTpuClient>,
 }
 
 impl TpuClient {
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     pub fn send_transaction(&self, transaction: &Transaction) -> bool {
-        let wire_transaction = serialize(transaction).expect("serialization should succeed");
-        self.send_wire_transaction(wire_transaction)
+        let _guard = RUNTIME.enter();
+        let send_transaction = self.tpu_client.send_transaction(transaction);
+        RUNTIME.block_on(send_transaction)
     }
 
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     pub fn send_wire_transaction(&self, wire_transaction: Vec<u8>) -> bool {
-        self.try_send_wire_transaction(wire_transaction).is_ok()
+        let _guard = RUNTIME.enter();
+        let send_wire_transaction = self.tpu_client.send_wire_transaction(wire_transaction);
+        RUNTIME.block_on(send_wire_transaction)
     }
 
     /// Serialize and send transaction to the current and upcoming leader TPUs according to fanout
     /// size
     /// Returns the last error if all sends fail
     pub fn try_send_transaction(&self, transaction: &Transaction) -> TransportResult<()> {
-        let wire_transaction = serialize(transaction).expect("serialization should succeed");
-        self.try_send_wire_transaction(wire_transaction)
+        let _guard = RUNTIME.enter();
+        let try_send_transaction = self.tpu_client.try_send_transaction(transaction);
+        RUNTIME.block_on(try_send_transaction)
     }
 
     /// Send a wire transaction to the current and upcoming leader TPUs according to fanout size
     /// Returns the last error if all sends fail
-    fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
-        let mut last_error: Option<TransportError> = None;
-        let mut some_success = false;
-
-        for tpu_address in self
-            .leader_tpu_service
-            .leader_tpu_sockets(self.fanout_slots)
-        {
-            let conn = self.connection_cache.get_connection(&tpu_address);
-            let result = conn.send_wire_transaction_async(wire_transaction.clone());
-            if let Err(err) = result {
-                last_error = Some(err);
-            } else {
-                some_success = true;
-            }
-        }
-        if !some_success {
-            Err(if let Some(err) = last_error {
-                err
-            } else {
-                std::io::Error::new(std::io::ErrorKind::Other, "No sends attempted").into()
-            })
-        } else {
-            Ok(())
-        }
+    pub fn try_send_wire_transaction(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
+        let _guard = RUNTIME.enter();
+        let try_send_wire_transaction = self.tpu_client.try_send_wire_transaction(wire_transaction);
+        RUNTIME.block_on(try_send_wire_transaction)
     }
 
     /// Create a new client that disconnects when dropped
@@ -146,8 +105,18 @@ impl TpuClient {
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let connection_cache = Arc::new(ConnectionCache::default());
-        Self::new_with_connection_cache(rpc_client, websocket_url, config, connection_cache)
+        let _guard = RUNTIME.enter();
+
+        let create_tpu_client =
+            NonblockingTpuClient::new(rpc_client.get_nonblocking_client(), websocket_url, config);
+
+        let tpu_client = RUNTIME.block_on(create_tpu_client)?;
+
+        Ok(Self {
+            _deprecated: UdpSocket::bind("0.0.0.0:0").unwrap(),
+            rpc_client,
+            tpu_client: Arc::new(tpu_client),
+        })
     }
 
     /// Create a new client that disconnects when dropped
@@ -157,17 +126,21 @@ impl TpuClient {
         config: TpuClientConfig,
         connection_cache: Arc<ConnectionCache>,
     ) -> Result<Self> {
-        let exit = Arc::new(AtomicBool::new(false));
-        let leader_tpu_service =
-            LeaderTpuService::new(rpc_client.clone(), websocket_url, exit.clone())?;
+        let _guard = RUNTIME.enter();
+
+        let create_tpu_client = NonblockingTpuClient::new_with_connection_cache(
+            rpc_client.get_nonblocking_client(),
+            websocket_url,
+            config,
+            connection_cache,
+        );
+
+        let tpu_client = RUNTIME.block_on(create_tpu_client)?;
 
         Ok(Self {
             _deprecated: UdpSocket::bind("0.0.0.0:0").unwrap(),
-            fanout_slots: config.fanout_slots.min(MAX_FANOUT_SLOTS).max(1),
-            leader_tpu_service,
-            exit,
             rpc_client,
-            connection_cache,
+            tpu_client: Arc::new(tpu_client),
         })
     }
 
@@ -176,332 +149,15 @@ impl TpuClient {
         messages: &[Message],
         signers: &T,
     ) -> Result<Vec<Option<TransactionError>>> {
-        let mut expired_blockhash_retries = 5;
-
-        let progress_bar = spinner::new_progress_bar();
-        progress_bar.set_message("Setting up...");
-
-        let mut transactions = messages
-            .iter()
-            .enumerate()
-            .map(|(i, message)| (i, Transaction::new_unsigned(message.clone())))
-            .collect::<Vec<_>>();
-        let total_transactions = transactions.len();
-        let mut transaction_errors = vec![None; transactions.len()];
-        let mut confirmed_transactions = 0;
-        let mut block_height = self.rpc_client.get_block_height()?;
-
-        while expired_blockhash_retries > 0 {
-            let (blockhash, last_valid_block_height) = self
-                .rpc_client
-                .get_latest_blockhash_with_commitment(self.rpc_client.commitment())?;
-
-            let mut pending_transactions = HashMap::new();
-            for (i, mut transaction) in transactions {
-                transaction.try_sign(signers, blockhash)?;
-                pending_transactions.insert(transaction.signatures[0], (i, transaction));
-            }
-
-            let mut last_resend = Instant::now() - TRANSACTION_RESEND_INTERVAL;
-            while block_height <= last_valid_block_height {
-                let num_transactions = pending_transactions.len();
-
-                // Periodically re-send all pending transactions
-                if Instant::now().duration_since(last_resend) > TRANSACTION_RESEND_INTERVAL {
-                    for (index, (_i, transaction)) in pending_transactions.values().enumerate() {
-                        if !self.send_transaction(transaction) {
-                            let _result = self.rpc_client.send_transaction(transaction).ok();
-                        }
-                        spinner::set_message_for_confirmed_transactions(
-                            &progress_bar,
-                            confirmed_transactions,
-                            total_transactions,
-                            None, //block_height,
-                            last_valid_block_height,
-                            &format!("Sending {}/{} transactions", index + 1, num_transactions,),
-                        );
-                        sleep(SEND_TRANSACTION_INTERVAL);
-                    }
-                    last_resend = Instant::now();
-                }
-
-                // Wait for the next block before checking for transaction statuses
-                let mut block_height_refreshes = 10;
-                spinner::set_message_for_confirmed_transactions(
-                    &progress_bar,
-                    confirmed_transactions,
-                    total_transactions,
-                    Some(block_height),
-                    last_valid_block_height,
-                    &format!("Waiting for next block, {} pending...", num_transactions),
-                );
-                let mut new_block_height = block_height;
-                while block_height == new_block_height && block_height_refreshes > 0 {
-                    sleep(Duration::from_millis(500));
-                    new_block_height = self.rpc_client.get_block_height()?;
-                    block_height_refreshes -= 1;
-                }
-                block_height = new_block_height;
-
-                // Collect statuses for the transactions, drop those that are confirmed
-                let pending_signatures = pending_transactions.keys().cloned().collect::<Vec<_>>();
-                for pending_signatures_chunk in
-                    pending_signatures.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
-                {
-                    if let Ok(result) = self
-                        .rpc_client
-                        .get_signature_statuses(pending_signatures_chunk)
-                    {
-                        let statuses = result.value;
-                        for (signature, status) in
-                            pending_signatures_chunk.iter().zip(statuses.into_iter())
-                        {
-                            if let Some(status) = status {
-                                if status.satisfies_commitment(self.rpc_client.commitment()) {
-                                    if let Some((i, _)) = pending_transactions.remove(signature) {
-                                        confirmed_transactions += 1;
-                                        if status.err.is_some() {
-                                            progress_bar.println(format!(
-                                                "Failed transaction: {:?}",
-                                                status
-                                            ));
-                                        }
-                                        transaction_errors[i] = status.err;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    spinner::set_message_for_confirmed_transactions(
-                        &progress_bar,
-                        confirmed_transactions,
-                        total_transactions,
-                        Some(block_height),
-                        last_valid_block_height,
-                        "Checking transaction status...",
-                    );
-                }
-
-                if pending_transactions.is_empty() {
-                    return Ok(transaction_errors);
-                }
-            }
-
-            transactions = pending_transactions.into_iter().map(|(_k, v)| v).collect();
-            progress_bar.println(format!(
-                "Blockhash expired. {} retries remaining",
-                expired_blockhash_retries
-            ));
-            expired_blockhash_retries -= 1;
-        }
-        Err(TpuSenderError::Custom("Max retries exceeded".into()))
+        let _guard = RUNTIME.enter();
+        let send_and_confirm_messages_with_spinner = self
+            .tpu_client
+            .send_and_confirm_messages_with_spinner(messages, signers);
+        RUNTIME.block_on(send_and_confirm_messages_with_spinner)
     }
 
     pub fn rpc_client(&self) -> &RpcClient {
         &self.rpc_client
-    }
-}
-
-impl Drop for TpuClient {
-    fn drop(&mut self) {
-        self.exit.store(true, Ordering::Relaxed);
-        self.leader_tpu_service.join();
-    }
-}
-
-pub(crate) struct LeaderTpuCacheUpdateInfo {
-    pub(crate) maybe_cluster_nodes: Option<ClientResult<Vec<RpcContactInfo>>>,
-    pub(crate) maybe_epoch_info: Option<ClientResult<EpochInfo>>,
-    pub(crate) maybe_slot_leaders: Option<ClientResult<Vec<Pubkey>>>,
-}
-impl LeaderTpuCacheUpdateInfo {
-    pub(crate) fn has_some(&self) -> bool {
-        self.maybe_cluster_nodes.is_some()
-            || self.maybe_epoch_info.is_some()
-            || self.maybe_slot_leaders.is_some()
-    }
-}
-
-pub(crate) struct LeaderTpuCache {
-    first_slot: Slot,
-    leaders: Vec<Pubkey>,
-    leader_tpu_map: HashMap<Pubkey, SocketAddr>,
-    slots_in_epoch: Slot,
-    last_epoch_info_slot: Slot,
-}
-
-impl LeaderTpuCache {
-    pub(crate) fn new(
-        first_slot: Slot,
-        slots_in_epoch: Slot,
-        leaders: Vec<Pubkey>,
-        cluster_nodes: Vec<RpcContactInfo>,
-    ) -> Self {
-        let leader_tpu_map = Self::extract_cluster_tpu_sockets(cluster_nodes);
-        Self {
-            first_slot,
-            leaders,
-            leader_tpu_map,
-            slots_in_epoch,
-            last_epoch_info_slot: first_slot,
-        }
-    }
-
-    // Last slot that has a cached leader pubkey
-    pub(crate) fn last_slot(&self) -> Slot {
-        self.first_slot + self.leaders.len().saturating_sub(1) as u64
-    }
-
-    pub(crate) fn slot_info(&self) -> (Slot, Slot, Slot) {
-        (
-            self.last_slot(),
-            self.last_epoch_info_slot,
-            self.slots_in_epoch,
-        )
-    }
-
-    // Get the TPU sockets for the current leader and upcoming leaders according to fanout size
-    pub(crate) fn get_leader_sockets(
-        &self,
-        current_slot: Slot,
-        fanout_slots: u64,
-    ) -> Vec<SocketAddr> {
-        let mut leader_set = HashSet::new();
-        let mut leader_sockets = Vec::new();
-        for leader_slot in current_slot..current_slot + fanout_slots {
-            if let Some(leader) = self.get_slot_leader(leader_slot) {
-                if let Some(tpu_socket) = self.leader_tpu_map.get(leader) {
-                    if leader_set.insert(*leader) {
-                        leader_sockets.push(*tpu_socket);
-                    }
-                } else {
-                    // The leader is probably delinquent
-                    trace!("TPU not available for leader {}", leader);
-                }
-            } else {
-                // Overran the local leader schedule cache
-                warn!(
-                    "Leader not known for slot {}; cache holds slots [{},{}]",
-                    leader_slot,
-                    self.first_slot,
-                    self.last_slot()
-                );
-            }
-        }
-        leader_sockets
-    }
-
-    pub(crate) fn get_slot_leader(&self, slot: Slot) -> Option<&Pubkey> {
-        if slot >= self.first_slot {
-            let index = slot - self.first_slot;
-            self.leaders.get(index as usize)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn extract_cluster_tpu_sockets(
-        cluster_contact_info: Vec<RpcContactInfo>,
-    ) -> HashMap<Pubkey, SocketAddr> {
-        cluster_contact_info
-            .into_iter()
-            .filter_map(|contact_info| {
-                Some((
-                    Pubkey::from_str(&contact_info.pubkey).ok()?,
-                    contact_info.tpu?,
-                ))
-            })
-            .collect()
-    }
-
-    pub(crate) fn fanout(slots_in_epoch: Slot) -> Slot {
-        (2 * MAX_FANOUT_SLOTS).min(slots_in_epoch)
-    }
-
-    pub(crate) fn update_all(
-        &mut self,
-        estimated_current_slot: Slot,
-        cache_update_info: LeaderTpuCacheUpdateInfo,
-    ) -> (bool, bool) {
-        let mut has_error = false;
-        let mut cluster_refreshed = false;
-        if let Some(cluster_nodes) = cache_update_info.maybe_cluster_nodes {
-            match cluster_nodes {
-                Ok(cluster_nodes) => {
-                    let leader_tpu_map = LeaderTpuCache::extract_cluster_tpu_sockets(cluster_nodes);
-                    self.leader_tpu_map = leader_tpu_map;
-                    cluster_refreshed = true;
-                }
-                Err(err) => {
-                    warn!("Failed to fetch cluster tpu sockets: {}", err);
-                    has_error = true;
-                }
-            }
-        }
-
-        if let Some(Ok(epoch_info)) = cache_update_info.maybe_epoch_info {
-            self.slots_in_epoch = epoch_info.slots_in_epoch;
-            self.last_epoch_info_slot = estimated_current_slot;
-        }
-
-        if let Some(slot_leaders) = cache_update_info.maybe_slot_leaders {
-            match slot_leaders {
-                Ok(slot_leaders) => {
-                    self.first_slot = estimated_current_slot;
-                    self.leaders = slot_leaders;
-                }
-                Err(err) => {
-                    warn!(
-                        "Failed to fetch slot leaders (current estimated slot: {}): {}",
-                        estimated_current_slot, err
-                    );
-                    has_error = true;
-                }
-            }
-        }
-        (has_error, cluster_refreshed)
-    }
-}
-
-fn maybe_fetch_cache_info(
-    leader_tpu_cache: &Arc<RwLock<LeaderTpuCache>>,
-    last_cluster_refresh: Instant,
-    rpc_client: &RpcClient,
-    recent_slots: &RecentLeaderSlots,
-) -> LeaderTpuCacheUpdateInfo {
-    // Refresh cluster TPU ports every 5min in case validators restart with new port configuration
-    // or new validators come online
-    let maybe_cluster_nodes = if last_cluster_refresh.elapsed() > Duration::from_secs(5 * 60) {
-        Some(rpc_client.get_cluster_nodes())
-    } else {
-        None
-    };
-
-    let estimated_current_slot = recent_slots.estimated_current_slot();
-    let (last_slot, last_epoch_info_slot, slots_in_epoch) = {
-        let leader_tpu_cache = leader_tpu_cache.read().unwrap();
-        leader_tpu_cache.slot_info()
-    };
-    let maybe_epoch_info =
-        if estimated_current_slot >= last_epoch_info_slot.saturating_sub(slots_in_epoch) {
-            Some(rpc_client.get_epoch_info())
-        } else {
-            None
-        };
-
-    let maybe_slot_leaders = if estimated_current_slot >= last_slot.saturating_sub(MAX_FANOUT_SLOTS)
-    {
-        Some(rpc_client.get_slot_leaders(
-            estimated_current_slot,
-            LeaderTpuCache::fanout(slots_in_epoch),
-        ))
-    } else {
-        None
-    };
-    LeaderTpuCacheUpdateInfo {
-        maybe_cluster_nodes,
-        maybe_epoch_info,
-        maybe_slot_leaders,
     }
 }
 
@@ -556,126 +212,6 @@ impl From<Vec<Slot>> for RecentLeaderSlots {
     fn from(recent_slots: Vec<Slot>) -> Self {
         assert!(!recent_slots.is_empty());
         Self(Arc::new(RwLock::new(recent_slots.into_iter().collect())))
-    }
-}
-
-/// Service that tracks upcoming leaders and maintains an up-to-date mapping
-/// of leader id to TPU socket address.
-struct LeaderTpuService {
-    recent_slots: RecentLeaderSlots,
-    leader_tpu_cache: Arc<RwLock<LeaderTpuCache>>,
-    subscription: Option<PubsubClientSubscription<SlotUpdate>>,
-    t_leader_tpu_service: Option<JoinHandle<()>>,
-}
-
-impl LeaderTpuService {
-    fn new(rpc_client: Arc<RpcClient>, websocket_url: &str, exit: Arc<AtomicBool>) -> Result<Self> {
-        let start_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::processed())?;
-
-        let recent_slots = RecentLeaderSlots::new(start_slot);
-        let slots_in_epoch = rpc_client.get_epoch_info()?.slots_in_epoch;
-        let leaders =
-            rpc_client.get_slot_leaders(start_slot, LeaderTpuCache::fanout(slots_in_epoch))?;
-        let cluster_nodes = rpc_client.get_cluster_nodes()?;
-        let leader_tpu_cache = Arc::new(RwLock::new(LeaderTpuCache::new(
-            start_slot,
-            slots_in_epoch,
-            leaders,
-            cluster_nodes,
-        )));
-
-        let subscription = if !websocket_url.is_empty() {
-            let recent_slots = recent_slots.clone();
-            Some(PubsubClient::slot_updates_subscribe(
-                websocket_url,
-                move |update| {
-                    let current_slot = match update {
-                        // This update indicates that a full slot was received by the connected
-                        // node so we can stop sending transactions to the leader for that slot
-                        SlotUpdate::Completed { slot, .. } => slot.saturating_add(1),
-                        // This update indicates that we have just received the first shred from
-                        // the leader for this slot and they are probably still accepting transactions.
-                        SlotUpdate::FirstShredReceived { slot, .. } => slot,
-                        _ => return,
-                    };
-                    recent_slots.record_slot(current_slot);
-                },
-            )?)
-        } else {
-            None
-        };
-
-        let t_leader_tpu_service = Some({
-            let recent_slots = recent_slots.clone();
-            let leader_tpu_cache = leader_tpu_cache.clone();
-            std::thread::Builder::new()
-                .name("ldr-tpu-srv".to_string())
-                .spawn(move || Self::run(rpc_client, recent_slots, leader_tpu_cache, exit))
-                .unwrap()
-        });
-
-        Ok(LeaderTpuService {
-            recent_slots,
-            leader_tpu_cache,
-            subscription,
-            t_leader_tpu_service,
-        })
-    }
-
-    fn join(&mut self) {
-        if let Some(mut subscription) = self.subscription.take() {
-            let _ = subscription.send_unsubscribe();
-            let _ = subscription.shutdown();
-        }
-        if let Some(t_handle) = self.t_leader_tpu_service.take() {
-            t_handle.join().unwrap();
-        }
-    }
-
-    fn leader_tpu_sockets(&self, fanout_slots: u64) -> Vec<SocketAddr> {
-        let current_slot = self.recent_slots.estimated_current_slot();
-        self.leader_tpu_cache
-            .read()
-            .unwrap()
-            .get_leader_sockets(current_slot, fanout_slots)
-    }
-
-    fn run(
-        rpc_client: Arc<RpcClient>,
-        recent_slots: RecentLeaderSlots,
-        leader_tpu_cache: Arc<RwLock<LeaderTpuCache>>,
-        exit: Arc<AtomicBool>,
-    ) {
-        let mut last_cluster_refresh = Instant::now();
-        let mut sleep_ms = 1000;
-        loop {
-            if exit.load(Ordering::Relaxed) {
-                break;
-            }
-
-            // Sleep a few slots before checking if leader cache needs to be refreshed again
-            sleep(Duration::from_millis(sleep_ms));
-            sleep_ms = 1000;
-
-            let cache_update_info = maybe_fetch_cache_info(
-                &leader_tpu_cache,
-                last_cluster_refresh,
-                &rpc_client,
-                &recent_slots,
-            );
-
-            if cache_update_info.has_some() {
-                let mut leader_tpu_cache = leader_tpu_cache.write().unwrap();
-                let (has_error, cluster_refreshed) = leader_tpu_cache
-                    .update_all(recent_slots.estimated_current_slot(), cache_update_info);
-                if has_error {
-                    sleep_ms = 100;
-                }
-                if cluster_refreshed {
-                    last_cluster_refresh = Instant::now();
-                }
-            }
-        }
     }
 }
 

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -4,7 +4,6 @@ use {
         connection_cache::ConnectionCache,
         nonblocking::tpu_client::TpuClient as NonblockingTpuClient, rpc_client::RpcClient,
     },
-    lazy_static::lazy_static,
     solana_sdk::{
         clock::Slot,
         message::Message,
@@ -109,7 +108,7 @@ impl TpuClient {
             _deprecated: UdpSocket::bind("0.0.0.0:0").unwrap(),
             rpc_client,
             tpu_client: Arc::new(tpu_client),
-            runtime
+            runtime,
         })
     }
 
@@ -120,7 +119,6 @@ impl TpuClient {
         config: TpuClientConfig,
         connection_cache: Arc<ConnectionCache>,
     ) -> Result<Self> {
-
         let create_tpu_client = NonblockingTpuClient::new_with_connection_cache(
             rpc_client.get_nonblocking_client(),
             websocket_url,
@@ -136,7 +134,7 @@ impl TpuClient {
             _deprecated: UdpSocket::bind("0.0.0.0:0").unwrap(),
             rpc_client,
             tpu_client: Arc::new(tpu_client),
-            runtime
+            runtime,
         })
     }
 
@@ -149,7 +147,8 @@ impl TpuClient {
         let send_and_confirm_messages_with_spinner = self
             .tpu_client
             .send_and_confirm_messages_with_spinner(messages, signers);
-        self.runtime.block_on(send_and_confirm_messages_with_spinner)
+        self.runtime
+            .block_on(send_and_confirm_messages_with_spinner)
     }
 
     pub fn rpc_client(&self) -> &RpcClient {

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -97,15 +97,21 @@ impl TpuClient {
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let create_tpu_client =
-            async {NonblockingTpuClient::new(Arc::new(rpc_client.get_nonblocking_client().copy().await), websocket_url, config).await};
+        let create_tpu_client = async {
+            NonblockingTpuClient::new(
+                Arc::new(rpc_client.get_nonblocking_client().copy().await),
+                websocket_url,
+                config,
+            )
+            .await
+        };
 
         let runtime = tokio::runtime::Builder::new_current_thread()
-        .thread_name("tpu-client")
-        .enable_io()
-        .enable_time()
-        .build()
-        .unwrap();//rpc_client.get_runtime();
+            .thread_name("tpu-client")
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap(); //rpc_client.get_runtime();
         let _guard = runtime.enter();
         let tpu_client = runtime.block_on(create_tpu_client)?;
 
@@ -124,19 +130,22 @@ impl TpuClient {
         config: TpuClientConfig,
         connection_cache: Arc<ConnectionCache>,
     ) -> Result<Self> {
-        let create_tpu_client = async {NonblockingTpuClient::new_with_connection_cache(
-            Arc::new(rpc_client.get_nonblocking_client().copy().await),
-            websocket_url,
-            config,
-            connection_cache,
-        ).await};
+        let create_tpu_client = async {
+            NonblockingTpuClient::new_with_connection_cache(
+                Arc::new(rpc_client.get_nonblocking_client().copy().await),
+                websocket_url,
+                config,
+                connection_cache,
+            )
+            .await
+        };
 
         let runtime = tokio::runtime::Builder::new_current_thread()
-        .thread_name("tpu-client")
-        .enable_io()
-        .enable_time()
-        .build()
-        .unwrap();
+            .thread_name("tpu-client")
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
         let _guard = runtime.enter();
         let tpu_client = runtime.block_on(create_tpu_client)?;
 

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -97,14 +97,10 @@ impl TpuClient {
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let create_tpu_client = async {
-            NonblockingTpuClient::new(
-                Arc::new(rpc_client.get_nonblocking_client().copy().await),
-                websocket_url,
-                config,
-            )
-            .await
-        };
+        let nonblocking_rpc_client = rpc_client.get_nonblocking_client_copy();
+
+        let create_tpu_client =
+            NonblockingTpuClient::new(nonblocking_rpc_client, websocket_url, config);
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .thread_name("tpu-client")
@@ -130,15 +126,14 @@ impl TpuClient {
         config: TpuClientConfig,
         connection_cache: Arc<ConnectionCache>,
     ) -> Result<Self> {
-        let create_tpu_client = async {
-            NonblockingTpuClient::new_with_connection_cache(
-                Arc::new(rpc_client.get_nonblocking_client().copy().await),
-                websocket_url,
-                config,
-                connection_cache,
-            )
-            .await
-        };
+        let nonblocking_rpc_client = rpc_client.get_nonblocking_client_copy();
+
+        let create_tpu_client = NonblockingTpuClient::new_with_connection_cache(
+            nonblocking_rpc_client,
+            websocket_url,
+            config,
+            connection_cache,
+        );
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .thread_name("tpu-client")


### PR DESCRIPTION
#### Problem
We currently have a lot of duplication of code between the sync and async TPU clients

#### Summary of Changes
Make the sync TPU client use the async TPU client

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
