### PR TITLE
add get_account to BenchTpsClient

### DIFF
--- a/bench-tps/src/bench_tps_client.rs
+++ b/bench-tps/src/bench_tps_client.rs
@@ -1,8 +1,9 @@
 use {
     solana_client::{client_error::ClientError, tpu_client::TpuSenderError},
     solana_sdk::{
-        commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash, message::Message,
-        pubkey::Pubkey, signature::Signature, transaction::Transaction, transport::TransportError,
+        account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
+        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+        transport::TransportError,
     },
     thiserror::Error,
 };
@@ -79,6 +80,9 @@ pub trait BenchTpsClient {
         lamports: u64,
         recent_blockhash: &Hash,
     ) -> Result<Signature>;
+
+    /// Returns all information associated with the account of the provided pubkey
+    fn get_account(&self, pubkey: &Pubkey) -> Result<Account>;
 }
 
 mod bank_client;

--- a/bench-tps/src/bench_tps_client/bank_client.rs
+++ b/bench-tps/src/bench_tps_client/bank_client.rs
@@ -85,14 +85,12 @@ impl BenchTpsClient for BankClient {
     }
 
     fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
-        let account = SyncClient::get_account(self, pubkey).map_err(|err| err.into());
-        if let Ok(account) = account {
-            if account.is_none() {
-                return Err(BenchTpsError::Custom("Account was not found".to_string()));
-            }
-            Ok(account.unwrap())
-        } else {
-            Err(account.err().unwrap())
-        }
+        SyncClient::get_account(self, pubkey)
+            .map_err(|err| err.into())
+            .and_then(|account| {
+                account.ok_or_else(|| {
+                    BenchTpsError::Custom(format!("AccountNotFound: pubkey={}", pubkey))
+                })
+            })
     }
 }

--- a/bench-tps/src/bench_tps_client/rpc_client.rs
+++ b/bench-tps/src/bench_tps_client/rpc_client.rs
@@ -2,8 +2,8 @@ use {
     crate::bench_tps_client::{BenchTpsClient, Result},
     solana_client::rpc_client::RpcClient,
     solana_sdk::{
-        commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash, message::Message,
-        pubkey::Pubkey, signature::Signature, transaction::Transaction,
+        account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
+        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
     },
 };
 
@@ -79,5 +79,9 @@ impl BenchTpsClient for RpcClient {
     ) -> Result<Signature> {
         RpcClient::request_airdrop_with_blockhash(self, pubkey, lamports, recent_blockhash)
             .map_err(|err| err.into())
+    }
+
+    fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
+        RpcClient::get_account(self, pubkey).map_err(|err| err.into())
     }
 }

--- a/bench-tps/src/bench_tps_client/thin_client.rs
+++ b/bench-tps/src/bench_tps_client/thin_client.rs
@@ -2,6 +2,7 @@ use {
     crate::bench_tps_client::{BenchTpsClient, Result},
     solana_client::thin_client::ThinClient,
     solana_sdk::{
+        account::Account,
         client::{AsyncClient, Client, SyncClient},
         commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
@@ -81,6 +82,12 @@ impl BenchTpsClient for ThinClient {
     ) -> Result<Signature> {
         self.rpc_client()
             .request_airdrop_with_blockhash(pubkey, lamports, recent_blockhash)
+            .map_err(|err| err.into())
+    }
+
+    fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
+        self.rpc_client()
+            .get_account(pubkey)
             .map_err(|err| err.into())
     }
 }

--- a/bench-tps/src/bench_tps_client/tpu_client.rs
+++ b/bench-tps/src/bench_tps_client/tpu_client.rs
@@ -2,8 +2,8 @@ use {
     crate::bench_tps_client::{BenchTpsClient, Result},
     solana_client::tpu_client::TpuClient,
     solana_sdk::{
-        commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash, message::Message,
-        pubkey::Pubkey, signature::Signature, transaction::Transaction,
+        account::Account, commitment_config::CommitmentConfig, epoch_info::EpochInfo, hash::Hash,
+        message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
     },
 };
 
@@ -94,6 +94,12 @@ impl BenchTpsClient for TpuClient {
     ) -> Result<Signature> {
         self.rpc_client()
             .request_airdrop_with_blockhash(pubkey, lamports, recent_blockhash)
+            .map_err(|err| err.into())
+    }
+
+    fn get_account(&self, pubkey: &Pubkey) -> Result<Account> {
+        self.rpc_client()
+            .get_account(pubkey)
             .map_err(|err| err.into())
     }
 }


### PR DESCRIPTION
#### Problem

There is no method `get_account` for `BenchTpsClient` which is needed for follow up PRs adding durable nonce transactions.

#### Summary of Changes

* Adds `get_account` method