### PR TITLE
AcctIdx: only advance age on thread 0

### DIFF
--- a/runtime/src/bucket_map_holder.rs
+++ b/runtime/src/bucket_map_holder.rs
@@ -132,11 +132,13 @@ impl<T: IndexValue> BucketMapHolder<T> {
         self.age.load(Ordering::Acquire)
     }
 
-    pub fn bucket_flushed_at_current_age(&self) {
+    pub fn bucket_flushed_at_current_age(&self, can_advance_age: bool) {
         let count_buckets_flushed = 1 + self.count_buckets_flushed.fetch_add(1, Ordering::AcqRel);
-        self.maybe_advance_age_internal(
-            self.all_buckets_flushed_at_current_age_internal(count_buckets_flushed),
-        );
+        if can_advance_age {
+            self.maybe_advance_age_internal(
+                self.all_buckets_flushed_at_current_age_internal(count_buckets_flushed),
+            );
+        }
     }
 
     /// have all buckets been flushed at the current age?
@@ -297,7 +299,12 @@ impl<T: IndexValue> BucketMapHolder<T> {
     }
 
     // intended to execute in a bg thread
-    pub fn background(&self, exit: Arc<AtomicBool>, in_mem: Vec<Arc<InMemAccountsIndex<T>>>) {
+    pub fn background(
+        &self,
+        exit: Arc<AtomicBool>,
+        in_mem: Vec<Arc<InMemAccountsIndex<T>>>,
+        can_advance_age: bool,
+    ) {
         let bins = in_mem.len();
         let flush = self.disk.is_some();
         let mut throttling_wait_ms = None;
@@ -312,6 +319,10 @@ impl<T: IndexValue> BucketMapHolder<T> {
                         .remaining_until_next_interval(self.age_interval_ms()),
                     self.stats.remaining_until_next_interval(),
                 );
+                if !can_advance_age {
+                    // if this thread cannot advance age, then make sure we don't sleep 0
+                    wait = wait.max(1);
+                }
                 if let Some(throttling_wait_ms) = throttling_wait_ms {
                     self.stats
                         .bg_throttling_wait_us
@@ -327,7 +338,9 @@ impl<T: IndexValue> BucketMapHolder<T> {
                     .bg_waiting_us
                     .fetch_add(m.as_us(), Ordering::Relaxed);
                 // likely some time has elapsed. May have been waiting for age time interval to elapse.
-                self.maybe_advance_age();
+                if can_advance_age {
+                    self.maybe_advance_age();
+                }
             }
             throttling_wait_ms = None;
 
@@ -339,7 +352,7 @@ impl<T: IndexValue> BucketMapHolder<T> {
             for _ in 0..bins {
                 if flush {
                     let index = self.next_bucket_to_flush();
-                    in_mem[index].flush();
+                    in_mem[index].flush(can_advance_age);
                 }
                 self.stats.report_stats(self);
                 if self.all_buckets_flushed_at_current_age() {
@@ -453,11 +466,11 @@ pub mod tests {
         let time = AGE_MS * 8 / 3;
         let expected = (time / AGE_MS) as Age;
         let now = Instant::now();
-        test.bucket_flushed_at_current_age(); // done with age 0
+        test.bucket_flushed_at_current_age(true); // done with age 0
         (0..threads).into_par_iter().for_each(|_| {
             while now.elapsed().as_millis() < (time as u128) {
                 if test.maybe_advance_age() {
-                    test.bucket_flushed_at_current_age();
+                    test.bucket_flushed_at_current_age(true);
                 }
             }
         });
@@ -472,7 +485,7 @@ pub mod tests {
         assert_eq!(test.current_age(), 0);
         for _ in 0..bins {
             assert!(!test.all_buckets_flushed_at_current_age());
-            test.bucket_flushed_at_current_age();
+            test.bucket_flushed_at_current_age(true);
         }
         std::thread::sleep(std::time::Duration::from_millis(AGE_MS * 2));
         test.maybe_advance_age();


### PR DESCRIPTION
#### Problem

Remove potential race condition by limiting age advancement to 1 special thread in the flushing pool.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
