### PR TITLE
test-validator: improve multi-value arg help output

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -193,20 +193,20 @@ fn main() {
         .arg(
             Arg::with_name("bpf_program")
                 .long("bpf-program")
-                .value_name("ADDRESS_OR_PATH BPF_PROGRAM.SO")
+                .value_names(&["ADDRESS_OR_KEYPAIR", "BPF_PROGRAM.SO"])
                 .takes_value(true)
                 .number_of_values(2)
                 .multiple(true)
                 .help(
                     "Add a BPF program to the genesis configuration. \
                        If the ledger already exists then this parameter is silently ignored. \
-                       First argument can be a public key or path to file that can be parsed as a keypair",
+                       First argument can be a pubkey string or path to a keypair",
                 ),
         )
         .arg(
             Arg::with_name("account")
                 .long("account")
-                .value_name("ADDRESS FILENAME.JSON")
+                .value_names(&["ADDRESS", "DUMP.JSON"])
                 .takes_value(true)
                 .number_of_values(2)
                 .allow_hyphen_values(true)


### PR DESCRIPTION
#### Problem

`solana-test-validator` has a couple args that take multiple values, but their help output confusingly stuffs them both into one pair of chevrons.

```
        --account <ADDRESS FILENAME.JSON>...
            Load an account from the provided JSON file (see `solana account --help` on how to dump an account to file).
            Files are searched for relatively to CWD and tests/fixtures. If the ledger already exists then this
            parameter is silently ignored
        --bpf-program <ADDRESS_OR_PATH BPF_PROGRAM.SO>...
            Add a BPF program to the genesis configuration. If the ledger already exists then this parameter is silently
            ignored. First argument can be a public key or path to file that can be parsed as a keypair
```

#### Summary of Changes

Split them by using `value_names()` instead of `value_name`

```
        --account <ADDRESS> <DUMP.JSON>
            Load an account from the provided JSON file (see `solana account --help` on how to dump an account to file).
            Files are searched for relatively to CWD and tests/fixtures. If ADDRESS is omitted via the `-` placeholder,
            the one in the file will be used. If the ledger already exists then this parameter is silently ignored
        --bpf-program <ADDRESS_OR_KEYPAIR> <BPF_PROGRAM.SO>
            Add a BPF program to the genesis configuration. If the ledger already exists then this parameter is silently
            ignored. First argument can be a pubkey string or path to a keypair
```