### PR TITLE
partially reverts #25963

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -408,6 +408,10 @@ pub mod include_account_index_in_rent_error {
     solana_sdk::declare_id!("2R72wpcQ7qV7aTJWUumdn8u5wmmTyXbK7qzEy7YSAgyY");
 }
 
+pub mod add_shred_type_to_shred_seed {
+    solana_sdk::declare_id!("Ds87KVeqhbv7Jw8W6avsS1mqz3Mw5J3pRTpPoDQ2QdiJ");
+}
+
 pub mod warp_timestamp_with_a_vengeance {
     solana_sdk::declare_id!("3BX6SBeEBibHaVQXywdkcgyUk6evfYZkHdztXiDtEpFS");
 }
@@ -540,6 +544,7 @@ lazy_static! {
         (add_set_compute_unit_price_ix::id(), "add compute budget ix for setting a compute unit price"),
         (disable_deploy_of_alloc_free_syscall::id(), "disable new deployments of deprecated sol_alloc_free_ syscall"),
         (include_account_index_in_rent_error::id(), "include account index in rent tx error #25190"),
+        (add_shred_type_to_shred_seed::id(), "add shred-type to shred seed #25556"),
         (warp_timestamp_with_a_vengeance::id(), "warp timestamp again, adjust bounding to 150% slow #25666"),
         (separate_nonce_from_blockhash::id(), "separate durable nonce and blockhash domains #25744"),
         (enable_durable_nonce::id(), "enable durable nonce #25744"),


### PR DESCRIPTION

#### Problem
This partially reverts commit 47e62add5bd9dfec86462cc27ea0935083b20c1a.

Adding back the feature-id so that the master branch can successfully
run ledger-tool across epoch-boundary which enabled the feature.

Note that #25963 backport did not remove the feature-id.

#### Summary of Changes
Adding back the feature-id so that the master branch can successfully
run ledger-tool across epoch-boundary which enabled the feature.
