### PR TITLE
Compute maximum parallel QUIC streams using client stake

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -293,7 +293,7 @@ impl ConnectionCache {
         client_pubkey: &Pubkey,
     ) {
         self.maybe_staked_nodes = Some(staked_nodes.clone());
-        self.maybe_client_pubkey = Some(client_pubkey.clone());
+        self.maybe_client_pubkey = Some(*client_pubkey);
     }
 
     pub fn with_udp(connection_pool_size: usize) -> Self {

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -97,6 +97,7 @@ impl Tpu {
         keypair: &Keypair,
         log_messages_bytes_limit: Option<usize>,
         enable_quic_servers: bool,
+        staked_nodes: &Arc<RwLock<StakedNodes>>,
     ) -> Self {
         let TpuSockets {
             transactions: transactions_sockets,
@@ -124,7 +125,6 @@ impl Tpu {
             Some(bank_forks.read().unwrap().get_vote_only_mode_signal()),
         );
 
-        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let staked_nodes_updater_service = StakedNodesUpdaterService::new(
             exit.clone(),
             cluster_info.clone(),
@@ -178,7 +178,7 @@ impl Tpu {
                 forwarded_packet_sender,
                 exit.clone(),
                 MAX_QUIC_CONNECTIONS_PER_PEER,
-                staked_nodes,
+                staked_nodes.clone(),
                 MAX_STAKED_CONNECTIONS.saturating_add(MAX_UNSTAKED_CONNECTIONS),
                 0, // Prevent unstaked nodes from forwarding transactions
                 stats,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -98,7 +98,7 @@ use {
         timing::timestamp,
     },
     solana_send_transaction_service::send_transaction_service,
-    solana_streamer::socket::SocketAddrSpace,
+    solana_streamer::{socket::SocketAddrSpace, streamer::StakedNodes},
     solana_vote_program::vote_state::VoteState,
     std::{
         collections::{HashMap, HashSet},
@@ -757,12 +757,15 @@ impl Validator {
         };
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
+
         let connection_cache = match use_quic {
             true => {
                 let mut connection_cache = ConnectionCache::new(tpu_connection_pool_size);
                 connection_cache
                     .update_client_certificate(&identity_keypair, node.info.gossip.ip())
                     .expect("Failed to update QUIC client certificates");
+                connection_cache.set_staked_nodes(&staked_nodes, &identity_keypair.pubkey());
                 Arc::new(connection_cache)
             }
             false => Arc::new(ConnectionCache::with_udp(tpu_connection_pool_size)),
@@ -1025,6 +1028,7 @@ impl Validator {
             &identity_keypair,
             config.runtime_config.log_messages_bytes_limit,
             config.enable_quic_servers,
+            &staked_nodes,
         );
 
         datapoint_info!(


### PR DESCRIPTION
#### Problem
QUIC client is always chunking transactions with `QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS` as maximum number of chunks. This limits staked clients (e.g. nodes forwarding transactions) on how fast the transactions can be sent.

The following graph is from master branch.
<img width="1517" alt="image" src="https://user-images.githubusercontent.com/40076733/181141733-f5600771-8e30-45a2-849b-8bffebf99cf6.png">

#### Summary of Changes
This PR updates client to use the same logic as QUIC streamer to calculate how many transactions can be sent in parallel. The calculation uses client's stake and total stake across cluster. The information is already available on a full validator node. 

The following graph is with this PR
<img width="1517" alt="image" src="https://user-images.githubusercontent.com/40076733/181138564-bec9c73d-922b-46cb-b72e-6d0615bc1e4a.png">

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
