### PR TITLE
Bugfix: slots_connected snapshot_slot not full

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -798,6 +798,8 @@ fn load_bank_forks(
     };
 
     if let Some(halt_slot) = process_options.halt_at_slot {
+        // Check if we have the slot data necessary to replay from starting_slot to halt_slot.
+        //  - This will not catch the case when loading from genesis without a full slot 0.
         if !blockstore.slots_connected(starting_slot, halt_slot) {
             eprintln!(
                 "Unable to load bank forks at slot {} due to disconnected blocks.",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -547,7 +547,8 @@ impl Blockstore {
         self.prepare_rooted_slot_iterator(slot, IteratorDirection::Reverse)
     }
 
-    /// Determines if starting_slot and ending_slot are connected
+    /// Determines if `starting_slot` and `ending_slot` are connected by full slots
+    /// `starting_slot` is excluded from the `is_full()` check
     pub fn slots_connected(&self, starting_slot: Slot, ending_slot: Slot) -> bool {
         if starting_slot == ending_slot {
             return true;


### PR DESCRIPTION
#### Problem
The snapshot slot (starting_slot) doesn't need to be full for us to process [starting_slot, ending_slot] (snapshot slot isn't reprocessed, we use the unpacked bank as-is), so the slots_connected function was overly restrictive.

#### Summary of Changes
* Short-circuit check if starting_slot == ending_slot.
* Special case for starting_slot to not be required full

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
