### PR TITLE
Refactor the various calculate_accounts_hash fns

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -10,7 +10,7 @@ use {
             test_utils::{create_test_accounts, update_accounts_bench},
             Accounts,
         },
-        accounts_db::AccountShrinkThreshold,
+        accounts_db::{AccountShrinkThreshold, AccountsDataSource},
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
         rent_collector::RentCollector,
@@ -121,15 +121,20 @@ fn main() {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
             let results = accounts.accounts_db.update_accounts_hash(
-                0,
+                AccountsDataSource::Index,
+                false,
+                solana_sdk::clock::Slot::default(),
                 &ancestors,
+                None,
+                false,
                 &EpochSchedule::default(),
                 &RentCollector::default(),
+                false,
             );
             time.stop();
             let mut time_store = Measure::start("hash using store");
-            let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
-                false,
+            let results_store = accounts.accounts_db.update_accounts_hash(
+                AccountsDataSource::Storages,
                 false,
                 solana_sdk::clock::Slot::default(),
                 &ancestors,

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -133,7 +133,7 @@ impl AccountsHashVerifier {
         let (accounts_hash, lamports) = accounts_package
             .accounts
             .accounts_db
-            .calculate_accounts_hash_without_index(
+            .calculate_accounts_hash_from_storages(
                 &CalcAccountsHashConfig {
                     use_bg_thread_pool: true,
                     check_hash: false,

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -9,7 +9,7 @@ use {
     rayon::iter::{IntoParallelRefIterator, ParallelIterator},
     solana_runtime::{
         accounts::{test_utils::create_test_accounts, AccountAddressFilter, Accounts},
-        accounts_db::AccountShrinkThreshold,
+        accounts_db::{AccountShrinkThreshold, AccountsDataSource},
         accounts_index::{AccountSecondaryIndexes, ScanConfig},
         ancestors::Ancestors,
         bank::*,
@@ -110,10 +110,15 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
     let ancestors = Ancestors::from(vec![0]);
     let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(
+        AccountsDataSource::Index,
+        false,
         0,
         &ancestors,
+        None,
+        false,
         &EpochSchedule::default(),
         &RentCollector::default(),
+        false,
     );
     let test_hash_calculation = false;
     bencher.iter(|| {
@@ -145,10 +150,15 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     let ancestors = Ancestors::from(vec![0]);
     bencher.iter(|| {
         accounts.accounts_db.update_accounts_hash(
+            AccountsDataSource::Index,
+            false,
             0,
             &ancestors,
+            None,
+            false,
             &EpochSchedule::default(),
             &RentCollector::default(),
+            false,
         );
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -3,8 +3,8 @@ use {
         account_overrides::AccountOverrides,
         account_rent_state::{check_rent_state_with_account, RentState},
         accounts_db::{
-            AccountShrinkThreshold, AccountsAddRootTiming, AccountsDb, AccountsDbConfig,
-            BankHashInfo, LoadHint, LoadedAccount, ScanStorageResult,
+            AccountShrinkThreshold, AccountsAddRootTiming, AccountsDataSource, AccountsDb,
+            AccountsDbConfig, BankHashInfo, LoadHint, LoadedAccount, ScanStorageResult,
             ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS, ACCOUNTS_DB_CONFIG_FOR_TESTING,
         },
         accounts_index::{
@@ -787,11 +787,10 @@ impl Accounts {
         epoch_schedule: &EpochSchedule,
         rent_collector: &RentCollector,
     ) -> u64 {
-        let use_index = false;
         let is_startup = true;
         self.accounts_db
-            .update_accounts_hash_with_index_option(
-                use_index,
+            .update_accounts_hash(
+                AccountsDataSource::Storages,
                 debug_verify,
                 slot,
                 ancestors,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -5,6 +5,7 @@
 mod stats;
 use {
     crate::{
+        accounts_db::AccountsDataSource,
         accounts_hash::CalcAccountsHashConfig,
         bank::{Bank, BankSlotDelta, DropCallback},
         bank_forks::BankForks,
@@ -191,8 +192,9 @@ impl SnapshotRequestHandler {
 
                 let previous_hash = if test_hash_calculation {
                     // We have to use the index version here.
-                    // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality. This comment is out of date and can be re-evaluated.
-                    snapshot_root_bank.update_accounts_hash_with_index_option(true, false, false)
+                    // We cannot calculate the non-index way because cache has not been flushed and stores don't match reality.
+                    // This comment is out of date and can be re-evaluated.
+                    snapshot_root_bank.update_accounts_hash()
                 } else {
                     Hash::default()
                 };
@@ -227,11 +229,10 @@ impl SnapshotRequestHandler {
                 flush_accounts_cache_time.stop();
 
                 let hash_for_testing = if test_hash_calculation {
-                    let use_index_hash_calculation = false;
                     let check_hash = false;
 
-                    let (this_hash, capitalization) = snapshot_root_bank.accounts().accounts_db.calculate_accounts_hash_helper(
-                        use_index_hash_calculation,
+                    let (this_hash, capitalization) = snapshot_root_bank.accounts().accounts_db.calculate_accounts_hash(
+                        AccountsDataSource::Storages,
                         snapshot_root_bank.slot(),
                         &CalcAccountsHashConfig {
                             use_bg_thread_pool: true,


### PR DESCRIPTION
#### Problem

There are a number of `calculate_accounts_hash()`/`update_accounts_hash()` functions. Some are quite different, some are quite similar. It's not always clear which fn should be used when without looking at each one's source.

#### Summary of Changes

* Refactor the fns to make the names more obvious
* Add some doc comments
* Add an enum to specify where the accounts data is sourced from (i.e. the storages vs the index)