### PR TITLE
chore: separate publish installer process

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -2,30 +2,30 @@
 # Build steps that run after the primary pipeline on pushes and tags.
 # Pull requests to not run these steps.
 steps:
-  - command: "ci/publish-tarball.sh"
+  - name: "publish tarball (x86_64-unknown-linux-gnu)"
+    command: "ci/publish-tarball.sh"
     agents:
       - "queue=release-build"
     timeout_in_minutes: 60
-    name: "publish tarball"
   - wait
-  - command: "sdk/docker-solana/build.sh"
+  - name: "publish docker"
+    command: "sdk/docker-solana/build.sh"
     agents:
       - "queue=release-build"
     timeout_in_minutes: 60
-    name: "publish docker"
-  - command: "ci/publish-crate.sh"
+  - name: "publish crate"
+    command: "ci/publish-crate.sh"
     agents:
       - "queue=release-build"
     timeout_in_minutes: 240
-    name: "publish crate"
     branches: "!master"
-  - command: "ci/publish-tarball.sh"
+  - name: "publish tarball (aarch64-apple-darwin)"
+    command: "ci/publish-tarball.sh"
     agents:
       - "queue=release-build-aarch64-apple-darwin"
     timeout_in_minutes: 60
-    name: "publish tarball (aarch64-apple-darwin)"
-  - command: "ci/publish-tarball.sh"
+  - name: "publish tarball (x86_64-apple-darwin)"
+    command: "ci/publish-tarball.sh"
     agents:
       - "queue=release-build-x86_64-apple-darwin"
     timeout_in_minutes: 60
-    name: "publish tarball (x86_64-apple-darwin)"

--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -7,6 +7,11 @@ steps:
     agents:
       - "queue=release-build"
     timeout_in_minutes: 60
+  - name: "publish installer"
+    command: "ci/publish-installer.sh"
+    agents:
+      - "queue=release-build"
+    timeout_in_minutes: 5
   - wait
   - name: "publish docker"
     command: "sdk/docker-solana/build.sh"

--- a/ci/publish-installer.sh
+++ b/ci/publish-installer.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+# check does it need to publish
+if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
+	echo "Skipping publishing install wrapper"
+	exit 0
+fi
+
+# check channel and tag
+eval "$(ci/channel-info.sh)"
+
+if [[ -n "$CI_TAG" ]]; then
+	CHANNEL_OR_TAG=$CI_TAG
+else
+	CHANNEL_OR_TAG=$CHANNEL
+fi
+
+if [[ -z $CHANNEL_OR_TAG ]]; then
+	echo +++ Unable to determine channel or tag to publish into, exiting.
+	exit 0
+fi
+
+# upload install script
+source ci/upload-ci-artifact.sh
+
+cat >release.solana.com-install <<EOF
+SOLANA_RELEASE=$CHANNEL_OR_TAG
+SOLANA_INSTALL_INIT_ARGS=$CHANNEL_OR_TAG
+SOLANA_DOWNLOAD_ROOT=https://release.solana.com
+EOF
+cat install/solana-install-init.sh >>release.solana.com-install
+
+echo --- AWS S3 Store: "install"
+upload-s3-artifact "/solana/release.solana.com-install" "s3://release.solana.com/$CHANNEL_OR_TAG/install"
+echo Published to:
+ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/install

--- a/ci/publish-installer.sh
+++ b/ci/publish-installer.sh
@@ -5,22 +5,22 @@ cd "$(dirname "$0")/.."
 
 # check does it need to publish
 if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
-	echo "Skipping publishing install wrapper"
-	exit 0
+  echo "Skipping publishing install wrapper"
+  exit 0
 fi
 
 # check channel and tag
 eval "$(ci/channel-info.sh)"
 
 if [[ -n "$CI_TAG" ]]; then
-	CHANNEL_OR_TAG=$CI_TAG
+  CHANNEL_OR_TAG=$CI_TAG
 else
-	CHANNEL_OR_TAG=$CHANNEL
+  CHANNEL_OR_TAG=$CHANNEL
 fi
 
 if [[ -z $CHANNEL_OR_TAG ]]; then
-	echo +++ Unable to determine channel or tag to publish into, exiting.
-	exit 0
+  echo +++ Unable to determine channel or tag to publish into, exiting.
+  exit 0
 fi
 
 # upload install script

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -150,23 +150,4 @@ for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.
   fi
 done
 
-
-# Create install wrapper for release.solana.com
-if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
-  echo "Skipping publishing install wrapper"
-elif [[ -n $BUILDKITE ]]; then
-  cat > release.solana.com-install <<EOF
-SOLANA_RELEASE=$CHANNEL_OR_TAG
-SOLANA_INSTALL_INIT_ARGS=$CHANNEL_OR_TAG
-SOLANA_DOWNLOAD_ROOT=https://release.solana.com
-EOF
-  echo release.solana.com-install
-  cat install/solana-install-init.sh >> release.solana.com-install
-
-  echo --- AWS S3 Store: "install"
-  $DRYRUN upload-s3-artifact "/solana/release.solana.com-install" "s3://release.solana.com/$CHANNEL_OR_TAG/install"
-  echo Published to:
-  $DRYRUN ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/install
-fi
-
 echo --- ok


### PR DESCRIPTION
#### Problem

Due to #26064, I found two things:

1. We upload installer script many times although they are the same
2. When we try to upload something, We run s3cmd in docker and volume the target files into it. The bug is that our x86 mac seems cache volume file for a while. I can reproduce the bug but haven't found the real reason.

I think we should solve both but ideally when this PR been merged and then 2.'s bug will be hidden. I'll merge this first and still investigating 2.

#### Summary of Changes

1. reorder steps attributes
4. extract publish installer logic as an independent step
