### PR TITLE
Nitty code simplification

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1797,21 +1797,14 @@ pub fn process_show_stakes(
 
     if let Some(withdraw_authority_pubkey) = withdraw_authority_pubkey {
         // withdrawer filter
-        let withdrawer_filter = vec![rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
+        let withdrawer_filter = rpc_filter::RpcFilterType::Memcmp(rpc_filter::Memcmp {
             offset: 44,
             bytes: rpc_filter::MemcmpEncodedBytes::Base58(withdraw_authority_pubkey.to_string()),
             encoding: Some(rpc_filter::MemcmpEncoding::Binary),
-        })];
+        });
 
-        match program_accounts_config.filters {
-            Some(filters) => {
-                // filter by withdrawer
-                program_accounts_config.filters = Some([filters, withdrawer_filter].concat())
-            }
-            None => {
-                program_accounts_config.filters = Some(withdrawer_filter);
-            }
-        }
+        let filters = program_accounts_config.filters.get_or_insert(vec![]);
+        filters.push(withdrawer_filter);
     }
 
     let all_stake_accounts = rpc_client


### PR DESCRIPTION
#### Problem
Why write a whole match when a mutable reference will do?

#### Summary of Changes
Fixup recently merged `solana stakes` code to simplify adding withdrawer-authority filter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
