### PR TITLE
Add fallback for ledger-tool commands to create new column families

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -624,6 +624,7 @@ pub fn bigtable_process_command(
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let verbose = matches.is_present("verbose");
+    let force_update_to_open = matches.is_present("force_update_to_open");
     let output_format = OutputFormat::from_matches(matches, "output_format", verbose);
 
     let (subcommand, sub_matches) = matches.subcommand();
@@ -650,6 +651,7 @@ pub fn bigtable_process_command(
                 AccessType::Secondary,
                 None,
                 shred_storage_type,
+                force_update_to_open,
             );
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: false,


### PR DESCRIPTION
#### Problem
RocksDB settings include an option to create_if_missing, which will
create missing columns or the entire rocksdb directory if starting from
scratch. However, create_if_missing functionality only works if the
session has Primary (read+write) access. Many ledger-tool commands only
need Secondary (read-only) access to the database, so these commands are
unable to open the Blockstore when a column must be added.

#### Summary of Changes
This change detects when Secondary access open fails due to missing
column(s) or files, opens the database temporarily with Primary access,
and then reattempts to open the database Secondary access.