### PR TITLE
cleanup feature; do_support_realloc

### DIFF
--- a/program-runtime/benches/pre_account.rs
+++ b/program-runtime/benches/pre_account.rs
@@ -28,7 +28,6 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             &post,
             &mut ExecuteDetailsTimings::default(),
             false,
-            true,
         ),
         Ok(())
     );
@@ -42,7 +41,6 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             &post,
             &mut ExecuteDetailsTimings::default(),
             false,
-            true,
         )
         .unwrap();
     });
@@ -67,7 +65,6 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             &post,
             &mut ExecuteDetailsTimings::default(),
             false,
-            true,
         )
         .unwrap();
     });

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -313,7 +313,6 @@ fn run_program(name: &str) -> u64 {
                     .unwrap(),
                 parameter_bytes.as_slice(),
                 &account_lengths,
-                true,
             )
             .unwrap();
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -43,9 +43,8 @@ use {
         feature_set::{
             cap_accounts_data_len, disable_bpf_deprecated_load_instructions,
             disable_bpf_unresolved_symbols_at_runtime, disable_deploy_of_alloc_free_syscall,
-            disable_deprecated_loader, do_support_realloc,
-            error_on_syscall_bpf_function_hash_collisions, reduce_required_deploy_balance,
-            reject_callx_r10, requestable_heap_size,
+            disable_deprecated_loader, error_on_syscall_bpf_function_hash_collisions,
+            reduce_required_deploy_balance, reject_callx_r10, requestable_heap_size,
         },
         instruction::{AccountMeta, InstructionError},
         loader_instruction::LoaderInstruction,
@@ -1277,9 +1276,6 @@ impl Executor for BpfExecutor {
                     .get_current_instruction_context()?,
                 parameter_bytes.as_slice(),
                 invoke_context.get_orig_account_lengths()?,
-                invoke_context
-                    .feature_set
-                    .is_active(&do_support_realloc::id()),
             )
         });
         deserialize_time.stop();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -431,7 +431,6 @@ impl Accounts {
             &payer_post_rent_state,
             payer_address,
             payer_account,
-            feature_set.is_active(&feature_set::do_support_realloc::id()),
             feature_set
                 .is_active(&feature_set::include_account_index_in_rent_error::ID)
                 .then(|| payer_index),

--- a/runtime/src/bank/transaction_account_state_info.rs
+++ b/runtime/src/bank/transaction_account_state_info.rs
@@ -58,9 +58,6 @@ impl Bank {
         let require_rent_exempt_accounts = self
             .feature_set
             .is_active(&feature_set::require_rent_exempt_accounts::id());
-        let do_support_realloc = self
-            .feature_set
-            .is_active(&feature_set::do_support_realloc::id());
         let include_account_index_in_err = self
             .feature_set
             .is_active(&feature_set::include_account_index_in_rent_error::id());
@@ -72,7 +69,6 @@ impl Bank {
                 post_state_info.rent_state.as_ref(),
                 transaction_context,
                 i,
-                do_support_realloc,
                 include_account_index_in_err,
             ) {
                 // Feature gate only wraps the actual error return so that the metrics and debug


### PR DESCRIPTION
#### Problem

Enabled on mainnet but still in master:

`75m6ysz33AfLA5DDEzWM1obBrnPQRSsdVQ2nRmc8Vuu1 | active since slot 133920008 | support account data reallocation`

#### Summary of Changes

Clean feature out of master
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
