### PR TITLE
add 2nd pass at hash calc when failure seen

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -147,6 +147,30 @@ impl AccountsHashVerifier {
             )
             .unwrap();
 
+        assert_eq!(accounts_package.expected_capitalization, lamports);
+        if let Some(expected_hash) = accounts_package.accounts_hash_for_testing {
+            // before we assert, run the hash calc again. This helps track down whether it could have been a failure in a race condition possibly with shrink.
+            // We could add diagnostics to the hash calc here to produce a per bin cap or something to help narrow down how many pubkeys are different.
+            if expected_hash != accounts_hash {
+                let _ = accounts_package
+                    .accounts
+                    .accounts_db
+                    .calculate_accounts_hash_without_index(
+                        &CalcAccountsHashConfig {
+                            use_bg_thread_pool: false,
+                            check_hash: false,
+                            ancestors: None,
+                            use_write_cache: false,
+                            epoch_schedule: &accounts_package.epoch_schedule,
+                            rent_collector: &accounts_package.rent_collector,
+                        },
+                        &sorted_storages,
+                        HashStats::default(),
+                    );
+            }
+            assert_eq!(expected_hash, accounts_hash);
+        };
+
         accounts_package
             .accounts
             .accounts_db
@@ -154,11 +178,6 @@ impl AccountsHashVerifier {
                 sorted_storages.max_slot_inclusive(),
                 &accounts_package.epoch_schedule,
             );
-
-        assert_eq!(accounts_package.expected_capitalization, lamports);
-        if let Some(expected_hash) = accounts_package.accounts_hash_for_testing {
-            assert_eq!(expected_hash, accounts_hash);
-        };
 
         measure_hash.stop();
         solana_runtime::serde_snapshot::reserialize_bank_with_new_accounts_hash(


### PR DESCRIPTION
#### Problem

help track down cap mismatch in accounts hash calc by running hash calc again prior to asserting failure

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
