### PR TITLE
fix(docs): separated the developing sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -109,6 +109,10 @@ module.exports = {
               label: "Introduction",
               to: "introduction",
             },
+            {
+              label: "Developing",
+              to: "developing/programming-model/overview",
+            },
           ],
         },
         {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,4 +1,76 @@
 module.exports = {
+  developingSidebar: [
+    {
+      type: "doc",
+      id: "developing/programming-model/overview",
+      label: "Overview",
+    },
+    {
+      type: "category",
+      label: "Core Concepts",
+      // collapsed: false,
+      items: [
+        "developing/programming-model/transactions",
+        "developing/programming-model/accounts",
+        "developing/programming-model/calling-between-programs",
+        "developing/programming-model/runtime",
+      ],
+    },
+    {
+      type: "category",
+      label: "Clients",
+      items: [
+        "developing/clients/jsonrpc-api",
+        "developing/clients/javascript-api",
+        "developing/clients/javascript-reference",
+        "developing/clients/rust-api",
+      ],
+    },
+    {
+      type: "category",
+      label: "Writing Programs",
+      items: [
+        "developing/on-chain-programs/overview",
+        "developing/on-chain-programs/developing-rust",
+        "developing/on-chain-programs/developing-c",
+        {
+          type: "doc",
+          label: "Deploying",
+          id: "developing/on-chain-programs/deploying",
+        },
+        {
+          type: "doc",
+          label: "Debugging",
+          id: "developing/on-chain-programs/debugging",
+        },
+        "developing/on-chain-programs/examples",
+        "developing/on-chain-programs/faq",
+      ],
+    },
+    {
+      type: "category",
+      label: "Native Programs",
+      items: [
+        {
+          type: "doc",
+          label: "Overview",
+          id: "developing/runtime-facilities/programs",
+        },
+        "developing/runtime-facilities/sysvars",
+      ],
+    },
+    
+    {
+      type: "category",
+      label: "Local Development",
+      collapsed: false,
+      items: [
+        "developing/test-validator",
+      ]
+    },
+    "developing/backwards-compatibility",
+    "developing/plugins/geyser-plugins"
+  ],
   docs: {
     About: ["introduction", "terminology", "history"],
     Wallets: [
@@ -34,53 +106,6 @@ module.exports = {
       "offline-signing",
       "offline-signing/durable-nonce",
       "cli/usage",
-    ],
-    Developing: [
-      {
-        type: "category",
-        label: "Programming Model",
-        items: [
-          "developing/programming-model/overview",
-          "developing/programming-model/transactions",
-          "developing/programming-model/accounts",
-          "developing/programming-model/runtime",
-          "developing/programming-model/calling-between-programs",
-        ],
-      },
-      {
-        type: "category",
-        label: "Clients",
-        items: [
-          "developing/clients/jsonrpc-api",
-          "developing/clients/javascript-api",
-          "developing/clients/javascript-reference",
-          "developing/clients/rust-api",
-        ],
-      },
-      {
-        type: "category",
-        label: "Runtime Facilities",
-        items: [
-          "developing/runtime-facilities/programs",
-          "developing/runtime-facilities/sysvars",
-        ],
-      },
-      {
-        type: "category",
-        label: "On-chain Programs",
-        items: [
-          "developing/on-chain-programs/overview",
-          "developing/on-chain-programs/developing-rust",
-          "developing/on-chain-programs/developing-c",
-          "developing/on-chain-programs/deploying",
-          "developing/on-chain-programs/debugging",
-          "developing/on-chain-programs/examples",
-          "developing/on-chain-programs/faq",
-        ],
-      },
-      "developing/test-validator",
-      "developing/backwards-compatibility",
-      "developing/plugins/geyser-plugins"
     ],
     Integrating: ["integrations/exchange"],
     Validating: [

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -59,7 +59,6 @@ module.exports = {
         "developing/runtime-facilities/sysvars",
       ],
     },
-    
     {
       type: "category",
       label: "Local Development",

--- a/docs/src/developing/on-chain-programs/debugging.md
+++ b/docs/src/developing/on-chain-programs/debugging.md
@@ -1,5 +1,5 @@
 ---
-title: "Debugging"
+title: "Debugging Programs"
 ---
 
 Solana programs run on-chain, so debugging them in the wild can be challenging.

--- a/docs/src/developing/on-chain-programs/deploying.md
+++ b/docs/src/developing/on-chain-programs/deploying.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploying"
+title: "Deploying Programs"
 ---
 
 ![SDK tools](/img/sdk-tools.svg)

--- a/docs/src/developing/on-chain-programs/examples.md
+++ b/docs/src/developing/on-chain-programs/examples.md
@@ -1,5 +1,5 @@
 ---
-title: "Examples"
+title: "Program Examples"
 ---
 
 ## Helloworld

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -26,7 +26,7 @@ function Home() {
                     <div className="card__header">
                       <h3>
                         <Translate description="start-building">
-                          ⛏ Start Building
+                          ⛏ Start Developing
                         </Translate>
                       </h3>
                     </div>
@@ -34,7 +34,7 @@ function Home() {
                       <p>
                         <Translate description="get-started-building">
                           Get started building your decentralized app or
-                          marketplace.
+                          marketplace with Solana.
                         </Translate>
                       </p>
                     </div>


### PR DESCRIPTION
#### Problem
The Solana docs "developing" sidebar restructure for #26699 

#### Summary of Changes
- segmented the "developing" section sidebar from the global sidebar
- added a footer link to the "developing overview" page
- updated 3 page titles to be more specific (for future SEO)
- updated the docs home page card "Start Building" to be more specific

Screenshot of the new "developing" section sidebar:

<a href="url"><img src="https://user-images.githubusercontent.com/75431177/180329084-1dc57f27-3890-4dd5-a252-aa1cf3380c45.png" align="left" height="300" /></a>
