### PR TITLE
uses RwLock<PohRecorder> instead of Mutex<PohRecorder>

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -74,7 +74,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let (exit, poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder(&bank, &blockstore, None, None);
 
-        let recorder = poh_recorder.lock().unwrap().recorder();
+        let recorder = poh_recorder.read().unwrap().recorder();
 
         let tx = test_tx();
         let transactions = vec![tx; 4194304];
@@ -233,7 +233,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
             Arc::new(RwLock::new(CostModel::default())),
             Arc::new(ConnectionCache::default()),
         );
-        poh_recorder.lock().unwrap().set_bank(&bank, false);
+        poh_recorder.write().unwrap().set_bank(&bank, false);
 
         let chunk_len = verified.len() / CHUNKS;
         let mut start = 0;

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -36,7 +36,7 @@ use {
     },
     std::{
         net::UdpSocket,
-        sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+        sync::{atomic::AtomicBool, Arc, RwLock},
         thread,
     },
 };
@@ -73,7 +73,7 @@ impl Tpu {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         cluster_info: &Arc<ClusterInfo>,
-        poh_recorder: &Arc<Mutex<PohRecorder>>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
         entry_receiver: Receiver<WorkingBankEntry>,
         retransmit_slots_receiver: RetransmitSlotsReceiver,
         sockets: TpuSockets,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -52,7 +52,7 @@ use {
     std::{
         collections::HashSet,
         net::UdpSocket,
-        sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+        sync::{atomic::AtomicBool, Arc, RwLock},
         thread,
     },
 };
@@ -105,7 +105,7 @@ impl Tvu {
         blockstore: Arc<Blockstore>,
         ledger_signal_receiver: Receiver<bool>,
         rpc_subscriptions: &Arc<RpcSubscriptions>,
-        poh_recorder: &Arc<Mutex<PohRecorder>>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
         maybe_process_block_store: Option<ProcessBlockStore>,
         tower_storage: Arc<dyn TowerStorage>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -106,7 +106,7 @@ use {
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
-            Arc, Mutex, RwLock,
+            Arc, RwLock,
         },
         thread::{sleep, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -341,7 +341,7 @@ pub struct Validator {
     serve_repair_service: ServeRepairService,
     completed_data_sets_service: CompletedDataSetsService,
     snapshot_packager_service: Option<SnapshotPackagerService>,
-    poh_recorder: Arc<Mutex<PohRecorder>>,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
     poh_service: PohService,
     tpu: Tpu,
     tvu: Tvu,
@@ -755,7 +755,7 @@ impl Validator {
                 exit.clone(),
             )
         };
-        let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+        let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let use_quic = UseQUIC::new(use_quic).expect("Failed to initialize QUIC flags");
         let connection_cache = Arc::new(ConnectionCache::new(use_quic, tpu_connection_pool_size));

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -7,7 +7,7 @@ use {
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{clock::Slot, transaction::Transaction},
     std::{
-        sync::{Arc, Mutex, RwLock},
+        sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
     },
 };
@@ -41,7 +41,7 @@ impl VotingService {
     pub fn new(
         vote_receiver: Receiver<VoteOp>,
         cluster_info: Arc<ClusterInfo>,
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         tower_storage: Arc<dyn TowerStorage>,
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> Self {
@@ -66,7 +66,7 @@ impl VotingService {
 
     pub fn handle_vote(
         cluster_info: &ClusterInfo,
-        poh_recorder: &Mutex<PohRecorder>,
+        poh_recorder: &RwLock<PohRecorder>,
         tower_storage: &dyn TowerStorage,
         vote_op: VoteOp,
         send_to_tpu_vote_port: bool,

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -9,7 +9,7 @@ use {
     std::{
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Mutex,
+            Arc, RwLock,
         },
         thread::{self, sleep, Builder, JoinHandle},
         time::Duration,
@@ -28,7 +28,7 @@ impl WarmQuicCacheService {
     pub fn new(
         connection_cache: Arc<ConnectionCache>,
         cluster_info: Arc<ClusterInfo>,
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let thread_hdl = Builder::new()
@@ -38,7 +38,7 @@ impl WarmQuicCacheService {
                 let mut maybe_last_leader = None;
                 while !exit.load(Ordering::Relaxed) {
                     let leader_pubkey =  poh_recorder
-                        .lock()
+                        .read()
                         .unwrap()
                         .leader_after_n_slots((CACHE_OFFSET_SLOT + slot_jitter) as u64);
                     if let Some(leader_pubkey) = leader_pubkey {

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -32,7 +32,7 @@ use {
         cmp,
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Mutex,
+            Arc, Mutex, RwLock,
         },
         time::{Duration, Instant},
     },
@@ -949,7 +949,7 @@ pub fn create_test_recorder(
     leader_schedule_cache: Option<Arc<LeaderScheduleCache>>,
 ) -> (
     Arc<AtomicBool>,
-    Arc<Mutex<PohRecorder>>,
+    Arc<RwLock<PohRecorder>>,
     PohService,
     Receiver<WorkingBankEntry>,
 ) {
@@ -973,7 +973,7 @@ pub fn create_test_recorder(
     );
     poh_recorder.set_bank(bank, false);
 
-    let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+    let poh_recorder = Arc::new(RwLock::new(poh_recorder));
     let poh_service = PohService::new(
         poh_recorder.clone(),
         &poh_config,

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -10,7 +10,7 @@ use {
     std::{
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Mutex,
+            Arc, Mutex, RwLock,
         },
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -95,7 +95,7 @@ impl PohTiming {
 
 impl PohService {
     pub fn new(
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_config: &Arc<PohConfig>,
         poh_exit: &Arc<AtomicBool>,
         ticks_per_slot: u64,
@@ -163,7 +163,7 @@ impl PohService {
     }
 
     fn sleepy_tick_producer(
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_config: &PohConfig,
         poh_exit: &AtomicBool,
         record_receiver: Receiver<Record>,
@@ -180,13 +180,13 @@ impl PohService {
             );
             if remaining_tick_time.is_zero() {
                 last_tick = Instant::now();
-                poh_recorder.lock().unwrap().tick();
+                poh_recorder.write().unwrap().tick();
             }
         }
     }
 
     pub fn read_record_receiver_and_process(
-        poh_recorder: &Arc<Mutex<PohRecorder>>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
         record_receiver: &Receiver<Record>,
         timeout: Duration,
     ) {
@@ -194,7 +194,7 @@ impl PohService {
         if let Ok(record) = record {
             if record
                 .sender
-                .send(poh_recorder.lock().unwrap().record(
+                .send(poh_recorder.write().unwrap().record(
                     record.slot,
                     record.mixin,
                     record.transactions,
@@ -207,7 +207,7 @@ impl PohService {
     }
 
     fn short_lived_sleepy_tick_producer(
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_config: &PohConfig,
         poh_exit: &AtomicBool,
         record_receiver: Receiver<Record>,
@@ -227,7 +227,7 @@ impl PohService {
             );
             if remaining_tick_time.is_zero() {
                 last_tick = Instant::now();
-                poh_recorder.lock().unwrap().tick();
+                poh_recorder.write().unwrap().tick();
                 elapsed_ticks += 1;
             }
             if poh_exit.load(Ordering::Relaxed) && !warned {
@@ -240,7 +240,7 @@ impl PohService {
     // returns true if we need to tick
     fn record_or_hash(
         next_record: &mut Option<Record>,
-        poh_recorder: &Arc<Mutex<PohRecorder>>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
         timing: &mut PohTiming,
         record_receiver: &Receiver<Record>,
         hashes_per_batch: u64,
@@ -252,7 +252,7 @@ impl PohService {
                 // received message to record
                 // so, record for as long as we have queued up record requests
                 let mut lock_time = Measure::start("lock");
-                let mut poh_recorder_l = poh_recorder.lock().unwrap();
+                let mut poh_recorder_l = poh_recorder.write().unwrap();
                 lock_time.stop();
                 timing.total_lock_time_ns += lock_time.as_ns();
                 let mut record_time = Measure::start("record");
@@ -332,14 +332,14 @@ impl PohService {
     }
 
     fn tick_producer(
-        poh_recorder: Arc<Mutex<PohRecorder>>,
+        poh_recorder: Arc<RwLock<PohRecorder>>,
         poh_exit: &AtomicBool,
         ticks_per_slot: u64,
         hashes_per_batch: u64,
         record_receiver: Receiver<Record>,
         target_ns_per_tick: u64,
     ) {
-        let poh = poh_recorder.lock().unwrap().poh.clone();
+        let poh = poh_recorder.read().unwrap().poh.clone();
         let mut timing = PohTiming::new();
         let mut next_record = None;
         loop {
@@ -356,7 +356,7 @@ impl PohService {
                 // Lock PohRecorder only for the final hash. record_or_hash will lock PohRecorder for record calls but not for hashing.
                 {
                     let mut lock_time = Measure::start("lock");
-                    let mut poh_recorder_l = poh_recorder.lock().unwrap();
+                    let mut poh_recorder_l = poh_recorder.write().unwrap();
                     lock_time.stop();
                     timing.total_lock_time_ns += lock_time.as_ns();
                     let mut tick_time = Measure::start("tick");
@@ -436,7 +436,7 @@ mod tests {
                 &poh_config,
                 exit.clone(),
             );
-            let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+            let poh_recorder = Arc::new(RwLock::new(poh_recorder));
             let ticks_per_slot = bank.ticks_per_slot();
             let bank_slot = bank.slot();
 
@@ -462,7 +462,7 @@ mod tests {
                         loop {
                             // send some data
                             let mut time = Measure::start("record");
-                            let _ = poh_recorder.lock().unwrap().record(
+                            let _ = poh_recorder.write().unwrap().record(
                                 bank_slot,
                                 h1,
                                 vec![tx.clone()],
@@ -500,7 +500,7 @@ mod tests {
                 hashes_per_batch,
                 record_receiver,
             );
-            poh_recorder.lock().unwrap().set_bank(&bank, false);
+            poh_recorder.write().unwrap().set_bank(&bank, false);
 
             // get some events
             let mut hashes = 0;

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -6,19 +6,19 @@ use {
     std::{
         collections::HashMap,
         net::SocketAddr,
-        sync::{Arc, Mutex},
+        sync::{Arc, RwLock},
     },
 };
 
 #[derive(Clone)]
 pub struct ClusterTpuInfo {
     cluster_info: Arc<ClusterInfo>,
-    poh_recorder: Arc<Mutex<PohRecorder>>,
+    poh_recorder: Arc<RwLock<PohRecorder>>,
     recent_peers: HashMap<Pubkey, SocketAddr>,
 }
 
 impl ClusterTpuInfo {
-    pub fn new(cluster_info: Arc<ClusterInfo>, poh_recorder: Arc<Mutex<PohRecorder>>) -> Self {
+    pub fn new(cluster_info: Arc<ClusterInfo>, poh_recorder: Arc<RwLock<PohRecorder>>) -> Self {
         Self {
             cluster_info,
             poh_recorder,
@@ -38,7 +38,7 @@ impl TpuInfo for ClusterTpuInfo {
     }
 
     fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr> {
-        let recorder = self.poh_recorder.lock().unwrap();
+        let recorder = self.poh_recorder.read().unwrap();
         let leaders: Vec<_> = (0..max_count)
             .filter_map(|i| recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS))
             .collect();
@@ -141,7 +141,7 @@ mod test {
             .collect();
             let leader_info = ClusterTpuInfo {
                 cluster_info,
-                poh_recorder: Arc::new(Mutex::new(poh_recorder)),
+                poh_recorder: Arc::new(RwLock::new(poh_recorder)),
                 recent_peers: recent_peers.clone(),
             };
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -45,7 +45,7 @@ use {
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
-            Arc, Mutex, RwLock,
+            Arc, RwLock,
         },
         thread::{self, Builder, JoinHandle},
     },
@@ -342,7 +342,7 @@ impl JsonRpcService {
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         blockstore: Arc<Blockstore>,
         cluster_info: Arc<ClusterInfo>,
-        poh_recorder: Option<Arc<Mutex<PohRecorder>>>,
+        poh_recorder: Option<Arc<RwLock<PohRecorder>>>,
         genesis_hash: Hash,
         ledger_path: &Path,
         validator_exit: Arc<RwLock<Exit>>,


### PR DESCRIPTION
#### Problem
A lot of read-only access to `PohRecorder`.
`Mutex` will cause redundant lock contention.

#### Summary of Changes
Replaced `Mutex<PohRecorder>` with `RwLock<PohRecorder>`.
