### PR TITLE
Remove bank test_max_accounts_data_size_exceeded()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -17954,62 +17954,6 @@ pub(crate) mod tests {
         );
     }
 
-    /// Test exceeding the max accounts data size by creating accounts in a loop
-    #[test]
-    fn test_max_accounts_data_size_exceeded() {
-        const NUM_ACCOUNTS: u64 = 20;
-        const ACCOUNT_SIZE: u64 = MAX_PERMITTED_DATA_LENGTH / (NUM_ACCOUNTS + 1);
-        const REMAINING_ACCOUNTS_DATA_SIZE: u64 = NUM_ACCOUNTS * ACCOUNT_SIZE;
-
-        let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000_000);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        bank.activate_feature(&feature_set::cap_accounts_data_len::id());
-        bank.accounts_data_size_initial = bank.accounts_data_size_limit()
-            - REMAINING_ACCOUNTS_DATA_SIZE
-            - bank.load_accounts_data_size_delta() as u64;
-
-        let mut i = 0;
-        let result = loop {
-            let txn = system_transaction::create_account(
-                &mint_keypair,
-                &Keypair::new(),
-                bank.last_blockhash(),
-                genesis_config
-                    .rent
-                    .minimum_balance(ACCOUNT_SIZE.try_into().unwrap()),
-                ACCOUNT_SIZE,
-                &solana_sdk::system_program::id(),
-            );
-
-            let accounts_data_size_before = bank.load_accounts_data_size();
-            let result = bank.process_transaction(&txn);
-            let accounts_data_size_after = bank.load_accounts_data_size();
-            assert!(accounts_data_size_after <= bank.accounts_data_size_limit());
-            if result.is_err() {
-                assert_eq!(i, NUM_ACCOUNTS);
-                break result;
-            }
-
-            assert_eq!(
-                accounts_data_size_after - accounts_data_size_before,
-                ACCOUNT_SIZE,
-            );
-            assert!(
-                i <= NUM_ACCOUNTS,
-                "test must complete within bounded limits"
-            );
-            i += 1;
-        };
-
-        assert!(matches!(
-            result,
-            Err(TransactionError::InstructionError(
-                _,
-                solana_sdk::instruction::InstructionError::MaxAccountsDataSizeExceeded,
-            ))
-        ));
-    }
-
     /// Test processing a good transaction correctly modifies the accounts data size
     #[test]
     fn test_accounts_data_size_with_good_transaction() {


### PR DESCRIPTION
#### Problem

The accounts data size total limit will not be checked per instruction, so no instruction error will be thrown. When that change occurs, this test will no longer be useful/needed. Tests to the check the total accounts data size will be moved to ReplayStage.

See https://github.com/solana-labs/solana/pull/26744 for full set of changes.

Part of https://github.com/solana-labs/solana/issues/26439.

#### Summary of Changes

Remove test_max_accounts_data_size_exceeded()