### PR TITLE
Refactor: Add get_delegated_stake method to VoteAccounts

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -611,10 +611,7 @@ impl ClusterInfoVoteListener {
             // 2) We do not know the hash of the earlier slot
             if slot == last_vote_slot {
                 let vote_accounts = epoch_stakes.stakes().vote_accounts();
-                let stake = vote_accounts
-                    .get(vote_pubkey)
-                    .map(|(stake, _)| *stake)
-                    .unwrap_or_default();
+                let stake = vote_accounts.get_delegated_stake(vote_pubkey);
                 let total_stake = epoch_stakes.total_stake();
 
                 // Fast track processing of the last slot in a vote transactions
@@ -795,9 +792,7 @@ impl ClusterInfoVoteListener {
 
     fn sum_stake(sum: &mut u64, epoch_stakes: Option<&EpochStakes>, pubkey: &Pubkey) {
         if let Some(stakes) = epoch_stakes {
-            if let Some(vote_account) = stakes.stakes().vote_accounts().get(pubkey) {
-                *sum += vote_account.0;
-            }
+            *sum += stakes.stakes().vote_accounts().get_delegated_stake(pubkey)
         }
     }
 }

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -55,9 +55,7 @@ impl EpochStakes {
     pub fn vote_account_stake(&self, vote_account: &Pubkey) -> u64 {
         self.stakes
             .vote_accounts()
-            .get(vote_account)
-            .map(|(stake, _)| *stake)
-            .unwrap_or(0)
+            .get_delegated_stake(vote_account)
     }
 
     fn parse_epoch_vote_accounts(

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -124,6 +124,13 @@ impl VoteAccounts {
         self.vote_accounts.get(pubkey)
     }
 
+    pub fn get_delegated_stake(&self, pubkey: &Pubkey) -> u64 {
+        self.vote_accounts
+            .get(pubkey)
+            .map(|(stake, ..)| *stake)
+            .unwrap_or_default()
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&Pubkey, &(u64, VoteAccount))> {
         self.vote_accounts.iter()
     }


### PR DESCRIPTION
#### Problem
There a few places that get the delegated stake for a vote account in the same way

#### Summary of Changes
- Add new `get_delegated_stake` method to `VoteAccounts` and use it instead of `VoteAccounts::get` where appropriate

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
