### PR TITLE
Prepare built-in program tests to deal with stricter account modification checks

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1485,7 +1485,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::MissingRequiredSignature),
         );
@@ -1500,7 +1500,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
         );
@@ -1516,7 +1516,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::AccountDataTooSmall),
         );
@@ -1550,7 +1550,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::MissingRequiredSignature),
         );
@@ -1564,7 +1564,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
         );
@@ -1580,7 +1580,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: program_id,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::InvalidAccountData),
         );
@@ -1774,7 +1774,7 @@ mod tests {
             AccountMeta {
                 pubkey: buffer_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: authority_address,
@@ -1834,7 +1834,7 @@ mod tests {
             AccountMeta {
                 pubkey: buffer_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: buffer_address,
@@ -3268,7 +3268,7 @@ mod tests {
         let programdata_meta = AccountMeta {
             pubkey: programdata_address,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         };
         let upgrade_authority_meta = AccountMeta {
             pubkey: upgrade_authority_address,
@@ -3440,7 +3440,7 @@ mod tests {
         let buffer_meta = AccountMeta {
             pubkey: buffer_address,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         };
         let authority_meta = AccountMeta {
             pubkey: authority_address,
@@ -3642,12 +3642,12 @@ mod tests {
         let buffer_meta = AccountMeta {
             pubkey: buffer_address,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         };
         let recipient_meta = AccountMeta {
             pubkey: recipient_address,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         };
         let authority_meta = AccountMeta {
             pubkey: authority_address,
@@ -3709,7 +3709,7 @@ mod tests {
                 AccountMeta {
                     pubkey: uninitialized_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 recipient_meta.clone(),
                 authority_meta.clone(),
@@ -3736,7 +3736,7 @@ mod tests {
                 AccountMeta {
                     pubkey: programdata_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 recipient_meta,
                 authority_meta,

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -218,7 +218,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: config_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
         );
@@ -250,7 +250,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: config_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
         );
@@ -276,7 +276,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: config_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::InvalidInstructionData),
         );
@@ -298,7 +298,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: config_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::MissingRequiredSignature),
         );
@@ -333,7 +333,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -404,7 +404,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer1_pubkey,
@@ -426,7 +426,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -469,7 +469,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -500,7 +500,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -536,7 +536,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -570,7 +570,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -614,7 +614,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -660,7 +660,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -694,7 +694,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -742,7 +742,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -767,7 +767,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,
@@ -793,7 +793,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: config_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::MissingRequiredSignature),
         );
@@ -840,7 +840,7 @@ mod tests {
                 AccountMeta {
                     pubkey: config_pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: signer0_pubkey,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -879,7 +879,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -900,7 +900,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: rent_address,
@@ -919,7 +919,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -932,7 +932,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -952,7 +952,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -992,7 +992,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -1021,7 +1021,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -1038,7 +1038,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: rewards_address,
@@ -1073,7 +1073,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -1085,7 +1085,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -1145,7 +1145,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: rent_address,
@@ -1216,7 +1216,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: clock_address,
@@ -1253,7 +1253,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: clock_address,
@@ -1339,7 +1339,7 @@ mod tests {
                 AccountMeta {
                     pubkey: address_with_seed,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: authorized_owner,
@@ -1380,7 +1380,7 @@ mod tests {
                 AccountMeta {
                     pubkey: address_with_seed,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: authorized_owner,
@@ -1440,7 +1440,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: withdrawer,
@@ -1485,7 +1485,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::rent::id(),
@@ -1594,7 +1594,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -1699,12 +1699,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -1766,7 +1766,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -1884,7 +1884,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: authority_base_address,
@@ -2018,7 +2018,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: vote_address,
@@ -2061,7 +2061,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -2086,7 +2086,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -2146,7 +2146,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -2222,7 +2222,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: vote_address,
@@ -2304,7 +2304,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -2458,7 +2458,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: vote_address,
@@ -2490,7 +2490,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -2542,12 +2542,12 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: recipient_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -2647,12 +2647,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -2785,12 +2785,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: recipient_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -2849,7 +2849,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::rent::id(),
@@ -2879,7 +2879,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -2936,7 +2936,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -3068,7 +3068,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: recipient_address,
@@ -3101,7 +3101,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -3193,12 +3193,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: recipient_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -3314,12 +3314,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: recipient_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -3406,7 +3406,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -3444,7 +3444,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -3542,7 +3542,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -3583,7 +3583,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::rent::id(),
@@ -3624,7 +3624,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: vote_address,
@@ -3745,7 +3745,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -3788,7 +3788,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::rent::id(),
@@ -3847,7 +3847,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: vote_address,
@@ -3945,12 +3945,12 @@ mod tests {
             AccountMeta {
                 pubkey: source_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: dest_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
         for (source_reserve, dest_reserve, expected_result) in [
@@ -4038,12 +4038,12 @@ mod tests {
             AccountMeta {
                 pubkey: source_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: dest_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
         for (reserve, expected_result) in [
@@ -4097,12 +4097,12 @@ mod tests {
             AccountMeta {
                 pubkey: source_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: destination_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
         for (destination_starting_balance, split_amount, expected_result) in [
@@ -4196,12 +4196,12 @@ mod tests {
             AccountMeta {
                 pubkey: source_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: destination_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
         for (destination_starting_balance, split_amount, expected_result) in [
@@ -4348,12 +4348,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: recipient_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -4483,7 +4483,7 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: vote_address,
@@ -4519,7 +4519,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::rent::id(),
@@ -4554,7 +4554,7 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -4581,12 +4581,12 @@ mod tests {
                 AccountMeta {
                     pubkey: stake_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: recipient_address,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: sysvar::clock::id(),
@@ -4646,12 +4646,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -4730,12 +4730,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -4803,12 +4803,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -4838,12 +4838,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
         let meta = Meta {
@@ -4953,12 +4953,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5077,12 +5077,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5205,12 +5205,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5281,12 +5281,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5376,12 +5376,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5463,12 +5463,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: split_to_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -5592,12 +5592,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: merge_from_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -5752,12 +5752,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -5795,12 +5795,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: merge_from_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -5886,12 +5886,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: merge_from_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -5992,12 +5992,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: merge_from_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -6101,12 +6101,12 @@ mod tests {
             AccountMeta {
                 pubkey: stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: merge_from_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -6291,7 +6291,7 @@ mod tests {
         let instruction_accounts = vec![AccountMeta {
             pubkey: stake_address,
             is_signer: false,
-            is_writable: false,
+            is_writable: true,
         }];
 
         mock_process_instruction(
@@ -6356,7 +6356,7 @@ mod tests {
             AccountMeta {
                 pubkey: good_stake_address,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: rent_address,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -1139,7 +1139,7 @@ mod tests {
                 is_writable: false,
             },
             AccountMeta {
-                pubkey: sysvar::clock::id(),
+                pubkey: authorized_withdrawer_pubkey,
                 is_signer: false,
                 is_writable: false,
             },

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -496,7 +496,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::rent::id(),
@@ -587,7 +587,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: node_pubkey,
@@ -655,7 +655,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: authorized_withdrawer,
@@ -718,7 +718,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::slot_hashes::id(),
@@ -833,7 +833,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -947,7 +947,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -1028,7 +1028,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: sysvar::clock::id(),
@@ -1052,7 +1052,7 @@ mod tests {
         instruction_accounts[1] = AccountMeta {
             pubkey: authorized_withdrawer_pubkey,
             is_signer: true,
-            is_writable: false,
+            is_writable: true,
         };
         transaction_accounts[0] = (vote_pubkey, accounts[0].clone());
         let accounts = process_instruction(
@@ -1136,12 +1136,12 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey_1,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: authorized_withdrawer_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -1897,7 +1897,7 @@ mod tests {
             AccountMeta {
                 pubkey: vote_pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: clock_address,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -686,12 +686,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Ok(()),
@@ -726,12 +726,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Ok(()),
@@ -768,12 +768,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: base,
@@ -862,12 +862,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Ok(()),
@@ -900,12 +900,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Err(SystemError::ResultWithNegativeLamports.into()),
@@ -923,12 +923,12 @@ mod tests {
             AccountMeta {
                 pubkey: from,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: to,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -1169,12 +1169,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Ok(()),
@@ -1251,7 +1251,7 @@ mod tests {
                 AccountMeta {
                     pubkey: new,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Err(InstructionError::InvalidArgument),
@@ -1275,7 +1275,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
             super::process_instruction,
@@ -1288,7 +1288,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             }],
             Err(InstructionError::MissingRequiredSignature),
             super::process_instruction,
@@ -1300,7 +1300,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
             super::process_instruction,
@@ -1316,7 +1316,7 @@ mod tests {
             vec![AccountMeta {
                 pubkey,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             }],
             Ok(()),
             super::process_instruction,
@@ -1367,12 +1367,12 @@ mod tests {
             AccountMeta {
                 pubkey: from,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: to,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -1417,12 +1417,12 @@ mod tests {
                 AccountMeta {
                     pubkey: from,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: to,
                     is_signer: false,
-                    is_writable: false,
+                    is_writable: true,
                 },
             ],
             Err(InstructionError::MissingRequiredSignature),
@@ -1448,7 +1448,7 @@ mod tests {
             AccountMeta {
                 pubkey: from,
                 is_signer: true,
-                is_writable: false,
+                is_writable: true,
             },
             AccountMeta {
                 pubkey: base,
@@ -1458,7 +1458,7 @@ mod tests {
             AccountMeta {
                 pubkey: to,
                 is_signer: false,
-                is_writable: false,
+                is_writable: true,
             },
         ];
 
@@ -1949,7 +1949,7 @@ mod tests {
                 AccountMeta {
                     pubkey,
                     is_signer: true,
-                    is_writable: false,
+                    is_writable: true,
                 },
                 AccountMeta {
                     pubkey: blockhash_id,


### PR DESCRIPTION
#### Problem
Spin-off from #25899.

#### Summary of Changes
- Mostly setting `is_writable: true` on accounts which are supposed to be modified in the tests.
- Fixes `test_vote_state_withdraw()` where the second argument is supposed to be the withdrawer not the clock sysvar.