### PR TITLE
VoteProgram.safeWithdraw function to safeguard against accidental vote account closures

### DIFF
--- a/web3.js/src/programs/vote.ts
+++ b/web3.js/src/programs/vote.ts
@@ -410,4 +410,25 @@ export class VoteProgram {
       data,
     });
   }
+
+  /**
+   * Generate a transaction to withdraw safely from a Vote account.
+   *
+   * This function was created as a safeguard for vote accounts running validators, `safeWithdraw`
+   * checks that the withdraw amount will not exceed the specified balance while leaving enough left
+   * to cover rent. If you wish to close the vote account by withdrawing the full amount, call the
+   * `withdraw` method directly.
+   */
+  static safeWithdraw(
+    params: WithdrawFromVoteAccountParams,
+    currentVoteAccountBalance: number,
+    rentExemptMinimum: number,
+  ): Transaction {
+    if (params.lamports > currentVoteAccountBalance - rentExemptMinimum) {
+      throw new Error(
+        'Withdraw will leave vote account with insuffcient funds.',
+      );
+    }
+    return VoteProgram.withdraw(params);
+  }
 }

--- a/web3.js/test/program-tests/vote.test.ts
+++ b/web3.js/test/program-tests/vote.test.ts
@@ -167,6 +167,21 @@ describe('VoteProgram', () => {
 
       // Withdraw from Vote account
       let recipient = Keypair.generate();
+      const voteBalance = await connection.getBalance(newVoteAccount.publicKey);
+
+      expect(() =>
+        VoteProgram.safeWithdraw(
+          {
+            votePubkey: newVoteAccount.publicKey,
+            authorizedWithdrawerPubkey: authorized.publicKey,
+            lamports: voteBalance - minimumAmount + 1,
+            toPubkey: recipient.publicKey,
+          },
+          voteBalance,
+          minimumAmount,
+        ),
+      ).to.throw('Withdraw will leave vote account with insuffcient funds.');
+
       let withdraw = VoteProgram.withdraw({
         votePubkey: newVoteAccount.publicKey,
         authorizedWithdrawerPubkey: authorized.publicKey,


### PR DESCRIPTION
#### Problem

Currently when withdrawing rewards from a vote account, the JS SDK can withdraw an amount that will leave the account with less than the minimum required for rent, and will transparently close the account without any confirmation or warning to the developer.

#### Summary of Changes

To get feature parity with the CLI, we've added a `safeWithdraw` method to the vote-program. The CLI offers an "ALL" option when withdrawing from a vote account which will leave enough SOL balance to cover the minimum rent for the account. If you accidentally withdraw the entire balance the vote account gets closed.
