### PR TITLE
Make documentation and examples more prominent in README

### DIFF
--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -27,7 +27,6 @@ This is the Solana Javascript API built on the Solana [JSON RPC API](https://doc
 
  - [The Solana Cookbook](https://solanacookbook.com/) has extensive task-based documentation using this library.
  - For more detail on individual functions, see the [latest API Documentation](https://solana-labs.github.io/solana-web3.js/)
- - [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
 
 ## Installation
 

--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -28,7 +28,6 @@ This is the Solana Javascript API built on the Solana [JSON RPC API](https://doc
  - [The Solana Cookbook](https://solanacookbook.com/) has extensive task-based documentation using this library.
  - For more detail on individual functions, see the [latest API Documentation](https://solana-labs.github.io/solana-web3.js/)
  - [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
- - [Token Program Examples](https://github.com/solana-labs/solana-program-library/tree/master/token/js/examples)
 
 ## Installation
 

--- a/web3.js/README.md
+++ b/web3.js/README.md
@@ -23,7 +23,12 @@
 
 This is the Solana Javascript API built on the Solana [JSON RPC API](https://docs.solana.com/apps/jsonrpc-api)
 
-[Latest API Documentation](https://solana-labs.github.io/solana-web3.js/)
+## Documentation and examples
+
+ - [The Solana Cookbook](https://solanacookbook.com/) has extensive task-based documentation using this library.
+ - For more detail on individual functions, see the [latest API Documentation](https://solana-labs.github.io/solana-web3.js/)
+ - [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
+ - [Token Program Examples](https://github.com/solana-labs/solana-program-library/tree/master/token/js/examples)
 
 ## Installation
 
@@ -83,16 +88,6 @@ console.log(solanaWeb3);
 // `solanaWeb3` is provided in the global namespace by the `solanaWeb3.min.js` script bundle.
 console.log(solanaWeb3);
 ```
-
-## Examples
-
-Example scripts for the web3.js repo and native programs:
-
-- [Web3 Examples](https://github.com/solana-labs/solana/tree/master/web3.js/examples)
-
-Example scripts for the Solana Program Library:
-
-- [Token Program Examples](https://github.com/solana-labs/solana-program-library/tree/master/token/js/examples)
 
 ## Flow Support (Discontinued)
 


### PR DESCRIPTION
#### Problem

There's a lot more documentation to this library than many users would see looking at the current README

#### Summary of Changes

- Make a dedicated 'Documentation and examples' heading
- Bring the Solana Cookbook (which has more examples than all the other documentation listed in the README) to the top 
- Mention the examples higher up in the README
