### PR TITLE
Create const &strs for rocksdb perf write operation names

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -5,6 +5,7 @@ use {
         blockstore_metrics::{
             maybe_enable_rocksdb_perf, report_rocksdb_read_perf, report_rocksdb_write_perf,
             BlockstoreRocksDbColumnFamilyMetrics, PerfSamplingStatus, PERF_METRIC_OP_NAME_GET,
+            PERF_METRIC_OP_NAME_PUT, PERF_METRIC_OP_NAME_WRITE_BATCH,
         },
         blockstore_options::{
             AccessType, BlockstoreOptions, LedgerColumnOptions, ShredStorageType,
@@ -486,8 +487,8 @@ impl Rocks {
         let result = self.db.write(batch);
         if let Some(op_start_instant) = op_start_instant {
             report_rocksdb_write_perf(
-                "write_batch", // We use write_batch as cf_name for write batch.
-                "write_batch", // op_name
+                PERF_METRIC_OP_NAME_WRITE_BATCH, // We use write_batch as cf_name for write batch.
+                PERF_METRIC_OP_NAME_WRITE_BATCH, // op_name
                 &op_start_instant.elapsed(),
                 &self.column_options,
             );
@@ -1221,7 +1222,7 @@ where
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
-                "put",
+                PERF_METRIC_OP_NAME_PUT,
                 &op_start_instant.elapsed(),
                 &self.column_options,
             );
@@ -1280,7 +1281,7 @@ where
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
-                "put",
+                PERF_METRIC_OP_NAME_PUT,
                 &op_start_instant.elapsed(),
                 &self.column_options,
             );
@@ -1373,7 +1374,7 @@ where
         if let Some(op_start_instant) = is_perf_enabled {
             report_rocksdb_write_perf(
                 C::NAME,
-                "put",
+                PERF_METRIC_OP_NAME_PUT,
                 &op_start_instant.elapsed(),
                 &self.column_options,
             );

--- a/ledger/src/blockstore_metrics.rs
+++ b/ledger/src/blockstore_metrics.rs
@@ -311,6 +311,9 @@ thread_local! {static PER_THREAD_ROCKS_PERF_CONTEXT: RefCell<PerfContext> = RefC
 const PERF_SAMPLING_MIN_DURATION: Duration = Duration::from_secs(1);
 pub(crate) const PERF_METRIC_OP_NAME_GET: &str = "get";
 
+pub(crate) const PERF_METRIC_OP_NAME_PUT: &str = "put";
+pub(crate) const PERF_METRIC_OP_NAME_WRITE_BATCH: &str = "write_batch";
+
 /// The function enables RocksDB PerfContext once for every `sample_interval`.
 ///
 /// PerfContext is a thread-local struct defined in RocksDB for collecting


### PR DESCRIPTION
#### Summary of Changes
Define PERF_METRIC_OP_NAME_PUT and PERF_METRIC_OP_NAME_WRITE_BATCH
to replace repetitive / hard-coded operation names for report_rocksdb_write_perf.

