### PR TITLE
Take `.max(1)` when computing MAX_RAYON_THREADS

### DIFF
--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -8,9 +8,10 @@ lazy_static! {
     // reduce the number of threads each pool is allowed to half the cpu core count, to avoid rayon
     // hogging cpu
     static ref MAX_RAYON_THREADS: usize =
-            env::var("SOLANA_RAYON_THREADS")
-                .map(|x| x.parse().unwrap_or(num_cpus::get() as usize / 2))
-                .unwrap_or(num_cpus::get() as usize / 2);
+            env::var("SOLANA_RAYON_THREADS").ok()
+            .and_then(|num_threads| num_threads.parse().ok())
+            .unwrap_or_else(|| num_cpus::get() as usize / 2)
+            .max(1);
 }
 
 pub fn get_thread_count() -> usize {


### PR DESCRIPTION
#### Problem

A third party fuzzer uncovered a divide-by-zero error in `blockstore_processor::execute_batches()`.

https://github.com/solana-labs/solana/blob/3e1fd4dad0919011925b1f4315957a97091c885e/ledger/src/blockstore_processor.rs#L356-L361

`target_batch_count` could be `0` due to the impl of `get_thread_count()`.

#### Summary of Changes

Add in a `.max(1)` to ensure the smallest number returned is 1, not 0.
