### PR TITLE
Revert "core: disable quic servers on mainnet-beta"

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -62,8 +62,8 @@ pub struct Tpu {
     banking_stage: BankingStage,
     cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
-    tpu_quic_t: Option<thread::JoinHandle<()>>,
-    tpu_forwards_quic_t: Option<thread::JoinHandle<()>>,
+    tpu_quic_t: thread::JoinHandle<()>,
+    tpu_forwards_quic_t: thread::JoinHandle<()>,
     find_packet_sender_stake_stage: FindPacketSenderStakeStage,
     vote_find_packet_sender_stake_stage: FindPacketSenderStakeStage,
     staked_nodes_updater_service: StakedNodesUpdaterService,
@@ -96,7 +96,6 @@ impl Tpu {
         connection_cache: &Arc<ConnectionCache>,
         keypair: &Keypair,
         log_messages_bytes_limit: Option<usize>,
-        enable_quic_servers: bool,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -154,37 +153,33 @@ impl Tpu {
         let (verified_sender, verified_receiver) = unbounded();
 
         let stats = Arc::new(StreamStats::default());
-        let tpu_quic_t = enable_quic_servers.then(|| {
-            spawn_server(
-                transactions_quic_sockets,
-                keypair,
-                cluster_info.my_contact_info().tpu.ip(),
-                packet_sender,
-                exit.clone(),
-                MAX_QUIC_CONNECTIONS_PER_PEER,
-                staked_nodes.clone(),
-                MAX_STAKED_CONNECTIONS,
-                MAX_UNSTAKED_CONNECTIONS,
-                stats.clone(),
-            )
-            .unwrap()
-        });
+        let tpu_quic_t = spawn_server(
+            transactions_quic_sockets,
+            keypair,
+            cluster_info.my_contact_info().tpu.ip(),
+            packet_sender,
+            exit.clone(),
+            MAX_QUIC_CONNECTIONS_PER_PEER,
+            staked_nodes.clone(),
+            MAX_STAKED_CONNECTIONS,
+            MAX_UNSTAKED_CONNECTIONS,
+            stats.clone(),
+        )
+        .unwrap();
 
-        let tpu_forwards_quic_t = enable_quic_servers.then(|| {
-            spawn_server(
-                transactions_forwards_quic_sockets,
-                keypair,
-                cluster_info.my_contact_info().tpu_forwards.ip(),
-                forwarded_packet_sender,
-                exit.clone(),
-                MAX_QUIC_CONNECTIONS_PER_PEER,
-                staked_nodes,
-                MAX_STAKED_CONNECTIONS.saturating_add(MAX_UNSTAKED_CONNECTIONS),
-                0, // Prevent unstaked nodes from forwarding transactions
-                stats,
-            )
-            .unwrap()
-        });
+        let tpu_forwards_quic_t = spawn_server(
+            transactions_forwards_quic_sockets,
+            keypair,
+            cluster_info.my_contact_info().tpu_forwards.ip(),
+            forwarded_packet_sender,
+            exit.clone(),
+            MAX_QUIC_CONNECTIONS_PER_PEER,
+            staked_nodes,
+            MAX_STAKED_CONNECTIONS.saturating_add(MAX_UNSTAKED_CONNECTIONS),
+            0, // Prevent unstaked nodes from forwarding transactions
+            stats,
+        )
+        .unwrap();
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::new(verified_sender);
@@ -271,13 +266,9 @@ impl Tpu {
             self.find_packet_sender_stake_stage.join(),
             self.vote_find_packet_sender_stake_stage.join(),
             self.staked_nodes_updater_service.join(),
+            self.tpu_quic_t.join(),
+            self.tpu_forwards_quic_t.join(),
         ];
-        if let Some(tpu_quic_t) = self.tpu_quic_t {
-            tpu_quic_t.join()?;
-        }
-        if let Some(tpu_forwards_quic_t) = self.tpu_forwards_quic_t {
-            tpu_forwards_quic_t.join()?;
-        }
         let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -90,7 +90,7 @@ use {
         clock::Slot,
         epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
         exit::Exit,
-        genesis_config::{ClusterType, GenesisConfig},
+        genesis_config::GenesisConfig,
         hash::Hash,
         pubkey::Pubkey,
         shred_version::compute_shred_version,
@@ -176,7 +176,6 @@ pub struct ValidatorConfig {
     pub wait_to_vote_slot: Option<Slot>,
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
-    pub enable_quic_servers: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -238,7 +237,6 @@ impl Default for ValidatorConfig {
             wait_to_vote_slot: None,
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
-            enable_quic_servers: false,
         }
     }
 }
@@ -992,18 +990,6 @@ impl Validator {
             &connection_cache,
         );
 
-        let enable_quic_servers = if genesis_config.cluster_type == ClusterType::MainnetBeta {
-            config.enable_quic_servers
-        } else {
-            if config.enable_quic_servers {
-                warn!(
-                    "ignoring --enable-quic-servers. QUIC is always enabled for cluster type: {:?}",
-                    genesis_config.cluster_type
-                );
-            }
-            true
-        };
-
         let tpu = Tpu::new(
             &cluster_info,
             &poh_recorder,
@@ -1036,7 +1022,6 @@ impl Validator {
             &connection_cache,
             &identity_keypair,
             config.runtime_config.log_messages_bytes_limit,
-            enable_quic_servers,
         );
 
         datapoint_info!(

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -63,7 +63,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         wait_to_vote_slot: config.wait_to_vote_slot,
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
-        enable_quic_servers: config.enable_quic_servers,
     }
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1211,11 +1211,6 @@ pub fn main() {
                 .help("Use QUIC to send transactions."),
         )
         .arg(
-            Arg::with_name("enable_quic_servers")
-                .hidden(true)
-                .long("enable-quic-servers")
-        )
-        .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)
@@ -2304,7 +2299,6 @@ pub fn main() {
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let tpu_use_quic = matches.is_present("tpu_use_quic");
-    let enable_quic_servers = matches.is_present("enable_quic_servers");
     let tpu_connection_pool_size = value_t_or_exit!(matches, "tpu_connection_pool_size", usize);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
@@ -2648,7 +2642,6 @@ pub fn main() {
             log_messages_bytes_limit: value_t!(matches, "log_messages_bytes_limit", usize).ok(),
             ..RuntimeConfig::default()
         },
-        enable_quic_servers,
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

QUIC disabled because of security issues

#### Summary of Changes

This reverts commit a5f290a66f10a25e0c3ee004a1fcd2889eca2785.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
