### PR TITLE
Bugfix/test get rent collection accounts remove random account

### DIFF
--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -412,6 +412,7 @@ mod tests {
             account::{AccountSharedData, ReadableAccount, WritableAccount},
             bpf_loader_upgradeable::{self, UpgradeableLoaderState},
             genesis_config::create_genesis_config,
+            genesis_config::GenesisConfig,
             pubkey::Pubkey,
             signer::Signer,
             stake,
@@ -423,7 +424,7 @@ mod tests {
     fn test_get_rent_collection_accounts() {
         solana_logger::setup();
 
-        let (genesis_config, _) = create_genesis_config(1_000_000);
+        let genesis_config = GenesisConfig::default();
         let bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
         // Slots correspond to subrange: A52Kf8KJNVhs1y61uhkzkSF82TXCLxZekqmFwiFXLnHu..=ChWNbfHUHLvFY3uhXj6kQhJ7a9iZB4ykh34WRGS5w9NE

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -411,8 +411,7 @@ mod tests {
         solana_sdk::{
             account::{AccountSharedData, ReadableAccount, WritableAccount},
             bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-            genesis_config::create_genesis_config,
-            genesis_config::GenesisConfig,
+            genesis_config::{create_genesis_config, GenesisConfig},
             pubkey::Pubkey,
             signer::Signer,
             stake,


### PR DESCRIPTION
#### Problem
There was a random pubkey generated during genesis config creation. This may have fallen in the rent collection range, and caused the test to fail.

This is branched off https://github.com/solana-labs/solana/pull/26177 which was causing build errors.

#### Summary of Changes
Use GenesisConfig::default instead, so there's no random account generated.

Fixes #26172 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
