### PR TITLE
added arg --rpc-max-request-payload-size to validator

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -160,6 +160,7 @@ pub struct JsonRpcConfig {
     pub full_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
+    pub rpc_max_request_payload_size: usize,
 }
 
 impl JsonRpcConfig {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -112,7 +112,7 @@ use {
 
 type RpcCustomResult<T> = std::result::Result<T, RpcCustomError>;
 
-pub const MAX_REQUEST_PAYLOAD_SIZE: usize = 50 * (1 << 10); // 50kB
+pub const MAX_REQUEST_BODY_SIZE: usize = 50 * (1 << 10); // 50kB
 pub const PERFORMANCE_SAMPLES_LIMIT: usize = 720;
 
 // Limit the length of the `epoch_credits` array for each validator in a `get_vote_accounts`
@@ -160,7 +160,7 @@ pub struct JsonRpcConfig {
     pub full_api: bool,
     pub obsolete_v1_7_api: bool,
     pub rpc_scan_and_fix_roots: bool,
-    pub rpc_max_request_payload_size: usize,
+    pub max_request_body_size: Option<usize>,
 }
 
 impl JsonRpcConfig {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -444,6 +444,7 @@ impl JsonRpcService {
 
         let full_api = config.full_api;
         let obsolete_v1_7_api = config.obsolete_v1_7_api;
+        let rpc_max_request_payload_size = config.rpc_max_request_payload_size;
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             snapshot_config.clone(),
@@ -515,7 +516,7 @@ impl JsonRpcService {
                 ]))
                 .cors_max_age(86400)
                 .request_middleware(request_middleware)
-                .max_request_body_size(MAX_REQUEST_PAYLOAD_SIZE)
+                .max_request_body_size(rpc_max_request_payload_size)
                 .start_http(&rpc_addr);
 
                 if let Err(e) = server {

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -444,7 +444,9 @@ impl JsonRpcService {
 
         let full_api = config.full_api;
         let obsolete_v1_7_api = config.obsolete_v1_7_api;
-        let rpc_max_request_payload_size = config.rpc_max_request_payload_size;
+        let max_request_body_size = config
+            .max_request_body_size
+            .unwrap_or(MAX_REQUEST_BODY_SIZE);
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             snapshot_config.clone(),
@@ -516,7 +518,7 @@ impl JsonRpcService {
                 ]))
                 .cors_max_age(86400)
                 .request_middleware(request_middleware)
-                .max_request_body_size(rpc_max_request_payload_size)
+                .max_request_body_size(max_request_body_size)
                 .start_http(&rpc_addr);
 
                 if let Err(e) = server {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -76,6 +76,9 @@ use {
         admin_rpc_service, bootstrap, dashboard::Dashboard, ledger_lockfile, lock_ledger,
         new_spinner_progress_bar, println_name_value, redirect_stderr_to_file,
     },
+    solana_rpc::{
+        rpc::MAX_REQUEST_PAYLOAD_SIZE,
+    },
     std::{
         collections::{HashSet, VecDeque},
         env,
@@ -469,6 +472,7 @@ pub fn main() {
     let default_rocksdb_fifo_shred_storage_size =
         &DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES.to_string();
     let default_tpu_connection_pool_size = &DEFAULT_TPU_CONNECTION_POOL_SIZE.to_string();
+    let default_rpc_max_request_payload_size = &MAX_REQUEST_PAYLOAD_SIZE.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1466,6 +1470,15 @@ pub fn main() {
                 .takes_value(false)
                 .requires("enable_rpc_transaction_history")
                 .help("Verifies blockstore roots on boot and fixes any gaps"),
+        )
+        .arg(
+            Arg::with_name("rpc_max_request_payload_size")
+                .long("rpc-max-request-payload-size")
+                .value_name("BYTES")
+                .takes_value(true)
+                .validator(is_parsable::<usize>)
+                .default_value(default_rpc_max_request_payload_size)
+                .help("The maximum request payload size accepted by rpc service"),
         )
         .arg(
             Arg::with_name("enable_accountsdb_repl")
@@ -2573,6 +2586,7 @@ pub fn main() {
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            rpc_max_request_payload_size: value_t_or_exit!(matches, "rpc_max_request_payload_size", usize)
         },
         geyser_plugin_config_files,
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2584,8 +2584,8 @@ pub fn main() {
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
             rpc_max_request_payload_size: value_t_or_exit!(
-                matches, 
-                "rpc_max_request_payload_size", 
+                matches,
+                "rpc_max_request_payload_size",
                 usize
             ),
         },

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -38,7 +38,7 @@ use {
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_rpc::{
-        rpc::{JsonRpcConfig, RpcBigtableConfig, MAX_REQUEST_PAYLOAD_SIZE},
+        rpc::{JsonRpcConfig, RpcBigtableConfig, MAX_REQUEST_BODY_SIZE},
         rpc_pubsub_service::PubSubConfig,
     },
     solana_runtime::{
@@ -469,7 +469,7 @@ pub fn main() {
     let default_rocksdb_fifo_shred_storage_size =
         &DEFAULT_ROCKS_FIFO_SHRED_STORAGE_SIZE_BYTES.to_string();
     let default_tpu_connection_pool_size = &DEFAULT_TPU_CONNECTION_POOL_SIZE.to_string();
-    let default_rpc_max_request_payload_size = &MAX_REQUEST_PAYLOAD_SIZE.to_string();
+    let default_rpc_max_request_body_size = &MAX_REQUEST_BODY_SIZE.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1469,13 +1469,13 @@ pub fn main() {
                 .help("Verifies blockstore roots on boot and fixes any gaps"),
         )
         .arg(
-            Arg::with_name("rpc_max_request_payload_size")
-                .long("rpc-max-request-payload-size")
+            Arg::with_name("rpc_max_request_body_size")
+                .long("rpc-max-request-body-size")
                 .value_name("BYTES")
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
-                .default_value(default_rpc_max_request_payload_size)
-                .help("The maximum request payload size accepted by rpc service"),
+                .default_value(default_rpc_max_request_body_size)
+                .help("The maximum request body size accepted by rpc service"),
         )
         .arg(
             Arg::with_name("enable_accountsdb_repl")
@@ -2583,11 +2583,11 @@ pub fn main() {
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
-            rpc_max_request_payload_size: value_t_or_exit!(
+            max_request_body_size: Some(value_t_or_exit!(
                 matches,
-                "rpc_max_request_payload_size",
+                "rpc_max_request_body_size",
                 usize
-            ),
+            )),
         },
         geyser_plugin_config_files,
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -38,7 +38,7 @@ use {
     solana_perf::recycler::enable_recycler_warming,
     solana_poh::poh_service,
     solana_rpc::{
-        rpc::{JsonRpcConfig, RpcBigtableConfig},
+        rpc::{JsonRpcConfig, RpcBigtableConfig, MAX_REQUEST_PAYLOAD_SIZE},
         rpc_pubsub_service::PubSubConfig,
     },
     solana_runtime::{
@@ -75,9 +75,6 @@ use {
     solana_validator::{
         admin_rpc_service, bootstrap, dashboard::Dashboard, ledger_lockfile, lock_ledger,
         new_spinner_progress_bar, println_name_value, redirect_stderr_to_file,
-    },
-    solana_rpc::{
-        rpc::MAX_REQUEST_PAYLOAD_SIZE,
     },
     std::{
         collections::{HashSet, VecDeque},
@@ -2586,7 +2583,11 @@ pub fn main() {
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
-            rpc_max_request_payload_size: value_t_or_exit!(matches, "rpc_max_request_payload_size", usize)
+            rpc_max_request_payload_size: value_t_or_exit!(
+                matches, 
+                "rpc_max_request_payload_size", 
+                usize
+            ),
         },
         geyser_plugin_config_files,
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {


### PR DESCRIPTION
#### Problem
Currently the  default is set in `MAX_REQUEST_PAYLOAD_SIZE` in rpc module. We need the ability to configure this for our RPC services as some payloads exceed 50KB.

#### Summary of Changes
Added a flag `--rpc-max-request-payload-size` to allow rpc operator to specify their own maximum request payload size.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
N/A