### PR TITLE
Bump typenum from 1.14.0 to 1.15.0 to fix SIGILL during build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7365,9 +7365,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"


### PR DESCRIPTION
#### Problem

Compiling Solana with `-C target-cpu` might fail with `SIGILL` when compiling the `typenum` dependency.

#### Summary of Changes

Version 1.15.0 fixes an issue where code that runs at build-time would be compiled with the `target_cpu` setting, and the target CPU might support instructions that the host system does not have, causing a SIGILL during the build.

See also https://github.com/paholg/typenum/issues/162 and https://github.com/paholg/typenum/pull/177.

[Changlelog of v1.15.0 shows no other changes relevant for Solana](https://github.com/paholg/typenum/blob/8de704766c020bc9b2af6728ebb04750a29b1411/CHANGELOG.md#1150-2021-12-25).
