### PR TITLE
Add Bank::update_accounts_data_size_delta_off_chain_for_tests()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4795,6 +4795,12 @@ impl Bank {
         self.accounts_data_size_initial = amount;
     }
 
+    /// Update the accounts data size off-chain delta
+    /// NOTE: This fn is *ONLY FOR TESTS*
+    pub fn update_accounts_data_size_delta_off_chain_for_tests(&self, amount: i64) {
+        self.update_accounts_data_size_delta_off_chain(amount)
+    }
+
     fn get_num_signatures_in_message(message: &SanitizedMessage) -> u64 {
         let mut num_signatures = u64::from(message.header().num_required_signatures);
         // This next part is really calculating the number of pre-processor


### PR DESCRIPTION
#### Problem

ReplayStage tests need to set the bank's accounts data size(s) but cannot.

See https://github.com/solana-labs/solana/pull/26744 for usage.

#### Summary of Changes

Add Bank::update_accounts_data_size_delta_off_chain_for_tests()