### PR TITLE
client: Support sync and async connections in cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4697,6 +4697,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
+ "solana-perf",
  "solana-sdk 1.11.0",
  "solana-streamer",
  "solana-transaction-status",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -62,6 +62,7 @@ anyhow = "1.0.57"
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"
 solana-logger = { path = "../logger", version = "=1.11.0" }
+solana-perf = { path = "../perf", version = "=1.11.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -1,16 +1,17 @@
 use {
     crate::{
-        nonblocking::quic_client::QuicLazyInitializedEndpoint,
-        quic_client::QuicTpuConnection,
-        tpu_connection::{ClientStats, Connection},
-        udp_client::UdpTpuConnection,
+        nonblocking::{
+            quic_client::{QuicClient, QuicLazyInitializedEndpoint},
+            tpu_connection::NonblockingConnection,
+        },
+        tpu_connection::{BlockingConnection, ClientStats},
     },
     indexmap::map::{Entry, IndexMap},
     rand::{thread_rng, Rng},
     solana_measure::measure::Measure,
     solana_sdk::{quic::QUIC_PORT_OFFSET, timing::AtomicInterval},
     std::{
-        net::SocketAddr,
+        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
@@ -297,54 +298,52 @@ impl ConnectionCache {
                     )
                 });
 
-        let (cache_hit, connection_cache_stats, num_evictions, eviction_timing_ms) =
-            if to_create_connection {
-                let connection: Connection = if self.use_quic {
-                    QuicTpuConnection::new(
-                        endpoint.as_ref().unwrap().clone(),
-                        *addr,
-                        self.stats.clone(),
-                    )
-                    .into()
-                } else {
-                    UdpTpuConnection::new(*addr, self.stats.clone()).into()
-                };
-
-                let connection = Arc::new(connection);
-
-                // evict a connection if the cache is reaching upper bounds
-                let mut num_evictions = 0;
-                let mut get_connection_cache_eviction_measure =
-                    Measure::start("get_connection_cache_eviction_measure");
-                while map.len() >= MAX_CONNECTIONS {
-                    let mut rng = thread_rng();
-                    let n = rng.gen_range(0, MAX_CONNECTIONS);
-                    map.swap_remove_index(n);
-                    num_evictions += 1;
-                }
-                get_connection_cache_eviction_measure.stop();
-
-                match map.entry(*addr) {
-                    Entry::Occupied(mut entry) => {
-                        let pool = entry.get_mut();
-                        pool.connections.push(connection);
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(ConnectionPool {
-                            connections: vec![connection],
-                            endpoint,
-                        });
-                    }
-                }
-                (
-                    false,
-                    self.stats.clone(),
-                    num_evictions,
-                    get_connection_cache_eviction_measure.as_ms(),
-                )
+        let (cache_hit, num_evictions, eviction_timing_ms) = if to_create_connection {
+            let connection = if self.use_quic {
+                let client = QuicClient::new(endpoint.as_ref().unwrap().clone(), *addr);
+                Connection::Quic(Arc::new(client))
             } else {
-                (true, self.stats.clone(), 0, 0)
+                let socket = solana_net_utils::bind_in_validator_port_range(IpAddr::V4(
+                    Ipv4Addr::new(0, 0, 0, 0),
+                ))
+                .unwrap();
+                Connection::Udp(Arc::new(socket))
             };
+
+            let connection = Arc::new(connection);
+
+            // evict a connection if the cache is reaching upper bounds
+            let mut num_evictions = 0;
+            let mut get_connection_cache_eviction_measure =
+                Measure::start("get_connection_cache_eviction_measure");
+            while map.len() >= MAX_CONNECTIONS {
+                let mut rng = thread_rng();
+                let n = rng.gen_range(0, MAX_CONNECTIONS);
+                map.swap_remove_index(n);
+                num_evictions += 1;
+            }
+            get_connection_cache_eviction_measure.stop();
+
+            match map.entry(*addr) {
+                Entry::Occupied(mut entry) => {
+                    let pool = entry.get_mut();
+                    pool.connections.push(connection);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(ConnectionPool {
+                        connections: vec![connection],
+                        endpoint,
+                    });
+                }
+            }
+            (
+                false,
+                num_evictions,
+                get_connection_cache_eviction_measure.as_ms(),
+            )
+        } else {
+            (true, 0, 0)
+        };
 
         let pool = map.get(addr).unwrap();
         let connection = pool.borrow_connection();
@@ -352,7 +351,7 @@ impl ConnectionCache {
         CreateConnectionResult {
             connection,
             cache_hit,
-            connection_cache_stats,
+            connection_cache_stats: self.stats.clone(),
             num_evictions,
             eviction_timing_ms,
         }
@@ -417,7 +416,10 @@ impl ConnectionCache {
         }
     }
 
-    pub fn get_connection(&self, addr: &SocketAddr) -> Arc<Connection> {
+    fn get_connection_and_log_stats(
+        &self,
+        addr: &SocketAddr,
+    ) -> (Arc<Connection>, Arc<ConnectionCacheStats>) {
         let mut get_connection_measure = Measure::start("get_connection_measure");
         let GetConnectionResult {
             connection,
@@ -464,7 +466,17 @@ impl ConnectionCache {
             .get_connection_ms
             .fetch_add(get_connection_measure.as_ms(), Ordering::Relaxed);
 
-        connection
+        (connection, connection_cache_stats)
+    }
+
+    pub fn get_connection(&self, addr: &SocketAddr) -> BlockingConnection {
+        let (connection, connection_cache_stats) = self.get_connection_and_log_stats(addr);
+        connection.new_tpu_connection(*addr, connection_cache_stats)
+    }
+
+    pub fn get_nonblocking_connection(&self, addr: &SocketAddr) -> NonblockingConnection {
+        let (connection, connection_cache_stats) = self.get_connection_and_log_stats(addr);
+        connection.new_nonblocking_tpu_connection(*addr, connection_cache_stats)
     }
 }
 
@@ -476,6 +488,45 @@ impl Default for ConnectionCache {
             last_stats: AtomicInterval::default(),
             use_quic: DEFAULT_TPU_USE_QUIC,
             connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
+        }
+    }
+}
+
+#[derive(Clone)]
+enum Connection {
+    Udp(Arc<UdpSocket>),
+    Quic(Arc<QuicClient>),
+}
+impl Connection {
+    fn new_tpu_connection(
+        &self,
+        addr: SocketAddr,
+        stats: Arc<ConnectionCacheStats>,
+    ) -> BlockingConnection {
+        use crate::{quic_client::QuicTpuConnection, udp_client::UdpTpuConnection};
+        match self {
+            Connection::Udp(udp_socket) => {
+                UdpTpuConnection::new_with_socket(addr, udp_socket.clone()).into()
+            }
+            Connection::Quic(quic_client) => {
+                QuicTpuConnection::new_with_client(quic_client.clone(), stats).into()
+            }
+        }
+    }
+
+    fn new_nonblocking_tpu_connection(
+        &self,
+        addr: SocketAddr,
+        stats: Arc<ConnectionCacheStats>,
+    ) -> NonblockingConnection {
+        use crate::nonblocking::{quic_client::QuicTpuConnection, udp_client::UdpTpuConnection};
+        match self {
+            Connection::Udp(udp_socket) => {
+                UdpTpuConnection::new_with_std_socket(addr, udp_socket.try_clone().unwrap()).into()
+            }
+            Connection::Quic(quic_client) => {
+                QuicTpuConnection::new_with_client(quic_client.clone(), stats).into()
+            }
         }
     }
 }
@@ -551,6 +602,7 @@ mod tests {
             assert!(map.len() == MAX_CONNECTIONS);
             addrs.iter().for_each(|a| {
                 let conn = &map.get(a).expect("Address not found").connections[0];
+                let conn = conn.new_tpu_connection(*a, connection_cache.stats.clone());
                 assert!(a.ip() == conn.tpu_addr().ip());
             });
         }

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -17,9 +17,7 @@ use {
     solana_measure::measure::Measure,
     solana_net_utils::VALIDATOR_PORT_RANGE,
     solana_sdk::{
-        quic::{
-            QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS,
-        },
+        quic::{QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS},
         transport::Result as TransportResult,
     },
     std::{
@@ -440,7 +438,11 @@ impl QuicTpuConnection {
         self.client.stats()
     }
 
-    pub fn new(endpoint: Arc<QuicLazyInitializedEndpoint>, addr: SocketAddr, connection_stats: Arc<ConnectionCacheStats>) -> Self {
+    pub fn new(
+        endpoint: Arc<QuicLazyInitializedEndpoint>,
+        addr: SocketAddr,
+        connection_stats: Arc<ConnectionCacheStats>,
+    ) -> Self {
         let client = Arc::new(QuicClient::new(endpoint, addr));
         Self::new_with_client(client, connection_stats)
     }

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -4,9 +4,10 @@
 use {
     crate::{
         client_error::ClientErrorKind, connection_cache::ConnectionCacheStats,
-        tpu_connection::ClientStats,
+        nonblocking::tpu_connection::TpuConnection, tpu_connection::ClientStats,
     },
     async_mutex::Mutex,
+    async_trait::async_trait,
     futures::future::join_all,
     itertools::Itertools,
     log::*,
@@ -15,7 +16,12 @@ use {
     },
     solana_measure::measure::Measure,
     solana_net_utils::VALIDATOR_PORT_RANGE,
-    solana_sdk::quic::{QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS},
+    solana_sdk::{
+        quic::{
+            QUIC_KEEP_ALIVE_MS, QUIC_MAX_CONCURRENT_STREAMS, QUIC_MAX_TIMEOUT_MS,
+        },
+        transport::Result as TransportResult,
+    },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::{atomic::Ordering, Arc},
@@ -420,5 +426,77 @@ impl QuicClient {
 
     pub fn stats(&self) -> Arc<ClientStats> {
         self.stats.clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct QuicTpuConnection {
+    client: Arc<QuicClient>,
+    connection_stats: Arc<ConnectionCacheStats>,
+}
+
+impl QuicTpuConnection {
+    pub fn base_stats(&self) -> Arc<ClientStats> {
+        self.client.stats()
+    }
+
+    pub fn new(endpoint: Arc<QuicLazyInitializedEndpoint>, addr: SocketAddr, connection_stats: Arc<ConnectionCacheStats>) -> Self {
+        let client = Arc::new(QuicClient::new(endpoint, addr));
+        Self::new_with_client(client, connection_stats)
+    }
+
+    pub fn new_with_client(
+        client: Arc<QuicClient>,
+        connection_stats: Arc<ConnectionCacheStats>,
+    ) -> Self {
+        Self {
+            client,
+            connection_stats,
+        }
+    }
+}
+
+#[async_trait]
+impl TpuConnection for QuicTpuConnection {
+    fn tpu_addr(&self) -> &SocketAddr {
+        self.client.tpu_addr()
+    }
+
+    async fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
+    where
+        T: AsRef<[u8]> + Send + Sync,
+    {
+        let stats = ClientStats::default();
+        let len = buffers.len();
+        let res = self
+            .client
+            .send_batch(buffers, &stats, self.connection_stats.clone())
+            .await;
+        self.connection_stats
+            .add_client_stats(&stats, len, res.is_ok());
+        res?;
+        Ok(())
+    }
+
+    async fn send_wire_transaction<T>(&self, wire_transaction: T) -> TransportResult<()>
+    where
+        T: AsRef<[u8]> + Send + Sync,
+    {
+        let stats = Arc::new(ClientStats::default());
+        let send_buffer =
+            self.client
+                .send_buffer(wire_transaction, &stats, self.connection_stats.clone());
+        if let Err(e) = send_buffer.await {
+            warn!(
+                "Failed to send transaction async to {}, error: {:?} ",
+                self.tpu_addr(),
+                e
+            );
+            datapoint_warn!("send-wire-async", ("failure", 1, i64),);
+            self.connection_stats.add_client_stats(&stats, 1, false);
+        } else {
+            self.connection_stats.add_client_stats(&stats, 1, true);
+        }
+        Ok(())
     }
 }

--- a/client/src/nonblocking/tpu_connection.rs
+++ b/client/src/nonblocking/tpu_connection.rs
@@ -1,7 +1,7 @@
 //! Trait defining async send functions, to be used for UDP or QUIC sending
 
 use {
-    crate::nonblocking::udp_client::UdpTpuConnection,
+    crate::nonblocking::{quic_client::QuicTpuConnection, udp_client::UdpTpuConnection},
     async_trait::async_trait,
     enum_dispatch::enum_dispatch,
     solana_sdk::{transaction::VersionedTransaction, transport::Result as TransportResult},
@@ -13,6 +13,7 @@ use {
 // trying to convert later.
 #[enum_dispatch]
 pub enum NonblockingConnection {
+    QuicTpuConnection,
     UdpTpuConnection,
 }
 

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -5,7 +5,10 @@ use {
     crate::{
         connection_cache::ConnectionCacheStats,
         nonblocking::{
-            quic_client::{QuicClient, QuicLazyInitializedEndpoint, QuicTpuConnection as NonblockingQuicTpuConnection},
+            quic_client::{
+                QuicClient, QuicLazyInitializedEndpoint,
+                QuicTpuConnection as NonblockingQuicTpuConnection,
+            },
             tpu_connection::TpuConnection as NonblockingTpuConnection,
         },
         tpu_connection::TpuConnection,
@@ -27,7 +30,11 @@ pub struct QuicTpuConnection {
     inner: NonblockingQuicTpuConnection,
 }
 impl QuicTpuConnection {
-    pub fn new(endpoint: Arc<QuicLazyInitializedEndpoint>, tpu_addr: SocketAddr, connection_stats: Arc<ConnectionCacheStats>) -> Self {
+    pub fn new(
+        endpoint: Arc<QuicLazyInitializedEndpoint>,
+        tpu_addr: SocketAddr,
+        connection_stats: Arc<ConnectionCacheStats>,
+    ) -> Self {
         let inner = NonblockingQuicTpuConnection::new(endpoint, tpu_addr, connection_stats);
         Self { inner }
     }

--- a/client/src/quic_client.rs
+++ b/client/src/quic_client.rs
@@ -4,11 +4,13 @@
 use {
     crate::{
         connection_cache::ConnectionCacheStats,
-        nonblocking::quic_client::{QuicClient, QuicLazyInitializedEndpoint},
-        tpu_connection::{ClientStats, TpuConnection},
+        nonblocking::{
+            quic_client::{QuicClient, QuicLazyInitializedEndpoint, QuicTpuConnection as NonblockingQuicTpuConnection},
+            tpu_connection::TpuConnection as NonblockingTpuConnection,
+        },
+        tpu_connection::TpuConnection,
     },
     lazy_static::lazy_static,
-    log::*,
     solana_sdk::transport::Result as TransportResult,
     std::{net::SocketAddr, sync::Arc},
     tokio::runtime::Runtime,
@@ -22,92 +24,47 @@ lazy_static! {
 }
 
 pub struct QuicTpuConnection {
-    client: Arc<QuicClient>,
-    connection_stats: Arc<ConnectionCacheStats>,
+    inner: NonblockingQuicTpuConnection,
 }
-
 impl QuicTpuConnection {
-    pub fn base_stats(&self) -> Arc<ClientStats> {
-        self.client.stats()
+    pub fn new(endpoint: Arc<QuicLazyInitializedEndpoint>, tpu_addr: SocketAddr, connection_stats: Arc<ConnectionCacheStats>) -> Self {
+        let inner = NonblockingQuicTpuConnection::new(endpoint, tpu_addr, connection_stats);
+        Self { inner }
     }
 
-    pub fn new(
-        endpoint: Arc<QuicLazyInitializedEndpoint>,
-        tpu_addr: SocketAddr,
+    pub fn new_with_client(
+        client: Arc<QuicClient>,
         connection_stats: Arc<ConnectionCacheStats>,
     ) -> Self {
-        let client = Arc::new(QuicClient::new(endpoint, tpu_addr));
-
-        Self {
-            client,
-            connection_stats,
-        }
+        let inner = NonblockingQuicTpuConnection::new_with_client(client, connection_stats);
+        Self { inner }
     }
 }
 
 impl TpuConnection for QuicTpuConnection {
     fn tpu_addr(&self) -> &SocketAddr {
-        self.client.tpu_addr()
+        self.inner.tpu_addr()
     }
 
     fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
     where
-        T: AsRef<[u8]>,
+        T: AsRef<[u8]> + Send + Sync,
     {
-        let stats = ClientStats::default();
-        let len = buffers.len();
-        let _guard = RUNTIME.enter();
-        let send_batch = self
-            .client
-            .send_batch(buffers, &stats, self.connection_stats.clone());
-        let res = RUNTIME.block_on(send_batch);
-        self.connection_stats
-            .add_client_stats(&stats, len, res.is_ok());
-        res?;
+        let _res = RUNTIME.block_on(self.inner.send_wire_transaction_batch(buffers))?;
         Ok(())
     }
 
     fn send_wire_transaction_async(&self, wire_transaction: Vec<u8>) -> TransportResult<()> {
-        let stats = Arc::new(ClientStats::default());
-        let _guard = RUNTIME.enter();
-        let client = self.client.clone();
-        let connection_stats = self.connection_stats.clone();
+        let inner = self.inner.clone();
         //drop and detach the task
-        let _ = RUNTIME.spawn(async move {
-            let send_buffer =
-                client.send_buffer(wire_transaction, &stats, connection_stats.clone());
-            if let Err(e) = send_buffer.await {
-                warn!(
-                    "Failed to send transaction async to {}, error: {:?} ",
-                    client.tpu_addr(),
-                    e
-                );
-                datapoint_warn!("send-wire-async", ("failure", 1, i64),);
-                connection_stats.add_client_stats(&stats, 1, false);
-            } else {
-                connection_stats.add_client_stats(&stats, 1, true);
-            }
-        });
+        let _ = RUNTIME.spawn(async move { inner.send_wire_transaction(wire_transaction).await });
         Ok(())
     }
 
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
-        let stats = Arc::new(ClientStats::default());
-        let _guard = RUNTIME.enter();
-        let client = self.client.clone();
-        let connection_stats = self.connection_stats.clone();
-        let len = buffers.len();
+        let inner = self.inner.clone();
         //drop and detach the task
-        let _ = RUNTIME.spawn(async move {
-            let send_batch = client.send_batch(&buffers, &stats, connection_stats.clone());
-            if let Err(e) = send_batch.await {
-                warn!("Failed to send transaction batch async to {:?}", e);
-                datapoint_warn!("send-wire-batch-async", ("failure", 1, i64),);
-                connection_stats.add_client_stats(&stats, len, false);
-            } else {
-                connection_stats.add_client_stats(&stats, len, true);
-            }
-        });
+        let _ = RUNTIME.spawn(async move { inner.send_wire_transaction_batch(&buffers).await });
         Ok(())
     }
 }

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -44,7 +44,7 @@ pub trait TpuConnection {
 
     fn send_wire_transaction<T>(&self, wire_transaction: T) -> TransportResult<()>
     where
-        T: AsRef<[u8]>,
+        T: AsRef<[u8]> + Send + Sync,
     {
         self.send_wire_transaction_batch(&[wire_transaction])
     }
@@ -65,7 +65,7 @@ pub trait TpuConnection {
 
     fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
     where
-        T: AsRef<[u8]>;
+        T: AsRef<[u8]> + Send + Sync;
 
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()>;
 }

--- a/client/src/tpu_connection.rs
+++ b/client/src/tpu_connection.rs
@@ -24,12 +24,12 @@ pub struct ClientStats {
 }
 
 #[enum_dispatch]
-pub enum Connection {
+pub enum BlockingConnection {
     UdpTpuConnection,
     QuicTpuConnection,
 }
 
-#[enum_dispatch(Connection)]
+#[enum_dispatch(BlockingConnection)]
 pub trait TpuConnection {
     fn tpu_addr(&self) -> &SocketAddr;
 

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -45,12 +45,13 @@ impl TpuConnection for UdpTpuConnection {
 
     fn send_wire_transaction_batch<T>(&self, buffers: &[T]) -> TransportResult<()>
     where
-        T: AsRef<[u8]>,
+        T: AsRef<[u8]> + Send + Sync,
     {
         let pkts: Vec<_> = buffers.iter().zip(repeat(self.tpu_addr())).collect();
         batch_send(&self.socket, &pkts)?;
         Ok(())
     }
+
     fn send_wire_transaction_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let pkts: Vec<_> = buffers.into_iter().zip(repeat(self.tpu_addr())).collect();
         batch_send(&self.socket, &pkts)?;

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -13,7 +13,7 @@ use {
 };
 
 pub struct UdpTpuConnection {
-    socket: UdpSocket,
+    socket: Arc<UdpSocket>,
     addr: SocketAddr,
 }
 
@@ -22,14 +22,15 @@ impl UdpTpuConnection {
         let socket =
             solana_net_utils::bind_in_validator_port_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
                 .unwrap();
-        Self {
-            socket,
-            addr: tpu_addr,
-        }
+        Self::new_with_socket(tpu_addr, Arc::new(socket))
     }
 
     pub fn new(tpu_addr: SocketAddr, _connection_stats: Arc<ConnectionCacheStats>) -> Self {
         Self::new_from_addr(tpu_addr)
+    }
+
+    pub fn new_with_socket(addr: SocketAddr, socket: Arc<UdpSocket>) -> Self {
+        Self { socket, addr }
     }
 }
 

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -133,7 +133,9 @@ mod tests {
         let connection_cache_stats = Arc::new(ConnectionCacheStats::default());
         let client = QuicTpuConnection::new(
             Arc::new(QuicLazyInitializedEndpoint::default()),
-            tpu_addr, connection_cache_stats);
+            tpu_addr,
+            connection_cache_stats,
+        );
 
         // Send a full size packet with single byte writes.
         let num_bytes = PACKET_DATA_SIZE;

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -1,17 +1,17 @@
 #[cfg(test)]
 mod tests {
     use {
-        crossbeam_channel::unbounded,
+        crossbeam_channel::{unbounded, Receiver},
         solana_client::{
             connection_cache::ConnectionCacheStats,
-            nonblocking::quic_client::QuicLazyInitializedEndpoint, quic_client::QuicTpuConnection,
-            tpu_connection::TpuConnection,
+            nonblocking::quic_client::QuicLazyInitializedEndpoint,
         },
+        solana_perf::packet::PacketBatch,
         solana_sdk::{packet::PACKET_DATA_SIZE, signature::Keypair},
-        solana_streamer::quic::{spawn_server, StreamStats},
+        solana_streamer::quic::StreamStats,
         std::{
             collections::HashMap,
-            net::{SocketAddr, UdpSocket},
+            net::{IpAddr, SocketAddr, UdpSocket},
             sync::{
                 atomic::{AtomicBool, Ordering},
                 Arc, RwLock,
@@ -20,17 +20,55 @@ mod tests {
         },
     };
 
+    fn check_packets(
+        receiver: Receiver<PacketBatch>,
+        num_bytes: usize,
+        num_expected_packets: usize,
+    ) {
+        let mut all_packets = vec![];
+        let now = Instant::now();
+        let mut total_packets = 0;
+        while now.elapsed().as_secs() < 5 {
+            if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
+                total_packets += packets.len();
+                all_packets.push(packets)
+            }
+            if total_packets >= num_expected_packets {
+                break;
+            }
+        }
+        for batch in all_packets {
+            for p in &batch {
+                assert_eq!(p.meta.size, num_bytes);
+            }
+        }
+        assert_eq!(total_packets, num_expected_packets);
+    }
+
+    fn server_args() -> (
+        UdpSocket,
+        Arc<AtomicBool>,
+        Keypair,
+        IpAddr,
+        Arc<StreamStats>,
+    ) {
+        (
+            UdpSocket::bind("127.0.0.1:0").unwrap(),
+            Arc::new(AtomicBool::new(false)),
+            Keypair::new(),
+            "127.0.0.1".parse().unwrap(),
+            Arc::new(StreamStats::default()),
+        )
+    }
+
     #[test]
     fn test_quic_client_multiple_writes() {
+        use solana_client::{quic_client::QuicTpuConnection, tpu_connection::TpuConnection};
         solana_logger::setup();
-        let s = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let exit = Arc::new(AtomicBool::new(false));
         let (sender, receiver) = unbounded();
-        let keypair = Keypair::new();
-        let ip = "127.0.0.1".parse().unwrap();
         let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
-        let stats = Arc::new(StreamStats::default());
-        let t = spawn_server(
+        let (s, exit, keypair, ip, stats) = server_args();
+        let t = solana_streamer::quic::spawn_server(
             s.try_clone().unwrap(),
             &keypair,
             ip,
@@ -61,26 +99,51 @@ mod tests {
 
         assert!(client.send_wire_transaction_batch_async(packets).is_ok());
 
-        let mut all_packets = vec![];
-        let now = Instant::now();
-        let mut total_packets = 0;
-        while now.elapsed().as_secs() < 5 {
-            if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
-                total_packets += packets.len();
-                all_packets.push(packets)
-            }
-            if total_packets >= num_expected_packets {
-                break;
-            }
-        }
-        for batch in all_packets {
-            for p in &batch {
-                assert_eq!(p.meta.size, num_bytes);
-            }
-        }
-        assert_eq!(total_packets, num_expected_packets);
-
+        check_packets(receiver, num_bytes, num_expected_packets);
         exit.store(true, Ordering::Relaxed);
         t.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_nonblocking_quic_client_multiple_writes() {
+        use solana_client::nonblocking::{
+            quic_client::QuicTpuConnection, tpu_connection::TpuConnection,
+        };
+        solana_logger::setup();
+        let (sender, receiver) = unbounded();
+        let staked_nodes = Arc::new(RwLock::new(HashMap::new()));
+        let (s, exit, keypair, ip, stats) = server_args();
+        let t = solana_streamer::nonblocking::quic::spawn_server(
+            s.try_clone().unwrap(),
+            &keypair,
+            ip,
+            sender,
+            exit.clone(),
+            1,
+            staked_nodes,
+            10,
+            10,
+            stats,
+        )
+        .unwrap();
+
+        let addr = s.local_addr().unwrap().ip();
+        let port = s.local_addr().unwrap().port();
+        let tpu_addr = SocketAddr::new(addr, port);
+        let connection_cache_stats = Arc::new(ConnectionCacheStats::default());
+        let client = QuicTpuConnection::new(
+            Arc::new(QuicLazyInitializedEndpoint::default()),
+            tpu_addr, connection_cache_stats);
+
+        // Send a full size packet with single byte writes.
+        let num_bytes = PACKET_DATA_SIZE;
+        let num_expected_packets: usize = 4000;
+        let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
+
+        assert!(client.send_wire_transaction_batch(&packets).await.is_ok());
+
+        check_packets(receiver, num_bytes, num_expected_packets);
+        exit.store(true, Ordering::Relaxed);
+        t.await.unwrap();
     }
 }

--- a/client/tests/quic_client.rs
+++ b/client/tests/quic_client.rs
@@ -27,10 +27,10 @@ mod tests {
     ) {
         let mut all_packets = vec![];
         let now = Instant::now();
-        let mut total_packets = 0;
+        let mut total_packets: usize = 0;
         while now.elapsed().as_secs() < 5 {
             if let Ok(packets) = receiver.recv_timeout(Duration::from_secs(1)) {
-                total_packets += packets.len();
+                total_packets = total_packets.saturating_add(packets.len());
                 all_packets.push(packets)
             }
             if total_packets >= num_expected_packets {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -605,7 +605,7 @@ impl BankingStage {
                 banking_stage_stats
                     .forwarded_vote_count
                     .fetch_add(packet_vec_len, Ordering::Relaxed);
-                Arc::new(UdpTpuConnection::new_from_addr(addr).into())
+                UdpTpuConnection::new_from_addr(addr).into()
             } else {
                 // All other transactions can be forwarded using QUIC, get_connection() will use
                 // system wide setting to pick the correct connection object.


### PR DESCRIPTION
#### Problem

As part of ongoing work to support async QUIC clients in #25383, we need to use one connection cache to either fetch a sync or async TpuConnection.

#### Summary of Changes

Add one more layer of `Connection` abstraction, so that the connection cache holds onto `UdpSocket` or `QuicClient`, which can be used by sync or async variants as needed.

Note that this builds on  #25826, so only the last commit needs to be examined.