### PR TITLE
batch update stake cache

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -169,13 +169,6 @@ use {
     },
 };
 
-struct StakeReward {
-    pubkey: Pubkey,
-    reward: RewardInfo,
-    balance: u64,
-    account: AccountSharedData,
-}
-
 #[derive(Debug, Default)]
 struct RewardsMetrics {
     load_vote_and_stake_accounts_us: AtomicU64,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -169,6 +169,13 @@ use {
     },
 };
 
+struct StakeReward {
+    pubkey: Pubkey,
+    reward: RewardInfo,
+    balance: u64,
+    account: AccountSharedData,
+}
+
 #[derive(Debug, Default)]
 struct RewardsMetrics {
     load_vote_and_stake_accounts_us: AtomicU64,
@@ -3074,7 +3081,6 @@ impl Bank {
             vote_with_stake_delegations_map
         };
 
-        // TODO (hyi): sharding on vote_pubkey over the slots
         let mut m = Measure::start("calculate_points");
         let points: u128 = thread_pool.install(|| {
             vote_with_stake_delegations_map
@@ -3107,7 +3113,6 @@ impl Bank {
             return 0.0;
         }
 
-        // TODO (hyi): sharding on vote_pubkey over the slots
         // pay according to point value
         let point_value = PointValue { rewards, points };
         let vote_account_rewards: DashMap<Pubkey, (AccountSharedData, u8, u64, bool)> =
@@ -3129,7 +3134,6 @@ impl Bank {
             },
         );
 
-        // TODO (hyi): sharding on stake_pubkey over the slots
         let mut m = Measure::start("redeem_rewards");
         let stake_rewards: Vec<StakeReward> = thread_pool.install(|| {
             stake_delegation_iterator

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1951,11 +1951,6 @@ impl Bank {
                         ),
                         ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
                         (
-                            "redeem_rewards_us",
-                            metrics.redeem_rewards_us.load(Relaxed),
-                            i64
-                        ),
-                        (
                             "store_stake_accounts_us",
                             metrics.store_stake_accounts_us.load(Relaxed),
                             i64
@@ -6240,7 +6235,9 @@ impl Bank {
             .accounts
             .store_accounts_cached((self.slot(), accounts));
         let mut m = Measure::start("stakes_cache.check_and_store");
-        self.stakes_cache.check_and_store_batch(accounts);
+        for (pubkey, account) in accounts {
+            self.stakes_cache.check_and_store(pubkey, account);
+        }
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,7 +91,6 @@ use {
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
     },
-    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{
             create_account_shared_data_with_fields as create_account, from_account, Account,
@@ -1876,14 +1875,8 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let num_threads = get_thread_count();
                     let (thread_pool, thread_pool_time) = Measure::this(
-                        |_| {
-                            ThreadPoolBuilder::new()
-                                .num_threads(num_threads)
-                                .build()
-                                .unwrap()
-                        },
+                        |_| ThreadPoolBuilder::new().build().unwrap(),
                         (),
                         "thread_pool_creation",
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -173,7 +173,7 @@ use {
 struct RewardsMetrics {
     load_vote_and_stake_accounts_us: AtomicU64,
     calculate_points_us: AtomicU64,
-    redeem_rewards_us: u64,
+    redeem_rewards_us: AtomicU64,
     store_stake_accounts_us: AtomicU64,
     store_vote_accounts_us: AtomicU64,
     invalid_cached_vote_accounts: usize,
@@ -1949,7 +1949,11 @@ impl Bank {
                             metrics.calculate_points_us.load(Relaxed),
                             i64
                         ),
-                        ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
+                        (
+                            "redeem_rewards_us",
+                            metrics.redeem_rewards_us.load(Relaxed),
+                            i64
+                        ),
                         (
                             "store_stake_accounts_us",
                             metrics.store_stake_accounts_us.load(Relaxed),
@@ -3179,7 +3183,7 @@ impl Bank {
                 .collect()
         });
         m.stop();
-        metrics.redeem_rewards_us += m.as_us();
+        metrics.redeem_rewards_us.fetch_add(m.as_us(), Relaxed);
 
         // store stake account even if stakers_reward is 0
         // because credits observed has changed
@@ -6235,9 +6239,7 @@ impl Bank {
             .accounts
             .store_accounts_cached((self.slot(), accounts));
         let mut m = Measure::start("stakes_cache.check_and_store");
-        for (pubkey, account) in accounts {
-            self.stakes_cache.check_and_store(pubkey, account);
-        }
+        self.stakes_cache.check_and_store_batch(accounts);
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -173,7 +173,7 @@ use {
 struct RewardsMetrics {
     load_vote_and_stake_accounts_us: AtomicU64,
     calculate_points_us: AtomicU64,
-    redeem_rewards_us: AtomicU64,
+    redeem_rewards_us: u64,
     store_stake_accounts_us: AtomicU64,
     store_vote_accounts_us: AtomicU64,
     invalid_cached_vote_accounts: usize,
@@ -1949,11 +1949,7 @@ impl Bank {
                             metrics.calculate_points_us.load(Relaxed),
                             i64
                         ),
-                        (
-                            "redeem_rewards_us",
-                            metrics.redeem_rewards_us.load(Relaxed),
-                            i64
-                        ),
+                        ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
                         (
                             "store_stake_accounts_us",
                             metrics.store_stake_accounts_us.load(Relaxed),
@@ -3183,7 +3179,7 @@ impl Bank {
                 .collect()
         });
         m.stop();
-        metrics.redeem_rewards_us.fetch_add(m.as_us(), Relaxed);
+        metrics.redeem_rewards_us += m.as_us();
 
         // store stake account even if stakers_reward is 0
         // because credits observed has changed

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6244,9 +6244,7 @@ impl Bank {
             .accounts
             .store_accounts_cached((self.slot(), accounts));
         let mut m = Measure::start("stakes_cache.check_and_store");
-        for (pubkey, account) in accounts {
-            self.stakes_cache.check_and_store(pubkey, account);
-        }
+        self.stakes_cache.check_and_store_batch(accounts);
         m.stop();
         self.rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1875,9 +1875,8 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let (thread_pool, thread_pool_time) = Measure::this(
-                        |_| ThreadPoolBuilder::new().build().unwrap(),
-                        (),
+                    let (thread_pool, thread_pool_time) = measure!(
+                        ThreadPoolBuilder::new().build().unwrap(),
                         "thread_pool_creation",
                     );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1959,6 +1959,11 @@ impl Bank {
                         ),
                         ("redeem_rewards_us", metrics.redeem_rewards_us, i64),
                         (
+                            "redeem_rewards_us",
+                            metrics.redeem_rewards_us.load(Relaxed),
+                            i64
+                        ),
+                        (
                             "store_stake_accounts_us",
                             metrics.store_stake_accounts_us.load(Relaxed),
                             i64
@@ -3076,6 +3081,7 @@ impl Bank {
             vote_with_stake_delegations_map
         };
 
+        // TODO (hyi): sharding on vote_pubkey over the slots
         let mut m = Measure::start("calculate_points");
         let points: u128 = thread_pool.install(|| {
             vote_with_stake_delegations_map
@@ -3108,6 +3114,7 @@ impl Bank {
             return 0.0;
         }
 
+        // TODO (hyi): sharding on vote_pubkey over the slots
         // pay according to point value
         let point_value = PointValue { rewards, points };
         let vote_account_rewards: DashMap<Pubkey, (AccountSharedData, u8, u64, bool)> =
@@ -3129,6 +3136,7 @@ impl Bank {
             },
         );
 
+        // TODO (hyi): sharding on stake_pubkey over the slots
         let mut m = Measure::start("redeem_rewards");
         let stake_rewards: Vec<StakeReward> = thread_pool.install(|| {
             stake_delegation_iterator

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,6 +91,7 @@ use {
         sysvar_cache::SysvarCache,
         timings::{ExecuteTimingType, ExecuteTimings},
     },
+    solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
         account::{
             create_account_shared_data_with_fields as create_account, from_account, Account,
@@ -1875,8 +1876,15 @@ impl Bank {
         let (_, update_epoch_time) = measure!(
             {
                 if parent_epoch < new.epoch() {
-                    let (thread_pool, thread_pool_time) = measure!(
-                        ThreadPoolBuilder::new().build().unwrap(),
+                    let num_threads = get_thread_count();
+                    let (thread_pool, thread_pool_time) = Measure::this(
+                        |_| {
+                            ThreadPoolBuilder::new()
+                                .num_threads(num_threads)
+                                .build()
+                                .unwrap()
+                        },
+                        (),
                         "thread_pool_creation",
                     );
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -125,6 +125,56 @@ impl StakesCache {
         }
     }
 
+    pub fn check_and_store_batch(&self, accounts: &[(&Pubkey, &AccountSharedData)]) {
+        let mut stakes = self.0.write().unwrap();
+
+        for (pubkey, account) in accounts {
+            // TODO: If the account is already cached as a vote or stake account
+            // but the owner changes, then this needs to evict the account from
+            // the cache. see:
+            // https://github.com/solana-labs/solana/pull/24200#discussion_r849935444
+            let pubkey = *pubkey;
+            let account = *account;
+            let owner = account.owner();
+            // Zero lamport accounts are not stored in accounts-db
+            // and so should be removed from cache as well.
+            if account.lamports() == 0 {
+                if solana_vote_program::check_id(owner) {
+                    stakes.remove_vote_account(pubkey);
+                } else if solana_stake_program::check_id(owner) {
+                    stakes.remove_stake_delegation(pubkey);
+                }
+                continue;
+            }
+            debug_assert_ne!(account.lamports(), 0u64);
+            if solana_vote_program::check_id(owner) {
+                if VoteState::is_correct_size_and_initialized(account.data()) {
+                    match VoteAccount::try_from(account.clone()) {
+                        Ok(vote_account) => {
+                            {
+                                // Called to eagerly deserialize vote state
+                                let _res = vote_account.vote_state();
+                            }
+                            stakes.upsert_vote_account(pubkey, vote_account);
+                        }
+                        Err(_) => stakes.remove_vote_account(pubkey),
+                    }
+                } else {
+                    stakes.remove_vote_account(pubkey)
+                };
+            } else if solana_stake_program::check_id(owner) {
+                match StakeAccount::try_from(account.clone()) {
+                    Ok(stake_account) => {
+                        stakes.upsert_stake_delegation(*pubkey, stake_account);
+                    }
+                    Err(_) => {
+                        stakes.remove_stake_delegation(pubkey);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn activate_epoch(&self, next_epoch: Epoch, thread_pool: &ThreadPool) {
         let mut stakes = self.0.write().unwrap();
         stakes.activate_epoch(next_epoch, thread_pool)
@@ -609,6 +659,34 @@ pub mod tests {
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
                 assert_eq!(vote_accounts.get(&vote_pubkey).unwrap().0, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_stakes_batch() {
+        for i in 0..4 {
+            let stakes_cache = StakesCache::new(Stakes {
+                epoch: i,
+                ..Stakes::default()
+            });
+
+            let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+                create_staked_node_accounts(10);
+
+            stakes_cache.check_and_store_batch(&[
+                (&vote_pubkey, &vote_account),
+                (&stake_pubkey, &stake_account),
+            ]);
+            let stake = stake_state::stake_from(&stake_account).unwrap();
+            {
+                let stakes = stakes_cache.stakes();
+                let vote_accounts = stakes.vote_accounts();
+                assert!(vote_accounts.get(&vote_pubkey).is_some());
+                assert_eq!(
+                    vote_accounts.get(&vote_pubkey).unwrap().0,
+                    stake.stake(i, None)
+                );
             }
         }
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -664,6 +664,34 @@ pub mod tests {
     }
 
     #[test]
+    fn test_stakes_batch() {
+        for i in 0..4 {
+            let stakes_cache = StakesCache::new(Stakes {
+                epoch: i,
+                ..Stakes::default()
+            });
+
+            let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+                create_staked_node_accounts(10);
+
+            stakes_cache.check_and_store_batch(&[
+                (&vote_pubkey, &vote_account),
+                (&stake_pubkey, &stake_account),
+            ]);
+            let stake = stake_state::stake_from(&stake_account).unwrap();
+            {
+                let stakes = stakes_cache.stakes();
+                let vote_accounts = stakes.vote_accounts();
+                assert!(vote_accounts.get(&vote_pubkey).is_some());
+                assert_eq!(
+                    vote_accounts.get(&vote_pubkey).unwrap().0,
+                    stake.stake(i, None)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_stakes_highest() {
         let stakes_cache = StakesCache::default();
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -125,56 +125,6 @@ impl StakesCache {
         }
     }
 
-    pub fn check_and_store_batch(&self, accounts: &[(&Pubkey, &AccountSharedData)]) {
-        let mut stakes = self.0.write().unwrap();
-
-        for (pubkey, account) in accounts {
-            // TODO: If the account is already cached as a vote or stake account
-            // but the owner changes, then this needs to evict the account from
-            // the cache. see:
-            // https://github.com/solana-labs/solana/pull/24200#discussion_r849935444
-            let pubkey = *pubkey;
-            let account = *account;
-            let owner = account.owner();
-            // Zero lamport accounts are not stored in accounts-db
-            // and so should be removed from cache as well.
-            if account.lamports() == 0 {
-                if solana_vote_program::check_id(owner) {
-                    stakes.remove_vote_account(pubkey);
-                } else if solana_stake_program::check_id(owner) {
-                    stakes.remove_stake_delegation(pubkey);
-                }
-                continue;
-            }
-            debug_assert_ne!(account.lamports(), 0u64);
-            if solana_vote_program::check_id(owner) {
-                if VoteState::is_correct_size_and_initialized(account.data()) {
-                    match VoteAccount::try_from(account.clone()) {
-                        Ok(vote_account) => {
-                            {
-                                // Called to eagerly deserialize vote state
-                                let _res = vote_account.vote_state();
-                            }
-                            stakes.upsert_vote_account(pubkey, vote_account);
-                        }
-                        Err(_) => stakes.remove_vote_account(pubkey),
-                    }
-                } else {
-                    stakes.remove_vote_account(pubkey)
-                };
-            } else if solana_stake_program::check_id(owner) {
-                match StakeAccount::try_from(account.clone()) {
-                    Ok(stake_account) => {
-                        stakes.upsert_stake_delegation(*pubkey, stake_account);
-                    }
-                    Err(_) => {
-                        stakes.remove_stake_delegation(pubkey);
-                    }
-                }
-            }
-        }
-    }
-
     pub fn activate_epoch(&self, next_epoch: Epoch, thread_pool: &ThreadPool) {
         let mut stakes = self.0.write().unwrap();
         stakes.activate_epoch(next_epoch, thread_pool)
@@ -659,34 +609,6 @@ pub mod tests {
                 let vote_accounts = stakes.vote_accounts();
                 assert!(vote_accounts.get(&vote_pubkey).is_some());
                 assert_eq!(vote_accounts.get(&vote_pubkey).unwrap().0, 0);
-            }
-        }
-    }
-
-    #[test]
-    fn test_stakes_batch() {
-        for i in 0..4 {
-            let stakes_cache = StakesCache::new(Stakes {
-                epoch: i,
-                ..Stakes::default()
-            });
-
-            let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
-                create_staked_node_accounts(10);
-
-            stakes_cache.check_and_store_batch(&[
-                (&vote_pubkey, &vote_account),
-                (&stake_pubkey, &stake_account),
-            ]);
-            let stake = stake_state::stake_from(&stake_account).unwrap();
-            {
-                let stakes = stakes_cache.stakes();
-                let vote_accounts = stakes.vote_accounts();
-                assert!(vote_accounts.get(&vote_pubkey).is_some());
-                assert_eq!(
-                    vote_accounts.get(&vote_pubkey).unwrap().0,
-                    stake.stake(i, None)
-                );
             }
         }
     }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -155,13 +155,9 @@ impl StakesCache {
                                 // Called to eagerly deserialize vote state
                                 let _res = vote_account.vote_state();
                             }
-                            let mut stakes = self.0.write().unwrap();
                             stakes.upsert_vote_account(pubkey, vote_account);
                         }
-                        Err(_) => {
-                            let mut stakes = self.0.write().unwrap();
-                            stakes.remove_vote_account(pubkey)
-                        }
+                        Err(_) => stakes.remove_vote_account(pubkey),
                     }
                 } else {
                     stakes.remove_vote_account(pubkey)


### PR DESCRIPTION
#### Problem

Batch update stake cache for the stake account improve the performance. 

With batch update (mnb)

```
store_stake_accounts_us=1767486i 
```

without batch update (mnb)
```
store_stake_accounts_us=1892393i 
```

A small improvement `130ms`

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
