### PR TITLE
Add 'airdrop' to terminology

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -20,6 +20,10 @@ The key may be one of:
 
 The address of the program that owns the account. Only the owning program is capable of modifying the account.
 
+## airdrop
+
+A way to ask testnet/devnet to put Sol into a wallet for testing purposes. 
+
 ## app
 
 A front-end application that interacts with a Solana cluster.


### PR DESCRIPTION
New to Solana but noticed this was missing. You might want to tweak this a little as I've only been coding on Sol a day or so.

#### Problem
'airdrop' was missing from terminology

#### Summary of Changes
Add 'airdrop' to terminology