### PR TITLE
[docs] added prettier config file

### DIFF
--- a/docs/.prettierrc.json
+++ b/docs/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
#### Problem
When making changes to the docs website, prettier auto-formatting may not be enabled in the user's code editor.
This can lead to minor changes discrepancies (like trailing white spaces) that could fail sanity checks from the CI. 

#### Summary of Changes
Added a prettier config file to standardize the prettier config settings used when saving the docs website files.