### PR TITLE
Backport writing new fields to snapshot

### DIFF
--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -365,7 +365,7 @@ mod test_bank_serialize {
 
     // This some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "ERbJJzaQD39td9tiE4FPAud374S2Hvk6pvsxejm6quWf")]
+    #[frozen_abi(digest = "dU93dNba5nEH7o8KR4QbTT6SYRfDFdjXrZdqQjNGzKa")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperNewer {
         #[serde(serialize_with = "wrapper_newer")]


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/23844 and https://github.com/solana-labs/solana/pull/25364 added new fields to be serialized in snapshots. Partial backports to v1.10 were added to allow a v1.10 client to consume snapshots produced by newer clients that contain these fields.

However, we also need the `lamports_per_signature` value to be stored in snapshots. If this value isn't stored, we could run into issues when restarting from a snapshot that was taken at a slot where the `lamports_per_signature` value was non-default. If the value isn't stored, we're forced to use the default on restart, and as such, we deviate from consensus immediately. See https://github.com/solana-labs/solana/issues/26069 for more info.


#### Summary of Changes
Make v1.10 serialize new fields (default for accountsdb / proper value for lamports_per_signature) into snapshots.

Fixes #26069
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

### Testing
To test the change, I did the following with the slots that were failing in GH 26069:
- Create new full snapshot at a slot with non-default lamports_per_signature
- Run `solana-ledger-tool verify` from the new snapshot
- Observed that correct bank hash was calculated at slot that was deviating from consensus without this change