### PR TITLE
generating index sets uncleaned_roots correctly

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8395,10 +8395,15 @@ impl AccountsDb {
         }
     }
 
-    /// Used during generate_index() to get the _duplicate_ accounts data len from the given pubkeys
+    /// Used during generate_index() to:
+    /// 1. get the _duplicate_ accounts data len from the given pubkeys
+    /// 2. get the slots that contained duplicate pubkeys
     /// Note this should only be used when ALL entries in the accounts index are roots.
-    /// returns (data len removed because were duplicates, slots that contained older duplicate pubkeys)
-    fn get_duplicate_accounts_slots_and_data_len(&self, pubkeys: &[Pubkey]) -> (u64, HashSet<Slot>) {
+    /// returns (data len sum of all older duplicates, slots that contained duplicate pubkeys)
+    fn get_duplicate_accounts_slots_and_data_len(
+        &self,
+        pubkeys: &[Pubkey],
+    ) -> (u64, HashSet<Slot>) {
         let mut accounts_data_len_from_duplicates = 0;
         let mut uncleaned_slots = HashSet::<Slot>::default();
         pubkeys.iter().for_each(|pubkey| {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8282,7 +8282,7 @@ impl AccountsDb {
                 m.stop();
                 index_flush_us = m.as_us();
 
-                // this has to happen before pubkeys_to_duplicate_accounts_data_len below
+                // this has to happen before get_duplicate_accounts_slots_and_data_len below
                 // get duplicate keys from acct idx. We have to wait until we've finished flushing.
                 for (slot, key) in self
                     .accounts_index
@@ -8315,7 +8315,7 @@ impl AccountsDb {
                     .par_chunks(4096)
                     .map(|pubkeys| {
                         let (count, uncleaned_roots_this_group) =
-                            self.pubkeys_to_duplicate_accounts_data_len(pubkeys);
+                            self.get_duplicate_accounts_slots_and_data_len(pubkeys);
                         let mut uncleaned_roots = uncleaned_roots.lock().unwrap();
                         uncleaned_roots_this_group.into_iter().for_each(|slot| {
                             uncleaned_roots.insert(slot);
@@ -8398,7 +8398,7 @@ impl AccountsDb {
     /// Used during generate_index() to get the _duplicate_ accounts data len from the given pubkeys
     /// Note this should only be used when ALL entries in the accounts index are roots.
     /// returns (data len removed because were duplicates, slots that contained older duplicate pubkeys)
-    fn pubkeys_to_duplicate_accounts_data_len(&self, pubkeys: &[Pubkey]) -> (u64, HashSet<Slot>) {
+    fn get_duplicate_accounts_slots_and_data_len(&self, pubkeys: &[Pubkey]) -> (u64, HashSet<Slot>) {
         let mut accounts_data_len_from_duplicates = 0;
         let mut uncleaned_slots = HashSet::<Slot>::default();
         pubkeys.iter().for_each(|pubkey| {


### PR DESCRIPTION
#### Problem

The prior startup behavior was to put EVERY slot in the uncleaned_roots HashSet.
Startup improvements led us to skip clean when we were using a locally generated snapshot.
Experiments with high #s of accounts then caused the first time clean ran to oom because EVERY slot would try to load every account into the in-mem accounts index to find duplicates and zero-lamport accounts. So, we skipped adding any slots to uncleaned_roots at startup if the initial clean was going to be skipped. This turned out to be a big problem because some older slots would never make it on the uncleaned_roots list. Therefore, some slots would never be cleaned and allowed to be shrunk or dropped. Most likely there was a cascading effect where because those older slots weren't thrown out, newer slots weren't thrown out. So, the # of roots continued to grow and append vecs were not shrunk since the index was not cleaned.

#### Summary of Changes

At startup, identify roots that contain older duplicate pubkey entries and add those roots to the uncleaned_roots set so those roots get cleaned.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
