### PR TITLE
Clarify micro-lamports is unit of Compute Unit Price

### DIFF
--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -223,7 +223,7 @@ A stack of proofs, each of which proves that some data existed before the proof 
 
 An additional fee user can specify in compute budget [instruction](#instruction) to prioritize their [transactions](#transaction).
 
-The prioritization fee is calculated by multiplying the request maximum compute units by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
+The prioritization fee is calculated by multiplying the requested maximum compute units by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
 
 Transactions should request the minimum amount of compute units required for execution to minimize fees.
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -223,7 +223,7 @@ A stack of proofs, each of which proves that some data existed before the proof 
 
 An additional fee user can specify in compute budget [instruction](#instruction) to prioritize their [transactions](#transaction).
 
-The prioritization fee is calculated from multiplying the number of compute units requested by the compute unit price (0.000001 lamports per compute unit) rounded up to the nearest lamport.
+The prioritization fee is calculated from multiplying the number of Compute Units Requested by the Compute Unit Price (in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
 
 Transactions should request the minimum amount of compute units required for execution to minimize fees.
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -223,7 +223,7 @@ A stack of proofs, each of which proves that some data existed before the proof 
 
 An additional fee user can specify in compute budget [instruction](#instruction) to prioritize their [transactions](#transaction).
 
-The prioritization fee is calculated from multiplying the number of Compute Units Requested by the Compute Unit Price (in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
+The prioritization fee is calculated by multiplying the request maximum compute units by the compute-unit price (specified in increments of 0.000001 lamports per compute unit) rounded up to the nearest lamport.
 
 Transactions should request the minimum amount of compute units required for execution to minimize fees.
 


### PR DESCRIPTION
#### Problem

Phrase `(0.000001 lamports per compute unit)` can be confused as const value of Compute Unit Price. 

#### Summary of Changes
Clarify it as smallest increment value of Compute Unit Price

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
