### PR TITLE
Use BankStatusCache in bank.rs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4037,7 +4037,7 @@ impl Bank {
     fn is_transaction_already_processed(
         &self,
         sanitized_tx: &SanitizedTransaction,
-        status_cache: &StatusCache<Result<()>>,
+        status_cache: &BankStatusCache,
     ) -> bool {
         let key = sanitized_tx.message_hash();
         let transaction_blockhash = sanitized_tx.message().recent_blockhash();


### PR DESCRIPTION
#### Problem

I found a lone `StatusCache<Result<()>>` in `bank.rs` while reading through the status cache code. Since we're in `bank.rs`, use the `BankStatusCache` type alias instead.

#### Summary of Changes

Replace `StatusCache<Result<()>>` with `BankStatusCache`.