### PR TITLE
skips shreds deserialization before retransmit

### DIFF
--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -51,7 +51,7 @@ fn get_retransmit_peers_deterministic(
         );
         let (_root_distance, _neighbors, _children) = cluster_nodes.get_retransmit_peers(
             slot_leader,
-            &shred,
+            &shred.id(),
             root_bank,
             solana_gossip::cluster_info::DATA_PLANE_FANOUT,
         );

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -155,7 +155,8 @@ fn bench_retransmitter(bencher: &mut Bencher) {
             shred.set_index(index);
             index += 1;
             index %= 200;
-            let _ = shreds_sender.send(vec![shred.clone()]);
+            let shred = shred.payload().clone();
+            let _ = shreds_sender.send(vec![shred]);
         }
         slot += 1;
 

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -419,7 +419,7 @@ pub fn broadcast_shreds(
             let root_bank = root_bank.clone();
             shreds.flat_map(move |shred| {
                 repeat(shred.payload()).zip(cluster_nodes.get_broadcast_addrs(
-                    shred,
+                    &shred.id(),
                     &root_bank,
                     DATA_PLANE_FANOUT,
                     socket_addr_space,

--- a/core/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/core/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -303,7 +303,12 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             .iter()
             .filter_map(|shred| {
                 let addr = cluster_nodes
-                    .get_broadcast_addrs(shred, &root_bank, DATA_PLANE_FANOUT, socket_addr_space)
+                    .get_broadcast_addrs(
+                        &shred.id(),
+                        &root_bank,
+                        DATA_PLANE_FANOUT,
+                        socket_addr_space,
+                    )
                     .first()
                     .copied()?;
                 let node = nodes.iter().find(|node| node.tvu == addr)?;

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -12,7 +12,7 @@ use {
         crds_value::{CrdsData, CrdsValue},
         weighted_shuffle::WeightedShuffle,
     },
-    solana_ledger::shred::Shred,
+    solana_ledger::shred::ShredId,
     solana_runtime::bank::Bank,
     solana_sdk::{
         clock::{Epoch, Slot},
@@ -116,13 +116,13 @@ impl ClusterNodes<BroadcastStage> {
 
     pub(crate) fn get_broadcast_addrs(
         &self,
-        shred: &Shred,
+        shred: &ShredId,
         root_bank: &Bank,
         fanout: usize,
         socket_addr_space: &SocketAddrSpace,
     ) -> Vec<SocketAddr> {
         const MAX_CONTACT_INFO_AGE: Duration = Duration::from_secs(2 * 60);
-        let shred_seed = shred.id().seed(&self.pubkey);
+        let shred_seed = shred.seed(&self.pubkey);
         let mut rng = ChaChaRng::from_seed(shred_seed);
         let index = match self.weighted_shuffle.first(&mut rng) {
             None => return Vec::default(),
@@ -177,7 +177,7 @@ impl ClusterNodes<RetransmitStage> {
     pub(crate) fn get_retransmit_addrs(
         &self,
         slot_leader: &Pubkey,
-        shred: &Shred,
+        shred: &ShredId,
         root_bank: &Bank,
         fanout: usize,
     ) -> (/*root_distance:*/ usize, Vec<SocketAddr>) {
@@ -213,7 +213,7 @@ impl ClusterNodes<RetransmitStage> {
     pub fn get_retransmit_peers(
         &self,
         slot_leader: &Pubkey,
-        shred: &Shred,
+        shred: &ShredId,
         root_bank: &Bank,
         fanout: usize,
     ) -> (
@@ -221,7 +221,7 @@ impl ClusterNodes<RetransmitStage> {
         Vec<&Node>, // neighbors
         Vec<&Node>, // children
     ) {
-        let shred_seed = shred.id().seed(slot_leader);
+        let shred_seed = shred.seed(slot_leader);
         let mut weighted_shuffle = self.weighted_shuffle.clone();
         // Exclude slot leader from list of nodes.
         if slot_leader == &self.pubkey {

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -4,7 +4,6 @@
 use {
     ahash::AHasher,
     rand::{thread_rng, Rng},
-    solana_ledger::shred::Shred,
     solana_perf::packet::Packet,
     std::hash::Hasher,
 };
@@ -29,8 +28,8 @@ impl PacketHasher {
         self.hash_data(packet.data(..).unwrap_or_default())
     }
 
-    pub(crate) fn hash_shred(&self, shred: &Shred) -> u64 {
-        self.hash_data(shred.payload())
+    pub(crate) fn hash_shred(&self, shred: &[u8]) -> u64 {
+        self.hash_data(shred)
     }
 
     fn hash_data(&self, data: &[u8]) -> u64 {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -798,7 +798,7 @@ impl Blockstore {
         is_repaired: Vec<bool>,
         leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
-        retransmit_sender: Option<&Sender<Vec<Shred>>>,
+        retransmit_sender: Option<&Sender<Vec</*shred:*/ Vec<u8>>>>,
         handle_duplicate: &F,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<(Vec<CompletedDataSetInfo>, Vec<usize>)>
@@ -937,7 +937,12 @@ impl Blockstore {
                 .collect();
             if !recovered_data_shreds.is_empty() {
                 if let Some(retransmit_sender) = retransmit_sender {
-                    let _ = retransmit_sender.send(recovered_data_shreds);
+                    let _ = retransmit_sender.send(
+                        recovered_data_shreds
+                            .into_iter()
+                            .map(Shred::into_payload)
+                            .collect(),
+                    );
                 }
             }
         }


### PR DESCRIPTION
#### Problem
Fully deserializing shreds in window-service before sending them to
retransmit stage adds latency to shreds propagation.

#### Summary of Changes
This commit instead channels through the payload and relies on only
partial deserialization of the few required fields: slot, shred-index,
shred-type.
