### PR TITLE
AccountsIndex::Scan takes iter

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2531,7 +2531,7 @@ impl AccountsDb {
                         let mut missing = 0;
                         let mut useful = 0;
                         self.accounts_index.scan(
-                            pubkeys,
+                            pubkeys.iter(),
                             // return true if we want this item to remain in the cache
                             |exists, slot_list, pubkey, ref_count| {
                                 let mut useless = true;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1293,7 +1293,7 @@ impl<T: IndexValue> AccountsIndex<T> {
 
     /// For each pubkey, find the slot list in the accounts index
     ///   call `callback`
-    pub(crate) fn scan<F>(&self, pubkeys: &[Pubkey], mut callback: F)
+    pub(crate) fn scan<'a, F, I>(&'a self, pubkeys: I, mut callback: F)
     where
         // return true if accounts index entry should be put in in_mem cache
         // params:
@@ -1302,11 +1302,12 @@ impl<T: IndexValue> AccountsIndex<T> {
         //  pubkey looked up
         //  refcount of entry in index
         F: FnMut(bool, &SlotList<T>, &Pubkey, RefCount) -> bool,
+        I: IntoIterator<Item = &'a Pubkey>,
     {
         let empty_slot_list = vec![];
         let mut lock = None;
         let mut last_bin = self.bins(); // too big, won't match
-        pubkeys.iter().for_each(|pubkey| {
+        pubkeys.into_iter().for_each(|pubkey| {
             let bin = self.bin_calculator.bin_from_pubkey(pubkey);
             if bin != last_bin {
                 // cannot re-use lock since next pubkey is in a different bin than previous one


### PR DESCRIPTION
#### Problem

This allows us to begin with [(Pubkey, ...)] and prevent making copies in re-use scenarios of this function.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
