### PR TITLE
Implement `VoteInstruction::AuthorizeWithSeed` & `VoteInstruction::AuthorizeWithSeedChecked`

### DIFF
--- a/docs/src/cluster/stake-delegation-and-rewards.md
+++ b/docs/src/cluster/stake-delegation-and-rewards.md
@@ -48,6 +48,13 @@ Updates the account with a new authorized voter or withdrawer, according to the 
 - `account[0]` - RW - The VoteState.
   `VoteState::authorized_voter` or `authorized_withdrawer` is set to `Pubkey`.
 
+### VoteInstruction::AuthorizeWithSeed\(VoteAuthorizeWithSeedArgs\)
+
+Updates the account with a new authorized voter or withdrawer, according to the VoteAuthorize parameter \(`Voter` or `Withdrawer`\). Unlike `VoteInstruction::Authorize` this instruction is for use when the Vote account's current `authorized_voter` or `authorized_withdrawer` is a derived key. The transaction must be signed by someone who can sign for the base key of that derived key.
+
+- `account[0]` - RW - The VoteState.
+  `VoteState::authorized_voter` or `authorized_withdrawer` is set to `Pubkey`.
+
 ### VoteInstruction::Vote\(Vote\)
 
 - `account[0]` - RW - The VoteState.

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -212,6 +212,17 @@ mod tests {
         std::{collections::HashSet, str::FromStr},
     };
 
+    struct VoteAccountTestFixtureWithAuthorities {
+        vote_account: AccountSharedData,
+        vote_pubkey: Pubkey,
+        voter_base_key: Pubkey,
+        voter_owner: Pubkey,
+        voter_seed: String,
+        withdrawer_base_key: Pubkey,
+        withdrawer_owner: Pubkey,
+        withdrawer_seed: String,
+    }
+
     fn create_default_account() -> AccountSharedData {
         AccountSharedData::new(0, 0, &Pubkey::new_unique())
     }
@@ -338,6 +349,41 @@ mod tests {
                 100,
             ),
         )
+    }
+
+    fn create_test_account_with_authorized_from_seed() -> VoteAccountTestFixtureWithAuthorities {
+        let vote_pubkey = Pubkey::new_unique();
+        let voter_base_key = Pubkey::new_unique();
+        let voter_owner = Pubkey::new_unique();
+        let voter_seed = String::from("VOTER_SEED");
+        let withdrawer_base_key = Pubkey::new_unique();
+        let withdrawer_owner = Pubkey::new_unique();
+        let withdrawer_seed = String::from("WITHDRAWER_SEED");
+        let authorized_voter =
+            Pubkey::create_with_seed(&voter_base_key, voter_seed.as_str(), &voter_owner).unwrap();
+        let authorized_withdrawer = Pubkey::create_with_seed(
+            &withdrawer_base_key,
+            withdrawer_seed.as_str(),
+            &withdrawer_owner,
+        )
+        .unwrap();
+
+        VoteAccountTestFixtureWithAuthorities {
+            vote_account: vote_state::create_account_with_authorized(
+                &Pubkey::new_unique(),
+                &authorized_voter,
+                &authorized_withdrawer,
+                0,
+                100,
+            ),
+            vote_pubkey,
+            voter_base_key,
+            voter_owner,
+            voter_seed,
+            withdrawer_base_key,
+            withdrawer_owner,
+            withdrawer_seed,
+        }
     }
 
     fn create_test_account_with_epoch_credits(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -82,6 +82,9 @@ pub fn process_instruction(
                 &invoke_context.feature_set,
             )
         }
+        VoteInstruction::AuthorizeCheckedWithSeed(_args) => {
+            unimplemented!("VoteInstruction::AuthorizeCheckedWithSeed")
+        }
         VoteInstruction::UpdateValidatorIdentity => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             let node_pubkey = transaction_context.get_key_of_account_at_index(

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -194,8 +194,8 @@ mod tests {
                 vote_switch, withdraw, VoteInstruction,
             },
             vote_state::{
-                Lockout, Vote, VoteAuthorize, VoteInit, VoteState, VoteStateUpdate,
-                VoteStateVersions,
+                Lockout, Vote, VoteAuthorize, VoteAuthorizeWithSeedArgs, VoteInit, VoteState,
+                VoteStateUpdate, VoteStateVersions,
             },
         },
         bincode::serialize,
@@ -1167,6 +1167,233 @@ mod tests {
             transaction_accounts,
             instruction_accounts,
             Ok(()),
+        );
+    }
+
+    fn perform_authorize_with_seed_test(
+        authorization_type: VoteAuthorize,
+        vote_pubkey: Pubkey,
+        vote_account: AccountSharedData,
+        current_authority_base_key: Pubkey,
+        current_authority_seed: String,
+        current_authority_owner: Pubkey,
+        new_authority_pubkey: Pubkey,
+    ) {
+        let clock = Clock {
+            epoch: 1,
+            leader_schedule_epoch: 2,
+            ..Clock::default()
+        };
+        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::clock::id(), clock_account),
+            (current_authority_base_key, AccountSharedData::default()),
+        ];
+        let mut instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: current_authority_base_key,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+
+        // Can't change authority unless base key signs.
+        instruction_accounts[2].is_signer = false;
+        process_instruction(
+            &serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type,
+                    current_authority_derived_key_owner: current_authority_owner,
+                    current_authority_derived_key_seed: current_authority_seed.clone(),
+                    new_authority: new_authority_pubkey,
+                },
+            ))
+            .unwrap(),
+            transaction_accounts.clone(),
+            instruction_accounts.clone(),
+            Err(InstructionError::MissingRequiredSignature),
+        );
+        instruction_accounts[2].is_signer = true;
+
+        // Can't change authority if seed doesn't match.
+        process_instruction(
+            &serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type,
+                    current_authority_derived_key_owner: current_authority_owner,
+                    current_authority_derived_key_seed: String::from("WRONG_SEED"),
+                    new_authority: new_authority_pubkey,
+                },
+            ))
+            .unwrap(),
+            transaction_accounts.clone(),
+            instruction_accounts.clone(),
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Can't change authority if owner doesn't match.
+        process_instruction(
+            &serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type,
+                    current_authority_derived_key_owner: Pubkey::new_unique(), // Wrong owner.
+                    current_authority_derived_key_seed: current_authority_seed.clone(),
+                    new_authority: new_authority_pubkey,
+                },
+            ))
+            .unwrap(),
+            transaction_accounts.clone(),
+            instruction_accounts.clone(),
+            Err(InstructionError::MissingRequiredSignature),
+        );
+
+        // Can change authority when base key signs for related derived key.
+        process_instruction(
+            &serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type,
+                    current_authority_derived_key_owner: current_authority_owner,
+                    current_authority_derived_key_seed: current_authority_seed,
+                    new_authority: new_authority_pubkey,
+                },
+            ))
+            .unwrap(),
+            transaction_accounts,
+            instruction_accounts,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_voter_base_key_can_authorize_new_voter() {
+        let VoteAccountTestFixtureWithAuthorities {
+            vote_pubkey,
+            voter_base_key,
+            voter_owner,
+            voter_seed,
+            vote_account,
+            ..
+        } = create_test_account_with_authorized_from_seed();
+        let new_voter_pubkey = Pubkey::new_unique();
+        perform_authorize_with_seed_test(
+            VoteAuthorize::Voter,
+            vote_pubkey,
+            vote_account,
+            voter_base_key,
+            voter_seed,
+            voter_owner,
+            new_voter_pubkey,
+        );
+    }
+
+    #[test]
+    fn test_withdrawer_base_key_can_authorize_new_voter() {
+        let VoteAccountTestFixtureWithAuthorities {
+            vote_pubkey,
+            withdrawer_base_key,
+            withdrawer_owner,
+            withdrawer_seed,
+            vote_account,
+            ..
+        } = create_test_account_with_authorized_from_seed();
+        let new_voter_pubkey = Pubkey::new_unique();
+        perform_authorize_with_seed_test(
+            VoteAuthorize::Voter,
+            vote_pubkey,
+            vote_account,
+            withdrawer_base_key,
+            withdrawer_seed,
+            withdrawer_owner,
+            new_voter_pubkey,
+        );
+    }
+
+    #[test]
+    fn test_voter_base_key_can_not_authorize_new_withdrawer() {
+        let VoteAccountTestFixtureWithAuthorities {
+            vote_pubkey,
+            voter_base_key,
+            voter_owner,
+            voter_seed,
+            vote_account,
+            ..
+        } = create_test_account_with_authorized_from_seed();
+        let new_withdrawer_pubkey = Pubkey::new_unique();
+        let clock = Clock {
+            epoch: 1,
+            leader_schedule_epoch: 2,
+            ..Clock::default()
+        };
+        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let transaction_accounts = vec![
+            (vote_pubkey, vote_account),
+            (sysvar::clock::id(), clock_account),
+            (voter_base_key, AccountSharedData::default()),
+        ];
+        let instruction_accounts = vec![
+            AccountMeta {
+                pubkey: vote_pubkey,
+                is_signer: false,
+                is_writable: true,
+            },
+            AccountMeta {
+                pubkey: sysvar::clock::id(),
+                is_signer: false,
+                is_writable: false,
+            },
+            AccountMeta {
+                pubkey: voter_base_key,
+                is_signer: true,
+                is_writable: false,
+            },
+        ];
+        // Despite having Voter authority, you may not change the Withdrawer authority.
+        process_instruction(
+            &serialize(&VoteInstruction::AuthorizeWithSeed(
+                VoteAuthorizeWithSeedArgs {
+                    authorization_type: VoteAuthorize::Withdrawer,
+                    current_authority_derived_key_owner: voter_owner,
+                    current_authority_derived_key_seed: voter_seed,
+                    new_authority: new_withdrawer_pubkey,
+                },
+            ))
+            .unwrap(),
+            transaction_accounts,
+            instruction_accounts,
+            Err(InstructionError::MissingRequiredSignature),
+        );
+    }
+
+    #[test]
+    fn test_withdrawer_base_key_can_authorize_new_withdrawer() {
+        let VoteAccountTestFixtureWithAuthorities {
+            vote_pubkey,
+            withdrawer_base_key,
+            withdrawer_owner,
+            withdrawer_seed,
+            vote_account,
+            ..
+        } = create_test_account_with_authorized_from_seed();
+        let new_withdrawer_pubkey = Pubkey::new_unique();
+        perform_authorize_with_seed_test(
+            VoteAuthorize::Withdrawer,
+            vote_pubkey,
+            vote_account,
+            withdrawer_base_key,
+            withdrawer_seed,
+            withdrawer_owner,
+            new_withdrawer_pubkey,
         );
     }
 

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -48,6 +48,9 @@ pub fn process_instruction(
                 &invoke_context.feature_set,
             )
         }
+        VoteInstruction::AuthorizeWithSeed(_args) => {
+            unimplemented!("VoteInstruction::AuthorizeWithSeed")
+        }
         VoteInstruction::UpdateValidatorIdentity => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             let node_pubkey = transaction_context.get_key_of_account_at_index(

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -248,6 +248,13 @@ pub struct VoteAuthorizeWithSeedArgs {
     pub new_authority: Pubkey,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteAuthorizeCheckedWithSeedArgs {
+    pub authorization_type: VoteAuthorize,
+    pub current_authority_derived_key_owner: Pubkey,
+    pub current_authority_derived_key_seed: String,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
 pub struct BlockTimestamp {
     pub slot: Slot,

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -240,6 +240,14 @@ pub enum VoteAuthorize {
     Withdrawer,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteAuthorizeWithSeedArgs {
+    pub authorization_type: VoteAuthorize,
+    pub current_authority_derived_key_owner: Pubkey,
+    pub current_authority_derived_key_seed: String,
+    pub new_authority: Pubkey,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
 pub struct BlockTimestamp {
     pub slot: Slot,

--- a/runtime/src/vote_parser.rs
+++ b/runtime/src/vote_parser.rs
@@ -82,6 +82,7 @@ fn parse_vote_instruction_data(
         }
         VoteInstruction::Authorize(_, _)
         | VoteInstruction::AuthorizeChecked(_)
+        | VoteInstruction::AuthorizeWithSeed(_)
         | VoteInstruction::InitializeAccount(_)
         | VoteInstruction::UpdateCommission(_)
         | VoteInstruction::UpdateValidatorIdentity

--- a/runtime/src/vote_parser.rs
+++ b/runtime/src/vote_parser.rs
@@ -83,6 +83,7 @@ fn parse_vote_instruction_data(
         VoteInstruction::Authorize(_, _)
         | VoteInstruction::AuthorizeChecked(_)
         | VoteInstruction::AuthorizeWithSeed(_)
+        | VoteInstruction::AuthorizeCheckedWithSeed(_)
         | VoteInstruction::InitializeAccount(_)
         | VoteInstruction::UpdateCommission(_)
         | VoteInstruction::UpdateValidatorIdentity

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -440,6 +440,10 @@ pub mod nonce_must_be_advanceable {
     solana_sdk::declare_id!("3u3Er5Vc2jVcwz4xr2GJeSAXT3fAj6ADHZ4BJMZiScFd");
 }
 
+pub mod vote_authorize_with_seed {
+    solana_sdk::declare_id!("6tRxEYKuy2L5nnv5bgn7iT28MxUbYxp5h7F3Ncf1exrT");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -544,6 +548,7 @@ lazy_static! {
         (quick_bail_on_panic::id(), "quick bail on panic"),
         (nonce_must_be_authorized::id(), "nonce must be authorized"),
         (nonce_must_be_advanceable::id(), "durable nonces must be advanceable"),
+        (vote_authorize_with_seed::id(), "An instruction you can use to change a vote accounts authority when the current authority is a derived key #25860"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -52,6 +52,21 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::AuthorizeWithSeed(args) => {
+            check_num_vote_accounts(&instruction.accounts, 3)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "authorizeWithSeed".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "clockSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "authorityBaseKey": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "authorityOwner": args.current_authority_derived_key_owner.to_string(),
+                    "authoritySeed": args.current_authority_derived_key_seed,
+                    "newAuthority": args.new_authority.to_string(),
+                    "authorityType": args.authorization_type,
+                }),
+            })
+        }
         VoteInstruction::Vote(vote) => {
             check_num_vote_accounts(&instruction.accounts, 4)?;
             let vote = json!({
@@ -267,6 +282,49 @@ mod test {
                     "voteAccount": vote_pubkey.to_string(),
                     "clockSysvar": sysvar::clock::ID.to_string(),
                     "authority": authorized_pubkey.to_string(),
+                    "newAuthority": new_authorized_pubkey.to_string(),
+                    "authorityType": authority_type,
+                }),
+            }
+        );
+        assert!(parse_vote(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..2], None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_vote_authorize_with_seed_ix() {
+        let vote_pubkey = Pubkey::new_unique();
+        let authorized_base_key = Pubkey::new_unique();
+        let new_authorized_pubkey = Pubkey::new_unique();
+        let authority_type = VoteAuthorize::Voter;
+        let current_authority_owner = Pubkey::new_unique();
+        let current_authority_seed = "AUTHORITY_SEED";
+        let instruction = vote_instruction::authorize_with_seed(
+            &vote_pubkey,
+            &authorized_base_key,
+            &current_authority_owner,
+            current_authority_seed,
+            &new_authorized_pubkey,
+            authority_type,
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_vote(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "authorizeWithSeed".to_string(),
+                info: json!({
+                    "voteAccount": vote_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                    "authorityBaseKey": authorized_base_key.to_string(),
+                    "authorityOwner": current_authority_owner.to_string(),
+                    "authoritySeed": current_authority_seed,
                     "newAuthority": new_authorized_pubkey.to_string(),
                     "authorityType": authority_type,
                 }),

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -67,6 +67,9 @@ pub fn parse_vote(
                 }),
             })
         }
+        VoteInstruction::AuthorizeCheckedWithSeed(_args) => {
+            unimplemented!("VoteInstruction::AuthorizeCheckedWithSeed")
+        }
         VoteInstruction::Vote(vote) => {
             check_num_vote_accounts(&instruction.accounts, 4)?;
             let vote = json!({

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -67,8 +67,20 @@ pub fn parse_vote(
                 }),
             })
         }
-        VoteInstruction::AuthorizeCheckedWithSeed(_args) => {
-            unimplemented!("VoteInstruction::AuthorizeCheckedWithSeed")
+        VoteInstruction::AuthorizeCheckedWithSeed(args) => {
+            check_num_vote_accounts(&instruction.accounts, 4)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "authorizeCheckedWithSeed".to_string(),
+                info: json!({
+                    "voteAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "clockSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "authorityBaseKey": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "authorityOwner": args.current_authority_derived_key_owner.to_string(),
+                    "authoritySeed": args.current_authority_derived_key_seed,
+                    "newAuthority": account_keys[instruction.accounts[3] as usize].to_string(),
+                    "authorityType": args.authorization_type,
+                }),
+            })
         }
         VoteInstruction::Vote(vote) => {
             check_num_vote_accounts(&instruction.accounts, 4)?;
@@ -336,6 +348,49 @@ mod test {
         assert!(parse_vote(
             &message.instructions[0],
             &AccountKeys::new(&message.account_keys[0..2], None)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parse_vote_authorize_with_seed_checked_ix() {
+        let vote_pubkey = Pubkey::new_unique();
+        let authorized_base_key = Pubkey::new_unique();
+        let new_authorized_pubkey = Pubkey::new_unique();
+        let authority_type = VoteAuthorize::Voter;
+        let current_authority_owner = Pubkey::new_unique();
+        let current_authority_seed = "AUTHORITY_SEED";
+        let instruction = vote_instruction::authorize_checked_with_seed(
+            &vote_pubkey,
+            &authorized_base_key,
+            &current_authority_owner,
+            current_authority_seed,
+            &new_authorized_pubkey,
+            authority_type,
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_vote(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "authorizeCheckedWithSeed".to_string(),
+                info: json!({
+                    "voteAccount": vote_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                    "authorityBaseKey": authorized_base_key.to_string(),
+                    "authorityOwner": current_authority_owner.to_string(),
+                    "authoritySeed": current_authority_seed,
+                    "newAuthority": new_authorized_pubkey.to_string(),
+                    "authorityType": authority_type,
+                }),
+            }
+        );
+        assert!(parse_vote(
+            &message.instructions[0],
+            &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
     }


### PR DESCRIPTION
#### Background

Given a base key, a seed (arbitrary data, like the string `"VOTER_SEED"`) and the address of a program, you can create a derived key for that program. This key can never sign for anything, because it has no associated secret key.

The vote program lets you authorize an account to be the ‘withdrawer.’

#### Problem

There's nothing stopping you from authorizing a derived key to be the ‘withdrawer’ authority on a vote account, but if you do, you'll never be able to withdraw funds, since nobody can sign for the derived key.

#### Summary of Changes

- [x] Add an `AuthorizeWithSeed` instruction/implementation/tests to the vote program. Now someone who can sign for the _base_ key of a derived key can at least _change_ such a ‘withdrawer’ authority to something else.
- [x] Add an `AuthorizeWithSeedChecked` instruction/implementation/tests to the vote program. Does the same as `AuthorizeWithSeed` except that it also checks that the base key of the _new_ authority has signed the transaction.
- [x] Add a feature gate that governs access to that new instruction
- [x] Update docs, wherever found
- [ ] Add `AuthorizeWithSeed` command to web3.js library   
- [ ] Add `AuthorizeWithSeedChecked` command to web3.js library   

Fixes #25860.
Feature Gate Issue: #25930.