### PR TITLE
Add ability to use a non-default app profile id in bigtable requests

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -579,7 +579,7 @@ impl BigTableSubCommand for App<'_, '_> {
 
 fn get_global_subcommand_arg<T: FromStr>(
     matches: &ArgMatches<'_>,
-    sub_matches: std::option::Option<&clap::ArgMatches>,
+    sub_matches: Option<&clap::ArgMatches>,
     name: &str,
     default: &str,
 ) -> T {

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -577,7 +577,12 @@ impl BigTableSubCommand for App<'_, '_> {
     }
 }
 
-fn get_global_subcommand_arg<T: FromStr>(matches: &ArgMatches<'_>, name: &str, default: &str) -> T {
+fn get_global_subcommand_arg<T: FromStr>(
+    matches: &ArgMatches<'_>,
+    sub_matches: std::option::Option<&clap::ArgMatches>,
+    name: &str,
+    default: &str,
+) -> T {
     // this is kinda stupid, but there seems to be a bug in clap when a subcommand
     // arg is marked both `global(true)` and `default_value("default_value")`.
     // despite the "global", when the arg is specified on the subcommand, its value
@@ -587,7 +592,6 @@ fn get_global_subcommand_arg<T: FromStr>(matches: &ArgMatches<'_>, name: &str, d
     // again resulting in the default value. the arg having declared a
     // `default_value()` obviates `is_present(...)` tests since they will always
     // return true. so we consede and compare against the expected default. :/
-    let (_, sub_matches) = matches.subcommand();
     let on_command = matches
         .value_of(name)
         .map(|v| v != default)
@@ -609,11 +613,13 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let (subcommand, sub_matches) = matches.subcommand();
     let instance_name = get_global_subcommand_arg(
         matches,
+        sub_matches,
         "rpc_bigtable_instance_name",
         solana_storage_bigtable::DEFAULT_INSTANCE_NAME,
     );
     let app_profile_id = get_global_subcommand_arg(
         matches,
+        sub_matches,
         "rpc_bigtable_app_profile_id",
         solana_storage_bigtable::DEFAULT_APP_PROFILE_ID,
     );

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -29,6 +29,7 @@ use {
         path::Path,
         process::exit,
         result::Result,
+        str::FromStr,
         sync::{atomic::AtomicBool, Arc},
     },
 };
@@ -343,6 +344,15 @@ impl BigTableSubCommand for App<'_, '_> {
                         .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
                         .help("Name of the target Bigtable instance")
                 )
+                .arg(
+                    Arg::with_name("rpc_bigtable_app_profile_id")
+                        .global(true)
+                        .long("rpc-bigtable-app-profile-id")
+                        .takes_value(true)
+                        .value_name("APP_PROFILE_ID")
+                        .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
+                        .help("Bigtable application profile id to use in requests")
+                )
                 .subcommand(
                     SubCommand::with_name("upload")
                         .about("Upload the ledger to BigTable")
@@ -469,6 +479,14 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("INSTANCE_NAME")
                                 .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
                                 .help("Name of the reference Bigtable instance to compare to")
+                        )
+                        .arg(
+                            Arg::with_name("reference_app_profile_id")
+                                .long("reference-app-profile-id")
+                                .takes_value(true)
+                                .value_name("APP_PROFILE_ID")
+                                .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
+                                .help("Reference Bigtable application profile id to use in requests")
                         ),
                 )
                 .subcommand(
@@ -559,12 +577,7 @@ impl BigTableSubCommand for App<'_, '_> {
     }
 }
 
-pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-
-    let verbose = matches.is_present("verbose");
-    let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
-
+fn get_global_subcommand_arg<T: FromStr>(matches: &ArgMatches<'_>, name: &str, default: &str) -> T {
     // this is kinda stupid, but there seems to be a bug in clap when a subcommand
     // arg is marked both `global(true)` and `default_value("default_value")`.
     // despite the "global", when the arg is specified on the subcommand, its value
@@ -574,17 +587,36 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     // again resulting in the default value. the arg having declared a
     // `default_value()` obviates `is_present(...)` tests since they will always
     // return true. so we consede and compare against the expected default. :/
-    let (subcommand, sub_matches) = matches.subcommand();
+    let (_, sub_matches) = matches.subcommand();
     let on_command = matches
-        .value_of("rpc_bigtable_instance_name")
-        .map(|v| v != solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
+        .value_of(name)
+        .map(|v| v != default)
         .unwrap_or(false);
-    let instance_name = if on_command {
-        value_t_or_exit!(matches, "rpc_bigtable_instance_name", String)
+    if on_command {
+        value_t_or_exit!(matches, name, T)
     } else {
         let sub_matches = sub_matches.as_ref().unwrap();
-        value_t_or_exit!(sub_matches, "rpc_bigtable_instance_name", String)
-    };
+        value_t_or_exit!(sub_matches, name, T)
+    }
+}
+
+pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let verbose = matches.is_present("verbose");
+    let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
+
+    let (subcommand, sub_matches) = matches.subcommand();
+    let instance_name = get_global_subcommand_arg(
+        matches,
+        "rpc_bigtable_instance_name",
+        solana_storage_bigtable::DEFAULT_INSTANCE_NAME,
+    );
+    let app_profile_id = get_global_subcommand_arg(
+        matches,
+        "rpc_bigtable_app_profile_id",
+        solana_storage_bigtable::DEFAULT_APP_PROFILE_ID,
+    );
 
     let future = match (subcommand, sub_matches) {
         ("upload", Some(arg_matches)) => {
@@ -599,6 +631,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
             runtime.block_on(upload(
@@ -614,6 +647,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: !arg_matches.is_present("force"),
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
             runtime.block_on(delete_slots(slots, config))
@@ -622,6 +656,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: true,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
             runtime.block_on(first_available_block(config))
@@ -631,6 +666,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
             runtime.block_on(block(slot, output_format, config))
@@ -641,6 +677,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 
@@ -652,6 +689,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 
@@ -663,10 +701,13 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
 
             let ref_instance_name =
                 value_t_or_exit!(arg_matches, "reference_instance_name", String);
+            let ref_app_profile_id =
+                value_t_or_exit!(arg_matches, "reference_app_profile_id", String);
             let ref_config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 credential_type: CredentialType::Filepath(credential_path),
                 instance_name: ref_instance_name,
+                app_profile_id: ref_app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 
@@ -681,6 +722,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 
@@ -700,6 +742,7 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: true,
                 instance_name,
+                app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -174,15 +174,18 @@ impl JsonRpcConfig {
 pub struct RpcBigtableConfig {
     pub enable_bigtable_ledger_upload: bool,
     pub bigtable_instance_name: String,
+    pub bigtable_app_profile_id: String,
     pub timeout: Option<Duration>,
 }
 
 impl Default for RpcBigtableConfig {
     fn default() -> Self {
         let bigtable_instance_name = solana_storage_bigtable::DEFAULT_INSTANCE_NAME.to_string();
+        let bigtable_app_profile_id = solana_storage_bigtable::DEFAULT_APP_PROFILE_ID.to_string();
         Self {
             enable_bigtable_ledger_upload: false,
             bigtable_instance_name,
+            bigtable_app_profile_id,
             timeout: None,
         }
     }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -395,6 +395,7 @@ impl JsonRpcService {
             if let Some(RpcBigtableConfig {
                 enable_bigtable_ledger_upload,
                 ref bigtable_instance_name,
+                ref bigtable_app_profile_id,
                 timeout,
             }) = config.rpc_bigtable_config
             {
@@ -403,6 +404,7 @@ impl JsonRpcService {
                     timeout,
                     credential_type: CredentialType::Filepath(None),
                     instance_name: bigtable_instance_name.clone(),
+                    app_profile_id: bigtable_app_profile_id.clone(),
                 };
                 runtime
                     .block_on(solana_storage_bigtable::LedgerStorage::new_with_config(

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -368,6 +368,7 @@ impl From<LegacyTransactionByAddrInfo> for TransactionByAddrInfo {
 }
 
 pub const DEFAULT_INSTANCE_NAME: &str = "solana-ledger";
+pub const DEFAULT_APP_PROFILE_ID: &str = "default";
 
 #[derive(Debug)]
 pub enum CredentialType {
@@ -381,6 +382,7 @@ pub struct LedgerStorageConfig {
     pub timeout: Option<std::time::Duration>,
     pub credential_type: CredentialType,
     pub instance_name: String,
+    pub app_profile_id: String,
 }
 
 impl Default for LedgerStorageConfig {
@@ -390,6 +392,7 @@ impl Default for LedgerStorageConfig {
             timeout: None,
             credential_type: CredentialType::Filepath(None),
             instance_name: DEFAULT_INSTANCE_NAME.to_string(),
+            app_profile_id: DEFAULT_APP_PROFILE_ID.to_string(),
         }
     }
 }
@@ -419,10 +422,12 @@ impl LedgerStorage {
             read_only,
             timeout,
             instance_name,
+            app_profile_id,
             credential_type,
         } = config;
         let connection = bigtable::BigTableConnection::new(
             instance_name.as_str(),
+            app_profile_id.as_str(),
             read_only,
             timeout,
             credential_type,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -176,6 +176,15 @@ fn main() {
                 .help("Name of BigTable instance to target"),
         )
         .arg(
+            Arg::with_name("rpc_bigtable_app_profile_id")
+                .long("rpc-bigtable-app-profile-id")
+                .value_name("APP_PROFILE_ID")
+                .takes_value(true)
+                .hidden(true)
+                .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
+                .help("Application profile id to use in Bigtable requests")
+        )
+        .arg(
             Arg::with_name("rpc_pubsub_enable_vote_subscription")
                 .long("rpc-pubsub-enable-vote-subscription")
                 .takes_value(false)
@@ -670,6 +679,11 @@ fn main() {
         Some(RpcBigtableConfig {
             enable_bigtable_ledger_upload: false,
             bigtable_instance_name: value_t_or_exit!(matches, "rpc_bigtable_instance", String),
+            bigtable_app_profile_id: value_t_or_exit!(
+                matches,
+                "rpc_bigtable_app_profile_id",
+                String
+            ),
             timeout: None,
         })
     } else {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1279,6 +1279,14 @@ pub fn main() {
                 .help("Name of the Bigtable instance to upload to")
         )
         .arg(
+            Arg::with_name("rpc_bigtable_app_profile_id")
+                .long("rpc-bigtable-app-profile-id")
+                .takes_value(true)
+                .value_name("APP_PROFILE_ID")
+                .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
+                .help("Bigtable application profile id to use in requests")
+        )
+        .arg(
             Arg::with_name("rpc_pubsub_worker_threads")
                 .long("rpc-pubsub-worker-threads")
                 .takes_value(true)
@@ -2395,6 +2403,11 @@ pub fn main() {
         Some(RpcBigtableConfig {
             enable_bigtable_ledger_upload: matches.is_present("enable_bigtable_ledger_upload"),
             bigtable_instance_name: value_t_or_exit!(matches, "rpc_bigtable_instance_name", String),
+            bigtable_app_profile_id: value_t_or_exit!(
+                matches,
+                "rpc_bigtable_app_profile_id",
+                String
+            ),
             timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
                 .ok()
                 .map(Duration::from_secs),


### PR DESCRIPTION
#### Problem
Google Cloud Bigtable uses [App Profiles](https://cloud.google.com/bigtable/docs/app-profiles) to manage routing traffic to clusters allowing users to maintain replicas, perform automatic-failover, and isolate workloads. The current `solana-bigtable` code always uses the default app profile (named `default`) that is created with each instance. Users are unable to override.

#### Summary of Changes
This PR adds the ability to override the default app profile in `solana-bigtable`. A flag is introduced in both the validator and the ledger-tool to override.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
