### PR TITLE
Remove `SlotT` type alias

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -2,12 +2,15 @@ use {
     crate::{
         accounts_index::{AccountsIndexConfig, IndexLimitMb, IndexValue},
         bucket_map_holder_stats::BucketMapHolderStats,
-        in_mem_accounts_index::{InMemAccountsIndex, SlotT},
+        in_mem_accounts_index::InMemAccountsIndex,
         waitable_condvar::WaitableCondvar,
     },
     solana_bucket_map::bucket_map::{BucketMap, BucketMapConfig},
     solana_measure::measure::Measure,
-    solana_sdk::{clock::SLOT_MS, timing::AtomicInterval},
+    solana_sdk::{
+        clock::{Slot, SLOT_MS},
+        timing::AtomicInterval,
+    },
     std::{
         fmt::Debug,
         sync::{
@@ -25,7 +28,7 @@ const AGE_MS: u64 = SLOT_MS; // match one age per slot time
 pub const DEFAULT_DISK_INDEX: Option<usize> = Some(10_000);
 
 pub struct BucketMapHolder<T: IndexValue> {
-    pub disk: Option<BucketMap<SlotT<T>>>,
+    pub disk: Option<BucketMap<(Slot, T)>>,
 
     pub count_buckets_flushed: AtomicUsize,
     pub age: AtomicU8,

--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -26,7 +26,6 @@ use {
 };
 type K = Pubkey;
 type CacheRangesHeld = RwLock<Vec<RangeInclusive<Pubkey>>>;
-pub type SlotT<T> = (Slot, T);
 
 type InMemMap<T> = HashMap<Pubkey, AccountMapEntry<T>>;
 
@@ -40,7 +39,7 @@ pub struct InMemAccountsIndex<T: IndexValue> {
     storage: Arc<BucketMapHolder<T>>,
     bin: usize,
 
-    bucket: Option<Arc<BucketApi<SlotT<T>>>>,
+    bucket: Option<Arc<BucketApi<(Slot, T)>>>,
 
     // pubkey ranges that this bin must hold in the cache while the range is present in this vec
     pub(crate) cache_ranges_held: CacheRangesHeld,


### PR DESCRIPTION
#### Problem

I find the `SlotT` type alias more confusing than it's worth. It changes `(Slot, T)` to `SlotT<T>`, which adds a level of indirection to the underlying type but doesn't _really_ abstract away anything.

#### Summary of Changes

Remove the `SlotT` type alias and use `(Slot, T)` directly.