### PR TITLE
Add metric for tracking Bigtable blocks uploaded

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -4,7 +4,7 @@ use {
     crate::bigtable::RowKey,
     log::*,
     serde::{Deserialize, Serialize},
-    solana_metrics::inc_new_counter_debug,
+    solana_metrics::{datapoint_info, inc_new_counter_debug},
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
         deserialize_utils::default_on_eof,
@@ -855,11 +855,12 @@ impl LedgerStorage {
             .connection
             .put_protobuf_cells_with_retry::<generated::ConfirmedBlock>("blocks", &blocks_cells)
             .await?;
-        info!(
-            "uploaded block for slot {}: {} transactions, {} bytes",
-            slot, num_transactions, bytes_written
+        datapoint_info!(
+            "storage-bigtable-upload-block",
+            ("slot", slot, i64),
+            ("transactions", num_transactions, i64),
+            ("bytes", bytes_written, i64),
         );
-
         Ok(())
     }
 


### PR DESCRIPTION
# Problem

There are no time series for tracking the latest block uploaded to Bigtable.

# Summary of Changes

This commit adds a datapoint metric called
"storage-bigtable-query-last-block-uploaded" which reports the most
recently uploaded block by the threads spawned inside the
"solana_ledger::bigtable_upload::upload_confirmed_blocks" function.

# Why

It gets the information into a time series database-compatible format,
which makes it a easier to build monitoring and alerting.

# Testing

We built the binary locally using the solanalabs/rust container image,
and tested the binary on a machine and saw log messages that looked like
this:

```
[2022-06-17T14:01:43.843999910Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987534i
[2022-06-17T14:01:43.871708319Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987530i
[2022-06-17T14:01:43.875518939Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987526i
[2022-06-17T14:01:43.985200230Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987520i
[2022-06-17T14:01:44.030815720Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987528i
[2022-06-17T14:01:44.126093176Z INFO  solana_metrics::metrics] datapoint: storage-bigtable-query-last-block-uploaded height=135987524i
```