### PR TITLE
explorer: support for pyth batch price update ix

### DIFF
--- a/explorer/src/components/instruction/pyth/PythDetailsCard.tsx
+++ b/explorer/src/components/instruction/pyth/PythDetailsCard.tsx
@@ -87,6 +87,14 @@ export function PythDetailsCard(props: {
             {...props}
           />
         );
+
+      case "UpdatePriceNoFailOnError":
+        return (
+          <UpdatePriceDetailsCard
+            info={PythInstruction.decodeUpdatePriceNoFailOnError(ix)}
+            {...props}
+          />
+        );
       case "AggregatePrice":
         return (
           <AggregatePriceDetailsCard

--- a/explorer/src/components/instruction/pyth/program.ts
+++ b/explorer/src/components/instruction/pyth/program.ts
@@ -22,7 +22,8 @@ export type PythInstructionType =
   | "InitPrice"
   | "InitTest"
   | "UpdateTest"
-  | "SetMinPublishers";
+  | "SetMinPublishers"
+  | "UpdatePriceNoFailOnError";
 
 export function headerLayout(property: string = "header") {
   return BufferLayout.struct(
@@ -185,6 +186,17 @@ export const PYTH_INSTRUCTION_LAYOUTS: {
       headerLayout(),
       BufferLayout.u8("minPublishers"),
       BufferLayout.blob(3, "unused1"),
+    ]),
+  },
+  UpdatePriceNoFailOnError: {
+    index: 13,
+    layout: BufferLayout.struct([
+      headerLayout(),
+      BufferLayout.u32("status"),
+      BufferLayout.u32("unused1"),
+      BufferLayout.ns64("price"),
+      BufferLayout.nu64("conf"),
+      BufferLayout.nu64("publishSlot"),
     ]),
   },
 });
@@ -420,6 +432,27 @@ export class PythInstruction {
   ): UpdatePriceParams {
     const { status, price, conf, publishSlot } = decodeData(
       PYTH_INSTRUCTION_LAYOUTS.UpdatePrice,
+      instruction.data
+    );
+
+    return {
+      publisherPubkey: instruction.keys[0].pubkey,
+      pricePubkey: instruction.keys[1].pubkey,
+      status,
+      price,
+      conf,
+      publishSlot,
+    };
+  }
+
+  /**
+   * Decode an "update price no fail error" instruction and retrieve the instruction params.
+   */
+  static decodeUpdatePriceNoFailOnError(
+    instruction: TransactionInstruction
+  ): UpdatePriceParams {
+    const { status, price, conf, publishSlot } = decodeData(
+      PYTH_INSTRUCTION_LAYOUTS.UpdatePriceNoFailOnError,
       instruction.data
     );
 


### PR DESCRIPTION
#### Problem
The Solana explorer shows Pyth batch price update instructions (e.g. https://explorer.solana.com/tx/5ZhsmeaVQ9N4sZAcEb89JHNk7PaAVFxDxf4bNgpu6sSMoRK2WD7MamUC4ZNvDSFz2wtaNb47syksFkJwPBqiMgiN) as "Unknown Instruction".

#### Summary of Changes
Add explorer support for Pyth batch price update instruction


