### PR TITLE
rbpf-cli: capture log

### DIFF
--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -298,24 +298,6 @@ native machine code before execting it in the virtual machine.",
     };
     let duration = Instant::now() - start_time;
 
-    let output = Output {
-        result: format!("{:?}", result),
-        instruction_count: vm.get_total_instruction_count(),
-        execution_time: duration,
-    };
-    match matches.value_of("output_format") {
-        Some("json") => {
-            println!("{}", serde_json::to_string_pretty(&output).unwrap());
-        }
-        Some("json-compact") => {
-            println!("{}", serde_json::to_string(&output).unwrap());
-        }
-        _ => {
-            println!("Program output:");
-            println!("{:?}", output);
-        }
-    }
-
     if matches.is_present("trace") {
         eprintln!("Trace is saved in trace.out");
         let mut file = File::create("trace.out").unwrap();
@@ -333,6 +315,33 @@ native machine code before execting it in the virtual machine.",
             .visualize_graphically(&mut file, Some(&dynamic_analysis))
             .unwrap();
     }
+
+    let instruction_count = vm.get_total_instruction_count();
+    drop(vm);
+
+    let output = Output {
+        result: format!("{:?}", result),
+        instruction_count,
+        execution_time: duration,
+        log: invoke_context
+            .get_log_collector()
+            .unwrap()
+            .borrow()
+            .get_recorded_content()
+            .to_vec(),
+    };
+    match matches.value_of("output_format") {
+        Some("json") => {
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
+        Some("json-compact") => {
+            println!("{}", serde_json::to_string(&output).unwrap());
+        }
+        _ => {
+            println!("Program output:");
+            println!("{:?}", output);
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -340,6 +349,7 @@ struct Output {
     result: String,
     instruction_count: u64,
     execution_time: Duration,
+    log: Vec<String>,
 }
 
 impl Debug for Output {
@@ -347,6 +357,9 @@ impl Debug for Output {
         writeln!(f, "Result: {}", self.result)?;
         writeln!(f, "Instruction Count: {}", self.instruction_count)?;
         writeln!(f, "Execution time: {} us", self.execution_time.as_micros())?;
+        for line in &self.log {
+            writeln!(f, "{}", line)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
#### Problem

`rbpf-cli` doesn't include log in output.

#### Summary of Changes

Includes program log (from `sol_log_`) in output.

Fixes #
