### PR TITLE
Add bench for StatusCache::slot_deltas()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -250,7 +250,7 @@ impl RentDebits {
     }
 }
 
-type BankStatusCache = StatusCache<Result<()>>;
+pub type BankStatusCache = StatusCache<Result<()>>;
 #[frozen_abi(digest = "2YZk2K45HmmAafmxPJnYVXyQ7uA7WuBrRkpwrCawdK31")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 


### PR DESCRIPTION
#### Problem

Evaluating changes to `StatusCache::slot_deltas()` is not easy because there is not a bench available to run.

#### Summary of Changes

Add a bench for `StatusCache::slot_deltas()`.