### PR TITLE
Split out voting and banking threads in banking stage

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -9,7 +9,9 @@ use {
     rand::{thread_rng, Rng},
     rayon::prelude::*,
     solana_core::{
-        banking_stage::{BankingStage, BankingStageStats},
+        banking_stage::{
+            BankingStage, BankingStageStats, ThreadType, UnprocessedTransactionStorage,
+        },
         leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
         qos_service::QosService,
         unprocessed_packet_batches::*,
@@ -80,8 +82,10 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let transactions = vec![tx; 4194304];
         let batches = transactions_to_deserialized_packets(&transactions).unwrap();
         let batches_len = batches.len();
-        let mut transaction_buffer =
-            UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len);
+        let mut transaction_buffer = UnprocessedTransactionStorage::TransactionStorage(
+            UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len),
+            ThreadType::Transactions,
+        );
         let (s, _r) = unbounded();
         // This tests the performance of buffering packets.
         // If the packet buffers are copied, performance will be poor.

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -9,12 +9,11 @@ use {
     rand::{thread_rng, Rng},
     rayon::prelude::*,
     solana_core::{
-        banking_stage::{
-            BankingStage, BankingStageStats, ThreadType, UnprocessedTransactionStorage,
-        },
+        banking_stage::{BankingStage, BankingStageStats},
         leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
         qos_service::QosService,
         unprocessed_packet_batches::*,
+        unprocessed_transaction_storage::{ThreadType, UnprocessedTransactionStorage},
     },
     solana_entry::entry::{next_hash, Entry},
     solana_gossip::cluster_info::{ClusterInfo, Node},
@@ -82,9 +81,10 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let transactions = vec![tx; 4194304];
         let batches = transactions_to_deserialized_packets(&transactions).unwrap();
         let batches_len = batches.len();
-        let mut transaction_buffer = UnprocessedTransactionStorage::TransactionStorage(
+        let mut transaction_buffer = UnprocessedTransactionStorage::new_transaction_storage(
             UnprocessedPacketBatches::from_iter(batches.into_iter(), 2 * batches_len),
             ThreadType::Transactions,
+            None,
         );
         let (s, _r) = unbounded();
         // This tests the performance of buffering packets.

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -490,7 +490,6 @@ impl UnprocessedTransactionStorage {
 
     pub fn filter_forwardable_packets_and_add_batches(
         &mut self,
-        bank: &Arc<Bank>,
         forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
     ) -> FilterForwardingResults {
         match self {
@@ -500,7 +499,7 @@ impl UnprocessedTransactionStorage {
             ),
             Self::VoteStorage(v, VoteSource::Tpu) => {
                 let total_forwardable_packets =
-                    v.get_and_insert_forwardable_packets(bank, forward_packet_batches_by_accounts);
+                    v.get_and_insert_forwardable_packets(forward_packet_batches_by_accounts);
                 FilterForwardingResults {
                     total_forwardable_packets,
                     ..FilterForwardingResults::default()
@@ -1244,10 +1243,7 @@ impl BankingStage {
         let mut forward_packet_batches_by_accounts =
             ForwardPacketBatchesByAccounts::new_with_default_batch_limits(current_bank.clone());
         let filter_forwarding_result = unprocessed_transaction_storage
-            .filter_forwardable_packets_and_add_batches(
-                &current_bank,
-                &mut forward_packet_batches_by_accounts,
-            );
+            .filter_forwardable_packets_and_add_batches(&mut forward_packet_batches_by_accounts);
 
         forward_packet_batches_by_accounts
             .iter_batches()

--- a/core/src/forward_packet_batches_by_accounts.rs
+++ b/core/src/forward_packet_batches_by_accounts.rs
@@ -99,7 +99,7 @@ impl ForwardBatch {
 pub struct ForwardPacketBatchesByAccounts {
     // Need a `bank` to load all accounts for VersionedTransaction. Currently
     // using current rooted bank for it.
-    current_bank: Arc<Bank>,
+    pub(crate) current_bank: Arc<Bank>,
     // Forwardable packets are staged in number of batches, each batch is limited
     // by cost_tracker on both account limit and block limits. Those limits are
     // set as `limit_ratio` of regular block limits to facilitate quicker iteration.

--- a/core/src/immutable_deserialized_packet.rs
+++ b/core/src/immutable_deserialized_packet.rs
@@ -28,6 +28,8 @@ pub enum DeserializedPacketError {
     SanitizeError(#[from] SanitizeError),
     #[error("transaction failed prioritization")]
     PrioritizationFailure,
+    #[error("vote transaction deserialization failure")]
+    VoteTransactionError,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -102,7 +104,7 @@ impl Ord for ImmutableDeserializedPacket {
 }
 
 /// Read the transaction message from packet data
-fn packet_message(packet: &Packet) -> Result<&[u8], DeserializedPacketError> {
+pub fn packet_message(packet: &Packet) -> Result<&[u8], DeserializedPacketError> {
     let (sig_len, sig_size) = packet
         .data(..)
         .and_then(|bytes| decode_shortu16_len(bytes).ok())

--- a/core/src/latest_unprocessed_votes.rs
+++ b/core/src/latest_unprocessed_votes.rs
@@ -1,0 +1,266 @@
+use {
+    crate::{
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
+        immutable_deserialized_packet::{DeserializedPacketError, ImmutableDeserializedPacket}
+    },
+    solana_perf::packet::{Packet, PacketBatch},
+    solana_sdk::{
+        clock::Slot,
+        message::Message,
+        program_utils::limited_deserialize,
+        pubkey::Pubkey,
+    },
+    solana_vote_program::vote_instruction::VoteInstruction,
+    std::{
+        cell::RefCell,
+        collections::HashMap,
+        rc::Rc,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            RwLock,
+        },
+    },
+};
+
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub enum VoteSource {
+    Gossip,
+    Tpu,
+}
+
+/// Holds deserialized vote messages as well as their source, foward status and slot
+#[derive(Debug)]
+pub struct DeserializedVotePacket {
+    vote_source: VoteSource,
+    pubkey: Pubkey,
+    vote: Option<Rc<ImmutableDeserializedPacket>>,
+    slot: Slot,
+    forwarded: bool,
+}
+
+impl DeserializedVotePacket {
+    pub fn new(packet: Packet, vote_source: VoteSource) -> Result<Self, DeserializedPacketError> {
+        if !packet.meta.is_simple_vote_tx() {
+            return Err(DeserializedPacketError::VoteTransactionError);
+        }
+
+        let vote = ImmutableDeserializedPacket::new(packet, None)?;
+        let message = vote.transaction().get_message();
+        let (_, instruction) = message
+            .program_instructions_iter()
+            .next()
+            .ok_or(DeserializedPacketError::VoteTransactionError)?;
+
+        match limited_deserialize::<VoteInstruction>(&instruction.data) {
+            Ok(VoteInstruction::UpdateVoteState(vote_state_update))
+            | Ok(VoteInstruction::UpdateVoteStateSwitch(vote_state_update, _)) => {
+                let &pubkey = message
+                    .message
+                    .static_account_keys()
+                    .get(0)
+                    .ok_or(DeserializedPacketError::VoteTransactionError)?;
+                let slot = vote_state_update.last_voted_slot().unwrap_or(0);
+
+                Ok(Self {
+                    vote: Some(Rc::new(vote)),
+                    slot,
+                    pubkey,
+                    vote_source,
+                    forwarded: false,
+                })
+            }
+            _ => Err(DeserializedPacketError::VoteTransactionError),
+        }
+    }
+
+    pub fn get_vote_packet(&mut self) -> Rc<ImmutableDeserializedPacket> {
+        self.vote.as_ref().unwrap().clone()
+    }
+
+    pub fn pubkey(&self) -> Pubkey {
+        self.pubkey
+    }
+
+    pub fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    pub fn is_forwarded(&self) -> bool {
+        // By definition all gossip votes have been forwarded
+        self.forwarded || matches!(self.vote_source, VoteSource::Gossip)
+    }
+
+    pub fn is_processed(&self) -> bool {
+        self.vote.is_none()
+    }
+
+    pub fn clear(&mut self) {
+        self.vote = None;
+    }
+}
+
+pub fn deserialize_packets<'a>(
+    packet_batch: &'a PacketBatch,
+    packet_indexes: &'a [usize],
+    vote_source: VoteSource,
+) -> impl Iterator<Item = DeserializedVotePacket> + 'a {
+    packet_indexes.iter().filter_map(move |packet_index| {
+        DeserializedVotePacket::new(packet_batch[*packet_index].clone(), vote_source).ok()
+    })
+}
+
+#[derive(Debug, Default)]
+pub struct LatestUnprocessedVotes {
+    pub(crate) latest_votes_per_pubkey:
+        RwLock<HashMap<Pubkey, RwLock<RefCell<DeserializedVotePacket>>>>,
+    pub(crate) size: AtomicUsize,
+}
+
+unsafe impl Send for LatestUnprocessedVotes {}
+unsafe impl Sync for LatestUnprocessedVotes {}
+
+impl LatestUnprocessedVotes {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.size.load(Ordering::Relaxed)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn insert_batch(
+        &self,
+        votes: impl Iterator<Item = DeserializedVotePacket>,
+    ) -> (usize, usize) {
+        let mut num_dropped_packets = 0;
+
+        for vote in votes {
+            if self.update_latest_vote(vote).is_some() {
+                num_dropped_packets += 1;
+            }
+        }
+
+        // Should not be any tracer packets in votes
+        (num_dropped_packets, 0)
+    }
+
+    /// If this vote causes an unprocessed vote to be removed, returns Some(old_vote)
+    /// If there is a newer vote processed / waiting to be processed returns Some(vote)
+    /// Otherwise returns None
+    pub fn update_latest_vote(
+        &self,
+        vote: DeserializedVotePacket,
+    ) -> Option<Rc<ImmutableDeserializedPacket>> {
+        let pubkey = vote.pubkey();
+        let slot = vote.slot();
+        if let Some(latest_vote) = self.latest_votes_per_pubkey.read().unwrap().get(&pubkey) {
+            let mut latest_slot = 0;
+            {
+                if let Some(latest) = latest_vote
+                    .read()
+                    .ok()
+                    .and_then(|v| v.try_borrow().ok().map(|vote| vote.slot()))
+                {
+                    latest_slot = latest;
+                }
+            }
+            if slot > latest_slot {
+                if let Ok(latest_vote) = latest_vote.write() {
+                    // At this point no one should have a borrow to this refcell as all borrows are
+                    // hidden behind read()
+                    if let Ok(mut latest_vote) = latest_vote.try_borrow_mut() {
+                        let latest_slot = latest_vote.slot();
+                        if slot > latest_slot {
+                            if latest_vote.is_processed() {
+                                self.size.fetch_add(1, Ordering::AcqRel);
+                            }
+                            let ret = std::mem::take(&mut latest_vote.vote);
+                            *latest_vote = vote;
+                            return ret;
+                        }
+                    } else {
+                        error!("Implementation error {} {} {:?}", slot, latest_slot, self);
+                    }
+                }
+            }
+            return vote.vote;
+        }
+
+        // Should have low lock contention because this is only hit on the first few blocks of startup
+        // and when a new vote account starts voting.
+        let mut latest_votes_per_pubkey = self.latest_votes_per_pubkey.write().unwrap();
+        latest_votes_per_pubkey.insert(pubkey, RwLock::new(RefCell::new(vote)));
+        self.size.fetch_add(1, Ordering::AcqRel);
+        None
+    }
+
+    pub fn get_latest_vote_slot(&self, pubkey: Pubkey) -> Option<Slot> {
+        self.latest_votes_per_pubkey
+            .read()
+            .ok()
+            .and_then(|latest_votes_per_pubkey| {
+                latest_votes_per_pubkey
+                    .get(&pubkey)
+                    .and_then(|l| l.read().ok())
+                    .and_then(|c| c.try_borrow().ok().map(|v| (*v).slot()))
+            })
+    }
+
+    /// Returns how many packets were forwardable
+    /// TODO: Should this also be prioritized by stake?
+    pub fn get_and_insert_forwardable_packets(
+        &self,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
+    ) -> usize {
+        if let Ok(latest_votes_per_pubkey) = self.latest_votes_per_pubkey.read() {
+            return latest_votes_per_pubkey
+                .values()
+                .filter(|lock| {
+                    if let Ok(cell) = lock.write() {
+                        if let Ok(mut vote) = cell.try_borrow_mut() {
+                            if !vote.is_processed() && !vote.is_forwarded() {
+                                if forward_packet_batches_by_accounts
+                                    .add_packet(vote.vote.as_ref().unwrap().clone())
+                                {
+                                    vote.forwarded = true;
+                                }
+                                return true;
+                            }
+                        }
+                    }
+                    false
+                })
+                .count();
+        }
+        0
+    }
+
+    /// Sometimes we forward and hold the packets, sometimes we forward and clear.
+    /// This also clears all gosisp votes since by definition they have been forwarded
+    /// TODO: Do we want this logic to apply to vote txs or should we treat them the same
+    pub fn clear_forwarded_packets(&self) {
+        if let Ok(latest_votes_per_pubkey) = self.latest_votes_per_pubkey.read() {
+            latest_votes_per_pubkey
+                .values()
+                .filter(|lock| {
+                    if let Ok(cell) = lock.read() {
+                        if let Ok(vote) = cell.try_borrow() {
+                            return vote.is_forwarded();
+                        }
+                    }
+                    false
+                })
+                .for_each(|lock| {
+                    if let Ok(cell) = lock.write() {
+                        if let Ok(mut vote) = cell.try_borrow_mut() {
+                            vote.clear();
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/core/src/leader_slot_banking_stage_metrics.rs
+++ b/core/src/leader_slot_banking_stage_metrics.rs
@@ -1,5 +1,8 @@
 use {
-    crate::leader_slot_banking_stage_timing_metrics::*,
+    crate::{
+        leader_slot_banking_stage_timing_metrics::*,
+        unprocessed_transaction_storage::InsertPacketBatchesSummary,
+    },
     solana_poh::poh_recorder::BankStart,
     solana_runtime::transaction_error_metrics::*,
     solana_sdk::{clock::Slot, saturating_add_assign},
@@ -496,6 +499,21 @@ impl LeaderSlotMetricsTracker {
                 .execute_and_commit_timings
                 .accumulate(execute_and_commit_timings);
         }
+    }
+
+    pub(crate) fn accumulate_insert_packet_batches_summary(
+        &mut self,
+        insert_packet_batches_summary: &InsertPacketBatchesSummary,
+    ) {
+        self.increment_exceeded_buffer_limit_dropped_packets_count(
+            insert_packet_batches_summary.num_dropped_packets as u64,
+        );
+        self.increment_dropped_gossip_vote_count(
+            insert_packet_batches_summary.num_dropped_gossip_vote_packets as u64,
+        );
+        self.increment_dropped_tpu_vote_count(
+            insert_packet_batches_summary.num_dropped_tpu_vote_packets as u64,
+        );
     }
 
     pub(crate) fn accumulate_transaction_errors(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,6 +75,7 @@ pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;
 pub mod unprocessed_packet_batches;
+mod unprocessed_transaction_storage;
 pub mod validator;
 pub mod verified_vote_packets;
 pub mod vote_simulator;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -75,7 +75,7 @@ pub mod tree_diff;
 pub mod tvu;
 pub mod unfrozen_gossip_verified_vote_hashes;
 pub mod unprocessed_packet_batches;
-mod unprocessed_transaction_storage;
+pub mod unprocessed_transaction_storage;
 pub mod validator;
 pub mod verified_vote_packets;
 pub mod vote_simulator;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod forward_packet_batches_by_accounts;
 pub mod gen_keys;
 pub mod heaviest_subtree_fork_choice;
 pub mod immutable_deserialized_packet;
+mod latest_unprocessed_votes;
 pub mod latest_validator_votes_for_frozen_banks;
 pub mod leader_slot_banking_stage_metrics;
 pub mod leader_slot_banking_stage_timing_metrics;

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -22,7 +22,7 @@ use {
 /// SanitizedTransaction
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeserializedPacket {
-    immutable_section: Rc<ImmutableDeserializedPacket>,
+    pub(crate) immutable_section: Rc<ImmutableDeserializedPacket>,
     pub forwarded: bool,
 }
 

--- a/core/src/unprocessed_packet_batches.rs
+++ b/core/src/unprocessed_packet_batches.rs
@@ -73,7 +73,7 @@ impl Ord for DeserializedPacket {
 /// Currently each banking_stage thread has a `UnprocessedPacketBatches` buffer to store
 /// PacketBatch's received from sigverify. Banking thread continuously scans the buffer
 /// to pick proper packets to add to the block.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct UnprocessedPacketBatches {
     pub packet_priority_queue: MinMaxHeap<Rc<ImmutableDeserializedPacket>>,
     pub message_hash_to_transaction: HashMap<Hash, DeserializedPacket>,

--- a/core/src/unprocessed_transaction_storage.rs
+++ b/core/src/unprocessed_transaction_storage.rs
@@ -1,0 +1,425 @@
+use {
+    crate::{
+        banking_stage::{
+            weighted_random_order_by_stake, BankingStage, FilterForwardingResults, ForwardOption,
+        },
+        forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
+        immutable_deserialized_packet::ImmutableDeserializedPacket,
+        latest_unprocessed_votes::{self, LatestUnprocessedVotes, VoteSource},
+        unprocessed_packet_batches::{self, UnprocessedPacketBatches},
+    },
+    itertools::Itertools,
+    min_max_heap::MinMaxHeap,
+    solana_perf::packet::PacketBatch,
+    solana_runtime::bank::Bank,
+    std::{rc::Rc, sync::Arc, sync::atomic::Ordering},
+};
+
+const MAX_STAKED_VALIDATORS: usize = 10_000;
+
+#[derive(Debug, Default)]
+pub struct InsertPacketBatchesSummary {
+    num_dropped_packets: usize,
+    num_dropped_gossip_vote_packets: usize,
+    num_dropped_tpu_vote_packets: usize,
+    num_dropped_tracer_packets: usize,
+}
+
+fn filter_processed_packets<'a, F>(
+    retryable_transaction_indexes: impl Iterator<Item = &'a usize>,
+    mut f: F,
+) where
+    F: FnMut(usize, usize),
+{
+    let mut prev_retryable_index = 0;
+    for (i, retryable_index) in retryable_transaction_indexes.enumerate() {
+        let start = if i == 0 { 0 } else { prev_retryable_index + 1 };
+
+        let end = *retryable_index;
+        prev_retryable_index = *retryable_index;
+
+        if start < end {
+            f(start, end)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum ThreadType {
+    Voting(VoteSource),
+    Transactions,
+}
+
+#[derive(Debug)]
+struct VoteStorage {
+    latest_unprocessed_votes: Arc<LatestUnprocessedVotes>,
+    vote_source: VoteSource,
+}
+
+impl VoteStorage {
+    fn is_empty(&self) -> bool {
+        self.latest_unprocessed_votes.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.latest_unprocessed_votes.len()
+    }
+
+    fn capacity(&self) -> usize {
+        MAX_STAKED_VALIDATORS
+    }
+
+    fn forward_option(&self) -> ForwardOption {
+        match self.vote_source {
+            VoteSource::Tpu => ForwardOption::ForwardTpuVote,
+            VoteSource::Gossip => ForwardOption::NotForward,
+        }
+    }
+
+    fn clear_forwarded_packets(&mut self) {
+        self.latest_unprocessed_votes.clear_forwarded_packets();
+    }
+
+    fn deserialize_and_insert_batch(
+        &mut self,
+        packet_batch: &PacketBatch,
+        packet_indexes: &[usize],
+    ) -> (usize, usize) {
+        self.latest_unprocessed_votes
+            .insert_batch(latest_unprocessed_votes::deserialize_packets(
+                packet_batch,
+                packet_indexes,
+                self.vote_source,
+            ))
+    }
+
+    fn filter_forwardable_packets_and_add_batches(
+        &mut self,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
+    ) -> FilterForwardingResults {
+        if matches!(self.vote_source, VoteSource::Tpu) {
+            let total_forwardable_packets = self
+                .latest_unprocessed_votes
+                .get_and_insert_forwardable_packets(forward_packet_batches_by_accounts);
+            return FilterForwardingResults {
+                total_forwardable_packets,
+                ..FilterForwardingResults::default()
+            };
+        }
+        FilterForwardingResults::default()
+    }
+
+    fn process_packets<F>(
+        &mut self,
+        bank: Option<Arc<Bank>>,
+        batch_size: usize,
+        mut processing_function: F,
+    ) where
+        F: FnMut(&Vec<Rc<ImmutableDeserializedPacket>>) -> Option<Vec<usize>>,
+    {
+        if matches!(self.vote_source, VoteSource::Gossip) {
+            panic!("Gossip vote thread should not be processing transactions");
+        }
+
+        // Based on the stake distribution present in the supplied bank, drain the unprocessed votes
+        // from each validator using a weighted random ordering. Votes from validators with
+        // 0 stake are ignored.
+        // TODO: Add proper error handling in case bank is missing?
+        let bank = bank.unwrap();
+
+        let latest_votes_per_pubkey = self
+            .latest_unprocessed_votes
+            .latest_votes_per_pubkey
+            .read()
+            .unwrap();
+
+        let retryable_votes = weighted_random_order_by_stake(&bank)
+            .filter_map(|pubkey| {
+                if let Some(lock) = latest_votes_per_pubkey.get(&pubkey) {
+                    if let Ok(latest_vote) = lock.write() {
+                        if let Ok(mut latest_vote) = latest_vote.try_borrow_mut() {
+                            if !latest_vote.is_processed() {
+                                let packet = latest_vote.clone();
+                                latest_vote.clear();
+                                self.latest_unprocessed_votes
+                                    .size
+                                    .fetch_sub(1, Ordering::AcqRel);
+                                return Some(packet);
+                            }
+                        }
+                    }
+                }
+                None
+            })
+            .chunks(batch_size)
+            .into_iter()
+            .flat_map(|vote_packets| {
+                let vote_packets = vote_packets.into_iter().collect_vec();
+                let packets_to_process = vote_packets
+                    .iter()
+                    .map(&DeserializedVotePacket::get_vote_packet)
+                    .collect_vec();
+                if let Some(retryable_vote_indices) = processing_function(&packets_to_process) {
+                    retryable_vote_indices
+                        .iter()
+                        .map(|i| vote_packets[*i].clone())
+                        .collect_vec()
+                } else {
+                    vote_packets
+                }
+            })
+            .collect_vec();
+        // Insert the retryable votes back in
+        self.latest_unprocessed_votes
+            .insert_batch(retryable_votes.into_iter());
+    }
+}
+
+#[derive(Debug)]
+struct TransactionStorage {
+    unprocessed_packet_batches: UnprocessedPacketBatches,
+    thread_type: ThreadType,
+}
+
+impl TransactionStorage {
+    fn is_empty(&self) -> bool {
+        self.unprocessed_packet_batches.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.unprocessed_packet_batches.len()
+    }
+
+    fn capacity(&self) -> usize {
+        self.unprocessed_packet_batches.capacity()
+    }
+
+    #[cfg(test)]
+    fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket> {
+        self.unprocessed_packet_batches.iter()
+    }
+
+    fn forward_option(&self) -> ForwardOption {
+        match self.thread_type {
+            ThreadType::Transactions => ForwardOption::ForwardTransaction,
+            ThreadType::Voting(VoteSource::Tpu) => ForwardOption::ForwardTpuVote,
+            ThreadType::Voting(VoteSource::Gossip) => ForwardOption::NotForward,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.unprocessed_packet_batches.clear();
+    }
+
+    fn deserialize_and_insert_batch(
+        &mut self,
+        packet_batch: &PacketBatch,
+        packet_indexes: &[usize],
+    ) -> (usize, usize) {
+        self.unprocessed_packet_batches.insert_batch(
+            unprocessed_packet_batches::deserialize_packets(packet_batch, packet_indexes),
+        )
+    }
+
+    fn filter_forwardable_packets_and_add_batches(
+        &mut self,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
+    ) -> FilterForwardingResults {
+        BankingStage::filter_valid_packets_for_forwarding(
+            &mut self.unprocessed_packet_batches,
+            forward_packet_batches_by_accounts,
+        )
+    }
+
+    fn process_packets<F>(&mut self, batch_size: usize, mut processing_function: F)
+    where
+        F: FnMut(&Vec<Rc<ImmutableDeserializedPacket>>) -> Option<Vec<usize>>,
+    {
+        let mut retryable_packets = {
+            let capacity = self.unprocessed_packet_batches.capacity();
+            std::mem::replace(
+                &mut self.unprocessed_packet_batches.packet_priority_queue,
+                MinMaxHeap::with_capacity(capacity),
+            )
+        };
+        let retryable_packets: MinMaxHeap<Rc<ImmutableDeserializedPacket>> = retryable_packets
+            .drain_desc()
+            .chunks(batch_size)
+            .into_iter()
+            .flat_map(|packets_to_process| {
+                let packets_to_process = packets_to_process.into_iter().collect_vec();
+                if let Some(retryable_transaction_indexes) =
+                    processing_function(&packets_to_process)
+                {
+                    // Remove the non-retryable packets, packets that were either:
+                    // 1) Successfully processed
+                    // 2) Failed but not retryable
+                    filter_processed_packets(
+                        retryable_transaction_indexes
+                            .iter()
+                            .chain(std::iter::once(&packets_to_process.len())),
+                        |start, end| {
+                            for processed_packet in &packets_to_process[start..end] {
+                                self.unprocessed_packet_batches
+                                    .message_hash_to_transaction
+                                    .remove(processed_packet.message_hash());
+                            }
+                        },
+                    );
+                    retryable_transaction_indexes
+                        .iter()
+                        .map(|i| packets_to_process[*i].clone())
+                        .collect_vec()
+                } else {
+                    packets_to_process
+                }
+            })
+            .collect::<MinMaxHeap<_>>();
+
+        self.unprocessed_packet_batches.packet_priority_queue = retryable_packets;
+
+        // Assert unprocessed queue is still consistent
+        assert_eq!(
+            self.unprocessed_packet_batches.packet_priority_queue.len(),
+            self.unprocessed_packet_batches
+                .message_hash_to_transaction
+                .len()
+        );
+    }
+}
+
+#[derive(Debug)]
+pub enum UnprocessedTransactionStorage {
+    VoteStorage(VoteStorage),
+    TransactionStorage(TransactionStorage),
+}
+
+impl UnprocessedTransactionStorage {
+    pub fn new_transaction_storage(unprocessed_packet_batches : UnprocessedPacketBatches, thread_type : ThreadType) -> Self {
+        Self::TransactionStorage(TransactionStorage {
+            unprocessed_packet_batches,
+            thread_type
+        })
+    }
+
+    pub fn new_vote_storage(latest_unprocessed_votes : Arc<LatestUnprocessedVotes>, vote_source : VoteSource) -> Self {
+        Self::VoteStorage(VoteStorage {
+            latest_unprocessed_votes,
+            vote_source,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::VoteStorage(vote_storage) => vote_storage.is_empty(),
+            Self::TransactionStorage(transaction_storage) => transaction_storage.is_empty(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::VoteStorage(vote_storage) => vote_storage.len(),
+            Self::TransactionStorage(transaction_storage) => transaction_storage.len(),
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        match self {
+            Self::VoteStorage(vote_storage) => vote_storage.capacity(),
+            Self::TransactionStorage(transaction_storage) => transaction_storage.capacity(),
+        }
+    }
+
+    pub fn should_not_process(&self) -> bool {
+        // The gossip vote thread does not need to process or forward any votes, that is
+        // handled by the tpu vote thread
+        if let Self::VoteStorage(vote_storage) = self {
+            return matches!(vote_storage.vote_source, VoteSource::Gossip);
+        }
+        false
+    }
+
+    #[cfg(test)]
+    pub fn iter(&mut self) -> impl Iterator<Item = &DeserializedPacket> {
+        match self {
+            Self::TransactionStorage(transaction_storage) => transaction_storage.iter(),
+            _ => panic!(),
+        }
+    }
+
+    pub fn forward_option(&self) -> ForwardOption {
+        match self {
+            Self::VoteStorage(vote_storage) => vote_storage.forward_option(),
+            Self::TransactionStorage(transaction_storage) => transaction_storage.forward_option(),
+        }
+    }
+
+    pub fn clear_forwarded_packets(&mut self) {
+        match self {
+            Self::TransactionStorage(transaction_storage) => transaction_storage.clear(), // Since we set everything as forwarded this is the same
+            Self::VoteStorage(vote_storage) => vote_storage.clear_forwarded_packets(),
+        }
+    }
+
+    pub fn deserialize_and_insert_batch(
+        &mut self,
+        packet_batch: &PacketBatch,
+        packet_indexes: &[usize],
+    ) -> InsertPacketBatchesSummary {
+        match self {
+            Self::VoteStorage(vote_storage) => {
+                let (num_dropped_gossip_vote_packets, num_dropped_tpu_vote_packets) =
+                    vote_storage.deserialize_and_insert_batch(packet_batch, packet_indexes);
+                InsertPacketBatchesSummary {
+                    num_dropped_packets: num_dropped_gossip_vote_packets
+                        + num_dropped_tpu_vote_packets,
+                    num_dropped_gossip_vote_packets,
+                    num_dropped_tpu_vote_packets,
+                    ..InsertPacketBatchesSummary::default()
+                }
+            }
+            Self::TransactionStorage(transaction_storage) => {
+                let (num_dropped_packets, num_dropped_tracer_packets) =
+                    transaction_storage.deserialize_and_insert_batch(packet_batch, packet_indexes);
+                InsertPacketBatchesSummary {
+                    num_dropped_packets,
+                    num_dropped_tracer_packets,
+                    ..InsertPacketBatchesSummary::default()
+                }
+            }
+        }
+    }
+
+    pub fn filter_forwardable_packets_and_add_batches(
+        &mut self,
+        forward_packet_batches_by_accounts: &mut ForwardPacketBatchesByAccounts,
+    ) -> FilterForwardingResults {
+        match self {
+            Self::TransactionStorage(transaction_storage) => transaction_storage
+                .filter_forwardable_packets_and_add_batches(forward_packet_batches_by_accounts),
+            Self::VoteStorage(vote_storage) => vote_storage
+                .filter_forwardable_packets_and_add_batches(forward_packet_batches_by_accounts),
+        }
+    }
+
+    /// The processing function takes a stream of packets ready to process, and returns the indices
+    /// of the unprocessed packets that are eligible for retry. A return value of None means that
+    /// all packets are unprocessed and eligible for retry.
+    pub fn process_packets<F>(
+        &mut self,
+        bank: Option<Arc<Bank>>,
+        batch_size: usize,
+        mut processing_function: F,
+    ) where
+        F: FnMut(&Vec<Rc<ImmutableDeserializedPacket>>) -> Option<Vec<usize>>,
+    {
+        match self {
+            Self::TransactionStorage(transaction_storage) => {
+                transaction_storage.process_packets(batch_size, processing_function)
+            }
+            Self::VoteStorage(vote_storage) => {
+                vote_storage.process_packets(bank, batch_size, processing_function)
+            }
+        }
+    }
+}

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -112,7 +112,7 @@ impl VoteTransaction {
         match self {
             VoteTransaction::Vote(vote) => vote.slots.last().copied(),
             VoteTransaction::VoteStateUpdate(vote_state_update) => {
-                Some(vote_state_update.lockouts.back()?.slot)
+                vote_state_update.last_voted_slot()
             }
             VoteTransaction::CompactVoteStateUpdate(compact_state_update) => {
                 compact_state_update.slots().last().copied()

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -1,5 +1,8 @@
 use {
-    solana_program::vote::{self, state::{Vote, VoteStateUpdate}},
+    solana_program::vote::{
+        self,
+        state::{Vote, VoteStateUpdate},
+    },
     solana_sdk::{
         clock::Slot,
         hash::Hash,

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -1,5 +1,5 @@
 use {
-    solana_program::vote::{self, state::Vote},
+    solana_program::vote::{self, state::{Vote, VoteStateUpdate}},
     solana_sdk::{
         clock::Slot,
         hash::Hash,
@@ -30,6 +30,36 @@ pub fn new_vote_transaction(
             &vote_keypair.pubkey(),
             &authorized_voter_keypair.pubkey(),
             votes,
+        )
+    };
+
+    let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
+
+    vote_tx.partial_sign(&[node_keypair], blockhash);
+    vote_tx.partial_sign(&[authorized_voter_keypair], blockhash);
+    vote_tx
+}
+
+pub fn new_vote_state_update_transaction(
+    vote_state_update: VoteStateUpdate,
+    blockhash: Hash,
+    node_keypair: &Keypair,
+    vote_keypair: &Keypair,
+    authorized_voter_keypair: &Keypair,
+    switch_proof_hash: Option<Hash>,
+) -> Transaction {
+    let vote_ix = if let Some(switch_proof_hash) = switch_proof_hash {
+        vote::instruction::update_vote_state_switch(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            vote_state_update,
+            switch_proof_hash,
+        )
+    } else {
+        vote::instruction::update_vote_state(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            vote_state_update,
         )
     };
 

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -155,6 +155,10 @@ impl VoteStateUpdate {
     pub fn compact(self) -> Option<CompactVoteStateUpdate> {
         CompactVoteStateUpdate::new(self.lockouts, self.root, self.hash, self.timestamp)
     }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.lockouts.back().map(|l| l.slot)
+    }
 }
 
 /// Ignoring overhead, in a full `VoteStateUpdate` the lockouts take up

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -510,6 +510,10 @@ pub mod vote_state_update_root_fix {
     solana_sdk::declare_id!("G74BkWBzmsByZ1kxHy44H3wjwp5hp7JbrGRuDpco22tY");
 }
 
+pub mod split_banking_threads {
+    solana_sdk::declare_id!("2D61LuTyDUJxERen6zWq8x5weqq9Yvk6cA1ffPx66aV6");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -632,6 +636,7 @@ lazy_static! {
         (relax_authority_signer_check_for_lookup_table_creation::id(), "relax authority signer check for lookup table creation #27205"),
         (stop_sibling_instruction_search_at_parent::id(), "stop the search in get_processed_sibling_instruction when the parent instruction is reached #27289"),
         (vote_state_update_root_fix::id(), "fix root in vote state updates #27361"),
+        (split_banking_threads::id(), "split out voting and tx processing threads in banking stage and consolidate votes when dealing with VoteStateUpdate"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
Additionally this allows us to aggressively prune the buffer for voting threads
as with the new vote state only the latest vote from each validator is
necessary.

#### Problem
We want to drop extraneous vote txs from banking stage but the current setup does not allow it. Initial discussion was had in #25961

#### Summary of Changes
- Split out the transaction store for voting and transaction threads
- Use a separate data structure to keep track of latest vote per pubkey and only write those transactions to bank

Fixes #
Feature Gate Issue: #24717
<!-- Don't forget to add the "feature-gate" label -->