### PR TITLE
explorer: mark verifiable builds as experimental

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -195,7 +195,7 @@ function SecurityLabel() {
 function LastVerifiedBuildLabel() {
   return (
     <InfoTooltip text="Indicates whether the program currently deployed on-chain is verified to match the associated published source code, when it is available.">
-      Verifiable Build Status
+      Verifiable Build Status (experimental)
     </InfoTooltip>
   );
 }

--- a/explorer/src/components/common/VerifiedBadge.tsx
+++ b/explorer/src/components/common/VerifiedBadge.tsx
@@ -11,7 +11,7 @@ export function VerifiedBadge({
     return (
       <h3 className="mb-0">
         <a
-          className="c-pointer badge bg-success-soft rank"
+          className="c-pointer badge bg-info-soft rank"
           href={verifiableBuild.url}
           target="_blank"
           rel="noreferrer"


### PR DESCRIPTION
Add "(experimental)" and use a neutral badge instead of a green one.

The current iteration of verifiable builds does not come with
particularly strong guarantees - best to avoid giving users
any false sense of security.

It relies on an unaudited third party service independent of the explorer,
and the nature of Cargo's build process means it is hard to make strong
claims about the resulting artifacts.

(CC @CherryWorm, who brought this up)