### PR TITLE
removes erroneous uses of std::mem::swap

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -458,8 +458,7 @@ impl<T: Clone + Copy> Bucket<T> {
     pub fn handle_delayed_grows(&mut self) {
         if self.reallocated.get_reallocated() {
             // swap out the bucket that was resized previously with a read lock
-            let mut items = ReallocatedItems::default();
-            std::mem::swap(&mut items, &mut self.reallocated.items.lock().unwrap());
+            let mut items = std::mem::take(&mut *self.reallocated.items.lock().unwrap());
 
             if let Some((random, bucket)) = items.index.take() {
                 self.apply_grow_index(random, bucket);

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -60,8 +60,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         // and make progress
         if bank.slot() > SLOT_TO_RESOLVE && !self.good_shreds.is_empty() {
             info!("Resolving bad shreds");
-            let mut shreds = vec![];
-            std::mem::swap(&mut shreds, &mut self.good_shreds);
+            let shreds = std::mem::take(&mut self.good_shreds);
             blockstore_sender.send((Arc::new(shreds), None))?;
         }
 

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -167,7 +167,7 @@ impl AggregateCommitmentService {
         );
         new_block_commitment.set_highest_confirmed_root(highest_confirmed_root);
 
-        std::mem::swap(&mut *w_block_commitment_cache, &mut new_block_commitment);
+        *w_block_commitment_cache = new_block_commitment;
         w_block_commitment_cache.commitment_slots()
     }
 

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -29,11 +29,11 @@ impl OptimisticConfirmationVerifier {
     ) -> Vec<(Slot, Hash)> {
         let root = root_bank.slot();
         let root_ancestors = &root_bank.ancestors;
-        let mut slots_before_root = self
+        let slots_after_root = self
             .unchecked_slots
             .split_off(&((root + 1), Hash::default()));
         // `slots_before_root` now contains all slots <= root
-        std::mem::swap(&mut slots_before_root, &mut self.unchecked_slots);
+        let slots_before_root = std::mem::replace(&mut self.unchecked_slots, slots_after_root);
         slots_before_root
             .into_iter()
             .filter(|(optimistic_slot, optimistic_hash)| {

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -310,8 +310,7 @@ impl RepairWeight {
         // Purge `self.unrooted_slots` of slots less than `new_root` as we know any
         // unrooted votes for slots < `new_root` will now be rejected, so we won't
         // need to check `self.unrooted_slots` to see if those slots are unrooted.
-        let mut new_unrooted_slots = self.unrooted_slots.split_off(&new_root);
-        std::mem::swap(&mut self.unrooted_slots, &mut new_unrooted_slots);
+        self.unrooted_slots = self.unrooted_slots.split_off(&new_root);
         self.root = new_root;
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3039,18 +3039,15 @@ impl ReplayStage {
         }
         progress.handle_new_root(&r_bank_forks);
         heaviest_subtree_fork_choice.set_root((new_root, r_bank_forks.root_bank().hash()));
-        let mut slots_ge_root = duplicate_slots_tracker.split_off(&new_root);
+        *duplicate_slots_tracker = duplicate_slots_tracker.split_off(&new_root);
         // duplicate_slots_tracker now only contains entries >= `new_root`
-        std::mem::swap(duplicate_slots_tracker, &mut slots_ge_root);
 
-        let mut slots_ge_root = gossip_duplicate_confirmed_slots.split_off(&new_root);
+        *gossip_duplicate_confirmed_slots = gossip_duplicate_confirmed_slots.split_off(&new_root);
         // gossip_confirmed_slots now only contains entries >= `new_root`
-        std::mem::swap(gossip_duplicate_confirmed_slots, &mut slots_ge_root);
 
         unfrozen_gossip_verified_vote_hashes.set_root(new_root);
-        let mut slots_ge_root = epoch_slots_frozen_slots.split_off(&new_root);
+        *epoch_slots_frozen_slots = epoch_slots_frozen_slots.split_off(&new_root);
         // epoch_slots_frozen_slots now only contains entries >= `new_root`
-        std::mem::swap(epoch_slots_frozen_slots, &mut slots_ge_root);
     }
 
     fn generate_new_bank_forks(

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -127,11 +127,7 @@ impl SigVerifier for TransactionSigVerifier {
         &mut self,
         packet_batches: Vec<PacketBatch>,
     ) -> Result<(), SigVerifyServiceError<Self::SendType>> {
-        let mut tracer_packet_stats_to_send = SigverifyTracerPacketStats::default();
-        std::mem::swap(
-            &mut tracer_packet_stats_to_send,
-            &mut self.tracer_packet_stats,
-        );
+        let tracer_packet_stats_to_send = std::mem::take(&mut self.tracer_packet_stats);
         self.packet_sender
             .send((packet_batches, Some(tracer_packet_stats_to_send)))?;
         Ok(())

--- a/core/src/unfrozen_gossip_verified_vote_hashes.rs
+++ b/core/src/unfrozen_gossip_verified_vote_hashes.rs
@@ -49,9 +49,8 @@ impl UnfrozenGossipVerifiedVoteHashes {
 
     // Cleanup `votes_per_slot` based on new roots
     pub fn set_root(&mut self, new_root: Slot) {
-        let mut slots_ge_root = self.votes_per_slot.split_off(&new_root);
+        self.votes_per_slot = self.votes_per_slot.split_off(&new_root);
         // `self.votes_per_slot` now only contains entries >= `new_root`
-        std::mem::swap(&mut self.votes_per_slot, &mut slots_ge_root);
     }
 
     pub fn remove_slot_hash(&mut self, slot: Slot, hash: &Hash) -> Option<Vec<Pubkey>> {

--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -49,9 +49,7 @@ impl Poh {
     pub fn reset(&mut self, hash: Hash, hashes_per_tick: Option<u64>) {
         // retains ticks_per_slot: this cannot change without restarting the validator
         let tick_number = 0;
-        let mut poh =
-            Poh::new_with_slot_info(hash, hashes_per_tick, self.ticks_per_slot, tick_number);
-        std::mem::swap(&mut poh, self);
+        *self = Poh::new_with_slot_info(hash, hashes_per_tick, self.ticks_per_slot, tick_number);
     }
 
     pub fn target_poh_time(&self, target_ns_per_tick: u64) -> Instant {

--- a/gossip/src/epoch_slots.rs
+++ b/gossip/src/epoch_slots.rs
@@ -216,8 +216,7 @@ impl CompressedSlots {
             CompressedSlots::Uncompressed(vals) => {
                 let unc = vals.clone();
                 let compressed = Flate2::deflate(unc)?;
-                let mut new = CompressedSlots::Flate2(compressed);
-                std::mem::swap(self, &mut new);
+                *self = CompressedSlots::Flate2(compressed);
                 Ok(())
             }
             CompressedSlots::Flate2(_) => Ok(()),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1703,8 +1703,7 @@ impl Blockstore {
                 current_slot += 1;
                 parent_slot = current_slot - 1;
                 remaining_ticks_in_slot = ticks_per_slot;
-                let mut current_entries = vec![];
-                std::mem::swap(&mut slot_entries, &mut current_entries);
+                let current_entries = std::mem::take(&mut slot_entries);
                 let start_index = {
                     if all_shreds.is_empty() {
                         start_index

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -220,9 +220,8 @@ impl SlotMeta {
     }
 
     pub fn clear_unconfirmed_slot(&mut self) {
-        let mut new_self = SlotMeta::new_orphan(self.slot);
-        std::mem::swap(&mut new_self.next_slots, &mut self.next_slots);
-        std::mem::swap(self, &mut new_self);
+        let old = std::mem::replace(self, SlotMeta::new_orphan(self.slot));
+        self.next_slots = old.next_slots;
     }
 
     pub(crate) fn new(slot: Slot, parent_slot: Option<Slot>) -> Self {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1423,13 +1423,9 @@ fn test_snapshots_restart_validity() {
         .full_snapshot_archives_dir;
 
     // Set up the cluster with 1 snapshotting validator
-    let mut all_account_storage_dirs = vec![vec![]];
-
-    std::mem::swap(
-        &mut all_account_storage_dirs[0],
+    let mut all_account_storage_dirs = vec![std::mem::take(
         &mut snapshot_test_config.account_storage_dirs,
-    );
-
+    )];
     let mut config = ClusterConfig {
         node_stakes: vec![DEFAULT_NODE_STAKE],
         cluster_lamports: DEFAULT_CLUSTER_LAMPORTS,

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -179,8 +179,7 @@ impl MetricsAgent {
     }
 
     fn collect_points(points: &mut Vec<DataPoint>, counters: &mut CounterMap) -> Vec<DataPoint> {
-        let mut ret: Vec<DataPoint> = Vec::default();
-        std::mem::swap(&mut ret, points);
+        let mut ret = std::mem::take(points);
         ret.extend(counters.values().map(|v| v.into()));
         counters.clear();
         ret

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -459,7 +459,6 @@ impl PohRecorder {
     // synchronize PoH with a bank
     pub fn reset(&mut self, reset_bank: Arc<Bank>, next_leader_slot: Option<(Slot, Slot)>) {
         self.clear_bank();
-        let mut cache = vec![];
         let blockhash = reset_bank.last_blockhash();
         let poh_hash = {
             let mut poh = self.poh.lock().unwrap();
@@ -475,8 +474,7 @@ impl PohRecorder {
             reset_bank.slot()
         );
 
-        std::mem::swap(&mut cache, &mut self.tick_cache);
-
+        self.tick_cache = vec![];
         self.start_bank = reset_bank;
         self.tick_height = (self.start_slot() + 1) * self.ticks_per_slot;
         self.start_tick_height = self.tick_height + 1;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4892,13 +4892,12 @@ pub mod tests {
                     slot,
                 ));
 
-            let mut new_block_commitment = BlockCommitmentCache::new(
+            let new_block_commitment = BlockCommitmentCache::new(
                 HashMap::new(),
                 0,
                 CommitmentSlots::new_from_slot(self.bank_forks.read().unwrap().highest_slot()),
             );
-            let mut w_block_commitment_cache = self.block_commitment_cache.write().unwrap();
-            std::mem::swap(&mut *w_block_commitment_cache, &mut new_block_commitment);
+            *self.block_commitment_cache.write().unwrap() = new_block_commitment;
             bank
         }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1857,12 +1857,10 @@ impl<'a, T: Fn(Slot) -> Option<Slot> + Sync + Send + Clone> AppendVecScan for Sc
         result
     }
     fn get_accum(&mut self) -> BinnedHashData {
-        let mut def = BinnedHashData::default();
-        std::mem::swap(&mut def, &mut self.accum);
-        def
+        std::mem::take(&mut self.accum)
     }
-    fn set_accum(&mut self, mut accum: BinnedHashData) {
-        std::mem::swap(&mut self.accum, &mut accum);
+    fn set_accum(&mut self, accum: BinnedHashData) {
+        self.accum = accum;
     }
 }
 
@@ -6320,9 +6318,7 @@ impl AccountsDb {
                         .map(|stored_account| stored_account.meta.pubkey)
                         .unwrap(), // will always be 'Some'
                 ) {
-                    let mut account: (StoredMetaWriteVersion, Option<StoredAccountMeta<'_>>) =
-                        (0, None);
-                    std::mem::swap(&mut account, found_account);
+                    let account = std::mem::take(found_account);
                     scanner.found_account(&LoadedAccount::Stored(account.1.unwrap()));
                 }
                 let next = progress[min_index].next().map(|stored_account| {
@@ -9369,12 +9365,10 @@ pub mod tests {
         }
         fn init_accum(&mut self, _count: usize) {}
         fn get_accum(&mut self) -> BinnedHashData {
-            let mut def = BinnedHashData::default();
-            std::mem::swap(&mut def, &mut self.accum);
-            def
+            std::mem::take(&mut self.accum)
         }
-        fn set_accum(&mut self, mut accum: BinnedHashData) {
-            std::mem::swap(&mut self.accum, &mut accum);
+        fn set_accum(&mut self, accum: BinnedHashData) {
+            self.accum = accum;
         }
         fn found_account(&mut self, loaded_account: &LoadedAccount) {
             self.calls.fetch_add(1, Ordering::Relaxed);
@@ -9633,12 +9627,10 @@ pub mod tests {
             self.accum
         }
         fn get_accum(&mut self) -> BinnedHashData {
-            let mut def = BinnedHashData::default();
-            std::mem::swap(&mut def, &mut self.accum);
-            def
+            std::mem::take(&mut self.accum)
         }
-        fn set_accum(&mut self, mut accum: BinnedHashData) {
-            std::mem::swap(&mut self.accum, &mut accum);
+        fn set_accum(&mut self, accum: BinnedHashData) {
+            self.accum = accum;
         }
     }
 

--- a/runtime/src/append_vec/test_utils.rs
+++ b/runtime/src/append_vec/test_utils.rs
@@ -12,8 +12,7 @@ pub struct TempFile {
 
 impl Drop for TempFile {
     fn drop(&mut self) {
-        let mut path = PathBuf::new();
-        std::mem::swap(&mut path, &mut self.path);
+        let path = std::mem::replace(&mut self.path, PathBuf::new());
         let _ignored = std::fs::remove_file(path);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4281,8 +4281,7 @@ impl Bank {
         );
 
         let prev_accounts_data_len = self.load_accounts_data_size();
-        let mut transaction_accounts = Vec::new();
-        std::mem::swap(&mut loaded_transaction.accounts, &mut transaction_accounts);
+        let transaction_accounts = std::mem::take(&mut loaded_transaction.accounts);
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,
             compute_budget.max_invoke_depth.saturating_add(1),

--- a/runtime/src/rolling_bit_field.rs
+++ b/runtime/src/rolling_bit_field.rs
@@ -294,8 +294,7 @@ pub mod tests {
 
     impl RollingBitField {
         pub fn clear(&mut self) {
-            let mut n = Self::new(self.max_width);
-            std::mem::swap(&mut n, self);
+            *self = Self::new(self.max_width);
         }
     }
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -268,7 +268,7 @@ fn test_bank_serialize_style(
             // This make serialized bytes not deterministic.
             // But, we can guarantee that the buffer is different if we change the hash!
             assert_ne!(buf, buf_reserialized);
-            std::mem::swap(&mut buf, &mut buf_reserialized);
+            buf = buf_reserialized;
         }
     }
 


### PR DESCRIPTION
#### Problem
Almost all instances should be replaced by `std::mem::{take,replace}`,
or plain assignment.


#### Summary of Changes
removed erroneous uses of `std::mem::swap`.