### PR TITLE
Prevent cargo from running a non-BPF compiler for BPF target

### DIFF
--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -17,6 +17,7 @@ use {
     tar::Archive,
 };
 
+#[derive(Debug)]
 struct Config<'a> {
     cargo_args: Option<Vec<&'a str>>,
     bpf_out_dir: Option<PathBuf>,
@@ -523,8 +524,19 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
         env::set_var("RUSTFLAGS", &rustflags);
     }
     if config.verbose {
-        println!("RUSTFLAGS={}", &rustflags);
-    };
+        println!(
+            "RUSTFLAGS=\"{}\"",
+            env::var("RUSTFLAGS").ok().unwrap_or_default()
+        );
+    }
+
+    // RUSTC variable overrides cargo +<toolchain> mechanism of
+    // selecting the rust compiler and makes cargo run a rust compiler
+    // other than the one linked in BPF toolchain. We have to prevent
+    // this by removing RUSTC from the child process environment.
+    if env::var("RUSTC").is_ok() {
+        env::remove_var("RUSTC")
+    }
 
     let cargo_build = PathBuf::from("cargo");
     let mut cargo_build_args = vec![
@@ -841,5 +853,9 @@ fn main() {
         workspace: matches.is_present("workspace"),
     };
     let manifest_path: Option<PathBuf> = matches.value_of_t("manifest_path").ok();
+    if config.verbose {
+        println!("{:?}", config);
+        println!("manifest_path: {:?}", manifest_path);
+    }
     build_bpf(config, manifest_path);
 }


### PR DESCRIPTION
#### Problem

cargo-build-bpf if started from cargo may run a wrong (non-BPF capable) rust compiler.

#### Summary of Changes

Remove RUSTC var from cargo-build-bpf environment

Fixes #26583

