### PR TITLE
sdk/bpf/c: support asm files

### DIFF
--- a/programs/bpf/c/src/add/add.s
+++ b/programs/bpf/c/src/add/add.s
@@ -1,0 +1,5 @@
+.global entrypoint
+entrypoint:
+    r1 += r2
+    r0 = r1
+    exit


### PR DESCRIPTION
#### Problem

The BPF C SDK cannot compile asm (`*.s`) files.

#### Summary of Changes

Adds rules to `bpf.mk` to auto-detect `*.s` files and assemble them with clang. 

Fixes #
