### PR TITLE
fix(docs): separated the introduction sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,31 +1,92 @@
 module.exports = {
+  introdutionSidebar: [
+    {
+      type: "category",
+      collapsed: false,
+      label: "Introduction to Solana",
+      items: [
+        {
+          type: "doc",
+          id: "introduction",
+          label: "What is Solana?",
+        },
+        {
+          type: "doc",
+          id: "economics_overview",
+          label: "How do the economics work?",
+        },
+        {
+          type: "doc",
+          id: "history",
+          label: "History of Solana",
+        },
+      ],
+    },
+    {
+      type: "category",
+      collapsed: false,
+      label: "Getting started with Solana",
+      items: [
+        {
+          type: "doc",
+          id: "wallet-guide",
+          label: "Wallets",
+        },
+        // This will be the future home of the `staking` page, with the introductory info on what staking on Solana looks like
+        // {
+        //   type: "doc",
+        //   id: "staking",
+        //   label: "Staking",
+        // },
+      ],
+    },
+    {
+      type: "category",
+      collapsed: false,
+      label: "Dive into Solana",
+      items: [
+        "terminology",
+        {
+          type: "link",
+          label: "Developers",
+          href: "developing/programming-model/overview",
+        },
+        {
+          type: "link",
+          label: "Validators",
+          href: "running-validator",
+        },
+        {
+          type: "link",
+          label: "Command Line",
+          href: "cli",
+        },
+      ],
+    },
+  ],
   docs: {
-    About: ["introduction", "terminology", "history"],
-    Wallets: [
-      "wallet-guide",
-      {
-        type: "category",
-        label: "Command-line Wallets",
-        items: [
-          "wallet-guide/cli",
-          "wallet-guide/paper-wallet",
-          {
-            type: "category",
-            label: "Hardware Wallets",
-            items: [
-              "wallet-guide/hardware-wallets",
-              "wallet-guide/hardware-wallets/ledger",
-            ],
-          },
-          "wallet-guide/file-system-wallet",
-        ],
-      },
-      "wallet-guide/support",
-    ],
     Staking: ["staking", "staking/stake-accounts"],
     "Command Line": [
       "cli",
       "cli/install-solana-cli-tools",
+        {
+          type: "category",
+          label: "Command-line Wallets",
+          items: [
+            "wallet-guide/cli",
+            "wallet-guide/paper-wallet",
+            {
+              type: "category",
+              label: "Hardware Wallets",
+              items: [
+                "wallet-guide/hardware-wallets",
+                "wallet-guide/hardware-wallets/ledger",
+              ],
+            },
+            "wallet-guide/file-system-wallet",
+            "wallet-guide/support",
+          ],
+        },
       "cli/conventions",
       "cli/choose-a-cluster",
       "cli/transfer-tokens",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -129,7 +129,7 @@ function Home() {
                 </Link>
               </div>
               <div className={clsx("col col--4", styles.feature)}>
-                <Link className="navbar__link" to="cluster/overview">
+                <Link className="navbar__link" to="introduction">
                   <div className="card">
                     <div className="card__header">
                       <h3>


### PR DESCRIPTION
#### Problem
The Solana docs sidebars restructure for #26699 

#### Summary of Changes
- segmented the "introduction" section sidebar from the global sidebar
- moved the "wallet-guide" into the introduction section
- moved the "command line wallets" section into the command line section of the global sidebar
- updated docs home page card "Learn how Solana works" to link to the "introduction" pages

Work in Progress for: #26699 

Screenshot of the new "introduction" section sidebar:
<a href="url"><img src="https://user-images.githubusercontent.com/75431177/180296093-2cfa427f-2289-4b91-a200-162854ec5219.png" align="left" height="300" /></a>
