### PR TITLE
cleanup feature: default units per instruction

### DIFF
--- a/core/src/transaction_priority_details.rs
+++ b/core/src/transaction_priority_details.rs
@@ -23,7 +23,6 @@ pub trait GetTransactionPriorityDetails {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 instructions,
-                true, // use default units per instruction
                 true, // don't reject txs that use set compute unit price ix
             )
             .ok()?;

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -126,7 +126,6 @@ impl ComputeBudget {
     pub fn process_instructions<'a>(
         &mut self,
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-        default_units_per_instruction: bool,
         support_set_compute_unit_price_ix: bool,
     ) -> Result<PrioritizationFeeDetails, TransactionError> {
         let mut num_non_compute_budget_instructions: usize = 0;
@@ -221,18 +220,15 @@ impl ComputeBudget {
             self.heap_size = Some(bytes as usize);
         }
 
-        self.compute_unit_limit = if default_units_per_instruction {
-            updated_compute_unit_limit.or_else(|| {
+        self.compute_unit_limit = updated_compute_unit_limit
+            .or_else(|| {
                 Some(
                     (num_non_compute_budget_instructions as u32)
                         .saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT),
                 )
             })
-        } else {
-            updated_compute_unit_limit
-        }
-        .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
-        .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
+            .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
+            .min(MAX_COMPUTE_UNIT_LIMIT) as u64;
 
         Ok(prioritization_fee
             .map(|fee_type| PrioritizationFeeDetails::new(fee_type, self.compute_unit_limit))
@@ -275,11 +271,8 @@ mod tests {
                 Hash::default(),
             ));
             let mut compute_budget = ComputeBudget::default();
-            let result = compute_budget.process_instructions(
-                tx.message().program_instructions_iter(),
-                true,
-                $type_change,
-            );
+            let result = compute_budget
+                .process_instructions(tx.message().program_instructions_iter(), $type_change);
             assert_eq!($expected_result, result);
             assert_eq!(compute_budget, $expected_budget);
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -108,8 +108,8 @@ use {
         epoch_schedule::EpochSchedule,
         feature,
         feature_set::{
-            self, add_set_compute_unit_price_ix, default_units_per_instruction,
-            disable_fee_calculator, enable_early_verification_of_account_modifications, FeatureSet,
+            self, add_set_compute_unit_price_ix, disable_fee_calculator,
+            enable_early_verification_of_account_modifications, FeatureSet,
         },
         fee::FeeStructure,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -4542,7 +4542,6 @@ impl Bank {
                             Measure::start("compute_budget_process_transaction_time");
                         let process_transaction_result = compute_budget.process_instructions(
                             tx.message().program_instructions_iter(),
-                            feature_set.is_active(&default_units_per_instruction::id()),
                             feature_set.is_active(&add_set_compute_unit_price_ix::id()),
                         );
                         compute_budget_process_transaction_time.stop();
@@ -4837,7 +4836,6 @@ impl Bank {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 message.program_instructions_iter(),
-                false,
                 support_set_compute_unit_price_ix,
             )
             .unwrap_or_default();


### PR DESCRIPTION
#### Problem

Feature `J2QdYx8crLbTVK8nur1jeLsmc3krDbfjoxoea2V1Uy5Q` was enabled in epoch 327 but featurization still exists

#### Summary of Changes

Cleanup feature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
