### PR TITLE
fix(docs): separated the cli sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -109,6 +109,10 @@ module.exports = {
               label: "Introduction",
               to: "introduction",
             },
+            {
+              label: "Command Line",
+              to: "cli",
+            },
           ],
         },
         {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,4 +1,16 @@
 module.exports = {
+  cliSidebar: [
+    "cli",
+    "cli/install-solana-cli-tools",
+    "cli/conventions",
+    "cli/choose-a-cluster",
+    "cli/transfer-tokens",
+    "cli/delegate-stake",
+    "cli/deploy-a-program",
+    "offline-signing",
+    "offline-signing/durable-nonce",
+    "cli/usage",
+  ],
   docs: {
     About: ["introduction", "terminology", "history"],
     Wallets: [
@@ -23,18 +35,6 @@ module.exports = {
       "wallet-guide/support",
     ],
     Staking: ["staking", "staking/stake-accounts"],
-    "Command Line": [
-      "cli",
-      "cli/install-solana-cli-tools",
-      "cli/conventions",
-      "cli/choose-a-cluster",
-      "cli/transfer-tokens",
-      "cli/delegate-stake",
-      "cli/deploy-a-program",
-      "offline-signing",
-      "offline-signing/durable-nonce",
-      "cli/usage",
-    ],
     Developing: [
       {
         type: "category",


### PR DESCRIPTION
#### Problem
The Solana docs "cli" sidebar restructure for #26699 

#### Summary of Changes
- segmented the "cli" section sidebar from the global sidebar
- added a footer link to the "command line" root page

Screenshot of the new "cli" section

<a href="url"><img src="https://user-images.githubusercontent.com/75431177/180678836-2e39ad2f-df8c-4e66-bdef-b62a9a557fee.png" align="left" width="300" /></a>