### PR TITLE
Remove `get_total_resize_remaining()` and `total_resize_limit` from `TransactionContext`

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2060,7 +2060,7 @@ fn read_and_verify_elf(program_location: &str) -> Result<Vec<u8>, Box<dyn std::e
     let mut program_data = Vec::new();
     file.read_to_end(&mut program_data)
         .map_err(|err| format!("Unable to read program file: {}", err))?;
-    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+    let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
 
     // Verify the program

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -101,7 +101,7 @@ fn create_inputs() -> TransactionContext {
             },
         )
         .collect::<Vec<_>>();
-    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1, 0);
+    let mut transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
     let instruction_data = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     transaction_context
         .push(&[0], &instruction_accounts, &instruction_data, true)

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -454,7 +454,7 @@ mod tests {
             &program_indices,
         );
         let mut transaction_context =
-            TransactionContext::new(preparation.transaction_accounts, 1, 1, 0);
+            TransactionContext::new(preparation.transaction_accounts, 1, 1);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -3373,7 +3373,7 @@ mod tests {
                 ),
                 ($program_key, AccountSharedData::new(0, 0, &$loader_key)),
             ];
-            let mut $transaction_context = TransactionContext::new(transaction_accounts, 1, 1, 0);
+            let mut $transaction_context = TransactionContext::new(transaction_accounts, 1, 1);
             let mut $invoke_context = InvokeContext::new_mock(&mut $transaction_context, &[]);
             $invoke_context.push(&[], &[0, 1], &[]).unwrap();
         };

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -2785,7 +2785,6 @@ mod tests {
             )],
             1,
             1,
-            0,
         )
     }
 
@@ -2895,7 +2894,7 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let good_stake = Stake {
             credits_observed: 4242,
@@ -2994,7 +2993,7 @@ mod tests {
 
     #[test]
     fn test_metas_can_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         // Identical Metas can merge
         assert!(MergeKind::metas_can_merge(
@@ -3141,7 +3140,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
@@ -3380,7 +3379,7 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let clock = Clock::default();
         let lamports = 424242;

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -107,8 +107,7 @@ fn bench_process_vote_instruction(
     instruction_data: Vec<u8>,
 ) {
     bencher.iter(|| {
-        let mut transaction_context =
-            TransactionContext::new(transaction_accounts.clone(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(transaction_accounts.clone(), 1, 1);
         let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         invoke_context
             .push(&instruction_accounts, &[0], &instruction_data)

--- a/rbpf-cli/src/main.rs
+++ b/rbpf-cli/src/main.rs
@@ -216,8 +216,7 @@ native machine code before execting it in the virtual machine.",
     let program_indices = [0, 1];
     let preparation =
         prepare_mock_invoke_context(transaction_accounts, instruction_accounts, &program_indices);
-    let mut transaction_context =
-        TransactionContext::new(preparation.transaction_accounts, 1, 1, 0);
+    let mut transaction_context = TransactionContext::new(preparation.transaction_accounts, 1, 1);
     let mut invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
     invoke_context
         .push(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4283,8 +4283,6 @@ impl Bank {
             transaction_accounts,
             compute_budget.max_invoke_depth.saturating_add(1),
             tx.message().instructions().len(),
-            self.accounts_data_size_limit()
-                .saturating_sub(prev_accounts_data_len),
         );
 
         let pre_account_state_info =
@@ -18567,7 +18565,6 @@ pub(crate) mod tests {
             loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
             compute_budget.max_invoke_depth.saturating_add(1),
             number_of_instructions_at_transaction_level,
-            0,
         );
 
         assert_eq!(

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -282,7 +282,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3, 0);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_keys = transaction_context.get_keys_of_accounts().to_vec();
@@ -502,7 +502,7 @@ mod tests {
                 create_loadable_account_for_test("mock_system_program"),
             ),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 3, 0);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 3);
         let program_indices = vec![vec![2]];
         let executors = Rc::new(RefCell::new(Executors::default()));
         let account_metas = vec![
@@ -661,7 +661,7 @@ mod tests {
             (secp256k1_program::id(), secp256k1_account),
             (mock_program_id, mock_program_account),
         ];
-        let mut transaction_context = TransactionContext::new(accounts, 1, 2, 0);
+        let mut transaction_context = TransactionContext::new(accounts, 1, 2);
 
         let message = SanitizedMessage::Legacy(Message::new(
             &[

--- a/runtime/src/nonce_keyed_account.rs
+++ b/runtime/src/nonce_keyed_account.rs
@@ -328,7 +328,7 @@ mod test {
                     is_writable: true,
                 },
             ];
-            let mut transaction_context = TransactionContext::new(accounts, 1, 2, 0);
+            let mut transaction_context = TransactionContext::new(accounts, 1, 2);
             let mut $invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         };
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1, 0);
+        let mut transaction_context = TransactionContext::new(Vec::new(), 1, 1);
         let invoke_context = InvokeContext::new_mock(&mut transaction_context, &[]);
         let from = Pubkey::new_unique();
         let seed = "dull boy";

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -48,7 +48,6 @@ pub struct TransactionContext {
     number_of_instructions_at_transaction_level: usize,
     instruction_trace: InstructionTrace,
     return_data: TransactionReturnData,
-    total_resize_limit: u64,
     total_resize_delta: RefCell<i64>,
 }
 
@@ -58,7 +57,6 @@ impl TransactionContext {
         transaction_accounts: Vec<TransactionAccount>,
         instruction_context_capacity: usize,
         number_of_instructions_at_transaction_level: usize,
-        total_resize_limit: u64,
     ) -> Self {
         let (account_keys, accounts): (Vec<Pubkey>, Vec<RefCell<AccountSharedData>>) =
             transaction_accounts
@@ -73,7 +71,6 @@ impl TransactionContext {
             number_of_instructions_at_transaction_level,
             instruction_trace: Vec::with_capacity(number_of_instructions_at_transaction_level),
             return_data: TransactionReturnData::default(),
-            total_resize_limit,
             total_resize_delta: RefCell::new(0),
         }
     }
@@ -253,18 +250,6 @@ impl TransactionContext {
     /// Returns instruction trace
     pub fn get_instruction_trace(&self) -> &InstructionTrace {
         &self.instruction_trace
-    }
-
-    /// Returns (in bytes) how much data can still be allocated
-    pub fn get_total_resize_remaining(&self) -> u64 {
-        let total_resize_delta = *self.total_resize_delta.borrow();
-        if total_resize_delta >= 0 {
-            self.total_resize_limit
-                .saturating_sub(total_resize_delta as u64)
-        } else {
-            self.total_resize_limit
-                .saturating_add(total_resize_delta.saturating_neg() as u64)
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem

It's not possible to deterministically enforce a cluster-wide global/per-block accounts data size limit within `TransactionContext`. So the code that currently attempts to do that should be removed.

For more context, please see https://github.com/solana-labs/solana/pull/26438#discussion_r916865675 and https://github.com/solana-labs/solana/issues/26439.

#### Summary of Changes

Remove `get_total_resize_remaining()` and `total_resize_limit` from `TransactionContext`.