### PR TITLE
Add inputs to indicate minimum beta and stable releases that support the feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-gate.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature-gate.yml
@@ -48,6 +48,20 @@ body:
     validations:
       required: true
   - type: input
+    id: beta-version
+    attributes:
+      label: Minimum Beta Version
+      placeholder: Edit this response when feature has landed in a beta release
+    validations:
+      required: false
+  - type: input
+    id: stable-version
+    attributes:
+      label: Minimum Stable Version
+      placeholder: Edit this response when feature has landed in a stable release
+    validations:
+      required: false
+  - type: input
     id: testnet
     attributes:
       label: Testnet Activation Epoch


### PR DESCRIPTION
#### Problem
It's always tedious to figure out the lowest release(s) a feature is present in

#### Summary of Changes
Add fields to the feature-gate issue template to store minimum version info for both stable and beta releases (these might be the same, but often they aren't)
