### PR TITLE
RPC instruction parser tests are missing some cases

### DIFF
--- a/transaction-status/src/parse_associated_token.rs
+++ b/transaction-status/src/parse_associated_token.rs
@@ -125,7 +125,7 @@ mod test {
             &convert_pubkey(mint),
         );
         let message = Message::new(&[create_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
@@ -145,6 +145,12 @@ mod test {
                 })
             }
         );
+        compiled_instruction.accounts.pop();
+        assert!(parse_associated_token(
+            &compiled_instruction,
+            &AccountKeys::new(&convert_account_keys(&message), None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -160,7 +166,7 @@ mod test {
             &convert_pubkey(mint),
         );
         let message = Message::new(&[create_ix], None);
-        let compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
+        let mut compiled_instruction = convert_compiled_instruction(&message.instructions[0]);
         assert_eq!(
             parse_associated_token(
                 &compiled_instruction,
@@ -179,5 +185,11 @@ mod test {
                 })
             }
         );
+        compiled_instruction.accounts.pop();
+        assert!(parse_associated_token(
+            &compiled_instruction,
+            &AccountKeys::new(&convert_account_keys(&message), None)
+        )
+        .is_err());
     }
 }

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -286,7 +286,7 @@ mod test {
             max_data_len,
         )
         .unwrap();
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[1],
@@ -306,6 +306,14 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[1].accounts.pop();
+        message.instructions[1].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[1],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -321,7 +329,7 @@ mod test {
             offset,
             bytes.clone(),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -341,6 +349,13 @@ mod test {
         assert!(parse_bpf_upgradeable_loader(
             &message.instructions[0],
             &AccountKeys::new(&message.account_keys[0..1], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
         )
         .is_err());
     }
@@ -367,7 +382,7 @@ mod test {
             max_data_len,
         )
         .unwrap();
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[1],
@@ -394,6 +409,13 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..7], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[1].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[1],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -413,7 +435,7 @@ mod test {
             &authority_address,
             &spill_address,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -438,6 +460,13 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..6], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -450,7 +479,7 @@ mod test {
             &current_authority_address,
             &new_authority_address,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -471,6 +500,14 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -487,7 +524,7 @@ mod test {
             &current_authority_address,
             Some(&new_authority_address),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -508,13 +545,21 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
 
         let instruction = bpf_loader_upgradeable::set_upgrade_authority(
             &program_address,
             &current_authority_address,
             None,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -535,6 +580,13 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
+        )
+        .is_err());
     }
 
     #[test]
@@ -544,7 +596,7 @@ mod test {
         let authority_address = Pubkey::new_unique();
         let instruction =
             bpf_loader_upgradeable::close(&close_address, &recipient_address, &authority_address);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
                 &message.instructions[0],
@@ -563,6 +615,13 @@ mod test {
         assert!(parse_bpf_upgradeable_loader(
             &message.instructions[0],
             &AccountKeys::new(&message.account_keys[0..1], None)
+        )
+        .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_bpf_upgradeable_loader(
+            &message.instructions[0],
+            &AccountKeys::new(&keys, None)
         )
         .is_err());
     }

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -329,7 +329,7 @@ mod test {
             &lockup,
             lamports,
         );
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_stake(
                 &message.instructions[1],
@@ -358,6 +358,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -373,7 +376,7 @@ mod test {
             StakeAuthorize::Staker,
             None,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -396,6 +399,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let instruction = instruction::authorize(
             &stake_pubkey,
@@ -404,7 +411,7 @@ mod test {
             StakeAuthorize::Withdrawer,
             Some(&custodian_pubkey),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -428,6 +435,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -437,7 +448,7 @@ mod test {
         let vote_pubkey = Pubkey::new_unique();
         let instruction =
             instruction::delegate_stake(&stake_pubkey, &authorized_pubkey, &vote_pubkey);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -461,6 +472,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..5], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -475,7 +489,7 @@ mod test {
             lamports,
             &split_stake_pubkey,
         );
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_stake(
                 &message.instructions[2],
@@ -497,6 +511,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -539,7 +556,7 @@ mod test {
             lamports,
             Some(&custodian_pubkey),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -564,6 +581,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..4], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -571,7 +592,7 @@ mod test {
         let stake_pubkey = Pubkey::new_unique();
         let authorized_pubkey = Pubkey::new_unique();
         let instruction = instruction::deactivate_stake(&stake_pubkey, &authorized_pubkey);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -592,6 +613,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -604,7 +628,7 @@ mod test {
             &source_stake_pubkey,
             &authorized_pubkey,
         );
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -627,6 +651,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..4], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -647,7 +674,7 @@ mod test {
             StakeAuthorize::Staker,
             None,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -672,6 +699,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let instruction = instruction::authorize_with_seed(
             &stake_pubkey,
@@ -682,7 +713,7 @@ mod test {
             StakeAuthorize::Withdrawer,
             Some(&custodian_pubkey),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -708,6 +739,11 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -778,7 +814,7 @@ mod test {
             custodian: Some(custodian),
         };
         let instruction = instruction::set_lockup(&keys[1], &lockup, &keys[0]);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -804,6 +840,9 @@ mod test {
             &AccountKeys::new(&keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let lockup = LockupArgs {
             unix_timestamp: Some(unix_timestamp),
@@ -836,7 +875,7 @@ mod test {
             custodian: None,
         };
         let instruction = instruction::set_lockup_checked(&keys[1], &lockup, &keys[0]);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -860,6 +899,9 @@ mod test {
             &AccountKeys::new(&keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let lockup = LockupArgs {
             unix_timestamp: Some(unix_timestamp),
@@ -867,7 +909,7 @@ mod test {
             custodian: Some(keys[1]),
         };
         let instruction = instruction::set_lockup_checked(&keys[2], &lockup, &keys[0]);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -892,6 +934,10 @@ mod test {
             &AccountKeys::new(&keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -907,7 +953,7 @@ mod test {
 
         let instructions =
             instruction::create_account_checked(&from_pubkey, &stake_pubkey, &authorized, lamports);
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_stake(
                 &message.instructions[1],
@@ -929,6 +975,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -945,7 +994,7 @@ mod test {
             StakeAuthorize::Staker,
             None,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -968,6 +1017,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let instruction = instruction::authorize_checked(
             &stake_pubkey,
@@ -976,7 +1029,7 @@ mod test {
             StakeAuthorize::Withdrawer,
             Some(&custodian_pubkey),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -1000,6 +1053,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..4], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -1020,7 +1077,7 @@ mod test {
             StakeAuthorize::Staker,
             None,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -1045,6 +1102,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
         let instruction = instruction::authorize_checked_with_seed(
             &stake_pubkey,
@@ -1055,7 +1116,7 @@ mod test {
             StakeAuthorize::Withdrawer,
             Some(&custodian_pubkey),
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_stake(
                 &message.instructions[0],
@@ -1081,5 +1142,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..4], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 }

--- a/transaction-status/src/parse_system.rs
+++ b/transaction-status/src/parse_system.rs
@@ -229,7 +229,7 @@ mod test {
             space,
             &owner_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -252,6 +252,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -259,7 +262,7 @@ mod test {
         let account_pubkey = Pubkey::new_unique();
         let owner_pubkey = Pubkey::new_unique();
         let instruction = system_instruction::assign(&account_pubkey, &owner_pubkey);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -275,6 +278,9 @@ mod test {
             }
         );
         assert!(parse_system(&message.instructions[0], &AccountKeys::new(&[], None)).is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -283,7 +289,7 @@ mod test {
         let from_pubkey = Pubkey::new_unique();
         let to_pubkey = Pubkey::new_unique();
         let instruction = system_instruction::transfer(&from_pubkey, &to_pubkey, lamports);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -304,6 +310,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -324,7 +333,7 @@ mod test {
             space,
             &owner_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -350,6 +359,10 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -357,7 +370,7 @@ mod test {
         let space = 128;
         let account_pubkey = Pubkey::new_unique();
         let instruction = system_instruction::allocate(&account_pubkey, space);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -373,6 +386,9 @@ mod test {
             }
         );
         assert!(parse_system(&message.instructions[0], &AccountKeys::new(&[], None)).is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -389,7 +405,7 @@ mod test {
             space,
             &owner_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -412,6 +428,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -426,7 +445,7 @@ mod test {
             seed,
             &owner_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -448,6 +467,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -466,7 +488,7 @@ mod test {
             &to_pubkey,
             lamports,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -490,6 +512,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -499,7 +524,7 @@ mod test {
 
         let instruction =
             system_instruction::advance_nonce_account(&nonce_pubkey, &authorized_pubkey);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -520,6 +545,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -535,7 +563,7 @@ mod test {
             &to_pubkey,
             lamports,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_system(
                 &message.instructions[0],
@@ -559,6 +587,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..4], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -574,7 +605,7 @@ mod test {
             &authorized_pubkey,
             lamports,
         );
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_system(
                 &message.instructions[1],
@@ -596,6 +627,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -610,9 +644,12 @@ mod test {
             &new_authority_pubkey,
         );
         let mut message = Message::new(&[instruction], None);
-        let keys = message.account_keys.clone();
         assert_eq!(
-            parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).unwrap(),
+            parse_system(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
             ParsedInstructionEnum {
                 instruction_type: "authorizeNonce".to_string(),
                 info: json!({
@@ -624,9 +661,10 @@ mod test {
         );
         assert!(parse_system(
             &message.instructions[0],
-            &AccountKeys::new(&keys[0..1], None)
+            &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
         assert!(parse_system(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }

--- a/transaction-status/src/parse_vote.rs
+++ b/transaction-status/src/parse_vote.rs
@@ -215,7 +215,7 @@ mod test {
             &vote_init,
             lamports,
         );
-        let message = Message::new(&instructions, None);
+        let mut message = Message::new(&instructions, None);
         assert_eq!(
             parse_vote(
                 &message.instructions[1],
@@ -240,6 +240,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -254,7 +257,7 @@ mod test {
             &new_authorized_pubkey,
             authority_type,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -277,6 +280,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -291,7 +297,7 @@ mod test {
         let vote_pubkey = Pubkey::new_unique();
         let authorized_voter_pubkey = Pubkey::new_unique();
         let instruction = vote_instruction::vote(&vote_pubkey, &authorized_voter_pubkey, vote);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -318,6 +324,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -332,7 +341,7 @@ mod test {
             lamports,
             &to_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -354,6 +363,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -366,7 +378,7 @@ mod test {
             &authorized_withdrawer_pubkey,
             &node_pubkey,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -387,6 +399,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..2], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -399,7 +414,7 @@ mod test {
             &authorized_withdrawer_pubkey,
             commission,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -420,6 +435,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..1], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -436,7 +454,7 @@ mod test {
         let proof_hash = Hash::new_from_array([2; 32]);
         let instruction =
             vote_instruction::vote_switch(&vote_pubkey, &authorized_voter_pubkey, vote, proof_hash);
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -464,6 +482,9 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 
     #[test]
@@ -478,7 +499,7 @@ mod test {
             &new_authorized_pubkey,
             authority_type,
         );
-        let message = Message::new(&[instruction], None);
+        let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_vote(
                 &message.instructions[0],
@@ -501,5 +522,8 @@ mod test {
             &AccountKeys::new(&message.account_keys[0..3], None)
         )
         .is_err());
+        let keys = message.account_keys.clone();
+        message.instructions[0].accounts.pop();
+        assert!(parse_vote(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
     }
 }


### PR DESCRIPTION
#### Problem
Instruction parser tests don't verify that the instruction parsers return a happy error instead of a panic when the instruction's `accounts` vector is too short to cover the indexes used.

#### Summary of Changes
Add such test cases


