### PR TITLE
temporarily make ancient append vecs 10x smaller to find intermittent bugs

### DIFF
--- a/runtime/src/ancient_append_vecs.rs
+++ b/runtime/src/ancient_append_vecs.rs
@@ -92,7 +92,8 @@ pub fn get_ancient_append_vec_capacity() -> u64 {
     use crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE;
     // smaller than max by a bit just in case
     // some functions add slop on allocation
-    MAXIMUM_APPEND_VEC_FILE_SIZE - 2048
+    // temporarily smaller to force ancient append vec operations to occur more often to flush out any bugs
+    MAXIMUM_APPEND_VEC_FILE_SIZE / 10 - 2048
 }
 
 /// true iff storage is ancient size and is almost completely full
@@ -202,7 +203,7 @@ pub mod tests {
     fn test_get_ancient_append_vec_capacity() {
         assert_eq!(
             get_ancient_append_vec_capacity(),
-            crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE - 2048
+            crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE / 10 - 2048
         );
     }
 


### PR DESCRIPTION
#### Problem

smaller ancient append vec sizes cause us to have more ancient append vecs. It also means fewer account writes are required to result in shrinking ancient append vecs. The goal is to cause the ancient append vec code to run more often to look for bugs.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
