### PR TITLE
fix: `getPerformanceSamples` no longer breaks when the connection has a default commitment

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -195,6 +195,9 @@ type RpcRequest = (methodName: string, args: Array<any>) => Promise<any>;
 
 type RpcBatchRequest = (requests: RpcParams[]) => Promise<any[]>;
 
+const NO_COMMITMENT =
+  typeof Symbol === 'function' ? Symbol('NO_COMMITMENT') : ({} as const);
+
 /**
  * @internal
  */
@@ -3431,7 +3434,7 @@ export class Connection {
   async getRecentPerformanceSamples(
     limit?: number,
   ): Promise<Array<PerfSample>> {
-    const args = this._buildArgs(limit ? [limit] : []);
+    const args = this._buildArgs(limit ? [limit] : [], NO_COMMITMENT);
     const unsafeRes = await this._rpcRequest(
       'getRecentPerformanceSamples',
       args,
@@ -5062,11 +5065,12 @@ export class Connection {
 
   _buildArgs(
     args: Array<any>,
-    override?: Commitment,
+    override?: Commitment | typeof NO_COMMITMENT,
     encoding?: 'jsonParsed' | 'base64',
     extra?: any,
   ): Array<any> {
-    const commitment = override || this._commitment;
+    const commitment =
+      override === NO_COMMITMENT ? undefined : override || this._commitment;
     if (commitment || encoding || extra) {
       let options: any = {};
       if (encoding) {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3154,29 +3154,41 @@ describe('Connection', function () {
     expect(supply.nonCirculatingAccounts.length).to.eq(0);
   });
 
-  it('get performance samples', async () => {
-    await mockRpcResponse({
-      method: 'getRecentPerformanceSamples',
-      params: [],
-      value: [
-        {
-          slot: 1234,
-          numTransactions: 1000,
-          numSlots: 60,
-          samplePeriodSecs: 60,
-        },
-      ],
-    });
+  [undefined, 'confirmed' as Commitment].forEach(function (commitment) {
+    describe.only(
+      "when the connection's default commitment is `" + commitment + '`',
+      () => {
+        let connectionWithCommitment: Connection;
+        beforeEach(() => {
+          connectionWithCommitment = new Connection(url, commitment);
+        });
+        it('get performance samples', async () => {
+          await mockRpcResponse({
+            method: 'getRecentPerformanceSamples',
+            params: [],
+            value: [
+              {
+                slot: 1234,
+                numTransactions: 1000,
+                numSlots: 60,
+                samplePeriodSecs: 60,
+              },
+            ],
+          });
 
-    const perfSamples = await connection.getRecentPerformanceSamples();
-    expect(Array.isArray(perfSamples)).to.be.true;
+          const perfSamples =
+            await connectionWithCommitment.getRecentPerformanceSamples();
+          expect(Array.isArray(perfSamples)).to.be.true;
 
-    if (perfSamples.length > 0) {
-      expect(perfSamples[0].slot).to.be.greaterThan(0);
-      expect(perfSamples[0].numTransactions).to.be.greaterThan(0);
-      expect(perfSamples[0].numSlots).to.be.greaterThan(0);
-      expect(perfSamples[0].samplePeriodSecs).to.be.greaterThan(0);
-    }
+          if (perfSamples.length > 0) {
+            expect(perfSamples[0].slot).to.be.greaterThan(0);
+            expect(perfSamples[0].numTransactions).to.be.greaterThan(0);
+            expect(perfSamples[0].numSlots).to.be.greaterThan(0);
+            expect(perfSamples[0].samplePeriodSecs).to.be.greaterThan(0);
+          }
+        });
+      },
+    );
   });
 
   it('get performance samples limit too high', async () => {


### PR DESCRIPTION
#### Problem

`_buildArgs` is dumb and always adds the connection's default commitment. Problem is, some API calls _don't take a commitment param_. When you send them one, they break.

#### Summary of Changes

* Create a sigil for use with `_buildArgs` that tells it not to override the commitment.

Fixes #26372.