### PR TITLE
do not count 0 lamport accounts as rent-paying

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7936,6 +7936,9 @@ impl AccountsDb {
         account: &T,
         rent_collector: &RentCollector,
     ) -> Option<u64> {
+        if account.lamports() == 0 {
+            return None;
+        }
         (rent_collector.should_collect_rent(pubkey, account)
             && !rent_collector.get_rent_due(account).is_exempt())
         .then(|| {


### PR DESCRIPTION
#### Problem

zero lamport accounts show up as owing rent, but they are not going to have rent collected from them. So, ignore them.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
