### PR TITLE
Hide vote txs that don't invoke any other programs like the comment says

### DIFF
--- a/explorer/src/components/block/BlockHistoryCard.tsx
+++ b/explorer/src/components/block/BlockHistoryCard.tsx
@@ -135,7 +135,7 @@ export function BlockHistoryCard({ block }: { block: BlockResponse }) {
           return true;
         } else if (programFilter === HIDE_VOTES) {
           // hide vote txs that don't invoke any other programs
-          return !(invocations.size === 1 || invocations.has(voteFilter));
+          return !(invocations.has(voteFilter) && invocations.size === 1);
         }
         return invocations.has(programFilter);
       })


### PR DESCRIPTION
#### Problem
Non vote transactions with a single invocation are hidden by the "All Except Votes" filter

#### Summary of Changes
|| => &&

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
