### PR TITLE
Add const_assert_eq to PACKET_DATA_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,6 +5954,7 @@ dependencies = [
  "solana-logger 1.11.2",
  "solana-program 1.11.2",
  "solana-sdk-macro 1.11.2",
+ "static_assertions",
  "thiserror",
  "tiny-bip39",
  "uriparse",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -86,6 +86,7 @@ js-sys = "0.3.57"
 [dev-dependencies]
 anyhow = "1.0.57"
 curve25519-dalek = "3.2.1"
+static_assertions = "1.1.0"
 tiny-bip39 = "0.8.2"
 
 [build-dependencies]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -9,6 +9,8 @@ use {
     },
 };
 
+#[cfg(test)]
+static_assertions::const_assert_eq!(PACKET_DATA_SIZE, 1232);
 /// Maximum over-the-wire size of a Transaction
 ///   1280 is IPv6 minimum MTU
 ///   40 bytes is the size of the IPv6 header


### PR DESCRIPTION
The well known magic number `1232` is always hard to `grep`...:

![image](https://user-images.githubusercontent.com/117807/175804013-77645e65-9eed-44a9-a452-8b4b634b5dfe.png)


precedent: #16812