### PR TITLE
fix explorer to show loading rather than "Details are not available" while transaction details are being fetched

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -330,7 +330,7 @@ function DetailsSection({ signature }: SignatureProps) {
 
   if (!status?.data?.info) {
     return null;
-  } else if (!details) {
+  } else if (!details || details.status === FetchStatus.Fetching) {
     return <LoadingCard />;
   } else if (details.status === FetchStatus.FetchFailed) {
     return <ErrorCard retry={refreshDetails} text="Failed to fetch details" />;


### PR DESCRIPTION
#### Problem

The explorer shows "Details are not available" while transaction details are being fetched

#### Summary of Changes

-

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
