### PR TITLE
Missing privkey, add 2nd feature key

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -157,6 +157,10 @@ pub mod libsecp256k1_fail_on_bad_count {
     solana_sdk::declare_id!("8aXvSuopd1PUj7UhehfXJRg6619RHp8ZvwTyyJHdUYsj");
 }
 
+pub mod libsecp256k1_fail_on_bad_count2 {
+    solana_sdk::declare_id!("54KAoNiUERNoWWUhTWWwXgym94gzoXFVnHyQwPA18V9A");
+}
+
 pub mod instructions_sysvar_owned_by_sysvar {
     solana_sdk::declare_id!("H3kBSaKdeiUsyHmeHqjJYNc27jesXZ6zWj3zWkowQbkV");
 }
@@ -478,6 +482,7 @@ lazy_static! {
         (curve25519_syscall_enabled::id(), "enable curve25519 syscalls"),
         (versioned_tx_message_enabled::id(), "enable versioned transaction message processing"),
         (libsecp256k1_fail_on_bad_count::id(), "fail libsec256k1_verify if count appears wrong"),
+        (libsecp256k1_fail_on_bad_count2::id(), "fail libsec256k1_verify if count appears wrong"),
         (instructions_sysvar_owned_by_sysvar::id(), "fix owner for instructions sysvar"),
         (stake_program_advance_activating_credits_observed::id(), "Enable advancing credits observed for activation epoch #19309"),
         (credits_auto_rewind::id(), "Auto rewind stake's credits_observed if (accidental) vote recreation is detected #22546"),

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -3,7 +3,8 @@
 use {
     crate::{
         feature_set::{
-            libsecp256k1_0_5_upgrade_enabled, libsecp256k1_fail_on_bad_count, FeatureSet,
+            libsecp256k1_0_5_upgrade_enabled, libsecp256k1_fail_on_bad_count,
+            libsecp256k1_fail_on_bad_count2, FeatureSet,
         },
         instruction::Instruction,
         precompiles::PrecompileError,
@@ -109,7 +110,10 @@ pub fn verify(
         return Err(PrecompileError::InvalidInstructionDataSize);
     }
     let count = data[0] as usize;
-    if feature_set.is_active(&libsecp256k1_fail_on_bad_count::id()) && count == 0 && data.len() > 1
+    if (feature_set.is_active(&libsecp256k1_fail_on_bad_count::id())
+        || feature_set.is_active(&libsecp256k1_fail_on_bad_count2::id()))
+        && count == 0
+        && data.len() > 1
     {
         // count is zero but the instruction data indicates that is probably not
         // correct, fail the instruction to catch probable invalid secp256k1


### PR DESCRIPTION
#### Problem

Missing privkey for 8aXvSuopd1PUj7UhehfXJRg6619RHp8ZvwTyyJHdUYsj


#### Summary of Changes

Add a 2nd key to enable on mainnet.  devnet and testnet will remain activated


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
