### PR TITLE
cleanup feature: sol_log_data_syscall_enabled

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -27,9 +27,8 @@ use {
             executables_incur_cpi_data_cost, fixed_memcpy_nonoverlapping_check,
             libsecp256k1_0_5_upgrade_enabled, limit_secp256k1_recovery_id,
             prevent_calling_precompiles_as_programs, quick_bail_on_panic,
-            return_data_syscall_enabled, secp256k1_recover_syscall_enabled,
-            sol_log_data_syscall_enabled, syscall_saturated_math, update_syscall_base_costs,
-            zk_token_sdk_enabled,
+            return_data_syscall_enabled, secp256k1_recover_syscall_enabled, syscall_saturated_math,
+            update_syscall_base_costs, zk_token_sdk_enabled,
         },
         hash::{Hasher, HASH_BYTES},
         instruction::{
@@ -149,9 +148,6 @@ pub fn register_syscalls(
     let return_data_syscall_enabled = invoke_context
         .feature_set
         .is_active(&return_data_syscall_enabled::id());
-    let sol_log_data_syscall_enabled = invoke_context
-        .feature_set
-        .is_active(&sol_log_data_syscall_enabled::id());
 
     let mut syscall_registry = SyscallRegistry::default();
 
@@ -352,9 +348,7 @@ pub fn register_syscalls(
     )?;
 
     // Log data
-    register_feature_gated_syscall!(
-        syscall_registry,
-        sol_log_data_syscall_enabled,
+    syscall_registry.register_syscall_by_name(
         b"sol_log_data",
         SyscallLogData::init,
         SyscallLogData::call,


### PR DESCRIPTION
#### Problem

Enabled on mainnet but still in master:

`6uaHcKPGUy4J7emLBgUTeufhJdiwhngW6a1R9B7c2ob9 | active since slot 117936008 | enable sol_log_data syscall`

#### Summary of Changes

Clean feature out of master

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
