### PR TITLE
docker-rust: Add cargo-store

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x \
  && rustup component add clippy \
  && rustup target add wasm32-unknown-unknown \
  && cargo install cargo-audit \
+ && cargo install cargo-sort \
  && cargo install mdbook \
  && cargo install mdbook-linkcheck \
  && cargo install svgbob_cli \


### PR DESCRIPTION
#26084 wants to use `cargo-sort` from CI, but we do not have that program installed in the docker image. 
Add it to the Dockerfile (a new stable docker image has already been published)