### PR TITLE
Optimize stake accounts store

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6196,9 +6196,7 @@ impl Bank {
             .accounts
             .store_accounts_cached(self.slot(), accounts);
         let mut m = Measure::start("stakes_cache.check_and_store");
-        for (pubkey, account) in accounts {
-            self.stakes_cache.check_and_store(pubkey, account);
-        }
+        self.stakes_cache.check_and_store_batch(accounts);
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1880,9 +1880,8 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let (thread_pool, thread_pool_time) = Measure::this(
-                        |_| ThreadPoolBuilder::new().build().unwrap(),
-                        (),
+                    let (thread_pool, thread_pool_time) = measure!(
+                        ThreadPoolBuilder::new().build().unwrap(),
                         "thread_pool_creation",
                     );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,6 +91,7 @@ use {
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
     },
+    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{
             create_account_shared_data_with_fields as create_account, from_account, Account,
@@ -1879,8 +1880,15 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let (thread_pool, thread_pool_time) = measure!(
-                        ThreadPoolBuilder::new().build().unwrap(),
+                    let num_threads = get_thread_count();
+                    let (thread_pool, thread_pool_time) = Measure::this(
+                        |_| {
+                            ThreadPoolBuilder::new()
+                                .num_threads(num_threads)
+                                .build()
+                                .unwrap()
+                        },
+                        (),
                         "thread_pool_creation",
                     );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -174,6 +174,7 @@ use {
 struct RewardsMetrics {
     load_vote_and_stake_accounts_us: AtomicU64,
     calculate_points_us: AtomicU64,
+    redeem_rewards_us: AtomicU64,
     store_stake_accounts_us: AtomicU64,
     store_vote_accounts_us: AtomicU64,
     invalid_cached_vote_accounts: usize,
@@ -1962,6 +1963,11 @@ impl Bank {
                             i64
                         ),
                         (
+                            "redeem_rewards_us",
+                            metrics.redeem_rewards_us.load(Relaxed),
+                            i64
+                        ),
+                        (
                             "store_stake_accounts_us",
                             metrics.store_stake_accounts_us.load(Relaxed),
                             i64
@@ -3002,7 +3008,7 @@ impl Bank {
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
-    ///   successfully load and parse, return the lamport value of one point
+    /// successfully load and parse, return the lamport value of one point
     fn pay_validator_rewards_with_thread_pool(
         &mut self,
         rewarded_epoch: Epoch,
@@ -3046,6 +3052,7 @@ impl Bank {
             vote_with_stake_delegations_map
         };
 
+        // TODO (hyi): sharding on vote_pubkey over the slots
         let mut m = Measure::start("calculate_points");
         let points: u128 = thread_pool.install(|| {
             vote_with_stake_delegations_map
@@ -3078,6 +3085,7 @@ impl Bank {
             return 0.0;
         }
 
+        // TODO (hyi): sharding on vote_pubkey over the slots
         // pay according to point value
         let point_value = PointValue { rewards, points };
         let vote_account_rewards: DashMap<Pubkey, (AccountSharedData, u8, u64, bool)> =
@@ -3099,71 +3107,85 @@ impl Bank {
             },
         );
 
+        // TODO (hyi): sharding on stake_pubkey over the slots
         let mut m = Measure::start("redeem_rewards");
-        let mut stake_rewards = thread_pool.install(|| {
-            stake_delegation_iterator
-                .filter_map(|(vote_pubkey, vote_state, (stake_pubkey, stake_account))| {
-                    // curry closure to add the contextual stake_pubkey
-                    let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
-                        // inner
-                        move |inner_event: &_| {
-                            outer(&RewardCalculationEvent::Staking(&stake_pubkey, inner_event))
-                        }
-                    });
-                    let (mut stake_account, stake_state) =
-                        <(AccountSharedData, StakeState)>::from(stake_account);
-                    let redeemed = stake_state::redeem_rewards(
-                        rewarded_epoch,
-                        stake_state,
-                        &mut stake_account,
-                        &vote_state,
-                        &point_value,
-                        Some(&stake_history),
-                        reward_calc_tracer.as_ref(),
-                        credits_auto_rewind,
-                    );
-                    if let Ok((stakers_reward, voters_reward)) = redeemed {
-                        // track voter rewards
-                        if let Some((
-                            _vote_account,
-                            _commission,
-                            vote_rewards_sum,
-                            vote_needs_store,
-                        )) = vote_account_rewards.get_mut(&vote_pubkey).as_deref_mut()
-                        {
-                            *vote_needs_store = true;
-                            *vote_rewards_sum = vote_rewards_sum.saturating_add(voters_reward);
-                        }
+        let stake_rewards: Vec<(Pubkey, RewardInfo, u64, AccountSharedData)> =
+            thread_pool.install(|| {
+                stake_delegation_iterator
+                    .filter_map(|(vote_pubkey, vote_state, (stake_pubkey, stake_account))| {
+                        // curry closure to add the contextual stake_pubkey
+                        let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
+                            // inner
+                            move |inner_event: &_| {
+                                outer(&RewardCalculationEvent::Staking(&stake_pubkey, inner_event))
+                            }
+                        });
+                        let (mut stake_account, stake_state) =
+                            <(AccountSharedData, StakeState)>::from(stake_account);
+                        let redeemed = stake_state::redeem_rewards(
+                            rewarded_epoch,
+                            stake_state,
+                            &mut stake_account,
+                            &vote_state,
+                            &point_value,
+                            Some(&stake_history),
+                            reward_calc_tracer.as_ref(),
+                            credits_auto_rewind,
+                        );
+                        if let Ok((stakers_reward, voters_reward)) = redeemed {
+                            // track voter rewards
+                            if let Some((
+                                _vote_account,
+                                _commission,
+                                vote_rewards_sum,
+                                vote_needs_store,
+                            )) = vote_account_rewards.get_mut(&vote_pubkey).as_deref_mut()
+                            {
+                                *vote_needs_store = true;
+                                *vote_rewards_sum = vote_rewards_sum.saturating_add(voters_reward);
+                            }
 
-                        // store stake account even if stakers_reward is 0
-                        // because credits observed has changed
-                        self.store_account(&stake_pubkey, &stake_account);
-
-                        if stakers_reward > 0 {
+                            let balance = stake_account.lamports();
                             return Some((
                                 stake_pubkey,
                                 RewardInfo {
                                     reward_type: RewardType::Staking,
                                     lamports: stakers_reward as i64,
-                                    post_balance: stake_account.lamports(),
+                                    post_balance: balance,
                                     commission: Some(vote_state.commission),
                                 },
+                                stakers_reward,
+                                stake_account,
                             ));
+                        } else {
+                            debug!(
+                                "stake_state::redeem_rewards() failed for {}: {:?}",
+                                stake_pubkey, redeemed
+                            );
                         }
-                    } else {
-                        debug!(
-                            "stake_state::redeem_rewards() failed for {}: {:?}",
-                            stake_pubkey, redeemed
-                        );
-                    }
-                    None
-                })
-                .collect()
-        });
+                        None
+                    })
+                    .collect()
+            });
+        m.stop();
+        metrics.redeem_rewards_us.fetch_add(m.as_us(), Relaxed);
+
+        let mut m = Measure::start("store_stake_account");
+        let accounts_to_store = stake_rewards
+            .iter()
+            .map(|x| (&x.0, &x.3))
+            .collect::<Vec<_>>();
+        self.store_accounts(&accounts_to_store);
         m.stop();
         metrics
             .store_stake_accounts_us
             .fetch_add(m.as_us(), Relaxed);
+
+        // filter out zero rewards stake accounts
+        let mut stake_rewards = stake_rewards
+            .iter()
+            .filter_map(|x| if x.2 > 0 { Some((x.0, x.1)) } else { None })
+            .collect();
 
         let mut m = Measure::start("store_vote_accounts");
         let mut vote_rewards = vote_account_rewards

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3010,7 +3010,6 @@ impl Bank {
         struct StakeReward {
             stake_pubkey: Pubkey,
             stake_reward_info: RewardInfo,
-            stake_reward: u64,
             stake_account: AccountSharedData,
         }
 
@@ -3141,11 +3140,10 @@ impl Bank {
                             stake_pubkey,
                             stake_reward_info: RewardInfo {
                                 reward_type: RewardType::Staking,
-                                lamports: stakers_reward as i64,
+                                lamports: i64::try_from(stakers_reward).unwrap(),
                                 post_balance,
                                 commission: Some(vote_state.commission),
                             },
-                            stake_reward: stakers_reward,
                             stake_account,
                         });
                     } else {
@@ -3176,7 +3174,7 @@ impl Bank {
 
         let mut stake_rewards = stake_rewards
             .into_iter()
-            .filter(|x| x.stake_reward > 0)
+            .filter(|x| x.stake_reward_info.lamports > 0)
             .map(|x| (x.stake_pubkey, x.stake_reward_info))
             .collect();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,7 +91,6 @@ use {
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
     },
-    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{
             create_account_shared_data_with_fields as create_account, from_account, Account,
@@ -1881,14 +1880,8 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let num_threads = get_thread_count();
                     let (thread_pool, thread_pool_time) = Measure::this(
-                        |_| {
-                            ThreadPoolBuilder::new()
-                                .num_threads(num_threads)
-                                .build()
-                                .unwrap()
-                        },
+                        |_| ThreadPoolBuilder::new().build().unwrap(),
                         (),
                         "thread_pool_creation",
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3147,7 +3147,7 @@ impl Bank {
                             stake_reward_info: RewardInfo {
                                 reward_type: RewardType::Staking,
                                 lamports: stakers_reward as i64,
-                                post_balance: post_balance,
+                                post_balance,
                                 commission: Some(vote_state.commission),
                             },
                             stake_reward: stakers_reward,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3166,7 +3166,8 @@ impl Bank {
         m.stop();
         metrics.redeem_rewards_us.fetch_add(m.as_us(), Relaxed);
 
-        // store stake account before filtering out 0 stake_reward below
+        // store stake account even if stakers_reward is 0
+        // because credits observed has changed
         let mut m = Measure::start("store_stake_account");
         let accounts_to_store = stake_rewards
             .iter()
@@ -3178,7 +3179,6 @@ impl Bank {
             .store_stake_accounts_us
             .fetch_add(m.as_us(), Relaxed);
 
-        // filter out zero rewards stake accounts
         let mut stake_rewards = stake_rewards
             .into_iter()
             .filter(|x| x.stake_reward > 0)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -140,13 +140,9 @@ impl StakesCache {
                                 // Called to eagerly deserialize vote state
                                 let _res = vote_account.vote_state();
                             }
-                            let mut stakes = self.0.write().unwrap();
                             stakes.upsert_vote_account(pubkey, vote_account);
                         }
-                        Err(_) => {
-                            let mut stakes = self.0.write().unwrap();
-                            stakes.remove_vote_account(pubkey)
-                        }
+                        Err(_) => stakes.remove_vote_account(pubkey),
                     }
                 } else {
                     stakes.remove_vote_account(pubkey)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -110,6 +110,60 @@ impl StakesCache {
         }
     }
 
+    pub fn check_and_store_batch(&self, accounts: &[(&Pubkey, &AccountSharedData)]) {
+        let mut stakes = self.0.write().unwrap();
+
+        for (pubkey, account) in accounts {
+            // TODO: If the account is already cached as a vote or stake account
+            // but the owner changes, then this needs to evict the account from
+            // the cache. see:
+            // https://github.com/solana-labs/solana/pull/24200#discussion_r849935444
+            let pubkey = *pubkey;
+            let account = *account;
+            let owner = account.owner();
+            // Zero lamport accounts are not stored in accounts-db
+            // and so should be removed from cache as well.
+            if account.lamports() == 0 {
+                if solana_vote_program::check_id(owner) {
+                    stakes.remove_vote_account(pubkey);
+                } else if solana_stake_program::check_id(owner) {
+                    stakes.remove_stake_delegation(pubkey);
+                }
+                continue;
+            }
+            debug_assert_ne!(account.lamports(), 0u64);
+            if solana_vote_program::check_id(owner) {
+                if VoteState::is_correct_size_and_initialized(account.data()) {
+                    match VoteAccount::try_from(account.clone()) {
+                        Ok(vote_account) => {
+                            {
+                                // Called to eagerly deserialize vote state
+                                let _res = vote_account.vote_state();
+                            }
+                            let mut stakes = self.0.write().unwrap();
+                            stakes.upsert_vote_account(pubkey, vote_account);
+                        }
+                        Err(_) => {
+                            let mut stakes = self.0.write().unwrap();
+                            stakes.remove_vote_account(pubkey)
+                        }
+                    }
+                } else {
+                    stakes.remove_vote_account(pubkey)
+                };
+            } else if solana_stake_program::check_id(owner) {
+                match StakeAccount::try_from(account.clone()) {
+                    Ok(stake_account) => {
+                        stakes.upsert_stake_delegation(*pubkey, stake_account);
+                    }
+                    Err(_) => {
+                        stakes.remove_stake_delegation(pubkey);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn activate_epoch(&self, next_epoch: Epoch, thread_pool: &ThreadPool) {
         let mut stakes = self.0.write().unwrap();
         stakes.activate_epoch(next_epoch, thread_pool)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -649,6 +649,34 @@ pub mod tests {
     }
 
     #[test]
+    fn test_stakes_batch() {
+        for i in 0..4 {
+            let stakes_cache = StakesCache::new(Stakes {
+                epoch: i,
+                ..Stakes::default()
+            });
+
+            let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+                create_staked_node_accounts(10);
+
+            stakes_cache.check_and_store_batch(&[
+                (&vote_pubkey, &vote_account),
+                (&stake_pubkey, &stake_account),
+            ]);
+            let stake = stake_state::stake_from(&stake_account).unwrap();
+            {
+                let stakes = stakes_cache.stakes();
+                let vote_accounts = stakes.vote_accounts();
+                assert!(vote_accounts.get(&vote_pubkey).is_some());
+                assert_eq!(
+                    vote_accounts.get(&vote_pubkey).unwrap().0,
+                    stake.stake(i, None)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_stakes_highest() {
         let stakes_cache = StakesCache::default();
 


### PR DESCRIPTION
#### Problem
Storing stake accounts suffers from RWLock contention on stake_cache.  That's why storing stake account (running highly parallel) takes much longer time than storing vote account (running single threaded).

#### Summary of Changes
Separate stake account store from reward redeem. Keep reward redeem running in parallel, batch the staking accounts to store and store the stake accounts in a single thread. 

**Result**
Store time reduced from 4.4s to 1.7s.


```
update_rewards_with_thread_pool_us=7230692i load_vote_and_stake_accounts_us=4454714i store_stake_accounts_us=1767486i
```
```
update_rewards_with_thread_pool_us=12077002i load_vote_and_stake_accounts_us=7272740i store_stake_accounts_us=4467960i
```
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
