### PR TITLE
Remove resolver=2 from Cargo.toml and add it to the Windows build

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,12 +43,6 @@ jobs:
         run: |
           git checkout ${{ inputs.commit }}
 
-
-      # The Windows build fails without resolver = "2", but including it in Cargo.toml causes
-      # other problems (see PR #26555 and Issue #22603). These lines add resolver = "2" to
-      # Cargo.toml and commit the change to the local build environment before building.
-      # Since the build environment does not persist the changes are discarded after the build
-      # and do not interfere with non-Windows builds.
       - name: Build
         id: build
         shell: bash
@@ -60,12 +54,6 @@ jobs:
           echo "::set-output name=tag::$CI_TAG"
           eval "$(ci/channel-info.sh)"
           echo "::set-output name=channel::$CHANNEL"
-          echo "resolver = \"2\"" >> Cargo.toml
-          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          git config --global user.email "<>"
-          git config --global user.name "Github Action Bot"
-          git add -u
-          git commit -m "Add resolver=2"
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -44,8 +44,8 @@ jobs:
           git checkout ${{ inputs.commit }}
 
 
-      # The Windows build fails without resolver = "2", but including it in Cargo.toml causes 
-      # other problems (see PR #26555 and Issue #22603). These lines add resolver = "2" to 
+      # The Windows build fails without resolver = "2", but including it in Cargo.toml causes
+      # other problems (see PR #26555 and Issue #22603). These lines add resolver = "2" to
       # Cargo.toml and commit the change to the local build environment before building.
       # Since the build environment does not persist the changes are discarded after the build
       # and do not interfere with non-Windows builds.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,6 +43,12 @@ jobs:
         run: |
           git checkout ${{ inputs.commit }}
 
+
+      # The Windows build fails without resolver = "2", but including it in Cargo.toml causes 
+      # other problems (see PR #26555 and Issue #22603). These lines add resolver = "2" to 
+      # Cargo.toml and commit the change to the local build environment before building.
+      # Since the build environment does not persist the changes are discarded after the build
+      # and do not interfere with non-Windows builds.
       - name: Build
         id: build
         shell: bash
@@ -54,6 +60,12 @@ jobs:
           echo "::set-output name=tag::$CI_TAG"
           eval "$(ci/channel-info.sh)"
           echo "::set-output name=channel::$CHANNEL"
+          echo "resolver = \"2\"" >> Cargo.toml
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          git config --global user.email "<>"
+          git config --global user.name "Github Action Bot"
+          git add -u
+          git commit -m "Add resolver=2"
           ci/publish-tarball.sh
 
       - name: Prepare Upload Files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,3 @@ members = [
 exclude = [
     "programs/bpf",
 ]
-
-# This prevents a Travis CI error when building for Windows.
-resolver = "2"

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -58,6 +58,11 @@ windows)
     git config core.symlinks true
     find . -type l -delete
     git reset --hard
+    # The Windows build fails without resolver = "2", but including it in Cargo.toml causes
+    # other problems (see PR #26555 and Issue #22603). This adds resolver = "2" to
+    # Cargo.toml before building. Since the build environment does not persist the changes
+    # are discarded after the build and do not interfere with non-Windows builds.
+    echo 'resolver = "2"' >> Cargo.toml
   )
   ;;
 *)


### PR DESCRIPTION
See discussion on PR #26555

#### Problem
PR #24196 added `resolver = "2"` to Cargo.toml. That fixed the broken Windows build but is causing other problems (see https://github.com/solana-labs/solana/issues/22603)

#### Summary of Changes
* Remove `resolver = "2"` from Cargo.toml
* Add steps to the Windows build that add `resolver = "2"` to the local copy of Cargo.toml immediately before the build.

Fixes #22603
