### PR TITLE
Manual Bump Version to 1.10.26

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3960,10 +3960,10 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-curve25519"
-version = "1.10.25"
+version = "1.10.26"
 dependencies = [
- "solana-program 1.10.25",
- "solana-zk-token-sdk 1.10.25",
+ "solana-program 1.10.26",
+ "solana-zk-token-sdk 1.10.26",
 ]
 
 [[package]]

--- a/programs/bpf/rust/curve25519/Cargo.toml
+++ b/programs/bpf/rust/curve25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-bpf-rust-curve25519"
-version = "1.10.25"
+version = "1.10.26"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
 edition = "2018"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.10.25" }
-solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.10.25" }
+solana-program = { path = "../../../../sdk/program", version = "=1.10.26" }
+solana-zk-token-sdk = { path = "../../../../zk-token-sdk", version = "=1.10.26" }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
curve25519 tests backport landed while the v1.10 automated version bump
was progressing through CI. As such, the Cargo.toml file didn't exist in
the repo yet to be picked up by the script for bump.