### PR TITLE
Enforce Cargo.toml tables are sorted in CI

### DIFF
--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://solana.com/"
 publish = false
 
 [dependencies]
-crossbeam-channel = "0.5"
 clap = { version = "3.1.5", features = ["cargo"] }
+crossbeam-channel = "0.5"
 solana-net-utils = { path = "../net-utils", version = "=1.11.2" }
 solana-streamer = { path = "../streamer", version = "=1.11.2" }
 solana-version = { path = "../version", version = "=1.11.2" }

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,7 +9,7 @@ To run the CI suite locally, you can run the `run-local.sh` script.
 Before you do, there are a few dependencies that need to be installed:
 
 ```bash
-cargo install grcov cargo-audit
+cargo install cargo-audit cargo-sort grcov
 ```
 
 ## macOS

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -71,6 +71,7 @@ fi
    --deny=warnings \
    --deny=clippy::integer_arithmetic \
 
+_ scripts/cargo-for-all-lock-files.sh -- nightly sort --workspace --check
 _ scripts/cargo-for-all-lock-files.sh -- nightly fmt --all -- --check
 
  _ ci/do-audit.sh

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -11,23 +11,23 @@ description = "Tool to send various requests to cluster in order to evaluate the
 
 [dependencies]
 bincode = "1.3.3"
-clap = {version = "3.1.5", features = ["derive", "cargo"]}
+clap = { version = "3.1.5", features = ["derive", "cargo"] }
+itertools = "0.10.3"
 log = "0.4.17"
 rand = "0.7.0"
 serde = "1.0.137"
-itertools = "0.10.3"
+solana-bench-tps = { path = "../bench-tps", version = "=1.11.2" }
 solana-client = { path = "../client", version = "=1.11.2" }
 solana-core = { path = "../core", version = "=1.11.2" }
+solana-faucet = { path = "../faucet", version = "=1.11.2" }
 solana-gossip = { path = "../gossip", version = "=1.11.2" }
 solana-logger = { path = "../logger", version = "=1.11.2" }
 solana-net-utils = { path = "../net-utils", version = "=1.11.2" }
 solana-perf = { path = "../perf", version = "=1.11.2" }
+solana-rpc = { path = "../rpc", version = "=1.11.2" }
 solana-sdk = { path = "../sdk", version = "=1.11.2" }
 solana-streamer = { path = "../streamer", version = "=1.11.2" }
 solana-version = { path = "../version", version = "=1.11.2" }
-solana-bench-tps = { path = "../bench-tps", version = "=1.11.2" }
-solana-faucet = { path = "../faucet", version = "=1.11.2" }
-solana-rpc = { path = "../rpc", version = "=1.11.2" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -15,8 +15,8 @@ bv = { version = "0.11.1", features = ["serde"] }
 lazy_static = "1.4.0"
 log = "0.4.17"
 serde = "1.0.137"
-serde_derive = "1.0.103"
 serde_bytes = "0.11"
+serde_derive = "1.0.103"
 sha2 = "0.10.2"
 solana-frozen-abi-macro = { path = "macro", version = "=1.11.2" }
 thiserror = "1.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -48,8 +48,8 @@ solana-vote-program = { path = "../programs/vote", version = "=1.11.2" }
 thiserror = "1.0"
 
 [dev-dependencies]
-regex = "1"
 num_cpus = "1.13.1"
+regex = "1"
 serial_test = "0.6.0"
 
 [build-dependencies]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/solana-ledger-tool"
 
 [dependencies]
 bs58 = "0.4.0"
-clap = "2.33.1"
 chrono = "0.4.11"
+clap = "2.33.1"
 crossbeam-channel = "0.5"
 csv = "1.1.6"
 dashmap = "4.0.2"

--- a/net-shaper/Cargo.toml
+++ b/net-shaper/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://solana.com/"
 publish = false
 
 [dependencies]
-rand = "0.7.0"
 clap = { version = "3.1.5", features = ["cargo"] }
+rand = "0.7.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 solana-logger = { path = "../logger", version = "=1.11.2" }

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,19 +26,19 @@ itertools = "0.10.1"
 log = "0.4.11"
 miow = "0.3.6"
 net2 = "0.2.37"
-solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.11.2"}
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.11.2"}
-solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.11.2"}
-solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.11.2"}
+solana-account-decoder = { path = "../../account-decoder", version = "=1.11.2" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.11.2" }
+solana-bpf-rust-invoke = { path = "rust/invoke", version = "=1.11.2" }
+solana-bpf-rust-realloc = { path = "rust/realloc", version = "=1.11.2" }
+solana-bpf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.11.2" }
 solana-cli-output = { path = "../../cli-output", version = "=1.11.2" }
 solana-logger = { path = "../../logger", version = "=1.11.2" }
 solana-measure = { path = "../../measure", version = "=1.11.2" }
-solana_rbpf = "=0.2.31"
-solana-runtime = { path = "../../runtime", version = "=1.11.2" }
 solana-program-runtime = { path = "../../program-runtime", version = "=1.11.2" }
+solana-runtime = { path = "../../runtime", version = "=1.11.2" }
 solana-sdk = { path = "../../sdk", version = "=1.11.2" }
 solana-transaction-status = { path = "../../transaction-status", version = "=1.11.2" }
-solana-account-decoder = { path = "../../account-decoder", version = "=1.11.2" }
+solana_rbpf = "=0.2.31"
 
 [[bench]]
 name = "bpf_loader"
@@ -56,10 +56,9 @@ members = [
     "rust/deprecated_loader",
     "rust/dup_accounts",
     "rust/error_handling",
-    "rust/log_data",
     "rust/external_spend",
-    "rust/get_minimum_delegation",
     "rust/finalize",
+    "rust/get_minimum_delegation",
     "rust/inner_instruction_alignment_check",
     "rust/instruction_introspection",
     "rust/invoke",
@@ -68,6 +67,7 @@ members = [
     "rust/invoke_and_return",
     "rust/invoked",
     "rust/iter",
+    "rust/log_data",
     "rust/many_args",
     "rust/many_args_dep",
     "rust/mem",
@@ -79,8 +79,8 @@ members = [
     "rust/rand",
     "rust/realloc",
     "rust/realloc_invoke",
-    "rust/ro_modify",
     "rust/ro_account_modify",
+    "rust/ro_modify",
     "rust/sanity",
     "rust/secp256k1_recover",
     "rust/sha",

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-128bit"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "=1.11.2" }
+solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2021"
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 # list of crates which must be buildable for bpf programs
 solana-address-lookup-table-program = { path = "../../../../programs/address-lookup-table", version = "=1.11.2" }
+solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-many-args"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "=1.11.2" }
+solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/solana-bpf-rust-param-passing"
 edition = "2021"
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "=1.11.2" }
+solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/realloc_invoke/Cargo.toml
+++ b/programs/bpf/rust/realloc_invoke/Cargo.toml
@@ -14,8 +14,8 @@ default = ["program"]
 program = []
 
 [dependencies]
-solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 solana-bpf-rust-realloc = { path = "../realloc", version = "=1.11.2", default-features = false }
+solana-program = { path = "../../../../sdk/program", version = "=1.11.2" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,6 +27,7 @@ index_list = "0.2.7"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
+lz4 = "1.23.3"
 memmap2 = "0.5.3"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
@@ -52,14 +53,13 @@ solana-stake-program = { path = "../programs/stake", version = "=1.11.2" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.2" }
 solana-zk-token-proof-program = { path = "../programs/zk-token-proof", version = "=1.11.2" }
 solana-zk-token-sdk = { path = "../zk-token-sdk", version = "=1.11.2" }
+strum = { version = "0.24", features = ["derive"] }
+strum_macros = "0.24"
 symlink = "0.1.0"
 tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0"
 zstd = "0.11.2"
-lz4 = "1.23.3"
-strum_macros = "0.24"
-strum = { version = "0.24", features = ["derive"] }
 
 [lib]
 crate-type = ["lib"]

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -18,7 +18,6 @@ solana-metrics = { path = "../metrics", version = "=1.11.2" }
 solana-runtime = { path = "../runtime", version = "=1.11.2" }
 solana-sdk = { path = "../sdk", version = "=1.11.2" }
 
-
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.11.2" }
 


### PR DESCRIPTION
#### Problem

Dependencies in Cargo.toml are occasionally unsorted.

#### Summary of Changes

- Run `cargo sort --workspace` to sort dependencies
- Introduce `cargo sort --workspace --check` in nits.sh 

Fixes #23608

