### PR TITLE
Make report_rocksdb_read_perf() to take a operation name.

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -4,7 +4,7 @@ use {
         blockstore_meta,
         blockstore_metrics::{
             maybe_enable_rocksdb_perf, report_rocksdb_read_perf, report_rocksdb_write_perf,
-            BlockstoreRocksDbColumnFamilyMetrics, PerfSamplingStatus,
+            BlockstoreRocksDbColumnFamilyMetrics, PerfSamplingStatus, PERF_METRIC_OP_NAME_GET,
         },
         blockstore_options::{
             AccessType, BlockstoreOptions, LedgerColumnOptions, ShredStorageType,
@@ -1136,7 +1136,12 @@ where
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
         if let Some(op_start_instant) = is_perf_enabled {
-            report_rocksdb_read_perf(C::NAME, &op_start_instant.elapsed(), &self.column_options);
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
+            );
         }
         result
     }
@@ -1251,7 +1256,12 @@ where
         }
 
         if let Some(op_start_instant) = is_perf_enabled {
-            report_rocksdb_read_perf(C::NAME, &op_start_instant.elapsed(), &self.column_options);
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
+            );
         }
         result
     }
@@ -1310,7 +1320,12 @@ where
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
         if let Some(op_start_instant) = is_perf_enabled {
-            report_rocksdb_read_perf(C::NAME, &op_start_instant.elapsed(), &self.column_options);
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
+            );
         }
 
         if let Some(serialized_value) = result? {
@@ -1331,7 +1346,12 @@ where
         );
         let result = self.backend.get_cf(self.handle(), &C::key(key));
         if let Some(op_start_instant) = is_perf_enabled {
-            report_rocksdb_read_perf(C::NAME, &op_start_instant.elapsed(), &self.column_options);
+            report_rocksdb_read_perf(
+                C::NAME,
+                PERF_METRIC_OP_NAME_GET,
+                &op_start_instant.elapsed(),
+                &self.column_options,
+            );
         }
 
         if let Some(serialized_value) = result? {

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -309,6 +309,7 @@ thread_local! {static PER_THREAD_ROCKS_PERF_CONTEXT: RefCell<PerfContext> = RefC
 
 // The minimum time duration between two RocksDB perf samples of the same operation.
 const PERF_SAMPLING_MIN_DURATION: Duration = Duration::from_secs(1);
+pub(crate) const PERF_METRIC_OP_NAME_GET: &str = "get";
 
 /// The function enables RocksDB PerfContext once for every `sample_interval`.
 ///
@@ -335,6 +336,7 @@ pub(crate) fn maybe_enable_rocksdb_perf(
 /// reporting.
 pub(crate) fn report_rocksdb_read_perf(
     cf_name: &'static str,
+    op_name: &'static str,
     total_op_duration: &Duration,
     column_options: &LedgerColumnOptions,
 ) {
@@ -344,7 +346,7 @@ pub(crate) fn report_rocksdb_read_perf(
         datapoint_info!(
             "blockstore_rocksdb_read_perf",
             // tags that support group-by operations
-            "op" => "get",
+            "op" => op_name,
             "cf_name" => cf_name,
             "storage" => column_options.get_storage_type_string(),
             "compression" => column_options.get_compression_type_string(),


### PR DESCRIPTION
#### Problem
report_rocksdb_read_perf() always uses the hard-coded operation name "get"

#### Summary of Changes
As we will add a new read operation -- multi_get(), report_rocksdb_read_perf()
needs to have an input parameter for operation name.
