### PR TITLE
rpc_client: Add get_stake_minimum_delegation_with_commitment()

### DIFF
--- a/client/src/nonblocking/rpc_client.rs
+++ b/client/src/nonblocking/rpc_client.rs
@@ -4544,8 +4544,42 @@ impl RpcClient {
     /// # Ok::<(), ClientError>(())
     /// ```
     pub async fn get_stake_minimum_delegation(&self) -> ClientResult<u64> {
+        self.get_stake_minimum_delegation_with_commitment(self.commitment())
+            .await
+    }
+
+    /// Returns the stake minimum delegation, in lamports, based on the commitment level.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getStakeMinimumDelegation`] RPC method.
+    ///
+    /// [`getStakeMinimumDelegation`]: https://docs.solana.com/developing/clients/jsonrpc-api#getstakeminimumdelegation
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_client::{
+    /// #     nonblocking::rpc_client::RpcClient,
+    /// #     client_error::ClientError,
+    /// # };
+    /// # use solana_sdk::commitment_config::CommitmentConfig;
+    /// # futures::executor::block_on(async {
+    /// #     let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let stake_minimum_delegation = rpc_client.get_stake_minimum_delegation_with_commitment(CommitmentConfig::confirmed()).await?;
+    /// #     Ok::<(), ClientError>(())
+    /// # })?;
+    /// # Ok::<(), ClientError>(())
+    /// ```
+    pub async fn get_stake_minimum_delegation_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<u64> {
         Ok(self
-            .send::<Response<u64>>(RpcRequest::GetStakeMinimumDelegation, Value::Null)
+            .send::<Response<u64>>(
+                RpcRequest::GetStakeMinimumDelegation,
+                json!([self.maybe_map_commitment(commitment_config).await?]),
+            )
             .await?
             .value)
     }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -3735,6 +3735,37 @@ impl RpcClient {
         self.invoke(self.rpc_client.get_stake_minimum_delegation())
     }
 
+    /// Returns the stake minimum delegation, in lamports, based on the commitment level.
+    ///
+    /// # RPC Reference
+    ///
+    /// This method corresponds directly to the [`getStakeMinimumDelegation`] RPC method.
+    ///
+    /// [`getStakeMinimumDelegation`]: https://docs.solana.com/developing/clients/jsonrpc-api#getstakeminimumdelegation
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use solana_client::{
+    /// #     rpc_client::RpcClient,
+    /// #     client_error::ClientError,
+    /// # };
+    /// # use solana_sdk::commitment_config::CommitmentConfig;
+    /// # let rpc_client = RpcClient::new_mock("succeeds".to_string());
+    /// let stake_minimum_delegation =
+    /// rpc_client.get_stake_minimum_delegation_with_commitment(CommitmentConfig::confirmed())?;
+    /// # Ok::<(), ClientError>(())
+    /// ```
+    pub fn get_stake_minimum_delegation_with_commitment(
+        &self,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<u64> {
+        self.invoke(
+            self.rpc_client
+                .get_stake_minimum_delegation_with_commitment(commitment_config),
+        )
+    }
+
     /// Request the transaction count.
     pub fn get_transaction_count(&self) -> ClientResult<u64> {
         self.invoke(self.rpc_client.get_transaction_count())
@@ -4345,7 +4376,19 @@ mod tests {
     fn test_get_stake_minimum_delegation() {
         let expected_minimum_delegation: u64 = 123_456_789;
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
-        let actual_minimum_delegation = rpc_client.get_stake_minimum_delegation().unwrap();
-        assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
+
+        // Test: without commitment
+        {
+            let actual_minimum_delegation = rpc_client.get_stake_minimum_delegation().unwrap();
+            assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
+        }
+
+        // Test: with commitment
+        {
+            let actual_minimum_delegation = rpc_client
+                .get_stake_minimum_delegation_with_commitment(CommitmentConfig::confirmed())
+                .unwrap();
+            assert_eq!(expected_minimum_delegation, actual_minimum_delegation);
+        }
     }
 }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2458,7 +2458,7 @@ Returns the stake minimum delegation, in lamports.
 
 #### Parameters:
 
-None
+- `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 


### PR DESCRIPTION
#### Problem

The CLI needs a way to specify commitment when querying the stake minimum delegation.

See https://github.com/solana-labs/solana/pull/26645#discussion_r925790164 for original context.

#### Summary of Changes

Add `get_stake_minimum_delegation_with_commitment()` to rpc_client
