### PR TITLE
[wip] Add rocksdb's kv dump subcommand

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -188,6 +188,10 @@ fn output_slot(
     verbose_level: u64,
     all_program_ids: &mut HashMap<Pubkey, u64>,
 ) -> Result<(), String> {
+    for (key, value) in blockstore.dump(slot) {
+        println!("{} {}", key.iter().map(|k| format!("{:02X}", k)).join(""), value.iter().map(|v| format!("{:02X}", v)).join(""));
+    }
+
     if blockstore.is_dead(slot) {
         if allow_dead_slots {
             if *method == LedgerOutputMethod::Print {


### PR DESCRIPTION
The output should be aligned with the following rocksdb's output:

$ sst_dump --file=path/to//011080.sst --command=scan --output_hex [--verify_checksum]

ref: https://github.com/solana-labs/solana/issues/9009

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
