### PR TITLE
Include forwarding counters in leader slot metrics

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1148,9 +1148,9 @@ impl BankingStage {
                             let poh = poh_recorder.lock().unwrap();
                             poh.bank_start()
                         };
-                        slot_metrics_tracker.apply_action(
-                            slot_metrics_tracker.check_leader_slot_boundary(&current_poh_bank),
-                        );
+                        let metrics_action =
+                            slot_metrics_tracker.check_leader_slot_boundary(&current_poh_bank);
+                        slot_metrics_tracker.apply_action(metrics_action);
                     },
                     "slot_metrics_checker_check_slot_boundary",
                 );

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -284,8 +284,8 @@ impl LeaderSlotMetrics {
         }
     }
 
-    fn slot_end_detected(&mut self) {
-        self.timing_metrics.slot_end_detected();
+    fn mark_slot_end_detected(&mut self) {
+        self.timing_metrics.mark_slot_end_detected();
     }
 }
 
@@ -322,7 +322,7 @@ impl LeaderSlotMetricsTracker {
             (None, None) => MetricsTrackerAction::Noop,
 
             (Some(leader_slot_metrics), None) => {
-                leader_slot_metrics.slot_end_detected();
+                leader_slot_metrics.mark_slot_end_detected();
                 MetricsTrackerAction::ReportAndResetTracker
             }
 
@@ -338,7 +338,7 @@ impl LeaderSlotMetricsTracker {
             (Some(leader_slot_metrics), Some(bank_start)) => {
                 if leader_slot_metrics.slot != bank_start.working_bank.slot() {
                     // Last slot has ended, new slot has began
-                    leader_slot_metrics.slot_end_detected();
+                    leader_slot_metrics.mark_slot_end_detected();
                     MetricsTrackerAction::ReportAndNewTracker(Some(LeaderSlotMetrics::new(
                         self.id,
                         bank_start.working_bank.slot(),

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -309,7 +309,7 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    // check leader slot, return MetricsTrackerAction to be applied by apply_action()
+    // Check leader slot, return MetricsTrackerAction to be applied by apply_action()
     pub(crate) fn check_leader_slot_boundary(
         &self,
         bank_start: &Option<BankStart>,

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -616,18 +616,6 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    pub(crate) fn increment_slot_metrics_check_slot_boundary_us(&mut self, us: u64) {
-        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
-            saturating_add_assign!(
-                leader_slot_metrics
-                    .timing_metrics
-                    .outer_loop_timings
-                    .slot_metrics_check_slot_boundary_us,
-                us
-            );
-        }
-    }
-
     pub(crate) fn increment_receive_and_buffer_packets_us(&mut self, us: u64) {
         if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
             saturating_add_assign!(

--- a/core/src/leader_slot_banking_stage_timing_metrics.rs
+++ b/core/src/leader_slot_banking_stage_timing_metrics.rs
@@ -133,9 +133,6 @@ pub(crate) struct OuterLoopTimings {
     // Time spent processing buffered packets
     pub process_buffered_packets_us: u64,
 
-    // Time spent checking for slot boundary and reporting leader slot metrics
-    pub slot_metrics_check_slot_boundary_us: u64,
-
     // Time spent processing new incoming packets to the banking thread
     pub receive_and_buffer_packets_us: u64,
 
@@ -153,7 +150,6 @@ impl OuterLoopTimings {
             bank_detected_time: Instant::now(),
             bank_detected_delay_us: bank_creation_time.elapsed().as_micros() as u64,
             process_buffered_packets_us: 0,
-            slot_metrics_check_slot_boundary_us: 0,
             receive_and_buffer_packets_us: 0,
             receive_and_buffer_packets_invoked_count: 0,
             bank_detected_to_slot_end_detected_us: 0,
@@ -185,11 +181,6 @@ impl OuterLoopTimings {
             (
                 "process_buffered_packets_us",
                 self.process_buffered_packets_us,
-                i64
-            ),
-            (
-                "slot_metrics_check_slot_boundary_us",
-                self.slot_metrics_check_slot_boundary_us,
                 i64
             ),
             (

--- a/core/src/leader_slot_banking_stage_timing_metrics.rs
+++ b/core/src/leader_slot_banking_stage_timing_metrics.rs
@@ -118,8 +118,8 @@ impl LeaderSlotTimingMetrics {
         self.execute_and_commit_timings.report(id, slot);
     }
 
-    pub(crate) fn slot_end_detected(&mut self) {
-        self.outer_loop_timings.slot_end_detected();
+    pub(crate) fn mark_slot_end_detected(&mut self) {
+        self.outer_loop_timings.mark_slot_end_detected();
     }
 }
 
@@ -161,7 +161,7 @@ impl OuterLoopTimings {
     }
 
     /// Call when detected slot end to capture elapsed time, which might be reported later
-    fn slot_end_detected(&mut self) {
+    fn mark_slot_end_detected(&mut self) {
         self.bank_detected_to_slot_end_detected_us =
             self.bank_detected_time.elapsed().as_micros() as u64;
     }


### PR DESCRIPTION
#### Problem

Counters for forwarding that accumulated between banks are not reported.
 
#### Summary of Changes
- Separate leader slot boundary checking and metrics reporting/resetting into two steps;
- report metrics _before_ consuming, or _after_ forwarding.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
