### PR TITLE
reorder notify_account_restore_from_snapshot call

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -705,6 +705,12 @@ where
 
     let mut measure_notify = Measure::start("accounts_notify");
 
+    let IndexGenerationInfo { accounts_data_len } = accounts_db.generate_index(
+        limit_load_slot_count_from_snapshot,
+        verify_index,
+        genesis_config,
+    );
+
     let accounts_db = Arc::new(accounts_db);
     let accounts_db_clone = accounts_db.clone();
     let handle = Builder::new()
@@ -713,12 +719,6 @@ where
             accounts_db_clone.notify_account_restore_from_snapshot();
         })
         .unwrap();
-
-    let IndexGenerationInfo { accounts_data_len } = accounts_db.generate_index(
-        limit_load_slot_count_from_snapshot,
-        verify_index,
-        genesis_config,
-    );
 
     accounts_db.maybe_add_filler_accounts(
         &genesis_config.epoch_schedule,


### PR DESCRIPTION
#### Problem

I need to reorder this call to allow me to mutably modify accounts_db.accounts_index after index generation. Is this ok?

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
