### PR TITLE
Increase the timeout for rpc_subscriptions test

### DIFF
--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -391,7 +391,7 @@ fn test_rpc_subscriptions() {
         }
     }
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(10);
     let mut account_notifications = transactions.len();
     while account_notifications > 0 {
         let timeout = deadline.saturating_duration_since(Instant::now());


### PR DESCRIPTION
#### Problem

CI fails not-infrequently due to `test_rpc_subscriptions` panics caused by timeouts waiting for account notifications. 
https://buildkite.com/solana-labs/solana/builds/77503#0181de45-a5dc-404a-a575-870b50eb0e2a

#### Summary of Changes

Bump the timeout to 10 seconds.