### PR TITLE
store_cached takes StorableAccounts to eliminate collect

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1203,11 +1203,11 @@ impl Accounts {
             leave_nonce_on_success,
         );
         self.accounts_db
-            .store_cached(slot, &accounts_to_store, Some(&txn_signatures));
+            .store_cached((slot, &accounts_to_store[..]), Some(&txn_signatures));
     }
 
     pub fn store_accounts_cached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        self.accounts_db.store_cached(slot, accounts, None)
+        self.accounts_db.store_cached((slot, accounts), None)
     }
 
     /// Add a slot to root.  Root slots cannot be purged

--- a/runtime/src/accounts_db/geyser_plugin_utils.rs
+++ b/runtime/src/accounts_db/geyser_plugin_utils.rs
@@ -340,24 +340,24 @@ pub mod tests {
         let account1 =
             AccountSharedData::new(account1_lamports1, 1, AccountSharedData::default().owner());
         let slot0 = 0;
-        accounts.store_cached(slot0, &[(&key1, &account1)], None);
+        accounts.store_cached((slot0, &[(&key1, &account1)][..]), None);
 
         let key2 = solana_sdk::pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_cached(slot0, &[(&key2, &account2)], None);
+        accounts.store_cached((slot0, &[(&key2, &account2)][..]), None);
 
         let account1_lamports2 = 2;
         let slot1 = 1;
         let account1 = AccountSharedData::new(account1_lamports2, 1, account1.owner());
-        accounts.store_cached(slot1, &[(&key1, &account1)], None);
+        accounts.store_cached((slot1, &[(&key1, &account1)][..]), None);
 
         let key3 = solana_sdk::pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_cached(slot1, &[(&key3, &account3)], None);
+        accounts.store_cached((slot1, &[(&key3, &account3)][..]), None);
 
         let notifier = notifier.write().unwrap();
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 2);


### PR DESCRIPTION
#### Problem

The collect to eliminate is several layers up. The change to this 1 function in this pr is messy enough to deserve its own pr.
The goal is to allow Vec<some stuff> to be used directly as a call to `store()` without having to reconstruct a Vec of just the right types.
The `StorableAccounts` trait solves that.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
