### PR TITLE
Set solana-tpu ALPN protocol ID

### DIFF
--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -25,7 +25,10 @@ use {
         signature::Keypair,
         transport::Result as TransportResult,
     },
-    solana_streamer::tls_certificates::new_self_signed_tls_certificate_chain,
+    solana_streamer::{
+        nonblocking::quic::ALPN_TPU_PROTOCOL_ID,
+        tls_certificates::new_self_signed_tls_certificate_chain,
+    },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
         sync::{atomic::Ordering, Arc},
@@ -92,6 +95,7 @@ impl QuicLazyInitializedEndpoint {
             )
             .expect("Failed to set QUIC client certificates");
         crypto.enable_early_data = true;
+        crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
         let mut endpoint =
             QuicNewConnection::create_endpoint(EndpointConfig::default(), client_socket);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -37,6 +37,8 @@ use {
 const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: f64 = 100_000f64;
 const WAIT_FOR_STREAM_TIMEOUT_MS: u64 = 100;
 
+pub const ALPN_TPU_PROTOCOL_ID: &[u8] = b"solana-tpu";
+
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_server(
     sock: UdpSocket,
@@ -695,6 +697,7 @@ pub mod test {
             .expect("Failed to use client certificate");
 
         crypto.enable_early_data = true;
+        crypto.alpn_protocols = vec![ALPN_TPU_PROTOCOL_ID.to_vec()];
 
         let mut config = ClientConfig::new(Arc::new(crypto));
 


### PR DESCRIPTION
#### Problem

QUIC server/client don't use ALPN

#### Summary of Changes

Sets solana-tpu ALPN protocol identifier for QUIC server and client.

Fixes #

Rebased version of #26176

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
