### PR TITLE
Bump rust edition to 2021 to match rest of repo

### DIFF
--- a/programs/bpf/rust/curve25519/Cargo.toml
+++ b/programs/bpf/rust/curve25519/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 solana-program = { path = "../../../../sdk/program", version = "=1.11.0" }

--- a/programs/bpf/rust/zk_token_elgamal/Cargo.toml
+++ b/programs/bpf/rust/zk_token_elgamal/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
 documentation = "https://docs.rs/solana-bpf-rust-zktoken_crypto"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 solana-program = { path = "../../../../sdk/program", version = "=1.11.0" }


### PR DESCRIPTION
The rest of the monorepo uses 2021 as the rust version, bumping these up to match.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
