### PR TITLE
Call StatusCache::append() directly

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -611,11 +611,6 @@ impl StatusCacheRc {
             .sorted()
             .collect()
     }
-
-    pub fn append(&self, slot_deltas: &[BankSlotDelta]) {
-        let mut sc = self.status_cache.write().unwrap();
-        sc.append(slot_deltas);
-    }
 }
 
 pub type TransactionCheckResult = (Result<()>, Option<NoncePartial>);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1663,7 +1663,7 @@ fn rebuild_bank_from_snapshots(
         Ok(slot_deltas)
     })?;
 
-    bank.src.append(&slot_deltas);
+    bank.src.status_cache.write().unwrap().append(&slot_deltas);
 
     bank.prepare_rewrites_for_hash();
 


### PR DESCRIPTION
#### Problem

`StatusCacheRc::append()` is only called in one place, and doesn't abstract anything away usefully (IMO).

#### Summary of Changes

Call `StatusCache::append()` directly.