### PR TITLE
feat: safeguard for executing withdraws that will clean out a vote account

### DIFF
--- a/web3.js/test/vote-program.test.ts
+++ b/web3.js/test/vote-program.test.ts
@@ -165,9 +165,25 @@ describe('VoteProgram', () => {
         minimumAmount + 10 * LAMPORTS_PER_SOL,
       );
 
-      // Withdraw from Vote account
+      // Withdraw from Vote account with invalid amount (clear all funds)
       let recipient = Keypair.generate();
       let withdraw = VoteProgram.withdraw({
+        votePubkey: newVoteAccount.publicKey,
+        authorizedWithdrawerPubkey: authorized.publicKey,
+        lamports: minimumAmount + 10 * LAMPORTS_PER_SOL,
+        toPubkey: recipient.publicKey,
+      });
+      await expect(
+        sendAndConfirmTransaction(connection, withdraw, [authorized], {
+          preflightCommitment: 'confirmed',
+        }),
+      ).to.be.rejectedWith(
+        Error,
+        `Withdraw transaction failed, vote account balance after withdrawal will be smaller than minimum balance required for rent.`,
+      );
+
+      // Withdraw from Vote account
+      withdraw = VoteProgram.withdraw({
         votePubkey: newVoteAccount.publicKey,
         authorizedWithdrawerPubkey: authorized.publicKey,
         lamports: LAMPORTS_PER_SOL,


### PR DESCRIPTION
#### Problem

Currently when withdrawing rewards from a vote account the user has the ability to withdraw an amount that will leave the account with less than the minimum required for rent, thus forcing the account to be closed.

#### Summary of Changes

I have added a check to the `sendAndConfirmTransaction` function which will check to see if the transaction sent contains instructions for a `VoteProgram` withdraw and if it does check that the amount being withdrawn will not leave the account with less than the minimum requirement for rent.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
