### PR TITLE
Dynamic threshold for number of packets going into sigverify dedup

### DIFF
--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -321,8 +321,8 @@ impl SigVerifyStage {
             },
         ) as usize;
         let num_unique = non_discarded_packets.saturating_sub(discard_or_dedup_fail);
-        deduper.update_max_packets(non_discarded_packets as u64, dedup_time.as_ns());
         dedup_time.stop();
+        deduper.update_max_packets(non_discarded_packets as u64, dedup_time.as_ns());
 
         let mut discard_time = Measure::start("sigverify_discard_time");
         let mut num_packets_to_verify = num_unique;

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -589,8 +589,8 @@ impl Deduper {
     }
 
     pub fn update_max_packets(&mut self, packets: u64, time: u64) {
-        if packets == 0 || time == 0 {
-            // Need meaningful timing data to update max dedup packet threshold.
+        if packets < MIN_MAX_DEDUP_BATCH as u64 || time == 0 {
+            // Need meaningful timing data and enough packets to amortize fixed cost in order to update max dedup packet threshold.
             return;
         }
         // Compute dedup max capability based on most recent iteration.


### PR DESCRIPTION
#### Problem
Current threshold for number of packets fed into dedup (as part of sigverify stage) is hard coded. This can result in one of two undesirable behaviors:
1. Shedding too many packets in the case where high powered machine could actually process more packets
2. Long latencies in dedup causing backpressure and bursts of dropped packets in the where low powered machine can't handle the hard coded number of packets

#### Summary of Changes
Use the existing measurements for dedup time to understand how many dedups per second the machine is capable of performing and use this to inform the threshold (with min/max bounds to avoid accidental runaway)
