### PR TITLE
Removes `LamportsError` from `BorrowedAccount`

### DIFF
--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -177,13 +177,11 @@ pub fn withdraw_nonce_account(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    from.checked_sub_lamports(lamports)
-        .map_err(|_| InstructionError::ArithmeticOverflow)?;
+    from.checked_sub_lamports(lamports)?;
     drop(from);
     let mut to = instruction_context
         .try_borrow_instruction_account(transaction_context, to_account_index)?;
-    to.checked_add_lamports(lamports)
-        .map_err(|_| InstructionError::ArithmeticOverflow)?;
+    to.checked_add_lamports(lamports)?;
 
     Ok(())
 }

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -4,7 +4,6 @@ use {
     crate::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         instruction::InstructionError,
-        lamports::LamportsError,
         pubkey::Pubkey,
     },
     std::{
@@ -559,7 +558,7 @@ impl<'a> BorrowedAccount<'a> {
         self.set_lamports(
             self.get_lamports()
                 .checked_add(lamports)
-                .ok_or(LamportsError::ArithmeticOverflow)?,
+                .ok_or(InstructionError::ArithmeticOverflow)?,
         )
     }
 
@@ -568,7 +567,7 @@ impl<'a> BorrowedAccount<'a> {
         self.set_lamports(
             self.get_lamports()
                 .checked_sub(lamports)
-                .ok_or(LamportsError::ArithmeticUnderflow)?,
+                .ok_or(InstructionError::ArithmeticOverflow)?,
         )
     }
 


### PR DESCRIPTION
#### Problem
Spin-off from #25899. Both kinds of `LamportsError` are turned into `InstructionError::ArithmeticOverflow` anyway. See https://github.com/solana-labs/solana/blob/39ca788b9562d67daaef657371c9d5330063f068/sdk/program/src/lamports.rs#L16

#### Summary of Changes
- Simplifies `BorrowedAccount::checked_add_lamports()` and `BorrowedAccount::checked_sub_lamports()`.
- Removes `.map_err(|_| InstructionError::ArithmeticOverflow)?` from `withdraw_nonce_account()`.