### PR TITLE
A more convenient store-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,6 +6289,7 @@ dependencies = [
  "log",
  "solana-logger 1.12.0",
  "solana-runtime",
+ "solana-sdk 1.12.0",
  "solana-version",
 ]
 

--- a/runtime/store-tool/Cargo.toml
+++ b/runtime/store-tool/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33.1"
 log = { version = "0.4.17" }
 solana-logger = { path = "../../logger", version = "=1.12.0" }
 solana-runtime = { path = "..", version = "=1.12.0" }
+solana-sdk = { path = "../../sdk", version = "=1.12.0" }
 solana-version = { path = "../../version", version = "=1.12.0" }
 
 [package.metadata.docs.rs]

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -1,7 +1,8 @@
 use {
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},
     log::*,
-    solana_runtime::append_vec::AppendVec,
+    solana_runtime::append_vec::{AppendVec, StoredAccountMeta},
+    solana_sdk::{account::AccountSharedData, hash::Hash, pubkey::Pubkey},
 };
 
 fn main() {
@@ -32,8 +33,8 @@ fn main() {
     let mut store = AppendVec::new_from_file_unchecked(file, len).expect("should succeed");
     store.set_no_remove_on_drop();
     info!("store: len: {} capacity: {}", store.len(), store.capacity());
-    let mut num_accounts = 0;
-    let mut stored_accounts_len = 0;
+    let mut num_accounts: usize = 0;
+    let mut stored_accounts_len: usize = 0;
     for account in store.account_iter() {
         if is_account_zeroed(&account) {
             break;
@@ -42,7 +43,21 @@ fn main() {
             "  account: {:?} version: {} data: {} hash: {:?}",
             account.meta.pubkey, account.meta.write_version, account.meta.data_len, account.hash
         );
+        num_accounts = num_accounts.saturating_add(1);
+        stored_accounts_len = stored_accounts_len.saturating_add(account.stored_size);
     }
+    info!(
+        "num_accounts: {} stored_accounts_len: {}",
+        num_accounts, stored_accounts_len
+    );
+}
+
+fn is_account_zeroed(account: &StoredAccountMeta) -> bool {
+    account.hash == &Hash::default()
+        && account.meta.data_len == 0
+        && account.meta.write_version == 0
+        && account.meta.pubkey == Pubkey::default()
+        && account.clone_account() == AccountSharedData::default()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
store-tool is inconvenient since we may not know the current_len of arbitrary appendvec files we want to inspect. 

#### Summary of Changes
With the change from #26795, we can skip sanitization checks and still print the contents of an appendvec file.

We can stop the loop when we hit a default account since that *should* indicate we've past the point of written data, this is guaranteed on POSIX systems (https://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html) since our initial seek when creating the appendvec files should fill the gaps with zeros.
On windows, this probably won't work though, but we can still provide the length as previously.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
