### PR TITLE
sign repair requests

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -17,7 +17,10 @@ use {
     solana_ledger::blockstore::{Blockstore, SlotMeta},
     solana_measure::measure::Measure,
     solana_runtime::{bank_forks::BankForks, contains::Contains},
-    solana_sdk::{clock::Slot, epoch_schedule::EpochSchedule, hash::Hash, pubkey::Pubkey},
+    solana_sdk::{
+        clock::Slot, epoch_schedule::EpochSchedule, hash::Hash, pubkey::Pubkey,
+        signer::keypair::Keypair,
+    },
     solana_streamer::sendmmsg::{batch_send, SendPktsError},
     std::{
         collections::{HashMap, HashSet},
@@ -246,7 +249,10 @@ impl RepairService {
         outstanding_requests: &RwLock<OutstandingShredRepairs>,
     ) {
         let mut repair_weight = RepairWeight::new(repair_info.bank_forks.read().unwrap().root());
-        let serve_repair = ServeRepair::new(repair_info.cluster_info.clone());
+        let serve_repair = ServeRepair::new(
+            repair_info.cluster_info.clone(),
+            repair_info.bank_forks.clone(),
+        );
         let id = repair_info.cluster_info.id();
         let mut repair_stats = RepairStats::default();
         let mut repair_timing = RepairTiming::default();
@@ -265,8 +271,11 @@ impl RepairService {
             let mut get_votes_elapsed;
             let mut add_votes_elapsed;
 
+            let root_bank = repair_info.bank_forks.read().unwrap().root_bank();
+            let sign_repair_requests_feature_epoch =
+                ServeRepair::sign_repair_requests_activated_epoch(&root_bank);
+
             let repairs = {
-                let root_bank = repair_info.bank_forks.read().unwrap().root_bank().clone();
                 let new_root = root_bank.slot();
 
                 // Purge outdated slots from the weighting heuristic
@@ -314,12 +323,24 @@ impl RepairService {
                 repairs
             };
 
+            let identity_keypair: &Keypair = &repair_info.cluster_info.keypair().clone();
+
             let mut build_repairs_batch_elapsed = Measure::start("build_repairs_batch_elapsed");
             let batch: Vec<(Vec<u8>, SocketAddr)> = {
                 let mut outstanding_requests = outstanding_requests.write().unwrap();
                 repairs
                     .iter()
                     .filter_map(|repair_request| {
+                        let sign_repair_request = ServeRepair::should_sign_repair_request(
+                            repair_request.slot(),
+                            &root_bank,
+                            sign_repair_requests_feature_epoch,
+                        );
+                        let maybe_keypair = if sign_repair_request {
+                            Some(identity_keypair)
+                        } else {
+                            None
+                        };
                         let (to, req) = serve_repair
                             .repair_request(
                                 &repair_info.cluster_slots,
@@ -328,6 +349,7 @@ impl RepairService {
                                 &mut repair_stats,
                                 &repair_info.repair_validators,
                                 &mut outstanding_requests,
+                                maybe_keypair,
                             )
                             .ok()?;
                         Some((req, to))
@@ -653,8 +675,13 @@ impl RepairService {
         repair_stats: &mut RepairStats,
         nonce: Nonce,
     ) -> Result<()> {
-        let req =
-            serve_repair.map_repair_request(repair_type, repair_pubkey, repair_stats, nonce)?;
+        let req = serve_repair.map_repair_request(
+            repair_type,
+            repair_pubkey,
+            repair_stats,
+            nonce,
+            None,
+        )?;
         repair_socket.send_to(&req, to)?;
         Ok(())
     }
@@ -722,9 +749,11 @@ mod test {
             blockstore::{
                 make_chaining_slot_entries, make_many_slot_entries, make_slot_entries, Blockstore,
             },
+            genesis_utils::{create_genesis_config, GenesisConfigInfo},
             get_tmp_ledger_path,
             shred::max_ticks_per_n_shreds,
         },
+        solana_runtime::bank::Bank,
         solana_sdk::signature::Keypair,
         solana_streamer::socket::SocketAddrSpace,
         std::collections::HashSet,
@@ -1044,11 +1073,16 @@ mod test {
 
     #[test]
     pub fn test_generate_and_send_duplicate_repairs() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let blockstore_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&blockstore_path).unwrap();
         let cluster_slots = ClusterSlots::default();
-        let serve_repair =
-            ServeRepair::new(Arc::new(new_test_cluster_info(Node::new_localhost().info)));
+        let serve_repair = ServeRepair::new(
+            Arc::new(new_test_cluster_info(Node::new_localhost().info)),
+            bank_forks,
+        );
         let mut duplicate_slot_repair_statuses = HashMap::new();
         let dead_slot = 9;
         let receive_socket = &UdpSocket::bind("0.0.0.0:0").unwrap();
@@ -1127,12 +1161,15 @@ mod test {
 
     #[test]
     pub fn test_update_duplicate_slot_repair_addr() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let dummy_addr = Some((
             Pubkey::default(),
             UdpSocket::bind("0.0.0.0:0").unwrap().local_addr().unwrap(),
         ));
         let cluster_info = Arc::new(new_test_cluster_info(Node::new_localhost().info));
-        let serve_repair = ServeRepair::new(cluster_info.clone());
+        let serve_repair = ServeRepair::new(cluster_info.clone(), bank_forks);
         let valid_repair_peer = Node::new_localhost().info;
 
         // Signal that this peer has confirmed the dead slot, and is thus

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -137,12 +137,9 @@ impl ShredFetchStage {
         let modifier_hdl = Builder::new()
             .name("solana-tvu-fetch-stage-packet-modifier".to_string())
             .spawn(move || {
-                let repair_context = repair_context.as_ref().map(|(socket, cluster_info)| {
-                    (
-                        <&UdpSocket>::from(socket),
-                        <&ClusterInfo>::from(cluster_info),
-                    )
-                });
+                let repair_context = repair_context
+                    .as_ref()
+                    .map(|(socket, cluster_info)| (socket.as_ref(), cluster_info.as_ref()));
                 Self::modify_packets(
                     packet_receiver,
                     sender,
@@ -178,7 +175,7 @@ impl ShredFetchStage {
             shred_version,
             "shred_fetch",
             PacketFlags::empty(),
-            None,
+            None, // repair_context
         );
 
         let (tvu_forwards_threads, fwd_thread_hdl) = Self::packet_modifier(
@@ -190,7 +187,7 @@ impl ShredFetchStage {
             shred_version,
             "shred_fetch_tvu_forwards",
             PacketFlags::FORWARDED,
-            None,
+            None, // repair_context
         );
 
         let (repair_receiver, repair_handler) = Self::packet_modifier(

--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -1,9 +1,10 @@
 //! The `shred_fetch_stage` pulls shreds from UDP sockets and sends it to a channel.
 
 use {
-    crate::packet_hasher::PacketHasher,
+    crate::{packet_hasher::PacketHasher, serve_repair::ServeRepair},
     crossbeam_channel::{unbounded, Sender},
     lru::LruCache,
+    solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::shred::{should_discard_shred, ShredFetchStats},
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, PacketFlags},
     solana_runtime::bank_forks::BankForks,
@@ -33,10 +34,14 @@ impl ShredFetchStage {
         shred_version: u16,
         name: &'static str,
         flags: PacketFlags,
+        repair_context: Option<(&UdpSocket, &ClusterInfo)>,
     ) {
         const STATS_SUBMIT_CADENCE: Duration = Duration::from_secs(1);
         let mut shreds_received = LruCache::new(DEFAULT_LRU_SIZE);
         let mut last_updated = Instant::now();
+        let mut keypair = repair_context
+            .as_ref()
+            .map(|(_, cluster_info)| cluster_info.keypair().clone());
 
         // In the case of bank_forks=None, setup to accept any slot range
         let mut last_root = 0;
@@ -59,8 +64,25 @@ impl ShredFetchStage {
                     let root_bank = bank_forks_r.root_bank();
                     slots_per_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
                 }
+                keypair = repair_context
+                    .as_ref()
+                    .map(|(_, cluster_info)| cluster_info.keypair().clone());
             }
             stats.shred_count += packet_batch.len();
+
+            if let Some((udp_socket, _)) = repair_context {
+                debug_assert_eq!(flags, PacketFlags::REPAIR);
+                debug_assert!(keypair.is_some());
+                if let Some(ref keypair) = keypair {
+                    ServeRepair::handle_repair_response_pings(
+                        udp_socket,
+                        keypair,
+                        &mut packet_batch,
+                        &mut stats,
+                    );
+                }
+            }
+
             // Limit shreds to 2 epochs away.
             let max_slot = last_slot + 2 * slots_per_epoch;
             for packet in packet_batch.iter_mut() {
@@ -94,6 +116,7 @@ impl ShredFetchStage {
         shred_version: u16,
         name: &'static str,
         flags: PacketFlags,
+        repair_context: Option<(Arc<UdpSocket>, Arc<ClusterInfo>)>,
     ) -> (Vec<JoinHandle<()>>, JoinHandle<()>) {
         let (packet_sender, packet_receiver) = unbounded();
         let streamers = sockets
@@ -111,10 +134,15 @@ impl ShredFetchStage {
                 )
             })
             .collect();
-
         let modifier_hdl = Builder::new()
             .name("solana-tvu-fetch-stage-packet-modifier".to_string())
             .spawn(move || {
+                let repair_context = repair_context.as_ref().map(|(socket, cluster_info)| {
+                    (
+                        <&UdpSocket>::from(socket),
+                        <&ClusterInfo>::from(cluster_info),
+                    )
+                });
                 Self::modify_packets(
                     packet_receiver,
                     sender,
@@ -122,6 +150,7 @@ impl ShredFetchStage {
                     shred_version,
                     name,
                     flags,
+                    repair_context,
                 )
             })
             .unwrap();
@@ -135,6 +164,7 @@ impl ShredFetchStage {
         sender: Sender<PacketBatch>,
         shred_version: u16,
         bank_forks: Arc<RwLock<BankForks>>,
+        cluster_info: Arc<ClusterInfo>,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let recycler = PacketBatchRecycler::warmed(100, 1024);
@@ -148,6 +178,7 @@ impl ShredFetchStage {
             shred_version,
             "shred_fetch",
             PacketFlags::empty(),
+            None,
         );
 
         let (tvu_forwards_threads, fwd_thread_hdl) = Self::packet_modifier(
@@ -159,10 +190,11 @@ impl ShredFetchStage {
             shred_version,
             "shred_fetch_tvu_forwards",
             PacketFlags::FORWARDED,
+            None,
         );
 
         let (repair_receiver, repair_handler) = Self::packet_modifier(
-            vec![repair_socket],
+            vec![repair_socket.clone()],
             exit,
             sender,
             recycler,
@@ -170,6 +202,7 @@ impl ShredFetchStage {
             shred_version,
             "shred_fetch_repair",
             PacketFlags::REPAIR,
+            Some((repair_socket, cluster_info)),
         );
 
         tvu_threads.extend(tvu_forwards_threads.into_iter());

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -152,6 +152,7 @@ impl Tvu {
             fetch_sender,
             tvu_config.shred_version,
             bank_forks.clone(),
+            cluster_info.clone(),
             exit,
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -880,7 +880,10 @@ impl Validator {
             Some(stats_reporter_sender.clone()),
             &exit,
         );
-        let serve_repair = Arc::new(RwLock::new(ServeRepair::new(cluster_info.clone())));
+        let serve_repair = Arc::new(RwLock::new(ServeRepair::new(
+            cluster_info.clone(),
+            bank_forks.clone(),
+        )));
         let serve_repair_service = ServeRepairService::new(
             &serve_repair,
             Some(blockstore.clone()),

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -109,6 +109,10 @@ impl Pong {
         };
         Ok(pong)
     }
+
+    pub fn from(&self) -> &Pubkey {
+        &self.from
+    }
 }
 
 impl Sanitize for Pong {

--- a/ledger/src/shred/stats.rs
+++ b/ledger/src/shred/stats.rs
@@ -30,6 +30,8 @@ pub struct ProcessShredsStats {
 pub struct ShredFetchStats {
     pub index_overrun: usize,
     pub shred_count: usize,
+    pub ping_count: usize,
+    pub ping_err_verify_count: usize,
     pub(crate) index_bad_deserialize: usize,
     pub(crate) index_out_of_bounds: usize,
     pub(crate) slot_bad_deserialize: usize,
@@ -115,6 +117,8 @@ impl ShredFetchStats {
             name,
             ("index_overrun", self.index_overrun, i64),
             ("shred_count", self.shred_count, i64),
+            ("ping_count", self.ping_count, i64),
+            ("ping_err_verify_count", self.ping_err_verify_count, i64),
             ("slot_bad_deserialize", self.slot_bad_deserialize, i64),
             ("index_bad_deserialize", self.index_bad_deserialize, i64),
             ("index_out_of_bounds", self.index_out_of_bounds, i64),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -484,6 +484,10 @@ pub mod compact_vote_state_updates {
     solana_sdk::declare_id!("86HpNqzutEZwLcPxS6EHDcMNYWk6ikhteg9un7Y2PBKE");
 }
 
+pub mod sign_repair_requests {
+    solana_sdk::declare_id!("sigrs6u1EWeHuoKFkY8RR7qcSsPmrAeBBPESyf5pnYe");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -599,6 +603,7 @@ lazy_static! {
         (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),
         (use_default_units_in_fee_calculation::id(), "use default units per instruction in fee calculation #26785"),
         (compact_vote_state_updates::id(), "Compact vote state updates to lower block size"),
+        (sign_repair_requests::id(), "sign repair requests #TODO"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -603,7 +603,7 @@ lazy_static! {
         (loosen_cpi_size_restriction::id(), "loosen cpi size restrictions #26641"),
         (use_default_units_in_fee_calculation::id(), "use default units per instruction in fee calculation #26785"),
         (compact_vote_state_updates::id(), "Compact vote state updates to lower block size"),
-        (sign_repair_requests::id(), "sign repair requests #TODO"),
+        (sign_repair_requests::id(), "sign repair requests #26834"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Repair requests should be signed.

#### Summary of Changes

- Expand `RepairProtocol` to include new variants with signature support.
- Verify signatures for incoming repair requests.
- Add ping/pong support for the repair port.
- Verify that an incoming request pubkey has completed a succussful ping/pong.

Fixes #26834
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
