### PR TITLE
Add push_vote failure path

### DIFF
--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -95,7 +95,7 @@ impl VotingService {
             VoteOp::PushVote {
                 tx, tower_slots, ..
             } => {
-                cluster_info.push_vote(&tower_slots, tx).unwrap_or_default();
+                let _ignored = cluster_info.push_vote(&tower_slots, tx);
             }
             VoteOp::RefreshVote {
                 tx,

--- a/core/src/voting_service.rs
+++ b/core/src/voting_service.rs
@@ -95,7 +95,7 @@ impl VotingService {
             VoteOp::PushVote {
                 tx, tower_slots, ..
             } => {
-                cluster_info.push_vote(&tower_slots, tx);
+                cluster_info.push_vote(&tower_slots, tx).unwrap_or_default();
             }
             VoteOp::RefreshVote {
                 tx,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1088,8 +1088,7 @@ impl ClusterInfo {
         // We don't write to an arbitrary index, because it may replace one of this validator's
         // existing votes on the network.
         if let Some(vote_index) = vote_index {
-            self.push_vote_at_index(vote, vote_index)
-                .unwrap_or_default();
+            let _ignored = self.push_vote_at_index(vote, vote_index);
         }
     }
 
@@ -3714,9 +3713,7 @@ RPC Enabled Nodes: 1"#;
             &[unrefresh_ix], // instructions
             None,            // payer
         );
-        cluster_info
-            .push_vote(&unrefresh_tower, unrefresh_tx.clone())
-            .unwrap_or_default();
+        let _ignored = cluster_info.push_vote(&unrefresh_tower, unrefresh_tx.clone());
         let mut cursor = Cursor::default();
         let votes = cluster_info.get_votes(&mut cursor);
         assert_eq!(votes, vec![unrefresh_tx.clone()]);
@@ -3745,9 +3742,7 @@ RPC Enabled Nodes: 1"#;
         assert!(votes.contains(&unrefresh_tx));
 
         // Push the new vote for `refresh_slot`
-        cluster_info
-            .push_vote(&refresh_tower, refresh_tx.clone())
-            .unwrap_or_default();
+        let _ignored = cluster_info.push_vote(&refresh_tower, refresh_tx.clone());
 
         // Should be two votes in gossip
         let votes = cluster_info.get_votes(&mut Cursor::default());
@@ -3816,9 +3811,7 @@ RPC Enabled Nodes: 1"#;
             None,  // payer
         );
         let tower = vec![7]; // Last slot in the vote.
-        cluster_info
-            .push_vote(&tower, tx.clone())
-            .unwrap_or_default();
+        let _ignored = cluster_info.push_vote(&tower, tx.clone());
 
         let (labels, votes) = cluster_info.get_votes_with_labels(&mut cursor);
         assert_eq!(votes, vec![tx]);
@@ -3877,7 +3870,7 @@ RPC Enabled Nodes: 1"#;
             let slot = k as Slot;
             tower.push(slot);
             let vote = new_vote_transaction(&mut rng, vec![slot]);
-            assert!(Ok(()) == cluster_info.push_vote(&tower, vote));
+            assert_eq!(Ok(()), cluster_info.push_vote(&tower, vote));
         }
         let vote_slots = get_vote_slots(&cluster_info);
         assert_eq!(vote_slots.len(), MAX_LOCKOUT_HISTORY);

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -362,7 +362,7 @@ pub fn cluster_info_scale() {
             None,  // payer
         );
         let tower = vec![num_votes + 5];
-        nodes[0].0.push_vote(&tower, tx.clone());
+        nodes[0].0.push_vote(&tower, tx.clone()).unwrap_or_default();
         let mut success = false;
         for _ in 0..(30 * 5) {
             let mut not_done = 0;

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -362,7 +362,7 @@ pub fn cluster_info_scale() {
             None,  // payer
         );
         let tower = vec![num_votes + 5];
-        nodes[0].0.push_vote(&tower, tx.clone()).unwrap_or_default();
+        let _ignored = nodes[0].0.push_vote(&tower, tx.clone());
         let mut success = false;
         for _ in 0..(30 * 5) {
             let mut not_done = 0;

--- a/local-cluster/tests/local_cluster_slow_1.rs
+++ b/local-cluster/tests/local_cluster_slow_1.rs
@@ -558,7 +558,9 @@ fn test_duplicate_shreds_broadcast_leader() {
                             );
                             gossip_vote_index += 1;
                             gossip_vote_index %= MAX_LOCKOUT_HISTORY;
-                            cluster_info.push_vote_at_index(vote_tx, gossip_vote_index as u8)
+                            cluster_info
+                                .push_vote_at_index(vote_tx, gossip_vote_index as u8)
+                                .unwrap_or_default()
                         }
                     }
                     // Give vote some time to propagate


### PR DESCRIPTION

push_vote may fail due to wallclock checks.  The current
function prototype lacks return value, likely to mislead
people to believe that push_vote always succeed in pushing
the vote into the datastore.
test_push_vote_with_tower failed due to this misled
assumption.
Adding the error return and handling the error fixes this
test.  Other push_vote calls in the code are appended with
unwrap_or_default() so the behavior is kept the same, but
error ignoring is more apparent.

#### Problem


#### Summary of Changes


Fixes #16680
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
