### PR TITLE
bpf_loader: adjust to AlignedMemory API changes

### DIFF
--- a/programs/bpf_loader/src/allocator_bump.rs
+++ b/programs/bpf_loader/src/allocator_bump.rs
@@ -2,21 +2,21 @@
 
 use {
     solana_program_runtime::invoke_context::{Alloc, AllocErr},
-    solana_rbpf::aligned_memory::AlignedMemory,
+    solana_rbpf::{aligned_memory::AlignedMemory, ebpf::HOST_ALIGN},
     std::alloc::Layout,
 };
 
 #[derive(Debug)]
 pub struct BpfAllocator {
     #[allow(dead_code)]
-    heap: AlignedMemory,
+    heap: AlignedMemory<{ HOST_ALIGN }>,
     start: u64,
     len: u64,
     pos: u64,
 }
 
 impl BpfAllocator {
-    pub fn new(heap: AlignedMemory, virtual_address: u64) -> Self {
+    pub fn new(heap: AlignedMemory<{ HOST_ALIGN }>, virtual_address: u64) -> Self {
         let len = heap.len() as u64;
         Self {
             heap,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -28,7 +28,7 @@ use {
     },
     solana_rbpf::{
         aligned_memory::AlignedMemory,
-        ebpf::{HOST_ALIGN, MM_INPUT_START},
+        ebpf::MM_INPUT_START,
         elf::Executable,
         error::{EbpfError, UserDefinedError},
         memory_region::MemoryRegion,
@@ -306,8 +306,7 @@ pub fn create_vm<'a, 'b>(
                 .saturating_mul(compute_budget.heap_cost),
         );
     }
-    let mut heap =
-        AlignedMemory::new_with_size(compute_budget.heap_size.unwrap_or(HEAP_LENGTH), HOST_ALIGN);
+    let mut heap = AlignedMemory::new_with_size(compute_budget.heap_size.unwrap_or(HEAP_LENGTH));
     let parameter_region = MemoryRegion::new_writable(parameter_bytes, MM_INPUT_START);
     let mut vm = EbpfVm::new(program, heap.as_slice_mut(), vec![parameter_region])?;
     syscalls::bind_syscall_context_objects(&mut vm, invoke_context, heap, orig_account_lengths)?;

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -17,7 +17,7 @@ use {
 pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-) -> Result<(AlignedMemory, Vec<usize>), InstructionError> {
+) -> Result<(AlignedMemory<{ HOST_ALIGN }>, Vec<usize>), InstructionError> {
     let is_loader_deprecated = *instruction_context
         .try_borrow_last_program_account(transaction_context)?
         .get_owner()
@@ -70,7 +70,7 @@ pub fn deserialize_parameters(
 pub fn serialize_parameters_unaligned(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-) -> Result<AlignedMemory, InstructionError> {
+) -> Result<AlignedMemory<{ HOST_ALIGN }>, InstructionError> {
     // Calculate size in order to alloc once
     let mut size = size_of::<u64>();
     for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts() {
@@ -96,7 +96,7 @@ pub fn serialize_parameters_unaligned(
     size += size_of::<u64>() // instruction data len
          + instruction_context.get_instruction_data().len() // instruction data
          + size_of::<Pubkey>(); // program id
-    let mut v = AlignedMemory::new(size, HOST_ALIGN);
+    let mut v = AlignedMemory::new(size);
 
     v.write_u64::<LittleEndian>(instruction_context.get_number_of_instruction_accounts() as u64)
         .map_err(|_| InstructionError::InvalidArgument)?;
@@ -188,7 +188,7 @@ pub fn deserialize_parameters_unaligned(
 pub fn serialize_parameters_aligned(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
-) -> Result<AlignedMemory, InstructionError> {
+) -> Result<AlignedMemory<{ HOST_ALIGN }>, InstructionError> {
     // Calculate size in order to alloc once
     let mut size = size_of::<u64>();
     for instruction_account_index in 0..instruction_context.get_number_of_instruction_accounts() {
@@ -219,7 +219,7 @@ pub fn serialize_parameters_aligned(
     size += size_of::<u64>() // data len
     + instruction_context.get_instruction_data().len()
     + size_of::<Pubkey>(); // program id;
-    let mut v = AlignedMemory::new(size, HOST_ALIGN);
+    let mut v = AlignedMemory::new(size);
 
     // Serialize into the buffer
     v.write_u64::<LittleEndian>(instruction_context.get_number_of_instruction_accounts() as u64)

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1,3 +1,4 @@
+use solana_rbpf::ebpf::HOST_ALIGN;
 #[allow(deprecated)]
 use {
     crate::{allocator_bump::BpfAllocator, BpfError},
@@ -360,7 +361,7 @@ pub fn register_syscalls(
 pub fn bind_syscall_context_objects<'a, 'b>(
     vm: &mut EbpfVm<'a, RequisiteVerifier, BpfError, crate::ThisInstructionMeter>,
     invoke_context: &'a mut InvokeContext<'b>,
-    heap: AlignedMemory,
+    heap: AlignedMemory<{ HOST_ALIGN }>,
     orig_account_lengths: Vec<usize>,
 ) -> Result<(), EbpfError<BpfError>> {
     let check_aligned = bpf_loader_deprecated::id()
@@ -4258,7 +4259,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
@@ -4300,7 +4301,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),
@@ -4341,7 +4342,7 @@ mod tests {
                 program_id,
                 bpf_loader::id(),
             );
-            let mut heap = AlignedMemory::new_with_size(100, HOST_ALIGN);
+            let mut heap = AlignedMemory::new_with_size(100);
             let mut memory_mapping = MemoryMapping::new::<UserError>(
                 vec![
                     MemoryRegion::default(),


### PR DESCRIPTION
#### Problem

AlignedMemory API changed to use const generics https://github.com/solana-labs/rbpf/pull/351

#### Summary of Changes

Made compiler happy again.