### PR TITLE
core: fix double-readlock in validator

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -699,10 +699,12 @@ impl Validator {
             };
 
         let mut block_commitment_cache = BlockCommitmentCache::default();
+        let bank_forks_guard = bank_forks.read().unwrap();
         block_commitment_cache.initialize_slots(
-            bank_forks.read().unwrap().working_bank().slot(),
-            bank_forks.read().unwrap().root(),
+            bank_forks_guard.working_bank().slot(),
+            bank_forks_guard.root(),
         );
+        drop(bank_forks_guard);
         let block_commitment_cache = Arc::new(RwLock::new(block_commitment_cache));
 
         let optimistically_confirmed_bank =


### PR DESCRIPTION
#### Problem

There is a possible deadlock caused by double readlock in fn `Validator::new`.

`bank_forks: Arc<RwLock<BankForks>>`

The first readlock is on L705 and the second on L706

https://github.com/solana-labs/solana/blob/fbf7143a97a18a872f5b111b9dd1ce0b7ba412a0/core/src/validator.rs#L704-L707

For more details on this kind of deadlock, see
https://www.reddit.com/r/rust/comments/urnqz8/different_behaviors_of_recursive_read_locks_in/

#### Summary of Changes

Call readlock once and reuse it. After the call, drop the guard.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
