### PR TITLE
fix: (web3.js) clear the idle timer whenever the websocket closes

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -4577,6 +4577,10 @@ export class Connection {
   _wsOnClose(code: number) {
     this._rpcWebSocketConnected = false;
     this._rpcWebSocketGeneration++;
+    if (this._rpcWebSocketIdleTimeout) {
+      clearTimeout(this._rpcWebSocketIdleTimeout);
+      this._rpcWebSocketIdleTimeout = null;
+    }
     if (this._rpcWebSocketHeartbeat) {
       clearInterval(this._rpcWebSocketHeartbeat);
       this._rpcWebSocketHeartbeat = null;


### PR DESCRIPTION
#### Problem

If the websocket _closes_ while there's an active idle timer, the connection can enter a corrupt state as described in #26198.

#### Summary of Changes

* Clear the idle timer whenever the websocket connection drops.

Fixes #26665.