### PR TITLE
runtime: fix double-readlock in in_mem_accounts_index.rs

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -1018,17 +1018,14 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
         }
 
         // during startup, nothing should be in the in-mem map
+        let map_internal = self.map_internal.read().unwrap();
         assert!(
-            self.map_internal.read().unwrap().is_empty(),
+            map_internal.is_empty(),
             "len: {}, first: {:?}",
-            self.map_internal.read().unwrap().len(),
-            self.map_internal
-                .read()
-                .unwrap()
-                .iter()
-                .take(1)
-                .collect::<Vec<_>>()
+            map_internal.len(),
+            map_internal.iter().take(1).collect::<Vec<_>>()
         );
+        drop(map_internal);
 
         let mut duplicates = vec![];
 


### PR DESCRIPTION
#### Problem

There is a possible deadlock caused by double readlock in `assert!` in fn `write_startup_info_to_disk`.
The read lock on L1024 is not released before acquiring another read lock on L1025.
For more details on this kind of deadlock, see
https://www.reddit.com/r/rust/comments/urnqz8/different_behaviors_of_recursive_read_locks_in/
Interestingly, the readlock on L1022 is immediately released and does not cause deadlock.

#### Summary of Changes

The fix is to acquire the read lock once and reuse it.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
