### PR TITLE
chore: set ndk21 as default

### DIFF
--- a/.github/workflows/client-targets.yml
+++ b/.github/workflows/client-targets.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Install cargo-ndk
         if: ${{ matrix.platform == 'android' }}
         run: cargo install cargo-ndk
+      - name: Set NDK 21 as default
+        if: ${{ matrix.platform == 'android' }}
+        run: |
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
       - uses: actions-rs/cargo@v1
         if: ${{ matrix.platform == 'android' }}
         with:


### PR DESCRIPTION
#### Problem

due to github action has upgraded their default ndk version
(https://github.com/actions/virtual-environments/issues/5595)

We will need to relink ndk 21 back so that our test won't break.
