### PR TITLE
Fix sol_get_processed_sibling_instruction on 32-bit hosts

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -1750,8 +1750,9 @@ declare_syscall!(
                 result
             );
 
-            if *data_len == instruction_context.get_instruction_data().len()
-                && *accounts_len == instruction_context.get_number_of_instruction_accounts()
+            if *data_len == (instruction_context.get_instruction_data().len() as u64)
+                && *accounts_len
+                    == (instruction_context.get_number_of_instruction_accounts() as u64)
             {
                 let program_id = question_mark!(
                     translate_type_mut::<Pubkey>(
@@ -1809,8 +1810,8 @@ declare_syscall!(
                 );
                 accounts.clone_from_slice(account_metas.as_slice());
             }
-            *data_len = instruction_context.get_instruction_data().len();
-            *accounts_len = instruction_context.get_number_of_instruction_accounts();
+            *data_len = instruction_context.get_instruction_data().len() as u64;
+            *accounts_len = instruction_context.get_number_of_instruction_accounts() as u64;
             *result = Ok(true as u64);
             return;
         }

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -664,9 +664,9 @@ impl CompiledInstruction {
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ProcessedSiblingInstruction {
     /// Length of the instruction data
-    pub data_len: usize,
+    pub data_len: u64,
     /// Number of AccountMeta structures
-    pub accounts_len: usize,
+    pub accounts_len: u64,
 }
 
 /// Returns a sibling instruction from the processed sibling instruction list.
@@ -698,8 +698,8 @@ pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
         } {
             let mut data = Vec::new();
             let mut accounts = Vec::new();
-            data.resize_with(meta.data_len, u8::default);
-            accounts.resize_with(meta.accounts_len, AccountMeta::default);
+            data.resize_with(meta.data_len as usize, u8::default);
+            accounts.resize_with(meta.accounts_len as usize, AccountMeta::default);
 
             let _ = unsafe {
                 crate::syscalls::sol_get_processed_sibling_instruction(


### PR DESCRIPTION
#### Problem

Syscall `sol_get_processed_sibling_instruction` writes struct `ProcessedSiblingInstruction` to VM memory. This struct contains `usize` parameters, which have different lengths across different architectures. The de-facto host `usize` is 64-bit on Solana, of course.

32-bit hosts such as `wasm32` would write 32-bit values, causing memory corruption in the VM.

#### Summary of Changes

Changes `usize` parameters in `ProcessedSiblingInstruction` to `u64`. This is a no-op on 64-bit host architectures.

Fixes #