### PR TITLE
Add ledger-tool bigtable upload loop

### DIFF
--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -45,7 +45,7 @@ pub async fn upload_confirmed_blocks(
     blockstore: Arc<Blockstore>,
     bigtable: solana_storage_bigtable::LedgerStorage,
     starting_slot: Slot,
-    ending_slot: Option<Slot>,
+    ending_slot: Slot,
     config: ConfirmedBlockUploadConfig,
     exit: Arc<AtomicBool>,
 ) -> Result<Slot, Box<dyn std::error::Error>> {
@@ -60,14 +60,7 @@ pub async fn upload_confirmed_blocks(
                 starting_slot, err
             )
         })?
-        .map_while(|slot| {
-            if let Some(ending_slot) = &ending_slot {
-                if slot > *ending_slot {
-                    return None;
-                }
-            }
-            Some(slot)
-        })
+        .map_while(|slot| (slot <= ending_slot).then(|| slot))
         .collect();
 
     if blockstore_slots.is_empty() {

--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -102,7 +102,7 @@ impl BigTableUploadService {
                 blockstore.clone(),
                 bigtable_ledger_storage.clone(),
                 start_slot,
-                Some(end_slot),
+                end_slot,
                 config.clone(),
                 exit.clone(),
             ));


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/24716 added a configurable limit to the number of blocks that `solana_ledger::bigtable_upload::upload_confirmed_blocks` checks at a time. However, it neglected to update `solana-ledger-tool`.

#### Summary of Changes
Add a loop to `solana-ledger-tool bigtable upload` so that the upload service iterates through the entire requested range, instead of stopping at the first limit.

Fixes #26023
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
