### PR TITLE
fix test_new_from_file_crafted_executable for m1

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -899,16 +899,16 @@ pub mod tests {
         let accounts = av.accounts(0);
         let account = accounts.first().unwrap();
 
+        // upper 7-bits are not 0, so sanitization should fail
+        assert!(!account.sanitize_executable());
+
         // we can observe crafted value by ref
         {
             let executable_bool: &bool = &account.account_meta.executable;
-            // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation
-            // assert_eq! thinks *executable_bool is equal to false but the if condition thinks it's not, contradictorily.
+            // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation.
+            // Behavior is dependent on compiler.
+            // assert! thinks !*executable_bool is true, for all compilers
             assert!(!*executable_bool);
-            const FALSE: bool = false; // keep clippy happy
-            if *executable_bool == FALSE {
-                panic!("This didn't occur if this test passed.");
-            }
             assert_eq!(*account.ref_executable_byte(), crafted_executable);
         }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -905,10 +905,16 @@ pub mod tests {
         // we can observe crafted value by ref
         {
             let executable_bool: &bool = &account.account_meta.executable;
-            // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation.
-            // Behavior is dependent on compiler.
-            // assert! thinks !*executable_bool is true, for all compilers
+            // Depending on use, *executable_bool can be truthy or falsy due to direct memory manipulation
+            // assert_eq! thinks *executable_bool is equal to false but the if condition thinks it's not, contradictorily.
             assert!(!*executable_bool);
+            #[cfg(not(target_arch = "aarch64"))]
+            {
+                const FALSE: bool = false; // keep clippy happy
+                if *executable_bool == FALSE {
+                    panic!("This didn't occur if this test passed.");
+                }
+            }
             assert_eq!(*account.ref_executable_byte(), crafted_executable);
         }
 


### PR DESCRIPTION
#### Problem
Test fails on m1 mac's w/ current rust compiler.

#### Summary of Changes
Assert that sanitize_executable fails (what we really care about).
Remove the check that `*executable_bool == FALSE`, which changes based on compilers.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
