### PR TITLE
Add minimum iterator packet count for rayon verification threads

### DIFF
--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -45,7 +45,9 @@ fn gen_batches(
         let tx = test_tx();
         to_packet_batches(&vec![tx; total_packets], packets_per_batch)
     } else {
-        let txs: Vec<_> = (0..total_packets).map(|_| test_tx()).collect();
+        let txs: Vec<_> = std::iter::repeat_with(test_tx)
+            .take(total_packets)
+            .collect();
         to_packet_batches(&txs, packets_per_batch)
     }
 }

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -15,6 +15,7 @@ use {
 };
 
 const NUM: usize = 256;
+const LARGE_BATCH_PACKET_COUNT: usize = 128;
 
 #[bench]
 fn bench_sigverify_simple(bencher: &mut Bencher) {
@@ -27,6 +28,93 @@ fn bench_sigverify_simple(bencher: &mut Bencher) {
         128,
     );
 
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    // verify packets
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+fn gen_batches(
+    use_same_tx: bool,
+    packets_per_batch: usize,
+    total_packets: usize,
+) -> Vec<PacketBatch> {
+    if use_same_tx {
+        let tx = test_tx();
+        to_packet_batches(&vec![tx; total_packets], packets_per_batch)
+    } else {
+        let txs: Vec<_> = (0..total_packets).map(|_| test_tx()).collect();
+        to_packet_batches(&txs, packets_per_batch)
+    }
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_low_packets_small_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD - 1;
+    let mut batches = gen_batches(false, 1, num_packets);
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_low_packets_large_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD - 1;
+    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_medium_packets_small_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 8;
+    let mut batches = gen_batches(false, 1, num_packets);
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_medium_packets_large_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 8;
+    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_high_packets_small_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 32;
+    let mut batches = gen_batches(false, 1, num_packets);
+    let recycler = Recycler::default();
+    let recycler_out = Recycler::default();
+    bencher.iter(|| {
+        sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out, false, num_packets);
+    })
+}
+
+#[bench]
+#[ignore]
+fn bench_sigverify_high_packets_large_batch(bencher: &mut Bencher) {
+    let num_packets = sigverify::VERIFY_MIN_PACKETS_PER_THREAD * 32;
+    let mut batches = gen_batches(false, LARGE_BATCH_PACKET_COUNT, num_packets);
     let recycler = Recycler::default();
     let recycler_out = Recycler::default();
     // verify packets

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -615,7 +615,7 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
         .saturating_div(VERIFY_MIN_PACKETS_PER_THREAD);
     if desired_thread_count <= 1 {
         // When using single thread, skip rayon overhead.
-        batches.into_iter().for_each(|batch| {
+        batches.iter_mut().for_each(|batch| {
             batch.iter_mut().for_each(|packet| {
                 if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
                     packet.meta.set_discard(true);

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -612,7 +612,7 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
     debug!("CPU ECDSA for {}", packet_count);
 
     let thread_count = packet_count
-        .saturating_add(VERIFY_MIN_PACKETS_PER_THREAD - 1)
+        .saturating_add(VERIFY_MIN_PACKETS_PER_THREAD)
         .saturating_div(VERIFY_MIN_PACKETS_PER_THREAD);
     if thread_count >= get_thread_count() {
         // When using all available threads, skip the overhead of flatting, collecting, etc.

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -40,7 +40,7 @@ const TRACER_KEY_BYTES: [u8; 32] = [
 const TRACER_KEY: Pubkey = Pubkey::new_from_array(TRACER_KEY_BYTES);
 const TRACER_KEY_OFFSET_IN_TRANSACTION: usize = 69;
 // Empirically derived to constrain max verify latency to ~8ms at lower packet counts
-const VERIFY_MIN_PACKETS_PER_THREAD: usize = 128;
+pub const VERIFY_MIN_PACKETS_PER_THREAD: usize = 128;
 
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -615,8 +615,8 @@ pub fn ed25519_verify_cpu(batches: &mut [PacketBatch], reject_non_vote: bool, pa
         .saturating_div(VERIFY_MIN_PACKETS_PER_THREAD);
     if desired_thread_count <= 1 {
         // When using single thread, skip rayon overhead.
-        batches.into_par_iter().for_each(|batch| {
-            batch.par_iter_mut().for_each(|packet| {
+        batches.into_iter().for_each(|batch| {
+            batch.iter_mut().for_each(|packet| {
                 if !packet.meta.discard() && !verify_packet(packet, reject_non_vote) {
                     packet.meta.set_discard(true);
                 }


### PR DESCRIPTION
Continuation from #25833 

#### Problem
When a node is about to become leader, there is a flood of traffic on the TPU port. This causes a spike in verify CPU time consumption, which takes away compute resources from replay and can slow it down. We've observed this slowdown in replay leading to forks and thus skipped slots, especially in lower core count systems.

#### Summary of Changes
Add minimum length iterator (for packet count) when dealing with lower packet counts to reduce the amount of CPU consumed. This minimum limit is dynamic based on incoming packet count and strives to have no more than X packets (taking ~X*100us to verify) per thread when possible.