### PR TITLE
cargo-build-sbf: support debug info

### DIFF
--- a/sdk/bpf/scripts/objcopy.sh
+++ b/sdk/bpf/scripts/objcopy.sh
@@ -3,4 +3,4 @@
 bpf_sdk=$(cd "$(dirname "$0")/.." && pwd)
 # shellcheck source=sdk/bpf/env.sh
 source "$bpf_sdk"/env.sh
-exec "$bpf_sdk"/dependencies/llvm-native/bin/llvm-objcopy "$@"
+exec "$bpf_sdk"/dependencies/bpf-tools/llvm/bin/llvm-objcopy "$@"


### PR DESCRIPTION
#### Problem

cargo-build-sbf does not generate debug info for release builds.

#### Summary of Changes

- When setting `--debug` flag
  - Adds the `-g` flag to RUSTFLAGS by default to generate debug symbols ([Rust Reference](https://doc.rust-lang.org/rustc/command-line-arguments.html#-g-include-debug-information))
  - Uses `llvm-objcopy --only-keep-debug` to create a `.debug` symbols file adjacent to the `.so` output file. Reference: [GDB: Separate Debug Files](https://sourceware.org/gdb/current/onlinedocs/gdb/Separate-Debug-Files.html#Separate-Debug-Files)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
