### PR TITLE
Update connection.ts, maxRetries no longer strips

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4442,7 +4442,7 @@ export class Connection {
     const preflightCommitment =
       (options && options.preflightCommitment) || this.commitment;
 
-    if (options && options.maxRetries) {
+    if (options && options.maxRetries != null) {
       config.maxRetries = options.maxRetries;
     }
     if (options && options.minContextSlot != null) {


### PR DESCRIPTION
#### Problem
maxRetries was stripping when it was set to 0. 

#### Summary of Changes
 I followed steveluscher's proposition and set the AND statement to check for null and not falsey. The commit makes the `maxRetries` in parallel structure with the `minContextSlot` IF statement below it!

Fixes #26295
<!-- OPTIONAL: Feature Gate Issue: # --> 


<!-- Don't forget to add the "feature-gate" label -->
