### PR TITLE
Update version bump check so it works on master branch

### DIFF
--- a/scripts/confirm-cargo-version-numbers-before-bump.sh
+++ b/scripts/confirm-cargo-version-numbers-before-bump.sh
@@ -5,7 +5,7 @@ usage() {
   cat <<EOF
 usage: $0 branch tag
 
-Checks that the tag matches the branch and the Cargo.toml versions match the tag.
+Checks that the tag matches the branch (unless branch is master) and the Cargo.toml versions match the tag.
 EOF
   exit 0
 }
@@ -13,13 +13,14 @@ EOF
 branch="$1"
 tag="$2"
 
+[[ -n $tag ]] || usage
 echo "branch: $branch tag: $tag"
 
-# The tag is expected to be the branch name plus a patch number. eg:
+# The tag is expected to be the branch name plus a patch number (unless branch is master). eg:
 #   tag:    v1.2.3
 #   branch: v1.2
-if [[ "$tag" != "$branch"* ]]; then
-    >&2 echo "Tag must start with the branch name. Tag: $tag   Branch: $branch"
+ if [[ "$tag" != "$branch"* && $branch != "master" ]]; then
+    >&2 echo "Tag must start with the branch name (unless branch is master). Tag: $tag   Branch: $branch"
     exit 1
 fi
 


### PR DESCRIPTION
#### Problem
The Github Action version bump checks if the tag and branch name match. If a release is tagged off master this check fails.

#### Summary of Changes
Add exception for master branch.
