### PR TITLE
Increase the QUIC stream timeout duration to improve perf

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -32,7 +32,7 @@ use {
 };
 
 const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: f64 = 100_000f64;
-const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 1;
+const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 100;
 
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_server(


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/26133 shortened the stream timeout too much and negatively impacted stream handling performance

#### Summary of Changes
Increase timeout from 1ms to 100ms

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
