### PR TITLE
Do not check accounts data size in InvokeContext

### DIFF
--- a/program-runtime/src/accounts_data_meter.rs
+++ b/program-runtime/src/accounts_data_meter.rs
@@ -1,7 +1,6 @@
 //! The accounts data space has a maximum size it is permitted to grow to.  This module contains
 //! the constants and types for tracking and metering the accounts data space during program
 //! runtime.
-use solana_sdk::instruction::InstructionError;
 
 /// The maximum allowed size, in bytes, of the accounts data
 /// 128 GB was chosen because it is the RAM amount listed under Hardware Recommendations on
@@ -12,9 +11,6 @@ pub const MAX_ACCOUNTS_DATA_LEN: u64 = 128_000_000_000;
 /// Meter and track the amount of available accounts data space
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct AccountsDataMeter {
-    /// The maximum amount of accounts data space that can be used (in bytes)
-    maximum: u64,
-
     /// The initial amount of accounts data space used (in bytes)
     initial: u64,
 
@@ -27,15 +23,9 @@ impl AccountsDataMeter {
     #[must_use]
     pub fn new(initial_accounts_data_len: u64) -> Self {
         Self {
-            maximum: MAX_ACCOUNTS_DATA_LEN,
             initial: initial_accounts_data_len,
             delta: 0,
         }
-    }
-
-    /// Return the maximum amount of accounts data space that can be used (in bytes)
-    pub fn maximum(&self) -> u64 {
-        self.maximum
     }
 
     /// Return the initial amount of accounts data space used (in bytes)
@@ -66,38 +56,9 @@ impl AccountsDataMeter {
         saturating_add_signed(self.initial, self.delta)
     }
 
-    /// Get the remaining amount of accounts data space (in bytes)
-    pub fn remaining(&self) -> u64 {
-        self.maximum.saturating_sub(self.current())
-    }
-
     /// Adjust the space used by accounts data by `amount` (in bytes).
-    ///
-    /// If `amount` is *positive*, we *increase* the space used by accounts data.  If `amount` is
-    /// *negative*, we *decrease* the space used by accounts data.  If `amount` is greater than
-    /// the remaining space, return an error and *do not* adjust accounts data space.
-    pub fn adjust_delta(&mut self, amount: i64) -> Result<(), InstructionError> {
-        if amount > self.remaining() as i64 {
-            return Err(InstructionError::MaxAccountsDataSizeExceeded);
-        }
-        self.adjust_delta_unchecked(amount);
-        Ok(())
-    }
-
-    /// Unconditionally adjust accounts data space.  Refer to `adjust_delta()` for more
-    /// documentation.
     pub fn adjust_delta_unchecked(&mut self, amount: i64) {
         self.delta = self.delta.saturating_add(amount);
-    }
-}
-
-#[cfg(test)]
-impl AccountsDataMeter {
-    pub fn set_maximum(&mut self, maximum: u64) {
-        self.maximum = maximum;
-    }
-    pub fn set_initial(&mut self, initial: u64) {
-        self.initial = initial;
     }
 }
 
@@ -109,91 +70,11 @@ mod tests {
     fn test_new() {
         let initial = 1234;
         let accounts_data_meter = AccountsDataMeter::new(initial);
-        assert_eq!(accounts_data_meter.maximum, MAX_ACCOUNTS_DATA_LEN);
         assert_eq!(accounts_data_meter.initial, initial);
     }
 
     #[test]
     fn test_new_can_use_max_len() {
         let _ = AccountsDataMeter::new(MAX_ACCOUNTS_DATA_LEN);
-    }
-
-    #[test]
-    fn test_remaining() {
-        let initial_accounts_data_len = 0;
-        let accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-        assert_eq!(accounts_data_meter.remaining(), MAX_ACCOUNTS_DATA_LEN);
-    }
-
-    #[test]
-    fn test_remaining_saturates() {
-        let initial_accounts_data_len = 0;
-        let mut accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-        // To test that remaining() saturates, need to break the invariant that initial <= maximum
-        accounts_data_meter.initial = MAX_ACCOUNTS_DATA_LEN + 1;
-        assert_eq!(accounts_data_meter.remaining(), 0);
-    }
-
-    #[test]
-    fn test_adjust_delta() {
-        let initial_accounts_data_len = 0;
-        let mut accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-
-        // Test: simple, positive numbers
-        let result = accounts_data_meter.adjust_delta(0);
-        assert!(result.is_ok());
-        let result = accounts_data_meter.adjust_delta(1);
-        assert!(result.is_ok());
-        let result = accounts_data_meter.adjust_delta(4);
-        assert!(result.is_ok());
-        let result = accounts_data_meter.adjust_delta(9);
-        assert!(result.is_ok());
-
-        // Test: adjust_delta can use up the remaining amount
-        let remaining = accounts_data_meter.remaining() as i64;
-        let result = accounts_data_meter.adjust_delta(remaining);
-        assert!(result.is_ok());
-        assert_eq!(accounts_data_meter.remaining(), 0);
-    }
-
-    #[test]
-    fn test_adjust_delta_deallocate() {
-        let initial_accounts_data_len = 10_000;
-        let mut accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-        let remaining_before = accounts_data_meter.remaining();
-
-        let amount = (initial_accounts_data_len / 2) as i64;
-        let amount = -amount;
-        let result = accounts_data_meter.adjust_delta(amount);
-        assert!(result.is_ok());
-        let remaining_after = accounts_data_meter.remaining();
-        assert_eq!(remaining_after, remaining_before + amount.unsigned_abs());
-    }
-
-    #[test]
-    fn test_adjust_delta_exceeding() {
-        let initial_accounts_data_len = 0;
-        let mut accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-
-        // Test: adjusting delta by more than what's available
-        // (1) returns an error,
-        // (2) does not adjust delta
-        let remaining = accounts_data_meter.remaining();
-        let result = accounts_data_meter.adjust_delta(remaining as i64 + 1);
-        assert!(result.is_err());
-        assert_eq!(accounts_data_meter.remaining(), remaining);
-    }
-
-    #[test]
-    fn test_adjust_delta_zero() {
-        // Pre-condition: set up the accounts data meter such that there is no remaining space
-        let initial_accounts_data_len = 1234;
-        let mut accounts_data_meter = AccountsDataMeter::new(initial_accounts_data_len);
-        accounts_data_meter.maximum = initial_accounts_data_len;
-        assert_eq!(accounts_data_meter.remaining(), 0);
-
-        // Test: can always adjust delta by zero, even if there is no remaining space
-        let result = accounts_data_meter.adjust_delta(0);
-        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
#### Problem

To fix https://github.com/solana-labs/solana/issues/26439, checking the total accounts data size is moving to ReplayStage. Checking if instructions exceed the accounts data size limit is no longer needed.

See https://github.com/solana-labs/solana/pull/26744 for full code.

#### Summary of Changes

- Remove checking if instructions exceed the accounts data size limit.
- Remove `maximum` from `AccountsDataMeter`
    - this also removes `remaining()`, `adjust_delta()`, and `maximum()`, plus their uses

Feature Gate Issue: modifies https://github.com/solana-labs/solana/issues/24135