### PR TITLE
removes is_exited:Arc<AtomicBool> from PohRecorder

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3624,7 +3624,6 @@ pub(crate) mod tests {
                 &blockstore,
                 &leader_schedule_cache,
                 &Arc::new(PohConfig::default()),
-                Arc::new(AtomicBool::new(false)),
             )
             .0,
         );

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -748,7 +748,6 @@ impl Validator {
                 &leader_schedule_cache,
                 &poh_config,
                 Some(poh_timing_point_sender),
-                exit.clone(),
             )
         };
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
@@ -912,8 +911,8 @@ impl Validator {
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
-            &poh_config,
-            &exit,
+            poh_config,
+            exit.clone(),
             bank_forks.read().unwrap().root_bank().ticks_per_slot(),
             config.poh_pinned_cpu_core,
             config.poh_hashes_per_batch,

--- a/rpc/src/cluster_tpu_info.rs
+++ b/rpc/src/cluster_tpu_info.rs
@@ -75,7 +75,6 @@ mod test {
             timing::timestamp,
         },
         solana_streamer::socket::SocketAddrSpace,
-        std::sync::atomic::AtomicBool,
     };
 
     #[test]
@@ -109,7 +108,6 @@ mod test {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
-                Arc::new(AtomicBool::default()),
             );
 
             let node_keypair = Arc::new(Keypair::new());


### PR DESCRIPTION
#### Problem
In order to avoid banking stage threads being blocked
indefinitely at exit time
```rust
is_exited: Arc<AtomicBool>
```
was added in https://github.com/solana-labs/solana/pull/16503 to `PohRecorder`.


#### Summary of Changes

To simplify this code for follow up changes, this commit removes
`is_exited` from `PohRecorder` and instead sends
```rust
Err(PohRecorderError::MaxHeightReached)
```
to waiting threads and then drops the receiver end of the channel
immediately.
Running the problematic tests repeatedly shows that this is sufficient
to unblock threads at exit time.
