### PR TITLE
cleanup feature: return_data_syscall_enabled

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -27,8 +27,8 @@ use {
             executables_incur_cpi_data_cost, fixed_memcpy_nonoverlapping_check,
             libsecp256k1_0_5_upgrade_enabled, limit_secp256k1_recovery_id,
             prevent_calling_precompiles_as_programs, quick_bail_on_panic,
-            return_data_syscall_enabled, secp256k1_recover_syscall_enabled, syscall_saturated_math,
-            update_syscall_base_costs, zk_token_sdk_enabled,
+            secp256k1_recover_syscall_enabled, syscall_saturated_math, update_syscall_base_costs,
+            zk_token_sdk_enabled,
         },
         hash::{Hasher, HASH_BYTES},
         instruction::{
@@ -145,9 +145,6 @@ pub fn register_syscalls(
     let disable_fees_sysvar = invoke_context
         .feature_set
         .is_active(&disable_fees_sysvar::id());
-    let return_data_syscall_enabled = invoke_context
-        .feature_set
-        .is_active(&return_data_syscall_enabled::id());
 
     let mut syscall_registry = SyscallRegistry::default();
 
@@ -332,16 +329,12 @@ pub fn register_syscalls(
     )?;
 
     // Return data
-    register_feature_gated_syscall!(
-        syscall_registry,
-        return_data_syscall_enabled,
+    syscall_registry.register_syscall_by_name(
         b"sol_set_return_data",
         SyscallSetReturnData::init,
         SyscallSetReturnData::call,
     )?;
-    register_feature_gated_syscall!(
-        syscall_registry,
-        return_data_syscall_enabled,
+    syscall_registry.register_syscall_by_name(
         b"sol_get_return_data",
         SyscallGetReturnData::init,
         SyscallGetReturnData::call,


### PR DESCRIPTION
#### Problem

Enabled on mainnet but still in master:

`DwScAzPUjuv65TMbDnFY7AgwmotzWy3xpEJMXM3hZFaB | active since slot 117936008 | enable sol_{set,get}_return_data syscall`

#### Summary of Changes

Clean feature out of master

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
