### PR TITLE
discards shreds in sigverify if the slot leader is the node itself

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -453,7 +453,6 @@ impl RetransmitStage {
             exit.clone(),
         );
 
-        let leader_schedule_cache_clone = leader_schedule_cache.clone();
         let repair_info = RepairInfo {
             bank_forks,
             epoch_schedule,
@@ -471,18 +470,12 @@ impl RetransmitStage {
             exit,
             repair_info,
             leader_schedule_cache,
-            move |id, shred, working_bank, last_root| {
+            move |shred, last_root| {
                 let turbine_disabled = turbine_disabled
                     .as_ref()
                     .map(|x| x.load(Ordering::Relaxed))
                     .unwrap_or(false);
-                let rv = should_retransmit_and_persist(
-                    shred,
-                    working_bank,
-                    &leader_schedule_cache_clone,
-                    id,
-                    last_root,
-                );
+                let rv = should_retransmit_and_persist(shred, last_root);
                 rv && !turbine_disabled
             },
             verified_vote_receiver,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -160,6 +160,7 @@ impl Tvu {
         let sigverify_stage = SigVerifyStage::new(
             fetch_receiver,
             ShredSigVerifier::new(
+                cluster_info.id(),
                 bank_forks.clone(),
                 leader_schedule_cache.clone(),
                 verified_sender,


### PR DESCRIPTION

#### Problem
Shreds are dropped in window-service if the slot leader is the node
itself:
https://github.com/solana-labs/solana/blob/cd2878acf/core/src/window_service.rs#L181-L185

However this is done after wasting resources verifying signature on
these shreds, and requires a redundant 2nd lookup of the slot leader.


#### Summary of Changes

This commit instead discards such shreds in sigverify stage where we
already know the leader for the slot.
