### PR TITLE
Reduce 2 iterators to one

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -324,14 +324,16 @@ fn execute_batches(
     cost_capacity_meter: Arc<RwLock<BlockCostCapacityMeter>>,
     cost_model: &CostModel,
 ) -> Result<()> {
-    let lock_results = batches
+    let (lock_results, sanitized_txs): (Vec<_>, Vec<_>) = batches
         .iter()
-        .flat_map(|batch| batch.lock_results().clone())
-        .collect::<Vec<_>>();
-    let sanitized_txs = batches
-        .iter()
-        .flat_map(|batch| batch.sanitized_transactions().to_vec())
-        .collect::<Vec<_>>();
+        .flat_map(|batch| {
+            batch
+                .lock_results()
+                .iter()
+                .cloned()
+                .zip(batch.sanitized_transactions().to_vec())
+        })
+        .unzip();
 
     let mut minimal_tx_cost = u64::MAX;
     let mut total_cost: u64 = 0;


### PR DESCRIPTION
#### Problem
Replay's blockstore_processor iterates through transaction batches twice to pull out lock results and then transactions. Could be done in one iteration instead.

#### Summary of Changes
Combine iterators into one (prep for adding another array in https://github.com/solana-labs/solana/pull/25688)
