### PR TITLE
Remove auto traits from ICE work-around

### DIFF
--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -91,24 +91,6 @@ impl AutoTraitBreakSendSync for InnerBuiltinFeatureTransition {}
 #[derive(AbiExample, Clone, Debug)]
 pub struct BuiltinFeatureTransition(InnerBuiltinFeatureTransition);
 
-// https://github.com/solana-labs/solana/pull/23233 added `BuiltinFeatureTransition`
-// to `Bank` which triggers https://github.com/rust-lang/rust/issues/92987 while
-// attempting to resolve `Sync` on `BankRc` in `AccountsBackgroundService::new` ala,
-//
-// query stack during panic:
-// #0 [evaluate_obligation] evaluating trait selection obligation `bank::BankRc: core::marker::Sync`
-// #1 [typeck] type-checking `accounts_background_service::<impl at runtime/src/accounts_background_service.rs:358:1: 520:2>::new`
-// #2 [typeck_item_bodies] type-checking all item bodies
-// #3 [analysis] running analysis passes on this crate
-// end of query stack
-//
-// Yoloing a `Sync` onto it avoids the auto trait evaluation and thus the ICE.
-//
-// We should remove this when upgrading to Rust 1.60.0, where the bug has been
-// fixed by https://github.com/rust-lang/rust/pull/93064
-unsafe impl Send for BuiltinFeatureTransition {}
-unsafe impl Sync for BuiltinFeatureTransition {}
-
 impl BuiltinFeatureTransition {
     pub fn to_action(
         &self,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -97,14 +97,6 @@ pub use solana_sdk_macro::pubkeys;
 #[rustversion::since(1.46.0)]
 pub use solana_sdk_macro::respan;
 
-#[deprecated(
-    since = "1.9.0",
-    note = "use only to break https://github.com/rust-lang/rust/issues/92987. remove when we move to Rust 1.60.0"
-)]
-#[doc(hidden)]
-#[cfg(debug_assertions)]
-pub trait AutoTraitBreakSendSync: Send + Sync {}
-
 // Unused `solana_sdk::program_stubs!()` macro retained for source backwards compatibility with older programs
 #[macro_export]
 #[deprecated(


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/pull/23295 added auto traits to `BuiltinFeatureTransition` to work around Rust issue https://github.com/rust-lang/rust/issues/92987. This bug was fixed in Rust v1.60.0, which is the version we use, so this work-around can be removed.

https://github.com/solana-labs/solana/blob/e344c8476f5aa63860602923c5db68f5fc33b7f8/runtime/src/builtins.rs#L94-L110

#### Summary of Changes

Remove work-around from #23295 and #23321.
