### PR TITLE
Add Display implementations for various ConfidentialTransfer pod structs

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/pod.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod.rs
@@ -43,6 +43,12 @@ impl fmt::Debug for ElGamalCiphertext {
     }
 }
 
+impl fmt::Display for ElGamalCiphertext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", base64::encode(self.0))
+    }
+}
+
 impl Default for ElGamalCiphertext {
     fn default() -> Self {
         Self::zeroed()
@@ -56,6 +62,12 @@ pub struct ElGamalPubkey(pub [u8; 32]);
 impl fmt::Debug for ElGamalPubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+impl fmt::Display for ElGamalPubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", base64::encode(self.0))
     }
 }
 
@@ -177,6 +189,12 @@ unsafe impl Pod for AeCiphertext {}
 impl fmt::Debug for AeCiphertext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+impl fmt::Display for AeCiphertext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", base64::encode(self.0))
     }
 }
 


### PR DESCRIPTION
#### Problem
We want to be able to parse ConfidentialTransfer extensions and instructions, but it's not straightforward to print the various fields.

#### Summary of Changes
Implement Display for structs used in extension states and instructions
