### PR TITLE
ci: Install gcc explicitly for client targets

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Install cargo-ndk
         if: ${{ matrix.platform == 'android' }}
         run: cargo install cargo-ndk
+      - name: Install gcc
+        if: ${{ matrix.platform == 'android' }}
+        run: sudo apt install -y gcc-multilib
+      - name: Install gcc
+        if: ${{ matrix.platform == 'ios' }}
+        run: brew install gcc
       - uses: actions-rs/cargo@v1
         if: ${{ matrix.platform == 'android' }}
         with:

--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -54,12 +54,14 @@ jobs:
       - name: Install cargo-ndk
         if: ${{ matrix.platform == 'android' }}
         run: cargo install cargo-ndk
-      - name: Install gcc
+      - name: Force install gcc
         if: ${{ matrix.platform == 'android' }}
-        run: sudo apt install -y gcc-multilib
-      - name: Install gcc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lib32gcc-7-dev gcc-multilib
+      - name: Force install gcc
         if: ${{ matrix.platform == 'ios' }}
-        run: brew install gcc
+        run: brew reinstall gcc
       - uses: actions-rs/cargo@v1
         if: ${{ matrix.platform == 'android' }}
         with:


### PR DESCRIPTION
#### Problem

Client jobs are failing due to a missing gcc library, ie https://github.com/solana-labs/solana/runs/6813194346

#### Summary of Changes

Force install gcc during the run.