### PR TITLE
Add user-agent header to Solana rust client requests

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -12,7 +12,7 @@ use {
     log::*,
     reqwest::{
         self,
-        header::{CONTENT_TYPE, RETRY_AFTER},
+        header::{self, CONTENT_TYPE, RETRY_AFTER},
         StatusCode,
     },
     std::{
@@ -46,8 +46,17 @@ impl HttpSender {
     ///
     /// The URL is an HTTP URL, usually for port 8899.
     pub fn new_with_timeout<U: ToString>(url: U, timeout: Duration) -> Self {
+        let mut default_headers = header::HeaderMap::new();
+        let user_agent_string =
+            format!("rust-solana-client/{}", solana_version::Version::default());
+        default_headers.append(
+            header::USER_AGENT,
+            header::HeaderValue::from_str(user_agent_string.as_str()).unwrap(),
+        );
+
         let client = Arc::new(
             reqwest::Client::builder()
+                .default_headers(default_headers)
                 .timeout(timeout)
                 .build()
                 .expect("build rpc client"),


### PR DESCRIPTION
#### Problem

RPC providers collect metrics today, but have no way of filtering those metrics by a particular version of the client. This would be useful in identifying regressions (eg. a version of the client that's particularly badly behaved) or improvements (eg. a version of the client that aims to reduce load on RPCs, like #26236).

#### Summary of Changes

* Added a `user-agent` HTTP header to each request.

#### Test plan

```
cd cli && cargo run block 125791054 
```

Attached a proxy and observed the header making it out.

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/13243/176014328-19324c1a-99b0-4a11-92e1-835af2f7d8a2.png">
