### PR TITLE
Fix sol_memset to return the correct value.

### DIFF
--- a/sdk/bpf/c/inc/sol/string.h
+++ b/sdk/bpf/c/inc/sol/string.h
@@ -41,6 +41,7 @@ static void *sol_memset(void *b, int c, size_t len) {
     a++;
     len--;
   }
+  return b;
 }
 
 /**


### PR DESCRIPTION
#### Problem
The compiler issues a warning every time I compile using the Solana C SDK.  Also I am pretty sure that if anyone tried to use the return value of sol_memset, they would experience an error.  The man page for memset says the return value should be:

"The memset() function returns a pointer to the memory area s."

Given the prototype:

void *memset(void *s, int c, size_t n);


#### Summary of Changes

Return the correct value.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
