### PR TITLE
test-validator: use or skip ADDRESS value from account flag

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -61,7 +61,7 @@ use {
 
 #[derive(Clone)]
 pub struct AccountInfo<'a> {
-    pub address: Pubkey,
+    pub address: Option<Pubkey>,
     pub filename: &'a str,
 }
 
@@ -317,7 +317,10 @@ impl TestValidatorGenesis {
                 }
                 Ok(deserialized) => deserialized,
             };
-            let address = Pubkey::from_str(account_info.keyed_account.pubkey.as_str()).unwrap();
+
+            let address = account.address.unwrap_or_else(|| {
+                Pubkey::from_str(account_info.keyed_account.pubkey.as_str()).unwrap()
+            });
             let account = account_info
                 .keyed_account
                 .account

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -209,10 +209,12 @@ fn main() {
                 .value_name("ADDRESS FILENAME.JSON")
                 .takes_value(true)
                 .number_of_values(2)
+                .allow_hyphen_values(true)
                 .multiple(true)
                 .help(
                     "Load an account from the provided JSON file (see `solana account --help` on how to dump \
                         an account to file). Files are searched for relatively to CWD and tests/fixtures. \
+                        If ADDRESS is omitted via the `-` placeholder, the one in the file will be used. \
                         If the ledger already exists then this parameter is silently ignored",
                 ),
         )
@@ -541,10 +543,14 @@ fn main() {
         for address_filename in values.chunks(2) {
             match address_filename {
                 [address, filename] => {
-                    let address = address.parse::<Pubkey>().unwrap_or_else(|err| {
-                        println!("Error: invalid address {}: {}", address, err);
-                        exit(1);
-                    });
+                    let address = if *address == "-" {
+                        None
+                    } else {
+                        Some(address.parse::<Pubkey>().unwrap_or_else(|err| {
+                            println!("Error: invalid address {}: {}", address, err);
+                            exit(1);
+                        }))
+                    };
 
                     accounts_to_load.push(AccountInfo { address, filename });
                 }


### PR DESCRIPTION
#### Problem
`solana-test-validator` has a flag for loading accounts from local files (`--account <ADDRESS FILENAME.JSON>`), but the `ADDRESS` value is silently ignored since as it's actually read from the specified file

https://github.com/solana-labs/solana/blob/e3d1fe52a26bc00ad376d6884f9d743c00814ccd/test-validator/src/lib.rs#L320

#### Summary of Changes
Use the `ADDRESS` value, or read it from the file if `-` is passed (`--account - FILENAME.JSON`)
