### PR TITLE
Update rust-rocksdb library to include batched_multi_get()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,9 +2340,8 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+version = "0.7.1+7.3.1"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5#ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3846,8 +3845,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5#ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -60,7 +60,8 @@ trees = "0.4.2"
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts
 # when also using the bzip2 crate
-version = "0.18.0"
+git = "https://github.com/rust-rocksdb/rust-rocksdb"
+rev = "ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5"
 default-features = false
 features = ["lz4"]
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -508,7 +508,7 @@ impl Rocks {
     ///
     /// Full list of properties that return int values could be found
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
-    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &str) -> Result<i64> {
+    fn get_int_property_cf(&self, cf: &ColumnFamily, name: &'static std::ffi::CStr) -> Result<i64> {
         match self.db.property_int_value_cf(cf, name) {
             Ok(Some(value)) => Ok(value.try_into().unwrap()),
             Ok(None) => Ok(0),
@@ -1229,7 +1229,7 @@ where
     ///
     /// Full list of properties that return int values could be found
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
-    pub fn get_int_property(&self, name: &str) -> Result<i64> {
+    pub fn get_int_property(&self, name: &'static std::ffi::CStr) -> Result<i64> {
         self.backend.get_int_property_cf(self.handle(), name)
     }
 }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2081,9 +2081,8 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+version = "0.7.1+7.3.1"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5#ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -3430,8 +3429,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5#ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
#### Summary of Changes
Bump the rocksdb version to https://github.com/rust-rocksdb/rust-rocksdb/commit/ac4ffa3ebe5b92bff3936deac36edabc4c3f24a5 that includes
batched_multi_get() API, the optimized version of multi_get().

The original rust-rocksdb PR:
https://github.com/rust-rocksdb/rust-rocksdb/pull/633

rocksdb PR:
https://github.com/facebook/rocksdb/pull/9952


