### PR TITLE
Backport ghsa x236 qc46 7v8j

### DIFF
--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,7 +1,7 @@
 pub use reqwest;
 use {
-    crate::{rpc_request, rpc_response},
-    quinn::{ConnectError, WriteError},
+    crate::{nonblocking::quic_client::QuicError, rpc_request, rpc_response},
+    quinn::ConnectError,
     solana_faucet::faucet::FaucetError,
     solana_sdk::{
         signature::SignerError, transaction::TransactionError, transport::TransportError,
@@ -73,9 +73,9 @@ impl From<ClientErrorKind> for TransportError {
     }
 }
 
-impl From<WriteError> for ClientErrorKind {
-    fn from(write_error: WriteError) -> Self {
-        Self::Custom(format!("{:?}", write_error))
+impl From<QuicError> for ClientErrorKind {
+    fn from(quic_error: QuicError) -> Self {
+        Self::Custom(format!("{:?}", quic_error))
     }
 }
 

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -330,7 +330,7 @@ impl QuicClient {
                                         "Cannot make 0rtt connection to {}, error {:}",
                                         self.addr, err
                                     );
-                                    return Err(err);
+                                    return Err(QuicError::WriteError(err));
                                 }
                             }
                         } else {

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -12,8 +12,8 @@ use {
     itertools::Itertools,
     log::*,
     quinn::{
-        ClientConfig, ConnectionError, Endpoint, EndpointConfig, IdleTimeout, NewConnection,
-        VarInt, WriteError,
+        ClientConfig, ConnectError, ConnectionError, Endpoint, EndpointConfig, IdleTimeout,
+        NewConnection, VarInt, WriteError,
     },
     solana_measure::measure::Measure,
     solana_net_utils::VALIDATOR_PORT_RANGE,
@@ -35,6 +35,7 @@ use {
         thread,
         time::Duration,
     },
+    thiserror::Error,
     tokio::{sync::RwLock, time::timeout},
 };
 
@@ -69,6 +70,16 @@ pub struct QuicClientCertificate {
 pub struct QuicLazyInitializedEndpoint {
     endpoint: RwLock<Option<Arc<Endpoint>>>,
     client_certificate: Arc<QuicClientCertificate>,
+}
+
+#[derive(Error, Debug)]
+pub enum QuicError {
+    #[error(transparent)]
+    WriteError(#[from] WriteError),
+    #[error(transparent)]
+    ConnectionError(#[from] ConnectionError),
+    #[error(transparent)]
+    ConnectError(#[from] ConnectError),
 }
 
 impl QuicLazyInitializedEndpoint {
@@ -162,11 +173,14 @@ impl QuicNewConnection {
         endpoint: Arc<QuicLazyInitializedEndpoint>,
         addr: SocketAddr,
         stats: &ClientStats,
-    ) -> Result<Self, WriteError> {
+    ) -> Result<Self, QuicError> {
         let mut make_connection_measure = Measure::start("make_connection_measure");
         let endpoint = endpoint.get_endpoint().await;
 
-        let connecting = endpoint.connect(addr, "connect").unwrap();
+        let connecting = endpoint
+            .connect(addr, "connect")
+            .expect("QuicNewConnection::make_connection endpoint.connect");
+
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
         if let Ok(connecting_result) = timeout(
             Duration::from_millis(QUIC_CONNECTION_HANDSHAKE_TIMEOUT_MS),
@@ -204,7 +218,11 @@ impl QuicNewConnection {
         addr: SocketAddr,
         stats: &ClientStats,
     ) -> Result<Arc<NewConnection>, WriteError> {
-        let connecting = self.endpoint.connect(addr, "connect").unwrap();
+        let connecting = self
+            .endpoint
+            .connect(addr, "connect")
+            .expect("QuicNewConnection::make_connection_0rtt endpoint.connect");
+
         stats.total_connections.fetch_add(1, Ordering::Relaxed);
         let connection = match connecting.into_0rtt() {
             Ok((connection, zero_rtt)) => {
@@ -264,7 +282,7 @@ impl QuicClient {
     async fn _send_buffer_using_conn(
         data: &[u8],
         connection: &NewConnection,
-    ) -> Result<(), WriteError> {
+    ) -> Result<(), QuicError> {
         let mut send_stream = connection.connection.open_uni().await?;
 
         send_stream.write_all(data).await?;
@@ -279,7 +297,7 @@ impl QuicClient {
         data: &[u8],
         stats: &ClientStats,
         connection_stats: Arc<ConnectionCacheStats>,
-    ) -> Result<Arc<NewConnection>, WriteError> {
+    ) -> Result<Arc<NewConnection>, QuicError> {
         let mut connection_try_count = 0;
         let mut last_connection_id = 0;
         let mut last_error = None;
@@ -382,7 +400,7 @@ impl QuicClient {
                     return Ok(connection);
                 }
                 Err(err) => match err {
-                    WriteError::ConnectionLost(_) => {
+                    QuicError::ConnectionError(_) => {
                         last_error = Some(err);
                     }
                     _ => {

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -5,6 +5,7 @@ use {
     fd_lock::{RwLock, RwLockWriteGuard},
     indicatif::{ProgressDrawTarget, ProgressStyle},
     solana_net_utils::MINIMUM_VALIDATOR_PORT_RANGE_WIDTH,
+    solana_sdk::quic::QUIC_PORT_OFFSET,
     std::{
         borrow::Cow,
         env,
@@ -98,6 +99,8 @@ pub fn port_range_validator(port_range: String) -> Result<(), String> {
                 start,
                 start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
             ))
+        } else if end.checked_add(QUIC_PORT_OFFSET).is_none() {
+            Err("Invalid dynamic_port_range.".to_string())
         } else {
             Ok(())
         }


### PR DESCRIPTION
#### Problem
The GHSA-x236-qc46-7v8j advisory needs to be patched for v1.10 for Quic support. With Quic enabled a peer that has a UDP tpu_port above U16::MAX - QUIC_PORT_OFFSET can cause an overflow when adding QUIC_PORT_OFFSET to it in order to obtain the corresponding Quic tpu_port. 

#### Summary of Changes
Backport fix for GHSA-x236-qc46-7v8j, in order to force nodes to set their UDP tpu_ports such that adding QUIC_PORT_OFFSET will not cause an overflow, and, when encountering a remote peer which does have a UDP tpu_port that is too large (e.g. due to not having yet upgraded), avoid the overflowing addition, and simply fall back on UDP.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
