### PR TITLE
Feature: Early verification of account modifications in `BorrowedAccount`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -46,6 +46,7 @@ use {
         signature::{keypair_from_seed, read_keypair_file, Keypair, Signature, Signer},
         system_instruction::{self, SystemError},
         system_program,
+        sysvar::rent::Rent,
         transaction::{Transaction, TransactionError},
         transaction_context::TransactionContext,
     },
@@ -2060,7 +2061,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+    let mut transaction_context = TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4532,7 +4532,10 @@ pub mod tests {
             mint_keypair,
             ..
         } = create_genesis_config((1_000_000 + NUM_ACCOUNTS + 1) * LAMPORTS_PER_SOL);
-        let bank = Bank::new_for_tests(&genesis_config);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        bank.deactivate_feature(
+            &feature_set::enable_early_verification_of_account_modifications::id(),
+        );
         let bank = Arc::new(bank);
         assert!(bank
             .feature_set
@@ -4595,6 +4598,9 @@ pub mod tests {
             mock_realloc::process_instruction,
         );
         bank.set_accounts_data_size_initial_for_tests(INITIAL_ACCOUNTS_DATA_SIZE);
+        bank.deactivate_feature(
+            &feature_set::enable_early_verification_of_account_modifications::id(),
+        );
         let bank = Arc::new(bank);
         let bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::new_unique(), 1));
         assert!(bank

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -848,9 +848,13 @@ impl<'a> InvokeContext<'a> {
                 .feature_set
                 .is_active(&record_instruction_in_transaction_context_push::id())
             {
+                let instruction_accounts_lamport_sum = self
+                    .transaction_context
+                    .instruction_accounts_lamport_sum(instruction_accounts)?;
                 self.transaction_context
                     .record_instruction(InstructionContext::new(
                         nesting_level,
+                        instruction_accounts_lamport_sum,
                         program_indices,
                         instruction_accounts,
                         instruction_data,
@@ -1186,8 +1190,8 @@ pub fn mock_process_instruction(
         )
         .and_then(|_| process_instruction(1, &mut invoke_context))
         .and_then(|_| invoke_context.verify(&preparation.instruction_accounts, &program_indices));
-    invoke_context.pop().unwrap();
-    assert_eq!(result, expected_result);
+    let pop_result = invoke_context.pop();
+    assert_eq!(result.and(pop_result), expected_result);
     let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();
     transaction_accounts.pop();
     transaction_accounts

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1199,7 +1199,7 @@ mod tests {
         super::*,
         crate::compute_budget,
         serde::{Deserialize, Serialize},
-        solana_sdk::account::{ReadableAccount, WritableAccount},
+        solana_sdk::account::WritableAccount,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -1277,16 +1277,13 @@ mod tests {
                 MockInstruction::NoopFail => return Err(InstructionError::GenericError),
                 MockInstruction::ModifyOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&[1])
-                    .unwrap(),
+                    .set_data(&[1])?,
                 MockInstruction::ModifyNotOwned => instruction_context
                     .try_borrow_instruction_account(transaction_context, 1)?
-                    .set_data(&[1])
-                    .unwrap(),
+                    .set_data(&[1])?,
                 MockInstruction::ModifyReadonly => instruction_context
                     .try_borrow_instruction_account(transaction_context, 2)?
-                    .set_data(&[1])
-                    .unwrap(),
+                    .set_data(&[1])?,
                 MockInstruction::ConsumeComputeUnits {
                     compute_units_to_consume,
                     desired_result,
@@ -1294,14 +1291,12 @@ mod tests {
                     invoke_context
                         .get_compute_meter()
                         .borrow_mut()
-                        .consume(compute_units_to_consume)
-                        .unwrap();
+                        .consume(compute_units_to_consume)?;
                     return desired_result;
                 }
                 MockInstruction::Resize { new_len } => instruction_context
                     .try_borrow_instruction_account(transaction_context, 0)?
-                    .set_data(&vec![0; new_len as usize])
-                    .unwrap(),
+                    .set_data(&vec![0; new_len as usize])?,
             }
         } else {
             return Err(InstructionError::InvalidInstructionData);

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1573,7 +1573,13 @@ mod tests {
             );
 
             assert!(result.is_ok());
-            assert_eq!(invoke_context.accounts_data_meter.remaining(), 0);
+            assert_eq!(
+                invoke_context
+                    .transaction_context
+                    .accounts_resize_delta()
+                    .unwrap(),
+                user_account_data_len as i64 * 2
+            );
         }
 
         // Test 2: Resize the account to *the same size*, so not consuming any additional size; this must succeed
@@ -1591,10 +1597,16 @@ mod tests {
             );
 
             assert!(result.is_ok());
-            assert_eq!(invoke_context.accounts_data_meter.remaining(), 0);
+            assert_eq!(
+                invoke_context
+                    .transaction_context
+                    .accounts_resize_delta()
+                    .unwrap(),
+                user_account_data_len as i64 * 2
+            );
         }
 
-        // Test 3: Resize the account to exceed the budget; this must fail
+        // Test 3: Resize the account to exceed the budget; this must succeed
         {
             let new_len = user_account_data_len + remaining_account_data_len + 1;
             let instruction_data =
@@ -1608,12 +1620,14 @@ mod tests {
                 &mut ExecuteTimings::default(),
             );
 
-            assert!(result.is_err());
-            assert!(matches!(
-                result,
-                Err(solana_sdk::instruction::InstructionError::MaxAccountsDataSizeExceeded)
-            ));
-            assert_eq!(invoke_context.accounts_data_meter.remaining(), 0);
+            assert!(result.is_ok());
+            assert_eq!(
+                invoke_context
+                    .transaction_context
+                    .accounts_resize_delta()
+                    .unwrap(),
+                user_account_data_len as i64 * 2 + 1
+            );
         }
     }
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -305,7 +305,7 @@ fn run_program(name: &str) -> u64 {
                     tracer = Some(vm.get_tracer().clone());
                 }
             }
-            deserialize_parameters(
+            assert!(match deserialize_parameters(
                 invoke_context.transaction_context,
                 invoke_context
                     .transaction_context
@@ -313,8 +313,21 @@ fn run_program(name: &str) -> u64 {
                     .unwrap(),
                 parameter_bytes.as_slice(),
                 &account_lengths,
-            )
-            .unwrap();
+            ) {
+                Ok(()) => true,
+                Err(InstructionError::ModifiedProgramId) => true,
+                Err(InstructionError::ExternalAccountLamportSpend) => true,
+                Err(InstructionError::ReadonlyLamportChange) => true,
+                Err(InstructionError::ExecutableLamportChange) => true,
+                Err(InstructionError::ExecutableAccountNotRentExempt) => true,
+                Err(InstructionError::ExecutableModified) => true,
+                Err(InstructionError::AccountDataSizeChanged) => true,
+                Err(InstructionError::InvalidRealloc) => true,
+                Err(InstructionError::ExecutableDataModified) => true,
+                Err(InstructionError::ReadonlyDataModified) => true,
+                Err(InstructionError::ExternalAccountDataModified) => true,
+                _ => false,
+            });
         }
         instruction_count
     })

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -9,6 +9,7 @@ use {
     solana_sdk::{
         account::{Account, AccountSharedData},
         bpf_loader,
+        sysvar::rent::Rent,
         transaction_context::{InstructionAccount, TransactionContext},
     },
     test::Bencher,
@@ -101,7 +102,8 @@ fn create_inputs() -> TransactionContext {
             },
         )
         .collect::<Vec<_>>();
-    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
+    let mut transaction_context =
+        TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
         .push(&[0], &instruction_accounts, &instruction_data, true)

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -512,16 +512,6 @@ mod tests {
             );
         }
 
-        for index_in_transaction in 1..original_accounts.len() {
-            let mut account = invoke_context
-                .transaction_context
-                .get_account_at_index(index_in_transaction)
-                .unwrap()
-                .borrow_mut();
-            account.set_lamports(0);
-            account.set_data(vec![0; 0]);
-            account.set_owner(Pubkey::default());
-        }
         deserialize_parameters(
             invoke_context.transaction_context,
             instruction_context,
@@ -545,13 +535,12 @@ mod tests {
             .unwrap()
             .1
             .set_owner(bpf_loader_deprecated::id());
-        let _ = invoke_context
+        invoke_context
             .transaction_context
-            .get_current_instruction_context()
+            .get_account_at_index(0)
             .unwrap()
-            .try_borrow_program_account(invoke_context.transaction_context, 0)
-            .unwrap()
-            .set_owner(bpf_loader_deprecated::id().as_ref());
+            .borrow_mut()
+            .set_owner(bpf_loader_deprecated::id());
 
         let (mut serialized, account_lengths) =
             serialize_parameters(invoke_context.transaction_context, instruction_context).unwrap();
@@ -578,15 +567,6 @@ mod tests {
             assert_eq!(account.rent_epoch(), account_info.rent_epoch);
         }
 
-        for index_in_transaction in 1..original_accounts.len() {
-            let mut account = invoke_context
-                .transaction_context
-                .get_account_at_index(index_in_transaction)
-                .unwrap()
-                .borrow_mut();
-            account.set_lamports(0);
-            account.set_data(vec![0; 0]);
-        }
         deserialize_parameters(
             invoke_context.transaction_context,
             instruction_context,

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -372,6 +372,7 @@ mod tests {
             bpf_loader,
             entrypoint::deserialize,
             instruction::AccountMeta,
+            sysvar::rent::Rent,
         },
         std::{
             cell::RefCell,
@@ -474,8 +475,12 @@ mod tests {
             instruction_accounts,
             &program_indices,
         );
-        let mut transaction_context =
-            TransactionContext::new(preparation.transaction_accounts, 1, 1);
+        let mut transaction_context = TransactionContext::new(
+            preparation.transaction_accounts,
+            Some(Rent::default()),
+            1,
+            1,
+        );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3395,7 +3395,8 @@ mod tests {
                 ),
                 ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
             ];
-            let mut $transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
+            let mut $transaction_context =
+                TransactionContext::new(transaction_accounts, Some(Rent::default()), 1, 1);
             let mut $invoke_context = InvokeContext::new_mock(&mut $transaction_context, &[]);
             $invoke_context.push(&[], &[0, 1], &[]).unwrap();
         };

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2783,6 +2783,7 @@ mod tests {
                 Rent::id(),
                 create_account_shared_data_for_test(&Rent::default()),
             )],
+            Some(Rent::default()),
             1,
             1,
         )
@@ -2894,7 +2895,8 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let good_stake = Stake {
             credits_observed: 4242,
@@ -2993,7 +2995,8 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
@@ -3140,7 +3143,8 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
@@ -3379,7 +3383,8 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let clock = Clock::default();
         let lamports = 424242;

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -107,7 +107,12 @@ fn bench_process_vote_instruction(
     instruction_data: Vec<u8>,
 ) {
     bencher.iter(|| {
-        let mut transaction_context = TransactionContext::new(transaction_accounts.clone(), 1, 1);
+        let mut transaction_context = TransactionContext::new(
+            transaction_accounts.clone(),
+            Some(sysvar::rent::Rent::default()),
+            1,
+            1,
+        );
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(&instruction_accounts, &[0], &instruction_data)

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -16,7 +16,7 @@ use {
     },
     solana_sdk::{
         account::AccountSharedData, bpf_loader, instruction::AccountMeta, pubkey::Pubkey,
-        transaction_context::TransactionContext,
+        sysvar::rent::Rent, transaction_context::TransactionContext,
     },
     std::{
         fmt::{Debug, Formatter},
@@ -216,7 +216,12 @@ native machine code before execting it in the virtual machine.",
     let program_indices = [0, 1];
     let preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
-    let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1, 1);
+    let mut transaction_context = TransactionContext::new(
+        preparation.transaction_accounts,
+        Some(Rent::default()),
+        1,
+        1,
+    );
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     invoke_context
         .push(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -18819,15 +18819,15 @@ pub(crate) mod tests {
     fn test_inner_instructions_list_from_instruction_trace() {
         let instruction_trace = vec![
             vec![
-                InstructionContext::new(0, &[], &[], &[1]),
-                InstructionContext::new(1, &[], &[], &[2]),
+                InstructionContext::new(0, 0, &[], &[], &[1]),
+                InstructionContext::new(1, 0, &[], &[], &[2]),
             ],
             vec![],
             vec![
-                InstructionContext::new(0, &[], &[], &[3]),
-                InstructionContext::new(1, &[], &[], &[4]),
-                InstructionContext::new(2, &[], &[], &[5]),
-                InstructionContext::new(1, &[], &[], &[6]),
+                InstructionContext::new(0, 0, &[], &[], &[3]),
+                InstructionContext::new(1, 0, &[], &[], &[4]),
+                InstructionContext::new(2, 0, &[], &[], &[5]),
+                InstructionContext::new(1, 0, &[], &[], &[6]),
             ],
         ];
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4274,6 +4274,14 @@ impl Bank {
         let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,
+            if self
+                .feature_set
+                .is_active(&enable_early_verification_of_account_modifications::id())
+            {
+                Some(self.rent_collector.rent)
+            } else {
+                None
+            },
             compute_budget.max_invoke_depth.saturating_add(1),
             tx.message().instructions().len(),
         );
@@ -18699,6 +18707,7 @@ pub(crate) mod tests {
         });
         let transaction_context = TransactionContext::new(
             loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
+            Some(Rent::default()),
             compute_budget.max_invoke_depth.saturating_add(1),
             number_of_instructions_at_transaction_level,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -17879,9 +17879,6 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000_000);
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.activate_feature(&feature_set::cap_accounts_data_len::id());
-        bank.activate_feature(
-            &feature_set::enable_early_verification_of_account_modifications::id(),
-        );
         bank.accounts_data_size_initial = bank.accounts_data_size_limit()
             - REMAINING_ACCOUNTS_DATA_SIZE
             - bank.load_accounts_data_size_delta() as u64;
@@ -17935,9 +17932,6 @@ pub(crate) mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1_000.));
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.activate_feature(&feature_set::cap_accounts_data_len::id());
-        bank.activate_feature(
-            &feature_set::enable_early_verification_of_account_modifications::id(),
-        );
         let transaction = system_transaction::create_account(
             &mint_keypair,
             &Keypair::new(),
@@ -17979,9 +17973,6 @@ pub(crate) mod tests {
         const ACCOUNT_SIZE: u64 = MAX_PERMITTED_DATA_LENGTH;
         let mut bank = create_simple_test_bank(1_000_000_000_000);
         bank.activate_feature(&feature_set::cap_accounts_data_len::id());
-        bank.activate_feature(
-            &feature_set::enable_early_verification_of_account_modifications::id(),
-        );
         let transaction = system_transaction::create_account(
             &Keypair::new(),
             &Keypair::new(),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -282,7 +282,8 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
+        let mut transaction_context =
+            TransactionContext::new(accounts, Some(Rent::default()), 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_keys = transaction_context.get_keys_of_accounts().to_vec();
@@ -502,7 +503,8 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
+        let mut transaction_context =
+            TransactionContext::new(accounts, Some(Rent::default()), 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_metas = vec![
@@ -661,7 +663,8 @@ mod tests {
             (secp256k1_program::id(), secp256k1_account),
             (mock_program_id, mock_program_account),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 2);
+        let mut transaction_context =
+            TransactionContext::new(accounts, Some(Rent::default()), 1, 2);
 
         let message = SanitizedMessage::Legacy(Message::new(
             &[

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -328,7 +328,8 @@ mod test {
                     is_writable: true,
                 },
             ];
-            let mut transaction_context = TransactionContext::new(accounts, 1, 2);
+            let mut transaction_context =
+                TransactionContext::new(accounts, Some(Rent::default()), 1, 2);
             let mut $invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         };
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -786,7 +786,8 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(Vec::new(), Some(Rent::default()), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -456,6 +456,10 @@ pub mod enable_bpf_loader_extend_program_data_ix {
     solana_sdk::declare_id!("8Zs9W7D9MpSEtUWSQdGniZk2cNmV22y6FLJwCx53asme");
 }
 
+pub mod enable_early_verification_of_account_modifications {
+    solana_sdk::declare_id!("7Vced912WrRnfjaiKRiNBcbuFw7RrnLv3E3z95Y4GTNc");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -564,6 +568,7 @@ lazy_static! {
         (cap_accounts_data_size_per_block::id(), "cap the accounts data size per block #25517"),
         (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
         (enable_bpf_loader_extend_program_data_ix::id(), "enable bpf upgradeable loader ExtendProgramData instruction #25234"),
+        (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -197,7 +197,7 @@ impl TransactionContext {
         instruction_data: &[u8],
         record_instruction_in_transaction_context_push: bool,
     ) -> Result<(), InstructionError> {
-        let instruction_accounts_lamport_sum =
+        let callee_instruction_accounts_lamport_sum =
             self.instruction_accounts_lamport_sum(instruction_accounts)?;
         let index_in_trace = if self.instruction_stack.is_empty() {
             debug_assert!(
@@ -205,27 +205,43 @@ impl TransactionContext {
             );
             let instruction_context = InstructionContext {
                 nesting_level: self.instruction_stack.len(),
-                instruction_accounts_lamport_sum,
+                instruction_accounts_lamport_sum: callee_instruction_accounts_lamport_sum,
                 program_accounts: program_accounts.to_vec(),
                 instruction_accounts: instruction_accounts.to_vec(),
                 instruction_data: instruction_data.to_vec(),
             };
             self.instruction_trace.push(vec![instruction_context]);
             self.instruction_trace.len().saturating_sub(1)
-        } else if let Some(instruction_trace) = self.instruction_trace.last_mut() {
-            if record_instruction_in_transaction_context_push {
-                let instruction_context = InstructionContext {
-                    nesting_level: self.instruction_stack.len(),
-                    instruction_accounts_lamport_sum,
-                    program_accounts: program_accounts.to_vec(),
-                    instruction_accounts: instruction_accounts.to_vec(),
-                    instruction_data: instruction_data.to_vec(),
-                };
-                instruction_trace.push(instruction_context);
-            }
-            instruction_trace.len().saturating_sub(1)
         } else {
-            return Err(InstructionError::CallDepth);
+            if self.is_early_verification_of_account_modifications_enabled() {
+                let caller_instruction_context = self.get_current_instruction_context()?;
+                let original_caller_instruction_accounts_lamport_sum =
+                    caller_instruction_context.instruction_accounts_lamport_sum;
+                let current_caller_instruction_accounts_lamport_sum = self
+                    .instruction_accounts_lamport_sum(
+                        &caller_instruction_context.instruction_accounts,
+                    )?;
+                if original_caller_instruction_accounts_lamport_sum
+                    != current_caller_instruction_accounts_lamport_sum
+                {
+                    return Err(InstructionError::UnbalancedInstruction);
+                }
+            }
+            if let Some(instruction_trace) = self.instruction_trace.last_mut() {
+                if record_instruction_in_transaction_context_push {
+                    let instruction_context = InstructionContext {
+                        nesting_level: self.instruction_stack.len(),
+                        instruction_accounts_lamport_sum: callee_instruction_accounts_lamport_sum,
+                        program_accounts: program_accounts.to_vec(),
+                        instruction_accounts: instruction_accounts.to_vec(),
+                        instruction_data: instruction_data.to_vec(),
+                    };
+                    instruction_trace.push(instruction_context);
+                }
+                instruction_trace.len().saturating_sub(1)
+            } else {
+                return Err(InstructionError::CallDepth);
+            }
         };
         if self.instruction_stack.len() >= self.instruction_context_capacity {
             return Err(InstructionError::CallDepth);

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -336,6 +336,14 @@ impl TransactionContext {
         }
         Ok(instruction_accounts_lamport_sum)
     }
+
+    /// Returns the accounts resize delta
+    pub fn accounts_resize_delta(&self) -> Result<i64, InstructionError> {
+        self.accounts_resize_delta
+            .try_borrow()
+            .map_err(|_| InstructionError::GenericError)
+            .map(|value_ref| *value_ref)
+    }
 }
 
 /// Return data at the end of a transaction

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -59,6 +59,7 @@ impl TransactionContext {
     /// Constructs a new TransactionContext
     pub fn new(
         transaction_accounts: Vec<TransactionAccount>,
+        rent: Option<Rent>,
         instruction_context_capacity: usize,
         number_of_instructions_at_transaction_level: usize,
     ) -> Self {
@@ -78,7 +79,7 @@ impl TransactionContext {
             instruction_trace: Vec::with_capacity(number_of_instructions_at_transaction_level),
             return_data: TransactionReturnData::default(),
             accounts_resize_delta: RefCell::new(0),
-            rent: None,
+            rent,
         }
     }
 
@@ -91,11 +92,6 @@ impl TransactionContext {
             .into_iter()
             .map(|account| account.into_inner())
             .collect())
-    }
-
-    /// Call this if `enable_early_verification_of_account_modifications` is active
-    pub fn enable_early_verification_of_account_modifications(&mut self, rent: &Rent) {
-        self.rent = Some(*rent);
     }
 
     /// Returns true if `enable_early_verification_of_account_modifications` is active


### PR DESCRIPTION
#### Problem
This is a continuation of #25380.

Currently, for BPF programs the verification cost is:
- One data copy from `AccountSharedData` to create or update the `PreAccount`
- One data copy from the BPF program into the `AccountSharedData` so we can compare it against `PreAccount`
- The actual comparison in `PreAccount` (this is skipped if the data is allowed to be modified)

Assuming that copies and comparison incur a similar cost (as they both need to access two different pointers, polluting the data cache), we could reduce this cost by 50% up to 66% for every account in every ABIv0 and ABIv1 BPF program executed. Built-in programs would also profit, reducing their verification cost by almost 100%. In ABIv2 BPF programs will be like built-in programs in this regard.

#### Summary of Changes
This PR introduces the feature `enable_early_verification_of_account_modifications` which controls the switch from the current behavior to the following:

1. Account modification errors are thrown earlier (hence the name of the feature). Specifically, they occur the moment they are attempted, not at the begin / end of instructions and CPI. The primary motivation is to get rid of `PreAccount` and all the redundant data copies and data comparisons that come with it. As a side effect, this should make debugging easier because we can get the call stack where the error occurs.

2. Similarly to the deprecation of `PreAccount`, `AccountsDataMeter` will also be deprecated and its functionality replicated inside `TransactionContext`. This was necessary as the `AccountsDataMeter` is currently updated and verified from withing the `PreAccount`s.

3. As a consequence, first corrupting (meta)data and then later correcting it into a valid state again won't fly anymore. Every change will have to be valid on its own. This however, does only apply to the runtime and built-in programs, not to BPF programs of ABIv0 and ABIv1 (all currently deployed programs) as they will continue to have their checks at the deserialization edge.

4. Failed attempted account modifications used to be counted as modifications, now they are not recorded as "touched" anymore.

5. All the explicit / dedicated account modification tests inside `InvokeContext`, `PreAccount` and `AccountsDataMeter` are disabled / become unreachable.

6. The loader and built-in tests on the other hand, become stricter as they now have to adhere to all account modification rules.

7. Two tests to trigger `InstructionError::UnbalancedInstruction` (which was not covered before) were added.

---

Feature Gate Issue: #26589