### PR TITLE
add accounts db config to bank tests

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -101,6 +101,7 @@ impl SnapshotTestConfig {
             false,
             accounts_db::AccountShrinkThreshold::default(),
             false,
+            None,
         );
         bank0.freeze();
         let mut bank_forks = BankForks::new(bank0);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3656,6 +3656,7 @@ pub mod tests {
             false,
             AccountShrinkThreshold::default(),
             false,
+            None,
         );
         *bank.epoch_schedule()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1475,6 +1475,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             false,
+            None,
         )
     }
 
@@ -1556,6 +1557,7 @@ impl Bank {
         accounts_db_caching_enabled: bool,
         shrink_ratio: AccountShrinkThreshold,
         debug_do_not_add_builtins: bool,
+        accounts_db_config: Option<AccountsDbConfig>,
     ) -> Self {
         Self::new_with_paths(
             genesis_config,
@@ -1566,7 +1568,7 @@ impl Bank {
             accounts_db_caching_enabled,
             shrink_ratio,
             debug_do_not_add_builtins,
-            Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
+            accounts_db_config.or(Some(ACCOUNTS_DB_CONFIG_FOR_TESTING)),
             None,
         )
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -3539,6 +3539,7 @@ mod tests {
             false,
             AccountShrinkThreshold::default(),
             false,
+            None,
         ));
         bank0
             .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())


### PR DESCRIPTION
#### Problem

This allows passing info to accounts db and accounts index at startup time for testing new features.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
