### PR TITLE
Add `--gossip-warmup-time`

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -49,6 +49,7 @@ pub struct RpcBootstrapConfig {
     pub max_genesis_archive_unpacked_size: u64,
     pub check_vote_account: Option<String>,
     pub incremental_snapshot_fetch: bool,
+    pub gossip_warmup_time: Duration,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -849,6 +850,16 @@ mod with_incremental_snapshots {
                     should_check_duplicate_instance,
                     socket_addr_space,
                 ));
+
+                debug!(
+                    "gossip warmup time: {:?}",
+                    bootstrap_config.gossip_warmup_time
+                );
+                if bootstrap_config.gossip_warmup_time > Duration::default() {
+                    info!("Waiting for gossip to warmup...");
+                    sleep(bootstrap_config.gossip_warmup_time);
+                    info!("Waiting for gossip to warmup... DONE");
+                }
             }
 
             let rpc_node_details = get_rpc_node(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1768,6 +1768,20 @@ pub fn main() {
                 .help("Allow contacting private ip addresses")
                 .hidden(true),
         )
+        .arg(
+            Arg::with_name("gossip_warmup_time")
+                .long("gossip-warmup-time")
+                .help("The amount of time to wait for gossip to warmup during bootstrap")
+                .long_help("The amount of time to wait, in seconds, for gossip to warmup during bootstrap. \
+                            Populating the gossip table takes time, and is used to discover snapshots on \
+                            cluster. To ensure all/enough of the table is available, an additional delay \
+                            may be necessary. Consider setting this option when you observe that incremental \
+                            snapshots are not being downloaded, and instead only very old full snapshots \
+                            are downloaded.")
+                .takes_value(true)
+                .value_name("SECONDS")
+                .default_value("0")
+        )
         .after_help("The default subcommand is run")
         .subcommand(
             SubCommand::with_name("exit")
@@ -2227,6 +2241,11 @@ pub fn main() {
             u64
         ),
         incremental_snapshot_fetch: !matches.is_present("no_incremental_snapshots"),
+        gossip_warmup_time: Duration::from_secs_f64(value_t_or_exit!(
+            matches,
+            "gossip_warmup_time",
+            f64
+        )),
     };
 
     let private_rpc = matches.is_present("private_rpc");


### PR DESCRIPTION
#### Problem

Gossip may not be fully warmed up by the time it is needed in bootstrap. Refer to issue #26180 for the full context. Refer to the long help in the diff as well.

#### Summary of Changes

Add a new validator cli `--gossip-warmup-time` to set the number of seconds to let gossip warmup before moving on.

Fixes #26180