### PR TITLE
moves packet-hasher out of the mutex

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod ledger_cleanup_service;
 pub mod ledger_metric_report_service;
 pub mod optimistic_confirmation_verifier;
 pub mod outstanding_requests;
-pub mod packet_hasher;
+mod packet_hasher;
 pub mod packet_threshold;
 pub mod poh_timing_report_service;
 pub mod poh_timing_reporter;

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -10,7 +10,7 @@ use {
 };
 
 #[derive(Clone)]
-pub struct PacketHasher {
+pub(crate) struct PacketHasher {
     seed1: u128,
     seed2: u128,
 }
@@ -39,7 +39,7 @@ impl PacketHasher {
         hasher.finish()
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         *self = Self::default();
     }
 }


### PR DESCRIPTION

#### Problem
Packet-hasher is not mutated across threads and does not need to be
wrapped in a mutex.


#### Summary of Changes
Moved packet-hasher out of the mutex.