### PR TITLE
log when shrink still contains extra stores

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3294,9 +3294,16 @@ impl AccountsDb {
 
             // Purge old, overwritten storage entries
             let mut start = Measure::start("write_storage_elapsed");
-            self.mark_dirty_dead_stores(slot, &mut dead_storages, |store| {
+            let remaining_stores = self.mark_dirty_dead_stores(slot, &mut dead_storages, |store| {
                 !store_ids.contains(&store.append_vec_id())
             });
+            if remaining_stores > 1 {
+                inc_new_counter_info!("accounts_db_shrink_extra_stores", 1);
+                info!(
+                    "after shrink, slot has extra stores: {}, {}",
+                    slot, remaining_stores
+                );
+            }
             start.stop();
             write_storage_elapsed = start.as_us();
         }
@@ -3354,14 +3361,16 @@ impl AccountsDb {
     /// get stores for 'slot'
     /// retain only the stores where 'should_retain(store)' == true
     /// for stores not retained, insert in 'dirty_stores' and 'dead_storages'
+    /// returns # of remaining stores for this slot
     pub(crate) fn mark_dirty_dead_stores(
         &self,
         slot: Slot,
         dead_storages: &mut Vec<Arc<AccountStorageEntry>>,
         should_retain: impl Fn(&AccountStorageEntry) -> bool,
-    ) {
+    ) -> usize {
         if let Some(slot_stores) = self.storage.get_slot_stores(slot) {
-            slot_stores.write().unwrap().retain(|_key, store| {
+            let mut list = slot_stores.write().unwrap();
+            list.retain(|_key, store| {
                 if !should_retain(store) {
                     self.dirty_stores
                         .insert((slot, store.append_vec_id()), store.clone());
@@ -3371,6 +3380,9 @@ impl AccountsDb {
                     true
                 }
             });
+            list.len()
+        } else {
+            0
         }
     }
 


### PR DESCRIPTION
#### Problem

Under expected situations, we should end up with 1 append vec (the newly shurnk one) after shrinking a slot. In the wild, we are seeing snapshots that contains multiple append vecs (the post-shrunk and pre-shrunk append vecs) included in a snapshot. This is not correct.

#### Summary of Changes

inc a counter and log when shrink leaves behind 2 append vecs

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
