### PR TITLE
Removes `serialized_len_ptr` from `CallerAccount`.

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -7,7 +7,6 @@ struct CallerAccount<'a> {
     data: &'a mut [u8],
     vm_data_addr: u64,
     ref_to_len_in_vm: &'a mut u64,
-    serialized_len_ptr: &'a mut u64,
     executable: bool,
     rent_epoch: u64,
 }
@@ -156,7 +155,7 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
                 invoke_context.get_check_aligned(),
             )?;
 
-            let (data, vm_data_addr, ref_to_len_in_vm, serialized_len_ptr) = {
+            let (data, vm_data_addr, ref_to_len_in_vm) = {
                 // Double translate data out of RefCell
                 let data = *translate_type::<&[u8]>(
                     memory_mapping,
@@ -177,13 +176,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
                     8,
                 )? as *mut u64;
                 let ref_to_len_in_vm = unsafe { &mut *translated };
-                let ref_of_len_in_input_buffer =
-                    (data.as_ptr() as *const _ as u64).saturating_sub(8);
-                let serialized_len_ptr = translate_type_mut::<u64>(
-                    memory_mapping,
-                    ref_of_len_in_input_buffer,
-                    invoke_context.get_check_aligned(),
-                )?;
                 let vm_data_addr = data.as_ptr() as u64;
                 (
                     translate_slice_mut::<u8>(
@@ -195,7 +187,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
                     )?,
                     vm_data_addr,
                     ref_to_len_in_vm,
-                    serialized_len_ptr,
                 )
             };
 
@@ -206,7 +197,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedRust<'a, 'b> {
                 data,
                 vm_data_addr,
                 ref_to_len_in_vm,
-                serialized_len_ptr,
                 executable: account_info.executable,
                 rent_epoch: account_info.rent_epoch,
             })
@@ -504,14 +494,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
             )?;
             let ref_to_len_in_vm = unsafe { &mut *(addr as *mut u64) };
 
-            let ref_of_len_in_input_buffer =
-                (account_info.data_addr as *mut u8 as u64).saturating_sub(8);
-            let serialized_len_ptr = translate_type_mut::<u64>(
-                memory_mapping,
-                ref_of_len_in_input_buffer,
-                invoke_context.get_check_aligned(),
-            )?;
-
             Ok(CallerAccount {
                 lamports,
                 owner,
@@ -519,7 +501,6 @@ impl<'a, 'b> SyscallInvokeSigned<'a, 'b> for SyscallInvokeSignedC<'a, 'b> {
                 data,
                 vm_data_addr,
                 ref_to_len_in_vm,
-                serialized_len_ptr,
                 executable: account_info.executable,
                 rent_epoch: account_info.rent_epoch,
             })
@@ -908,7 +889,14 @@ fn call<'a, 'b: 'a>(
                     invoke_context.get_check_size(),
                 )?;
                 *caller_account.ref_to_len_in_vm = new_len as u64;
-                *caller_account.serialized_len_ptr = new_len as u64;
+                let serialized_len_ptr = translate_type_mut::<u64>(
+                    memory_mapping,
+                    caller_account
+                        .vm_data_addr
+                        .saturating_sub(std::mem::size_of::<u64>() as u64),
+                    invoke_context.get_check_aligned(),
+                )?;
+                *serialized_len_ptr = new_len as u64;
             }
             let to_slice = &mut caller_account.data;
             let from_slice = callee_account


### PR DESCRIPTION
#### Problem
`serialized_len_ptr` follows the same calculation in the C and the Rust version of CPI.

#### Summary of Changes
Merges the two identical calculations of `serialized_len_ptr` to one at the end of the CPI call.