### PR TITLE
1.10 only: hide confusing cli option

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1604,8 +1604,9 @@ pub fn main() {
         .arg(
             Arg::with_name("disable_accounts_disk_index")
                 .long("disable-accounts-disk-index")
-                .help("Disable the disk-based accounts index if it is enabled by default.")
+                .help("Disable the disk-based accounts index if it is enabled.")
                 .conflicts_with("accounts_index_memory_limit_mb")
+                .hidden(true)
         )
         .arg(
             Arg::with_name("accounts_index_bins")


### PR DESCRIPTION
#### Problem

this could also be deleted. The more surgical change is to just hide the parameter. The original intent was to make disk index default, but that got cancelled.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
