### PR TITLE
update `scripts/cargo-fmt.sh` to  reflect changes in 9425478

### DIFF
--- a/scripts/cargo-fmt.sh
+++ b/scripts/cargo-fmt.sh
@@ -14,7 +14,7 @@ set -ex
 
 "$cargo" nightly fmt --all
 (cd programs/bpf && "$cargo" nightly fmt --all)
-(cd sdk/cargo-build-bpf/tests/crates/fail && "$cargo" nightly fmt --all)
-(cd sdk/cargo-build-bpf/tests/crates/noop && "$cargo" nightly fmt --all)
+(cd sdk/cargo-build-sbf/tests/crates/fail && "$cargo" nightly fmt --all)
+(cd sdk/cargo-build-sbf/tests/crates/noop && "$cargo" nightly fmt --all)
 (cd storage-bigtable/build-proto && "$cargo" nightly fmt --all)
 (cd web3.js/test/fixtures/noop-program && "$cargo" nightly fmt --all)


### PR DESCRIPTION
#### Problem

9425478 broke paths referenced in `scripts/cargo-fmt.sh`, which is presently decoupled from CI

#### Summary of Changes

update them

NOTE: backport not necessary, 9425478 is only in master