### PR TITLE
StatusCache::roots() returns `Slot`s not `u64`s

### DIFF
--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -175,7 +175,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         self.purge_roots();
     }
 
-    pub fn roots(&self) -> &HashSet<u64> {
+    pub fn roots(&self) -> &HashSet<Slot> {
         &self.roots
     }
 


### PR DESCRIPTION
The PR's title and the diff should be sufficient for this tiny PR 😄
