### PR TITLE
improve clean acct idx calls

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7336,15 +7336,19 @@ impl AccountsDb {
         let mut measure = Measure::start("unref_from_storage");
         if let Some(purged_stored_account_slots) = purged_stored_account_slots {
             let len = purged_stored_account_slots.len();
-            // we could build a higher level function in accounts_index to group by bin
             const BATCH_SIZE: usize = 10_000;
             let batches = 1 + (len / BATCH_SIZE);
             self.thread_pool_clean.install(|| {
                 (0..batches).into_par_iter().for_each(|batch| {
                     let skip = batch * BATCH_SIZE;
-                    for (_slot, pubkey) in purged_slot_pubkeys.iter().skip(skip).take(BATCH_SIZE) {
-                        self.accounts_index.unref_from_storage(pubkey);
-                    }
+                    self.accounts_index.scan(
+                        purged_slot_pubkeys
+                            .iter()
+                            .skip(skip)
+                            .take(BATCH_SIZE)
+                            .map(|(_slot, pubkey)| pubkey),
+                        |_pubkey, _slots_refs| AccountsIndexScanResult::Unref,
+                    )
                 })
             });
             for (slot, pubkey) in purged_slot_pubkeys {


### PR DESCRIPTION
#### Problem

use a function designed to iterate the accounts index to unref.
This function has recently been reworked. We could sort by pubkey to group by bin to improve performance. But, sort isn't free.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
