### PR TITLE
Make clear_unconfirmed_slot() update parent's next_slots list

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -994,8 +994,9 @@ impl Blockstore {
         self.completed_slots_senders.lock().unwrap().clear();
     }
 
-    /// Range-delete all entries which prefix matches the specified `slot` and
-    /// clear all the related `SlotMeta` except its next_slots.
+    /// Range-delete all entries which prefix matches the specified `slot`,
+    /// remove `slot` its' parents SlotMeta next_slots list, and
+    /// clear `slot`'s SlotMeta (except for next_slots).
     ///
     /// This function currently requires `insert_shreds_lock`, as both
     /// `clear_unconfirmed_slot()` and `insert_shreds_handle_duplicate()`
@@ -1011,6 +1012,21 @@ impl Blockstore {
             self.run_purge(slot, slot, PurgeType::PrimaryIndex)
                 .expect("Purge database operations failed");
 
+            // Clear this slot as a next slot from parent
+            if let Some(parent_slot) = slot_meta.parent_slot {
+                let mut parent_slot_meta = self
+                    .meta(parent_slot)
+                    .expect("Couldn't fetch from SlotMeta column family")
+                    .expect("Unconfirmed slot should have had parent slot set");
+                // .retain() is a linear scan; however, next_slots should
+                // only contain several elements so this isn't so bad
+                parent_slot_meta
+                    .next_slots
+                    .retain(|&next_slot| next_slot != slot);
+                self.meta_cf
+                    .put(parent_slot, &parent_slot_meta)
+                    .expect("Couldn't insert into SlotMeta column family");
+            }
             // Reinsert parts of `slot_meta` that are important to retain, like the `next_slots`
             // field.
             slot_meta.clear_unconfirmed_slot();
@@ -8583,7 +8599,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_clear_unconfirmed_slot_readd_slot() {
+    fn test_clear_unconfirmed_slot_and_insert_again() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -8614,13 +8630,11 @@ pub mod tests {
 
         // Re-add unconfirmed_slot and confirm that confirmed_slot only has
         // unconfirmed_slot in next_slots once
-        blockstore.insert_shreds(unconfirmed_slot_shreds, None, false).unwrap();
+        blockstore
+            .insert_shreds(unconfirmed_slot_shreds, None, false)
+            .unwrap();
         assert_eq!(
-            blockstore
-                .meta(confirmed_slot)
-                .unwrap()
-                .unwrap()
-                .next_slots,
+            blockstore.meta(confirmed_slot).unwrap().unwrap().next_slots,
             vec![unconfirmed_slot]
         );
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -8617,7 +8617,7 @@ pub mod tests {
         let unconfirmed_slot_shreds = vec![shreds[1].clone()];
         assert_eq!(unconfirmed_slot_shreds[0].slot(), unconfirmed_slot);
 
-        // Insert into slot 9, mark it as dead
+        // Insert into slot 9
         blockstore.insert_shreds(shreds, None, false).unwrap();
 
         // Purge the slot


### PR DESCRIPTION
#### Problem
This issue was discovered from investigations into https://github.com/solana-labs/solana/issues/26028. A more detailed writeup is included in [this comment](https://github.com/solana-labs/solana/issues/26028#issuecomment-1161361398), but the quick summary is:

Given a slot `s` with parent slot `p`, it is possible for `s` to be inserted into `p`'s SlotMeta::next_slots Vec multiple times when `Blockstore::clear_unconfirmed_slot()` is called on slot `s`. If `p` was processed again, `s` would be added to the queue of slots to be processed multiple times. 

#### Summary of Changes
Make `clear_unconfirmed_slot()` on slot `s` remove `s` as a next slot from `s`'s parent.

#### Alternative Approaches

Some alternative ways that we could fix this specific bug:
- Update the below function to check if value exists before inserting. `next_slots` is a `Vec` so this would require a linear scan of the Vec for every new child slot. While that Vec is small, I opted to put logic in `clear_unconfirmed_slot()` instead of incurring the extra work in the normal case.
https://github.com/solana-labs/solana/blob/1ee4b412b23d1573e62d33f1b531199e70ac66cf/ledger/src/blockstore.rs#L3691-L3700
- Put a uniqueness check in `blockstore_processor`, probably somewhere around here:
https://github.com/solana-labs/solana/blob/1ee4b412b23d1573e62d33f1b531199e70ac66cf/ledger/src/blockstore_processor.rs#L1321-L1324
or here:
https://github.com/solana-labs/solana/blob/1ee4b412b23d1573e62d33f1b531199e70ac66cf/ledger/src/blockstore_processor.rs#L1134-L1139

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
