### PR TITLE
feature: don't do rewrites in rent collection

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7613,7 +7613,10 @@ impl AccountsDb {
     /// 1. pubkey, hash pairs for the slot
     /// 2. us spent scanning
     /// 3. Measure started when we began accumulating
-    fn get_pubkey_hash_for_slot(&self, slot: Slot) -> (Vec<(Pubkey, Hash)>, u64, Measure) {
+    pub(crate) fn get_pubkey_hash_for_slot(
+        &self,
+        slot: Slot,
+    ) -> (Vec<(Pubkey, Hash)>, u64, Measure) {
         let mut scan = Measure::start("scan");
 
         let scan_result: ScanStorageResult<(Pubkey, Hash), DashMapVersionHash> = self

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5342,6 +5342,15 @@ impl Bank {
         }
     }
 
+    /// true if rent collection does NOT rewrite accounts whose pubkey indicates
+    ///  it is time for rent collection, but the account is rent exempt.
+    /// false if rent collection DOES rewrite accounts if the account is rent exempt
+    /// This is the default behavior historically.
+    fn bank_hash_skips_rent_rewrites(&self) -> bool {
+        self.feature_set
+            .is_active(&feature_set::skip_rent_rewrites::id())
+    }
+
     /// Collect rent from `accounts`
     ///
     /// This fn is called inside a parallel loop from `collect_rent_in_partition()`.  Avoid adding
@@ -5363,7 +5372,7 @@ impl Bank {
             Vec::<(&Pubkey, &AccountSharedData)>::with_capacity(accounts.len());
         let mut time_collecting_rent_us = 0;
         let mut time_storing_accounts_us = 0;
-        let can_skip_rewrites = false; // this will be goverened by a feature soon
+        let can_skip_rewrites = self.bank_hash_skips_rent_rewrites();
         let set_exempt_rent_epoch_max: bool = self
             .feature_set
             .is_active(&solana_sdk::feature_set::set_exempt_rent_epoch_max::id());

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -462,6 +462,10 @@ pub mod enable_early_verification_of_account_modifications {
     solana_sdk::declare_id!("7Vced912WrRnfjaiKRiNBcbuFw7RrnLv3E3z95Y4GTNc");
 }
 
+pub mod skip_rent_rewrites {
+    solana_sdk::declare_id!("CGB2jM8pwZkeeiXQ66kBMyBR6Np61mggL7XUsmLjVcrw");
+}
+
 pub mod prevent_crediting_accounts_that_end_rent_paying {
     solana_sdk::declare_id!("812kqX67odAp5NFwM8D2N24cku7WTm9CHUTFUXaDkWPn");
 }
@@ -679,6 +683,7 @@ lazy_static! {
         (stake_redelegate_instruction::id(), "enable the redelegate stake instruction #26294"),
         (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
         (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),
+        (skip_rent_rewrites::id(), "skip rewriting rent exempt accounts during rent collection #26491"),
         (enable_early_verification_of_account_modifications::id(), "enable early verification of account modifications #25899"),
         (disable_rehash_for_rent_epoch::id(), "on accounts hash calculation, do not try to rehash accounts #28934"),
         (account_hash_ignore_slot::id(), "ignore slot when calculating an account hash #28420"),


### PR DESCRIPTION
#### Problem
At some point, we want to stop doing rewrites in rent collection. This will eliminate needless work.
This pr introduces the feature flag which will govern when rewrites stop occurring.
Activating this feature requires that ancient append vecs be enabled by default. Otherwise, validators will exhaust their mmap file handle limit.

#### Summary of Changes
introduce feature flag that causes us to skip rewrites in rent collection.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

Feature Gate Issue: #26599