### PR TITLE
Fix duplicate / incorrect docs in solana_sdk by removing the solana_program::* import

### DIFF
--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -9,10 +9,8 @@ extern crate self as solana_sdk;
 pub use signer::signers;
 // These solana_program imports could be *-imported, but that causes a bunch of
 // confusing duplication in the docs due to a rustdoc bug. #26211
-#[allow(deprecated)]
-pub use solana_program::info;
-#[cfg(target_os = "solana")]
-pub use solana_program::syscalls;
+#[cfg(not(target_os = "solana"))]
+pub use solana_program::program_stubs;
 pub use solana_program::{
     account_info, address_lookup_table_account, blake3, borsh, bpf_loader, bpf_loader_deprecated,
     bpf_loader_upgradeable, clock, clone_zeroed, config, copy_field, custom_heap_default,
@@ -20,8 +18,8 @@ pub use solana_program::{
     decode_error, ed25519_program, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator,
     instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction, message,
     msg, native_token, nonce, program, program_error, program_memory, program_option, program_pack,
-    program_stubs, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serialize_utils,
-    short_vec, slot_hashes, slot_history, stake, stake_history, system_instruction, system_program,
+    rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serialize_utils, short_vec,
+    slot_hashes, slot_history, stake, stake_history, syscalls, system_instruction, system_program,
     sysvar, unchecked_div_by_const, vote, wasm_bindgen,
 };
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,7 +7,23 @@ extern crate self as solana_sdk;
 
 #[cfg(feature = "full")]
 pub use signer::signers;
-pub use solana_program::*;
+// These solana_program imports could be *-imported, but that causes a bunch of
+// confusing duplication in the docs due to a rustdoc bug. #26211
+#[allow(deprecated)]
+pub use solana_program::info;
+#[cfg(target_os = "solana")]
+pub use solana_program::syscalls;
+pub use solana_program::{
+    account_info, address_lookup_table_account, blake3, borsh, bpf_loader, bpf_loader_deprecated,
+    bpf_loader_upgradeable, clock, clone_zeroed, config, copy_field, custom_heap_default,
+    custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
+    decode_error, ed25519_program, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator,
+    instruction, keccak, lamports, loader_instruction, loader_upgradeable_instruction, message,
+    msg, native_token, nonce, program, program_error, program_memory, program_option, program_pack,
+    program_stubs, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serialize_utils,
+    short_vec, slot_hashes, slot_history, stake, stake_history, system_instruction, system_program,
+    sysvar, unchecked_div_by_const, vote, wasm_bindgen,
+};
 
 pub mod account;
 pub mod account_utils;


### PR DESCRIPTION
#### Problem
 
The docs for solana_sdk show many duplicated modules and macros. Per https://github.com/solana-labs/solana/issues/26211 this is due to a bug in rustdoc (https://github.com/rust-lang/rust/issues/60522) that causes *-imports that are shadowed by local definitions to not be removed from the docs.

This bug not only causes duplicate listings of items, but also non-deterministically causes the docs for those items to show shadowed *-imported version, causing some items defined within those duplicated modules to not be documented at all.

#### Summary of Changes

This patch removes the `solana_program::*` import and instead lists every non-shadowed import explicitly.

This is obviously a lot harder to maintain so long as every item in solana_program is intended to be reexported, and made more difficult by some items being target-specific. If this solution is not acceptable I am willing to attempt to make the upstream rustdoc fix, though it will take some time.

Fixes https://github.com/solana-labs/solana/issues/26211
