### PR TITLE
Add StatusCache::root_slot_deltas() and use it

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -281,11 +281,17 @@ mod tests {
         let last_bank_snapshot_info =
             snapshot_utils::get_highest_bank_snapshot_pre(bank_snapshots_dir)
                 .expect("no bank snapshots found in path");
+        let slot_deltas = last_bank
+            .src
+            .status_cache
+            .read()
+            .unwrap()
+            .root_slot_deltas();
         let accounts_package = AccountsPackage::new(
             &last_bank,
             &last_bank_snapshot_info,
             bank_snapshots_dir,
-            last_bank.src.slot_deltas(&last_bank.src.roots()),
+            slot_deltas,
             &snapshot_config.full_snapshot_archives_dir,
             &snapshot_config.incremental_snapshot_archives_dir,
             last_bank.get_snapshot_storages(None),
@@ -626,7 +632,13 @@ mod tests {
                 .get(snapshot_test_config.bank_forks.root())
                 .unwrap()
                 .src
-                .roots();
+                .status_cache
+                .read()
+                .unwrap()
+                .roots()
+                .iter()
+                .cloned()
+                .sorted();
             assert!(slots_to_snapshot.into_iter().eq(expected_slots_to_snapshot));
         }
     }

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -3,7 +3,6 @@ extern crate test;
 
 use {
     bincode::serialize,
-    itertools::Itertools,
     solana_runtime::{bank::BankStatusCache, status_cache::*},
     solana_sdk::{
         hash::{hash, Hash},
@@ -63,44 +62,4 @@ fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     }
 
     bencher.iter(|| test::black_box(status_cache.root_slot_deltas()));
-}
-
-// bprumo TODO: remove this bench
-#[bench]
-fn bench_status_cache_slot_deltas_get_roots_sorted(bencher: &mut Bencher) {
-    let mut status_cache = BankStatusCache::default();
-
-    // fill the status cache
-    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
-    for slot in &slots {
-        for _ in 0..5 {
-            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
-        }
-        status_cache.add_root(*slot);
-    }
-
-    bencher.iter(|| {
-        let slots: Vec<_> = status_cache.roots().iter().cloned().sorted().collect();
-        test::black_box(status_cache.slot_deltas(&slots))
-    });
-}
-
-// bprumo TODO: remove this bench
-#[bench]
-fn bench_status_cache_slot_deltas_get_roots_unsorted(bencher: &mut Bencher) {
-    let mut status_cache = BankStatusCache::default();
-
-    // fill the status cache
-    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
-    for slot in &slots {
-        for _ in 0..5 {
-            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
-        }
-        status_cache.add_root(*slot);
-    }
-
-    bencher.iter(|| {
-        let slots: Vec<_> = status_cache.roots().iter().cloned().collect();
-        test::black_box(status_cache.slot_deltas(&slots))
-    });
 }

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -3,6 +3,7 @@ extern crate test;
 
 use {
     bincode::serialize,
+    itertools::Itertools,
     solana_runtime::{bank::BankStatusCache, status_cache::*},
     solana_sdk::{
         hash::{hash, Hash},
@@ -46,4 +47,60 @@ fn bench_status_cache_slot_deltas(bencher: &mut Bencher) {
     }
 
     bencher.iter(|| test::black_box(status_cache.slot_deltas(&slots)));
+}
+
+#[bench]
+fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
+    let mut status_cache = BankStatusCache::default();
+
+    // fill the status cache
+    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
+    for slot in &slots {
+        for _ in 0..5 {
+            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
+        }
+        status_cache.add_root(*slot);
+    }
+
+    bencher.iter(|| test::black_box(status_cache.root_slot_deltas()));
+}
+
+// bprumo TODO: remove this bench
+#[bench]
+fn bench_status_cache_slot_deltas_get_roots_sorted(bencher: &mut Bencher) {
+    let mut status_cache = BankStatusCache::default();
+
+    // fill the status cache
+    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
+    for slot in &slots {
+        for _ in 0..5 {
+            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
+        }
+        status_cache.add_root(*slot);
+    }
+
+    bencher.iter(|| {
+        let slots: Vec<_> = status_cache.roots().iter().cloned().sorted().collect();
+        test::black_box(status_cache.slot_deltas(&slots))
+    });
+}
+
+// bprumo TODO: remove this bench
+#[bench]
+fn bench_status_cache_slot_deltas_get_roots_unsorted(bencher: &mut Bencher) {
+    let mut status_cache = BankStatusCache::default();
+
+    // fill the status cache
+    let slots: Vec<_> = (42..).take(MAX_CACHE_ENTRIES).collect();
+    for slot in &slots {
+        for _ in 0..5 {
+            status_cache.insert(&Hash::new_unique(), Hash::new_unique(), *slot, Ok(()));
+        }
+        status_cache.add_root(*slot);
+    }
+
+    bencher.iter(|| {
+        let slots: Vec<_> = status_cache.roots().iter().cloned().collect();
+        test::black_box(status_cache.slot_deltas(&slots))
+    });
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -595,24 +595,6 @@ pub struct StatusCacheRc {
     pub status_cache: Arc<RwLock<BankStatusCache>>,
 }
 
-impl StatusCacheRc {
-    pub fn slot_deltas(&self, slots: &[Slot]) -> Vec<BankSlotDelta> {
-        let sc = self.status_cache.read().unwrap();
-        sc.slot_deltas(slots)
-    }
-
-    pub fn roots(&self) -> Vec<Slot> {
-        self.status_cache
-            .read()
-            .unwrap()
-            .roots()
-            .iter()
-            .cloned()
-            .sorted()
-            .collect()
-    }
-}
-
 pub type TransactionCheckResult = (Result<()>, Option<NoncePartial>);
 
 pub struct TransactionResults {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -278,13 +278,18 @@ impl BankForks {
                 {
                     let snapshot_root_bank = self.root_bank();
                     let root_slot = snapshot_root_bank.slot();
+                    // Save off the status cache because these may get pruned if another
+                    // `set_root()` is called before the snapshots package can be generated
+                    let status_cache_slot_deltas = snapshot_root_bank
+                        .src
+                        .status_cache
+                        .read()
+                        .unwrap()
+                        .root_slot_deltas();
                     if let Err(e) =
                         accounts_background_request_sender.send_snapshot_request(SnapshotRequest {
                             snapshot_root_bank,
-                            // Save off the status cache because these may get pruned
-                            // if another `set_root()` is called before the snapshots package
-                            // can be generated
-                            status_cache_slot_deltas: bank.src.slot_deltas(&bank.src.roots()),
+                            status_cache_slot_deltas,
                         })
                     {
                         warn!(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1949,11 +1949,12 @@ pub fn package_and_archive_full_snapshot(
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,
 ) -> Result<FullSnapshotArchiveInfo> {
+    let slot_deltas = bank.src.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new(
         bank,
         bank_snapshot_info,
         bank_snapshots_dir,
-        bank.src.slot_deltas(&bank.src.roots()),
+        slot_deltas,
         &full_snapshot_archives_dir,
         &incremental_snapshot_archives_dir,
         snapshot_storages,
@@ -1998,11 +1999,12 @@ pub fn package_and_archive_incremental_snapshot(
     maximum_full_snapshot_archives_to_retain: usize,
     maximum_incremental_snapshot_archives_to_retain: usize,
 ) -> Result<IncrementalSnapshotArchiveInfo> {
+    let slot_deltas = bank.src.status_cache.read().unwrap().root_slot_deltas();
     let accounts_package = AccountsPackage::new(
         bank,
         bank_snapshot_info,
         bank_snapshots_dir,
-        bank.src.slot_deltas(&bank.src.roots()),
+        slot_deltas,
         &full_snapshot_archives_dir,
         &incremental_snapshot_archives_dir,
         snapshot_storages,

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -47,7 +47,7 @@ impl<T: Serialize + Clone> Default for StatusCache<T> {
         Self {
             cache: HashMap::default(),
             // 0 is always a root
-            roots: [0].iter().cloned().collect(),
+            roots: HashSet::from([0]),
             slot_deltas: HashMap::default(),
         }
     }
@@ -230,7 +230,21 @@ impl<T: Serialize + Clone> StatusCache<T> {
                 (
                     *slot,
                     self.roots.contains(slot),
-                    self.slot_deltas.get(slot).unwrap_or(&empty).clone(),
+                    Arc::clone(self.slot_deltas.get(slot).unwrap_or(&empty)),
+                )
+            })
+            .collect()
+    }
+
+    /// Get the statuses for all the root slots
+    pub fn root_slot_deltas(&self) -> Vec<SlotDelta<T>> {
+        self.roots
+            .iter()
+            .map(|slot| {
+                (
+                    *slot,
+                    true,
+                    self.slot_deltas.get(slot).cloned().unwrap_or_default(),
                 )
             })
             .collect()
@@ -450,7 +464,7 @@ mod tests {
         for i in 0..(MAX_CACHE_ENTRIES + 1) {
             status_cache.add_root(i as u64);
         }
-        let slots: Vec<_> = (0_u64..MAX_CACHE_ENTRIES as u64 + 1).collect();
+        let slots: Vec<_> = (0..MAX_CACHE_ENTRIES as u64 + 1).collect();
         assert_eq!(status_cache.slot_deltas.len(), 1);
         assert!(status_cache.slot_deltas.get(&1).is_some());
         let slot_deltas = status_cache.slot_deltas(&slots);


### PR DESCRIPTION
#### Problem

All uses of `StatusCacheRc::slot_deltas()` (1) only get the roots from the status cache, and (2) unnecessarily sort. These are performance loses.

#### Summary of Changes

1. Add `StatusCache::root_slot_deltas()` which gets the slot deltas from its roots
2. Remove `StatusCacheRc::slot_deltas()` and call `StatusCache::root_slot_deltas()` instead
3. Add benchmarks to ensure this is actually a speedup

```sh
1. test bench_status_cache_root_slot_deltas               ... bench:       8,366 ns/iter (+/- 592)
2. test bench_status_cache_slot_deltas                    ... bench:       9,200 ns/iter (+/- 612)
3. test bench_status_cache_slot_deltas_get_roots_sorted   ... bench:      16,086 ns/iter (+/- 2,978)
4. test bench_status_cache_slot_deltas_get_roots_unsorted ... bench:      10,692 ns/iter (+/- 809)
```

In (2), that is the current call to `StatusCache::slot_deltas()`. However, no code just calls (2); they all call `StatusCache::roots()` first. So (3) and (4) show the true results for the current way we get the slot deltas (really just (3)). And (1) is the new way.

The existing code performed a `sort` on the roots passed into `slot_deltas()`, but this is unnecessary. The vector returned is never indexed; in fact, it's only used for the snapshot, and its deserialization puts the vector back into a HashMap.

Getting the slot deltas is called during `bank_forks::set_root()`, so anything to speed that path up is useful.

Note: benches 3 and 4 are not part of the final PR. They are in the first commit, should you like to look at them and/or run them.