### PR TITLE
refactor: extract get_stake_reward fn from StakeReward

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1414,6 +1414,12 @@ struct StakeReward {
     stake_account: AccountSharedData,
 }
 
+impl StakeReward {
+    pub fn get_stake_reward(&self) -> i64 {
+        self.stake_reward_info.lamports
+    }
+}
+
 /// allow [StakeReward] to be passed to `StoreAccounts` directly without copies or vec construction
 impl<'a> StorableAccounts<'a, AccountSharedData> for (Slot, &'a [StakeReward]) {
     fn pubkey(&self, index: usize) -> &Pubkey {
@@ -3232,7 +3238,7 @@ impl Bank {
 
         let mut stake_rewards = stake_rewards
             .into_iter()
-            .filter(|x| x.stake_reward_info.lamports > 0)
+            .filter(|x| x.get_stake_reward() > 0)
             .map(|x| (x.stake_pubkey, x.stake_reward_info))
             .collect();
 


### PR DESCRIPTION
#### Problem

Instead of accessing nested struct members to get stake reward, add a more meaningful fn to get stake reward.

#### Summary of Changes

extract get_stake_reward fn from StakeReward

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
