### PR TITLE
Only take the latest vote for each validator in gossip

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -392,7 +392,7 @@ impl ClusterInfoVoteListener {
                 .unwrap()
                 .would_be_leader(3 * slot_hashes::MAX_ENTRIES as u64 * DEFAULT_TICKS_PER_SLOT);
             let feature_set = poh_recorder
-                .lock()
+                .read()
                 .unwrap()
                 .bank()
                 .map(|bank| bank.feature_set.clone());

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -391,10 +391,16 @@ impl ClusterInfoVoteListener {
                 .read()
                 .unwrap()
                 .would_be_leader(3 * slot_hashes::MAX_ENTRIES as u64 * DEFAULT_TICKS_PER_SLOT);
+            let feature_set = poh_recorder
+                .lock()
+                .unwrap()
+                .bank()
+                .map(|bank| bank.feature_set.clone());
 
             if let Err(e) = verified_vote_packets.receive_and_process_vote_packets(
                 &verified_vote_label_packets_receiver,
                 would_be_leader,
+                feature_set,
             ) {
                 match e {
                     Error::RecvTimeout(RecvTimeoutError::Disconnected)

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -173,7 +173,7 @@ pub enum SingleValidatorVotes {
 }
 
 impl SingleValidatorVotes {
-    fn get_latest_slot_sent_to_bank(&self) -> Slot {
+    fn get_latest_gossip_slot(&self) -> Slot {
         match self {
             Self::FullTowerVote(vote) => vote.slot,
             _ => 0,
@@ -227,12 +227,12 @@ impl VerifiedVotePackets {
 
                     match (vote, is_full_tower_vote_enabled) {
                         (VoteStateUpdate(_), true) => {
-                            let latest_slot_sent_to_bank = match self.0.get(&vote_account_key) {
-                                Some(vote) => vote.get_latest_slot_sent_to_bank(),
+                            let latest_gossip_slot = match self.0.get(&vote_account_key) {
+                                Some(vote) => vote.get_latest_gossip_slot(),
                                 _ => 0,
                             };
                             // Since votes are not incremental, we keep only the latest vote
-                            if slot > latest_slot_sent_to_bank {
+                            if slot > latest_gossip_slot {
                                 self.0.insert(
                                     vote_account_key,
                                     FullTowerVote(GossipVote {
@@ -615,7 +615,7 @@ mod tests {
             .0
             .get(&vote_account_key)
             .unwrap()
-            .get_latest_slot_sent_to_bank();
+            .get_latest_gossip_slot();
         assert_eq!(11, slot);
 
         // Now send the third_vote, it should overwrite second_vote
@@ -634,7 +634,7 @@ mod tests {
             .0
             .get(&vote_account_key)
             .unwrap()
-            .get_latest_slot_sent_to_bank();
+            .get_latest_gossip_slot();
         assert_eq!(13, slot);
 
         // Now send all three, but keep the feature off
@@ -789,7 +789,7 @@ mod tests {
                 .0
                 .get(&vote_account_key)
                 .unwrap()
-                .get_latest_slot_sent_to_bank()
+                .get_latest_gossip_slot()
         );
 
         // Now try to send an incremental vote
@@ -813,7 +813,7 @@ mod tests {
                 .0
                 .get(&vote_account_key)
                 .unwrap()
-                .get_latest_slot_sent_to_bank()
+                .get_latest_gossip_slot()
         );
     }
 }


### PR DESCRIPTION
#### Problem
Since the new vote updates are no longer incremental, there
is no value in storing intermediate votes.

#### Summary of Changes
Only store the latest vote for each validator before sending to banking stage. 

Fixes #
Feature Gate Issue: #24717
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
