### PR TITLE
fix(docs): separated the architecture sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -109,6 +109,10 @@ module.exports = {
               label: "Introduction",
               to: "introduction",
             },
+            {
+              label: "Architecture",
+              to: "cluster/overview",
+            },
           ],
         },
         {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,4 +1,42 @@
 module.exports = {
+  architectureSidebar: [
+    {
+      type: "doc",
+      label: "What is a Solana Cluster?",
+      id: "cluster/overview",
+    },
+    {
+      type: "category",
+      label: "Consensus",
+      collapsed: false,
+      items: [
+        "cluster/synchronization",
+        "cluster/leader-rotation",
+        "cluster/fork-generation",
+        "cluster/managing-forks",
+        "cluster/turbine-block-propagation",
+        "cluster/vote-signing",
+        "cluster/stake-delegation-and-rewards",
+      ],
+    },
+    {
+      type: "category",
+      label: "Validators",
+      collapsed: false,
+      items: [
+        {
+          type:"doc",
+          label:"Overview",
+          id:"validator/anatomy",
+        },
+        "validator/tpu",
+        "validator/tvu",
+        "validator/blockstore",
+        "validator/gossip",
+        "validator/runtime",
+      ],
+    },
+  ],
   docs: {
     About: ["introduction", "terminology", "history"],
     Wallets: [
@@ -99,34 +137,6 @@ module.exports = {
       "cluster/rpc-endpoints",
       "cluster/bench-tps",
       "cluster/performance-metrics",
-    ],
-    Architecture: [
-      {
-        type: "category",
-        label: "Cluster",
-        items: [
-          "cluster/overview",
-          "cluster/synchronization",
-          "cluster/leader-rotation",
-          "cluster/fork-generation",
-          "cluster/managing-forks",
-          "cluster/turbine-block-propagation",
-          "cluster/vote-signing",
-          "cluster/stake-delegation-and-rewards",
-        ],
-      },
-      {
-        type: "category",
-        label: "Validator",
-        items: [
-          "validator/anatomy",
-          "validator/tpu",
-          "validator/tvu",
-          "validator/blockstore",
-          "validator/gossip",
-          "validator/runtime",
-        ],
-      },
     ],
     Economics: [
       "economics_overview",


### PR DESCRIPTION
#### Problem
The Solana docs "architecture" sidebar restructure for #26699 

#### Summary of Changes
- segmented the "architecture" section sidebar from the global sidebar
- added a footer link to the "architecture" root page

Screenshot of the new "architecture" section sidebar:

<a href="url"><img src="https://user-images.githubusercontent.com/75431177/180665659-f2a8f63e-73fd-4791-b85a-0813db56a2f7.png" align="left" width="300" /></a>