### PR TITLE
Only take the latest vote for each validator in banking stage

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -106,7 +106,7 @@ impl VoteTransaction {
         match self {
             VoteTransaction::Vote(vote) => vote.slots.last().copied(),
             VoteTransaction::VoteStateUpdate(vote_state_update) => {
-                Some(vote_state_update.lockouts.back()?.slot)
+                vote_state_update.last_voted_slot()
             }
         }
     }
@@ -223,6 +223,10 @@ impl VoteStateUpdate {
 
     pub fn slots(&self) -> Vec<Slot> {
         self.lockouts.iter().map(|lockout| lockout.slot).collect()
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.lockouts.back().map(|l| l.slot)
     }
 }
 


### PR DESCRIPTION
#### Problem
The new votes are not incremental so there's no value in storing and processing intermediate transactions. 

#### Summary of Changes
Once the transactions are deserialized, for each batch filter out extraneous votes. 

Feature gate issue: #24717
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
