### PR TITLE
Dynamically set verification packet limit per iteration

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -174,16 +174,19 @@ impl SigVerifier for TransactionSigVerifier {
         packet_count: usize,
         active_thread_count: usize,
     ) {
-        let packets_per_iteration = packet_count * SIGVERIFY_TIME_BUDGET_US / verify_time_us;
-        let packets_per_iteration_max = if perf_libs::api().is_none() {
-            packets_per_iteration / active_thread_count.min(get_thread_count()) * get_thread_count()
-        } else {
-            // TODO: Scale this using number of GPU cores active during last iteration
-            packets_per_iteration.max(MAX_SIGVERIFY_BATCH_DEFAULT)
-        };
-        self.max_verify_batch -= self.max_verify_batch >> 5;
-        self.max_verify_batch += packets_per_iteration_max >> 5;
-        // Establish an absolute floor to avoid death spiral overly restricting verification packet count.
-        self.max_verify_batch = self.max_verify_batch.max(MAX_SIGVERIFY_BATCH_MIN);
+        if packet_count > 0 && verify_time_us > 0 {
+            let packets_per_iteration = packet_count * SIGVERIFY_TIME_BUDGET_US / verify_time_us;
+            let packets_per_iteration_max = if perf_libs::api().is_none() {
+                packets_per_iteration / active_thread_count.min(get_thread_count())
+                    * get_thread_count()
+            } else {
+                // TODO: Scale this using number of GPU cores active during last iteration
+                packets_per_iteration.max(MAX_SIGVERIFY_BATCH_DEFAULT)
+            };
+            self.max_verify_batch -= self.max_verify_batch >> 5;
+            self.max_verify_batch += packets_per_iteration_max >> 5;
+            // Establish an absolute floor to avoid death spiral overly restricting verification packet count.
+            self.max_verify_batch = self.max_verify_batch.max(MAX_SIGVERIFY_BATCH_MIN);
+        }
     }
 }


### PR DESCRIPTION
#### Problem
Max packets to verify per iteration is set statically based on looking at cluster level average data. However, individual validators may have very different capabilities. Setting this value too low may result in dropping packets unnecessarily for high powered machines. Setting too high may result in a long time spent in verification and large amount of backpressure (and potentially even OOM cases) on low powered machines.

#### Summary of Changes
Dynamically set max packets per verification iteration based on measuring what machine is capable of and trying to fit a 50ms window.

Note: Setting a proper limit here will be dependent on having some understanding of amount of parallelism being employed. Using temp values until #25915 lands
