### PR TITLE
explorer add toggle for token balances owner column

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -442,10 +442,7 @@ export function tokenLabel(
   if (!tokenRegistry) return;
   const tokenInfo = tokenRegistry.get(address);
   if (!tokenInfo) return;
-  if (tokenInfo.name === tokenInfo.symbol) {
-    return tokenInfo.name;
-  }
-  return `${tokenInfo.symbol} - ${tokenInfo.name}`;
+  return tokenInfo.symbol;
 }
 
 export function addressLabel(


### PR DESCRIPTION
#### Problem
In most cases tokens are transferred, so the explorer should allow reading the most common data a user would want to see.

Unfortunately there isn't enough space to display address + owner, possibly one is enough

#### Summary of Changes
Add a toggle to allow displaying owner rather than address under token balances.
Also remove "name" from token label, it is unnecessarily over verbose, symbol is enough.

Let me know if we want to default to owner rather than address.
I wonder if this the toggle state should be saved in local storage. So user can multiple txs without having to toggle again and again.

A tx i found in Jito dashboard https://explorer.solana.com/tx/2DTWtf7RVFAFW7TtZtp4b2mmKF53Z3d6h5KRFvyNiUF8FZSWNnrtZtXWL4Ww1LFnL9o6t9Pjw3rWTaGaPsa6bv4b

stSOL => wSOL => stSOL arbitrage, we can see how messy things can get if we have to mentally convert each address to its owner.

Fixes #

