### PR TITLE
feat(web3.js): add support for get stake minimum delegation

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -454,6 +454,14 @@ export type GetBlockConfig = {
 };
 
 /**
+ * Configuration object for changing `getStakeMinimumDelegation` query behavior
+ */
+export type GetStakeMinimumDelegationConfig = {
+  /** The level of commitment desired */
+  commitment?: Commitment;
+};
+
+/**
  * Configuration object for changing `getBlockHeight` query behavior
  */
 export type GetBlockHeightConfig = {
@@ -4302,6 +4310,25 @@ export class Connection {
     } finally {
       this._pollingBlockhash = false;
     }
+  }
+
+  /**
+   * get the stake minimum delegation
+   */
+  async getStakeMinimumDelegation(
+    config?: GetStakeMinimumDelegationConfig,
+  ): Promise<RpcResponseAndContext<number>> {
+    const {commitment, config: configArg} = extractCommitmentFromConfig(config);
+    const args = this._buildArgs([], commitment, 'base64', configArg);
+    const unsafeRes = await this._rpcRequest('getStakeMinimumDelegation', args);
+    const res = create(unsafeRes, jsonRpcResultAndContext(number()));
+    if ('error' in res) {
+      throw new SolanaJSONRPCError(
+        res.error,
+        `failed to get stake minimum delegation`,
+      );
+    }
+    return res.result;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -3804,6 +3804,10 @@ describe('Connection', function () {
   }
 
   if (process.env.TEST_LIVE) {
+    it('getStakeMinimumDelegation', async () => {
+      const {value} = await connection.getStakeMinimumDelegation();
+      expect(value).to.be.a('number');
+    });
     it('simulate transaction with message', async () => {
       connection._commitment = 'confirmed';
 

--- a/web3.js/test/stake-program.test.ts
+++ b/web3.js/test/stake-program.test.ts
@@ -382,13 +382,15 @@ describe('StakeProgram', () => {
   if (process.env.TEST_LIVE) {
     it('live staking actions', async () => {
       const connection = new Connection(url, 'confirmed');
-      const SYSTEM_ACCOUNT_MIN_BALANCE =
-        await connection.getMinimumBalanceForRentExemption(0);
-      const STAKE_ACCOUNT_MIN_BALANCE =
-        await connection.getMinimumBalanceForRentExemption(StakeProgram.space);
-
-      // todo: use `Connection.getMinimumStakeDelegation` when implemented
-      const MIN_STAKE_DELEGATION = LAMPORTS_PER_SOL;
+      const [
+        SYSTEM_ACCOUNT_MIN_BALANCE,
+        STAKE_ACCOUNT_MIN_BALANCE,
+        {value: MIN_STAKE_DELEGATION},
+      ] = await Promise.all([
+        connection.getMinimumBalanceForRentExemption(0),
+        connection.getMinimumBalanceForRentExemption(StakeProgram.space),
+        connection.getStakeMinimumDelegation(),
+      ]);
 
       const voteAccounts = await connection.getVoteAccounts();
       const voteAccount = voteAccounts.current.concat(


### PR DESCRIPTION
The PR adds --
1). support for ```getStakeMinimumDelegation``` to web3.js with a test.

fixes #26564 