### PR TITLE
Bump --contact-debug-interval default to 2m from 10s

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -942,7 +942,7 @@ pub fn main() {
                 .long("contact-debug-interval")
                 .value_name("CONTACT_DEBUG_INTERVAL")
                 .takes_value(true)
-                .default_value("10000")
+                .default_value("120000")
                 .help("Milliseconds between printing contact debug from gossip."),
         )
         .arg(


### PR DESCRIPTION
The gossip contact info table log output is now incredibly spammy on both testnet and mainnet with with 4000+ and 2000+ nodes respectively. While this information was a useful debugging aid in earlier days, in modern times its value is less making the 10s default seem ridiculous.  

Why 2m? I've been running with this setting in my local validator scripts for a while and it feels pretty ok relatively.