### PR TITLE
Add non-atomic interval for timing report

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -40,7 +40,7 @@ use {
         pubkey::Pubkey,
         signature::Signature,
         slot_hashes,
-        timing::AtomicInterval,
+        timing::NonAtomicInterval,
         transaction::Transaction,
     },
     std::{
@@ -187,7 +187,7 @@ impl BankSendVotesStats {
 struct VoteProcessingTiming {
     gossip_txn_processing_time_us: u64,
     gossip_slot_confirming_time_us: u64,
-    last_report: AtomicInterval,
+    last_report: NonAtomicInterval,
 }
 
 const VOTE_PROCESSING_REPORT_INTERVAL_MS: u64 = 1_000;

--- a/sdk/benches/interval.rs
+++ b/sdk/benches/interval.rs
@@ -1,0 +1,33 @@
+#![feature(test)]
+
+extern crate test;
+use {
+    solana_sdk::timing::{AtomicInterval, NonAtomicInterval},
+    test::Bencher,
+};
+
+#[bench]
+fn bench_atomic_interval(b: &mut Bencher) {
+    let interval = AtomicInterval::default();
+    b.iter(|| {
+        let mut _c = 0;
+        for _ in 0..1_00 {
+            if interval.should_update(1) {
+                _c += 1;
+            }
+        }
+    });
+}
+
+#[bench]
+fn bench_non_atomic_interval(b: &mut Bencher) {
+    let mut interval = NonAtomicInterval::default();
+    b.iter(|| {
+        let mut _c = 0;
+        for _ in 0..1_00 {
+            if interval.should_update(1) {
+                _c += 1;
+            }
+        }
+    });
+}

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -139,8 +139,8 @@ impl Interval<u64> {
     }
 }
 
-/// Thread safe. Can be used to time single/mutli thread execution. If you are timing single thread
-/// exectuion, consider using NonAtomicInterval, the no thread safe but with better performance.
+/// Thread safe. Can be used to time single/multi thread execution. If you are timing single thread
+/// execution, consider using NonAtomicInterval, the non thread safe version, but with better performance.
 pub type AtomicInterval = Interval<AtomicU64>;
 
 /// Not thread safe. Should only be used to time single thread execution.

--- a/sdk/src/timing.rs
+++ b/sdk/src/timing.rs
@@ -123,7 +123,7 @@ impl Interval<u64> {
         if passed || last == 0 {
             self.last_update = now;
         }
-        return passed;
+        passed
     }
 
     /// return ms elapsed since the last time the time was set


### PR DESCRIPTION
#### Problem

`AtomicInterval` in `sdk::timing` is convenient for timing report for both muti-thread and single thread execution. But for single thread execution, it incurs an unnecessary overhead for accessing and updating atomic variables. 


#### Summary of Changes
Add a non-atomic interval for timing single thread execution. 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
