### PR TITLE
sdk/bpf/c: fix sol_get_return_data signature

### DIFF
--- a/sdk/bpf/c/inc/sol/return_data.h
+++ b/sdk/bpf/c/inc/sol/return_data.h
@@ -41,10 +41,10 @@ static void sol_set_return_data(const uint8_t * arg1, uint64_t arg2) {
  * @param result length of return data (may exceed bytes_len if the return data is longer)
  */
 #ifndef SOL_SBFV2
-uint64_t sol_get_return_data(const uint8_t *, uint64_t, SolPubkey *);
+uint64_t sol_get_return_data(uint8_t *, uint64_t, SolPubkey *);
 #else
-typedef uint64_t(*sol_get_return_data_pointer_type)(const uint8_t *, uint64_t, SolPubkey *);
-static uint64_t sol_get_return_data(const uint8_t * arg1, uint64_t arg2, SolPubkey * arg3) {
+typedef uint64_t(*sol_get_return_data_pointer_type)(uint8_t *, uint64_t, SolPubkey *);
+static uint64_t sol_get_return_data(uint8_t * arg1, uint64_t arg2, SolPubkey * arg3) {
   sol_get_return_data_pointer_type sol_get_return_data_pointer = (sol_get_return_data_pointer_type) 1562527204;
   return sol_get_return_data_pointer(arg1, arg2, arg3);
 }


### PR DESCRIPTION
#### Problem

C SDK syscall `sol_get_return_data` incorrectly declares a const pointer for the first function argument, although the syscall actually writes data to it.

#### Summary of Changes

```diff
-typedef uint64_t(*sol_get_return_data_pointer_type)(const uint8_t *, uint64_t, SolPubkey *);
+typedef uint64_t(*sol_get_return_data_pointer_type)(uint8_t *, uint64_t, SolPubkey *);
```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
