### PR TITLE
Compile for bpf target for compatibility when cargo-build-bpf is used

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -90,7 +90,7 @@ test-stable-bpf)
 
   bpf_dump_archive="bpf-dumps.tar.bz2"
   rm -f "$bpf_dump_archive"
-  tar cjvf "$bpf_dump_archive" "${bpf_target_path}"/{deploy/*.txt,sbf-solana-solana/release/*.so}
+  tar cjvf "$bpf_dump_archive" "${bpf_target_path}"/{deploy/*.txt,bpfel-unknown-unknown/release/*.so}
   exit 0
   ;;
 test-stable-perf)

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -26,6 +26,8 @@ fn main() {
             args.remove(0);
         }
     }
+    args.push("--arch".to_string());
+    args.push("bpf".to_string());
     print!("cargo-build-bpf child: {}", program.display());
     for a in &args {
         print!(" {}", a);

--- a/sdk/cargo-test-bpf/src/main.rs
+++ b/sdk/cargo-test-bpf/src/main.rs
@@ -32,6 +32,8 @@ fn main() {
             args.remove(0);
         }
     }
+    args.push("--arch".to_string());
+    args.push("bpf".to_string());
     print!("cargo-test-bpf child: {}", program.display());
     for a in &args {
         print!(" {}", a);

--- a/sdk/cargo-test-sbf/src/main.rs
+++ b/sdk/cargo-test-sbf/src/main.rs
@@ -319,7 +319,7 @@ fn main() {
         .arg(
             Arg::new("arch")
                 .long("arch")
-                .possible_values(&["sbf", "sbfv2"])
+                .possible_values(&["bpf", "sbf", "sbfv2"])
                 .default_value("sbf")
                 .help("Build for the given SBF version"),
         )


### PR DESCRIPTION
#### Problem

Switching to SBF breaks 3rd party projects that rely on target_arch being "bpf".

#### Summary of Changes

Depending on the arch command line option compile for either sbf or bpf target.

Fixes #26485
