### PR TITLE
fix(docs): separated the validators sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -109,6 +109,10 @@ module.exports = {
               label: "Introduction",
               to: "introduction",
             },
+            {
+              label: "Validators",
+              to: "running-validator",
+            },
           ],
         },
         {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,4 +1,37 @@
 module.exports = {
+  validatorsSidebar: [
+    "running-validator",
+    {
+      type: "category",
+      label: "Getting Started",
+      collapsed: false,
+      items: [
+        "running-validator/validator-reqs",
+      ],
+    },
+    {
+      type: "category",
+      label: "Voting Setup",
+      collapsed: false,
+      items: [
+        "running-validator/validator-start",
+        "running-validator/vote-accounts",
+        "running-validator/validator-stake",
+        "running-validator/validator-monitor",
+        "running-validator/validator-info",
+        "running-validator/validator-failover",
+        "running-validator/validator-troubleshoot",
+      ],
+    },
+    {
+      type: "category",
+      label: "Geyser",
+      collapsed: false,
+      items: [
+        "developing/plugins/geyser-plugins"
+      ]
+    },
+  ],
   docs: {
     About: ["introduction", "terminology", "history"],
     Wallets: [
@@ -80,20 +113,8 @@ module.exports = {
       },
       "developing/test-validator",
       "developing/backwards-compatibility",
-      "developing/plugins/geyser-plugins"
     ],
     Integrating: ["integrations/exchange"],
-    Validating: [
-      "running-validator",
-      "running-validator/validator-reqs",
-      "running-validator/validator-start",
-      "running-validator/vote-accounts",
-      "running-validator/validator-stake",
-      "running-validator/validator-monitor",
-      "running-validator/validator-info",
-      "running-validator/validator-failover",
-      "running-validator/validator-troubleshoot",
-    ],
     Clusters: [
       "clusters",
       "cluster/rpc-endpoints",


### PR DESCRIPTION
#### Problem
The Solana docs "validators" sidebar restructure for #26699 

#### Summary of Changes
- segmented the "validators" section sidebar from the global sidebar
- added a footer link to the "validators" root page
- relocated the "geyser" page under the validator sidebar

Screenshot of the new "validators" section sidebar:

<a href="url"><img src="https://user-images.githubusercontent.com/75431177/180680443-f4cb8ce0-d131-4c63-92ff-b5b3b7de320e.png" align="left" width="300" /></a>