### PR TITLE
Replicates `AccountsDataMeter` in `TransactionContext`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2074,7 +2074,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -101,7 +101,7 @@ fn create_inputs() -> TransactionContext {
             },
         )
         .collect::<Vec<_>>();
-    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
+    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1, 0);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
         .push(&[0], &instruction_accounts, &instruction_data, true)

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -454,7 +454,7 @@ mod tests {
             &program_indices,
         );
         let mut transaction_context =
-            TransactionContext::new(preparation.transaction_accounts, 1, 1);
+            TransactionContext::new(preparation.transaction_accounts, 1, 1, 0);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3366,17 +3366,14 @@ mod tests {
          $program_key:ident,
          $loader_key:expr $(,)?) => {
             let $program_key = Pubkey::new_unique();
-            let mut $transaction_context = TransactionContext::new(
-                vec![
-                    (
-                        $loader_key,
-                        AccountSharedData::new(0, 0, &native_loader::id()),
-                    ),
-                    ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
-                ],
-                1,
-                1,
-            );
+            let transaction_accounts = vec![
+                (
+                    $loader_key,
+                    AccountSharedData::new(0, 0, &native_loader::id()),
+                ),
+                ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
+            ];
+            let mut $transaction_context = TransactionContext::new(transaction_accounts, 1, 1, 0);
             let mut $invoke_context = InvokeContext::new_mock(&mut $transaction_context, &[]);
             $invoke_context.push(&[], &[0, 1], &[]).unwrap();
         };

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2785,6 +2785,7 @@ mod tests {
             )],
             1,
             1,
+            0,
         )
     }
 
@@ -2894,7 +2895,7 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let good_stake = Stake {
             credits_observed: 4242,
@@ -2993,7 +2994,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
@@ -3140,7 +3141,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
@@ -3379,7 +3380,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let clock = Clock::default();
         let lamports = 424242;

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -107,7 +107,8 @@ fn bench_process_vote_instruction(
     instruction_data: Vec<u8>,
 ) {
     bencher.iter(|| {
-        let mut transaction_context = TransactionContext::new(transaction_accounts.clone(), 1, 1);
+        let mut transaction_context =
+            TransactionContext::new(transaction_accounts.clone(), 1, 1, 0);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(&instruction_accounts, &[0], &instruction_data)

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -216,7 +216,8 @@ native machine code before execting it in the virtual machine.",
     let program_indices = [0, 1];
     let preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
-    let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1, 1);
+    let mut transaction_context =
+        TransactionContext::new(preparation.transaction_accounts, 1, 1, 0);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     invoke_context
         .push(

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -282,7 +282,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3, 0);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_keys = transaction_context.get_keys_of_accounts().to_vec();
@@ -502,7 +502,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3, 0);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_metas = vec![
@@ -661,7 +661,7 @@ mod tests {
             (secp256k1_program::id(), secp256k1_account),
             (mock_program_id, mock_program_account),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 2);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 2, 0);
 
         let message = SanitizedMessage::Legacy(Message::new(
             &[

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -359,7 +359,7 @@ mod test {
                     is_writable: true,
                 },
             ];
-            let mut transaction_context = TransactionContext::new(accounts, 1, 2);
+            let mut transaction_context = TransactionContext::new(accounts, 1, 2, 0);
             let mut $invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         };
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -792,7 +792,7 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";


### PR DESCRIPTION
#### Problem
Spin-off from #25899.

#### Summary of Changes
Adds these two properties to `TransactionContext`:
- `total_resize_limit`: Maximum number of bytes which can be allocated in this transaction (measured at the beginning of the transaction).
- `total_resize_delta`: Negative bytes numbers mean the total allocation decreased, positive bytes numbers mean it increased.

Also adds the method `TransactionContext::get_total_resize_remaining()` which calculates the difference between these two properties.