### PR TITLE
explorer: Add account bytes to tx inspector

### DIFF
--- a/explorer/src/pages/inspector/AddressWithContext.tsx
+++ b/explorer/src/pages/inspector/AddressWithContext.tsx
@@ -81,21 +81,21 @@ function AccountInfo({
   const errorMessage = validator && validator(info.data);
   if (errorMessage) return <span className="text-warning">{errorMessage}</span>;
 
-  if (info.data.details?.executable) {
-    return <span className="text-muted">Executable Program</span>;
+  if (!info.data.details) {
+    return <span className="text-muted">Account doesn't exist</span>;
   }
 
-  const owner = info.data.details?.owner;
-  const ownerAddress = owner?.toBase58();
-  const ownerLabel = ownerAddress && addressLabel(ownerAddress, cluster);
+  const owner = info.data.details.owner;
+  const ownerAddress = owner.toBase58();
+  const ownerLabel = addressLabel(ownerAddress, cluster);
 
   return (
     <span className="text-muted">
-      {ownerAddress
-        ? `Owned by ${
-            ownerLabel || ownerAddress
-          }. Balance is ${lamportsToSolString(info.data.lamports)} SOL`
-        : "Account doesn't exist"}
+      {`Owned by ${ownerLabel || ownerAddress}.`}
+      {` Balance is ${lamportsToSolString(info.data.lamports)} SOL.`}
+      {` Size is ${new Intl.NumberFormat("en-US").format(
+        info.data.details.space
+      )} byte(s).`}
     </span>
   );
 }


### PR DESCRIPTION
#### Problem
The tx inspector (`/inspect`) doesn't annotate the size of the account inputs

#### Summary of Changes
- Add size in account details
- Remove special handling for executable accounts

<img width="1015" alt="Screen Shot 2022-06-24 at 11 33 12 AM" src="https://user-images.githubusercontent.com/1076145/175517732-70635301-983c-40e1-b184-b41ee8341128.png">


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
