### PR TITLE
Do not unwrap the oldest IP in QUIC connectiont table

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -415,9 +415,15 @@ impl ConnectionTable {
                     }
                 }
             }
-            if let Some(removed) = self.table.remove(&oldest_ip.unwrap()) {
-                self.total_size -= removed.len();
-                num_pruned += removed.len();
+            if let Some(oldest_ip) = oldest_ip {
+                if let Some(removed) = self.table.remove(&oldest_ip) {
+                    self.total_size -= removed.len();
+                    num_pruned += removed.len();
+                }
+            } else {
+                // No valid entries in the table with an IP address. Continuing the loop will cause
+                // infinite looping.
+                break;
             }
         }
         num_pruned


### PR DESCRIPTION
#### Problem
Calling `unwrap` on `oldest_ip` while it's `None` is causing crash.

#### Summary of Changes
If the table is empty, or has no valid entry, the value of `oldest_ip` will be `None`.
This is a defensive check to use `oldest_ip` only when it is not `None`. 

Fixes #26263
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
