### PR TITLE
fix: match wallet + dapp ordering with ft metadata on Explorer

### DIFF
--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -195,14 +195,14 @@ export function AccountHeader({
     let token;
     let unverified = false;
 
-    if (tokenDetails) {
-      token = tokenDetails;
-    } else {
+    if (data?.nftData) {
       token = {
         logoURI: data?.nftData?.json?.image,
         name: data?.nftData?.json?.name,
       };
       unverified = true;
+    } else if (tokenDetails) {
+      token = tokenDetails;
     }
 
     return (


### PR DESCRIPTION
#### Problem

Since we take present legacy token-list data over metaplex metadata for ft metadata, legacy token-list tokens can't update their metadata by creating a metaplex metadata account

Wallets also take metadata in this order:

1. Metaplex metadata if exists
2. Otherwise legacy token-list

#### Summary of Changes

Make the explorer retrieve metadata the same way wallets do to allow updating metadata on legacy token-list tokens via creating a new metadata account.
