### PR TITLE
rpc: fix possible deadlock in rpc

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1431,12 +1431,12 @@ impl JsonRpcRequestProcessor {
         bank: &Arc<Bank>,
     ) -> Option<TransactionStatus> {
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
-        let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
         let optimistically_confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
         let optimistically_confirmed =
             optimistically_confirmed_bank.get_signature_status_slot(&signature);
 
+        let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
         let confirmations = if r_block_commitment_cache.root() >= slot
             && is_finalized(&r_block_commitment_cache, bank, &self.blockstore, slot)
         {


### PR DESCRIPTION
#### Problem

There is a possible deadlock caused by double readlock in fn `get_transaction_status`.

`block_commitment_cache` is an `Arc<RwLock<...>>`.

The first readlock is on L1434
https://github.com/solana-labs/solana/blob/fbf7143a97a18a872f5b111b9dd1ce0b7ba412a0/rpc/src/rpc.rs#L1434-L1436
The second readlock is on L253 in fn `bank`
https://github.com/solana-labs/solana/blob/fbf7143a97a18a872f5b111b9dd1ce0b7ba412a0/rpc/src/rpc.rs#L250-L254

For more details on this kind of deadlock, see
https://www.reddit.com/r/rust/comments/urnqz8/different_behaviors_of_recursive_read_locks_in/

#### Summary of Changes
The fix is to move the first readlock after the calling of fn `bank`.
But I wonder if this is correct or optimal.
1. I do not know if `optimistically_confirmed` should be protected by `block_commitment_cache`? OR
2. can we drop `r_block_commitment_cache` immediately after the creation of `confirmations` on L1440-1448.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
