### PR TITLE
add info to ledger tool for total execution time

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1156,6 +1156,7 @@ fn main() {
         .max(rent.minimum_balance(StakeState::size_of()))
         .to_string();
 
+    let mut measure_total_execution_time = Measure::start("ledger tool");
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -3715,5 +3716,7 @@ fn main() {
             }
             _ => unreachable!(),
         };
+        measure_total_execution_time.stop();
+        info!("{}", measure_total_execution_time);
     }
 }


### PR DESCRIPTION
#### Problem

Ledger tool is a useful tool for perf improvements.
It is helpful to have an overall execution time ball park # reported.

```ledger tool total execution time took 327.6s```

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
