### PR TITLE
Add streaming_unpack_snapshot to send entry files during unpack

### DIFF
--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -300,6 +300,7 @@ impl ParallelSelector {
     }
 }
 
+/// Unpacks snapshot and collects AppendVec file names & paths
 pub fn unpack_snapshot<A: Read>(
     archive: &mut Archive<A>,
     ledger_dir: &Path,
@@ -319,6 +320,28 @@ pub fn unpack_snapshot<A: Read>(
         |_| {},
     )
     .map(|_| unpacked_append_vec_map)
+}
+
+/// Unpacks snapshots and sends entry file paths through the `sender` channel
+pub fn streaming_unpack_snapshot<A: Read>(
+    archive: &mut Archive<A>,
+    ledger_dir: &Path,
+    account_paths: &[PathBuf],
+    parallel_selector: Option<ParallelSelector>,
+    sender: &crossbeam_channel::Sender<PathBuf>,
+) -> Result<()> {
+    unpack_snapshot_with_processors(
+        archive,
+        ledger_dir,
+        account_paths,
+        parallel_selector,
+        |_, _| {},
+        |entry_path_buf| {
+            if entry_path_buf.is_file() {
+                sender.send(entry_path_buf).unwrap();
+            }
+        },
+    )
 }
 
 fn unpack_snapshot_with_processors<A, F, G>(

--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -783,7 +783,7 @@ mod tests {
 
     fn finalize_and_unpack_snapshot(archive: tar::Builder<Vec<u8>>) -> Result<()> {
         with_finalize_and_unpack(archive, |a, b| {
-            unpack_snapshot(a, b, &[PathBuf::new()], None).map(|_| ())
+            unpack_snapshot_with_processors(a, b, &[PathBuf::new()], None, |_, _| {}, |_| {})
         })
     }
 


### PR DESCRIPTION
#### Problem
Used in #26590 - separate enough functionality moving to a new PR.

#### Summary of Changes
Adds a new `streaming_unpack_snapshot`, which sends all unpacked entries over a crossbeam channel. Instead of `unpack_snapshot` which collects all accounts files in a hashmap.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
