### PR TITLE
Do not exclude failed simple vote transactions from consensus

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3536,15 +3536,13 @@ pub mod tests {
         // Create an transaction that references the new blockhash, should still
         // be able to find the blockhash if we process transactions all in the same
         // batch
-        let mut expected_successful_voter_pubkeys = BTreeSet::new();
+        let mut expected_signatures = BTreeSet::new();
         let vote_txs: Vec<_> = validator_keypairs
             .iter()
             .enumerate()
             .map(|(i, validator_keypairs)| {
-                if i % 3 == 0 {
+                let vote_tx = if i % 3 == 0 {
                     // These votes are correct
-                    expected_successful_voter_pubkeys
-                        .insert(validator_keypairs.vote_keypair.pubkey());
                     vote_transaction::new_vote_transaction(
                         vec![0],
                         bank0.hash(),
@@ -3576,18 +3574,20 @@ pub mod tests {
                         &validator_keypairs.vote_keypair,
                         None,
                     )
-                }
+                };
+                expected_signatures.insert(vote_tx.signatures[0]);
+                vote_tx
             })
             .collect();
         let entry = next_entry(&bank_1_blockhash, 1, vote_txs);
         let (replay_vote_sender, replay_vote_receiver) = crossbeam_channel::unbounded();
         let _ =
             process_entries_for_tests(&bank1, vec![entry], true, None, Some(&replay_vote_sender));
-        let successes: BTreeSet<Pubkey> = replay_vote_receiver
+        let signatures: BTreeSet<_> = replay_vote_receiver
             .try_iter()
-            .map(|(vote_pubkey, ..)| vote_pubkey)
+            .map(|(.., signature)| signature)
             .collect();
-        assert_eq!(successes, expected_successful_voter_pubkeys);
+        assert_eq!(signatures, expected_signatures);
     }
 
     fn make_slot_with_vote_tx(

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -43,8 +43,8 @@ pub fn find_and_send_votes(
         sanitized_txs
             .iter()
             .zip(execution_results.iter())
-            .for_each(|(tx, result)| {
-                if tx.is_simple_vote_transaction() && result.was_executed_successfully() {
+            .for_each(|(tx, _result)| {
+                if tx.is_simple_vote_transaction() {
                     if let Some(parsed_vote) = vote_parser::parse_sanitized_vote_transaction(tx) {
                         if parsed_vote.1.last_voted_slot().is_some() {
                             let _ = vote_sender.send(parsed_vote);


### PR DESCRIPTION
Simple vote transactions that land in incompatible forks are currently being suppressed and never reach `ClusterInfoVoteListener`.

This is not ideal because all signed and valid simple vote transactions should contribute to consensus as quickly as possible, regardless if whether they successfully executed or not.

Conversely, this is not fatal because (a) votes are gossiped, and gossip-based votes are not executed at all before being processed, (b) eventually a simple vote transaction should find it's way into a compatible fork and be counted, assuming the fork has meaningful stake behind it.

Therefore including these failed simple vote transactions shouldn't harm, and in some case may allow nodes to more quickly compute the stake weight between competing forks.

