### PR TITLE
zk-token-sdk: implement Display for ciphertexts

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -15,7 +15,7 @@ use {
         signature::Signature,
         signer::{Signer, SignerError},
     },
-    std::convert::TryInto,
+    std::{convert::TryInto, fmt},
     zeroize::Zeroize,
 };
 
@@ -126,6 +126,12 @@ impl AeCiphertext {
             nonce: *nonce,
             ciphertext: *ciphertext,
         })
+    }
+}
+
+impl fmt::Display for AeCiphertext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", base64::encode(self.to_bytes()))
     }
 }
 

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -457,6 +457,12 @@ impl ElGamalCiphertext {
     }
 }
 
+impl fmt::Display for ElGamalCiphertext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", base64::encode(self.to_bytes()))
+    }
+}
+
 impl<'a, 'b> Add<&'b ElGamalCiphertext> for &'a ElGamalCiphertext {
     type Output = ElGamalCiphertext;
 


### PR DESCRIPTION
#### Summary of Changes
Implementing the `Display` trait for `AeCiphertext` and `ElGamalCiphertext` structs.
