### PR TITLE
Revert "fix double count of account index del stats (#25797)"

### DIFF
--- a/runtime/src/in_mem_accounts_index.rs
+++ b/runtime/src/in_mem_accounts_index.rs
@@ -294,6 +294,7 @@ impl<T: IndexValue> InMemAccountsIndex<T> {
                     //  the arc, but someone may already have retrieved a clone of it.
                     // account index in_mem flushing is one such possibility
                     self.delete_disk_key(occupied.key());
+                    self.stats().dec_mem_count(self.bin);
                     occupied.remove();
                 }
                 result


### PR DESCRIPTION
    This reverts commit 05cb25d8da06e590a13f6bc9a17cde826f5c40b2.

#25797

#### Problem

note that today I saw a negative account count:
![image](https://user-images.githubusercontent.com/75863576/174858754-9f5d6fe9-43d2-4e62-aeef-15705c8f2bee.png)

Trying to figure out how that happened.
I don't think this was caused by the original change, but I'm not sure yet.

```
2022-06-20T16:04:19.314331706Z INFO solana_metrics::metrics] datapoint: accounts_index estimate_mem_bytes=535184i flush_should_evict_us=0i count_in_mem=10291i count=-4838i bg_w
```
#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
