### PR TITLE
Use single send socket in UdpTpuConnection

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -5,7 +5,7 @@ use {
     log::*,
     rand::{thread_rng, Rng},
     rayon::prelude::*,
-    solana_client::connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
+    solana_client::connection_cache::{ConnectionCache, UseQUIC, DEFAULT_TPU_CONNECTION_POOL_SIZE},
     solana_core::banking_stage::BankingStage,
     solana_gossip::cluster_info::{ClusterInfo, Node},
     solana_ledger::{
@@ -341,7 +341,8 @@ fn main() {
             SocketAddrSpace::Unspecified,
         );
         let cluster_info = Arc::new(cluster_info);
-        let tpu_use_quic = matches.is_present("tpu_use_quic");
+        let tpu_use_quic = UseQUIC::new(matches.is_present("tpu_use_quic"))
+            .expect("Failed to initialize QUIC flags");
         let banking_stage = BankingStage::new_num_threads(
             &cluster_info,
             &poh_recorder,

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -8,7 +8,7 @@ use {
         keypairs::get_keypairs,
     },
     solana_client::{
-        connection_cache::ConnectionCache,
+        connection_cache::{ConnectionCache, UseQUIC},
         rpc_client::RpcClient,
         thin_client::ThinClient,
         tpu_client::{TpuClient, TpuClientConfig},
@@ -103,8 +103,9 @@ fn main() {
             do_bench_tps(client, cli_config, keypairs);
         }
         ExternalClientType::ThinClient => {
+            let use_quic = UseQUIC::new(*use_quic).expect("Failed to initialize QUIC flags");
             let connection_cache =
-                Arc::new(ConnectionCache::new(*use_quic, *tpu_connection_pool_size));
+                Arc::new(ConnectionCache::new(use_quic, *tpu_connection_pool_size));
 
             let client = if let Ok(rpc_addr) = value_t!(matches, "rpc_addr", String) {
                 let rpc = rpc_addr.parse().unwrap_or_else(|e| {
@@ -175,8 +176,9 @@ fn main() {
                 json_rpc_url.to_string(),
                 CommitmentConfig::confirmed(),
             ));
+            let use_quic = UseQUIC::new(*use_quic).expect("Failed to initialize QUIC flags");
             let connection_cache =
-                Arc::new(ConnectionCache::new(*use_quic, *tpu_connection_pool_size));
+                Arc::new(ConnectionCache::new(use_quic, *tpu_connection_pool_size));
 
             let client = Arc::new(
                 TpuClient::new_with_connection_cache(

--- a/client/src/udp_client.rs
+++ b/client/src/udp_client.rs
@@ -7,28 +7,30 @@ use {
     solana_sdk::transport::Result as TransportResult,
     solana_streamer::sendmmsg::batch_send,
     std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
+        net::{SocketAddr, UdpSocket},
         sync::Arc,
     },
 };
 
 pub struct UdpTpuConnection {
-    socket: UdpSocket,
+    socket: Arc<UdpSocket>,
     addr: SocketAddr,
 }
 
 impl UdpTpuConnection {
-    pub fn new_from_addr(tpu_addr: SocketAddr) -> Self {
-        let socket =
-            solana_net_utils::bind_with_any_port(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))).unwrap();
+    pub fn new_from_addr(local_socket: Arc<UdpSocket>, tpu_addr: SocketAddr) -> Self {
         Self {
-            socket,
+            socket: local_socket,
             addr: tpu_addr,
         }
     }
 
-    pub fn new(tpu_addr: SocketAddr, _connection_stats: Arc<ConnectionCacheStats>) -> Self {
-        Self::new_from_addr(tpu_addr)
+    pub fn new(
+        local_socket: Arc<UdpSocket>,
+        tpu_addr: SocketAddr,
+        _connection_stats: Arc<ConnectionCacheStats>,
+    ) -> Self {
+        Self::new_from_addr(local_socket, tpu_addr)
     }
 }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -25,7 +25,7 @@ use {
     },
     crossbeam_channel::{bounded, unbounded, Receiver},
     rand::{thread_rng, Rng},
-    solana_client::connection_cache::ConnectionCache,
+    solana_client::connection_cache::{ConnectionCache, UseQUIC},
     solana_entry::poh::compute_hash_time_ns,
     solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService,
     solana_gossip::{
@@ -753,6 +753,7 @@ impl Validator {
         };
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
+        let use_quic = UseQUIC::new(use_quic).expect("Failed to initialize QUIC flags");
         let connection_cache = Arc::new(ConnectionCache::new(use_quic, tpu_connection_pool_size));
 
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -45,7 +45,7 @@ use {
     rand::{thread_rng, Rng},
     solana_bench_tps::{bench::generate_and_fund_keypairs, bench_tps_client::BenchTpsClient},
     solana_client::{
-        connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
+        connection_cache::{ConnectionCache, UseQUIC, DEFAULT_TPU_CONNECTION_POOL_SIZE},
         rpc_client::RpcClient,
         tpu_connection::TpuConnection,
     },
@@ -423,6 +423,7 @@ fn run_dos_transactions<T: 'static + BenchTpsClient + Send + Sync>(
     //let connection_cache_stats = Arc::new(ConnectionCacheStats::default());
     //let udp_client = UdpTpuConnection::new(target, connection_cache_stats);
 
+    let tpu_use_quic = UseQUIC::new(tpu_use_quic).expect("Failed to initialize QUIC flags");
     let connection_cache = ConnectionCache::new(tpu_use_quic, DEFAULT_TPU_CONNECTION_POOL_SIZE);
     let connection = connection_cache.get_connection(&target);
 
@@ -621,8 +622,10 @@ fn main() {
             exit(1);
         });
 
+        let tpu_use_quic =
+            UseQUIC::new(cmd_params.tpu_use_quic).expect("Failed to initialize QUIC flags");
         let connection_cache = Arc::new(ConnectionCache::new(
-            cmd_params.tpu_use_quic,
+            tpu_use_quic,
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         ));
         let (client, num_clients) =

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -8,7 +8,7 @@ use {
     log::*,
     solana_client::{
         connection_cache::{
-            ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
+            ConnectionCache, UseQUIC, DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_TPU_USE_QUIC,
         },
         thin_client::ThinClient,
     },
@@ -277,13 +277,15 @@ impl LocalCluster {
 
         validators.insert(leader_pubkey, cluster_leader);
 
+        let tpu_use_quic =
+            UseQUIC::new(config.tpu_use_quic).expect("Failed to initialize QUIC flags");
         let mut cluster = Self {
             funding_keypair: mint_keypair,
             entry_point_info: leader_contact_info,
             validators,
             genesis_config,
             connection_cache: Arc::new(ConnectionCache::new(
-                config.tpu_use_quic,
+                tpu_use_quic,
                 config.tpu_connection_pool_size,
             )),
         };

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -8,7 +8,7 @@ use {
     solana_account_decoder::UiAccount,
     solana_client::{
         client_error::{ClientErrorKind, Result as ClientResult},
-        connection_cache::{ConnectionCache, DEFAULT_TPU_CONNECTION_POOL_SIZE},
+        connection_cache::{ConnectionCache, UseQUIC, DEFAULT_TPU_CONNECTION_POOL_SIZE},
         nonblocking::pubsub_client::PubsubClient,
         rpc_client::RpcClient,
         rpc_config::{RpcAccountInfoConfig, RpcSignatureSubscribeConfig},
@@ -420,6 +420,7 @@ fn run_tpu_send_transaction(tpu_use_quic: bool) {
         test_validator.rpc_url(),
         CommitmentConfig::processed(),
     ));
+    let tpu_use_quic = UseQUIC::new(tpu_use_quic).expect("Failed to initialize QUIC flags");
     let connection_cache = Arc::new(ConnectionCache::new(
         tpu_use_quic,
         DEFAULT_TPU_CONNECTION_POOL_SIZE,


### PR DESCRIPTION
#### Problem
Every instance of`UdpTpuConnection` creates a new socket to send packets. The current design leads to opening of excessive amount of UDP ports. A single UDP socket should be sufficient. 

#### Summary of Changes
The user of `UdpTpuConnection` will initialize the send socket, and provide it to `UdpTpuConnection` at init time.

Fixes #26077 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
