### PR TITLE
test-validator: add account-dir flag

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -356,6 +356,8 @@ impl TestValidatorGenesis {
             json_files.extend(matched_files);
         }
 
+        debug!("account files found: {:?}", json_files);
+
         let accounts: Vec<_> = json_files
             .iter()
             .map(|filename| AccountInfo {

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -48,7 +48,9 @@ use {
     solana_streamer::socket::SocketAddrSpace,
     std::{
         collections::{HashMap, HashSet},
-        fs::{remove_dir_all, File},
+        ffi::OsStr,
+        fmt::Display,
+        fs::{self, remove_dir_all, File},
         io::Read,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
@@ -331,6 +333,39 @@ impl TestValidatorGenesis {
 
             self.add_account(address, account);
         }
+        self
+    }
+
+    pub fn add_accounts_from_directories<T, P>(&mut self, dirs: T) -> &mut Self
+    where
+        T: IntoIterator<Item = P>,
+        P: AsRef<Path> + Display,
+    {
+        let mut json_files: HashSet<String> = HashSet::new();
+        for dir in dirs {
+            let matched_files = fs::read_dir(&dir)
+                .unwrap_or_else(|err| {
+                    error!("Cannot read directory {}: {}", dir, err);
+                    solana_core::validator::abort();
+                })
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.is_file() && path.extension() == Some(OsStr::new("json")))
+                .map(|path| String::from(path.to_string_lossy()));
+
+            json_files.extend(matched_files);
+        }
+
+        let accounts: Vec<_> = json_files
+            .iter()
+            .map(|filename| AccountInfo {
+                address: None,
+                filename,
+            })
+            .collect();
+
+        self.add_accounts_from_json_files(&accounts);
+
         self
     }
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -219,8 +219,8 @@ fn main() {
                 ),
         )
         .arg(
-            Arg::with_name("accounts_from_dir")
-                .long("accounts-from-dir")
+            Arg::with_name("account_dir")
+                .long("account-dir")
                 .value_name("DIRECTORY")
                 .validator(|value| {
                     value
@@ -592,7 +592,7 @@ fn main() {
     }
 
     let accounts_from_dirs: HashSet<_> = matches
-        .values_of("accounts_from_dir")
+        .values_of("account_dir")
         .unwrap_or_default()
         .collect();
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -230,7 +230,7 @@ fn main() {
                             if path.exists() && path.is_dir() {
                                 Ok(())
                             } else {
-                                Err(format!("wrong directory '{}'", value))
+                                Err(format!("path does not exist or is not a directory: {}", value))
                             }
                         })
                 })

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -219,6 +219,30 @@ fn main() {
                 ),
         )
         .arg(
+            Arg::with_name("accounts_from_dir")
+                .long("accounts-from-dir")
+                .value_name("DIRECTORY")
+                .validator(|value| {
+                    value
+                        .parse::<PathBuf>()
+                        .map_err(|err| format!("error parsing '{}': {}", value, err))
+                        .and_then(|path| {
+                            if path.exists() && path.is_dir() {
+                                Ok(())
+                            } else {
+                                Err(format!("wrong directory '{}'", value))
+                            }
+                        })
+                })
+                .takes_value(true)
+                .multiple(true)
+                .help(
+                    "Load all the accounts from the JSON files found in the specified DIRECTORY \
+                        (see also the `--account` flag). \
+                        If the ledger already exists then this parameter is silently ignored",
+                ),
+        )
+        .arg(
             Arg::with_name("no_bpf_jit")
                 .long("no-bpf-jit")
                 .takes_value(false)
@@ -567,6 +591,11 @@ fn main() {
         }
     }
 
+    let accounts_from_dirs: HashSet<_> = matches
+        .values_of("accounts_from_dir")
+        .unwrap_or_default()
+        .collect();
+
     let accounts_to_clone: HashSet<_> = pubkeys_of(&matches, "clone_account")
         .map(|v| v.into_iter().collect())
         .unwrap_or_default();
@@ -727,6 +756,7 @@ fn main() {
         .rpc_port(rpc_port)
         .add_programs_with_path(&programs_to_load)
         .add_accounts_from_json_files(&accounts_to_load)
+        .add_accounts_from_directories(&accounts_from_dirs)
         .deactivate_features(&features_to_deactivate);
 
     if !accounts_to_clone.is_empty() {


### PR DESCRIPTION
#### Problem
although it is possible to load multiple accounts via 
> `$ solana-test-validator --account - file.json --account - another_file.json ...`

it quickly becomes very cumbersome when the number of accounts is high

#### Summary of Changes
add the flag `--account-dir <DIRECTORY>` that finds all json files in the specified directory, and loads them as accounts
