### PR TITLE
UdpTpuConnection no longer restricts its local port to the 8000-10000 range

### DIFF
--- a/client/src/nonblocking/udp_client.rs
+++ b/client/src/nonblocking/udp_client.rs
@@ -19,8 +19,7 @@ pub struct UdpTpuConnection {
 impl UdpTpuConnection {
     pub fn new(tpu_addr: SocketAddr) -> Self {
         let socket =
-            solana_net_utils::bind_in_validator_port_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
-                .unwrap();
+            solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))).unwrap();
         socket.set_nonblocking(true).unwrap();
         Self::new_with_std_socket(tpu_addr, socket)
     }
@@ -104,8 +103,7 @@ mod tests {
         let addr_str = "0.0.0.0:50101";
         let addr = addr_str.parse().unwrap();
         let socket =
-            solana_net_utils::bind_in_validator_port_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
-                .unwrap();
+            solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))).unwrap();
         socket.set_nonblocking(true).unwrap();
         let connection = UdpTpuConnection::new_with_std_socket(addr, socket);
         let reader = UdpSocket::bind(addr_str).await.expect("bind");

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -20,8 +20,7 @@ pub struct UdpTpuConnection {
 impl UdpTpuConnection {
     pub fn new_from_addr(tpu_addr: SocketAddr) -> Self {
         let socket =
-            solana_net_utils::bind_in_validator_port_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))
-                .unwrap();
+            solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))).unwrap();
         Self {
             socket,
             addr: tpu_addr,


### PR DESCRIPTION
v1.10 will panic when all ports in the 8000-10000 range are bound:
1. https://github.com/solana-labs/solana/blob/d2f61c7bb62111805120ae874c3404e2e1c99bba/core/src/banking_stage.rs#L608
2. https://github.com/solana-labs/solana/blob/d2f61c7bb62111805120ae874c3404e2e1c99bba/client/src/nonblocking/udp_client.rs#L22

v1.9 still panics but only when all u16 ports are bound:
1. https://github.com/solana-labs/solana/blob/f60d8522ebfcea3dc22c20d067e22a2927c0b75d/core/src/banking_stage.rs#L958

Restore the full u16 range for master/v1.10 as this panic has been observed in real life. It'd be nice to handle the unwrap more gracefully as a long-term cleanup item





