### PR TITLE
runtime: fix possible deadlock in in_mem_accounts_index

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -147,6 +147,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                 result.push((*k, Arc::clone(v)));
             }
         });
+        drop(map);
         self.hold_range_in_memory(range, false);
         Self::update_stat(&self.stats().items, 1);
         Self::update_time_stat(&self.stats().items_us, m);


### PR DESCRIPTION
#### Problem

There is a possible deadlock in in_mem_accounts_index.

`self.map()` returns `&RwLock<...>`.

The first Read lock in fn `items`:
https://github.com/solana-labs/solana/blob/a5f290a66f10a25e0c3ee004a1fcd2889eca2785/runtime/src/in_mem_accounts_index.rs#L143-L150

https://github.com/solana-labs/solana/blob/a5f290a66f10a25e0c3ee004a1fcd2889eca2785/runtime/src/in_mem_accounts_index.rs#L844-L854

The second Write lock in fn `put_range_in_cache`:
https://github.com/solana-labs/solana/blob/a5f290a66f10a25e0c3ee004a1fcd2889eca2785/runtime/src/in_mem_accounts_index.rs#L861-L871

#### Summary of Changes

Add `drop(map)` before calling fn `hold_range_in_memory`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
