### PR TITLE
removes RwLock+Once in favor of OnceCell in caching staked-nodes

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2533,7 +2533,7 @@ impl Bank {
                     .stakes_cache
                     .stakes()
                     .vote_accounts()
-                    .delegated_stakes_iter()
+                    .delegated_stakes()
                     .map(|(pubkey, stake)| (*pubkey, stake))
                     .collect();
                 info!(


### PR DESCRIPTION
#### Problem
`VoteAccounts` uses `std::sync::{RwLock, Once}` to lazily compute and cache
`staked_nodes`:
https://github.com/solana-labs/solana/blob/032bee13a/runtime/src/vote_account.rs#L89-L104

`RwLock` overhead is unnecessary for this purpose.

#### Summary of Changes

This commit instead switches to using `once_cell::sync::OnceCell` which
provides this exact intended functionality by design.

