### PR TITLE
moves Shred::seed to ShredId and adds test coverage

### DIFF
--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -50,7 +50,7 @@ fn get_retransmit_peers_deterministic(
             0,
         );
         let (_root_distance, _neighbors, _children) = cluster_nodes.get_retransmit_peers(
-            *slot_leader,
+            slot_leader,
             &shred,
             root_bank,
             solana_gossip::cluster_info::DATA_PLANE_FANOUT,

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -122,7 +122,7 @@ impl ClusterNodes<BroadcastStage> {
         socket_addr_space: &SocketAddrSpace,
     ) -> Vec<SocketAddr> {
         const MAX_CONTACT_INFO_AGE: Duration = Duration::from_secs(2 * 60);
-        let shred_seed = shred.seed(self.pubkey);
+        let shred_seed = shred.id().seed(&self.pubkey);
         let mut rng = ChaChaRng::from_seed(shred_seed);
         let index = match self.weighted_shuffle.first(&mut rng) {
             None => return Vec::default(),
@@ -176,7 +176,7 @@ impl ClusterNodes<BroadcastStage> {
 impl ClusterNodes<RetransmitStage> {
     pub(crate) fn get_retransmit_addrs(
         &self,
-        slot_leader: Pubkey,
+        slot_leader: &Pubkey,
         shred: &Shred,
         root_bank: &Bank,
         fanout: usize,
@@ -212,7 +212,7 @@ impl ClusterNodes<RetransmitStage> {
 
     pub fn get_retransmit_peers(
         &self,
-        slot_leader: Pubkey,
+        slot_leader: &Pubkey,
         shred: &Shred,
         root_bank: &Bank,
         fanout: usize,
@@ -221,12 +221,12 @@ impl ClusterNodes<RetransmitStage> {
         Vec<&Node>, // neighbors
         Vec<&Node>, // children
     ) {
-        let shred_seed = shred.seed(slot_leader);
+        let shred_seed = shred.id().seed(slot_leader);
         let mut weighted_shuffle = self.weighted_shuffle.clone();
         // Exclude slot leader from list of nodes.
-        if slot_leader == self.pubkey {
+        if slot_leader == &self.pubkey {
             error!("retransmit from slot leader: {}", slot_leader);
-        } else if let Some(index) = self.index.get(&slot_leader) {
+        } else if let Some(index) = self.index.get(slot_leader) {
             weighted_shuffle.remove_index(*index);
         };
         let mut rng = ChaChaRng::from_seed(shred_seed);

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -255,7 +255,7 @@ fn retransmit(
             .map(|(index, (shred, slot_leader, cluster_nodes))| {
                 let (root_distance, num_nodes) = retransmit_shred(
                     &shred,
-                    slot_leader,
+                    &slot_leader,
                     &root_bank,
                     &cluster_nodes,
                     socket_addr_space,
@@ -274,7 +274,7 @@ fn retransmit(
                     let index = thread_pool.current_thread_index().unwrap();
                     let (root_distance, num_nodes) = retransmit_shred(
                         &shred,
-                        slot_leader,
+                        &slot_leader,
                         &root_bank,
                         &cluster_nodes,
                         socket_addr_space,
@@ -296,7 +296,7 @@ fn retransmit(
 
 fn retransmit_shred(
     shred: &Shred,
-    slot_leader: Pubkey,
+    slot_leader: &Pubkey,
     root_bank: &Bank,
     cluster_nodes: &ClusterNodes<RetransmitStage>,
     socket_addr_space: &SocketAddrSpace,


### PR DESCRIPTION
#### Problem
Following commits will skip shreds deserializaton before retransmit, and
so we will only have a `ShredId` and not a fully deserialized shred to
obtain the shuffling seed from.


#### Summary of Changes
moved `Shred::seed` to `ShredId` and adds test coverage