### PR TITLE
Support local CI on macOS

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -2,6 +2,38 @@
 Our CI infrastructure is built around [BuildKite](https://buildkite.com) with some
 additional GitHub integration provided by https://github.com/mvines/ci-gate
 
+# Running Locally
+
+To run the CI suite locally, you can run the `run-local.sh` script.
+
+Before you do, there are a few dependencies that need to be installed:
+
+```bash
+cargo install grcov cargo-audit
+```
+
+## macOS
+
+On macOS, you will need to install coreutils:
+
+```bash
+brew install coreutils
+```
+
+Make sure to update your PATH environment variable:
+
+```bash
+export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+```
+
+If you notice the error `UnableToSetOpenFileDescriptorLimit` you may need to
+increase the number of available file descriptors:
+
+```bash
+sudo launchctl limit maxfiles 100000
+ulimit -n 1000000
+```
+
 # Agent Queues
 
 We define two [Agent Queues](https://buildkite.com/docs/agent/v3/queues):

--- a/ci/run-local.sh
+++ b/ci/run-local.sh
@@ -6,16 +6,6 @@ export CI_LOCAL_RUN=true
 
 set -e
 
-case $(uname -o) in
-  */Linux)
-    export CI_OS_NAME=linux
-    ;;
-  *)
-    echo "local CI runs are only supported on Linux" 1>&2
-    exit 1
-    ;;
-esac
-
 steps=()
 steps+=(test-sanity)
 steps+=(shellcheck)

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -22,7 +22,12 @@ export RUSTFLAGS="-D warnings"
 source scripts/ulimit-n.sh
 
 # limit jobs to 4gb/thread
-JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+if [[ -f "/proc/meminfo" ]]; then
+  JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+else
+  JOBS=$(sysctl hw.memsize | awk '{printf "%.0f", ($2 / (4 * 1024**3))}')
+fi
+
 NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 

--- a/scripts/coverage-in-disk.sh
+++ b/scripts/coverage-in-disk.sh
@@ -70,7 +70,12 @@ if [[ -n $CI || -z $1 ]]; then
 fi
 
 # limit jobs to 4gb/thread
-JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+if [[ -f "/proc/meminfo" ]]; then
+  JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+else
+  JOBS=$(sysctl hw.memsize | awk '{printf "%.0f", ($2 / (4 * 1024**3))}')
+fi
+
 NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -69,7 +69,12 @@ if [[ -n $CI || -z $1 ]]; then
 fi
 
 # limit jobs to 4gb/thread
-JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+if [[ -f "/proc/meminfo" ]]; then
+  JOBS=$(grep MemTotal /proc/meminfo | awk '{printf "%.0f", ($2 / (4 * 1024 * 1024))}')
+else
+  JOBS=$(sysctl hw.memsize | awk '{printf "%.0f", ($2 / (4 * 1024**3))}')
+fi
+
 NPROC=$(nproc)
 JOBS=$((JOBS>NPROC ? NPROC : JOBS))
 


### PR DESCRIPTION
#### Problem

Running CI locally using `ci/run-local.sh` on macOS fails with "local CI runs are only supported on Linux".

#### Summary of Changes

- Fallback to `sysctl hw.memsize` instead of `/proc/meminfo` to obtain installed memory if `/proc/meminfo` is not found
- Remove `uname -o` check which allows only Linux OS to run local CI
- Add instructions for installing prerequisites
