### PR TITLE
Consolidate dep features in Cargo.toml files to minimize rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,8 +1697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5114,21 +5116,32 @@ dependencies = [
 name = "solana-frozen-abi"
 version = "1.11.3"
 dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
  "bs58",
  "bv",
+ "byteorder",
+ "cc",
+ "either",
  "generic-array 0.14.5",
+ "getrandom 0.1.16",
+ "hashbrown 0.11.2",
  "im",
  "lazy_static",
  "log",
  "memmap2",
  "once_cell",
+ "rand_core 0.6.3",
  "rustc_version 0.4.0",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
  "solana-frozen-abi-macro 1.11.3",
  "solana-logger 1.11.3",
+ "subtle",
  "thiserror",
 ]
 
@@ -5675,13 +5688,15 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.1.16",
+ "getrandom 0.2.3",
  "itertools",
  "js-sys",
  "lazy_static",
+ "libc",
  "libsecp256k1",
  "log",
  "memoffset",
@@ -5689,6 +5704,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rustc_version 0.4.0",
  "rustversion",
  "serde",
@@ -5703,7 +5719,9 @@ dependencies = [
  "solana-sdk-macro 1.11.3",
  "static_assertions",
  "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -13,22 +13,34 @@ edition = "2021"
 bs58 = "0.4.0"
 bv = { version = "0.11.1", features = ["serde"] }
 lazy_static = "1.4.0"
-log = "0.4.17"
+log = { version = "0.4.17", features = ["std"] }
 once_cell = "1.12.0"
-serde = "1.0.138"
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
-serde_derive = "1.0.103"
+serde_derive = "1.0"
+serde_json = "1.0"
 sha2 = "0.10.2"
 solana-frozen-abi-macro = { path = "macro", version = "=1.11.3" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
+ahash = { version = "0.7.6", features = ["default", "std"] }
+blake3 = { version = "1.3.1", features = ["digest", "traits-preview"] }
+block-buffer = { version = "0.9.0", features = ["block-padding"] }
+byteorder = { version = "1.4.3", features = ["default", "i128", "std"] }
+cc = { version = "1.0.67", features = ["jobserver", "parallel"] }
+either = { version = "1.6.1", features = ["use_std"] }
 generic-array = { version = "0.14.5", default-features = false, features = [
 	"serde",
 	"more_lengths"
 ] }
+getrandom = { version = "0.1", features = ["dummy"] }
+hashbrown = { version = "0.11", features = ["raw"] }
 im = { version = "15.1.0", features = ["rayon", "serde"] }
 memmap2 = "0.5.3"
+once_cell = { version = "1.8", features = ["alloc", "default", "race", "std"] }
+rand_core = { version = "0.6.3", features = ["alloc", "getrandom", "std"] }
+subtle = { version = "2.4.1", features = ["default", "i128", "std"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.11.3" }

--- a/frozen-abi/macro/Cargo.toml
+++ b/frozen-abi/macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "1.0", features = ["full", "extra-traits", "visit-mut"] }
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1467,8 +1467,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4693,20 +4695,31 @@ dependencies = [
 name = "solana-frozen-abi"
 version = "1.11.3"
 dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
  "bs58",
  "bv",
+ "byteorder 1.4.3",
+ "cc",
+ "either",
  "generic-array 0.14.5",
+ "getrandom 0.1.14",
+ "hashbrown 0.11.2",
  "im",
  "lazy_static",
  "log",
  "memmap2",
  "once_cell",
+ "rand_core 0.6.3",
  "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
  "solana-frozen-abi-macro 1.11.3",
+ "subtle",
  "thiserror",
 ]
 
@@ -5034,13 +5047,15 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.1.14",
+ "getrandom 0.2.4",
  "itertools",
  "js-sys",
  "lazy_static",
+ "libc",
  "libsecp256k1",
  "log",
  "memoffset",
@@ -5048,18 +5063,22 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
+ "rand_chacha 0.2.2",
  "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
  "solana-frozen-abi 1.11.3",
  "solana-frozen-abi-macro 1.11.3",
  "solana-sdk-macro 1.11.3",
  "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.1"
-blake3 = { version = "1.2.0", features = ["traits-preview"] }
+blake3 = { version = "1.3.1", features = ["digest", "traits-preview"] }
 borsh = "0.9.1"
 borsh-derive = "0.9.1"
 bs58 = "0.4.0"
@@ -20,14 +20,15 @@ bytemuck = { version = "1.8.0", features = ["derive"] }
 bv = { version = "0.11.1", features = ["serde"] }
 itertools =  "0.10.1"
 lazy_static = "1.4.0"
-log = "0.4.14"
+log = "0.4.17"
 memoffset = "0.6"
 num-derive = "0.3"
 num-traits = "0.2"
 rustversion = "1.0.7"
-serde = "1.0.112"
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-serde_derive = "1.0.103"
+serde_derive = "1.0"
+serde_json = "1.0"
 sha2 = "0.10.0"
 sha3 = "0.10.0"
 solana-frozen-abi = { path = "../../frozen-abi", version = "=1.11.3" }
@@ -37,12 +38,16 @@ thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bitflags = "1.3.1"
-base64 = "0.13"
-curve25519-dalek = "3.2.1"
-libsecp256k1 = "0.6.0"
-rand = "0.7.0"
+base64 = { version = "0.13", features = ["alloc", "std"] }
+curve25519-dalek = { version = "3.2.1", features = ["serde"] }
 itertools = "0.10.1"
+libc = { version = "0.2.126", features = ["extra_traits"] }
+libsecp256k1 = "0.6.0"
+rand = "0.7"
+rand_chacha = { version = "0.2.2", default-features = true, features = ["simd", "std"] }
+tiny-bip39 = "0.8.2"
 wasm-bindgen = "0.2"
+zeroize = { version = "1.3", default-features = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 solana-logger = { path = "../../logger", version = "=1.11.3" }
@@ -51,7 +56,7 @@ solana-logger = { path = "../../logger", version = "=1.11.3" }
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.0"
 js-sys = "0.3.55"
-getrandom = { version = "0.1", features = ["wasm-bindgen"] }
+getrandom = { version = "0.2", features = ["js", "wasm-bindgen"] }
 
 [target.'cfg(not(target_pointer_width = "64"))'.dependencies]
 parking_lot = "0.12"
@@ -66,6 +71,7 @@ serde_json = "1.0.56"
 static_assertions = "1.1.0"
 
 [build-dependencies]
+cc = { version = "1.0.67", features = ["jobserver", "parallel"] }
 rustc_version = "0.4"
 
 [package.metadata.docs.rs]

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 sha3 = "0.9"
 solana-sdk = { path = "../sdk", version = "=1.11.3" }
 subtle = "2"
-thiserror = "1"
+thiserror = "1.0"
 zeroize = { version = "1.3", default-features = false, features = ["zeroize_derive"] }
 
 [lib]


### PR DESCRIPTION
Indirect dependency packages introduce variations in features of other
dependencies, which affect the fingerprints of previously built
packages such as solana-program and cause redundant rebuilds of
affected packages.  These changes specify several features in
dependencies specifications explicitly to a common set of
features. The result of such consolidation is improved re-usability of
previously built binary packages across programs/bpf/rust/ packages
when these packages are built in CI jobs.

Fixes #25765

