### PR TITLE
Filter stakes by withdrawer

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -103,7 +103,7 @@ pub enum CliCommand {
     ShowStakes {
         use_lamports_unit: bool,
         vote_account_pubkeys: Option<Vec<Pubkey>>,
-        withdrawer_pubkey: Option<Pubkey>,
+        withdraw_authority: Option<Pubkey>,
     },
     ShowValidators {
         use_lamports_unit: bool,
@@ -900,13 +900,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowStakes {
             use_lamports_unit,
             vote_account_pubkeys,
-            withdrawer_pubkey,
+            withdraw_authority,
         } => process_show_stakes(
             &rpc_client,
             config,
             *use_lamports_unit,
             vote_account_pubkeys.as_deref(),
-            withdrawer_pubkey.as_ref(),
+            withdraw_authority.as_ref(),
         ),
         CliCommand::WaitForMaxStake { max_stake_percent } => {
             process_wait_for_max_stake(&rpc_client, config, *max_stake_percent)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -103,6 +103,7 @@ pub enum CliCommand {
     ShowStakes {
         use_lamports_unit: bool,
         vote_account_pubkeys: Option<Vec<Pubkey>>,
+        withdrawer_pubkey: Opetion<Pubkey>,
     },
     ShowValidators {
         use_lamports_unit: bool,
@@ -899,11 +900,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowStakes {
             use_lamports_unit,
             vote_account_pubkeys,
+            withdrawer_pubkey,
         } => process_show_stakes(
             &rpc_client,
             config,
             *use_lamports_unit,
             vote_account_pubkeys.as_deref(),
+            withdrawer_pubkey,
         ),
         CliCommand::WaitForMaxStake { max_stake_percent } => {
             process_wait_for_max_stake(&rpc_client, config, *max_stake_percent)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -103,7 +103,7 @@ pub enum CliCommand {
     ShowStakes {
         use_lamports_unit: bool,
         vote_account_pubkeys: Option<Vec<Pubkey>>,
-        withdrawer_pubkey: Opetion<Pubkey>,
+        withdrawer_pubkey: Option<Pubkey>,
     },
     ShowValidators {
         use_lamports_unit: bool,
@@ -906,7 +906,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             *use_lamports_unit,
             vote_account_pubkeys.as_deref(),
-            withdrawer_pubkey,
+            withdrawer_pubkey.as_ref(),
         ),
         CliCommand::WaitForMaxStake { max_stake_percent } => {
             process_wait_for_max_stake(&rpc_client, config, *max_stake_percent)

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -329,17 +329,22 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             SubCommand::with_name("stakes")
                 .about("Show stake account information")
                 .arg(
+                    Arg::with_name("lamports")
+                        .long("lamports")
+                        .takes_value(false)
+                        .help("Display balance in lamports instead of SOL"),
+                )
+                .arg(
                     pubkey!(Arg::with_name("vote_account_pubkeys")
-                        .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .multiple(true),
                         "Only show stake accounts delegated to the provided vote accounts. "),
                 )
                 .arg(
-                    Arg::with_name("lamports")
-                        .long("lamports")
-                        .takes_value(false)
-                        .help("Display balance in lamports instead of SOL"),
+                    pubkey!(Arg::with_name("withdrawer_pubkey")
+                    .value_name("WITHDRAWER_PUBKEY")
+                    .index(1),
+                    "To filter using withdraw authority"),
                 ),
         )
         .subcommand(
@@ -624,7 +629,7 @@ pub fn parse_show_stakes(
     let use_lamports_unit = matches.is_present("lamports");
     let vote_account_pubkeys =
         pubkeys_of_multiple_signers(matches, "vote_account_pubkeys", wallet_manager)?;
-    let withdrawer_pubkey = pubkey_of_signer(matches, "withdrawer_pubkey", wallet_manager)?;
+    let withdrawer_pubkey = pubkey_of(matches, "withdrawer_pubkey");
     Ok(CliCommandInfo {
         command: CliCommand::ShowStakes {
             use_lamports_unit,
@@ -1847,7 +1852,7 @@ pub fn process_show_stakes(
         if let Ok(stake_state) = stake_account.state() {
             match stake_state {
                 StakeState::Initialized(_) => {
-                    if vote_account_pubkeys.is_none() {
+                    if vote_account_pubkeys.is_none() && withdraw_authority_pubkey.is_none() {
                         stake_accounts.push(CliKeyedStakeState {
                             stake_pubkey: stake_pubkey.to_string(),
                             stake_state: build_stake_state(
@@ -1860,11 +1865,13 @@ pub fn process_show_stakes(
                         });
                     }
                 }
-                StakeState::Stake(_, stake) => {
-                    if vote_account_pubkeys.is_none()
+                StakeState::Stake(meta, stake) => {
+                    if (vote_account_pubkeys.is_none()
                         || vote_account_pubkeys
                             .unwrap()
-                            .contains(&stake.delegation.voter_pubkey)
+                            .contains(&stake.delegation.voter_pubkey))
+                        && (withdraw_authority_pubkey.is_none()
+                            || (*withdraw_authority_pubkey.unwrap()) == meta.authorized.withdrawer)
                     {
                         stake_accounts.push(CliKeyedStakeState {
                             stake_pubkey: stake_pubkey.to_string(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1790,35 +1790,38 @@ pub fn process_show_stakes(
     }
 
     if let Some(withdraw_authority_pubkey) = withdraw_authority_pubkey {
-
         match program_accounts_config.filters {
             Some(filters) => {
-
-                program_accounts_config.filters = Some([filters, // Filter by withdrawer
-                    vec![rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
-                    offset: 44,
-                        bytes: rpc_filter::MemcmpEncodedBytes::Base58(
-                            withdraw_authority_pubkey.to_string(),
-                        ),
-                    encoding: Some(rpc_filter::MemcmpEncoding::Binary),
-                })]].concat())
-            },
+                program_accounts_config.filters = Some(
+                    [
+                        filters, // Filter by withdrawer
+                        vec![rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
+                            offset: 44,
+                            bytes: rpc_filter::MemcmpEncodedBytes::Base58(
+                                withdraw_authority_pubkey.to_string(),
+                            ),
+                            encoding: Some(rpc_filter::MemcmpEncoding::Binary),
+                        })],
+                    ]
+                    .concat(),
+                )
+            }
             None => {
                 program_accounts_config.filters = Some(vec![
                     // Filter by `StakeState::Stake(_, _)`
-                    rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp{
-                        offset : 0,
+                    rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
+                        offset: 0,
                         bytes: rpc_filter::MemcmpEncodedBytes::Base58(
                             bs58::encode([2, 0, 0, 0]).into_string(),
                         ),
-                        encoding: Some(rpc_filter::MemcmpEncoding::Binary)
+                        encoding: Some(rpc_filter::MemcmpEncoding::Binary),
                     }),
                     // Filter by withdrawer
                     rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
                         offset: 44,
-                            bytes: rpc_filter::MemcmpEncodedBytes::Base58(
-                                withdraw_authority_pubkey.to_string(),
-                            ),
+                        bytes: rpc_filter::MemcmpEncodedBytes::Base58(
+                            withdraw_authority_pubkey.to_string(),
+                        ),
                         encoding: Some(rpc_filter::MemcmpEncoding::Binary),
                     }),
                 ]);

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -342,10 +342,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         "Only show stake accounts delegated to the provided vote accounts. "),
                 )
                 .arg(
-                    pubkey!(Arg::with_name("withdrawer_pubkey")
+                    pubkey!(Arg::with_name("withdraw_authority")
                     .value_name("PUBKEY")
-                    .long("withdraw-autority"),
-                    "Filter stakes with the given withdraw authority. "),
+                    .long("withdraw-authority"),
+                    "Only show stake accounts with the provided withdraw authority. "),
                 ),
         )
         .subcommand(
@@ -630,12 +630,12 @@ pub fn parse_show_stakes(
     let use_lamports_unit = matches.is_present("lamports");
     let vote_account_pubkeys =
         pubkeys_of_multiple_signers(matches, "vote_account_pubkeys", wallet_manager)?;
-    let withdrawer_pubkey = pubkey_of(matches, "withdrawer_pubkey");
+    let withdraw_authority = pubkey_of(matches, "withdraw_authority");
     Ok(CliCommandInfo {
         command: CliCommand::ShowStakes {
             use_lamports_unit,
             vote_account_pubkeys,
-            withdrawer_pubkey,
+            withdraw_authority,
         },
         signers: vec![],
     })


### PR DESCRIPTION
#### Problem

Currently we cannot search stakes and filtering by withdraw authority. I have added into cli stakes command a way to filter it with withdraw authority.

#### Summary of Changes

Updating cli to pass withdrawer_pubkey and filter the results out by doing memcmp on the stakes.

Fixes #25462
