### PR TITLE
Adjust `solana validators -n` header to be correctly aligned with the columns

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -454,7 +454,7 @@ impl fmt::Display for CliValidators {
             "Credits",
             "Version",
             "Active Stake",
-            padding = padding + 1
+            padding = padding + 2
         ))
         .bold();
         writeln!(f, "{}", header)?;


### PR DESCRIPTION
#### Pre
```
$ solana validators -n -ul | head -n2
   Identity                                      Vote Account                            Commission  Last Vote        Root Slot     Skip Rate  Credits  Version            Active Stake
1   12GxYJMVymf9KsigAqcakWhk774xi4yi19hfPBBmKqhw  CXsSF1ytAddR9rd1CpkArifiZ78xhxXAbAWwoMrWXsZd    0%      12644 (  0)      12613 (  0)   0.02%    12567   1.11.3    999999.997717120 SOL (100.00%)
```

#### Post
```
$ solana validators -n -ul | head -n2
    Identity                                      Vote Account                            Commission  Last Vote        Root Slot     Skip Rate  Credits  Version            Active Stake
1   12GxYJMVymf9KsigAqcakWhk774xi4yi19hfPBBmKqhw  CXsSF1ytAddR9rd1CpkArifiZ78xhxXAbAWwoMrWXsZd    0%      12689 (  0)      12658 (  0)   0.02%    12612   1.11.3    999999.997717120 SOL (100.00%)
```
