### PR TITLE
Revert "cleanup feature: default units per instruction (#26684)"

### DIFF
--- a/core/src/transaction_priority_details.rs
+++ b/core/src/transaction_priority_details.rs
@@ -23,6 +23,7 @@ pub trait GetTransactionPriorityDetails {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 instructions,
+                true, // use default units per instruction
                 true, // don't reject txs that use set compute unit price ix
             )
             .ok()?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -108,8 +108,8 @@ use {
         epoch_schedule::EpochSchedule,
         feature,
         feature_set::{
-            self, add_set_compute_unit_price_ix, disable_fee_calculator,
-            enable_early_verification_of_account_modifications, FeatureSet,
+            self, add_set_compute_unit_price_ix, default_units_per_instruction,
+            disable_fee_calculator, enable_early_verification_of_account_modifications, FeatureSet,
         },
         fee::FeeStructure,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -4542,6 +4542,7 @@ impl Bank {
                             Measure::start("compute_budget_process_transaction_time");
                         let process_transaction_result = compute_budget.process_instructions(
                             tx.message().program_instructions_iter(),
+                            feature_set.is_active(&default_units_per_instruction::id()),
                             feature_set.is_active(&add_set_compute_unit_price_ix::id()),
                         );
                         compute_budget_process_transaction_time.stop();
@@ -4836,6 +4837,7 @@ impl Bank {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 message.program_instructions_iter(),
+                false,
                 support_set_compute_unit_price_ix,
             )
             .unwrap_or_default();


### PR DESCRIPTION
This reverts commit 39a34db52a4f545d1f6572e421e0dc43c4edc5ab.

#### Problem

mnb validators are failing with vote errors

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
