### PR TITLE
Ensure that staked nodes is populated before returning length

### DIFF
--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -66,7 +66,7 @@ impl VoteAccounts {
     }
 
     pub fn num_staked_nodes(&self) -> usize {
-        self.staked_nodes.read().unwrap().len()
+        self.staked_nodes().len()
     }
 }
 


### PR DESCRIPTION
#### Problem
`VoteAccounts::num_staked_nodes` doesn't ensure that the lazily computed `staked_nodes` map has been constructed before returning the length

#### Summary of Changes
Ensure that staked nodes is populated before returning length

Fixes https://github.com/solana-labs/solana/issues/26249
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
