### PR TITLE
fix: use `maxSupportedTransactionVersion` param when getting raw transactions in Explorer

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -21,7 +21,7 @@
         "@sentry/react": "^7.6.0",
         "@solana/buffer-layout": "^3.0.0",
         "@solana/spl-token-registry": "^0.2.3736",
-        "@solana/web3.js": "^1.49.0",
+        "@solana/web3.js": "^1.50.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.2.3",
@@ -5171,9 +5171,9 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.49.0.tgz",
-      "integrity": "sha512-u+M5Nf1arU1cam+Oot2fZyOcuITSbSWBLVfpoLiKPG48JWsqf59oTdl+q9Q/jZTn/eaxeSvA9LZVKGkvAxZjHA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.50.0.tgz",
+      "integrity": "sha512-9KCuF3QLHd/dkYlffYPSHPbPFaBKqiwwDqWR+C/z1CZZbQybu+NCydWvwHHqrrlG50wn15L/6zYLb5Tjr6tOkA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
@@ -31133,9 +31133,9 @@
       }
     },
     "@solana/web3.js": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.49.0.tgz",
-      "integrity": "sha512-u+M5Nf1arU1cam+Oot2fZyOcuITSbSWBLVfpoLiKPG48JWsqf59oTdl+q9Q/jZTn/eaxeSvA9LZVKGkvAxZjHA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.50.0.tgz",
+      "integrity": "sha512-9KCuF3QLHd/dkYlffYPSHPbPFaBKqiwwDqWR+C/z1CZZbQybu+NCydWvwHHqrrlG50wn15L/6zYLb5Tjr6tOkA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -15,7 +15,7 @@
     "@sentry/react": "^7.6.0",
     "@solana/buffer-layout": "^3.0.0",
     "@solana/spl-token-registry": "^0.2.3736",
-    "@solana/web3.js": "^1.49.0",
+    "@solana/web3.js": "^1.50.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.3",

--- a/explorer/src/providers/transactions/raw.tsx
+++ b/explorer/src/providers/transactions/raw.tsx
@@ -66,7 +66,12 @@ async function fetchRawTransaction(
 ) {
   let fetchStatus;
   try {
-    const response = await new Connection(url).getTransaction(signature);
+    const response = await new Connection(url).getTransaction(signature, {
+      maxSupportedTransactionVersion: process.env
+        .REACT_APP_MAX_SUPPORTED_TRANSACTION_VERSION
+        ? parseInt(process.env.REACT_APP_MAX_SUPPORTED_TRANSACTION_VERSION, 10)
+        : 0,
+    });
     fetchStatus = FetchStatus.Fetched;
 
     let data: Details = { raw: null };


### PR DESCRIPTION
Addresses #26391.