### PR TITLE
Share function to get priority details from various transaction types

### DIFF
--- a/core/src/forward_packet_batches_by_accounts.rs
+++ b/core/src/forward_packet_batches_by_accounts.rs
@@ -187,7 +187,10 @@ impl ForwardPacketBatchesByAccounts {
 mod tests {
     use {
         super::*,
-        crate::unprocessed_packet_batches::{DeserializedPacket, TransactionPriorityDetails},
+        crate::{
+            transaction_priority_details::TransactionPriorityDetails,
+            unprocessed_packet_batches::DeserializedPacket,
+        },
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,6 +68,7 @@ mod tower1_7_14;
 pub mod tower_storage;
 pub mod tpu;
 pub mod tracer_packet_stats;
+pub mod transaction_priority_details;
 pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;

--- a/core/src/transaction_priority_details.rs
+++ b/core/src/transaction_priority_details.rs
@@ -1,0 +1,177 @@
+use {
+    solana_program_runtime::compute_budget::ComputeBudget,
+    solana_sdk::{
+        instruction::CompiledInstruction,
+        pubkey::Pubkey,
+        transaction::{SanitizedTransaction, SanitizedVersionedTransaction},
+    },
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TransactionPriorityDetails {
+    pub priority: u64,
+    pub compute_unit_limit: u64,
+}
+
+pub trait GetTransactionPriorityDetails {
+    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails>;
+
+    fn process_compute_budget_instruction<'a>(
+        instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
+    ) -> Option<TransactionPriorityDetails> {
+        let mut compute_budget = ComputeBudget::default();
+        let prioritization_fee_details = compute_budget
+            .process_instructions(
+                instructions,
+                true, // use default units per instruction
+                true, // don't reject txs that use set compute unit price ix
+            )
+            .ok()?;
+        Some(TransactionPriorityDetails {
+            priority: prioritization_fee_details.get_priority(),
+            compute_unit_limit: compute_budget.compute_unit_limit,
+        })
+    }
+}
+
+impl GetTransactionPriorityDetails for SanitizedVersionedTransaction {
+    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails> {
+        Self::process_compute_budget_instruction(self.get_message().program_instructions_iter())
+    }
+}
+
+impl GetTransactionPriorityDetails for SanitizedTransaction {
+    fn get_transaction_priority_details(&self) -> Option<TransactionPriorityDetails> {
+        Self::process_compute_budget_instruction(self.message().program_instructions_iter())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk::{
+            compute_budget::ComputeBudgetInstruction,
+            message::Message,
+            pubkey::Pubkey,
+            signature::{Keypair, Signer},
+            system_instruction,
+            transaction::{Transaction, VersionedTransaction},
+        },
+    };
+
+    #[test]
+    fn test_get_priority_with_valid_request_heap_frame_tx() {
+        let keypair = Keypair::new();
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::transfer(&keypair.pubkey(), &Pubkey::new_unique(), 1),
+                ComputeBudgetInstruction::request_heap_frame(32 * 1024),
+            ],
+            Some(&keypair.pubkey()),
+        ));
+
+        // assert for SanitizedVersionedTransaction
+        let versioned_transaction = VersionedTransaction::from(transaction.clone());
+        let sanitized_versioned_transaction =
+            SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
+        assert_eq!(
+            sanitized_versioned_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: 0,
+                compute_unit_limit:
+                    solana_program_runtime::compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                        as u64
+            })
+        );
+
+        // assert for SanitizedTransaction
+        let sanitized_transaction =
+            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        assert_eq!(
+            sanitized_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: 0,
+                compute_unit_limit:
+                    solana_program_runtime::compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                        as u64
+            })
+        );
+    }
+
+    #[test]
+    fn test_get_priority_with_valid_set_compute_units_limit() {
+        let requested_cu = 101u32;
+        let keypair = Keypair::new();
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::transfer(&keypair.pubkey(), &Pubkey::new_unique(), 1),
+                ComputeBudgetInstruction::set_compute_unit_limit(requested_cu),
+            ],
+            Some(&keypair.pubkey()),
+        ));
+
+        // assert for SanitizedVersionedTransaction
+        let versioned_transaction = VersionedTransaction::from(transaction.clone());
+        let sanitized_versioned_transaction =
+            SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
+        assert_eq!(
+            sanitized_versioned_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: 0,
+                compute_unit_limit: requested_cu as u64,
+            })
+        );
+
+        // assert for SanitizedTransaction
+        let sanitized_transaction =
+            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        assert_eq!(
+            sanitized_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: 0,
+                compute_unit_limit: requested_cu as u64,
+            })
+        );
+    }
+
+    #[test]
+    fn test_get_priority_with_valid_set_compute_unit_price() {
+        let requested_price = 1_000;
+        let keypair = Keypair::new();
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::transfer(&keypair.pubkey(), &Pubkey::new_unique(), 1),
+                ComputeBudgetInstruction::set_compute_unit_price(requested_price),
+            ],
+            Some(&keypair.pubkey()),
+        ));
+
+        // assert for SanitizedVersionedTransaction
+        let versioned_transaction = VersionedTransaction::from(transaction.clone());
+        let sanitized_versioned_transaction =
+            SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
+        assert_eq!(
+            sanitized_versioned_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: requested_price,
+                compute_unit_limit:
+                    solana_program_runtime::compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                        as u64
+            })
+        );
+
+        // assert for SanitizedTransaction
+        let sanitized_transaction =
+            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        assert_eq!(
+            sanitized_transaction.get_transaction_priority_details(),
+            Some(TransactionPriorityDetails {
+                priority: requested_price,
+                compute_unit_limit:
+                    solana_program_runtime::compute_budget::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
+                        as u64
+            })
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
To share function of getting priority details (eg, compute-unit price, requested compute-units) from `SanitizedVersionedTransaction` and/or `SanitizedTransaction`. 

#### Summary of Changes
Add trait `GetTransactionPriorityDetails`, implemented for above transaction types.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
