### PR TITLE
Parse ConfidentialTransaction extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,9 +6699,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e684f055853cf11bdc9cd3301da1a3238bc95d25c9e563fd67533c2314900eab"
+checksum = "f0a97cbf60b91b610c846ccf8eecca96d92a24a19ffbf9fe06cd0c84e76ec45e"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,6 +3112,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -5185,35 +5194,23 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d2bcb469e59d941e9d45702c91af940f6a8f4a5947f51bafe72844ed9b71a4"
+checksum = "49a5d3280421bb53fc12bdba1eaa505153fb4f99a06b5609dae22192652ead3b"
 dependencies = [
- "ahash",
- "blake3",
- "block-buffer 0.9.0",
  "bs58",
  "bv",
- "byteorder",
- "cc",
- "either",
  "generic-array 0.14.5",
- "getrandom 0.1.16",
- "hashbrown 0.11.2",
  "im",
  "lazy_static",
  "log",
  "memmap2",
- "once_cell",
- "rand_core 0.6.3",
  "rustc_version 0.4.0",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.11.3",
- "subtle",
+ "solana-frozen-abi-macro 1.10.33",
  "thiserror",
 ]
 
@@ -5252,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1f8cd2f387d17ccfb2bd5dd097d9b3c1fa14acfa49e95a63ece15a4622b8d0"
+checksum = "635c60ac96b1347af272c625465068b908aff919d19f29b5795a44310310494d"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -5567,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3faca9d9fe587dc5827e06acdcca072e5b744bef0488b98fb21b77932e642afb"
+checksum = "b12cb6e6f1f9c9876d356c928b8c2ac532f6715e7cd2a1b4343d747bee3eca73"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5738,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57df37154125f5e4ba0eaa0e5ea3cbc747a950480ddd89395036c4d3b77b66b"
+checksum = "eeecf504cee2821b006871f70e7a1f54db15f914cedf259eaf5976fe606470f0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5751,38 +5748,31 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
- "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.2.3",
+ "getrandom 0.1.16",
  "itertools",
  "js-sys",
  "lazy_static",
- "libc",
  "libsecp256k1",
  "log",
- "memoffset",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "rand_chacha 0.2.2",
  "rustc_version 0.4.0",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.3",
- "solana-frozen-abi-macro 1.11.3",
- "solana-sdk-macro 1.11.3",
+ "solana-frozen-abi 1.10.33",
+ "solana-frozen-abi-macro 1.10.33",
+ "solana-sdk-macro 1.10.33",
  "thiserror",
- "tiny-bip39",
  "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -6053,9 +6043,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d17897e0ca6c36cf90dc4d58a8f6bb2e3af80afc74b1825e779ee087af5c4a"
+checksum = "636f6c615aca6f75e22b6baceaf0ffed9d74367f9320b07ed57cd9b5ce2e4ff9"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -6080,7 +6070,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.11.0",
+ "pbkdf2 0.10.1",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -6092,11 +6082,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.3",
- "solana-frozen-abi-macro 1.11.3",
- "solana-logger 1.11.3",
- "solana-program 1.11.3",
- "solana-sdk-macro 1.11.3",
+ "solana-frozen-abi 1.10.33",
+ "solana-frozen-abi-macro 1.10.33",
+ "solana-logger 1.10.33",
+ "solana-program 1.10.33",
+ "solana-sdk-macro 1.10.33",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -6157,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148d14ba16fed65d2426cd33fbe0661c4c8543721bfb5472f486a509cf01f8c2"
+checksum = "2b8bcac4394644f21dc013e932a7df9f536fcecef3e5df43fe362b4ec532ce30"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -6567,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ca28bafde8d752654a1efbe0911cffc0f2f1518d3eefe094db94cbda8fc965"
+checksum = "410ee53a26ac91098c289c983863535d4fbb6604b229ae1159503f48fa4fc90f"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -6588,8 +6578,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.11.3",
- "solana-sdk 1.11.3",
+ "solana-program 1.10.33",
+ "solana-sdk 1.10.33",
  "subtle",
  "thiserror",
  "zeroize",
@@ -6670,7 +6660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
 dependencies = [
  "borsh",
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
  "spl-token",
 ]
 
@@ -6680,7 +6670,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
 ]
 
 [[package]]
@@ -6693,7 +6683,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
  "thiserror",
 ]
 
@@ -6708,8 +6698,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.3",
- "solana-zk-token-sdk 1.11.3",
+ "solana-program 1.10.33",
+ "solana-zk-token-sdk 1.10.33",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -23,7 +23,7 @@ solana-config-program = { path = "../programs/config", version = "=1.11.5" }
 solana-sdk = { path = "../sdk", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.11.2"
 

--- a/account-decoder/src/parse_token_extension.rs
+++ b/account-decoder/src/parse_token_extension.rs
@@ -14,8 +14,8 @@ pub enum UiExtension {
     TransferFeeConfig(UiTransferFeeConfig),
     TransferFeeAmount(UiTransferFeeAmount),
     MintCloseAuthority(UiMintCloseAuthority),
-    ConfidentialTransferMint,    // Implementation of extension state to come
-    ConfidentialTransferAccount, // Implementation of extension state to come
+    ConfidentialTransferMint(UiConfidentialTransferMint),
+    ConfidentialTransferAccount(UiConfidentialTransferAccount),
     DefaultAccountState(UiDefaultAccountState),
     ImmutableOwner,
     MemoTransfer(UiMemoTransfer),
@@ -42,8 +42,14 @@ pub fn parse_extension<S: BaseState>(
             .get_extension::<extension::mint_close_authority::MintCloseAuthority>()
             .map(|&extension| UiExtension::MintCloseAuthority(extension.into()))
             .unwrap_or(UiExtension::UnparseableExtension),
-        ExtensionType::ConfidentialTransferMint => UiExtension::ConfidentialTransferMint,
-        ExtensionType::ConfidentialTransferAccount => UiExtension::ConfidentialTransferAccount,
+        ExtensionType::ConfidentialTransferMint => account
+            .get_extension::<extension::confidential_transfer::ConfidentialTransferMint>()
+            .map(|&extension| UiExtension::ConfidentialTransferMint(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
+        ExtensionType::ConfidentialTransferAccount => account
+            .get_extension::<extension::confidential_transfer::ConfidentialTransferAccount>()
+            .map(|&extension| UiExtension::ConfidentialTransferAccount(extension.into()))
+            .unwrap_or(UiExtension::UnparseableExtension),
         ExtensionType::DefaultAccountState => account
             .get_extension::<extension::default_account_state::DefaultAccountState>()
             .map(|&extension| UiExtension::DefaultAccountState(extension.into()))
@@ -194,6 +200,89 @@ impl From<extension::interest_bearing_mint::InterestBearingConfig> for UiInteres
                 interest_bearing_config.last_update_timestamp,
             ),
             current_rate: i16::from(interest_bearing_config.current_rate),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiConfidentialTransferMint {
+    pub authority: String,
+    pub auto_approve_new_accounts: bool,
+    pub auditor_encryption_pubkey: String,
+    pub withdraw_withheld_authority_encryption_pubkey: String,
+    pub withheld_amount: String,
+}
+
+impl From<extension::confidential_transfer::ConfidentialTransferMint>
+    for UiConfidentialTransferMint
+{
+    fn from(
+        confidential_transfer_mint: extension::confidential_transfer::ConfidentialTransferMint,
+    ) -> Self {
+        Self {
+            authority: confidential_transfer_mint.authority.to_string(),
+            auto_approve_new_accounts: confidential_transfer_mint.auto_approve_new_accounts.into(),
+            auditor_encryption_pubkey: format!(
+                "{}",
+                confidential_transfer_mint.auditor_encryption_pubkey
+            ),
+            withdraw_withheld_authority_encryption_pubkey: format!(
+                "{}",
+                confidential_transfer_mint.withdraw_withheld_authority_encryption_pubkey
+            ),
+            withheld_amount: format!("{}", confidential_transfer_mint.withheld_amount),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiConfidentialTransferAccount {
+    pub approved: bool,
+    pub encryption_pubkey: String,
+    pub pending_balance_lo: String,
+    pub pending_balance_hi: String,
+    pub available_balance: String,
+    pub decryptable_available_balance: String,
+    pub allow_balance_credits: bool,
+    pub pending_balance_credit_counter: u64,
+    pub maximum_pending_balance_credit_counter: u64,
+    pub expected_pending_balance_credit_counter: u64,
+    pub actual_pending_balance_credit_counter: u64,
+    pub withheld_amount: String,
+}
+
+impl From<extension::confidential_transfer::ConfidentialTransferAccount>
+    for UiConfidentialTransferAccount
+{
+    fn from(
+        confidential_transfer_account: extension::confidential_transfer::ConfidentialTransferAccount,
+    ) -> Self {
+        Self {
+            approved: confidential_transfer_account.approved.into(),
+            encryption_pubkey: format!("{}", confidential_transfer_account.encryption_pubkey),
+            pending_balance_lo: format!("{}", confidential_transfer_account.pending_balance_lo),
+            pending_balance_hi: format!("{}", confidential_transfer_account.pending_balance_hi),
+            available_balance: format!("{}", confidential_transfer_account.available_balance),
+            decryptable_available_balance: format!(
+                "{}",
+                confidential_transfer_account.decryptable_available_balance
+            ),
+            allow_balance_credits: confidential_transfer_account.allow_balance_credits.into(),
+            pending_balance_credit_counter: confidential_transfer_account
+                .pending_balance_credit_counter
+                .into(),
+            maximum_pending_balance_credit_counter: confidential_transfer_account
+                .maximum_pending_balance_credit_counter
+                .into(),
+            expected_pending_balance_credit_counter: confidential_transfer_account
+                .expected_pending_balance_credit_counter
+                .into(),
+            actual_pending_balance_credit_counter: confidential_transfer_account
+                .actual_pending_balance_credit_counter
+                .into(),
+            withheld_amount: format!("{}", confidential_transfer_account.withheld_amount),
         }
     }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -49,7 +49,7 @@ solana-streamer = { path = "../streamer", version = "=1.11.5" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.11.5" }
 solana-version = { path = "../version", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
-spl-token-2022 = { version = "=0.4.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }
 tokio-stream = "0.1.9"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -5891,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e684f055853cf11bdc9cd3301da1a3238bc95d25c9e563fd67533c2314900eab"
+checksum = "f0a97cbf60b91b610c846ccf8eecca96d92a24a19ffbf9fe06cd0c84e76ec45e"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2840,6 +2840,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -4753,35 +4762,23 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d2bcb469e59d941e9d45702c91af940f6a8f4a5947f51bafe72844ed9b71a4"
+checksum = "49a5d3280421bb53fc12bdba1eaa505153fb4f99a06b5609dae22192652ead3b"
 dependencies = [
- "ahash",
- "blake3",
- "block-buffer 0.9.0",
  "bs58",
  "bv",
- "byteorder 1.4.3",
- "cc",
- "either",
  "generic-array 0.14.5",
- "getrandom 0.1.14",
- "hashbrown 0.11.2",
  "im",
  "lazy_static",
  "log",
  "memmap2",
- "once_cell",
- "rand_core 0.6.3",
  "rustc_version",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.2",
- "solana-frozen-abi-macro 1.11.3",
- "subtle",
+ "solana-frozen-abi-macro 1.10.33",
  "thiserror",
 ]
 
@@ -4819,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1f8cd2f387d17ccfb2bd5dd097d9b3c1fa14acfa49e95a63ece15a4622b8d0"
+checksum = "635c60ac96b1347af272c625465068b908aff919d19f29b5795a44310310494d"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -4977,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3faca9d9fe587dc5827e06acdcca072e5b744bef0488b98fb21b77932e642afb"
+checksum = "b12cb6e6f1f9c9876d356c928b8c2ac532f6715e7cd2a1b4343d747bee3eca73"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5088,9 +5085,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57df37154125f5e4ba0eaa0e5ea3cbc747a950480ddd89395036c4d3b77b66b"
+checksum = "eeecf504cee2821b006871f70e7a1f54db15f914cedf259eaf5976fe606470f0"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -5101,38 +5098,31 @@ dependencies = [
  "bs58",
  "bv",
  "bytemuck",
- "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.2.4",
+ "getrandom 0.1.14",
  "itertools",
  "js-sys",
  "lazy_static",
- "libc",
  "libsecp256k1",
  "log",
- "memoffset",
  "num-derive",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "rand_chacha 0.2.2",
  "rustc_version",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.3",
- "solana-frozen-abi-macro 1.11.3",
- "solana-sdk-macro 1.11.3",
+ "solana-frozen-abi 1.10.33",
+ "solana-frozen-abi-macro 1.10.33",
+ "solana-sdk-macro 1.10.33",
  "thiserror",
- "tiny-bip39",
  "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -5365,9 +5355,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d17897e0ca6c36cf90dc4d58a8f6bb2e3af80afc74b1825e779ee087af5c4a"
+checksum = "636f6c615aca6f75e22b6baceaf0ffed9d74367f9320b07ed57cd9b5ce2e4ff9"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -5392,7 +5382,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2 0.11.0",
+ "pbkdf2 0.10.1",
  "qstring",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -5404,11 +5394,11 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3 0.10.1",
- "solana-frozen-abi 1.11.3",
- "solana-frozen-abi-macro 1.11.3",
- "solana-logger 1.11.3",
- "solana-program 1.11.3",
- "solana-sdk-macro 1.11.3",
+ "solana-frozen-abi 1.10.33",
+ "solana-frozen-abi-macro 1.10.33",
+ "solana-logger 1.10.33",
+ "solana-program 1.10.33",
+ "solana-sdk-macro 1.10.33",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -5465,9 +5455,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148d14ba16fed65d2426cd33fbe0661c4c8543721bfb5472f486a509cf01f8c2"
+checksum = "2b8bcac4394644f21dc013e932a7df9f536fcecef3e5df43fe362b4ec532ce30"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.41",
@@ -5759,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.11.3"
+version = "1.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ca28bafde8d752654a1efbe0911cffc0f2f1518d3eefe094db94cbda8fc965"
+checksum = "410ee53a26ac91098c289c983863535d4fbb6604b229ae1159503f48fa4fc90f"
 dependencies = [
  "aes-gcm-siv",
  "arrayref",
@@ -5780,8 +5770,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.11.3",
- "solana-sdk 1.11.3",
+ "solana-program 1.10.33",
+ "solana-sdk 1.10.33",
  "subtle",
  "thiserror",
  "zeroize",
@@ -5862,7 +5852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
 dependencies = [
  "borsh",
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
  "spl-token",
 ]
 
@@ -5872,7 +5862,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
 ]
 
 [[package]]
@@ -5885,7 +5875,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.3",
+ "solana-program 1.10.33",
  "thiserror",
 ]
 
@@ -5900,8 +5890,8 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.11.3",
- "solana-zk-token-sdk 1.11.3",
+ "solana-program 1.10.33",
+ "solana-zk-token-sdk 1.10.33",
  "spl-memo",
  "spl-token",
  "thiserror",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -50,7 +50,7 @@ solana-transaction-status = { path = "../transaction-status", version = "=1.11.5
 solana-version = { path = "../version", version = "=1.11.5" }
 solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 stream-cancel = "0.8.1"
 thiserror = "1.0"
 tokio = { version = "~1.14.1", features = ["full"] }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,7 +29,7 @@ solana-vote-program = { path = "../programs/vote", version = "=1.11.5" }
 spl-associated-token-account = { version = "=1.0.5", features = ["no-entrypoint"] }
 spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token = { version = "=3.3.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "=0.4.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "=0.4.2", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
#### Problem
Parsing apis for spl-token-2022 ConfidentialTransaction extensions are only stubs.

#### Summary of Changes
- Flesh out parsing
- Also, bump spl-token-2022 version, and do tedious rollback of Cargo.lock changes from #26746 (in retrospect, I'm not sure why cargo forced that solana v1.11.3 bump on me...)
