### PR TITLE
support outgoing merkle shred creation

### DIFF
--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -51,7 +51,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
     const NUM_SHREDS: usize = 32;
-    let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
+    let shred = Shred::new_from_data(None, 0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
     let shreds = vec![shred; NUM_SHREDS];
     let mut stakes = HashMap::new();
     const NUM_PEERS: usize = 200;

--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -40,6 +40,7 @@ fn get_retransmit_peers_deterministic(
     for i in 0..num_simulated_shreds {
         let index = i as u32;
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             index,
             parent_offset,

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -122,7 +122,17 @@ fn bench_deshredder(bencher: &mut Bencher) {
 fn bench_deserialize_hdr(bencher: &mut Bencher) {
     let data = vec![0; LEGACY_SHRED_DATA_CAPACITY];
 
-    let shred = Shred::new_from_data(2, 1, 1, &data, ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 1);
+    let shred = Shred::new_from_data(
+        None,
+        2,
+        1,
+        1,
+        &data,
+        ShredFlags::LAST_SHRED_IN_SLOT,
+        0,
+        0,
+        1,
+    );
 
     bencher.iter(|| {
         let payload = shred.payload().clone();

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -77,6 +77,7 @@ impl StandardBroadcastRun {
                     .unwrap_or(state.next_shred_index);
                 let fec_set_index = Shredder::fec_set_index(state.next_shred_index, fec_set_offset);
                 let mut shred = Shred::new_from_data(
+                    None, // legacy
                     state.slot,
                     state.next_shred_index,
                     parent_offset as u16,

--- a/core/src/outstanding_requests.rs
+++ b/core/src/outstanding_requests.rs
@@ -109,7 +109,7 @@ pub(crate) mod tests {
         let repair_type = ShredRepairType::Orphan(9);
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
-        let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
+        let shred = Shred::new_from_data(None, 0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
 
         let expire_timestamp = outstanding_requests
             .requests
@@ -129,7 +129,7 @@ pub(crate) mod tests {
         let mut outstanding_requests = OutstandingRequests::default();
         let nonce = outstanding_requests.add_request(repair_type, timestamp());
 
-        let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
+        let shred = Shred::new_from_data(None, 0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);
         let mut expire_timestamp = outstanding_requests
             .requests
             .get(&nonce)

--- a/core/src/repair_response.rs
+++ b/core/src/repair_response.rs
@@ -66,6 +66,7 @@ mod test {
     fn run_test_sigverify_shred_cpu_repair(slot: Slot) {
         solana_logger::setup();
         let mut shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3794,6 +3794,7 @@ pub(crate) mod tests {
             let gibberish = [0xa5u8; LEGACY_SHRED_DATA_CAPACITY];
             let parent_offset = bank.slot() - bank.parent_slot();
             let shred = Shred::new_from_data(
+                None, // legacy
                 bank.slot(),
                 0, // index,
                 parent_offset as u16,

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -536,6 +536,7 @@ mod tests {
         let index = 5;
         let version = 0x40;
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             index,
             0,
@@ -552,6 +553,7 @@ mod tests {
         assert!(should_skip_retransmit(&shred, &shreds_received));
 
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             index,
             2,
@@ -567,6 +569,7 @@ mod tests {
         assert!(should_skip_retransmit(&shred, &shreds_received));
 
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             index,
             8,
@@ -580,19 +583,19 @@ mod tests {
         assert!(should_skip_retransmit(&shred, &shreds_received));
         assert!(should_skip_retransmit(&shred, &shreds_received));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 0, 1, 1, 0, version);
+        let shred = Shred::new_from_parity_shard(None, slot, index, &[], 0, 1, 1, 0, version);
         // Coding at (1, 5) passes
         assert!(!should_skip_retransmit(&shred, &shreds_received));
         // then blocked
         assert!(should_skip_retransmit(&shred, &shreds_received));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 2, 1, 1, 0, version);
+        let shred = Shred::new_from_parity_shard(None, slot, index, &[], 2, 1, 1, 0, version);
         // 2nd unique coding at (1, 5) passes
         assert!(!should_skip_retransmit(&shred, &shreds_received));
         // same again is blocked
         assert!(should_skip_retransmit(&shred, &shreds_received));
 
-        let shred = Shred::new_from_parity_shard(slot, index, &[], 3, 1, 1, 0, version);
+        let shred = Shred::new_from_parity_shard(None, slot, index, &[], 3, 1, 1, 0, version);
         // Another unique coding at (1, 5) always blocked
         assert!(should_skip_retransmit(&shred, &shreds_received));
         assert!(should_skip_retransmit(&shred, &shreds_received));

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -874,7 +874,7 @@ mod tests {
                 nonce,
             );
             assert!(rv.is_none());
-            let shred = Shred::new_from_data(slot, 1, 1, &[], ShredFlags::empty(), 0, 2, 0);
+            let shred = Shred::new_from_data(None, slot, 1, 1, &[], ShredFlags::empty(), 0, 2, 0);
 
             blockstore
                 .insert_shreds(vec![shred], None, false)
@@ -1300,7 +1300,7 @@ mod tests {
     #[test]
     fn test_verify_shred_response() {
         fn new_test_data_shred(slot: Slot, index: u32) -> Shred {
-            Shred::new_from_data(slot, index, 1, &[], ShredFlags::empty(), 0, 0, 0)
+            Shred::new_from_data(None, slot, index, 1, &[], ShredFlags::empty(), 0, 0, 0)
         }
         let repair = ShredRepairType::Orphan(9);
         // Ensure new options are addded to this test

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -228,6 +228,7 @@ mod tests {
 
         let slot = 1;
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             3,   // shred index
             0,   // parent offset
@@ -299,7 +300,8 @@ mod tests {
         );
         assert_eq!(stats.index_overrun, 1);
         assert!(packet.meta.discard());
-        let shred = Shred::new_from_data(1, 3, 0, &[], ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 0);
+        let shred =
+            Shred::new_from_data(None, 1, 3, 0, &[], ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 0);
         shred.copy_to_packet(&mut packet);
 
         // rejected slot is 1, root is 3
@@ -342,6 +344,7 @@ mod tests {
         assert!(packet.meta.discard());
 
         let shred = Shred::new_from_data(
+            None, // legacy
             1_000_000,
             3,
             0,
@@ -367,7 +370,17 @@ mod tests {
         assert!(packet.meta.discard());
 
         let index = MAX_DATA_SHREDS_PER_SLOT as u32;
-        let shred = Shred::new_from_data(5, index, 0, &[], ShredFlags::LAST_SHRED_IN_SLOT, 0, 0, 0);
+        let shred = Shred::new_from_data(
+            None,
+            5,
+            index,
+            0,
+            &[],
+            ShredFlags::LAST_SHRED_IN_SLOT,
+            0,
+            0,
+            0,
+        );
         shred.copy_to_packet(&mut packet);
         ShredFetchStage::process_packet(
             &mut packet,

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -102,6 +102,7 @@ pub mod tests {
     fn test_sigverify_shreds_read_slots() {
         solana_logger::setup();
         let mut shred = Shred::new_from_data(
+            None, // legacy
             0xdead_c0de,
             0xc0de,
             0xdead,
@@ -125,6 +126,7 @@ pub mod tests {
         batches[0][0].meta.size = shred.payload().len();
 
         let mut shred = Shred::new_from_data(
+            None, // legacy
             0xc0de_dead,
             0xc0de,
             0xdead,
@@ -160,6 +162,7 @@ pub mod tests {
         let mut batches = vec![batch];
 
         let mut shred = Shred::new_from_data(
+            None, // legacy
             0,
             0xc0de,
             0xdead,
@@ -174,6 +177,7 @@ pub mod tests {
         batches[0][0].meta.size = shred.payload().len();
 
         let mut shred = Shred::new_from_data(
+            None, // legacy
             0,
             0xbeef,
             0xc0de,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -867,14 +867,15 @@ mod test {
 
         // coding shreds don't contain parent slot information, test that slot >= root
         let mut coding_shred = Shred::new_from_parity_shard(
-            5,   // slot
-            5,   // index
-            &[], // parity_shard
-            5,   // fec_set_index
-            6,   // num_data_shreds
-            6,   // num_coding_shreds
-            3,   // position
-            0,   // version
+            None, // legacy
+            5,    // slot
+            5,    // index
+            &[],  // parity_shard
+            5,    // fec_set_index
+            6,    // num_data_shreds
+            6,    // num_coding_shreds
+            3,    // position
+            0,    // version
         );
         coding_shred.sign(&leader_keypair);
         // shred.slot() > root, shred continues
@@ -950,14 +951,15 @@ mod test {
         };
         solana_logger::setup();
         let shred = Shred::new_from_parity_shard(
-            5,   // slot
-            5,   // index
-            &[], // parity_shard
-            5,   // fec_set_index
-            6,   // num_data_shreds
-            6,   // num_coding_shreds
-            4,   // position
-            0,   // version
+            None, // legacy
+            5,    // slot
+            5,    // index
+            &[],  // parity_shard
+            5,    // fec_set_index
+            6,    // num_data_shreds
+            6,    // num_coding_shreds
+            4,    // position
+            0,    // version
         );
         let mut shreds = vec![shred.clone(), shred.clone(), shred];
         let _from_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);

--- a/ledger/benches/sigverify_shreds.rs
+++ b/ledger/benches/sigverify_shreds.rs
@@ -26,6 +26,7 @@ fn bench_sigverify_shreds_sign_gpu(bencher: &mut Bencher) {
     let slot = 0xdead_c0de;
     for p in packet_batch.iter_mut() {
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,
@@ -57,6 +58,7 @@ fn bench_sigverify_shreds_sign_cpu(bencher: &mut Bencher) {
     packet_batch.resize(NUM_PACKETS, Packet::default());
     for p in packet_batch.iter_mut() {
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5702,6 +5702,7 @@ pub mod tests {
         let shreds: Vec<_> = (0..64)
             .map(|i| {
                 Shred::new_from_data(
+                    None, // legacy
                     slot,
                     (i * gap) as u32,
                     0,
@@ -5830,6 +5831,7 @@ pub mod tests {
         // may be used as signals (broadcast does so to indicate a slot was interrupted)
         // Reuse shred5's header values to avoid a false negative result
         let empty_shred = Shred::new_from_data(
+            None, // legacy
             shred5.slot(),
             shred5.index(),
             {
@@ -5937,6 +5939,7 @@ pub mod tests {
 
         let slot = 1;
         let coding_shred = Shred::new_from_parity_shard(
+            None, // legacy
             slot,
             11,  // index
             &[], // parity_shard
@@ -5995,6 +5998,7 @@ pub mod tests {
 
         let slot = 1;
         let mut coding_shred = Shred::new_from_parity_shard(
+            None, // legacy
             slot,
             11,  // index
             &[], // parity_shard
@@ -6236,6 +6240,7 @@ pub mod tests {
 
         // Insert an empty shred that won't deshred into entries
         let shreds = vec![Shred::new_from_data(
+            None, // legacy
             slot,
             next_shred_index as u32,
             1,

--- a/ledger/src/shred/traits.rs
+++ b/ledger/src/shred/traits.rs
@@ -1,6 +1,6 @@
 use {
     crate::shred::{CodingShredHeader, DataShredHeader, Error, ShredCommonHeader},
-    solana_sdk::{clock::Slot, signature::Signature},
+    solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature},
 };
 
 pub(super) trait Shred: Sized {
@@ -26,6 +26,8 @@ pub(super) trait Shred: Sized {
 
     // Portion of the payload which is signed.
     fn signed_message(&self) -> &[u8];
+
+    fn verify(&self, pubkey: &Pubkey) -> bool;
 
     // Only for tests.
     fn set_index(&mut self, index: u32);

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -128,6 +128,7 @@ impl Shredder {
             let parent_offset = self.slot - self.parent_slot;
             let fec_set_index = Self::fec_set_index(shred_index, fec_set_offset);
             let mut shred = Shred::new_from_data(
+                None, // legacy
                 self.slot,
                 shred_index,
                 parent_offset as u16,
@@ -255,6 +256,7 @@ impl Shredder {
             .map(|(i, parity)| {
                 let index = next_code_index + u32::try_from(i).unwrap();
                 Shred::new_from_parity_shard(
+                    None, // legacy
                     slot,
                     index,
                     parity,

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -431,6 +431,7 @@ mod tests {
         solana_logger::setup();
         let mut packet = Packet::default();
         let mut shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,
@@ -473,6 +474,7 @@ mod tests {
         solana_logger::setup();
         let mut batches = [PacketBatch::default()];
         let mut shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,
@@ -527,6 +529,7 @@ mod tests {
 
         let mut batches = [PacketBatch::default()];
         let mut shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,
@@ -595,6 +598,7 @@ mod tests {
 
         for (i, p) in packet_batch.iter_mut().enumerate() {
             let shred = Shred::new_from_data(
+                None, // legacy
                 slot,
                 0xc0de,
                 i as u16,
@@ -640,6 +644,7 @@ mod tests {
         let mut batches = [PacketBatch::default()];
         let keypair = Keypair::new();
         let shred = Shred::new_from_data(
+            None, // legacy
             slot,
             0xc0de,
             0xdead,


### PR DESCRIPTION
#### Problem

Need support for merkle shred creation.

#### Summary of Changes

- add merkle shred support for `new_from_data` and `new_from_parity_shard`
- moves merkle proof verification from `sanitize` to `verify`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
