### PR TITLE
verifies shred-version in fetch stage

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,7 +54,7 @@ pub mod rewards_recorder_service;
 pub mod sample_performance_service;
 pub mod serve_repair;
 pub mod serve_repair_service;
-pub mod shred_fetch_stage;
+mod shred_fetch_stage;
 pub mod sigverify;
 pub mod sigverify_shreds;
 pub mod sigverify_stage;

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -407,7 +407,6 @@ impl RetransmitStage {
         cluster_slots_update_receiver: ClusterSlotsUpdateReceiver,
         epoch_schedule: EpochSchedule,
         turbine_disabled: Option<Arc<AtomicBool>>,
-        shred_version: u16,
         cluster_slots: Arc<ClusterSlots>,
         duplicate_slots_reset_sender: DuplicateSlotsResetSender,
         verified_vote_receiver: VerifiedVoteReceiver,
@@ -468,7 +467,6 @@ impl RetransmitStage {
                     &leader_schedule_cache_clone,
                     id,
                     last_root,
-                    shred_version,
                 );
                 rv && !turbine_disabled
             },

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -11,6 +11,7 @@ use {
     },
     solana_perf::{self, packet::PacketBatch, recycler_cache::RecyclerCache},
     solana_runtime::bank_forks::BankForks,
+    solana_sdk::clock::Slot,
     std::{
         collections::{HashMap, HashSet},
         sync::{Arc, RwLock},
@@ -39,10 +40,11 @@ impl ShredSigVerifier {
             packet_sender,
         }
     }
-    fn read_slots(batches: &[PacketBatch]) -> HashSet<u64> {
+    fn read_slots(batches: &[PacketBatch]) -> HashSet<Slot> {
         batches
             .iter()
             .flat_map(PacketBatch::iter)
+            .filter(|packet| !packet.meta.discard())
             .filter_map(shred::layout::get_shred)
             .filter_map(shred::layout::get_slot)
             .collect()

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -154,8 +154,9 @@ impl Tvu {
             fetch_sockets,
             forward_sockets,
             repair_socket.clone(),
-            &fetch_sender,
-            Some(bank_forks.clone()),
+            fetch_sender,
+            tvu_config.shred_version,
+            bank_forks.clone(),
             exit,
         );
 
@@ -189,7 +190,6 @@ impl Tvu {
             cluster_slots_update_receiver,
             *bank_forks.read().unwrap().working_bank().epoch_schedule(),
             turbine_disabled,
-            tvu_config.shred_version,
             cluster_slots.clone(),
             duplicate_slots_reset_sender,
             verified_vote_receiver,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -14,7 +14,7 @@ use {
     rayon::{prelude::*, ThreadPool},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
-        blockstore::{self, Blockstore, BlockstoreInsertionMetrics, MAX_DATA_SHREDS_PER_SLOT},
+        blockstore::{self, Blockstore, BlockstoreInsertionMetrics},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{Nonce, Shred, ShredType},
     },
@@ -177,7 +177,6 @@ pub(crate) fn should_retransmit_and_persist(
     leader_schedule_cache: &LeaderScheduleCache,
     my_pubkey: &Pubkey,
     root: u64,
-    shred_version: u16,
 ) -> bool {
     let slot_leader_pubkey = leader_schedule_cache.slot_leader_at(shred.slot(), bank.as_deref());
     if let Some(leader_id) = slot_leader_pubkey {
@@ -186,15 +185,6 @@ pub(crate) fn should_retransmit_and_persist(
             false
         } else if !verify_shred_slot(shred, root) {
             inc_new_counter_debug!("streamer-recv_window-outdated_transmission", 1);
-            false
-        } else if shred.version() != shred_version {
-            inc_new_counter_debug!("streamer-recv_window-incorrect_shred_version", 1);
-            false
-        } else if shred.index() >= MAX_DATA_SHREDS_PER_SLOT as u32 {
-            inc_new_counter_warn!("streamer-recv_window-shred_index_overrun", 1);
-            false
-        } else if shred.sanitize().is_err() {
-            inc_new_counter_warn!("streamer-recv_window-invalid-shred", 1);
             false
         } else {
             true
@@ -783,17 +773,6 @@ mod test {
             &cache,
             &me_id,
             0,
-            0
-        ));
-
-        // with the wrong shred_version, shred gets thrown out
-        assert!(!should_retransmit_and_persist(
-            &shreds[0],
-            Some(bank.clone()),
-            &cache,
-            &me_id,
-            0,
-            1
         ));
 
         // substitute leader_pubkey for me_id so it looks I was the leader
@@ -804,7 +783,6 @@ mod test {
             &cache,
             &leader_pubkey,
             0,
-            0
         ));
         assert!(!should_retransmit_and_persist(
             &shreds[0],
@@ -812,7 +790,6 @@ mod test {
             &cache,
             &leader_pubkey,
             0,
-            0
         ));
 
         // change the shred's slot so leader lookup fails
@@ -825,19 +802,6 @@ mod test {
             &cache,
             &me_id,
             0,
-            0
-        ));
-
-        // with an invalid index, shred gets thrown out
-        let mut bad_index_shred = shreds[0].clone();
-        bad_index_shred.set_index((MAX_DATA_SHREDS_PER_SLOT + 1) as u32);
-        assert!(!should_retransmit_and_persist(
-            &bad_index_shred,
-            Some(bank.clone()),
-            &cache,
-            &me_id,
-            0,
-            0
         ));
 
         // with a shred where shred.slot() == root, shred gets thrown out
@@ -849,7 +813,6 @@ mod test {
             &cache,
             &me_id,
             root,
-            0
         ));
 
         // with a shred where shred.parent() < root, shred gets thrown out
@@ -862,7 +825,6 @@ mod test {
             &cache,
             &me_id,
             root,
-            0
         ));
 
         // coding shreds don't contain parent slot information, test that slot >= root
@@ -884,7 +846,6 @@ mod test {
             &cache,
             &me_id,
             0,
-            0
         ));
         // shred.slot() == root, shred continues
         assert!(should_retransmit_and_persist(
@@ -893,7 +854,6 @@ mod test {
             &cache,
             &me_id,
             5,
-            0
         ));
         // shred.slot() < root, shred gets thrown out
         assert!(!should_retransmit_and_persist(
@@ -902,7 +862,6 @@ mod test {
             &cache,
             &me_id,
             6,
-            0
         ));
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3334,10 +3334,6 @@ fn get_last_hash<'a>(iterator: impl Iterator<Item = &'a Entry> + 'a) -> Option<H
     iterator.last().map(|entry| entry.hash)
 }
 
-fn is_valid_write_to_slot_0(slot_to_write: u64, parent_slot: Slot, last_root: u64) -> bool {
-    slot_to_write == 0 && last_root == 0 && parent_slot == 0
-}
-
 fn send_signals(
     new_shreds_signals: &[Sender<bool>],
     completed_slots_senders: &[Sender<Vec<u64>>],
@@ -3947,22 +3943,13 @@ macro_rules! create_new_tmp_ledger_fifo_auto_delete {
     };
 }
 
-pub fn verify_shred_slots(slot: Slot, parent_slot: Slot, last_root: Slot) -> bool {
-    if !is_valid_write_to_slot_0(slot, parent_slot, last_root) {
-        // Check that the parent_slot < slot
-        if parent_slot >= slot {
-            return false;
-        }
-
-        // Ignore shreds that chain to slots before the last root
-        if parent_slot < last_root {
-            return false;
-        }
-
-        // Above two checks guarantee that by this point, slot > last_root
+pub fn verify_shred_slots(slot: Slot, parent: Slot, root: Slot) -> bool {
+    if slot == 0 && parent == 0 && root == 0 {
+        return true; // valid write to slot zero.
     }
-
-    true
+    // Ignore shreds that chain to slots before the root,
+    // or have invalid parent >= slot.
+    root <= parent && parent < slot
 }
 
 // Same as `create_new_ledger()` but use a temporary ledger name based on the provided `name`

--- a/ledger/src/shred/legacy.rs
+++ b/ledger/src/shred/legacy.rs
@@ -322,7 +322,11 @@ impl ShredCode {
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::shred::MAX_DATA_SHREDS_PER_SLOT, matches::assert_matches};
+    use {
+        super::*,
+        crate::shred::{ShredType, MAX_DATA_SHREDS_PER_SLOT},
+        matches::assert_matches,
+    };
 
     #[test]
     fn test_sanitize_data_shred() {
@@ -369,7 +373,10 @@ mod test {
         {
             let mut shred = shred.clone();
             shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32;
-            assert_matches!(shred.sanitize(), Err(Error::InvalidDataShredIndex(32768)));
+            assert_matches!(
+                shred.sanitize(),
+                Err(Error::InvalidShredIndex(ShredType::Data, 32768))
+            );
         }
         {
             let mut shred = shred.clone();
@@ -423,6 +430,14 @@ mod test {
                 Err(Error::InvalidErasureShardIndex { .. })
             );
         }
+        {
+            let mut shred = shred.clone();
+            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32;
+            assert_matches!(
+                shred.sanitize(),
+                Err(Error::InvalidShredIndex(ShredType::Code, 32768))
+            );
+        }
         // pos >= num_coding is invalid.
         {
             let mut shred = shred.clone();
@@ -437,21 +452,18 @@ mod test {
         // shred has index > u32::MAX should fail.
         {
             let mut shred = shred.clone();
-            shred.common_header.fec_set_index = std::u32::MAX - 1;
+            shred.common_header.fec_set_index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
             shred.coding_header.num_data_shreds = 2;
             shred.coding_header.num_coding_shreds = 4;
             shred.coding_header.position = 1;
-            shred.common_header.index = std::u32::MAX - 1;
+            shred.common_header.index = MAX_DATA_SHREDS_PER_SLOT as u32 - 2;
             assert_matches!(
                 shred.sanitize(),
                 Err(Error::InvalidErasureShardIndex { .. })
             );
 
             shred.coding_header.num_coding_shreds = 2000;
-            assert_matches!(
-                shred.sanitize(),
-                Err(Error::InvalidErasureShardIndex { .. })
-            );
+            assert_matches!(shred.sanitize(), Err(Error::InvalidNumCodingShreds(2000)));
 
             // Decreasing the number of num_coding_shreds will put it within
             // the allowed limit.

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -3,11 +3,14 @@ use {
         common::dispatch,
         legacy, merkle,
         traits::{Shred, ShredCode as ShredCodeTrait},
-        CodingShredHeader, Error, ShredCommonHeader, MAX_DATA_SHREDS_PER_FEC_BLOCK, SIZE_OF_NONCE,
+        CodingShredHeader, Error, ShredCommonHeader, ShredType, MAX_DATA_SHREDS_PER_FEC_BLOCK,
+        MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
     solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
 };
+
+const MAX_CODE_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT;
 
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
 
@@ -92,15 +95,23 @@ impl From<merkle::ShredCode> for ShredCode {
 #[inline]
 pub(super) fn erasure_shard_index<T: ShredCodeTrait>(shred: &T) -> Option<usize> {
     // Assert that the last shred index in the erasure set does not
-    // overshoot u32.
+    // overshoot MAX_{DATA,CODE}_SHREDS_PER_SLOT.
     let common_header = shred.common_header();
     let coding_header = shred.coding_header();
-    common_header
+    if common_header
         .fec_set_index
-        .checked_add(u32::from(coding_header.num_data_shreds.checked_sub(1)?))?;
-    shred
+        .checked_add(u32::from(coding_header.num_data_shreds.checked_sub(1)?))? as usize
+        >= MAX_DATA_SHREDS_PER_SLOT
+    {
+        return None;
+    }
+    if shred
         .first_coding_index()?
-        .checked_add(u32::from(coding_header.num_coding_shreds.checked_sub(1)?))?;
+        .checked_add(u32::from(coding_header.num_coding_shreds.checked_sub(1)?))? as usize
+        >= MAX_CODE_SHREDS_PER_SLOT
+    {
+        return None;
+    }
     let num_data_shreds = usize::from(coding_header.num_data_shreds);
     let num_coding_shreds = usize::from(coding_header.num_coding_shreds);
     let position = usize::from(coding_header.position);
@@ -113,15 +124,22 @@ pub(super) fn sanitize<T: ShredCodeTrait>(shred: &T) -> Result<(), Error> {
     if shred.payload().len() != T::SIZE_OF_PAYLOAD {
         return Err(Error::InvalidPayloadSize(shred.payload().len()));
     }
+    let common_header = shred.common_header();
     let coding_header = shred.coding_header();
-    let _shard_index = shred.erasure_shard_index()?;
-    let _erasure_shard = shred.erasure_shard_as_slice()?;
+    if common_header.index as usize >= MAX_CODE_SHREDS_PER_SLOT {
+        return Err(Error::InvalidShredIndex(
+            ShredType::Code,
+            common_header.index,
+        ));
+    }
     let num_coding_shreds = u32::from(coding_header.num_coding_shreds);
     if num_coding_shreds > 8 * MAX_DATA_SHREDS_PER_FEC_BLOCK {
         return Err(Error::InvalidNumCodingShreds(
             coding_header.num_coding_shreds,
         ));
     }
+    let _shard_index = shred.erasure_shard_index()?;
+    let _erasure_shard = shred.erasure_shard_as_slice()?;
     Ok(())
 }
 

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -36,6 +36,7 @@ pub struct ShredFetchStats {
     pub duplicate_shred: usize,
     pub slot_out_of_range: usize,
     pub(crate) bad_shred_type: usize,
+    pub shred_version_mismatch: usize,
     since: Option<Instant>,
 }
 
@@ -118,6 +119,8 @@ impl ShredFetchStats {
             ("index_out_of_bounds", self.index_out_of_bounds, i64),
             ("slot_out_of_range", self.slot_out_of_range, i64),
             ("duplicate_shred", self.duplicate_shred, i64),
+            ("bad_shred_type", self.bad_shred_type, i64),
+            ("shred_version_mismatch", self.shred_version_mismatch, i64),
         );
         *self = Self {
             since: Some(Instant::now()),


### PR DESCRIPTION

#### Problem
Shred versions are not verified until window-service where resources are
already wasted to sig-verify and deserialize shreds.


#### Summary of Changes
The commit verifies shred-version earlier in the pipeline in fetch stage.
