### PR TITLE
store-tool use accounts_iter

### DIFF
--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         store.capacity(),
         num_accounts,
     );
-    for account in store.accounts(0) {
+    for account in store.account_iter() {
         info!(
             "  account: {:?} version: {} data: {} hash: {:?}",
             account.meta.pubkey, account.meta.write_version, account.meta.data_len, account.hash


### PR DESCRIPTION
#### Problem
accounts(0) will allocate memory for all the accounts, we really just want to iterate through them and print

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
