### PR TITLE
Accounts::store_accounts_cached uses StorableAccounts

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6166,7 +6166,7 @@ impl Bank {
         assert!(!self.freeze_started());
         self.rc
             .accounts
-            .store_accounts_cached(self.slot(), accounts);
+            .store_accounts_cached((self.slot(), accounts));
         let mut m = Measure::start("stakes_cache.check_and_store");
         for (pubkey, account) in accounts {
             self.stakes_cache.check_and_store(pubkey, account);


### PR DESCRIPTION
#### Problem

pushing `StorableAccounts` one function farther upstream.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
