### PR TITLE
Fix active vote account close error

### DIFF
--- a/programs/vote/src/vote_error.rs
+++ b/programs/vote/src/vote_error.rs
@@ -64,6 +64,9 @@ pub enum VoteError {
 
     #[error("Proposed root is not in slot hashes")]
     RootOnDifferentFork,
+
+    #[error("Cannot close vote account unless it stopped voting at least one full epoch ago")]
+    ActiveVoteAccountClose,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1178,7 +1178,7 @@ mod tests {
             &serialize(&VoteInstruction::Withdraw(lamports)).unwrap(),
             transaction_accounts.clone(),
             instruction_accounts.clone(),
-            Err(InstructionError::ActiveVoteAccountClose),
+            Err(VoteError::ActiveVoteAccountClose.into()),
         );
 
         // Both features disabled:

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -1336,7 +1336,7 @@ pub fn withdraw<S: std::hash::BuildHasher>(
 
         if reject_active_vote_account_close {
             datapoint_debug!("vote-account-close", ("reject-active", 1, i64));
-            return Err(InstructionError::ActiveVoteAccountClose);
+            return Err(VoteError::ActiveVoteAccountClose.into());
         } else {
             // Deinitialize upon zero-balance
             datapoint_debug!("vote-account-close", ("allow", 1, i64));


### PR DESCRIPTION
#### Problem
The `ActiveVoteAccountClose` error was added to `InstructionError` and `ProgramError` instead of `VoteError`

#### Summary of Changes
Fix the error

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
