### PR TITLE
Enable wire compression in Solana CLI and Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +153,20 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-mutex"
@@ -445,6 +474,27 @@ dependencies = [
  "proc-macro2 1.0.38",
  "quote 1.0.18",
  "syn 1.0.93",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3741,6 +3791,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
@@ -3768,6 +3819,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.23.3",
+ "tokio-util 0.6.9",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4892,7 +4944,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "raptorq",
  "rayon",
- "reqwest",
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ humantime = "2.0.1"
 log = "0.4.17"
 num-traits = "0.2"
 pretty-hex = "0.3.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.10"
 serde = "1.0.137"
 serde_derive = "1.0.103"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,7 +32,7 @@ quinn-proto = "0.8.3"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.3"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 rustls = { version = "0.20.6", features = ["dangerous_configuration"] }
 semver = "1.0.10"
 serde = "1.0.137"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,7 +67,6 @@ trees = "0.4.2"
 [dev-dependencies]
 matches = "0.1.9"
 raptorq = "1.7.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde_json = "1.0.81"
 serial_test = "0.6.0"
 solana-logger = { path = "../logger", version = "=1.11.2" }

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 console = "0.15.0"
 indicatif = "0.16.2"
 log = "0.4.17"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-runtime = { path = "../runtime", version = "=1.11.2" }
 solana-sdk = { path = "../sdk", version = "=1.11.2" }
 

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -22,7 +22,7 @@ dirs-next = "2.0.0"
 indicatif = "0.16.2"
 lazy_static = "1.4.0"
 nix = "0.24.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_yaml = "0.8.24"

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -14,7 +14,7 @@ crossbeam-channel = "0.5"
 gethostname = "0.2.3"
 lazy_static = "1.4.0"
 log = "0.4.17"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "=1.11.2" }
 
 [dev-dependencies]

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde_json = "1.0"
 
 [lib]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -81,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +139,20 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-mutex"
@@ -404,6 +433,27 @@ dependencies = [
  "proc-macro2 1.0.38",
  "quote 1.0.18",
  "syn 1.0.93",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3325,6 +3375,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
@@ -3352,6 +3403,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.23.2",
+ "tokio-util 0.6.9",
  "url 2.2.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -16,7 +16,7 @@ bs58 = "0.4.0"
 crossbeam-channel = "0.5"
 futures-util = "0.3.21"
 log = "0.4.17"
-reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
 serde = "1.0.137"
 serde_json = "1.0.81"
 solana-account-decoder = { path = "../account-decoder", version = "=1.11.2" }


### PR DESCRIPTION
#### Problem

Are you feeling **SQUEEZED**? Has life got you in a **VICE**? Is the **PRESSURE** getting to you? Well _SQUEEZE BACK_!

JSON is a _terrible_ wire format, full of redundant markup and waste. The easiest mitigation for this is to employ a wire _compression_ algorithm, like gzip. Savings can be as much as 80%.

Wire compression, however, works better when you turn it on.

#### Summary of Changes

* Enable gzip, deflate, and brotli compression in the Solana CLI and Rust client, wherever supported by an RPC provider.
* Actually, just go and enable it everywhere.
* Remove `reqwest` dependency from `core`, where it is – in fact – not used.

#### Test plan

This PR doesn't need to be tested, per se, because the implementation of the HTTP header-crafting and response decompression is [already tested](https://github.com/seanmonstar/reqwest/blob/master/tests/gzip.rs) as part of the Rust `reqwest` crate.

Here's a run of `cargo run block 125791054` with a proxy on the wire. You can see the new `accept-encoding` header being sent in the request, and Triton's RPC proxy responding with a gzipped response body. 80% reduction in bytes over the wire too!

![A screenshot of a wire proxy showing an 80% reduction in bytes over the wire when making a request for a block from an RPC](https://user-images.githubusercontent.com/13243/175874603-f5a2d035-a8c9-4438-8d13-e48637359876.png)

#### Thanks!

Thank you to @linuskendall for bringing this one to my attention!