### PR TITLE
Add explicit comment about get_stake_account to StakeInstruction enum

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -455,6 +455,20 @@ pub fn process_instruction(
                 Err(InstructionError::InvalidInstructionData)
             }
         }
+        // In order to prevent consensus issues, any new StakeInstruction variant added before the
+        // `add_get_minimum_delegation_instruction_to_stake_program` is activated needs to check
+        // the validity of the stake account by calling the `get_stake_account()` method outside
+        // its own feature gate, as per the following pattern:
+        //  ```
+        //  Ok(StakeInstruction::Variant) -> {
+        //      let mut me = get_stake_account()?;
+        //      if invoke_context
+        //         .feature_set
+        //         .is_active(&feature_set::stake_variant_feature::id()) { .. }
+        //  }
+        // ```
+        // TODO: Remove this comment when `add_get_minimum_delegation_instruction_to_stake_program`
+        // is cleaned up
         Err(err) => {
             if !invoke_context.feature_set.is_active(
                 &feature_set::add_get_minimum_delegation_instruction_to_stake_program::id(),


### PR DESCRIPTION
#### Problem
As per https://github.com/solana-labs/solana/pull/26294#discussion_r922747616, it's easy to miss the check needed to preserve consensus when adding a new feature-gated stake instruction while `add_get_minimum_delegation_instruction_to_stake_program` is not yet active.

#### Summary of Changes
Add explicit comment describing pattern to follow
