### PR TITLE
Close QUIC connection before dropping the entry

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -7,7 +7,8 @@ use {
     futures_util::stream::StreamExt,
     percentage::Percentage,
     quinn::{
-        Connecting, Endpoint, EndpointConfig, Incoming, IncomingUniStreams, NewConnection, VarInt,
+        Connecting, Connection, Endpoint, EndpointConfig, Incoming, IncomingUniStreams,
+        NewConnection, VarInt,
     },
     solana_perf::packet::PacketBatch,
     solana_sdk::{
@@ -177,6 +178,7 @@ async fn setup_connection(
         if stake != 0 || max_unstaked_connections > 0 {
             if let Some((last_update, stream_exit)) = connection_table_l.try_add_connection(
                 &remote_addr,
+                Some(connection),
                 timing::timestamp(),
                 max_connections_per_ip,
             ) {
@@ -369,14 +371,21 @@ struct ConnectionEntry {
     exit: Arc<AtomicBool>,
     last_update: Arc<AtomicU64>,
     port: u16,
+    connection: Option<Connection>,
 }
 
 impl ConnectionEntry {
-    fn new(exit: Arc<AtomicBool>, last_update: Arc<AtomicU64>, port: u16) -> Self {
+    fn new(
+        exit: Arc<AtomicBool>,
+        last_update: Arc<AtomicU64>,
+        port: u16,
+        connection: Option<Connection>,
+    ) -> Self {
         Self {
             exit,
             last_update,
             port,
+            connection,
         }
     }
 
@@ -387,6 +396,9 @@ impl ConnectionEntry {
 
 impl Drop for ConnectionEntry {
     fn drop(&mut self) {
+        if let Some(conn) = &self.connection {
+            conn.close(0u32.into(), &[0u8]);
+        }
         self.exit.store(true, Ordering::Relaxed);
     }
 }
@@ -426,6 +438,7 @@ impl ConnectionTable {
     fn try_add_connection(
         &mut self,
         addr: &SocketAddr,
+        connection: Option<Connection>,
         last_update: u64,
         max_connections_per_ip: usize,
     ) -> Option<(Arc<AtomicU64>, Arc<AtomicBool>)> {
@@ -442,6 +455,7 @@ impl ConnectionTable {
                 exit.clone(),
                 last_update.clone(),
                 addr.port(),
+                connection,
             ));
             self.total_size += 1;
             Some((last_update, exit))
@@ -831,12 +845,12 @@ pub mod test {
             .collect();
         for (i, socket) in sockets.iter().enumerate() {
             table
-                .try_add_connection(socket, i as u64, max_connections_per_ip)
+                .try_add_connection(socket, None, i as u64, max_connections_per_ip)
                 .unwrap();
         }
         num_entries += 1;
         table
-            .try_add_connection(&sockets[0], 5, max_connections_per_ip)
+            .try_add_connection(&sockets[0], None, 5, max_connections_per_ip)
             .unwrap();
 
         let new_size = 3;
@@ -868,11 +882,11 @@ pub mod test {
             .collect();
         for (i, socket) in sockets.iter().enumerate() {
             table
-                .try_add_connection(socket, (i * 2) as u64, max_connections_per_ip)
+                .try_add_connection(socket, None, (i * 2) as u64, max_connections_per_ip)
                 .unwrap();
 
             table
-                .try_add_connection(socket, (i * 2 + 1) as u64, max_connections_per_ip)
+                .try_add_connection(socket, None, (i * 2 + 1) as u64, max_connections_per_ip)
                 .unwrap();
         }
 
@@ -881,6 +895,7 @@ pub mod test {
         table
             .try_add_connection(
                 &single_connection_addr,
+                None,
                 (num_ips * 2) as u64,
                 max_connections_per_ip,
             )

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -396,7 +396,7 @@ impl ConnectionEntry {
 
 impl Drop for ConnectionEntry {
     fn drop(&mut self) {
-        if let Some(conn) = &self.connection {
+        if let Some(conn) = self.connection.take() {
             conn.close(0u32.into(), &[0u8]);
         }
         self.exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
Handling of QUIC stream exit can be improved.
Reference: https://github.com/solana-labs/solana/pull/26116#discussion_r903468164

#### Summary of Changes
Close the connection on dropping (pruning) the connection. This will force all corresponding streams to also close. That'll help cleanup the stream faster than waiting for the timeouts.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
