### PR TITLE
BigtableUploadService: recheck first_available_block

### DIFF
--- a/ledger/src/bigtable_upload_service.rs
+++ b/ledger/src/bigtable_upload_service.rs
@@ -112,6 +112,9 @@ impl BigTableUploadService {
                 Err(err) => {
                     warn!("bigtable: upload_confirmed_blocks: {}", err);
                     std::thread::sleep(std::time::Duration::from_secs(2));
+                    if start_slot == 0 {
+                        start_slot = blockstore.get_first_available_block().unwrap_or_default();
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Problem
When a node with a BigtableUploadService starts from a snapshot with a fresh ledger, it can get stuck on the error `bigtable: upload_confirmed_blocks: Ledger has no slots from 0 to XXX` and never upload blocks until it is rebooted. This is because the BigtableUploadService only checks `Blockstore::get_first_available_block()` once when the service is booted, and the first available block is always zero until the node makes it's first post-snapshot root.

#### Summary of Changes
Recheck `Blockstore::get_first_available_block()` if no blocks were uploaded and the BigtableUploadService's start_slot remains zero


Fixes #26080
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
