### PR TITLE
Add IO metrics

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -916,12 +916,6 @@ data" as &[u8];
     }
 
     #[test]
-    fn test_bw_temp() {
-        solana_logger::setup();
-        SystemMonitorService::report_io_stats();
-    }
-
-    #[test]
     fn test_calc_percent() {
         assert!(SystemMonitorService::calc_percent(99, 100) < 100.0);
         let one_tb_as_kb = (1u64 << 40) >> 10;

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -281,6 +281,7 @@ fn read_io_stats() -> Result<IoStats, String> {
         .arg("-x")
         .output()
         .map_err(|e| e.to_string())?;
+    warn!("stdout = {:?}", output.stdout);
     let mut reader_io = &output.stdout as &[u8];
     parse_io_stats(&mut reader_io)
 }
@@ -296,6 +297,7 @@ fn parse_io_stats(reader_io: &mut impl BufRead) -> Result<IoStats, String> {
         }
 
         let line = line.map_err(|e| e.to_string())?;
+        warn!("line {} = {:?}", line_number, line);
         let values: Vec<_> = line.split_ascii_whitespace().collect();
 
         if values.len() != 21 {
@@ -765,6 +767,8 @@ impl SystemMonitorService {
                     f64
                 ),
             )
+        } else {
+            warn!("read_io_stats returned err");
         }
     }
 
@@ -908,6 +912,12 @@ data" as &[u8];
         let mut mock_io = UNEXPECTED_DATA;
         let stats = parse_io_stats(&mut mock_io);
         assert!(stats.is_err());
+    }
+
+    #[test]
+    fn test_bw_temp() {
+        solana_logger::setup();
+        SystemMonitorService::report_io_stats();
     }
 
     #[test]

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "linux")]
-use std::{fs::File, io::BufReader, process::Command};
+use std::{fs::File, io::BufReader};
 use {
     solana_sdk::timing::AtomicInterval,
     std::{
@@ -676,122 +676,122 @@ impl SystemMonitorService {
                 new_stats
                     .reads_completed
                     .saturating_sub(old_stats.reads_completed),
-                u64
+                i64
             ),
             (
                 "reads_merged",
                 new_stats
                     .reads_merged
                     .saturating_sub(old_stats.reads_merged),
-                u64
+                i64
             ),
             (
                 "sectors_read",
                 new_stats
                     .sectors_read
                     .saturating_sub(old_stats.sectors_read),
-                u64
+                i64
             ),
             (
                 "time_reading_ms",
                 new_stats
                     .time_reading_ms
                     .saturating_sub(old_stats.time_reading_ms),
-                u64
+                i64
             ),
             (
                 "writes_completed",
                 new_stats
                     .writes_completed
                     .saturating_sub(old_stats.writes_completed),
-                u64
+                i64
             ),
             (
                 "writes_merged",
                 new_stats
                     .writes_merged
                     .saturating_sub(old_stats.writes_merged),
-                u64
+                i64
             ),
             (
                 "sectors_written",
                 new_stats
                     .sectors_written
                     .saturating_sub(old_stats.sectors_written),
-                u64
+                i64
             ),
             (
                 "time_writing_ms",
                 new_stats
                     .time_writing_ms
                     .saturating_sub(old_stats.time_writing_ms),
-                u64
+                i64
             ),
             (
                 "io_in_progress",
                 new_stats
                     .io_in_progress
                     .saturating_sub(old_stats.io_in_progress),
-                u64
+                i64
             ),
             (
                 "time_io_ms",
                 new_stats.time_io_ms.saturating_sub(old_stats.time_io_ms),
-                u64
+                i64
             ),
             (
                 "time_io_weighted_ms",
                 new_stats
                     .time_io_weighted_ms
                     .saturating_sub(old_stats.time_io_weighted_ms),
-                u64
+                i64
             ),
             (
                 "discards_completed",
                 new_stats
                     .discards_completed
                     .saturating_sub(old_stats.discards_completed),
-                u64
+                i64
             ),
             (
                 "discards_merged",
                 new_stats
                     .discards_merged
                     .saturating_sub(old_stats.discards_merged),
-                u64
+                i64
             ),
             (
                 "sectors_discarded",
                 new_stats
                     .sectors_discarded
                     .saturating_sub(old_stats.sectors_discarded),
-                u64
+                i64
             ),
             (
                 "time_discarding",
                 new_stats
                     .time_discarding
                     .saturating_sub(old_stats.time_discarding),
-                u64
+                i64
             ),
             (
                 "flushes_completed",
                 new_stats
                     .flushes_completed
                     .saturating_sub(old_stats.flushes_completed),
-                u64
+                i64
             ),
             (
                 "time_flushing",
                 new_stats
                     .time_flushing
                     .saturating_sub(old_stats.time_flushing),
-                u64
+                i64
             ),
             (
                 "num_disks",
                 new_stats.num_disks.saturating_sub(old_stats.num_disks),
-                u64
+                i64
             ),
         )
     }

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -276,11 +276,12 @@ pub fn verify_net_stats_access() -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn read_io_stats() -> Result<IoStats, String> {
     let output = Command::new("iostat")
-                .arg("-d")
-                .arg("-m")
-                .arg("-x")
-                .output()?;
-    let reader_io = output.stdout;
+        .arg("-d")
+        .arg("-m")
+        .arg("-x")
+        .output()
+        .map_err(|e| e.to_string())?;
+    let mut reader_io = &output.stdout as &[u8];
     parse_io_stats(&mut reader_io)
 }
 
@@ -321,13 +322,16 @@ fn parse_io_stats(reader_io: &mut impl BufRead) -> Result<IoStats, String> {
         stats.write_avg_req_sectors += values[12].parse::<f64>().map_err(|e| e.to_string())?;
         stats.discard_iops += values[13].parse::<f64>().map_err(|e| e.to_string())?;
         stats.discard_mbps += values[14].parse::<f64>().map_err(|e| e.to_string())?;
-        stats.discard_req_merged_per_second += values[15].parse::<f64>().map_err(|e| e.to_string())?;
+        stats.discard_req_merged_per_second +=
+            values[15].parse::<f64>().map_err(|e| e.to_string())?;
         stats.discard_req_merged_percent += values[16].parse::<f64>().map_err(|e| e.to_string())?;
         stats.discard_avg_await_ms += values[17].parse::<f64>().map_err(|e| e.to_string())?;
         stats.discard_avg_req_sectors += values[18].parse::<f64>().map_err(|e| e.to_string())?;
         stats.avg_queue_length += values[19].parse::<f64>().map_err(|e| e.to_string())?;
         stats.utilization_percent_avg += values[20].parse::<f64>().map_err(|e| e.to_string())?;
-        stats.utilization_percent_max = stats.utilization_percent_max.max(values[20].parse::<f64>().map_err(|e| e.to_string())?);
+        stats.utilization_percent_max = stats
+            .utilization_percent_max
+            .max(values[20].parse::<f64>().map_err(|e| e.to_string())?);
     }
 
     if num_devices > 1.0 {
@@ -705,25 +709,61 @@ impl SystemMonitorService {
                 "io-stats",
                 ("read_iops", stats.read_iops, f64),
                 ("read_mbps", stats.read_mbps, f64),
-                ("read_req_merged_per_second", stats.read_req_merged_per_second, f64),
-                ("read_req_merged_percent", stats.read_req_merged_percent, f64),
+                (
+                    "read_req_merged_per_second",
+                    stats.read_req_merged_per_second,
+                    f64
+                ),
+                (
+                    "read_req_merged_percent",
+                    stats.read_req_merged_percent,
+                    f64
+                ),
                 ("read_avg_await_ms", stats.read_avg_await_ms, f64),
                 ("read_avg_req_sectors", stats.read_avg_req_sectors, f64),
                 ("write_iops", stats.write_iops, f64),
                 ("write_mbps", stats.write_mbps, f64),
-                ("write_req_merged_per_second", stats.write_req_merged_per_second, f64),
-                ("write_req_merged_percent", stats.write_req_merged_percent, f64),
+                (
+                    "write_req_merged_per_second",
+                    stats.write_req_merged_per_second,
+                    f64
+                ),
+                (
+                    "write_req_merged_percent",
+                    stats.write_req_merged_percent,
+                    f64
+                ),
                 ("write_avg_await_ms", stats.write_avg_await_ms, f64),
                 ("write_avg_req_sectors", stats.write_avg_req_sectors, f64),
                 ("discard_iops", stats.discard_iops, f64),
                 ("discard_mbps", stats.discard_mbps, f64),
-                ("discard_req_merged_per_second", stats.discard_req_merged_per_second, f64),
-                ("discard_req_merged_percent", stats.discard_req_merged_percent, f64),
+                (
+                    "discard_req_merged_per_second",
+                    stats.discard_req_merged_per_second,
+                    f64
+                ),
+                (
+                    "discard_req_merged_percent",
+                    stats.discard_req_merged_percent,
+                    f64
+                ),
                 ("discard_avg_await_ms", stats.discard_avg_await_ms, f64),
-                ("discard_avg_req_sectors", stats.discard_avg_req_sectors, f64),
+                (
+                    "discard_avg_req_sectors",
+                    stats.discard_avg_req_sectors,
+                    f64
+                ),
                 ("avg_queue_length", stats.avg_queue_length, f64),
-                ("utilization_percent_avg", stats.utilization_percent_avg, f64),
-                ("utilization_percent_max", stats.utilization_percent_max, f64),
+                (
+                    "utilization_percent_avg",
+                    stats.utilization_percent_avg,
+                    f64
+                ),
+                (
+                    "utilization_percent_max",
+                    stats.utilization_percent_max,
+                    f64
+                ),
             )
         }
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -161,7 +161,7 @@ pub struct ValidatorConfig {
     pub no_os_memory_stats_reporting: bool,
     pub no_os_network_stats_reporting: bool,
     pub no_os_cpu_stats_reporting: bool,
-    pub no_os_io_stats_reporting: bool,
+    pub no_os_disk_stats_reporting: bool,
     pub poh_pinned_cpu_core: usize,
     pub poh_hashes_per_batch: u64,
     pub account_indexes: AccountSecondaryIndexes,
@@ -224,7 +224,7 @@ impl Default for ValidatorConfig {
             no_os_memory_stats_reporting: true,
             no_os_network_stats_reporting: true,
             no_os_cpu_stats_reporting: true,
-            no_os_io_stats_reporting: true,
+            no_os_disk_stats_reporting: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
             account_indexes: AccountSecondaryIndexes::default(),
@@ -506,7 +506,7 @@ impl Validator {
             !config.no_os_memory_stats_reporting,
             !config.no_os_network_stats_reporting,
             !config.no_os_cpu_stats_reporting,
-            !config.no_os_io_stats_reporting,
+            !config.no_os_disk_stats_reporting,
         ));
 
         let (poh_timing_point_sender, poh_timing_point_receiver) = unbounded();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -161,6 +161,7 @@ pub struct ValidatorConfig {
     pub no_os_memory_stats_reporting: bool,
     pub no_os_network_stats_reporting: bool,
     pub no_os_cpu_stats_reporting: bool,
+    pub no_os_io_stats_reporting: bool,
     pub poh_pinned_cpu_core: usize,
     pub poh_hashes_per_batch: u64,
     pub account_indexes: AccountSecondaryIndexes,
@@ -223,6 +224,7 @@ impl Default for ValidatorConfig {
             no_os_memory_stats_reporting: true,
             no_os_network_stats_reporting: true,
             no_os_cpu_stats_reporting: true,
+            no_os_io_stats_reporting: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             poh_hashes_per_batch: poh_service::DEFAULT_HASHES_PER_BATCH,
             account_indexes: AccountSecondaryIndexes::default(),
@@ -504,6 +506,7 @@ impl Validator {
             !config.no_os_memory_stats_reporting,
             !config.no_os_network_stats_reporting,
             !config.no_os_cpu_stats_reporting,
+            !config.no_os_io_stats_reporting,
         ));
 
         let (poh_timing_point_sender, poh_timing_point_receiver) = unbounded();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2392,6 +2392,7 @@ fn main() {
                     !no_os_memory_stats_reporting,
                     false,
                     false,
+                    false,
                 );
 
                 accounts_index_config.index_limit_mb = if let Some(limit) =

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -48,7 +48,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         no_os_memory_stats_reporting: config.no_os_memory_stats_reporting,
         no_os_network_stats_reporting: config.no_os_network_stats_reporting,
         no_os_cpu_stats_reporting: config.no_os_cpu_stats_reporting,
-        no_os_io_stats_reporting: config.no_os_io_stats_reporting,
+        no_os_disk_stats_reporting: config.no_os_disk_stats_reporting,
         poh_pinned_cpu_core: config.poh_pinned_cpu_core,
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -48,6 +48,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         no_os_memory_stats_reporting: config.no_os_memory_stats_reporting,
         no_os_network_stats_reporting: config.no_os_network_stats_reporting,
         no_os_cpu_stats_reporting: config.no_os_cpu_stats_reporting,
+        no_os_io_stats_reporting: config.no_os_io_stats_reporting,
         poh_pinned_cpu_core: config.poh_pinned_cpu_core,
         account_indexes: config.account_indexes.clone(),
         accounts_db_caching_enabled: config.accounts_db_caching_enabled,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -972,9 +972,9 @@ pub fn main() {
                 .help("Disable reporting of OS CPU statistics.")
         )
         .arg(
-            Arg::with_name("no_os_io_stats_reporting")
-                .long("no-os-io-stats-reporting")
-                .help("Disable reporting of OS IO statistics.")
+            Arg::with_name("no_os_disk_stats_reporting")
+                .long("no-os-disk-stats-reporting")
+                .help("Disable reporting of OS disk statistics.")
         )
         .arg(
             Arg::with_name("accounts-hash-interval-slots")
@@ -2646,7 +2646,7 @@ pub fn main() {
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),
         no_os_network_stats_reporting: matches.is_present("no_os_network_stats_reporting"),
         no_os_cpu_stats_reporting: matches.is_present("no_os_cpu_stats_reporting"),
-        no_os_io_stats_reporting: matches.is_present("no_os_io_stats_reporting"),
+        no_os_disk_stats_reporting: matches.is_present("no_os_disk_stats_reporting"),
         poh_pinned_cpu_core: value_of(&matches, "poh_pinned_cpu_core")
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         poh_hashes_per_batch: value_of(&matches, "poh_hashes_per_batch")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -972,6 +972,11 @@ pub fn main() {
                 .help("Disable reporting of OS CPU statistics.")
         )
         .arg(
+            Arg::with_name("no_os_io_stats_reporting")
+                .long("no-os-io-stats-reporting")
+                .help("Disable reporting of OS IO statistics.")
+        )
+        .arg(
             Arg::with_name("accounts-hash-interval-slots")
                 .long("accounts-hash-interval-slots")
                 .value_name("NUMBER")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2641,6 +2641,7 @@ pub fn main() {
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),
         no_os_network_stats_reporting: matches.is_present("no_os_network_stats_reporting"),
         no_os_cpu_stats_reporting: matches.is_present("no_os_cpu_stats_reporting"),
+        no_os_io_stats_reporting: matches.is_present("no_os_io_stats_reporting"),
         poh_pinned_cpu_core: value_of(&matches, "poh_pinned_cpu_core")
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         poh_hashes_per_batch: value_of(&matches, "poh_hashes_per_batch")


### PR DESCRIPTION
#### Problem
Currently have very limited insight into storage device performance.

#### Summary of Changes
Start tracking aggregated metrics from `/proc/diskstats` to understand storage device performance and bottlenecks