### PR TITLE
patches bug in retransmit stats where slot stats are erroneously dropped

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -101,31 +101,33 @@ impl RetransmitStats {
         let num_peers = cluster_nodes_cache
             .get(root_bank.slot(), root_bank, working_bank, cluster_info)
             .num_peers();
-        let stats = std::mem::replace(self, Self::new(Instant::now()));
         datapoint_info!("retransmit-num_nodes", ("count", num_peers, i64));
         datapoint_info!(
             "retransmit-stage",
-            ("total_time", stats.total_time, i64),
-            ("epoch_fetch", stats.epoch_fetch, i64),
-            ("epoch_cache_update", stats.epoch_cache_update, i64),
-            ("total_batches", stats.total_batches, i64),
-            ("num_small_batches", stats.num_small_batches, i64),
-            ("num_nodes", stats.num_nodes.into_inner(), i64),
-            ("num_addrs_failed", stats.num_addrs_failed.into_inner(), i64),
-            ("num_shreds", stats.num_shreds, i64),
-            ("num_shreds_skipped", stats.num_shreds_skipped, i64),
-            ("retransmit_total", stats.retransmit_total.into_inner(), i64),
+            ("total_time", self.total_time, i64),
+            ("epoch_fetch", self.epoch_fetch, i64),
+            ("epoch_cache_update", self.epoch_cache_update, i64),
+            ("total_batches", self.total_batches, i64),
+            ("num_small_batches", self.num_small_batches, i64),
+            ("num_nodes", *self.num_nodes.get_mut(), i64),
+            ("num_addrs_failed", *self.num_addrs_failed.get_mut(), i64),
+            ("num_shreds", self.num_shreds, i64),
+            ("num_shreds_skipped", self.num_shreds_skipped, i64),
+            ("retransmit_total", *self.retransmit_total.get_mut(), i64),
             (
                 "compute_turbine",
-                stats.compute_turbine_peers_total.into_inner(),
+                *self.compute_turbine_peers_total.get_mut(),
                 i64
             ),
             (
                 "unknown_shred_slot_leader",
-                stats.unknown_shred_slot_leader,
+                self.unknown_shred_slot_leader,
                 i64
             ),
         );
+        // slot_stats are submited at a different cadence.
+        let old = std::mem::replace(self, Self::new(Instant::now()));
+        self.slot_stats = old.slot_stats;
     }
 }
 


### PR DESCRIPTION

#### Problem
`slot_stats` are submitted at a different cadence from the rest of
`RetransmitStats`. Current code erroneously clears `slot_stats` before
submitting any metrics.


#### Summary of Changes
stop dropping slot_stats when submit retransmit stats.