### PR TITLE
Add feature gate to use default units per instruction for fee calculation

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -3779,6 +3779,7 @@ fn test_program_fees() {
         congestion_multiplier,
         &fee_structure,
         true,
+        true,
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3799,6 +3800,7 @@ fn test_program_fees() {
         &sanitized_message,
         congestion_multiplier,
         &fee_structure,
+        true,
         true,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -34,7 +34,9 @@ use {
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{BankId, Slot, INITIAL_RENT_EPOCH},
-        feature_set::{self, add_set_compute_unit_price_ix, FeatureSet},
+        feature_set::{
+            self, add_set_compute_unit_price_ix, use_default_units_in_fee_calculation, FeatureSet,
+        },
         fee::FeeStructure,
         genesis_config::ClusterType,
         hash::Hash,
@@ -553,6 +555,7 @@ impl Accounts {
                             lamports_per_signature,
                             fee_structure,
                             feature_set.is_active(&add_set_compute_unit_price_ix::id()),
+                            feature_set.is_active(&use_default_units_in_fee_calculation::id()),
                         )
                     } else {
                         return (Err(TransactionError::BlockhashNotFound), None);
@@ -1662,6 +1665,7 @@ mod tests {
             &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
             lamports_per_signature,
             &FeeStructure::default(),
+            true,
             true,
         );
         assert_eq!(fee, lamports_per_signature);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -109,7 +109,8 @@ use {
         feature,
         feature_set::{
             self, add_set_compute_unit_price_ix, default_units_per_instruction,
-            disable_fee_calculator, enable_early_verification_of_account_modifications, FeatureSet,
+            disable_fee_calculator, enable_early_verification_of_account_modifications,
+            use_default_units_in_fee_calculation, FeatureSet,
         },
         fee::FeeStructure,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -3708,6 +3709,8 @@ impl Bank {
             &self.fee_structure,
             self.feature_set
                 .is_active(&add_set_compute_unit_price_ix::id()),
+            self.feature_set
+                .is_active(&use_default_units_in_fee_calculation::id()),
         ))
     }
 
@@ -3749,6 +3752,8 @@ impl Bank {
             &self.fee_structure,
             self.feature_set
                 .is_active(&add_set_compute_unit_price_ix::id()),
+            self.feature_set
+                .is_active(&use_default_units_in_fee_calculation::id()),
         )
     }
 
@@ -4829,6 +4834,7 @@ impl Bank {
         lamports_per_signature: u64,
         fee_structure: &FeeStructure,
         support_set_compute_unit_price_ix: bool,
+        use_default_units_per_instruction: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
         const BASE_CONGESTION: f64 = 5_000.0;
@@ -4843,7 +4849,7 @@ impl Bank {
         let prioritization_fee_details = compute_budget
             .process_instructions(
                 message.program_instructions_iter(),
-                false,
+                use_default_units_per_instruction,
                 support_set_compute_unit_price_ix,
             )
             .unwrap_or_default();
@@ -4910,6 +4916,8 @@ impl Bank {
                     &self.fee_structure,
                     self.feature_set
                         .is_active(&add_set_compute_unit_price_ix::id()),
+                    self.feature_set
+                        .is_active(&use_default_units_in_fee_calculation::id()),
                 );
 
                 // In case of instruction error, even though no accounts
@@ -10872,6 +10880,7 @@ pub(crate) mod tests {
                 .lamports_per_signature,
             &FeeStructure::default(),
             true,
+            true,
         );
 
         let (expected_fee_collected, expected_fee_burned) =
@@ -11053,6 +11062,7 @@ pub(crate) mod tests {
             cheap_lamports_per_signature,
             &FeeStructure::default(),
             true,
+            true,
         );
         assert_eq!(
             bank.get_balance(&mint_keypair.pubkey()),
@@ -11069,6 +11079,7 @@ pub(crate) mod tests {
             &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
             expensive_lamports_per_signature,
             &FeeStructure::default(),
+            true,
             true,
         );
         assert_eq!(
@@ -11184,6 +11195,7 @@ pub(crate) mod tests {
                                 .create_fee_calculator()
                                 .lamports_per_signature,
                             &FeeStructure::default(),
+                            true,
                             true,
                         ) * 2
                     )
@@ -17783,7 +17795,8 @@ pub(crate) mod tests {
                     lamports_per_signature: 0,
                     ..FeeStructure::default()
                 },
-                true
+                true,
+                true,
             ),
             0
         );
@@ -17797,7 +17810,8 @@ pub(crate) mod tests {
                     lamports_per_signature: 1,
                     ..FeeStructure::default()
                 },
-                true
+                true,
+                true,
             ),
             1
         );
@@ -17816,7 +17830,8 @@ pub(crate) mod tests {
                     lamports_per_signature: 2,
                     ..FeeStructure::default()
                 },
-                true
+                true,
+                true,
             ),
             4
         );
@@ -17836,7 +17851,7 @@ pub(crate) mod tests {
         let message =
             SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, true,),
             max_fee + lamports_per_signature
         );
 
@@ -17848,7 +17863,7 @@ pub(crate) mod tests {
             SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique())))
                 .unwrap();
         assert_eq!(
-            Bank::calculate_fee(&message, 1, &fee_structure, true),
+            Bank::calculate_fee(&message, 1, &fee_structure, true, true,),
             max_fee + 3 * lamports_per_signature
         );
 
@@ -17881,7 +17896,7 @@ pub(crate) mod tests {
                 Some(&Pubkey::new_unique()),
             ))
             .unwrap();
-            let fee = Bank::calculate_fee(&message, 1, &fee_structure, true);
+            let fee = Bank::calculate_fee(&message, 1, &fee_structure, true, true);
             assert_eq!(
                 fee,
                 lamports_per_signature + prioritization_fee_details.get_fee()
@@ -17919,7 +17934,10 @@ pub(crate) mod tests {
             Some(&key0),
         ))
         .unwrap();
-        assert_eq!(Bank::calculate_fee(&message, 1, &fee_structure, true), 2);
+        assert_eq!(
+            Bank::calculate_fee(&message, 1, &fee_structure, true, true,),
+            2
+        );
 
         secp_instruction1.data = vec![0];
         secp_instruction2.data = vec![10];
@@ -17928,7 +17946,10 @@ pub(crate) mod tests {
             Some(&key0),
         ))
         .unwrap();
-        assert_eq!(Bank::calculate_fee(&message, 1, &fee_structure, true), 11);
+        assert_eq!(
+            Bank::calculate_fee(&message, 1, &fee_structure, true, true,),
+            11
+        );
     }
 
     #[test]

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -472,6 +472,10 @@ pub mod loosen_cpi_size_restriction {
     solana_sdk::declare_id!("GDH5TVdbTPUpRnXaRyQqiKUa7uZAbZ28Q2N9bhbKoMLm");
 }
 
+pub mod use_default_units_in_fee_calculation {
+    solana_sdk::declare_id!("8sKQrMQoUHtQSUP83SPG4ta2JDjSAiWs7t5aJ9uEd6To");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -584,6 +588,7 @@ lazy_static! {
         (prevent_crediting_accounts_that_end_rent_paying::id(), "prevent crediting rent paying accounts #26606"),
         (cap_bpf_program_instruction_accounts::id(), "enforce max number of accounts per bpf program instruction #26628"),
         (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),
+        (use_default_units_in_fee_calculation::id(), "use default units per instruction in fee calculation #26785"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
When bank calculates transaction fee, it's hardcoded to not to use default units per instruction, which is a feature already enabled in mainnet-beta. It should use default units. 

#### Summary of Changes
Add feature to pass `false` (current behavior) when feature is not enabled, and `true` (desired behavior) when feature is enabled.

Fixes #26785 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
