### PR TITLE
explorer falls back to token list when uri is blank and tokenDetails exists

### DIFF
--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -195,10 +195,13 @@ export function AccountHeader({
     let token;
     let unverified = false;
 
-    if (data?.nftData) {
+    // Fall back to legacy token list when there is stub metadata (blank uri), updatable by default by the mint authority
+    if (!data?.nftData?.metadata.data.uri && tokenDetails) {
+      token = tokenDetails;
+    } else if (data?.nftData) {
       token = {
         logoURI: data?.nftData?.json?.image,
-        name: data?.nftData?.json?.name,
+        name: data?.nftData?.json?.name ?? data?.nftData.metadata.data.name,
       };
       unverified = true;
     } else if (tokenDetails) {


### PR DESCRIPTION
#### Problem
Most tokens broken on the explorer

Circle cannot update the metadata because the update authority is a token Multisig account
https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v

Same for USDT...

Example of token without an update authority but no uri set so looks broken: https://explorer.solana.com/address/SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt/metadata

#### Summary of Changes
Fall back to tokenDetails if uri is missing and tokenDetails exist

Fixes #
