### PR TITLE
Add error handling to quic_client

### DIFF
--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -28,6 +28,8 @@ pub enum ClientErrorKind {
     FaucetError(#[from] FaucetError),
     #[error("Custom: {0}")]
     Custom(String),
+    #[error(transparent)]
+    QuinnError(#[from] QuinnError),
 }
 
 impl ClientErrorKind {
@@ -69,19 +71,28 @@ impl From<ClientErrorKind> for TransportError {
             ClientErrorKind::SigningError(err) => Self::Custom(format!("{:?}", err)),
             ClientErrorKind::FaucetError(err) => Self::Custom(format!("{:?}", err)),
             ClientErrorKind::Custom(err) => Self::Custom(format!("{:?}", err)),
+            ClientErrorKind::QuinnError(err) => Self::Custom(format!("{:?}", err)),
         }
     }
 }
 
+#[derive(Error, Debug)]
+pub enum QuinnError {
+    #[error(transparent)]
+    WriteError(#[from] WriteError),
+    #[error(transparent)]
+    ConnectError(#[from] ConnectError),
+}
+
 impl From<WriteError> for ClientErrorKind {
     fn from(write_error: WriteError) -> Self {
-        Self::Custom(format!("{:?}", write_error))
+        write_error.into()
     }
 }
 
 impl From<ConnectError> for ClientErrorKind {
     fn from(connect_error: ConnectError) -> Self {
-        Self::Custom(format!("{:?}", connect_error))
+        connect_error.into()
     }
 }
 

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,7 +1,7 @@
 pub use reqwest;
 use {
     crate::{rpc_request, rpc_response},
-    quinn::{ConnectError, WriteError},
+    quinn::{ConnectError, ConnectionError, WriteError},
     solana_faucet::faucet::FaucetError,
     solana_sdk::{
         signature::SignerError, transaction::TransactionError, transport::TransportError,
@@ -93,6 +93,12 @@ impl From<WriteError> for ClientErrorKind {
 impl From<ConnectError> for ClientErrorKind {
     fn from(connect_error: ConnectError) -> Self {
         connect_error.into()
+    }
+}
+
+impl From<ConnectionError> for ClientErrorKind {
+    fn from(connection_error: ConnectionError) -> Self {
+        connection_error.into()
     }
 }
 

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -1,6 +1,7 @@
 //! Simple nonblocking client that connects to a given UDP port with the QUIC protocol
 //! and provides an interface for sending transactions which is restricted by the
 //! server's flow control.
+
 use {
     crate::{
         client_error::ClientErrorKind, connection_cache::ConnectionCacheStats,


### PR DESCRIPTION
#### Problem

`nonblocking/quic_client.rs` has several points that may panic.

#### Summary of Changes

- Extend `ClientErrorKind` to support more error types
- For every function that might panic, return `Result<T, ClientErrorKind>` and propagate errors correctly

Fixes #26101