### PR TITLE
cli-output: Add CliBalance

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2713,6 +2713,45 @@ impl fmt::Display for CliPingConfirmationStats {
 impl QuietDisplay for CliPingConfirmationStats {}
 impl VerboseDisplay for CliPingConfirmationStats {}
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CliBalance {
+    pub lamports: u64,
+    #[serde(skip)]
+    pub config: BuildBalanceMessageConfig,
+}
+
+impl QuietDisplay for CliBalance {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        let config = BuildBalanceMessageConfig {
+            show_unit: false,
+            trim_trailing_zeros: true,
+            ..self.config
+        };
+        let balance_message = build_balance_message_with_config(self.lamports, &config);
+        write!(w, "{}", balance_message)
+    }
+}
+
+impl VerboseDisplay for CliBalance {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        let config = BuildBalanceMessageConfig {
+            show_unit: true,
+            trim_trailing_zeros: false,
+            ..self.config
+        };
+        let balance_message = build_balance_message_with_config(self.lamports, &config);
+        write!(w, "{}", balance_message)
+    }
+}
+
+impl fmt::Display for CliBalance {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let balance_message = build_balance_message_with_config(self.lamports, &self.config);
+        write!(f, "{}", balance_message)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {


### PR DESCRIPTION
#### Problem

There is not a unified way to output balances via the cli.

Original context: https://github.com/solana-labs/solana/issues/26698

#### Summary of Changes

Add `CliBalance` as a generic way to output balances that respects the cli config.

#### Example Output

##### Original 

```
❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue
0.0428736 SOL

❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --lamports
42873600 lamports

❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --verbose
RPC URL: https://api.mainnet-beta.solana.com
Default Signer Path: /id.json
Commitment: confirmed
0.0428736 SOL

❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json
0.0428736 SOL

❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json-compact
0.0428736 SOL

❯ solana balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json-compact --lamports
42873600 lamports
```

##### This PR

```
❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue
0.0428736 SOL

❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --lamports
42873600 lamports

❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --verbose
RPC URL: https://api.mainnet-beta.solana.com
Default Signer Path: /id.json
Commitment: confirmed
0.042873600 SOL

❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json
{
  "lamports": 42873600
}

❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json-compact
{"lamports":42873600}

❯ cargo run --bin solana -- balance 98pjRuQjK3qA6gXts96PqZT4Ze5QmnCmt3QYjhbUSPue --output json-compact --lamports
{"lamports":42873600}
```

