### PR TITLE
Dump the whole tx binary with --dump-transaction[-message] as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4797,6 +4797,7 @@ version = "1.11.2"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
+ "bincode",
  "chrono",
  "clap 2.33.3",
  "console",

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -21,13 +21,6 @@ pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
     help: "Provide a public-key/signature pair for the transaction",
 };
 
-pub const DUMP_TRANSACTION: ArgConstant<'static> = ArgConstant {
-    name: "dump_transaction_message", // for compatibility
-    long: "dump-transaction",
-    help:
-        "Display the base64 encoded binary transaction (and the enclosed message) in sign-only mode",
-};
-
 pub const DUMP_TRANSACTION_MESSAGE: ArgConstant<'static> = ArgConstant {
     name: "dump_transaction_message",
     long: "dump-transaction-message",
@@ -62,17 +55,10 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
         .help(SIGNER_ARG.help)
 }
 
-pub fn dump_transaction<'a, 'b>() -> Arg<'a, 'b> {
-    Arg::with_name(DUMP_TRANSACTION.name)
-        .long(DUMP_TRANSACTION.long)
-        .takes_value(false)
-        .requires(SIGN_ONLY_ARG.name)
-        .help(DUMP_TRANSACTION.help)
-}
-
 pub fn dump_transaction_message<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(DUMP_TRANSACTION_MESSAGE.name)
         .long(DUMP_TRANSACTION_MESSAGE.long)
+        .visible_alias("dump-transaction")
         .takes_value(false)
         .requires(SIGN_ONLY_ARG.name)
         .help(DUMP_TRANSACTION_MESSAGE.help)
@@ -88,10 +74,6 @@ pub trait ArgsConfig {
     fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg
     }
-    fn dump_transaction_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
-        arg
-    }
-
     fn dump_transaction_message_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg
     }
@@ -107,7 +89,6 @@ impl OfflineArgs for App<'_, '_> {
         self.arg(config.blockhash_arg(blockhash_arg()))
             .arg(config.sign_only_arg(sign_only_arg()))
             .arg(config.signer_arg(signer_arg()))
-            .arg(config.dump_transaction_arg(dump_transaction()))
             .arg(config.dump_transaction_message_arg(dump_transaction_message()))
     }
     fn offline_args(self) -> Self {

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -21,10 +21,17 @@ pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
     help: "Provide a public-key/signature pair for the transaction",
 };
 
+pub const DUMP_TRANSACTION: ArgConstant<'static> = ArgConstant {
+    name: "dump_transaction_message", // for compatibility
+    long: "dump-transaction",
+    help:
+        "Display the base64 encoded binary transaction (and the enclosed message) in sign-only mode",
+};
+
 pub const DUMP_TRANSACTION_MESSAGE: ArgConstant<'static> = ArgConstant {
     name: "dump_transaction_message",
     long: "dump-transaction-message",
-    help: "Display the base64 encoded binary transaction message in sign-only mode",
+    help: "Display the base64 encoded binary transaction message (and the enclosing transaction) in sign-only mode",
 };
 
 pub fn blockhash_arg<'a, 'b>() -> Arg<'a, 'b> {
@@ -55,6 +62,14 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
         .help(SIGNER_ARG.help)
 }
 
+pub fn dump_transaction<'a, 'b>() -> Arg<'a, 'b> {
+    Arg::with_name(DUMP_TRANSACTION.name)
+        .long(DUMP_TRANSACTION.long)
+        .takes_value(false)
+        .requires(SIGN_ONLY_ARG.name)
+        .help(DUMP_TRANSACTION.help)
+}
+
 pub fn dump_transaction_message<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(DUMP_TRANSACTION_MESSAGE.name)
         .long(DUMP_TRANSACTION_MESSAGE.long)
@@ -73,6 +88,10 @@ pub trait ArgsConfig {
     fn signer_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg
     }
+    fn dump_transaction_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
+        arg
+    }
+
     fn dump_transaction_message_arg<'a, 'b>(&self, arg: Arg<'a, 'b>) -> Arg<'a, 'b> {
         arg
     }
@@ -88,6 +107,7 @@ impl OfflineArgs for App<'_, '_> {
         self.arg(config.blockhash_arg(blockhash_arg()))
             .arg(config.sign_only_arg(sign_only_arg()))
             .arg(config.signer_arg(signer_arg()))
+            .arg(config.dump_transaction_arg(dump_transaction()))
             .arg(config.dump_transaction_message_arg(dump_transaction_message()))
     }
     fn offline_args(self) -> Self {

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/solana-cli-output"
 [dependencies]
 Inflector = "0.11.4"
 base64 = "0.13.0"
+bincode = "1.3.3"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "2.33.0"
 console = "0.15.0"

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1629,7 +1629,17 @@ impl fmt::Display for CliSignOnlyData {
         writeln!(f)?;
         writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         if let Some(transaction) = self.transaction.as_ref() {
-            writeln_name_value(f, "Signed Transaction:", transaction)?;
+            let signature_completeness = if self.absent.is_empty() && self.bad_sig.is_empty() {
+                "Fully-Signed"
+            } else {
+                "Partially-Signed"
+            };
+
+            writeln_name_value(
+                f,
+                &format!("Transaction ({}):", signature_completeness),
+                transaction,
+            )?;
         }
         if let Some(message) = self.message.as_ref() {
             writeln_name_value(f, "Transaction Message:", message)?;

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2153,14 +2153,14 @@ pub fn return_signers_data(tx: &Transaction, config: &ReturnSignersConfig) -> Cl
                 bad_sig.push(key.to_string());
             }
         });
-    let dumped_message = if config.dump_transaction_message {
-        let message_data = tx.message_data();
-        Some(base64::encode(&message_data))
+    let dumped_transaction = if config.dump_transaction_message {
+        Some(base64::encode(serialize(tx).unwrap()))
     } else {
         None
     };
-    let dumped_transaction = if config.dump_transaction_message {
-        Some(base64::encode(serialize(tx).unwrap()))
+    let dumped_message = if config.dump_transaction_message {
+        let message_data = tx.message_data();
+        Some(base64::encode(&message_data))
     } else {
         None
     };
@@ -2793,21 +2793,14 @@ mod tests {
             res_data,
             CliSignOnlyData {
                 blockhash: blockhash.to_string(),
-                message: None,
                 transaction: None,
+                message: None,
                 signers: vec![format!("{}={}", present.pubkey(), tx.signatures[1])],
                 absent: vec![absent.pubkey().to_string()],
                 bad_sig: vec![bad.pubkey().to_string()],
             }
         );
 
-        let expected_msg = "AwECBwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDgTl3Dqh9\
-            F19Wo1Rmw0x+zMuNipG07jeiXfYPW4/Js5QEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE\
-            BAQEBAUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBgYGBgYGBgYGBgYGBgYGBgYG\
-            BgYGBgYGBgYGBgYGBgYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFaO\
-            4IqEX3PSl4jPA1wxRbIas0TYBi6pQAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH\
-            BwcCBQMEBgIEBAAAAAUCAQMMAgAAACoAAAAAAAAA"
-            .to_string();
         let expected_tx = "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
             AAAAAAAAAAAAAAAAAAAAAAAAAAAAAC74RMZET6o+SO8FoacTbuwTl/WzV8llT3k7s9OEJQsM\
             g9pcb/VxtSxiXacZ5Ly2eO0WBXTDWhGu+w9U+lzehgLAQEBAQEBAQEBAQEBAQEBAQEBAQEBA\
@@ -2818,6 +2811,13 @@ mod tests {
             AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGp9UXGSxWjuCKhF9z0peIzwNcMUWyGrNE2AYuqUAAA\
             AcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHAgUDBAYCBAQAAAAFAgEDDAIAAAAqA\
             AAAAAAAAA=="
+            .to_string();
+        let expected_msg = "AwECBwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDgTl3Dqh9\
+            F19Wo1Rmw0x+zMuNipG07jeiXfYPW4/Js5QEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE\
+            BAQEBAUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBgYGBgYGBgYGBgYGBgYGBgYG\
+            BgYGBgYGBgYGBgYGBgYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFaO\
+            4IqEX3PSl4jPA1wxRbIas0TYBi6pQAAABwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcH\
+            BwcCBQMEBgIEBAAAAAUCAQMMAgAAACoAAAAAAAAA"
             .to_string();
         let config = ReturnSignersConfig {
             dump_transaction_message: true,
@@ -2835,8 +2835,8 @@ mod tests {
             res_data,
             CliSignOnlyData {
                 blockhash: blockhash.to_string(),
-                message: Some(expected_msg),
                 transaction: Some(expected_tx),
+                message: Some(expected_msg),
                 signers: vec![format!("{}={}", present.pubkey(), tx.signatures[1])],
                 absent: vec![absent.pubkey().to_string()],
                 bad_sig: vec![bad.pubkey().to_string()],

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1629,7 +1629,7 @@ impl fmt::Display for CliSignOnlyData {
         writeln!(f)?;
         writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         if let Some(transaction) = self.transaction.as_ref() {
-            writeln_name_value(f, "Transaction:", transaction)?;
+            writeln_name_value(f, "Signed Transaction:", transaction)?;
         }
         if let Some(message) = self.message.as_ref() {
             writeln_name_value(f, "Transaction Message:", message)?;

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -4467,6 +4467,7 @@ version = "1.11.2"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
+ "bincode",
  "chrono",
  "clap 2.33.3",
  "console",


### PR DESCRIPTION
#### Problem

- There is no easy way to dump the transaction binary, which is readily consumable by RPC's `sendTransaction` and the TPU udp port for manual broadcasting for various devs/debugging.
  - if transaction could be dumped as a whole, `solana` cli isn't strictly needed anymore for internet-facing node, which is paired with custody's air-gapped production env. So this pr might have small utility for production actually...
  - Also, currently cli dump can only inspected by explorer's inspect without _sig verifications_ (because message dumping is only supported by cli).
- There is no easy way to check/study/hexedit the final form of serialization of transaction legacy <=> v0.
  - note that it must use the actual code for `solana-validator`'s de-/serialization (not web3.js one) for security auditing purpose by definition.

#### Summary of Changes

before:
```
$ solana -ut transfer 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j 0 --dump-transaction-message --sign-only --blockhash EgMTJy7L1o8HXb2dTtANGBo6kWKqJW4jxeL6wXtG1FW7

Blockhash: EgMTJy7L1o8HXb2dTtANGBo6kWKqJW4jxeL6wXtG1FW7
Transaction Message: AQABAlxIo7Qf5acVIsotZaw1Wx/CUxBwlsieJAvD3Mpxue+4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADLPLVlKmlm5sAsmM5j+Nnh3zxOPQNa29OIlaMCVLbC4AEBAgAADAIAAAAAAAAAAAAAAA==
Signers (Pubkey=Signature):
 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j=JNnq6bCBJPUKArcKxb2DCuRm6rXMGgxSvT41BAHq6AHts6Nwv3n8kiTsYt2uh6xHEUwDN7a2NrpXqf3a4S1Zkh9
```


after:
```
$ solana -ut transfer 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j 0 --dump-transaction --sign-only --blockhash EgMTJy7L1o8HXb2dTtANGBo6kWKqJW4jxeL6wXtG1FW7

Blockhash: EgMTJy7L1o8HXb2dTtANGBo6kWKqJW4jxeL6wXtG1FW7
Transaction: AQ778HCJ2q+2BSwowin/sRJ525d7Nf2FNm9tiD5VLREnXc7LxlPz1d2BoRQVNgGucwUHHTPdeSSfc++CoArtSwQBAAECXEijtB/lpxUiyi1lrDVbH8JTEHCWyJ4kC8PcynG577gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMs8tWUqaWbmwCyYzmP42eHfPE49A1rb04iVowJUtsLgAQECAAAMAgAAAAAAAAAAAAAA
Transaction Message: AQABAlxIo7Qf5acVIsotZaw1Wx/CUxBwlsieJAvD3Mpxue+4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADLPLVlKmlm5sAsmM5j+Nnh3zxOPQNa29OIlaMCVLbC4AEBAgAADAIAAAAAAAAAAAAAAA==
Signers (Pubkey=Signature):
 7DEkZ3z7cWA7DpfBZjR6iCEdc5zkfr8wZi2TNBTkbt6j=JNnq6bCBJPUKArcKxb2DCuRm6rXMGgxSvT41BAHq6AHts6Nwv3n8kiTsYt2uh6xHEUwDN7a2NrpXqf3a4S1Zkh9
```

note that I omitted the whole plumbing intentionally like adding `.dump_transaction` along side the existing `.dump_transaction_message`. I don't think the effort would pay off. Rather, just starting dumping the transaction binary as well  by changing current behavior would be fine and compatibility concern should be limited.

That said, lazy me still managed to add the new `--dump-transaction` flag, which is simply overloaded with `--dump-transaction-message`. xD

Also, under the off-line signing use case, it's possible that partially signed transaction binary is dumped, which is useless as a whole. Still, i don't think it's erroneous behavior because the intended cli user must be advanced enough. Also, seeing zero padding at the missing sig position is also handy for debugging.

as for security, this starts to print potentially-executable signature against clusters including mb. So, theoretically, it's possible to expose those sigs if any service is blindly publishing the whole CLI outputs after a careless update of their solana cli version. but i don't think this is a substantive threat.

(I'm requesting somewhat large audience as reviewers. The intention is casual comments, rather than rigid multiparty review, assuming this pr isn't controversial.)

Lastly, I'll soon do the same for `spl-token`, once this pr got `+1`-ed.