### PR TITLE
Removes `AccountSharedData` from `SysvarCache`.

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -281,24 +281,22 @@ impl<'a> InvokeContext<'a> {
         builtin_programs: &'a [BuiltinProgram],
     ) -> Self {
         let mut sysvar_cache = SysvarCache::default();
-        sysvar_cache.fill_missing_entries(|pubkey| {
-            (0..transaction_context.get_number_of_accounts()).find_map(|index| {
+        sysvar_cache.fill_missing_entries(|pubkey, callback| {
+            for index in 0..transaction_context.get_number_of_accounts() {
                 if transaction_context
                     .get_key_of_account_at_index(index)
                     .unwrap()
                     == pubkey
                 {
-                    Some(
+                    callback(
                         transaction_context
                             .get_account_at_index(index)
                             .unwrap()
                             .borrow()
-                            .clone(),
-                    )
-                } else {
-                    None
+                            .data(),
+                    );
                 }
-            })
+            }
         });
         Self::new(
             transaction_context,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -3764,7 +3764,7 @@ mod tests {
             epoch: Epoch::MAX,
             ..Clock::default()
         };
-        transaction_accounts[3] = (
+        transaction_accounts[4] = (
             sysvar::clock::id(),
             account::create_account_shared_data_for_test(&clock),
         );

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -1,9 +1,16 @@
-use {super::Bank, solana_program_runtime::sysvar_cache::SysvarCache};
+use {
+    super::Bank, solana_program_runtime::sysvar_cache::SysvarCache,
+    solana_sdk::account::ReadableAccount,
+};
 
 impl Bank {
     pub(crate) fn fill_missing_sysvar_cache_entries(&self) {
         let mut sysvar_cache = self.sysvar_cache.write().unwrap();
-        sysvar_cache.fill_missing_entries(|pubkey| self.get_account_with_fixed_root(pubkey));
+        sysvar_cache.fill_missing_entries(|pubkey, callback| {
+            if let Some(account) = self.get_account_with_fixed_root(pubkey) {
+                callback(account.data());
+            }
+        });
     }
 
     pub(crate) fn reset_sysvar_cache(&self) {


### PR DESCRIPTION
#### Problem
`SysvarCache` explicitly expects `AccountSharedData` even though it only needs `&[u8]` data.

#### Summary of Changes
Replaces the callback which returns `AccountSharedData` by a second nested callback which deserializes the data in place. This is a double control-flow back pass, similar to a coroutine.