### PR TITLE
Clarify error message when ledger-tool doesn't have proper bank

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2520,7 +2520,7 @@ fn main() {
                             .unwrap()
                             .get(snapshot_slot)
                             .unwrap_or_else(|| {
-                                eprintln!("Error: Slot {} is not available", snapshot_slot);
+                                error!("Bank for slot {} is unavailable", snapshot_slot);
                                 exit(1);
                             });
 
@@ -2907,7 +2907,7 @@ fn main() {
                         let bank_forks = bank_forks.read().unwrap();
                         let slot = bank_forks.working_bank().slot();
                         let bank = bank_forks.get(slot).unwrap_or_else(|| {
-                            eprintln!("Error: Slot {} is not available", slot);
+                            error!("Bank for slot {} is unavailable", slot);
                             exit(1);
                         });
 


### PR DESCRIPTION
#### Problem
The current error message is kind of ambiguous, could be the block missing (blockstore) or the bank missing (from bank_forks).

#### Summary of Changes
Include "bank" in error message