### PR TITLE
Refactor `push` and `pop` in `InvokeContext::process_instruction()`.

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -896,7 +896,7 @@ impl<'a> InvokeContext<'a> {
                 );
                 result
             })
-            // Pop if and only if `push` succeeded, independed of `result`.
+            // MUST pop if and only if `push` succeeded, independent of `result`.
             // Thus, the `.and()` instead of an `.and_then()`.
             .and(self.pop())
     }

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -917,7 +917,7 @@ impl<'a> InvokeContext<'a> {
                 .try_borrow_program_account(self.transaction_context, 0)
                 .map_err(|_| InstructionError::UnsupportedProgramId)?;
             let owner_id = borrowed_root_account.get_owner();
-            if solana_sdk::native_loader::check_id(owner_id) {
+            if native_loader::check_id(owner_id) {
                 (1, *borrowed_root_account.get_key())
             } else {
                 (0, *owner_id)
@@ -1138,7 +1138,7 @@ pub fn with_mock_invoke_context<R, F: FnMut(&mut InvokeContext) -> R>(
     let transaction_accounts = vec![
         (
             loader_id,
-            AccountSharedData::new(0, 0, &solana_sdk::native_loader::id()),
+            AccountSharedData::new(0, 0, &native_loader::id()),
         ),
         (
             Pubkey::new_unique(),
@@ -1182,7 +1182,7 @@ pub fn mock_process_instruction(
     program_indices.insert(0, transaction_accounts.len());
     let mut preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
-    let processor_account = AccountSharedData::new(0, 0, &solana_sdk::native_loader::id());
+    let processor_account = AccountSharedData::new(0, 0, &native_loader::id());
     preparation
         .transaction_accounts
         .push((*loader_id, processor_account));

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -881,22 +881,23 @@ impl<'a> InvokeContext<'a> {
         let mut result = self.process_executable_chain(compute_units_consumed, timings);
 
         // Verify the called program has not misbehaved
-        let mut verify_callee_time = Measure::start("verify_callee_time");
         result = result.and_then(|_| {
-            if is_top_level_instruction {
+            let mut verify_callee_time = Measure::start("verify_callee_time");
+            let result = if is_top_level_instruction {
                 self.verify(instruction_accounts, program_indices)
             } else {
                 self.verify_and_update(instruction_accounts, false)
-            }
+            };
+            verify_callee_time.stop();
+            saturating_add_assign!(
+                timings
+                    .execute_accessories
+                    .process_instructions
+                    .verify_callee_us,
+                verify_callee_time.as_us()
+            );
+            result
         });
-        verify_callee_time.stop();
-        saturating_add_assign!(
-            timings
-                .execute_accessories
-                .process_instructions
-                .verify_callee_us,
-            verify_callee_time.as_us()
-        );
 
         // Pop if and only if `push` succeeded, independed of `result`.
         // Thus, the `.and()` instead of an `.and_then()`.


### PR DESCRIPTION
#### Problem

There are three sources of errors in `InvokeContext::process_instruction()`:
- `self.push()`
- The part in between: `self.process_executable_chain()` and `self.verify()` or `self.verify_and_update()`
- `self.pop()`

The `pop` always happens, even if the `push` did not. Thus `InvokeContext::process_instruction()` loses its stack height invariance if the `push` fails.

#### Summary of Changes
The only important thing is that the error priority / order is maintained, so that this PR does not need a feature gate. The change to the stack height invariance now being maintained is irrelevant for now, as the stack is not used anymore after an error occurs. Also, the result of `pop` is no longer ignored, but `pop` is guaranteed to return `Ok(())` as it only happens if the preceding `push` succeeded.