### PR TITLE
Fix/system instruction processor tests

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1196,7 +1196,8 @@ pub fn mock_process_instruction(
             &program_indices,
             instruction_data,
         )
-        .and_then(|_| process_instruction(1, &mut invoke_context));
+        .and_then(|_| process_instruction(1, &mut invoke_context))
+        .and_then(|_| invoke_context.verify(&preparation.instruction_accounts, &program_indices));
     invoke_context.pop().unwrap();
     assert_eq!(result, expected_result);
     let mut transaction_accounts = transaction_context.deconstruct_without_keys().unwrap();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -916,7 +916,7 @@ mod tests {
     #[test]
     fn test_request_more_than_allowed_data_length() {
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new(100, 0, &Pubkey::new_unique());
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
         let to = Pubkey::new_unique();
         let to_account = AccountSharedData::new(0, 0, &Pubkey::default());
         let instruction_accounts = vec![
@@ -1359,7 +1359,7 @@ mod tests {
     #[test]
     fn test_transfer_lamports() {
         let from = Pubkey::new_unique();
-        let from_account = AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
         let to = Pubkey::new(&[3; 32]);
         let to_account = AccountSharedData::new(1, 0, &to); // account owner should not matter
         let transaction_accounts = vec![(from, from_account), (to, to_account)];
@@ -1439,7 +1439,7 @@ mod tests {
         let from_seed = "42".to_string();
         let from_owner = system_program::id();
         let from = Pubkey::create_with_seed(&base, from_seed.as_str(), &from_owner).unwrap();
-        let from_account = AccountSharedData::new(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
+        let from_account = AccountSharedData::new(100, 0, &system_program::id());
         let to = Pubkey::new(&[3; 32]);
         let to_account = AccountSharedData::new(1, 0, &to); // account owner should not matter
         let transaction_accounts =


### PR DESCRIPTION
#### Problem
Another spin-off from #25899.  This PR aims to make the built-in program tests stricter to match the requirements once `enable_early_verification_of_account_modifications` is introduced.

#### Summary of Changes
- Adds `invoke_context.verify(&preparation.instruction_accounts, &program_indices)` to `mock_process_instruction()`.
- Fixes three tests in system_instruction_processor.rs where the owner of the source / sender / from account was wrong.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
