### PR TITLE
Remove truncate from "blocks_to_upload"

### DIFF
--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -136,7 +136,6 @@ pub async fn upload_confirmed_blocks(
             .cloned()
             .collect::<Vec<_>>();
         blocks_to_upload.sort_unstable();
-        blocks_to_upload.truncate(config.max_num_slots_to_check);
         blocks_to_upload
     };
 


### PR DESCRIPTION
# Problem

If we truncate the blocks we intend to upload in bigtable_upload.rs, then the maximum number of blocks the _solana-ledger-tool bigtable upload_ program can uplaod is vCPUs * 2.

For example, on a machine with 28 vCPUs:

```
solana_ledger::bigtable_upload] Found 7010 slots in the range (135986342, 135995282)
solana_ledger::bigtable_upload] Loading list of bigtable blocks between slots 135986342 and 135995282...
solana_ledger::bigtable_upload] 56 blocks to be uploaded to the bucket in the range (135986342, 135986449)
```

# Summary of changes

Remove this line from the program:

```rust
blocks_to_upload.truncate(config.max_num_slots_to_check);
```

With this change, the _solana-ledger_tool_ will work through all the blocks, and we notice no difference in upload times. This is what it looks like after the change:

```
solana_ledger::bigtable_upload] Found 6731 slots in the range (135986743, 135995282)
solana_ledger::bigtable_upload] Loading list of bigtable blocks between slots 135986743 and 135995282...
solana_ledger::bigtable_upload] 6687 blocks to be uploaded to the bucket in the range (135986800, 135995282)
```