### PR TITLE
Fix flaky message kitchen sink test

### DIFF
--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -176,7 +176,9 @@ impl Pubkey {
 
         let mut b = [0u8; 32];
         let i = I.fetch_add(1);
-        b[0..8].copy_from_slice(&i.to_le_bytes());
+        // use big endian representation to ensure that recent unique pubkeys
+        // are always greater than less recent unique pubkeys
+        b[0..8].copy_from_slice(&i.to_be_bytes());
         Self::new(&b)
     }
 


### PR DESCRIPTION
#### Problem
The message kitchen sink test assumes that unique pubkeys are always greater than previously created unique pubkeys but this assumption breaks as soon as the static counter goes from 255 to 256:

Key 255: `JAQxrJ2WuDF4APfSifurJJ4HzV5Z3FyBuBeSMj7mo9aw` (encoded as [255, 0, ..])
Key 256: `1tJ93RwaVfE1PEMxd5rpZZuPtLCwbEaDCrNBhAy8Cw` (encoded as [0, 1, ..])

Failing CI test: https://buildkite.com/solana-labs/solana/builds/77855#0181f45d-f09d-4b0d-ba22-ff33b632cb5b

#### Summary of Changes
Use big endian encoding for unique pubkeys generated from the static counter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
