### PR TITLE
Add github-actions bot to approved commit author list

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - author≠@core-contributors
       - author≠mergify[bot]
       - author≠dependabot[bot]
+      - author≠github-actions[bot]
     actions:
       label:
         add:
@@ -18,6 +19,7 @@ pull_request_rules:
       - author≠@core-contributors
       - author≠mergify[bot]
       - author≠dependabot[bot]
+      - author≠github-actions[bot]
       # Only request reviews from the pr subscribers group if no one
       # has reviewed the community PR yet. These checks only match
       # reviewers with admin, write or maintain permission on the repository.


### PR DESCRIPTION
#### Problem
No need to ping community-pr-subscribers list / add community tag for commits from github-actions bot.