### PR TITLE
encapsulates AuthorizeNonceAccount implementation in the nonce module

### DIFF
--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -5,7 +5,7 @@ use {
         instruction::{checked_add, InstructionError},
         nonce::{
             self,
-            state::{DurableNonce, Versions},
+            state::{AuthorizeNonceError, DurableNonce, Versions},
             State,
         },
         pubkey::Pubkey,
@@ -268,30 +268,12 @@ pub fn authorize_nonce_account(
         );
         return Err(InstructionError::InvalidArgument);
     }
-
-    let state: Versions = account.get_state()?;
-    let separate_domains = state.separate_domains();
-    match state.state() {
-        State::Initialized(data) => {
-            if !signers.contains(&data.authority) {
-                ic_msg!(
-                    invoke_context,
-                    "Authorize nonce account: Account {} must sign",
-                    data.authority
-                );
-                return Err(InstructionError::MissingRequiredSignature);
-            }
-            let new_data = nonce::state::Data::new(
-                *nonce_authority,
-                data.durable_nonce,
-                data.get_lamports_per_signature(),
-            );
-            account.set_state(&Versions::new(
-                State::Initialized(new_data),
-                separate_domains,
-            ))
-        }
-        State::Uninitialized => {
+    match account
+        .get_state::<Versions>()?
+        .authorize(signers, *nonce_authority)
+    {
+        Ok(versions) => account.set_state(&versions),
+        Err(AuthorizeNonceError::Uninitialized) => {
             ic_msg!(
                 invoke_context,
                 "Authorize nonce account: Account {} state is invalid",
@@ -301,6 +283,14 @@ pub fn authorize_nonce_account(
                 NonceError::BadAccountState,
                 merge_nonce_error_into_system_error,
             ))
+        }
+        Err(AuthorizeNonceError::MissingRequiredSignature(account_authority)) => {
+            ic_msg!(
+                invoke_context,
+                "Authorize nonce account: Account {} must sign",
+                account_authority
+            );
+            Err(InstructionError::MissingRequiredSignature)
         }
     }
 }


### PR DESCRIPTION

#### Problem
Moving out portion of https://github.com/solana-labs/solana/pull/26055 which is new code into a separate pull request.

#### Summary of Changes
Follow up commit removes feature gate code separating durable nonce from
blockhash domain. This commit allows to encapsulate any logic
distinguishing legacy vs current nonce versions in the nonce module
after removing the feature gate.
