### PR TITLE
[docs] fixing incorrect/unknown redirects 

### DIFF
--- a/docs/publish-docs.sh
+++ b/docs/publish-docs.sh
@@ -31,20 +31,20 @@ cat > "$CONFIG_FILE" <<EOF
   "scope": "solana-labs",
   "redirects": [
     { "source": "/apps", "destination": "/developing/programming-model/overview" },
-    { "source": "/apps/bakcwards-compatibility", "destination": "/developing/backwards-compatibility" },
+    { "source": "/apps/backwards-compatibility", "destination": "/developing/backwards-compatibility" },
     { "source": "/apps/break", "destination": "/developing/on-chain-programs/examples" },
-    { "source": "/apps/builtins", "destination": "/developing/builtin-programs" },
+    { "source": "/apps/builtins", "destination": "/developing/runtime-facilities/programs" },
     { "source": "/apps/drones", "destination": "/developing/on-chain-programs/examples" },
     { "source": "/apps/hello-world", "destination": "/developing/on-chain-programs/examples" },
     { "source": "/apps/javascript-api", "destination": "/developing/clients/javascript-api" },
     { "source": "/apps/jsonrpc-api", "destination": "/developing/clients/jsonrpc-api" },
     { "source": "/apps/programming-faq", "destination": "/developing/on-chain-programs/faq" },
-    { "source": "/apps/rent", "destination": "/developing/programming-model/accounts" },
-    { "source": "/apps/sysvars", "destination": "/developing/programming-model/sysvars" },
-    { "source": "/apps/webwallet", "destination": "/developing/on-chain-programs/examples" },
-    { "source": "/implemented-proposals/cross-program-invocation", "destination": "/developing/programming-model/cpi" },
-    { "source": "/implemented-proposals/program-derived-addresses", "destination": "/developing/programming-model/program-derived-addresses" },
-    { "source": "/implemented-proposals/secp256k1_instruction", "destination": "/developing/programming-model/secpk1-instructions" }
+    { "source": "/apps/rent", "destination": "/developing/programming-model/accounts#rent" },
+    { "source": "/apps/sysvars", "destination": "/developing/runtime-facilities/sysvars" },
+    { "source": "/apps/webwallet", "destination": "/wallet-guide" },
+    { "source": "/implemented-proposals/cross-program-invocation", "destination": "/developing/programming-model/calling-between-programs" },
+    { "source": "/implemented-proposals/program-derived-addresses", "destination": "/developing/programming-model/calling-between-programs#program-derived-addresses" },
+    { "source": "/implemented-proposals/secp256k1_instruction", "destination": "/developing/runtime-facilities/programs#secp256k1-program" }
   ]
 }
 EOF


### PR DESCRIPTION
#### Problem
The `publish-docs.sh` script being used to generate the redirects for Vercel are sending multiple pages to incorrect or unknown pages.

#### Summary of Changes
Updates the `publish-docs.sh` script to correctly redirect to known live URLs on the docs site.
