### PR TITLE
Add a derivable trait for generating datapoint_info metric reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5064,6 +5064,7 @@ dependencies = [
  "solana-logger 1.11.5",
  "solana-measure",
  "solana-metrics",
+ "solana-metrics-reporter",
  "solana-net-utils",
  "solana-perf",
  "solana-poh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5632,6 +5632,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-metrics-reporter"
+version = "1.11.5"
+dependencies = [
+ "log",
+ "solana-logger 1.11.5",
+ "solana-metrics",
+ "solana-metrics-reporter-derive",
+]
+
+[[package]]
+name = "solana-metrics-reporter-derive"
+version = "1.11.5"
+dependencies = [
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "solana-net-shaper"
 version = "1.11.5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
     "merkle-root-bench",
     "merkle-tree",
     "metrics",
+    "metrics_reporter",
+    "metrics_reporter/derive",
     "net-shaper",
     "net-utils",
     "notifier",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,6 +46,7 @@ solana-gossip = { path = "../gossip", version = "=1.11.5" }
 solana-ledger = { path = "../ledger", version = "=1.11.5" }
 solana-measure = { path = "../measure", version = "=1.11.5" }
 solana-metrics = { path = "../metrics", version = "=1.11.5" }
+solana-metrics-reporter = { path = "../metrics_reporter", version = "=1.11.5" }
 solana-net-utils = { path = "../net-utils", version = "=1.11.5" }
 solana-perf = { path = "../perf", version = "=1.11.5" }
 solana-poh = { path = "../poh", version = "=1.11.5" }

--- a/metrics_reporter/Cargo.toml
+++ b/metrics_reporter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-metrics-reporter"
+version = "1.11.5"
+description = "Solana Metrics Reporter"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-metrics-reporter"
+edition = "2021"
+
+[dependencies]
+log = "0.4.17"
+solana-logger = { path = "../logger", version = "=1.11.5" }
+solana-metrics = { path = "../metrics", version = "1.11.5" }
+solana-metrics-reporter-derive = { path = "./derive", version = "=1.11.5" }
+
+[lib]
+name = "solana_metrics_reporter"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/metrics_reporter/derive/Cargo.toml
+++ b/metrics_reporter/derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "solana-metrics-reporter-derive"
+version = "1.11.5"
+description = "Solana Metrics Reporter Derive"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-metrics-reporter-derive"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"
+
+[lib]
+name = "solana_metrics_reporter_derive"
+proc_macro = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/metrics_reporter/derive/src/lib.rs
+++ b/metrics_reporter/derive/src/lib.rs
@@ -53,6 +53,62 @@ pub fn metrics_reporter_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
+#[proc_macro_derive(
+    MetricsReporterInterval,
+    attributes(report_name, report_ignore, report_with, report_no_reset,)
+)]
+pub fn metrics_reporter_interval_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let report_name = find_metrics_reporter_name(&input.attrs)
+        .expect("Struct must have a report_name attribute to derive MetricsReporter");
+
+    let name = &input.ident;
+    let metric_fields = get_metrics_fields(&input.data);
+
+    let metric_reports = metric_fields.into_iter().map(|field| {
+        let field_name = field.ident.as_ref().expect("Field must have a name");
+        let field_name_str = field_name.to_string();
+        let field_type = get_field_type(&field);
+        let mapped_type = get_mapped_type(&field_type);
+
+        let loader = if let Some(report_with) =
+            field.attrs.iter().find(|a| a.path.is_ident("report_with"))
+        {
+            let expression: syn::Expr = report_with.parse_args().unwrap();
+            quote! { #expression }
+        } else if field
+            .attrs
+            .iter()
+            .any(|a| a.path.is_ident("report_no_reset"))
+        {
+            get_default_loader(field_name, &field_type, &mapped_type)
+        } else {
+            get_default_loader_with_reset(field_name, &field_type, &mapped_type)
+        };
+
+        quote! {
+            (#field_name_str, #loader, #mapped_type),
+        }
+    });
+
+    let expanded = quote! {
+        impl MetricsReporterInterval for #name {
+            fn report(&mut self) {
+                // Publish datapoints
+                datapoint_info!(
+                    &#report_name,
+                    #(
+                        #metric_reports
+                    )*
+                );
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
 fn find_metrics_reporter_name(attrs: &[Attribute]) -> Option<String> {
     attrs
         .iter()
@@ -115,6 +171,31 @@ fn get_default_loader(
         "AtomicI64" | "AtomicI32" | "AtomicI16" | "AtomicI8" | "AtomicUSize" | "AtomicU64"
         | "AtomicU32" | "AtomicU16" | "AtomicU8" | "AtomicF32" | "AtomicF64" | "AtomicBool" => {
             quote! { self.#field_name.load(std::sync::atomic::Ordering::Relaxed) as #mapped_type }
+        }
+        unexpected_type => panic!("Unexpected type: {unexpected_type}"),
+    }
+}
+
+fn get_default_loader_with_reset(
+    field_name: &Ident,
+    field_type: &Ident,
+    mapped_type: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    match field_type.to_string().as_str() {
+        "i64" | "i32" | "i16" | "i8" | "usize" | "u64" | "u32" | "u16" | "u8" => {
+            quote! { std::mem::replace(&mut self.#field_name, 0) as #mapped_type }
+        }
+        "f64" | "f32" => quote! { std::mem::replace(&mut self.#field_name, 0.0) as #mapped_type },
+        "bool" => quote! { std::mem::replace(&mut self.#field_name, false) },
+        "AtomicI64" | "AtomicI32" | "AtomicI16" | "AtomicI8" | "AtomicUSize" | "AtomicU64"
+        | "AtomicU32" | "AtomicU16" | "AtomicU8" => {
+            quote! { self.#field_name.swap(0, std::sync::atomic::Ordering::Relaxed) as #mapped_type }
+        }
+        "AtomicF32" | "AtomicF64" => {
+            quote! { self.#field_name.swap(0.0, std::sync::atomic::Ordering::Relaxed) as #mapped_type }
+        }
+        "AtomicBool" => {
+            quote! { self.#field_name.swap(false, std::sync::atomic::Ordering::Relaxed) }
         }
         unexpected_type => panic!("Unexpected type: {unexpected_type}"),
     }

--- a/metrics_reporter/derive/src/lib.rs
+++ b/metrics_reporter/derive/src/lib.rs
@@ -1,0 +1,121 @@
+use {
+    proc_macro::TokenStream,
+    quote::quote,
+    syn::{parse_macro_input, Attribute, Data, DeriveInput, Field, Ident},
+};
+
+extern crate proc_macro;
+
+#[proc_macro_derive(MetricsReporter, attributes(report_name, report_ignore, report_with,))]
+pub fn metrics_reporter_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let report_name = find_metrics_reporter_name(&input.attrs)
+        .expect("Struct must have a report_name attribute to derive MetricsReporter");
+
+    let name = &input.ident;
+    let metric_fields = get_metrics_fields(&input.data);
+
+    let metric_reports = metric_fields.into_iter().map(|field| {
+        let field_name = field.ident.as_ref().expect("Field must have a name");
+        let field_name_str = field_name.to_string();
+        let field_type = get_field_type(&field);
+        let mapped_type = get_mapped_type(&field_type);
+
+        let loader = if let Some(report_with) =
+            field.attrs.iter().find(|a| a.path.is_ident("report_with"))
+        {
+            let expression: syn::Expr = report_with.parse_args().unwrap();
+            quote! { #expression }
+        } else {
+            get_default_loader(field_name, &field_type, &mapped_type)
+        };
+
+        quote! {
+            (#field_name_str, #loader, #mapped_type),
+        }
+    });
+
+    let expanded = quote! {
+        impl MetricsReporter for #name {
+            fn report(&self) {
+                // Publish datapoints
+                datapoint_info!(
+                    &#report_name,
+                    #(
+                        #metric_reports
+                    )*
+                );
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn find_metrics_reporter_name(attrs: &[Attribute]) -> Option<String> {
+    attrs
+        .iter()
+        .find(|a| a.path.is_ident("report_name"))
+        .map(|a| {
+            let literal: syn::LitStr = a
+                .parse_args()
+                .expect("\"report_name\" value should be a str");
+            literal.value()
+        })
+}
+
+fn get_metrics_fields(data: &Data) -> impl Iterator<Item = Field> + '_ {
+    match data {
+        syn::Data::Struct(data_struct) => match &data_struct.fields {
+            syn::Fields::Named(fields) => fields
+                .named
+                .iter()
+                .cloned()
+                .filter(|field| !field.attrs.iter().any(|a| a.path.is_ident("report_ignore"))),
+            _ => panic!("Can only derive MetricsReporter for named fields"),
+        },
+        _ => panic!("Can only derive MetricsReporter for structs"),
+    }
+}
+
+fn get_field_type(field: &Field) -> Ident {
+    match &field.ty {
+        syn::Type::Path(type_path) => {
+            let last_segment = type_path
+                .path
+                .segments
+                .last()
+                .expect("type should have segments");
+            last_segment.ident.clone()
+        }
+        unexpected_field_type => panic!("Unexpected field type: {unexpected_field_type:?}"),
+    }
+}
+
+fn get_mapped_type(field_type: &Ident) -> proc_macro2::TokenStream {
+    match field_type.to_string().as_str() {
+        "i64" | "i32" | "i16" | "i8" | "usize" | "u64" | "u32" | "u16" | "u8" | "AtomicI64"
+        | "AtomicI32" | "AtomicI16" | "AtomicI8" | "AtomicUSize" | "AtomicU64" | "AtomicU32"
+        | "AtomicU16" | "AtomicU8" => quote! {i64},
+        "f64" | "f32" | "AtomicF64" | "AtomicF32" => quote! {f64},
+        "bool" | "AtomicBool" => quote! {bool},
+        unexpected_type => panic!("Unexpected type: {unexpected_type}"),
+    }
+}
+
+fn get_default_loader(
+    field_name: &Ident,
+    field_type: &Ident,
+    mapped_type: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    match field_type.to_string().as_str() {
+        "i64" | "i32" | "i16" | "i8" | "usize" | "u64" | "u32" | "u16" | "u8" | "f64" | "f32"
+        | "bool" => quote! { self.#field_name as #mapped_type },
+        "AtomicI64" | "AtomicI32" | "AtomicI16" | "AtomicI8" | "AtomicUSize" | "AtomicU64"
+        | "AtomicU32" | "AtomicU16" | "AtomicU8" | "AtomicF32" | "AtomicF64" | "AtomicBool" => {
+            quote! { self.#field_name.load(std::sync::atomic::Ordering::Relaxed) as #mapped_type }
+        }
+        unexpected_type => panic!("Unexpected type: {unexpected_type}"),
+    }
+}

--- a/metrics_reporter/src/lib.rs
+++ b/metrics_reporter/src/lib.rs
@@ -1,0 +1,9 @@
+pub use {
+    solana_metrics::datapoint_info,
+    solana_metrics_reporter_derive::MetricsReporter,
+};
+
+pub trait MetricsReporter {
+    /// Reports metrics using datapoint_info!
+    fn report(&self);
+}

--- a/metrics_reporter/src/lib.rs
+++ b/metrics_reporter/src/lib.rs
@@ -1,9 +1,14 @@
 pub use {
     solana_metrics::datapoint_info,
-    solana_metrics_reporter_derive::MetricsReporter,
+    solana_metrics_reporter_derive::{MetricsReporter, MetricsReporterInterval},
 };
 
 pub trait MetricsReporter {
     /// Reports metrics using datapoint_info!
     fn report(&self);
+}
+
+pub trait MetricsReporterInterval {
+    /// Reports metrics using datapoint_info! and resets fields
+    fn report(&mut self);
 }


### PR DESCRIPTION
#### Problem
It's annoying to write and keep datapoint_info calls up to date.

#### Summary of Changes
Add traits for reseting and non-reseting metrics reporting, and use proc_macros to derive the traits.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
