### PR TITLE
chore: correct the types of `Rpc{Batch}Request` to prevent type errors in `Connection.ts`

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -191,9 +191,9 @@ type Subscription = BaseSubscription &
   StatefulSubscription &
   DistributiveOmit<SubscriptionConfig, 'callback'>;
 
-type RpcRequest = (methodName: string, args: Array<any>) => any;
+type RpcRequest = (methodName: string, args: Array<any>) => Promise<any>;
 
-type RpcBatchRequest = (requests: RpcParams[]) => any;
+type RpcBatchRequest = (requests: RpcParams[]) => Promise<any[]>;
 
 /**
  * @internal


### PR DESCRIPTION
#### Problem

The return value of these was incorrect, leading to an `any` propagating through the code, which led to real breakages in the framework (eg. #26099).

#### Summary of Changes

When we properly represent this return type as a _promise for an array_ then array methods like `map()` return correct types.