### PR TITLE
serialize snapshots dir first

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -342,7 +342,7 @@ pub fn archive_snapshot_package(
 
         let do_archive_files = |encoder: &mut dyn Write| -> Result<()> {
             let mut archive = tar::Builder::new(encoder);
-            for dir in ["accounts", "snapshots"] {
+            for dir in ["snapshots", "accounts"] {
                 archive.append_dir_all(dir, staging_dir.as_ref().join(dir))?;
             }
             archive.append_path_with_name(staging_dir.as_ref().join("version"), "version")?;


### PR DESCRIPTION
#### Problem
We can begin indexing our snapshots as we untar other files, however we run into the issue that we don't the know the `current_len` of the append_vec files until we untar the snapshots directory. Currently the snapshots dir is serialized after the accounts directory.

#### Summary of Changes
Serialize the snapshots directory before the accounts directory.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
