### PR TITLE
Move Blockstore::blockstore_directory() to ShredStorageType

### DIFF
--- a/ledger/src/blockstore_options.rs
+++ b/ledger/src/blockstore_options.rs
@@ -135,12 +135,23 @@ impl Default for ShredStorageType {
     }
 }
 
+const BLOCKSTORE_DIRECTORY_ROCKS_LEVEL: &str = "rocksdb";
+const BLOCKSTORE_DIRECTORY_ROCKS_FIFO: &str = "rocksdb_fifo";
+
 impl ShredStorageType {
     /// Returns ShredStorageType::RocksFifo where the specified
     /// `shred_storage_size` is equally allocated to shred_data_cf_size
     /// and shred_code_cf_size.
     pub fn rocks_fifo(shred_storage_size: u64) -> ShredStorageType {
         ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::new(shred_storage_size))
+    }
+
+    /// The directory under `ledger_path` to the underlying blockstore.
+    pub fn blockstore_directory(&self) -> &str {
+        match self {
+            ShredStorageType::RocksLevel => BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+            ShredStorageType::RocksFifo(_) => BLOCKSTORE_DIRECTORY_ROCKS_FIFO,
+        }
     }
 }
 
@@ -209,4 +220,16 @@ impl BlockstoreCompressionType {
             Self::Zlib => RocksCompressionType::Zlib,
         }
     }
+}
+
+#[test]
+fn test_rocksdb_directory() {
+    assert_eq!(
+        ShredStorageType::RocksLevel.blockstore_directory(),
+        BLOCKSTORE_DIRECTORY_ROCKS_LEVEL
+    );
+    assert_eq!(
+        ShredStorageType::RocksFifo(BlockstoreRocksFifoOptions::default()).blockstore_directory(),
+        BLOCKSTORE_DIRECTORY_ROCKS_FIFO
+    );
 }


### PR DESCRIPTION
#### Summary of Changes
Blockstore::blockstore_directory() function takes a ShredStorageType and returns a path.
As it's a ShredStorageType related function, moving it under ShredStorageType as a
member function is a better fit.

In addition, as we start doing automatic shred compaction type selection under ledger-tool,
it becomes more convenient to reuse the function and const under blockstore_options
namespace instead of blockstore.

